### PR TITLE
geogfn: use Contains instead of IntersectsCell for point intersects

### DIFF
--- a/pkg/geo/geogfn/intersects.go
+++ b/pkg/geo/geogfn/intersects.go
@@ -57,7 +57,7 @@ func singleRegionIntersects(aRegion s2.Region, bRegion s2.Region) (bool, error) 
 	case s2.Point:
 		switch bRegion := bRegion.(type) {
 		case s2.Point:
-			return aRegion.IntersectsCell(s2.CellFromPoint(bRegion)), nil
+			return aRegion.Contains(bRegion), nil
 		case *s2.Polyline:
 			return bRegion.IntersectsCell(s2.CellFromPoint(aRegion)), nil
 		case *s2.Polygon:


### PR DESCRIPTION
Release justification: low risk performance enhancement

Resolves #69761

Release note (performance improvement, sql change): geography point
intersection is slightly faster as we use a speedier intersection
function. However, this also means point intersection is "stricter",
requiring points be equal rather than having a small possible leeway
(<1cm) to be considered intersecting.