### PR TITLE
sql: disallow tenants to set zone configs on some named zones

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
@@ -18,3 +18,46 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 ----
 0   RANGE default
 53  TABLE test.public.t
+
+# The tests below test semantics around named zone for tenants. Tenants aren't
+# allowed to alter any named zones other than RANGE DEFAULT. RANGE DEFAULT
+# can't be deleted.
+subtest named_zones_tenants
+
+statement error pq: non-system tenants cannot configure zone for liveness range
+ALTER RANGE liveness CONFIGURE ZONE USING num_replicas=3;
+
+statement error pq: non-system tenants cannot configure zone for liveness range
+ALTER RANGE liveness CONFIGURE ZONE DISCARD
+
+statement error pq: non-system tenants cannot configure zone for meta range
+ALTER RANGE meta CONFIGURE ZONE USING num_replicas=3
+
+statement error pq: non-system tenants cannot configure zone for meta range
+ALTER RANGE meta CONFIGURE ZONE DISCARD
+
+statement error pq: non-system tenants cannot configure zone for timeseries range
+ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=3
+
+statement error pq: non-system tenants cannot configure zone for timeseries range
+ALTER RANGE timeseries CONFIGURE ZONE DISCARD
+
+statement error pq: non-system tenants cannot configure zone for system range
+ALTER RANGE system CONFIGURE ZONE USING num_replicas=3
+
+statement error pq: non-system tenants cannot configure zone for system range
+ALTER RANGE system CONFIGURE ZONE DISCARD
+
+statement error pq: non-system tenants cannot configure zone for tenants range
+ALTER RANGE tenants CONFIGURE ZONE USING num_replicas=3
+
+statement error pq: non-system tenants cannot configure zone for tenants range
+ALTER RANGE tenants CONFIGURE ZONE DISCARD
+
+# Tenants are allowed to alter RANGE DEFAULT
+statement ok
+ALTER RANGE default CONFIGURE ZONE USING num_replicas=3
+
+# Removing RANGE DEFAULT is not allowed (for both host and secondary tenants)
+statement error pq: cannot remove default zone
+ALTER RANGE default CONFIGURE ZONE DISCARD

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -32,3 +32,45 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 25  TABLE system.public.replication_constraint_stats
 27  TABLE system.public.replication_stats
 53  TABLE test.public.t
+
+# The tests below test semantics around named zone for the system tenant. The
+# system tenant is allowed to alter all named zones. All named zones bar
+# RANGE DEFAULT can be deleted.
+subtest named_zones_system_tenant
+
+statement ok
+ALTER RANGE liveness CONFIGURE ZONE USING num_replicas=3;
+
+statement ok
+ALTER RANGE liveness CONFIGURE ZONE DISCARD
+
+statement ok
+ALTER RANGE meta CONFIGURE ZONE USING num_replicas=3
+
+statement ok
+ALTER RANGE meta CONFIGURE ZONE DISCARD
+
+statement ok
+ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=3
+
+statement ok
+ALTER RANGE timeseries CONFIGURE ZONE DISCARD
+
+statement ok
+ALTER RANGE system CONFIGURE ZONE USING num_replicas=3
+
+statement ok
+ALTER RANGE system CONFIGURE ZONE DISCARD
+
+statement ok
+ALTER RANGE tenants CONFIGURE ZONE USING num_replicas=3
+
+statement ok
+ALTER RANGE tenants CONFIGURE ZONE DISCARD
+
+statement ok
+ALTER RANGE default CONFIGURE ZONE USING num_replicas=3
+
+# Removing RANGE DEFAULT is not allowed (for both host and secondary tenants)
+statement error pq: cannot remove default zone
+ALTER RANGE default CONFIGURE ZONE DISCARD

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -491,6 +491,19 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				"cannot remove default zone")
 		}
 
+		// Secondary tenants are not allowed to set zone configurations on any named
+		// zones other than RANGE DEFAULT.
+		if !params.p.execCfg.Codec.ForSystemTenant() {
+			zoneName, found := zonepb.NamedZonesByID[uint32(targetID)]
+			if found && zoneName != zonepb.DefaultZoneName {
+				return pgerror.Newf(
+					pgcode.CheckViolation,
+					"non-system tenants cannot configure zone for %s range",
+					zoneName,
+				)
+			}
+		}
+
 		// resolveSubzone determines the sub-parts of the zone
 		// specifier. This ought to succeed regardless of whether there is
 		// already a zone config.


### PR DESCRIPTION
This patch disallows secondary tenants from setting zone configurations
on all named zones bar RANGE DEFAULT. The other named zone, namely
`liveness`, `meta`, `system`, `tenants`, and `timeseries`, should only
ever be configured by the system tenant.

Secondary tenants do have a notion of RANGE DEFAULT however and should
be able to configure it.

Closes #69770

Release justification: non-production code changes
Release note: None