### PR TITLE
vendor: bump Pebble to 1f862845897e

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -648,8 +648,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:rhU7I8RPlTKlFcDXoruEIk5RGjCWa6mdpWMfLLBzJ+s=",
-        version = "v0.0.0-20210826190118-2b4f90f7395e",
+        sum = "h1:F4UkAxf62F/gSVymu1KO1QPbyPn8vL6NSmSEHej4Hq8=",
+        version = "v0.0.0-20210902215233-1f862845897e",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210826190118-2b4f90f7395e
+	github.com/cockroachdb/pebble v0.0.0-20210902215233-1f862845897e
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210826190118-2b4f90f7395e h1:rhU7I8RPlTKlFcDXoruEIk5RGjCWa6mdpWMfLLBzJ+s=
-github.com/cockroachdb/pebble v0.0.0-20210826190118-2b4f90f7395e/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210902215233-1f862845897e h1:F4UkAxf62F/gSVymu1KO1QPbyPn8vL6NSmSEHej4Hq8=
+github.com/cockroachdb/pebble v0.0.0-20210902215233-1f862845897e/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
1f86284 vfs/atomicfs: add Marker type
8731fd6 sstable: Fix bug in dynamic readahead
085aaac sstable: support block checksum validation for entire SSTables
6236eba pebble: Unflake TestCacheEvict
38dd75e ci: remove support for Go v1.14; remove TravisCI
```

Release note: none

Release justification: non-production code changes, low-risk high
benefit to existing functionality (8731fd6)