### PR TITLE
sql: add opaque keys to fetcher

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -786,7 +786,15 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 1); err != nil {
 				return r, err
 			}
-			if core.JoinReader.LookupColumns != nil || !core.JoinReader.LookupExpr.Empty() {
+			if !core.JoinReader.LookupExpr.Empty() {
+				return r, errors.AssertionFailedf("lookup join reader with exprs is unsupported in vectorized")
+			}
+			if core.JoinReader.LookupColumns != nil {
+				if core.JoinReader.LookupColumnsAreKey && !core.JoinReader.LeftJoinWithPairedJoiner && core.JoinReader.
+					Type == descpb.JoinType_INNER {
+					// Special case: we can support a simple lookup join.
+
+				}
 				return r, errors.AssertionFailedf("lookup join reader is unsupported in vectorized")
 			}
 			// We have to create a separate account in order for the cFetcher to

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -94,6 +94,7 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 	if err := s.rf.StartScan(
 		s.flowCtx.Txn,
 		s.spans,
+		nil, /* keys */
 		s.bsHeader,
 		limitBatches,
 		s.batchBytesLimit,
@@ -107,7 +108,7 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 
 // Next is part of the Operator interface.
 func (s *ColBatchScan) Next() coldata.Batch {
-	bat, err := s.rf.NextBatch(s.Ctx)
+	bat, _, err := s.rf.NextBatch(s.Ctx)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -35,14 +35,15 @@ type singleKVFetcher struct {
 }
 
 // nextBatch implements the kvBatchFetcher interface.
-func (f *singleKVFetcher) nextBatch(
-	ctx context.Context,
-) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
+func (f *singleKVFetcher) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
 	if f.done {
-		return false, nil, nil, nil
+		return kvBatchFetcherResponse{}, nil
 	}
 	f.done = true
-	return true, f.kvs[:], nil, nil
+	return kvBatchFetcherResponse{
+		moreKVs: true,
+		kvs:     f.kvs[:],
+	}, nil
 }
 
 // ConvertBatchError attempts to map a key-value error generated during a


### PR DESCRIPTION
The upcoming `Streamer` interface will expect callers to pass in opaque
integer keys to keep track of which response corresponds to which input.
This commit plumbs these opaque keys in via the fetcher stack in
preparation.

Release note: None