### PR TITLE
kv: deflake and unskip TestPushTxnHeartbeatTimeout

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1506,7 +1506,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, testutils.DefaultSucceedsSoonDuration)
 		defer cancel()
-		defer txnwait.TestingOverrideTxnLivenessThreshold(2 * testutils.DefaultSucceedsSoonDuration)
+		defer txnwait.TestingOverrideTxnLivenessThreshold(2 * testutils.DefaultSucceedsSoonDuration)()
 
 		// Create a transaction that won't complete until after the merge.
 		txn1 := kv.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */)

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -78,6 +78,9 @@ func UnderBazelWithIssue(t SkippableTest, githubIssueID int, args ...interface{}
 	}
 }
 
+// Ignore unused warnings.
+var _ = UnderBazelWithIssue
+
 // UnderShort skips this test if the -short flag is specified.
 func UnderShort(t SkippableTest, args ...interface{}) {
 	t.Helper()


### PR DESCRIPTION
Fixes #62860.

In #62860, we found that `TestPushTxnHeartbeatTimeout` became flaky after d77c3ed merged, but only when run with Bazel. That change having such an effect did not make a lot of sense. Furthermore, the fact that this only failed under Bazel and not under normal `go test` was even more fascinating. This was highly reproducible, and remained so until the merge of 4321fa8. After that change, the flakiness disappeared. Again, this was surprising, as the change was unrelated.

It turns out that this flakiness was due to the way that Bazel runs tests in the same package. Adding tests like those two commits did must have shuffled the order and grouping of tests into Bazel shards (https://docs.bazel.build/versions/main/test-encyclopedia.html#test-sharding), which revealed a bug when `TestStoreRangeMergeInFlightTxns` and `TestPushTxnHeartbeatTimeout` were run in the same shard and in that order. `TestStoreRangeMergeInFlightTxns` was unintentionally mutating the `txnwait.TxnLivenessThreshold` global variable, which was tripping up `TestPushTxnHeartbeatTimeout`.

This commit deflakes `TestPushTxnHeartbeatTimeout` by fixing a bug in `TestStoreRangeMergeInFlightTxns`, which is quite amusing. It then unskips the test.

Release justification: testing only