### PR TITLE
kvserver: respect guaranteed time budget in gc queue

### DIFF
--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -115,8 +115,12 @@ func newGCQueue(store *Store) *gcQueue {
 			needsLease:           true,
 			needsSystemConfig:    true,
 			acceptsUnsplitRanges: false,
-			processTimeoutFunc: func(_ *cluster.Settings, _ replicaInQueue) time.Duration {
-				return gcQueueTimeout
+			processTimeoutFunc: func(st *cluster.Settings, _ replicaInQueue) time.Duration {
+				timeout := gcQueueTimeout
+				if d := queueGuaranteedProcessingTimeBudget.Get(&st.SV); d > timeout {
+					timeout = d
+				}
+				return timeout
 			},
 			successes:       store.metrics.GCQueueSuccesses,
 			failures:        store.metrics.GCQueueFailures,


### PR DESCRIPTION
Release justification: (not going to merge this before the cut)
Release note (bug fix): The GC queue now respects the
`kv.queue.process.guaranteed_time_budget` cluster setting.
