### PR TITLE
kv/kvserver: use generalized engine keys in debug printing

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -269,12 +269,12 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 			}
 			return strings.Join(pairs, ", "), nil
 		}
-		kvserver.DebugSprintKeyValueDecoders = append(kvserver.DebugSprintKeyValueDecoders, fn)
+		kvserver.DebugSprintMVCCKeyValueDecoders = append(kvserver.DebugSprintMVCCKeyValueDecoders, fn)
 	}
 	printer := printKey
 	if debugCtx.values {
 		printer = func(kv storage.MVCCKeyValue) (bool, error) {
-			kvserver.PrintKeyValue(kv)
+			kvserver.PrintMVCCKeyValue(kv)
 			return false, nil
 		}
 	}
@@ -512,7 +512,7 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 		if kvserver.IsRangeDescriptorKey(kv.Key) != nil {
 			return nil
 		}
-		kvserver.PrintKeyValue(kv)
+		kvserver.PrintMVCCKeyValue(kv)
 		return nil
 	})
 }
@@ -583,7 +583,7 @@ Decode and print a hexadecimal-encoded key-value pair.
 			}
 		}
 
-		kvserver.PrintKeyValue(storage.MVCCKeyValue{
+		kvserver.PrintMVCCKeyValue(storage.MVCCKeyValue{
 			Key:   k,
 			Value: bs[1],
 		})
@@ -646,7 +646,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 
 	// NB: raft log does not have intents.
 	return db.MVCCIterate(start, end, storage.MVCCKeyIterKind, func(kv storage.MVCCKeyValue) error {
-		kvserver.PrintKeyValue(kv)
+		kvserver.PrintMVCCKeyValue(kv)
 		return nil
 	})
 }
@@ -1497,7 +1497,7 @@ func (m mvccValueFormatter) Format(f fmt.State, c rune) {
 		errors.FormatError(m.err, f, c)
 		return
 	}
-	fmt.Fprint(f, kvserver.SprintKeyValue(m.kv, false /* printKey */))
+	fmt.Fprint(f, kvserver.SprintMVCCKeyValue(m.kv, false /* printKey */))
 }
 
 // lockValueFormatter is a fmt.Formatter for lock values.

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -388,6 +388,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//proto",
         "@com_github_google_btree//:btree",

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -27,30 +27,67 @@ import (
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
-// PrintKeyValue attempts to pretty-print the specified MVCCKeyValue to
-// os.Stdout, falling back to '%q' formatting.
-func PrintKeyValue(kv storage.MVCCKeyValue) {
-	fmt.Println(SprintKeyValue(kv, true /* printKey */))
+// PrintEngineKeyValue attempts to print the given key-value pair to
+// os.Stdout, utilizing SprintMVCCKeyValue in the case of an MVCCKeyValue.
+func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
+	fmt.Println(SprintEngineKeyValue(k, v))
 }
 
-// SprintKey pretty-prints the specified MVCCKey.
-func SprintKey(key storage.MVCCKey) string {
+// PrintMVCCKeyValue attempts to pretty-print the specified MVCCKeyValue to
+// os.Stdout, falling back to '%q' formatting.
+func PrintMVCCKeyValue(kv storage.MVCCKeyValue) {
+	fmt.Println(SprintMVCCKeyValue(kv, true /* printKey */))
+}
+
+// SprintEngineKey pretty-prints the specified EngineKey, using the correct
+// MVCC or Lock Table version formatting.
+func SprintEngineKey(key storage.EngineKey) string {
+	if key.IsMVCCKey() {
+		if mvccKey, err := key.ToMVCCKey(); err == nil {
+			return SprintMVCCKey(mvccKey)
+		}
+	}
+
+	return fmt.Sprintf("%s %x (%#x): ", key.Key, key.Version, key.Encode())
+}
+
+// SprintMVCCKey pretty-prints the specified MVCCKey.
+func SprintMVCCKey(key storage.MVCCKey) string {
 	return fmt.Sprintf("%s %s (%#x): ", key.Timestamp, key.Key, storage.EncodeKey(key))
 }
 
-// DebugSprintKeyValueDecoders allows injecting alternative debug decoders.
-var DebugSprintKeyValueDecoders []func(kv storage.MVCCKeyValue) (string, error)
+// SprintEngineKeyValue is like PrintEngineKeyValue, but returns a string.  In
+// the case of an MVCCKey, it will utilize SprintMVCCKeyValue for proper MVCC
+// formatting.
+func SprintEngineKeyValue(k storage.EngineKey, v []byte) string {
+	if k.IsMVCCKey() {
+		if key, err := k.ToMVCCKey(); err == nil {
+			return SprintMVCCKeyValue(storage.MVCCKeyValue{Key: key, Value: v}, true /* printKey */)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s %x (%#x): ", k.Key, k.Version, k.Encode())
+	if out, err := tryIntent(storage.MVCCKeyValue{Value: v}); err == nil {
+		sb.WriteString(out)
+	} else {
+		fmt.Fprintf(&sb, "%x", v)
+	}
+	return sb.String()
+}
 
-// SprintKeyValue is like PrintKeyValue, but returns a string. If
+// DebugSprintMVCCKeyValueDecoders allows injecting alternative debug decoders.
+var DebugSprintMVCCKeyValueDecoders []func(kv storage.MVCCKeyValue) (string, error)
+
+// SprintMVCCKeyValue is like PrintMVCCKeyValue, but returns a string. If
 // printKey is true, prints the key and the value together; otherwise,
 // prints just the value.
-func SprintKeyValue(kv storage.MVCCKeyValue, printKey bool) string {
+func SprintMVCCKeyValue(kv storage.MVCCKeyValue, printKey bool) string {
 	var sb strings.Builder
 	if printKey {
-		sb.WriteString(SprintKey(kv.Key))
+		sb.WriteString(SprintMVCCKey(kv.Key))
 	}
 
-	decoders := append(DebugSprintKeyValueDecoders,
+	decoders := append(DebugSprintMVCCKeyValueDecoders,
 		tryRaftLogEntry,
 		tryRangeDescriptor,
 		tryMeta,
@@ -126,46 +163,40 @@ func decodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 	for r.Next() {
 		switch r.BatchType() {
 		case storage.BatchTypeDeletion:
-			mvccKey, err := r.MVCCKey()
+			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
-			sb.WriteString(fmt.Sprintf("Delete: %s\n", SprintKey(mvccKey)))
+			sb.WriteString(fmt.Sprintf("Delete: %s\n", SprintEngineKey(engineKey)))
 		case storage.BatchTypeValue:
-			mvccKey, err := r.MVCCKey()
+			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
-			sb.WriteString(fmt.Sprintf("Put: %s\n", SprintKeyValue(storage.MVCCKeyValue{
-				Key:   mvccKey,
-				Value: r.Value(),
-			}, true /* printKey */)))
+			sb.WriteString(fmt.Sprintf("Put: %s\n", SprintEngineKeyValue(engineKey, r.Value())))
 		case storage.BatchTypeMerge:
-			mvccKey, err := r.MVCCKey()
+			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
-			sb.WriteString(fmt.Sprintf("Merge: %s\n", SprintKeyValue(storage.MVCCKeyValue{
-				Key:   mvccKey,
-				Value: r.Value(),
-			}, true /* printKey */)))
+			sb.WriteString(fmt.Sprintf("Merge: %s\n", SprintEngineKeyValue(engineKey, r.Value())))
 		case storage.BatchTypeSingleDeletion:
-			mvccKey, err := r.MVCCKey()
+			engineKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
-			sb.WriteString(fmt.Sprintf("Single Delete: %s\n", SprintKey(mvccKey)))
+			sb.WriteString(fmt.Sprintf("Single Delete: %s\n", SprintEngineKey(engineKey)))
 		case storage.BatchTypeRangeDeletion:
-			mvccStartKey, err := r.MVCCKey()
+			engineStartKey, err := r.EngineKey()
 			if err != nil {
 				return sb.String(), err
 			}
-			mvccEndKey, err := r.MVCCEndKey()
+			engineEndKey, err := r.EngineEndKey()
 			if err != nil {
 				return sb.String(), err
 			}
 			sb.WriteString(fmt.Sprintf(
-				"Delete Range: [%s, %s)\n", SprintKey(mvccStartKey), SprintKey(mvccEndKey),
+				"Delete Range: [%s, %s)\n", SprintEngineKey(engineStartKey), SprintEngineKey(engineEndKey),
 			))
 		default:
 			sb.WriteString(fmt.Sprintf("unsupported batch type: %d\n", r.BatchType()))
@@ -385,22 +416,4 @@ func (s *stringifyWriteBatch) String() string {
 		return wbStr
 	}
 	return fmt.Sprintf("failed to stringify write batch (%x): %s", s.Data, err)
-}
-
-// PrintEngineKeyValue attempts to print the given key-value pair.
-func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
-	if k.IsMVCCKey() {
-		if key, err := k.ToMVCCKey(); err == nil {
-			PrintKeyValue(storage.MVCCKeyValue{Key: key, Value: v})
-			return
-		}
-	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%s %x (%#x): ", k.Key, k.Version, k.Encode())
-	if out, err := tryIntent(storage.MVCCKeyValue{Value: v}); err == nil {
-		sb.WriteString(out)
-	} else {
-		fmt.Fprintf(&sb, "%x", v)
-	}
-	fmt.Println(sb.String())
 }

--- a/pkg/kv/kvserver/replica_consistency_diff.go
+++ b/pkg/kv/kvserver/replica_consistency_diff.go
@@ -52,7 +52,7 @@ func (rsds ReplicaSnapshotDiffSlice) SafeFormat(buf redact.SafePrinter, _ rune) 
 		buf.Printf(format,
 			prefix, d.Timestamp, d.Key,
 			prefix, d.Timestamp.GoTime(),
-			prefix, SprintKeyValue(storage.MVCCKeyValue{Key: mvccKey, Value: d.Value}, false /* printKey */),
+			prefix, SprintMVCCKeyValue(storage.MVCCKeyValue{Key: mvccKey, Value: d.Value}, false /* printKey */),
 			prefix, storage.EncodeKey(mvccKey), d.Value)
 	}
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1994,7 +1994,7 @@ func (r *Replica) printRaftTail(
 			Key:   mvccKey,
 			Value: it.Value(),
 		}
-		sb.WriteString(truncateEntryString(SprintKeyValue(kv, true /* printKey */), 2000))
+		sb.WriteString(truncateEntryString(SprintMVCCKeyValue(kv, true /* printKey */), 2000))
 		sb.WriteRune('\n')
 
 		valid, err := it.PrevEngineKey()

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -295,11 +295,24 @@ func (r *RocksDBBatchReader) Value() []byte {
 }
 
 // MVCCEndKey returns the MVCC end key of the current batch entry.
+//lint:ignore U1001 unused
 func (r *RocksDBBatchReader) MVCCEndKey() (MVCCKey, error) {
 	if r.typ != BatchTypeRangeDeletion {
-		panic("cannot only call Value on a range deletion entry")
+		panic("can only ask for EndKey on a range deletion entry")
 	}
 	return decodeMVCCKey(r.Value())
+}
+
+// EngineEndKey returns the engine end key of the current batch entry.
+func (r *RocksDBBatchReader) EngineEndKey() (EngineKey, error) {
+	if r.typ != BatchTypeRangeDeletion {
+		panic("can only ask for EndKey on a range deletion entry")
+	}
+	key, ok := DecodeEngineKey(r.Value())
+	if !ok {
+		return key, errors.Errorf("invalid encoded engine key: %x", r.Value())
+	}
+	return key, nil
 }
 
 // Next advances to the next entry in the batch, returning false when the batch


### PR DESCRIPTION
Previously the CLI debug command only printed `MVCCKey`s, resulting in
the debug printer to error on key decoding whenever a `LockTableKey` was
encountered.  By switching to the more generalized `EngineKey` (and
utilizing the existing MVCC key formatting whenever the key has an MVCC
version), we can increase visibility into our debug logs while investigating
issues.

Related to #69414

Release justification: Non-production bug fix
Release note: None