### PR TITLE
cli: make the color behavior of `debug merge-log` customizable

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -684,8 +684,8 @@ def go_deps():
         name = "com_github_cockroachdb_ttycolor",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/ttycolor",
-        sum = "h1:S2vg+TZySZ0jBGFPM2kmcYr0OwIPRoMX8/AMTajFmzE=",
-        version = "v0.0.0-20210717002733-a2a538deeb8c",
+        sum = "h1:Hli+oX84dKq44sLVCcsGKqifm5Lg9J8VoJ2P3h9iPdI=",
+        version = "v0.0.0-20210902133924-c7d7dcdde4e8",
     )
     go_repository(
         name = "com_github_codahale_hdrhistogram",

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2
 	github.com/cockroachdb/stress v0.0.0-20170808184505-29b5d31b4c3a
-	github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c
+	github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
 	github.com/containerd/containerd v1.4.6
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847/go.mod h
 github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11 h1:UAqRo5xPCyTtZznAJ9iPVpDUFxGI0a6QWtQ8E+zwJRg=
 github.com/cockroachdb/teamcity v0.0.0-20180905144921-8ca25c33eb11/go.mod h1:3299Mt0Q7PkqGqbsxhvbrTpMqRyIcZ6OMw4IEmiO09g=
 github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
-github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c h1:S2vg+TZySZ0jBGFPM2kmcYr0OwIPRoMX8/AMTajFmzE=
-github.com/cockroachdb/ttycolor v0.0.0-20210717002733-a2a538deeb8c/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
+github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8 h1:Hli+oX84dKq44sLVCcsGKqifm5Lg9J8VoJ2P3h9iPdI=
+github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8/go.mod h1:75wnig8+TF6vst9hChkpcFO7YrRLddouJ5is8uqpfv0=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82 h1:8htEd1lLILqfjKardWfKKGgXVCs0WmcgEj9cXnmcuos=
 github.com/cockroachdb/vitess v0.0.0-20210218160543-54524729cc82/go.mod h1:+bhevpN4bd6bstiRREkJDaMWZR3lTe5ypydTtXgf7GU=
 github.com/cockroachdb/yaml v0.0.0-20210825132133-2d6955c8edbc h1:vVVz+IAeHhYPxGW9EC8j6HR7uZl/1wSP0Wijaxs4frw=

--- a/pkg/util/log/format_crdb.go
+++ b/pkg/util/log/format_crdb.go
@@ -27,37 +27,25 @@ const MessageTimeFormat = "060102 15:04:05.999999"
 
 // FormatLegacyEntry writes the contents of the legacy log entry struct to the specified writer.
 func FormatLegacyEntry(e logpb.Entry, w io.Writer) error {
-	return formatLegacyEntry(e, w, nil /* cp */)
+	return FormatLegacyEntryWithOptionalColors(e, w, nil /* cp */)
 }
 
-// FormatLegacyEntryTTY writes the legacy log entry to the specified writer,
-// using colors if possible.
-func FormatLegacyEntryTTY(e logpb.Entry, w io.Writer) error {
-	cp := ttycolor.StderrProfile
-	if logging.stderrSink.noColor.Get() {
-		cp = nil
-	}
-	return formatLegacyEntry(e, w, cp)
-}
-
-func formatLegacyEntry(e logpb.Entry, w io.Writer, cp ttycolor.Profile) error {
+// FormatLegacyEntryWithOptionalColors is like FormatLegacyEntry but the caller can specify
+// a color profile.
+func FormatLegacyEntryWithOptionalColors(e logpb.Entry, w io.Writer, cp ttycolor.Profile) error {
 	buf := formatLogEntryInternalV1(e, false /* isHeader */, true /* showCounter */, cp)
 	defer putBuffer(buf)
 	_, err := w.Write(buf.Bytes())
 	return err
 }
 
-// FormatLegacyEntryPrefixTTY writes a color-decorated prefix to the specified
+// FormatLegacyEntryPrefix writes a color-decorated prefix to the specified
 // writer. The color is rendered in the background of the prefix and is chosen
 // from an arbitrary but deterministic mapping from the prefix bytes to the
 // color profile entries.
-func FormatLegacyEntryPrefixTTY(prefix []byte, w io.Writer) (err error) {
+func FormatLegacyEntryPrefix(prefix []byte, w io.Writer, cp ttycolor.Profile) (err error) {
 	if prefix == nil {
 		return nil
-	}
-	cp := ttycolor.StderrProfile
-	if logging.stderrSink.noColor.Get() {
-		cp = nil
 	}
 
 	if cp != nil {


### PR DESCRIPTION
Fixes #69692.

Prior to this patch, `debug merge-log` would choose colorized output
based on whether the `stderr` stream was a color-compatible terminal.

However, this was unsuitable because it made it hard to disable color
output when redirecting the output to a file. Meanwhile we cannot
completely change the auto-detection to use stdout instead of stderr,
as some folk would like to pipe the output to `less -R` and still
observe colors.

This patch enhances the behavior by introducing a new `--color` flag
with three settings: `true` (force color), `false` (force no colors)
and `auto` (detect based on stdout). The default is `auto`.

Release justification: low risk, high benefit changes to existing functionality

Release note: None