### PR TITLE
sql: drop database cascade can fail resolving schemas

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -134,6 +134,11 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	ctx := params.ctx
 	p := params.p
 
+	// Drop all of the collected objects.
+	if err := n.d.dropAllCollectedObjects(ctx, p); err != nil {
+		return err
+	}
+
 	var schemasIDsToDelete []descpb.ID
 	for _, schemaWithDbDesc := range n.d.schemasToDelete {
 		schemaToDelete := schemaWithDbDesc.schema
@@ -166,11 +171,6 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		n.d.typesToDelete,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
 	); err != nil {
-		return err
-	}
-
-	// Drop all of the collected objects.
-	if err := n.d.dropAllCollectedObjects(ctx, p); err != nil {
 		return err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -256,3 +256,32 @@ DROP DATABASE db1;
 
 statement error pq: database "db1" does not exist
 SELECT * FROM crdb_internal.session_variables;
+
+subtest missing-schema-error-69713
+
+statement ok
+CREATE DATABASE db69713;
+
+statement ok
+USE db69713;
+
+statement ok
+CREATE SCHEMA s;
+
+statement ok
+CREATE TYPE s.testenum AS ENUM ('foo', 'bar', 'baz');
+
+statement ok
+CREATE TABLE db69713.s.pg_indexdef_test (
+    a INT PRIMARY KEY,
+    e s.testenum
+);
+
+statement ok
+CREATE TABLE db69713.s.pg_constraintdef_test (
+  a int,
+  FOREIGN KEY(a) REFERENCES db69713.s.pg_indexdef_test(a) ON DELETE CASCADE
+);
+
+statement ok
+DROP DATABASE db69713;


### PR DESCRIPTION
Fixes: #69713

Previously, drop database cascade would drop the schema first,
and then drop any objects under those schemas after. This was
inadequate because as we look up any objects under the schemas,
we may need to resolve types, which will may lead to a look up
on the schema. If the schema is dropped then we will fail while
resolving any types. To address this, this patch drops the objects
under the schema first followed by the database.

Release justification: Low risk bug fix for drop database cascade
Release note (bug fix): Drop database cascade can fail while resolving
a schema in a certain scenarios with the following error:
 "ERROR: error resolving referenced table ID <ID>: descriptor is
  being dropped"