### PR TITLE
changefeedccl: reset job run stats when checkpointing

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1369,6 +1369,15 @@ func (cf *changeFrontier) checkpointJobProgress(
 		}
 
 		ju.UpdateProgress(progress)
+
+		// Reset RunStats.NumRuns to 1 since the changefeed is
+		// now running. By resetting the NumRuns, we avoid
+		// future job system level retries from having large
+		// backoffs because of past failures.
+		if md.RunStats != nil {
+			ju.UpdateRunStats(1, md.RunStats.LastRun)
+		}
+
 		return nil
 	})
 }

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -86,9 +86,6 @@ type cdcTestArgs struct {
 func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	db.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
-	// jobs.registry.retry.max_delay is set to work around #69037.
-	// TODO(ssd): revert once #69037 is fixed.
-	db.Exec(t, "SET CLUSTER SETTING jobs.registry.retry.max_delay = '1s'")
 	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = true")
 }
 


### PR DESCRIPTION
By default, the job system now tracks the number of times a job has
run and exponentially backs off future adoptions of that job to
prevent failing jobs from overwhelming the system.

However, this behavior does not work well for changefeeds as they are
long running jobs and also have a fatal failure condition if they fall
behind the GC TTL.

Here, we reset the number of runs when checkpointing since
checkpointing is a clear point at which we know we've been able to
make forward progress and it is likely that past failures are no
longer relevant to future backoff decisions.

Informs #69037

Release justification: Mitigation for bug in new default behavior.

Release note: None