### PR TITLE
kvserver: replace settings dictating follower_read_timestamp()

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1732,7 +1732,7 @@ func TestChangefeedStopOnSchemaChange(t *testing.T) {
 		// for timestamps to get resolved.
 		sqlDB.Exec(t, "SET CLUSTER SETTING changefeed.experimental_poll_interval = '200ms'")
 		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'")
-		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.close_fraction = .99")
+		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'")
 
 		t.Run("add column not null", func(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TABLE add_column_not_null (a INT PRIMARY KEY)`)
@@ -1862,7 +1862,7 @@ func TestChangefeedNoBackfill(t *testing.T) {
 		// for timestamps to get resolved.
 		sqlDB.Exec(t, "SET CLUSTER SETTING changefeed.experimental_poll_interval = '200ms'")
 		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms'")
-		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.close_fraction = .99")
+		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'")
 
 		t.Run("add column not null", func(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TABLE add_column_not_null (a INT PRIMARY KEY)`)
@@ -2184,7 +2184,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 		const expectedLatency = 5 * time.Second
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = $1`,
 			(expectedLatency / 3).String())
-		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.close_fraction = 1.0`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'`)
 
 		testutils.SucceedsSoon(t, func() error {
 			waitForBehindNanos := 2 * expectedLatency.Nanoseconds()

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -12,7 +12,6 @@ package kvfollowerreadsccl
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"time"
 
@@ -32,22 +31,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-// followerReadMultiple is the multiple of kv.closed_timestmap.target_duration
-// which the implementation of the follower read capable replica policy ought
-// to use to determine if a request can be used for reading.
-var followerReadMultiple = settings.RegisterFloatSetting(
-	"kv.follower_read.target_multiple",
-	"if above 1, encourages the distsender to perform a read against the "+
-		"closest replica if a request is older than kv.closed_timestamp.target_duration"+
-		" * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty "+
-		"interval. This value also is used to create follower_timestamp().",
-	3,
-	func(v float64) error {
-		if v < 1 {
-			return fmt.Errorf("%v is not >= 1", v)
-		}
-		return nil
-	},
+// ClosedTimestampPropagationSlack is used by follower_read_timestamp() as a
+// measure of how long closed timestamp updates are supposed to take from the
+// leaseholder to the followers.
+var ClosedTimestampPropagationSlack = settings.RegisterDurationSetting(
+	"kv.closed_timestamp.propagation_slack",
+	"a conservative estimate of the amount of time expect for closed timestamps to "+
+		"propagate from a leaseholder to followers. This is taken into account by "+
+		"follower_read_timestamp().",
+	time.Second,
+	settings.NonNegativeDuration,
 )
 
 // getFollowerReadLag returns the (negative) offset duration from hlc.Now()
@@ -55,17 +48,16 @@ var followerReadMultiple = settings.RegisterFloatSetting(
 // determine at the kv layer if a query can use a follower read for ranges with
 // the default LAG_BY_CLUSTER_SETTING closed timestamp policy.
 func getFollowerReadLag(st *cluster.Settings) time.Duration {
-	targetMultiple := followerReadMultiple.Get(&st.SV)
 	targetDuration := closedts.TargetDuration.Get(&st.SV)
-	closeFraction := closedts.CloseFraction.Get(&st.SV)
+	sideTransportInterval := closedts.SideTransportCloseInterval.Get(&st.SV)
+	slack := ClosedTimestampPropagationSlack.Get(&st.SV)
 	// Zero targetDuration means follower reads are disabled.
 	if targetDuration == 0 {
 		// Returning an infinitely large negative value would push safe
 		// request timestamp into the distant past thus disabling follower reads.
 		return math.MinInt64
 	}
-	return -1 * time.Duration(float64(targetDuration)*
-		(1+closeFraction*targetMultiple))
+	return -targetDuration - sideTransportInterval - slack
 }
 
 // getGlobalReadsLead returns the (positive) offset duration from hlc.Now()

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -184,6 +184,7 @@ go_library(
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_golang_mock//gomock",
+        "@com_github_jackc_pgtype//:pgtype",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_prometheus_client_golang//api",

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -380,11 +380,8 @@ func TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases(t *testing.T) {
 	// with the caveat that under extreme stress, we need to make sure that the
 	// subsystem remains live.
 	const closedTimestampDuration = 15 * time.Millisecond
-	const closedTimestampFraction = 1
 	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = $1",
 		closedTimestampDuration.String())
-	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.close_fraction = $1",
-		closedTimestampFraction)
 	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = $1",
 		closedTimestampDuration.String())
 

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -196,8 +196,7 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	clusterArgs.ReplicationMode = base.ReplicationManual
 	// NB: setupClusterForClosedTSTesting sets a low closed timestamp target
 	// duration.
-	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, clusterArgs, "cttest", "kv")
+	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, clusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	tc.AddNonVotersOrFatal(t, desc.StartKey.AsRawKey(), tc.Target(1))
 

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -75,8 +75,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 		// Disable the replicateQueue so that it doesn't interfere with replica
 		// membership ranges.
 		clusterArgs.ReplicationMode = base.ReplicationManual
-		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-			testingCloseFraction, clusterArgs, dbName, tableName)
+		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, clusterArgs, dbName, tableName)
 		defer tc.Stopper().Stop(ctx)
 
 		if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
@@ -147,8 +146,7 @@ func TestClosedTimestampCanServeOnVoterIncoming(t *testing.T) {
 	clusterArgs.ReplicationMode = base.ReplicationManual
 	knobs, ltk := makeReplicationTestKnobs()
 	clusterArgs.ServerArgs.Knobs = knobs
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, testingCloseFraction,
-		clusterArgs, dbName, tableName)
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, clusterArgs, dbName, tableName)
 	defer tc.Stopper().Stop(ctx)
 
 	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
@@ -184,8 +182,7 @@ func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
 	skip.UnderRace(t)
 
 	ctx := context.Background()
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 
@@ -258,8 +255,7 @@ func TestClosedTimestampCanServeWithConflictingIntent(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
@@ -333,8 +329,7 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	skip.UnderRace(t)
 
 	ctx := context.Background()
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 	// Disable the automatic merging.
 	if _, err := db0.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
@@ -414,8 +409,7 @@ func TestClosedTimestampCantServeBasedOnUncertaintyLimit(t *testing.T) {
 	ctx := context.Background()
 	// Set up the target duration to be very long and rely on lease transfers to
 	// drive MaxClosed.
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 
@@ -448,8 +442,7 @@ func TestClosedTimestampCanServeForWritingTransaction(t *testing.T) {
 	skip.UnderRace(t)
 
 	ctx := context.Background()
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 
@@ -496,8 +489,7 @@ func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 	skip.UnderRace(t)
 
 	ctx := context.Background()
-	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 
@@ -539,8 +531,7 @@ func TestClosedTimestampCantServeForNonTransactionalBatch(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "tsFromServer", func(t *testing.T, tsFromServer bool) {
 		ctx := context.Background()
-		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-			testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 		defer tc.Stopper().Stop(ctx)
 		repls := replsForRange(ctx, t, tc, desc, numNodes)
 
@@ -672,16 +663,19 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 					},
 				},
 			}
-			// If the initial phase of the merge txn takes longer than the closed
-			// timestamp target duration, its initial CPuts can have their write
-			// timestamps bumped due to an intervening closed timestamp update. This
-			// causes the entire merge txn to retry. So we use a long closed timestamp
-			// duration at the beginning of the test until we have the merge txn
-			// suspended at its commit trigger, and then change it back down to
-			// `testingTargetDuration`.
-			tc, leftDesc, rightDesc := setupClusterForClosedTSTestingWithSplitRanges(ctx, t, 5*time.Second,
-				testingCloseFraction, clusterArgs)
+
+			// Set up the closed timestamp timing such that, when we block a merge and
+			// transfer the RHS lease, the closed timestamp advances over the LHS
+			// lease but not over the RHS lease.
+			tc, _ := setupTestClusterWithDummyRange(t, clusterArgs, "cttest" /* dbName */, "kv" /* tableName */, numNodes)
 			defer tc.Stopper().Stop(ctx)
+			_, err := tc.ServerConn(0).Exec(fmt.Sprintf(`
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s';
+SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
+`, 5*time.Second, 100*time.Millisecond))
+			require.NoError(t, err)
+			leftDesc, rightDesc := splitDummyRangeInTestCluster(t, tc, "cttest", "kv", hlc.Timestamp{} /* splitExpirationTime */)
 
 			leftLeaseholder := getCurrentLeaseholder(t, tc, leftDesc)
 			rightLeaseholder := getCurrentLeaseholder(t, tc, rightDesc)
@@ -722,9 +716,11 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 			var rhsLeaseStart hlc.Timestamp
 			if test.transferLease != nil {
 				// Transfer the RHS lease while the RHS is subsumed.
+				log.Infof(ctx, "test: transferring RHS lease...")
 				rightLeaseholder, rhsLeaseStart = test.transferLease(ctx, t, tc, rightDesc, rightLeaseholder, manual)
 				// Sanity check.
 				require.True(t, freezeStartTimestamp.Less(rhsLeaseStart))
+				log.Infof(ctx, "test: transferring RHS lease... done")
 			}
 
 			// Sleep a bit and assert that the closed timestamp has not advanced while
@@ -773,6 +769,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 				mergedLeaseholder, err := leftLeaseholderStore.GetReplica(leftDesc.RangeID)
 				require.NoError(t, err)
 				writeTime := rhsLeaseStart.Prev()
+				require.True(t, mergedLeaseholder.GetClosedTimestamp(ctx).Less(writeTime))
 				var baWrite roachpb.BatchRequest
 				baWrite.Header.RangeID = leftDesc.RangeID
 				baWrite.Header.Timestamp = writeTime
@@ -933,21 +930,6 @@ func mergeWithRightNeighbor(
 	return err.GoError()
 }
 
-func setupClusterForClosedTSTestingWithSplitRanges(
-	ctx context.Context,
-	t *testing.T,
-	targetDuration time.Duration,
-	closeFraction float64,
-	clusterArgs base.TestClusterArgs,
-) (serverutils.TestClusterInterface, roachpb.RangeDescriptor, roachpb.RangeDescriptor) {
-	dbName, tableName := "cttest", "kv"
-	tc, _, _ := setupClusterForClosedTSTesting(ctx, t, targetDuration, closeFraction,
-		clusterArgs, dbName, tableName)
-	leftDesc, rightDesc := splitDummyRangeInTestCluster(t, tc, dbName, tableName,
-		hlc.Timestamp{} /* splitExpirationTime */)
-	return tc, leftDesc, rightDesc
-}
-
 func getEncodedKeyForTable(
 	t *testing.T, db *gosql.DB, dbName, tableName string, val tree.Datum,
 ) roachpb.Key {
@@ -1078,7 +1060,8 @@ func countNotLeaseHolderErrors(ba roachpb.BatchRequest, repls []*kvserver.Replic
 // We don't want to be more aggressive than that since it's also
 // a limit on how long transactions can run.
 const testingTargetDuration = 300 * time.Millisecond
-const testingCloseFraction = 0.333
+
+const testingSideTransportInterval = 100 * time.Millisecond
 const numNodes = 3
 
 func replsForRange(
@@ -1159,26 +1142,18 @@ func setupClusterForClosedTSTesting(
 	ctx context.Context,
 	t *testing.T,
 	targetDuration time.Duration,
-	closeFraction float64,
 	clusterArgs base.TestClusterArgs,
 	dbName, tableName string,
 ) (tc serverutils.TestClusterInterface, db0 *gosql.DB, kvTableDesc roachpb.RangeDescriptor) {
 	tc, desc := setupTestClusterWithDummyRange(t, clusterArgs, dbName, tableName, numNodes)
-	require.NoError(t, enableFollowerReadsForTesting(tc.ServerConn(0), targetDuration, closeFraction))
-	return tc, tc.ServerConn(0), desc
-}
-
-func enableFollowerReadsForTesting(
-	db *gosql.DB, targetDuration time.Duration, closeFraction float64,
-) error {
-	if _, err := db.Exec(fmt.Sprintf(`
+	_, err := tc.ServerConn(0).Exec(fmt.Sprintf(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
-SET CLUSTER SETTING kv.closed_timestamp.close_fraction = %.3f;
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
-`, targetDuration, closeFraction)); err != nil {
-		return err
-	}
-	return nil
+`, targetDuration, targetDuration/4))
+	require.NoError(t, err)
+
+	return tc, tc.ServerConn(0), desc
 }
 
 // setupTestClusterWithDummyRange creates a TestCluster with an empty table. It

--- a/pkg/kv/kvserver/closedts/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/roachpb:with-mocks",
         "//pkg/settings",
         "//pkg/util/hlc",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/errors"
 )
 
 // TargetDuration is the follower reads closed timestamp update target duration.
@@ -24,19 +23,6 @@ var TargetDuration = settings.RegisterDurationSetting(
 	3*time.Second,
 	settings.NonNegativeDuration,
 )
-
-// CloseFraction is the fraction of TargetDuration determining how often closed
-// timestamp updates are to be attempted.
-var CloseFraction = settings.RegisterFloatSetting(
-	"kv.closed_timestamp.close_fraction",
-	"fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced",
-	0.2,
-	func(v float64) error {
-		if v <= 0 || v > 1 {
-			return errors.New("value not between zero and one")
-		}
-		return nil
-	})
 
 // SideTransportCloseInterval determines the ClosedTimestampSender's frequency.
 var SideTransportCloseInterval = settings.RegisterDurationSetting(

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -887,7 +887,7 @@ func TestLearnerAndVoterOutgoingFollowerRead(t *testing.T) {
 	tr := tc.Server(0).Tracer().(*tracing.Tracer)
 	db.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s'`,
 		testingTargetDuration))
-	db.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.close_fraction = $1`, testingCloseFraction)
+	db.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '%s'`, testingSideTransportInterval))
 	db.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true`)
 
 	scratchStartKey := tc.ScratchRange(t)

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -789,8 +789,7 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
-		testingCloseFraction, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
+	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
 	repls := replsForRange(ctx, t, tc, desc, numNodes)
 

--- a/pkg/server/settingswatcher/row_decoder_external_test.go
+++ b/pkg/server/settingswatcher/row_decoder_external_test.go
@@ -51,7 +51,7 @@ func TestRowDecoder(t *testing.T) {
 			expStr:     "17s",
 			expValType: "d",
 		},
-		"kv.closed_timestamp.close_fraction": {
+		"sql.txn_stats.sample_rate": {
 			val:        .23,
 			expStr:     "0.23",
 			expValType: "f",

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -50,7 +50,7 @@ func TestSettingWatcher(t *testing.T) {
 	toSet := map[string][]interface{}{
 		"sql.defaults.experimental_hash_sharded_indexes.enabled": {true, false},
 		"kv.queue.process.guaranteed_time_budget":                {"17s", "20s"},
-		"kv.closed_timestamp.close_fraction":                     {.23, .55},
+		"sql.txn_stats.sample_rate":                              {.23, .55},
 		"cluster.organization":                                   {"foobar", "bazbax"},
 	}
 	fakeTenant := roachpb.MakeTenantID(2)

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -103,6 +103,8 @@ var retiredSettings = map[string]struct{}{
 	"sql.defaults.optimizer_improve_disjunction_selectivity.enabled": {},
 	"bulkio.backup.proxy_file_writes.enabled":                        {},
 	"sql.distsql.prefer_local_execution.enabled":                     {},
+	"kv.follower_read.target_multiple":                               {},
+	"kv.closed_timestamp.close_fraction":                             {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
Before this patch, follower_read_timestamp() was computing a timestamp
likely enough to be closed on all followers according to the funky
formula:

kv.closed_timestamp.target_duration *
(1 + kv.closed_timestamp.close_fraction * kv.follower_read.target_multiple)

close_fraction and target_multiple no longer play a role in the closing
of timestamps (since the closed timestamp mechanism was recently
rewritten), so this formula was bogus. Even in the times when it wasn't
bogus, this formula and its constituents were too hard to reason about.

This patch removes kv.follower_read.target_multiple and kv.closed_timestamp.close_fraction.
It introduces a new setting: kv.closed_timestamp.propagation_slack, and
makes follower_read_timestamp() use the relatively simple formula:
targetDuration - sideTransportInterval - slack

kv.closed_timestamp.target_duration +
kv.closed_timestamp.side_transport_interval +
kv.closed_timestamp.propagation_slack

Release note (general change): The kv.closed_timestamp.closed_fraction
and kv.follower_read.target_multiple settings are deprecated and turned
into no-ops. They had already stopped controlling the closing of
timestamps in v21.1, but were still influencing the
follower_read_timestamp() computation for a timestamps that's likely to
be closed on all followers. To replace them, a simpler
kv.closed_timestamp.propagation_slack setting is introduced, modelling
the delay between when a leaseholder closes a timestamp and when all the
followers become aware of it (defaults conservatively to 1s).
follower_read_timestamp() is now computed as kv.closed_timestamp.target_duration +
kv.closed_timestamp.side_transport_interval + kv.closed_timestamp.propagation_slack.
This defaults to 4.2s (instead of the previous default of 4.8s).

Release justification: somewhere between a low risk change and a bug
fix