### PR TITLE
sql: prevent persisted sql stats from being accidentally returned

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -482,7 +482,7 @@ func (s *Server) GetReportedSQLStatsController() *sslocal.Controller {
 func (s *Server) GetScrubbedStmtStats(
 	ctx context.Context,
 ) ([]roachpb.CollectedStatementStatistics, error) {
-	return s.getScrubbedStmtStats(ctx, s.sqlStats)
+	return s.getScrubbedStmtStats(ctx, s.sqlStats.GetLocalMemProvider())
 }
 
 // Avoid lint errors.
@@ -499,7 +499,7 @@ func (s *Server) GetUnscrubbedStmtStats(
 		return nil
 	}
 	err :=
-		s.sqlStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
+		s.sqlStats.GetLocalMemProvider().IterateStatementStats(ctx, &sqlstats.IteratorOptions{}, stmtStatsVisitor)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch statement stats")
@@ -519,7 +519,7 @@ func (s *Server) GetUnscrubbedTxnStats(
 		return nil
 	}
 	err :=
-		s.sqlStats.IterateTransactionStats(ctx, &sqlstats.IteratorOptions{}, txnStatsVisitor)
+		s.sqlStats.GetLocalMemProvider().IterateTransactionStats(ctx, &sqlstats.IteratorOptions{}, txnStatsVisitor)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch statement stats")
@@ -2444,7 +2444,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		TxnModesSetter:         ex,
 		Jobs:                   &ex.extraTxnState.jobs,
 		SchemaChangeJobRecords: ex.extraTxnState.schemaChangeJobRecords,
-		statsStorage:           ex.server.sqlStats,
+		statsProvider:          ex.server.sqlStats,
 		indexUsageStats:        ex.indexUsageStats,
 	}
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
@@ -97,7 +96,7 @@ type extendedEvalContext struct {
 	// SchemaChangeJobRecords refers to schemaChangeJobsCache in extraTxnState.
 	SchemaChangeJobRecords map[descpb.ID]*jobs.Record
 
-	statsStorage sqlstats.Storage
+	statsProvider *persistedsqlstats.PersistedSQLStats
 
 	indexUsageStats *idxusage.LocalIndexUsageStats
 

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -155,6 +155,12 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 	})
 }
 
+// GetLocalMemProvider returns a sqlstats.Provider that can only be used to
+// access local in-memory sql statistics.
+func (s *PersistedSQLStats) GetLocalMemProvider() sqlstats.Provider {
+	return s.SQLStats
+}
+
 // nextFlushInterval calculates the wait interval that is between:
 // [(1 - SQLStatsFlushJitter) * SQLStatsFlushInterval),
 //  (1 + SQLStatsFlushJitter) * SQLStatsFlushInterval)]

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -40,8 +40,9 @@ go_test(
         "main_test.go",
         "sql_stats_test.go",
     ],
-    embed = [":sslocal"],
     deps = [
+        ":sslocal",
+        "//pkg/base",
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/security/securitytest",
@@ -49,6 +50,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
Previously, persisted sql stats would be returned to node-only virtual
tables such as `crdb_internal.node_statement_statistics` and
`crdb_internal.node_transaction_statistics`. This was because
when PersistedSQLStats was introduced, it replaces the SQLStats
as the default provider to the rest of the system.
This commit addresses this issue by selecting the correct provider.

Resolves #69810

Release justification: Bug fixes and low-risk updates to new
functionality

Release note: None