### PR TITLE
colexechash: optimize the hash aggregator and unordered distinct

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1086,7 +1086,10 @@ func benchmarkAggregateFunction(
 // benchmark is measuring the performance of the aggregators themselves
 // depending on the parameters of the input.
 func BenchmarkAggregator(b *testing.B) {
-	aggFn := execinfrapb.Min
+	// We choose any_not_null aggregate function because it is the simplest
+	// possible and, thus, its Compute function call will have the least impact
+	// when benchmarking the aggregator logic.
+	aggFn := execinfrapb.AnyNotNull
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
 	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize()}
 	if testing.Short() {

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1091,7 +1091,7 @@ func BenchmarkAggregator(b *testing.B) {
 	// when benchmarking the aggregator logic.
 	aggFn := execinfrapb.AnyNotNull
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
-	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize()}
+	groupSizes := []int{1, 16, 256, 4096, 32768}
 	if testing.Short() {
 		numRows = []int{32, 32 * coldata.BatchSize()}
 		groupSizes = []int{1, coldata.BatchSize()}

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -753,6 +753,7 @@ func TestAggregators(t *testing.T) {
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
+	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 	for _, tc := range aggregatorsTestCases {
 		constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
@@ -776,7 +777,7 @@ func TestAggregators(t *testing.T) {
 			}
 			colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, verifier,
 				func(input []colexecop.Operator) (colexecop.Operator, error) {
-					return agg.new(&colexecagg.NewAggregatorArgs{
+					args := &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
 						MemAccount:     testMemAcc,
 						Input:          input[0],
@@ -786,7 +787,9 @@ func TestAggregators(t *testing.T) {
 						Constructors:   constructors,
 						ConstArguments: constArguments,
 						OutputTypes:    outputTypes,
-					})
+					}
+					args.TestingKnobs.HashTableNumBuckets = uint64(1 + rng.Intn(7))
+					return agg.new(args)
 				})
 		}
 	}
@@ -895,7 +898,7 @@ func TestAggregatorRandom(t *testing.T) {
 						&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 					)
 					require.NoError(t, err)
-					a, err := agg.new(&colexecagg.NewAggregatorArgs{
+					args := &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
 						MemAccount:     testMemAcc,
 						Input:          source,
@@ -905,7 +908,9 @@ func TestAggregatorRandom(t *testing.T) {
 						Constructors:   constructors,
 						ConstArguments: constArguments,
 						OutputTypes:    outputTypes,
-					})
+					}
+					args.TestingKnobs.HashTableNumBuckets = uint64(1 + rng.Intn(31))
+					a, err := agg.new(args)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -33,4 +33,11 @@ type NewAggregatorArgs struct {
 	Constructors   []execinfrapb.AggregateConstructor
 	ConstArguments []tree.Datums
 	OutputTypes    []*types.T
+
+	TestingKnobs struct {
+		// HashTableNumBuckets if positive will override the initial number of
+		// buckets to be used by the hash table (if this struct is passed to the
+		// hash aggregator).
+		HashTableNumBuckets uint64
+	}
 }

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -422,42 +422,6 @@ func (ht *HashTable) ComputeHashAndBuildChains(batch coldata.Batch) {
 	ht.buildNextChains(ht.ProbeScratch.First, ht.ProbeScratch.Next, 1 /* offset */, uint64(batchLength))
 }
 
-// FindBuckets finds the buckets for all tuples in batch when probing against a
-// hash table that is specified by 'first' and 'next' vectors as well as
-// 'duplicatesChecker'. `duplicatesChecker` takes a slice of key columns of the
-// batch, number of tuples to check, and the selection vector of the batch, and
-// it returns number of tuples that needs to be checked for next iteration.
-// The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
-// NOTE: *first* and *next* vectors should be properly populated.
-// NOTE: batch is assumed to be non-zero length.
-func (ht *HashTable) FindBuckets(
-	batch coldata.Batch,
-	keyCols []coldata.Vec,
-	first, next []uint64,
-	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
-) {
-	batchLength := batch.Length()
-	sel := batch.Selection()
-
-	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
-	// Early bounds checks.
-	groupIDs := ht.ProbeScratch.GroupID
-	_ = groupIDs[batchLength-1]
-	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-		f := first[hash]
-		//gcassert:bce
-		groupIDs[i] = f
-	}
-	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
-
-	for nToCheck := uint64(batchLength); nToCheck > 0; {
-		// Continue searching for the build table matching keys while the ToCheck
-		// array is non-empty.
-		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
-		ht.FindNext(next, nToCheck)
-	}
-}
-
 // RemoveDuplicates updates the selection vector of the batch to only include
 // distinct tuples when probing against a hash table specified by 'first' and
 // 'next' vectors as well as 'duplicatesChecker'.
@@ -609,14 +573,6 @@ func (p *hashTableProbeBuffer) SetupLimitedSlices(length int, buildMode HashTabl
 		p.ToCheck = make([]uint64, length)
 	} else {
 		p.ToCheck = p.ToCheck[:length]
-	}
-}
-
-// FindNext determines the id of the next key inside the GroupID buckets for
-// each equality column key in ToCheck.
-func (ht *HashTable) FindNext(next []uint64, nToCheck uint64) {
-	for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-		ht.ProbeScratch.GroupID[toCheck] = next[ht.ProbeScratch.GroupID[toCheck]]
 	}
 }
 

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -11086,12 +11086,18 @@ func (ht *HashTable) FindBuckets(
 				batchLength := batch.Length()
 				sel := batch.Selection()
 				// Early bounds checks.
+				hashBuffer := ht.ProbeScratch.HashBuffer
 				groupIDs := ht.ProbeScratch.GroupID
+				toCheck := ht.ProbeScratch.ToCheck
+				headIDs := ht.ProbeScratch.HeadID
+				_ = hashBuffer[batchLength-1]
 				_ = groupIDs[batchLength-1]
-				var tupleIdx, nToCheck uint64
-				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					tupleIdx = uint64(i)
-					nextGroupIDToCheck := first[hash]
+				_ = toCheck[batchLength-1]
+				_ = headIDs[batchLength-1]
+				var nToCheck uint64
+				//for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				for tupleIdx := uint64(0); tupleIdx < uint64(batchLength) && nToCheck < uint64(batchLength); tupleIdx++ {
+					nextGroupIDToCheck := first[hashBuffer[tupleIdx]]
 					// When probing against itself, we know for sure that
 					// 'nextGroupIDToCheck' will not be zero - we definitely have a
 					// match when using the same probing tuple on the build side.
@@ -11106,7 +11112,8 @@ func (ht *HashTable) FindBuckets(
 						if needToCheck {
 							//gcassert:bce
 							groupIDs[tupleIdx] = nextGroupIDToCheck
-							ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+							//gcassert:bce
+							toCheck[nToCheck] = tupleIdx
 							nToCheck++
 						} else {
 							// No need to check this tuple.
@@ -11124,7 +11131,7 @@ func (ht *HashTable) FindBuckets(
 					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
 					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
 					nToCheck = 0
-					for _, tupleIdx = range toCheckSlice {
+					for _, tupleIdx := range toCheckSlice {
 						nextGroupIDToCheck := next[groupIDs[tupleIdx]]
 						// When we're probing against itself, all the tuples that have
 						// non-zero HeadID can be skipped because they are the part of
@@ -11142,7 +11149,7 @@ func (ht *HashTable) FindBuckets(
 						{
 							if needToCheck {
 								groupIDs[tupleIdx] = nextGroupIDToCheck
-								ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+								toCheck[nToCheck] = tupleIdx
 								nToCheck++
 							} else {
 								// No need to check this tuple.
@@ -11160,12 +11167,18 @@ func (ht *HashTable) FindBuckets(
 				batchLength := batch.Length()
 				sel := batch.Selection()
 				// Early bounds checks.
+				hashBuffer := ht.ProbeScratch.HashBuffer
 				groupIDs := ht.ProbeScratch.GroupID
+				toCheck := ht.ProbeScratch.ToCheck
+				headIDs := ht.ProbeScratch.HeadID
+				_ = hashBuffer[batchLength-1]
 				_ = groupIDs[batchLength-1]
-				var tupleIdx, nToCheck uint64
-				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					tupleIdx = uint64(i)
-					nextGroupIDToCheck := first[hash]
+				_ = toCheck[batchLength-1]
+				_ = headIDs[batchLength-1]
+				var nToCheck uint64
+				//for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				for tupleIdx := uint64(0); tupleIdx < uint64(batchLength) && nToCheck < uint64(batchLength); tupleIdx++ {
+					nextGroupIDToCheck := first[hashBuffer[tupleIdx]]
 					// When 'nextGroupIDToCheck' is zero, then the tuple doesn't have a
 					// duplicate in the hash table because we don't have a hash match.
 					needToCheck := nextGroupIDToCheck != 0
@@ -11173,7 +11186,8 @@ func (ht *HashTable) FindBuckets(
 						if needToCheck {
 							//gcassert:bce
 							groupIDs[tupleIdx] = nextGroupIDToCheck
-							ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+							//gcassert:bce
+							toCheck[nToCheck] = tupleIdx
 							nToCheck++
 						} else {
 							// No need to check this tuple.
@@ -11191,7 +11205,7 @@ func (ht *HashTable) FindBuckets(
 					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
 					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
 					nToCheck = 0
-					for _, tupleIdx = range toCheckSlice {
+					for _, tupleIdx := range toCheckSlice {
 						nextGroupIDToCheck := next[groupIDs[tupleIdx]]
 						// When 'nextGroupIDToCheck' is zero, then the tuple doesn't have a
 						// duplicate in the hash table because we have already exhausted all
@@ -11200,7 +11214,7 @@ func (ht *HashTable) FindBuckets(
 						{
 							if needToCheck {
 								groupIDs[tupleIdx] = nextGroupIDToCheck
-								ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+								toCheck[nToCheck] = tupleIdx
 								nToCheck++
 							} else {
 								// No need to check this tuple.
@@ -11220,12 +11234,18 @@ func (ht *HashTable) FindBuckets(
 				batchLength := batch.Length()
 				sel := batch.Selection()
 				// Early bounds checks.
+				hashBuffer := ht.ProbeScratch.HashBuffer
 				groupIDs := ht.ProbeScratch.GroupID
+				toCheck := ht.ProbeScratch.ToCheck
+				headIDs := ht.ProbeScratch.HeadID
+				_ = hashBuffer[batchLength-1]
 				_ = groupIDs[batchLength-1]
-				var tupleIdx, nToCheck uint64
-				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					tupleIdx = uint64(i)
-					nextGroupIDToCheck := first[hash]
+				_ = toCheck[batchLength-1]
+				_ = headIDs[batchLength-1]
+				var nToCheck uint64
+				//for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				for tupleIdx := uint64(0); tupleIdx < uint64(batchLength) && nToCheck < uint64(batchLength); tupleIdx++ {
+					nextGroupIDToCheck := first[hashBuffer[tupleIdx]]
 					// When probing against itself, we know for sure that
 					// 'nextGroupIDToCheck' will not be zero - we definitely have a
 					// match when using the same probing tuple on the build side.
@@ -11240,14 +11260,17 @@ func (ht *HashTable) FindBuckets(
 						if needToCheck {
 							//gcassert:bce
 							groupIDs[tupleIdx] = nextGroupIDToCheck
-							ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+							//gcassert:bce
+							toCheck[nToCheck] = tupleIdx
 							nToCheck++
 						} else {
 							// No need to check this tuple.
 							_ = true
 							// Set the HeadID of this tuple to point to itself since it is an
 							// equality chain consisting only of a single element.
-							ht.ProbeScratch.HeadID[tupleIdx] = tupleIdx + 1
+							_ = true
+							//gcassert:bce
+							headIDs[tupleIdx] = tupleIdx + 1
 						}
 					}
 				}
@@ -11258,7 +11281,7 @@ func (ht *HashTable) FindBuckets(
 					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
 					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
 					nToCheck = 0
-					for _, tupleIdx = range toCheckSlice {
+					for _, tupleIdx := range toCheckSlice {
 						nextGroupIDToCheck := next[groupIDs[tupleIdx]]
 						// When we're probing against itself, all the tuples that have
 						// non-zero HeadID can be skipped because they are the part of
@@ -11276,14 +11299,15 @@ func (ht *HashTable) FindBuckets(
 						{
 							if needToCheck {
 								groupIDs[tupleIdx] = nextGroupIDToCheck
-								ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+								toCheck[nToCheck] = tupleIdx
 								nToCheck++
 							} else {
 								// No need to check this tuple.
 								_ = true
 								// Set the HeadID of this tuple to point to itself since it is an
 								// equality chain consisting only of a single element.
-								ht.ProbeScratch.HeadID[tupleIdx] = tupleIdx + 1
+								_ = true
+								headIDs[tupleIdx] = tupleIdx + 1
 							}
 						}
 					}
@@ -11294,12 +11318,18 @@ func (ht *HashTable) FindBuckets(
 				batchLength := batch.Length()
 				sel := batch.Selection()
 				// Early bounds checks.
+				hashBuffer := ht.ProbeScratch.HashBuffer
 				groupIDs := ht.ProbeScratch.GroupID
+				toCheck := ht.ProbeScratch.ToCheck
+				headIDs := ht.ProbeScratch.HeadID
+				_ = hashBuffer[batchLength-1]
 				_ = groupIDs[batchLength-1]
-				var tupleIdx, nToCheck uint64
-				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					tupleIdx = uint64(i)
-					nextGroupIDToCheck := first[hash]
+				_ = toCheck[batchLength-1]
+				_ = headIDs[batchLength-1]
+				var nToCheck uint64
+				//for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				for tupleIdx := uint64(0); tupleIdx < uint64(batchLength) && nToCheck < uint64(batchLength); tupleIdx++ {
+					nextGroupIDToCheck := first[hashBuffer[tupleIdx]]
 					// When 'nextGroupIDToCheck' is zero, then the tuple doesn't have a
 					// duplicate in the hash table because we don't have a hash match.
 					needToCheck := nextGroupIDToCheck != 0
@@ -11307,14 +11337,17 @@ func (ht *HashTable) FindBuckets(
 						if needToCheck {
 							//gcassert:bce
 							groupIDs[tupleIdx] = nextGroupIDToCheck
-							ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+							//gcassert:bce
+							toCheck[nToCheck] = tupleIdx
 							nToCheck++
 						} else {
 							// No need to check this tuple.
 							_ = true
 							// Set the HeadID of this tuple to point to itself since it is an
 							// equality chain consisting only of a single element.
-							ht.ProbeScratch.HeadID[tupleIdx] = tupleIdx + 1
+							_ = true
+							//gcassert:bce
+							headIDs[tupleIdx] = tupleIdx + 1
 						}
 					}
 				}
@@ -11325,7 +11358,7 @@ func (ht *HashTable) FindBuckets(
 					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
 					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
 					nToCheck = 0
-					for _, tupleIdx = range toCheckSlice {
+					for _, tupleIdx := range toCheckSlice {
 						nextGroupIDToCheck := next[groupIDs[tupleIdx]]
 						// When 'nextGroupIDToCheck' is zero, then the tuple doesn't have a
 						// duplicate in the hash table because we have already exhausted all
@@ -11334,14 +11367,15 @@ func (ht *HashTable) FindBuckets(
 						{
 							if needToCheck {
 								groupIDs[tupleIdx] = nextGroupIDToCheck
-								ht.ProbeScratch.ToCheck[nToCheck] = tupleIdx
+								toCheck[nToCheck] = tupleIdx
 								nToCheck++
 							} else {
 								// No need to check this tuple.
 								_ = true
 								// Set the HeadID of this tuple to point to itself since it is an
 								// equality chain consisting only of a single element.
-								ht.ProbeScratch.HeadID[tupleIdx] = tupleIdx + 1
+								_ = true
+								headIDs[tupleIdx] = tupleIdx + 1
 							}
 						}
 					}
@@ -11363,8 +11397,6 @@ const _ = "template_findBuckets"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "template_processNextGroupIDToCheck"
 
@@ -11389,8 +11421,6 @@ const _ = "inlined_findBuckets_false_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_true"
 
@@ -11403,8 +11433,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_false"
 
@@ -11417,8 +11445,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_true"
 
@@ -11431,7 +11457,5 @@ const _ = "inlined_processNextGroupIDToCheck_false_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -11222,8 +11222,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 			if ht.ProbeScratch.HeadID[toCheck] == 0 {
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}
-		}
-		if ht.ProbeScratch.differs[toCheck] {
+		} else {
 			// Continue probing in this next chain for the probe key.
 			ht.ProbeScratch.differs[toCheck] = false
 			//gcassert:bce
@@ -11324,4 +11323,42 @@ func (ht *HashTable) DistinctCheck(nToCheck uint64, probeSel []int) uint64 {
 		}
 	}
 	return nDiffers
+}
+
+// FindBuckets finds the buckets for all tuples in batch when probing against a
+// hash table that is specified by 'first' and 'next' vectors as well as
+// 'duplicatesChecker'. `duplicatesChecker` takes a slice of key columns of the
+// batch, number of tuples to check, and the selection vector of the batch, and
+// it returns number of tuples that needs to be checked for next iteration.
+// The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
+// NOTE: *first* and *next* vectors should be properly populated.
+// NOTE: batch is assumed to be non-zero length.
+func (ht *HashTable) FindBuckets(
+	batch coldata.Batch,
+	keyCols []coldata.Vec,
+	first, next []uint64,
+	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+) {
+	batchLength := batch.Length()
+	sel := batch.Selection()
+
+	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
+	// Early bounds checks.
+	groupIDs := ht.ProbeScratch.GroupID
+	_ = groupIDs[batchLength-1]
+	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+		f := first[hash]
+		//gcassert:bce
+		groupIDs[i] = f
+	}
+	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
+
+	for nToCheck := uint64(batchLength); nToCheck > 0; {
+		// Continue searching for the build table matching keys while the ToCheck
+		// array is non-empty.
+		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+		for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+			ht.ProbeScratch.GroupID[toCheck] = next[ht.ProbeScratch.GroupID[toCheck]]
+		}
+	}
 }

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -11091,13 +11091,21 @@ func (ht *HashTable) FindBuckets(
 				var nToCheck uint64
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
 					f := first[hash]
-					if f != 0 {
+					// When probing against itself, we know for sure that 'f' will not
+					// be zero - we definitely have a match when using the same probing
+					// tuple on the build side. Additionally, we can skip checking this
+					// scenario since we know that the tuple is equal to itself.
+					if uint64(i) != f-1 {
 						//gcassert:bce
 						groupIDs[i] = f
 						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
 						nToCheck++
 					} else {
-						// This tuple doesn't have a duplicate in the hash table.
+						// This tuple is the head of its equality chain, so we treat it
+						// as distinct from all others. Note that if
+						// probingAgainstItself is true, then zeroHeadIDForDistinctTuple
+						// is false, so the function call below will set up HeadID for
+						// the tuple to point to itself.
 						{
 							var i uint64 = uint64(i)
 							// We leave the HeadID of this tuple unchanged (i.e. zero - that was set
@@ -11202,13 +11210,21 @@ func (ht *HashTable) FindBuckets(
 				var nToCheck uint64
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
 					f := first[hash]
-					if f != 0 {
+					// When probing against itself, we know for sure that 'f' will not
+					// be zero - we definitely have a match when using the same probing
+					// tuple on the build side. Additionally, we can skip checking this
+					// scenario since we know that the tuple is equal to itself.
+					if uint64(i) != f-1 {
 						//gcassert:bce
 						groupIDs[i] = f
 						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
 						nToCheck++
 					} else {
-						// This tuple doesn't have a duplicate in the hash table.
+						// This tuple is the head of its equality chain, so we treat it
+						// as distinct from all others. Note that if
+						// probingAgainstItself is true, then zeroHeadIDForDistinctTuple
+						// is false, so the function call below will set up HeadID for
+						// the tuple to point to itself.
 						{
 							var i uint64 = uint64(i)
 							// Set the HeadID of this tuple to point to itself since it is an

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -5577,9 +5577,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -5638,9 +5635,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5703,9 +5697,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -5763,9 +5754,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5832,9 +5820,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -5893,9 +5878,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5958,9 +5940,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6018,9 +5997,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6094,9 +6070,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6147,9 +6120,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6204,9 +6174,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6256,9 +6223,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6317,9 +6281,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6370,9 +6331,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6427,9 +6385,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6479,9 +6434,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6561,9 +6513,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6614,9 +6563,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6671,9 +6617,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6723,9 +6666,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6784,9 +6724,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6837,9 +6774,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -6894,9 +6828,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -6946,9 +6877,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7031,9 +6959,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7095,9 +7020,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7163,9 +7085,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7226,9 +7145,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7298,9 +7214,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7362,9 +7275,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7430,9 +7340,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7493,9 +7400,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7581,9 +7485,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7645,9 +7546,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7713,9 +7611,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7776,9 +7671,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7848,9 +7740,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -7912,9 +7801,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -7980,9 +7866,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8043,9 +7926,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8133,9 +8013,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8197,9 +8074,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8265,9 +8139,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8328,9 +8199,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8400,9 +8268,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8464,9 +8329,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8532,9 +8394,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8595,9 +8454,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8699,9 +8555,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8771,9 +8624,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8847,9 +8697,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -8918,9 +8765,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -8998,9 +8842,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9070,9 +8911,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9146,9 +8984,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9217,9 +9052,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9303,9 +9135,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9363,9 +9192,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9427,9 +9253,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9486,9 +9309,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9554,9 +9374,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9614,9 +9431,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9678,9 +9492,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9737,9 +9548,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9813,9 +9621,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9866,9 +9671,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -9923,9 +9725,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -9975,9 +9774,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10036,9 +9832,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10089,9 +9882,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10146,9 +9936,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10198,9 +9985,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10280,9 +10064,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10339,9 +10120,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10402,9 +10180,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10460,9 +10235,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10527,9 +10299,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10586,9 +10355,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10649,9 +10415,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10707,9 +10470,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10785,9 +10545,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10840,9 +10597,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -10899,9 +10653,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -10953,9 +10704,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -11016,9 +10764,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -11071,9 +10816,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -11130,9 +10872,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							} else {
 								var (
@@ -11185,9 +10924,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
 								}
 							}
 						}
@@ -11219,9 +10955,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 			// If the current key matches with the probe key, we want to update HeadID
 			// with the current key if it has not been set yet.
 			keyID := ht.ProbeScratch.GroupID[toCheck]
-			if ht.ProbeScratch.HeadID[toCheck] == 0 {
-				ht.ProbeScratch.HeadID[toCheck] = keyID
-			}
+			ht.ProbeScratch.HeadID[toCheck] = keyID
 		} else {
 			// Continue probing in this next chain for the probe key.
 			ht.ProbeScratch.differs[toCheck] = false
@@ -11331,6 +11065,10 @@ func (ht *HashTable) DistinctCheck(nToCheck uint64, probeSel []int) uint64 {
 // batch, number of tuples to check, and the selection vector of the batch, and
 // it returns number of tuples that needs to be checked for next iteration.
 // The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
+// If zeroHeadIDForDistinctTuple is true, then all tuples that are distinct
+// (i.e. they don't have duplicates) will have HeadID value of 0.
+// - probingAgainstItself indicates whether 'first' and 'next' "represent" the
+// hash table built on the probing batch.
 // NOTE: *first* and *next* vectors should be properly populated.
 // NOTE: batch is assumed to be non-zero length.
 func (ht *HashTable) FindBuckets(
@@ -11338,27 +11076,255 @@ func (ht *HashTable) FindBuckets(
 	keyCols []coldata.Vec,
 	first, next []uint64,
 	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+	zeroHeadIDForDistinctTuple bool,
+	probingAgainstItself bool,
 ) {
-	batchLength := batch.Length()
-	sel := batch.Selection()
+	ht.ProbeScratch.SetupLimitedSlices(batch.Length(), ht.BuildMode)
+	if zeroHeadIDForDistinctTuple {
+		if probingAgainstItself {
+			{
+				batchLength := batch.Length()
+				sel := batch.Selection()
+				// Early bounds checks.
+				groupIDs := ht.ProbeScratch.GroupID
+				_ = groupIDs[batchLength-1]
+				var nToCheck uint64
+				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+					f := first[hash]
+					if f != 0 {
+						//gcassert:bce
+						groupIDs[i] = f
+						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
+						nToCheck++
+					} else {
+						// This tuple doesn't have a duplicate in the hash table.
+						{
+							var i uint64 = uint64(i)
+							// We leave the HeadID of this tuple unchanged (i.e. zero - that was set
+							// in SetupLimitedSlices).
+							_ = i
+						}
+					}
+				}
 
-	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
-	// Early bounds checks.
-	groupIDs := ht.ProbeScratch.GroupID
-	_ = groupIDs[batchLength-1]
-	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-		f := first[hash]
-		//gcassert:bce
-		groupIDs[i] = f
-	}
-	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
+				for nToCheck > 0 {
+					// Continue searching for the build table matching keys while the ToCheck
+					// array is non-empty.
+					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+					nToCheck = 0
+					for _, toCheck := range toCheckSlice {
+						nextGroupIDToCheck := next[groupIDs[toCheck]]
+						// When we're probing against itself, all the tuples that have
+						// non-zero HeadID can be skipped because they are the part of
+						// already found equality chains. We must have already compared
+						// the 'toCheck' tuple against the head of the corresponding
+						// equality chain, so there is no reason to perform the check
+						// against another element from the same equality chain.
+						for nextGroupIDToCheck != 0 && ht.ProbeScratch.HeadID[nextGroupIDToCheck-1] != 0 {
+							nextGroupIDToCheck = next[nextGroupIDToCheck]
+						}
+						if nextGroupIDToCheck != 0 {
+							groupIDs[toCheck] = nextGroupIDToCheck
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							// This tuple doesn't have a duplicate.
+							{
+								var i uint64 = toCheck
+								// We leave the HeadID of this tuple unchanged (i.e. zero - that was set
+								// in SetupLimitedSlices).
+								_ = i
+							}
+						}
+					}
+				}
+			}
+		} else {
+			{
+				batchLength := batch.Length()
+				sel := batch.Selection()
+				// Early bounds checks.
+				groupIDs := ht.ProbeScratch.GroupID
+				_ = groupIDs[batchLength-1]
+				var nToCheck uint64
+				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+					f := first[hash]
+					if f != 0 {
+						//gcassert:bce
+						groupIDs[i] = f
+						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
+						nToCheck++
+					} else {
+						// This tuple doesn't have a duplicate in the hash table.
+						{
+							var i uint64 = uint64(i)
+							// We leave the HeadID of this tuple unchanged (i.e. zero - that was set
+							// in SetupLimitedSlices).
+							_ = i
+						}
+					}
+				}
 
-	for nToCheck := uint64(batchLength); nToCheck > 0; {
-		// Continue searching for the build table matching keys while the ToCheck
-		// array is non-empty.
-		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
-		for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-			ht.ProbeScratch.GroupID[toCheck] = next[ht.ProbeScratch.GroupID[toCheck]]
+				for nToCheck > 0 {
+					// Continue searching for the build table matching keys while the ToCheck
+					// array is non-empty.
+					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+					nToCheck = 0
+					for _, toCheck := range toCheckSlice {
+						nextGroupIDToCheck := next[groupIDs[toCheck]]
+						if nextGroupIDToCheck != 0 {
+							groupIDs[toCheck] = nextGroupIDToCheck
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							// This tuple doesn't have a duplicate.
+							{
+								var i uint64 = toCheck
+								// We leave the HeadID of this tuple unchanged (i.e. zero - that was set
+								// in SetupLimitedSlices).
+								_ = i
+							}
+						}
+					}
+				}
+			}
+		}
+	} else {
+		if probingAgainstItself {
+			{
+				batchLength := batch.Length()
+				sel := batch.Selection()
+				// Early bounds checks.
+				groupIDs := ht.ProbeScratch.GroupID
+				_ = groupIDs[batchLength-1]
+				var nToCheck uint64
+				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+					f := first[hash]
+					if f != 0 {
+						//gcassert:bce
+						groupIDs[i] = f
+						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
+						nToCheck++
+					} else {
+						// This tuple doesn't have a duplicate in the hash table.
+						{
+							var i uint64 = uint64(i)
+							// Set the HeadID of this tuple to point to itself since it is an
+							// equality chain consisting only of a single element.
+							ht.ProbeScratch.HeadID[i] = i + 1
+						}
+					}
+				}
+
+				for nToCheck > 0 {
+					// Continue searching for the build table matching keys while the ToCheck
+					// array is non-empty.
+					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+					nToCheck = 0
+					for _, toCheck := range toCheckSlice {
+						nextGroupIDToCheck := next[groupIDs[toCheck]]
+						// When we're probing against itself, all the tuples that have
+						// non-zero HeadID can be skipped because they are the part of
+						// already found equality chains. We must have already compared
+						// the 'toCheck' tuple against the head of the corresponding
+						// equality chain, so there is no reason to perform the check
+						// against another element from the same equality chain.
+						for nextGroupIDToCheck != 0 && ht.ProbeScratch.HeadID[nextGroupIDToCheck-1] != 0 {
+							nextGroupIDToCheck = next[nextGroupIDToCheck]
+						}
+						if nextGroupIDToCheck != 0 {
+							groupIDs[toCheck] = nextGroupIDToCheck
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							// This tuple doesn't have a duplicate.
+							{
+								var i uint64 = toCheck
+								// Set the HeadID of this tuple to point to itself since it is an
+								// equality chain consisting only of a single element.
+								ht.ProbeScratch.HeadID[i] = i + 1
+							}
+						}
+					}
+				}
+			}
+		} else {
+			{
+				batchLength := batch.Length()
+				sel := batch.Selection()
+				// Early bounds checks.
+				groupIDs := ht.ProbeScratch.GroupID
+				_ = groupIDs[batchLength-1]
+				var nToCheck uint64
+				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+					f := first[hash]
+					if f != 0 {
+						//gcassert:bce
+						groupIDs[i] = f
+						ht.ProbeScratch.ToCheck[nToCheck] = uint64(i)
+						nToCheck++
+					} else {
+						// This tuple doesn't have a duplicate in the hash table.
+						{
+							var i uint64 = uint64(i)
+							// Set the HeadID of this tuple to point to itself since it is an
+							// equality chain consisting only of a single element.
+							ht.ProbeScratch.HeadID[i] = i + 1
+						}
+					}
+				}
+
+				for nToCheck > 0 {
+					// Continue searching for the build table matching keys while the ToCheck
+					// array is non-empty.
+					nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+					toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+					nToCheck = 0
+					for _, toCheck := range toCheckSlice {
+						nextGroupIDToCheck := next[groupIDs[toCheck]]
+						if nextGroupIDToCheck != 0 {
+							groupIDs[toCheck] = nextGroupIDToCheck
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							// This tuple doesn't have a duplicate.
+							{
+								var i uint64 = toCheck
+								// Set the HeadID of this tuple to point to itself since it is an
+								// equality chain consisting only of a single element.
+								ht.ProbeScratch.HeadID[i] = i + 1
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 }
+
+// execgen:inline
+const _ = "template_findBuckets"
+
+// execgen:inline
+const _ = "template_setHeadIDForDistinctTuple"
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_false"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_false"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_true"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -8353,3 +8353,21 @@ func (ht *HashTable) checkCol(
 		}
 	}
 }
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_false"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_false"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_true"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -8375,8 +8375,6 @@ const _ = "inlined_findBuckets_false_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_true"
 
@@ -8389,8 +8387,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_false"
 
@@ -8403,8 +8399,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_true"
 
@@ -8417,7 +8411,5 @@ const _ = "inlined_processNextGroupIDToCheck_false_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -8366,8 +8366,58 @@ const _ = "inlined_findBuckets_false_true"
 // execgen:inline
 const _ = "inlined_findBuckets_false_false"
 
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
 // execgen:inline
-const _ = "inlined_setHeadIDForDistinctTuple_true"
+const _ = "inlined_processNextGroupIDToCheck_true_true"
 
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
 // execgen:inline
-const _ = "inlined_setHeadIDForDistinctTuple_false"
+const _ = "inlined_processNextGroupIDToCheck_true_false"
+
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
+// execgen:inline
+const _ = "inlined_processNextGroupIDToCheck_false_true"
+
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
+// execgen:inline
+const _ = "inlined_processNextGroupIDToCheck_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -9198,21 +9198,21 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					}
 					firstID := ht.ProbeScratch.HeadID[toCheck]
 					if !ht.Visited[keyID] {
-						// We can then add this keyID into the same array at the end of the
-						// corresponding linked list and mark this ID as visited. Since there
-						// can be multiple keys that match this probe key, we want to mark
-						// differs at this position to be true. This way, the prober will
-						// continue probing for this key until it reaches the end of the next
-						// chain.
-						ht.ProbeScratch.differs[toCheck] = true
+						// We can then add this keyID into the same array at the end of
+						// the corresponding linked list and mark this ID as visited.
 						ht.Visited[keyID] = true
 						if firstID != keyID {
 							ht.Same[keyID] = ht.Same[firstID]
 							ht.Same[firstID] = keyID
 						}
+						// Since there can be multiple keys that match this probe key,
+						// we need to continue probing for this key until it reaches the
+						// end of the next chain.
+						//gcassert:bce
+						toCheckSlice[nDiffers] = toCheck
+						nDiffers++
 					}
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
@@ -9233,8 +9233,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
@@ -9275,8 +9274,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 						}
 					}
 					continue
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
@@ -9315,8 +9313,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 						}
 					}
 					continue
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -9347,8 +9347,6 @@ const _ = "inlined_findBuckets_false_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_true"
 
@@ -9361,8 +9359,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_true_false"
 
@@ -9375,8 +9371,6 @@ const _ = "inlined_processNextGroupIDToCheck_true_false"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_true"
 
@@ -9389,7 +9383,5 @@ const _ = "inlined_processNextGroupIDToCheck_false_true"
 // probe the current tuple against on the next iteration
 // - nToCheck tracks the number of tuples we have already included for probing
 // on the next iteration and might be incremented.
-// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
-// and ht.ProbeScratch.HeadID.
 // execgen:inline
 const _ = "inlined_processNextGroupIDToCheck_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -9273,7 +9273,6 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 							nDiffers++
 						}
 					}
-					continue
 				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
@@ -9312,7 +9311,6 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 							nDiffers++
 						}
 					}
-					continue
 				} else {
 					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
@@ -9327,3 +9325,21 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 	}
 	return nDiffers
 }
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_true_false"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false_false"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_true"
+
+// execgen:inline
+const _ = "inlined_setHeadIDForDistinctTuple_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -9338,8 +9338,58 @@ const _ = "inlined_findBuckets_false_true"
 // execgen:inline
 const _ = "inlined_findBuckets_false_false"
 
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
 // execgen:inline
-const _ = "inlined_setHeadIDForDistinctTuple_true"
+const _ = "inlined_processNextGroupIDToCheck_true_true"
 
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
 // execgen:inline
-const _ = "inlined_setHeadIDForDistinctTuple_false"
+const _ = "inlined_processNextGroupIDToCheck_true_false"
+
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
+// execgen:inline
+const _ = "inlined_processNextGroupIDToCheck_false_true"
+
+// processNextGroupIDToCheck processes the information about a single tuple and
+// prepares the tuple for being probed on the next iteration.
+// - needToCheck indicates whether the tuple needs to be probed, if it is false,
+// then we already know how to handle it (which depends on
+// zeroHeadIDForDistinctTuple parameter)
+// - nextGroupIDToCheck is the ID of the tuple in the hash table that we want to
+// probe the current tuple against on the next iteration
+// - nToCheck tracks the number of tuples we have already included for probing
+// on the next iteration and might be incremented.
+// TODO(yuzefovich): check whether we can get BCE for ht.ProbeScratch.ToCheck
+// and ht.ProbeScratch.HeadID.
+// execgen:inline
+const _ = "inlined_processNextGroupIDToCheck_false_false"

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -539,7 +539,11 @@ func (hj *hashJoiner) exec() coldata.Batch {
 				// buckets. If the key is found or end of next chain is reached, the key is
 				// removed from the ToCheck array.
 				nToCheck = hj.ht.DistinctCheck(nToCheck, sel)
-				hj.ht.FindNext(hj.ht.BuildScratch.Next, nToCheck)
+				// TODO(yuzefovich): check whether we can omit the 'toCheck'
+				// tuple if the new GroupID is 0.
+				for _, toCheck := range hj.ht.ProbeScratch.ToCheck[:nToCheck] {
+					hj.ht.ProbeScratch.GroupID[toCheck] = hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.GroupID[toCheck]]
+				}
 			}
 
 			nResults = hj.distinctCollect(batch, batchSize, sel)
@@ -548,7 +552,11 @@ func (hj *hashJoiner) exec() coldata.Batch {
 				// Continue searching for the build table matching keys while the ToCheck
 				// array is non-empty.
 				nToCheck = hj.ht.Check(hj.ht.Keys, nToCheck, sel)
-				hj.ht.FindNext(hj.ht.BuildScratch.Next, nToCheck)
+				// TODO(yuzefovich): check whether we can omit the 'toCheck'
+				// tuple if the new GroupID is 0.
+				for _, toCheck := range hj.ht.ProbeScratch.ToCheck[:nToCheck] {
+					hj.ht.ProbeScratch.GroupID[toCheck] = hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.GroupID[toCheck]]
+				}
 			}
 
 			// We're processing a new batch, so we'll reset the index to start

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -370,9 +370,11 @@ func TestDistinct(t *testing.T) {
 	for _, tc := range distinctTestCases {
 		log.Infof(context.Background(), "unordered")
 		tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewUnorderedDistinct(
+			ud := NewUnorderedDistinct(
 				testAllocator, input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup,
-			), nil
+			).(*unorderedDistinct)
+			ud.hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			return ud, nil
 		})
 		if tc.isOrderedOnDistinctCols {
 			for numOrderedCols := 1; numOrderedCols < len(tc.distinctCols); numOrderedCols++ {
@@ -420,7 +422,9 @@ func TestUnorderedDistinctRandom(t *testing.T) {
 	tups, expected := generateRandomDataForUnorderedDistinct(rng, nTuples, nCols, newTupleProbability)
 	colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tups}, [][]*types.T{typs}, expected, colexectestutils.UnorderedVerifier,
 		func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewUnorderedDistinct(testAllocator, input[0], distinctCols, typs, false /* nullsAreDistinct */, "" /* errorOnDup */), nil
+			ud := NewUnorderedDistinct(testAllocator, input[0], distinctCols, typs, false /* nullsAreDistinct */, "" /* errorOnDup */).(*unorderedDistinct)
+			ud.hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			return ud, nil
 		},
 	)
 }

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -333,6 +333,7 @@ func BenchmarkExternalDistinct(b *testing.B) {
 				},
 				name,
 				true, /* isExternal */
+				true, /* shuffleInput */
 			)
 		}
 	}

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -220,7 +220,7 @@ func (op *hashAggregator) Init(ctx context.Context) {
 	// These numbers were chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
 	const hashTableLoadFactor = 0.1
-	const hashTableNumBuckets = 256
+	const hashTableNumBuckets = 32
 	op.ht = colexechash.NewHashTable(
 		op.Ctx,
 		op.hashTableAllocator,


### PR DESCRIPTION
**colexechash: some mechanical changes to the hash table**

This commit moves one method into the templated code and inlines another
method. This is a purely mechanical change in preparation for the
follow-up commit that will be templating the touched code.

Additionally, this commit simplifies the probing logic a bit by
squashing two `if` blocks into one via duplicating the code that needs to
run in some cases in both arms of the conditional.

Release note: None

**colexechash: optimize the hash aggregator and unordered distinct**

This commit optimizes the hash table code when it is used by the hash
aggregator or the unordered distinct. The following changes are made:
- now all tuples that are known to be distinct before probing (when the
tuple doesn't have a hash match) are omitted from probing entirely.
- the case when we're probing the batch against itself (in order to find
duplicates within the batch) has been optimized by taking advantage of
the following fact: if probing of `i`th tuple against `groupID[i]` tuple
revealed a mismatch, then we can skip probing against all tuples that
have non-zero `HeadID` - all such tuples are parts of the already
established equality chains, and it is guaranteed that the `i`th tuple
will be different from all of them too.
- a redundant `if` conditional is removed.

Additionally, in order to improve the chance of hash collisions in the
unit tests, this commit plumbs the testing knobs to reduce the number of
buckets used by the hash table.

Release note: None