### PR TITLE
ui: hide node, regions, diagnostics on serverless

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -63,6 +63,7 @@ export interface OwnProps {
   cancelSession: (payload: ICancelSessionRequest) => void;
   cancelQuery: (payload: ICancelQueryRequest) => void;
   uiConfig?: UIConfigState["pages"]["sessionDetails"];
+  isTenant?: UIConfigState["isTenant"];
   onBackButtonClick?: () => void;
   onTerminateSessionClick?: () => void;
   onTerminateStatementClick?: () => void;
@@ -91,11 +92,16 @@ export const MemoryUsageItem: React.FC<{
 export class SessionDetails extends React.Component<SessionDetailsProps> {
   terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
   terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
-  static defaultProps = { uiConfig: { showGatewayNodeLink: true } };
+  static defaultProps = {
+    uiConfig: { showGatewayNodeLink: true },
+    isTenant: false,
+  };
 
   componentDidMount() {
-    this.props.refreshNodes();
-    this.props.refreshNodesLiveness();
+    if (!this.props.isTenant) {
+      this.props.refreshNodes();
+      this.props.refreshNodesLiveness();
+    }
     this.props.refreshSessions();
   }
 
@@ -218,6 +224,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
     if (!this.props.session) {
       return null;
     }
+    const { isTenant } = this.props;
     const { session } = this.props.session;
 
     if (!session) {
@@ -346,20 +353,22 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 value={TimestampToMoment(session.start).format(DATE_FORMAT)}
                 className={cx("details-item")}
               />
-              <SummaryCardItem
-                label={"Gateway Node"}
-                value={
-                  this.props.uiConfig.showGatewayNodeLink ? (
-                    <NodeLink
-                      nodeId={session.node_id.toString()}
-                      nodeNames={this.props.nodeNames}
-                    />
-                  ) : (
-                    session.node_id.toString()
-                  )
-                }
-                className={cx("details-item")}
-              />
+              {!isTenant && (
+                <SummaryCardItem
+                  label={"Gateway Node"}
+                  value={
+                    this.props.uiConfig.showGatewayNodeLink ? (
+                      <NodeLink
+                        nodeId={session.node_id.toString()}
+                        nodeNames={this.props.nodeNames}
+                      />
+                    ) : (
+                      session.node_id.toString()
+                    )
+                  }
+                  className={cx("details-item")}
+                />
+              )}
             </Col>
             <Col className="gutter-row" span={4}></Col>
             <Col className="gutter-row" span={10}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -22,6 +22,7 @@ import { actions as nodesActions } from "src/store/nodes";
 import { actions as nodesLivenessActions } from "src/store/liveness";
 
 import { nodeDisplayNameByIDSelector } from "src/store/nodes";
+import { selectIsTenant } from "../store/uiConfig";
 
 export const SessionDetailsPageConnected = withRouter(
   connect(
@@ -30,6 +31,7 @@ export const SessionDetailsPageConnected = withRouter(
       session: selectSession(state, props),
       sessionError: state.adminUI.sessions.lastError,
       uiConfig: selectSessionDetailsUiConfig(state),
+      isTenant: selectIsTenant(state),
     }),
     {
       refreshSessions: sessionsActions.refresh,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -352,16 +352,20 @@ export class StatementDetails extends React.Component<
 
   componentDidMount() {
     this.refreshStatements();
-    this.props.refreshStatementDiagnosticsRequests();
-    this.props.refreshNodes();
-    this.props.refreshNodesLiveness();
+    if (!this.props.isTenant) {
+      this.props.refreshStatementDiagnosticsRequests();
+      this.props.refreshNodes();
+      this.props.refreshNodesLiveness();
+    }
   }
 
   componentDidUpdate() {
     this.refreshStatements();
-    this.props.refreshStatementDiagnosticsRequests();
-    this.props.refreshNodes();
-    this.props.refreshNodesLiveness();
+    if (!this.props.isTenant) {
+      this.props.refreshStatementDiagnosticsRequests();
+      this.props.refreshNodes();
+      this.props.refreshNodesLiveness();
+    }
   }
 
   onTabChange = (tabId: string) => {
@@ -703,25 +707,27 @@ export class StatementDetails extends React.Component<
             </Col>
           </Row>
         </TabPane>
-        <TabPane
-          tab={`Diagnostics ${
-            hasDiagnosticReports ? `(${diagnosticsReports.length})` : ""
-          }`}
-          key="diagnostics"
-        >
-          <DiagnosticsView
-            activate={createStatementDiagnosticsReport}
-            diagnosticsReports={diagnosticsReports}
-            dismissAlertMessage={dismissStatementDiagnosticsAlertMessage}
-            hasData={hasDiagnosticReports}
-            statementFingerprint={statement}
-            onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
-            showDiagnosticsViewLink={
-              this.props.uiConfig.showStatementDiagnosticsLink
-            }
-            onSortingChange={this.props.onSortingChange}
-          />
-        </TabPane>
+        {!isTenant && (
+          <TabPane
+            tab={`Diagnostics ${
+              hasDiagnosticReports ? `(${diagnosticsReports.length})` : ""
+            }`}
+            key="diagnostics"
+          >
+            <DiagnosticsView
+              activate={createStatementDiagnosticsReport}
+              diagnosticsReports={diagnosticsReports}
+              dismissAlertMessage={dismissStatementDiagnosticsAlertMessage}
+              hasData={hasDiagnosticReports}
+              statementFingerprint={statement}
+              onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
+              showDiagnosticsViewLink={
+                this.props.uiConfig.showStatementDiagnosticsLink
+              }
+              onSortingChange={this.props.onSortingChange}
+            />
+          </TabPane>
+        )}
         <TabPane tab="Explain Plan" key="explain-plan">
           <SummaryCard>
             <PlanView

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -37,6 +37,8 @@ import { actions as nodesActions } from "../store/nodes";
 import { actions as nodeLivenessActions } from "../store/liveness";
 import { selectDateRange } from "../statementsPage/statementsPage.selectors";
 
+// For tenant cases, we don't show information about node, regions and
+// diagnostics.
 const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
   const statement = selectStatement(state, props);
   const statementFingerprint = statement?.statement;
@@ -44,12 +46,14 @@ const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
     statement,
     statementsError: state.adminUI.statements.lastError,
     dateRange: selectIsTenant(state) ? null : selectDateRange(state),
-    nodeNames: nodeDisplayNameByIDSelector(state),
-    nodeRegions: nodeRegionsByIDSelector(state),
-    diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(
-      state,
-      statementFingerprint,
-    ),
+    nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
+    nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
+    diagnosticsReports: selectIsTenant(state)
+      ? []
+      : selectDiagnosticsReportsByStatementFingerprint(
+          state,
+          statementFingerprint,
+        ),
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),
   };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -252,7 +252,9 @@ export class StatementsPage extends React.Component<
 
   componentDidMount() {
     this.refreshStatements();
-    this.props.refreshStatementDiagnosticsRequests();
+    if (!this.props.isTenant) {
+      this.props.refreshStatementDiagnosticsRequests();
+    }
   }
 
   componentDidUpdate = (
@@ -263,7 +265,9 @@ export class StatementsPage extends React.Component<
       this.props.onSearchComplete(this.filteredStatementsData());
     }
     this.refreshStatements();
-    this.props.refreshStatementDiagnosticsRequests();
+    if (!this.props.isTenant) {
+      this.props.refreshStatementDiagnosticsRequests();
+    }
   };
 
   componentWillUnmount() {
@@ -455,6 +459,7 @@ export class StatementsPage extends React.Component<
       totalWorkload,
       nodeRegions,
       "statement",
+      isTenant,
       search,
       this.activateDiagnosticsRef,
       onDiagnosticsReportDownload,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -11,7 +11,7 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
-import moment, { Moment } from "moment";
+import { Moment } from "moment";
 
 import { AppState } from "src/store";
 import { actions as statementsActions } from "src/store/statements";
@@ -54,7 +54,7 @@ export const ConnectedStatementsPage = withRouter(
       totalFingerprints: selectTotalFingerprints(state),
       lastReset: selectLastReset(state),
       columns: selectColumns(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
+      nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
       isTenant: selectIsTenant(state),
       dateRange: selectIsTenant(state) ? null : selectDateRange(state),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -32,6 +32,7 @@ storiesOf("StatementsSortedTable", module)
         calculateTotalWorkload(statements),
         { "1": "gcp-europe-west1", "2": "gcp-us-east1", "3": "gcp-us-west1" },
         "statement",
+        false,
       )}
       sortSetting={{
         ascending: false,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -239,6 +239,7 @@ export function makeStatementsColumns(
   totalWorkload: number,
   nodeRegions: { [nodeId: string]: string },
   statType: StatisticType,
+  isTenant: boolean,
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
   onDiagnosticsDownload?: (report: IStatementDiagnosticsReport) => void,
@@ -256,7 +257,7 @@ export function makeStatementsColumns(
     ...makeCommonColumns(statements, totalWorkload, nodeRegions, statType),
   );
 
-  if (activateDiagnosticsRef) {
+  if (activateDiagnosticsRef && !isTenant) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
       name: "diagnostics",
       title: statisticsTableTitles.diagnostics(statType),


### PR DESCRIPTION
Hiding information about nodes, regions and diagnostics
on Statements, Statements Details, Transactions, Sessions
and Session details.

Also stop the refresh of info for node and diagnostics on
these pages.

Release justification: Category 4 - Low risk, high benefit changes
Release note: None