### PR TITLE
ui: add nodes and region information to databases pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -66,11 +66,14 @@ const withData: DatabaseDetailsPageProps = {
         roles: roles,
         grants: grants,
       },
+      showNodeRegionsColumn: true,
       stats: {
         loading: false,
         loaded: true,
         replicationSizeInBytes: _.random(1000.0) * 1024 ** _.random(1, 2),
         rangeCount: _.random(50, 500),
+        nodesByRegionString:
+          "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
       },
     };
   }),

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -68,6 +68,7 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 //         loaded: boolean;
 //         replicationSizeInBytes: number;
 //         rangeCount: number;
+//         nodesByRegionString: string;
 //       };
 //     }[];
 //   }
@@ -76,6 +77,7 @@ export interface DatabaseDetailsPageData {
   loaded: boolean;
   name: string;
   tables: DatabaseDetailsPageDataTable[];
+  showNodeRegionsColumn?: boolean;
 }
 
 export interface DatabaseDetailsPageDataTable {
@@ -99,6 +101,7 @@ export interface DatabaseDetailsPageDataTableStats {
   loaded: boolean;
   replicationSizeInBytes: number;
   rangeCount: number;
+  nodesByRegionString?: string;
 }
 
 export interface DatabaseDetailsPageActions {
@@ -267,6 +270,22 @@ export class DatabaseDetailsPage extends React.Component<
         sort: table => table.details.indexCount,
         className: cx("database-table__col-index-count"),
         name: "indexCount",
+      },
+      {
+        title: (
+          <Tooltip
+            placement="bottom"
+            title="Regions/nodes on which the table data is stored."
+          >
+            Regions
+          </Tooltip>
+        ),
+        cell: table => table.stats.nodesByRegionString || "None",
+        sort: table => table.stats.nodesByRegionString,
+        className: cx("database-table__col--regions"),
+        name: "regions",
+        showByDefault: this.props.showNodeRegionsColumn,
+        hideIfTenant: true,
       },
     ];
   }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -71,11 +71,14 @@ const withData: DatabaseTablePageProps = {
       }),
     ),
   },
+  showNodeRegionsSection: true,
   stats: {
     loading: false,
     loaded: true,
     sizeInBytes: 44040192,
     rangeCount: 4200,
+    nodesByRegionString:
+      "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
   },
   refreshTableDetails: () => {},
   refreshTableStats: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -54,6 +54,7 @@ const { TabPane } = Tabs;
 //       loaded: boolean;
 //       sizeInBytes: number;
 //       rangeCount: number;
