### PR TITLE
workload: synchronise concurrent access to preparedStatements map

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/bufalloc",
         "//pkg/util/encoding/csv",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload/histogram",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/workload/sql_runner.go
+++ b/pkg/workload/sql_runner.go
@@ -119,10 +119,9 @@ func (sr *SQLRunner) Init(
 		for i, s := range sr.stmts {
 			stmtName := fmt.Sprintf("%s-%d", name, i+1)
 			s.preparedName = stmtName
-			mcp.preparedStatements[stmtName] = s.sql
+			mcp.AddPreparedStatement(stmtName, s.sql)
 		}
 	}
-
 	sr.mcp = mcp
 	sr.initialized = true
 	return nil


### PR DESCRIPTION
After 60dd572e, the TPCC workload started to fail with

```
fatal error: concurrent map writes
```

because it attempts to start multiple sq runners using the same
MultiConnPool. This fix allows for that by putting a mutex around the
map accesses.

Fixes #69758
Fixes #69757
Fixes #69755
Fixes #69751
Fixes #69750
Fixes #69749
Fixes #69748
Fixes #69745
Fixes #69744
Fixes #69743
Fixes #69742
Fixes #69741
Fixes #69740
Fixes #69739
Fixes #69738
Fixes #69735
Fixes #69734

Release justification: Fixes critical bug in TPCC workload.

Release note: None