### PR TITLE
changefeedccl: Clear out event alloc when detaching.

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -166,8 +166,7 @@ func (b *Event) MVCCTimestamp() hlc.Timestamp {
 // DetachAlloc detaches and returns allocation associated with this event.
 func (b *Event) DetachAlloc() Alloc {
 	a := b.alloc
-	b.alloc.entries = 0
-	b.alloc.bytes = 0
+	b.alloc.clear()
 	return a
 }
 


### PR DESCRIPTION
Minor fix to clear out alloc when detaching it.

Release Justification: Low danger, correctness fix.

Release Notes: None