### PR TITLE
kv: deflake TestReplicaStateMachineChangeReplicas

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -77,7 +77,7 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 
 				confChange = raftpb.ConfChange{
 					Type:   raftpb.ConfChangeAddNode,
-					NodeID: uint64(addedReplDesc.NodeID),
+					NodeID: uint64(addedReplDesc.ReplicaID),
 				}
 			} else {
 				// Remove ourselves from the Range.
@@ -100,7 +100,7 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 
 				confChange = raftpb.ConfChange{
 					Type:   raftpb.ConfChangeRemoveNode,
-					NodeID: uint64(removedReplDesc.NodeID),
+					NodeID: uint64(removedReplDesc.ReplicaID),
 				}
 			}
 


### PR DESCRIPTION
Fixes #69229.

The test was reaching below Raft and adding a peer on a node that does not
exist. With a large enough pause between `r.raftMu.Unlock()` and `testContext`
teardown, it was possible for the replica to be ticked, which would cause it to
attempt to reach out and heartbeat this node. This could cause issues. In fact,
the `testContext` uses a dummy `RaftTransport`, so any attempt to send traffic
to another Raft peer would panic.

This commit resolves the issue by giving testContext a slightly more real
version of a RaftTransport (i.e. one configured with a nodedialer). This feels a
bit wrong, as a testContext should really never need to use a RaftTransport, but
given how little impact this has on the dependency structure of a testContext
and given that the testContext was already doing something similar with gossip,
I think this is fine.

Release justification: test fix.