+//       nodesByRegionString: string;
 //     };
 //   }
 export interface DatabaseTablePageData {
@@ -61,6 +62,7 @@ export interface DatabaseTablePageData {
   name: string;
   details: DatabaseTablePageDataDetails;
   stats: DatabaseTablePageDataStats;
+  showNodeRegionsSection?: boolean;
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -82,11 +84,13 @@ export interface DatabaseTablePageDataStats {
   loaded: boolean;
   sizeInBytes: number;
   rangeCount: number;
+  nodesByRegionString?: string;
 }
 
 export interface DatabaseTablePageActions {
   refreshTableDetails: (database: string, table: string) => void;
   refreshTableStats: (databse: string, table: string) => void;
+  refreshNodes?: () => void;
 }
 
 export type DatabaseTablePageProps = DatabaseTablePageData &
@@ -121,6 +125,9 @@ export class DatabaseTablePage extends React.Component<
   }
 
   private refresh() {
+    if (this.props.refreshNodes != null) {
+      this.props.refreshNodes();
+    }
     if (!this.props.details.loaded && !this.props.details.loading) {
       return this.props.refreshTableDetails(
         this.props.databaseName,
@@ -212,6 +219,12 @@ export class DatabaseTablePage extends React.Component<
 
                 <Col span={14}>
                   <SummaryCard className={cx("summary-card")}>
+                    {this.props.showNodeRegionsSection && (
+                      <SummaryCardItem
+                        label="Regions/nodes"
+                        value={this.props.stats.nodesByRegionString}
+                      />
+                    )}
                     <SummaryCardItem
                       label="Database"
                       value={this.props.databaseName}

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -37,6 +37,7 @@ const withoutData: DatabasesPageProps = {
 const withData: DatabasesPageProps = {
   loading: false,
   loaded: true,
+  showNodeRegionsColumn: true,
   databases: _.map(Array(42), _item => {
     return {
       loading: false,
@@ -46,8 +47,11 @@ const withData: DatabasesPageProps = {
       tableCount: _.random(5, 100),
       rangeCount: _.random(50, 500),
       missingTables: [],
+      nodesByRegionString:
+        "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
     };
   }),
+
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -53,6 +53,7 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 //       sizeInBytes: number;
 //       tableCount: number;
 //       rangeCount: number;
+//       nodesByRegionString: string;
 //       missingTables: { // DatabasesPageDataMissingTable[]
 //         loading: boolean;
 //         name: string;
@@ -63,6 +64,7 @@ export interface DatabasesPageData {
   loading: boolean;
   loaded: boolean;
   databases: DatabasesPageDataDatabase[];
+  showNodeRegionsColumn?: boolean;
 }
 
 export interface DatabasesPageDataDatabase {
@@ -73,6 +75,9 @@ export interface DatabasesPageDataDatabase {
   tableCount: number;
   rangeCount: number;
   missingTables: DatabasesPageDataMissingTable[];
+  // String of nodes grouped by region in alphabetical order, e.g.
+  // regionA(n1,n2), regionB(n3)
+  nodesByRegionString?: string;
 }
 
 // A "missing" table is one for which we were unable to gather size and range
@@ -91,6 +96,7 @@ export interface DatabasesPageActions {
   refreshDatabases: () => void;
   refreshDatabaseDetails: (database: string) => void;
   refreshTableStats: (database: string, table: string) => void;
+  refreshNodes?: () => void;
 }
 
 export type DatabasesPageProps = DatabasesPageData & DatabasesPageActions;
@@ -130,6 +136,10 @@ export class DatabasesPage extends React.Component<
   }
 
   private refresh() {
+    if (this.props.refreshNodes != null) {
+      this.props.refreshNodes();
+    }
+
     if (!this.props.loaded && !this.props.loading) {
       return this.props.refreshDatabases();
     }
@@ -217,9 +227,27 @@ export class DatabasesPage extends React.Component<
       className: cx("databases-table__col-range-count"),
       name: "rangeCount",
     },
+    {
+      title: (
+        <Tooltip
+          placement="bottom"
+          title="Regions/nodes on which the database tables are located."
+        >
+          Regions/nodes
+        </Tooltip>
+      ),
+      cell: database => database.nodesByRegionString || "None",
+      sort: database => database.nodesByRegionString,
+      className: cx("databases-table__col-node-regions"),
+      name: "nodeRegions",
+      hideIfTenant: true,
+    },
   ];
 
   render() {
+    this.columns.find(
+      c => c.name === "nodeRegions",
+    ).showByDefault = this.props.showNodeRegionsColumn;
     return (
       <div>
         <section className={baseHeadingClasses.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -193,8 +193,7 @@ export class SortedTable<T> extends React.Component<
     (props: SortedTableProps<T>) => props.data,
     (props: SortedTableProps<T>) => props.columns,
     (data: T[], columns: ColumnDescriptor<T>[]) => {
-      return _.map(
-        columns,
+      return columns.map(
         (c): React.ReactNode => {
           if (c.rollup) {
             return c.rollup(data);
@@ -219,9 +218,7 @@ export class SortedTable<T> extends React.Component<
       if (!sortSetting) {
         return this.paginatedData();
       }
-      const sortColumn = columns.filter(
-        c => c.name === sortSetting.columnTitle,
-      )[0];
+      const sortColumn = columns.find(c => c.name === sortSetting.columnTitle);
       if (!sortColumn || !sortColumn.sort) {
         return this.paginatedData();
       }
@@ -249,20 +246,21 @@ export class SortedTable<T> extends React.Component<
       rollups: React.ReactNode[],
       columns: ColumnDescriptor<T>[],
     ) => {
-      return _.map(
-        columns,
-        (cd, ii): SortableColumn => {
-          return {
-            name: cd.name,
-            title: cd.title,
-            cell: index => cd.cell(sorted[index]),
-            columnTitle: cd.sort ? cd.name : undefined,
-            rollup: rollups[ii],
-            className: cd.className,
-            titleAlign: cd.titleAlign,
-          };
-        },
-      );
+      return columns
+        .filter(col => col.alwaysShow || col.showByDefault !== false)
+        .map(
+          (cd, ii): SortableColumn => {
+            return {
+              name: cd.name,
+              title: cd.title,
+              cell: index => cd.cell(sorted[index]),
+              columnTitle: cd.sort ? cd.name : undefined,
+              rollup: rollups[ii],
+              className: cd.className,
+              titleAlign: cd.titleAlign,
+            };
+          },
+        );
     },
   );
 

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -338,6 +338,15 @@ export const nodeRegionsByIDSelector = createSelector(
   },
 );
 
+// selectIsMoreThanOneNode returns a boolean describing whether or not there
+// exists more than one node in the cluster.
+export const selectIsMoreThanOneNode = createSelector(
+  (state: AdminUIState) => nodeRegionsByIDSelector(state),
+  (nodeRegions): boolean => {
+    return Object.keys(nodeRegions).length > 1;
+  },
+);
+
 // selectStoreIDsByNodeID returns a map from node ID to a list of store IDs for
 // that node. Like nodeIDsSelector, the store ids are converted to strings.
 export const selectStoreIDsByNodeID = createSelector(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -124,6 +124,7 @@ describe("Database Details Page", function() {
       loading: false,
       loaded: false,
       name: "things",
+      showNodeRegionsColumn: false,
       tables: [],
     });
   });
@@ -139,6 +140,7 @@ describe("Database Details Page", function() {
       loading: false,
       loaded: true,
       name: "things",
+      showNodeRegionsColumn: false,
       tables: [
         {
           name: "foo",
@@ -156,6 +158,7 @@ describe("Database Details Page", function() {
             loaded: false,
             replicationSizeInBytes: 0,
             rangeCount: 0,
+            nodesByRegionString: "",
           },
         },
         {
@@ -174,6 +177,7 @@ describe("Database Details Page", function() {
             loaded: false,
             replicationSizeInBytes: 0,
             rangeCount: 0,
+            nodesByRegionString: "",
           },
         },
       ],
@@ -317,6 +321,7 @@ describe("Database Details Page", function() {
       loaded: true,
       replicationSizeInBytes: 44040192,
       rangeCount: 4200,
+      nodesByRegionString: "",
     });
 
     driver.assertTableStats("bar", {
@@ -324,6 +329,7 @@ describe("Database Details Page", function() {
       loaded: true,
       replicationSizeInBytes: 8675309,
       rangeCount: 1023,
+      nodesByRegionString: "",
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -117,6 +117,7 @@ describe("Database Table Page", function() {
     driver.assertProperties({
       databaseName: "DATABASE",
       name: "TABLE",
+      showNodeRegionsSection: false,
       details: {
         loading: false,
         loaded: false,
@@ -130,6 +131,7 @@ describe("Database Table Page", function() {
         loaded: false,
         sizeInBytes: 0,
         rangeCount: 0,
+        nodesByRegionString: "",
       },
     });
   });
@@ -180,6 +182,7 @@ describe("Database Table Page", function() {
       loaded: true,
       sizeInBytes: 44040192,
       rangeCount: 4200,
+      nodesByRegionString: "",
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -95,6 +95,7 @@ describe("Databases Page", function() {
       loading: false,
       loaded: false,
       databases: [],
+      showNodeRegionsColumn: false,
     });
   });
 
@@ -116,6 +117,7 @@ describe("Databases Page", function() {
           sizeInBytes: 0,
           tableCount: 0,
           rangeCount: 0,
+          nodesByRegionString: "",
           missingTables: [],
         },
         {
@@ -125,9 +127,11 @@ describe("Databases Page", function() {
           sizeInBytes: 0,
           tableCount: 0,
           rangeCount: 0,
+          nodesByRegionString: "",
           missingTables: [],
         },
       ],
+      showNodeRegionsColumn: false,
     });
   });
 
@@ -165,6 +169,7 @@ describe("Databases Page", function() {
       sizeInBytes: 7168,
       tableCount: 2,
       rangeCount: 3,
+      nodesByRegionString: "",
       missingTables: [],
     });
 
@@ -175,6 +180,7 @@ describe("Databases Page", function() {
       sizeInBytes: 1234,
       tableCount: 1,
       rangeCount: 42,
+      nodesByRegionString: "",
       missingTables: [],
     });
   });
@@ -205,6 +211,7 @@ describe("Databases Page", function() {
           sizeInBytes: 7168,
           tableCount: 2,
           rangeCount: 3,
+          nodesByRegionString: "",
           missingTables: [{ loading: false, name: "bar" }],
         });
       });
@@ -239,6 +246,7 @@ describe("Databases Page", function() {
           sizeInBytes: 8192,
           tableCount: 2,
           rangeCount: 8,
+          nodesByRegionString: "",
           missingTables: [],
         });
       });
@@ -264,6 +272,7 @@ describe("Databases Page", function() {
           sizeInBytes: 0,
           tableCount: 2,
           rangeCount: 0,
+          nodesByRegionString: "",
           missingTables: [
             { loading: false, name: "foo" },
             { loading: false, name: "bar" },
@@ -301,6 +310,7 @@ describe("Databases Page", function() {
           sizeInBytes: 7168,
           tableCount: 2,
           rangeCount: 3,
+          nodesByRegionString: "",
           missingTables: [{ loading: false, name: "bar" }],
         });
 
@@ -313,6 +323,7 @@ describe("Databases Page", function() {
           sizeInBytes: 8192,
           tableCount: 2,
           rangeCount: 8,
+          nodesByRegionString: "",
           missingTables: [],
         });
       });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -10,7 +10,10 @@
 
 import _ from "lodash";
 import { createSelector } from "reselect";
-import { DatabasesPageData } from "@cockroachlabs/cluster-ui";
+import {
+  DatabasesPageData,
+  DatabasesPageDataDatabase,
+} from "@cockroachlabs/cluster-ui";
 
 import { cockroach } from "src/js/protos";
 import {
@@ -18,77 +21,102 @@ import {
   refreshDatabases,
   refreshDatabaseDetails,
   refreshTableStats,
+  refreshNodes,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
+import {
+  nodeRegionsByIDSelector,
+  selectIsMoreThanOneNode,
+} from "src/redux/nodes";
+import { getNodesByRegionString } from "../utils";
 
 const { DatabaseDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
-export const mapStateToProps = createSelector(
+const selectLoading = createSelector(
   (state: AdminUIState) => state.cachedData.databases,
+  databases => databases.inFlight,
+);
+
+const selectLoaded = createSelector(
+  (state: AdminUIState) => state.cachedData.databases,
+  databases => databases.valid,
+);
+
+const selectDatabases = createSelector(
+  (state: AdminUIState) => state.cachedData.databases.data?.databases,
   (state: AdminUIState) => state.cachedData.databaseDetails,
   (state: AdminUIState) => state.cachedData.tableStats,
+  (state: AdminUIState) => nodeRegionsByIDSelector(state),
+  (
+    databases,
+    databaseDetails,
+    tableStats,
+    nodeRegions,
+  ): DatabasesPageDataDatabase[] =>
+    (databases || []).map(database => {
+      const details = databaseDetails[database];
 
-  (databases, databaseDetails, tableStats): DatabasesPageData => {
-    return {
-      loading: databases.inFlight,
-      loaded: databases.valid,
-      databases: _.map(databases.data?.databases, database => {
-        const details = databaseDetails[database];
+      const stats = details?.data?.stats;
+      let sizeInBytes = FixLong(stats?.approximate_disk_bytes || 0).toNumber();
+      let rangeCount = FixLong(stats?.range_count || 0).toNumber();
+      const nodes = stats?.node_ids || [];
 
-        const stats = details?.data?.stats;
-        let sizeInBytes = FixLong(
-          stats?.approximate_disk_bytes || 0,
+      // We offer the component a chance to refresh any table-level stats we
+      // weren't able to gather during the initial database details call, by
+      // exposing a list of "missing tables."
+      //
+      // Furthermore, when the database-level stats are completely absent
+      // from the database details response (perhaps we're talking to an
+      // older backend that doesn't support them), we mark _all_ the tables
+      // as "missing", so that the component can trigger refresh calls for
+      // all of their individual stats.
+
+      const possiblyMissingTables = stats
+        ? stats.missing_tables.map(table => table.name)
+        : details?.data?.table_names;
+
+      const [individuallyLoadedTables, missingTables] = _.partition(
+        possiblyMissingTables,
+        table => {
+          return !!tableStats[generateTableID(database, table)]?.valid;
+        },
+      );
+
+      individuallyLoadedTables.forEach(table => {
+        const stats = tableStats[generateTableID(database, table)];
+        sizeInBytes += FixLong(
+          stats?.data?.approximate_disk_bytes || 0,
         ).toNumber();
-        let rangeCount = FixLong(stats?.range_count || 0).toNumber();
+        rangeCount += FixLong(stats?.data?.range_count || 0).toNumber();
+      });
 
-        // We offer the component a chance to refresh any table-level stats we
-        // weren't able to gather during the initial database details call, by
-        // exposing a list of "missing tables."
-        //
-        // Furthermore, when the database-level stats are completely absent
-        // from the database details response (perhaps we're talking to an
-        // older backend that doesn't support them), we mark _all_ the tables
-        // as "missing", so that the component can trigger refresh calls for
-        // all of their individual stats.
+      const nodesByRegionString = getNodesByRegionString(nodes, nodeRegions);
 
-        const possiblyMissingTables = stats
-          ? _.map(stats.missing_tables, table => table.name)
-          : details?.data?.table_names;
-
-        const [individuallyLoadedTables, missingTables] = _.partition(
-          possiblyMissingTables,
-          table => {
-            return !!tableStats[generateTableID(database, table)]?.valid;
-          },
-        );
-
-        _.each(individuallyLoadedTables, table => {
-          const stats = tableStats[generateTableID(database, table)];
-          sizeInBytes += FixLong(
-            stats?.data?.approximate_disk_bytes || 0,
-          ).toNumber();
-          rangeCount += FixLong(stats?.data?.range_count || 0).toNumber();
-        });
-
-        return {
-          loading: !!details?.inFlight,
-          loaded: !!details?.valid,
-          name: database,
-          sizeInBytes: sizeInBytes,
-          tableCount: details?.data?.table_names?.length || 0,
-          rangeCount: rangeCount,
-          missingTables: _.map(missingTables, table => {
-            return {
-              loading: !!tableStats[generateTableID(database, table)]?.inFlight,
-              name: table,
-            };
-          }),
-        };
-      }),
-    };
-  },
+      return {
+        loading: !!details?.inFlight,
+        loaded: !!details?.valid,
+        name: database,
+        sizeInBytes: sizeInBytes,
+        tableCount: details?.data?.table_names?.length || 0,
+        rangeCount: rangeCount,
+        nodesByRegionString,
+        missingTables: missingTables.map(table => {
+          return {
+            loading: !!tableStats[generateTableID(database, table)]?.inFlight,
+            name: table,
+          };
+        }),
+      };
+    }),
 );
+
+export const mapStateToProps = (state: AdminUIState): DatabasesPageData => ({
+  loading: selectLoading(state),
+  loaded: selectLoaded(state),
+  databases: selectDatabases(state),
+  showNodeRegionsColumn: selectIsMoreThanOneNode(state),
+});
 
 export const mapDispatchToProps = {
   refreshDatabases,
@@ -102,4 +130,6 @@ export const mapDispatchToProps = {
   refreshTableStats: (database: string, table: string) => {
     return refreshTableStats(new TableStatsRequest({ database, table }));
   },
+
+  refreshNodes,
 };

--- a/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
@@ -1,0 +1,60 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// createNodesByRegionMap creates a mapping of regions to nodes,
+// based on the nodes list provided and nodeRegions, which is a full
+// list of node id to the region it resides.
+export function createNodesByRegionMap(
+  nodes: number[],
+  nodeRegions: Record<string, string>,
+): Record<string, number[]> {
+  const nodesByRegionMap: Record<string, number[]> = {};
+  nodes.forEach((node: number) => {
+    const region: string = nodeRegions[node.toString()];
+    if (nodesByRegionMap[region] == null) {
+      nodesByRegionMap[region] = [];
+    }
+    nodesByRegionMap[region].push(node);
+  });
+  return nodesByRegionMap;
+}
+
+// nodesByRegionMapToString converts a map of regions to node ids,
+// ordered by region name, e.g. converts:
+// { regionA: [1, 2], regionB: [2, 3] }
+// to:
+// regionA(n1, n2), regionB(n2,n3), ...
+export function nodesByRegionMapToString(
+  nodesByRegion: Record<string, number[]>,
+): string {
+  // Sort the nodes on each key.
+  const regions = Object.keys(nodesByRegion).sort();
+  regions.forEach((region: string) => {
+    nodesByRegion[region].sort();
+  });
+
+  return regions
+    .map((region: string) => {
+      const nodes = nodesByRegion[region];
+      return `${region}(${nodes.map(id => `n${id}`).join(",")})`;
+    })
+    .join(", ");
+}
+
+// getNodesByRegionString converts a list of node ids and map of
+// node ids to region to a string of node ids by region, ordered
+// by region name, e.g.
+// regionA(n1, n2), regionB(n2,n3), ...
+export function getNodesByRegionString(
+  nodes: number[],
+  nodeRegions: Record<string, string>,
+): string {
+  return nodesByRegionMapToString(createNodesByRegionMap(nodes, nodeRegions));
+}


### PR DESCRIPTION
This commit adds node and region information
to the databases table, databases details table, and
table details page. This information is hidden if there
is only one node in the cluster.

Closes: cockroachdb#63391

Release justification: low-risk, high benefit changes to
existing functionality

Release note (ui change): We are now able to show which
nodes and regions a database uses. In the databases page,
a new column has been added showing node/region information
for each database. On the database details page, a column is
added displayign node/region information for each table.
On the table page, we add a summary section of the nodes and
regions the table data is stored.

For the new table columns and region/node sections are  only
displayed if we have more than one node.

---------------
Databases page:
![image](https://user-images.githubusercontent.com/20136951/131930108-d32abab8-6337-44ce-b272-08c700ea2210.png)
Db details page:
![image](https://user-images.githubusercontent.com/20136951/131930159-c02206bb-cc68-417f-8a0f-b9cebf3268e6.png)
table page:
![image](https://user-images.githubusercontent.com/20136951/131930014-3c16aa24-c29d-4f05-b529-bd7a48a939f5.png)

Region/node info hidden if there is only one node:
![image](https://user-images.githubusercontent.com/20136951/132358997-4a197403-4262-43eb-b990-dd3f15dd7a1c.png)
![image](https://user-images.githubusercontent.com/20136951/132359045-56debee5-c32b-4fc3-a5e5-b5a7a62236b4.png)
![image](https://user-images.githubusercontent.com/20136951/132359090-2b3db16e-3950-4c39-8daa-1d0c3387ed1b.png)

