### PR TITLE
changefeedccl: remove experimental from all cloudstorage sinks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -162,10 +162,10 @@ func changefeedPlanHook(
 			}
 		}
 
-		if opts[changefeedbase.OptFormat] == changefeedbase.DeprecatedOptFormatAvro {
+		if newFormat, ok := changefeedbase.NoLongerExperimental[opts[changefeedbase.OptFormat]]; ok {
 			p.BufferClientNotice(ctx, pgnotice.Newf(
 				`%[1]s is no longer experimental, use %[2]s=%[1]s`,
-				changefeedbase.OptFormatAvro, changefeedbase.OptFormat),
+				newFormat, changefeedbase.OptFormat),
 			)
 			// Still serialize the experimental_ form for backwards compatibility
 		}
@@ -287,6 +287,13 @@ func changefeedPlanHook(
 		if err != nil {
 			return err
 		}
+		if newScheme, ok := changefeedbase.NoLongerExperimental[parsedSink.Scheme]; ok {
+			parsedSink.Scheme = newScheme // This gets munged anyway when building the sink
+			p.BufferClientNotice(ctx, pgnotice.Newf(`%[1]s is no longer experimental, use %[1]s://`,
+				newScheme),
+			)
+		}
+
 		if details, err = validateDetails(details); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1339,7 +1339,7 @@ func TestChangefeedAuthorization(t *testing.T) {
 			errMsg:    `connecting to kafka`,
 		},
 		{name: `cloud`,
-			statement: `CREATE CHANGEFEED FOR d.table_a INTO 'experimental-nodelocal://12/nope/'`,
+			statement: `CREATE CHANGEFEED FOR d.table_a INTO 'nodelocal://12/nope/'`,
 			errMsg:    `connecting to node 12`,
 		},
 		{name: `sinkless`,
@@ -2883,10 +2883,6 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	// Sanity check webhook sink options.
-	sqlDB.ExpectErr(
-		t, `unsupported sink: https. HTTP endpoints can be used with webhook-https and experimental-https`,
-		`CREATE CHANGEFEED FOR foo INTO $1`, `https://fake-host`,
-	)
 	sqlDB.ExpectErr(
 		t, `param insecure_tls_skip_verify must be a bool`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `webhook-https://fake-host?insecure_tls_skip_verify=foo`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -96,7 +96,13 @@ const (
 	OptOnErrorFail  OnErrorType = `fail`
 	OptOnErrorPause OnErrorType = `pause`
 
-	DeprecatedOptFormatAvro = `experimental_avro`
+	DeprecatedOptFormatAvro                   = `experimental_avro`
+	DeprecatedSinkSchemeCloudStorageAzure     = `experimental-azure`
+	DeprecatedSinkSchemeCloudStorageGCS       = `experimental-gs`
+	DeprecatedSinkSchemeCloudStorageHTTP      = `experimental-http`
+	DeprecatedSinkSchemeCloudStorageHTTPS     = `experimental-https`
+	DeprecatedSinkSchemeCloudStorageNodelocal = `experimental-nodelocal`
+	DeprecatedSinkSchemeCloudStorageS3        = `experimental-s3`
 
 	// OptKafkaSinkConfig is a JSON configuration for kafka sink (kafkaSinkConfig).
 	OptKafkaSinkConfig   = `kafka_sink_config`
@@ -111,12 +117,12 @@ const (
 	SinkParamSkipTLSVerify          = `insecure_tls_skip_verify`
 	SinkParamTopicPrefix            = `topic_prefix`
 	SinkParamTopicName              = `topic_name`
-	SinkSchemeCloudStorageAzure     = `experimental-azure`
-	SinkSchemeCloudStorageGCS       = `experimental-gs`
-	SinkSchemeCloudStorageHTTP      = `experimental-http`
-	SinkSchemeCloudStorageHTTPS     = `experimental-https`
-	SinkSchemeCloudStorageNodelocal = `experimental-nodelocal`
-	SinkSchemeCloudStorageS3        = `experimental-s3`
+	SinkSchemeCloudStorageAzure     = `azure`
+	SinkSchemeCloudStorageGCS       = `gs`
+	SinkSchemeCloudStorageHTTP      = `http`
+	SinkSchemeCloudStorageHTTPS     = `https`
+	SinkSchemeCloudStorageNodelocal = `nodelocal`
+	SinkSchemeCloudStorageS3        = `s3`
 	SinkSchemeExperimentalSQL       = `experimental-sql`
 	SinkSchemeHTTP                  = `http`
 	SinkSchemeHTTPS                 = `https`
@@ -193,3 +199,14 @@ var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTi
 
 // CaseInsensitiveOpts options which supports case Insensitive value
 var CaseInsensitiveOpts = makeStringSet(OptFormat, OptEnvelope, OptCompression, OptSchemaChangeEvents, OptSchemaChangePolicy, OptOnError)
+
+// NoLongerExperimental aliases options prefixed with experimental that no longer need to be
+var NoLongerExperimental = map[string]string{
+	DeprecatedOptFormatAvro:                   string(OptFormatAvro),
+	DeprecatedSinkSchemeCloudStorageAzure:     SinkSchemeCloudStorageAzure,
+	DeprecatedSinkSchemeCloudStorageGCS:       SinkSchemeCloudStorageGCS,
+	DeprecatedSinkSchemeCloudStorageHTTP:      SinkSchemeCloudStorageHTTP,
+	DeprecatedSinkSchemeCloudStorageHTTPS:     SinkSchemeCloudStorageHTTPS,
+	DeprecatedSinkSchemeCloudStorageNodelocal: SinkSchemeCloudStorageNodelocal,
+	DeprecatedSinkSchemeCloudStorageS3:        SinkSchemeCloudStorageS3,
+}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -78,6 +78,9 @@ func getSink(
 	if err != nil {
 		return nil, err
 	}
+	if scheme, ok := changefeedbase.NoLongerExperimental[u.Scheme]; ok {
+		u.Scheme = scheme
+	}
 
 	// check that options are compatible with the given sink
 	validateOptionsAndMakeSink := func(sinkSpecificOpts map[string]struct{}, makeSink func() (Sink, error)) (Sink, error) {
@@ -115,9 +118,6 @@ func getSink(
 			return validateOptionsAndMakeSink(changefeedbase.SQLValidOptions, func() (Sink, error) {
 				return makeSQLSink(sinkURL{URL: u}, sqlSinkTableName, feedCfg.Targets)
 			})
-		case u.Scheme == changefeedbase.SinkSchemeHTTP || u.Scheme == changefeedbase.SinkSchemeHTTPS:
-			return nil, errors.Errorf(`unsupported sink: %s. HTTP endpoints can be used with %s and %s`,
-				u.Scheme, changefeedbase.SinkSchemeWebhookHTTPS, changefeedbase.SinkSchemeCloudStorageHTTPS)
 		case u.Scheme == "":
 			return nil, errors.Errorf(`no scheme found for sink URL %q`, feedCfg.SinkURI)
 		default:


### PR DESCRIPTION
Previously all cloudstorage sinks looked like
`INTO 'experimental-https://`
or
`experimental-s3`, etc.
These are now mature, so the experimental- prefix is deprecated

Release justification: cosmetic backwards-compatible syntax change
Release note (enterprise change): cloud storage sinks are no longer experimental

Closes #69069