### PR TITLE
roachtest: make roachtest recognize 21.2

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -14,6 +14,7 @@ var activeRecordBlocklists = blocklistsForVersion{
 	{"v20.2", "activeRecordBlockList20_2", activeRecordBlockList20_2, "activeRecordIgnoreList20_2", activeRecordIgnoreList20_2},
 	{"v21.1", "activeRecordBlockList21_1", activeRecordBlockList21_1, "activeRecordIgnoreList21_1", activeRecordIgnoreList21_1},
 	{"v21.2", "activeRecordBlockList21_2", activeRecordBlockList21_2, "activeRecordIgnoreList21_2", activeRecordIgnoreList21_2},
+	{"v22.1", "activeRecordBlockList22_1", activeRecordBlockList22_1, "activeRecordIgnoreList22_1", activeRecordIgnoreList22_1},
 }
 
 // These are lists of known activerecord test errors and failures.
@@ -27,11 +28,15 @@ var activeRecordBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var activeRecordBlockList22_1 = blocklist{}
+
 var activeRecordBlockList21_2 = blocklist{}
 
 var activeRecordBlockList21_1 = blocklist{}
 
 var activeRecordBlockList20_2 = blocklist{}
+
+var activeRecordIgnoreList22_1 = activeRecordIgnoreList21_2
 
 var activeRecordIgnoreList21_2 = blocklist{
 	"ActiveRecord::CockroachDB::UnloggedTablesTest#test_gracefully_handles_temporary_tables": "modified to pass on 20.2",

--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -165,14 +165,19 @@ var djangoBlocklists = blocklistsForVersion{
 	{"v20.2", "djangoBlocklist20_2", djangoBlocklist20_2, "djangoIgnoreList20_2", djangoIgnoreList20_2},
 	{"v21.1", "djangoBlocklist21_1", djangoBlocklist21_1, "djangoIgnoreList21_1", djangoIgnoreList21_1},
 	{"v21.2", "djangoBlocklist21_2", djangoBlocklist21_2, "djangoIgnoreList21_2", djangoIgnoreList21_2},
+	{"v22.1", "djangoBlocklist22_1", djangoBlocklist22_1, "djangoIgnoreList22_1", djangoIgnoreList22_1},
 }
 
 // Maintain that this list is alphabetized.
+var djangoBlocklist22_1 = djangoBlocklist21_2
+
 var djangoBlocklist21_2 = djangoBlocklist21_1
 
 var djangoBlocklist21_1 = djangoBlocklist20_2
 
 var djangoBlocklist20_2 = blocklist{}
+
+var djangoIgnoreList22_1 = djangoIgnoreList21_2
 
 var djangoIgnoreList21_2 = blocklist{
 	"migrations.test_operations.OperationTests.test_alter_fk_non_fk":  "will be fixed in django-cockroachdb v3.2.2",

--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -14,6 +14,7 @@ var gopgBlocklists = blocklistsForVersion{
 	{"v20.2", "gopgBlockList20_2", gopgBlockList20_2, "gopgIgnoreList20_2", gopgIgnoreList20_2},
 	{"v21.1", "gopgBlockList21_1", gopgBlockList21_1, "gopgIgnoreList21_1", gopgIgnoreList21_1},
 	{"v21.2", "gopgBlockList21_2", gopgBlockList21_2, "gopgIgnoreList21_2", gopgIgnoreList21_2},
+	{"v22.1", "gopgBlockList22_1", gopgBlockList22_1, "gopgIgnoreList22_1", gopgIgnoreList22_1},
 }
 
 // These are lists of known gopg test errors and failures.
@@ -24,6 +25,8 @@ var gopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+
+var gopgBlockList22_1 = gopgBlockList21_2
 
 var gopgBlockList21_2 = gopgBlockList21_1
 
@@ -74,6 +77,8 @@ var gopgBlockList20_2 = blocklist{
 	"v10.TestReadColumnValue":                                         "26925",
 	"v10.TestUnixSocket":                                              "31113",
 }
+
+var gopgIgnoreList22_1 = gopgIgnoreList21_2
 
 var gopgIgnoreList21_2 = gopgIgnoreList21_1
 

--- a/pkg/cmd/roachtest/tests/gorm_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gorm_blocklist.go
@@ -14,13 +14,18 @@ var gormBlocklists = blocklistsForVersion{
 	{"v20.2", "gormBlocklist20_2", gormBlocklist20_2, "gormIgnorelist20_2", gormIgnorelist20_2},
 	{"v21.1", "gormBlocklist21_1", gormBlocklist21_1, "gormIgnorelist21_1", gormIgnorelist21_1},
 	{"v21.2", "gormBlocklist21_2", gormBlocklist21_2, "gormIgnorelist21_2", gormIgnorelist21_2},
+	{"v22.1", "gormBlocklist22_1", gormBlocklist22_1, "gormIgnorelist22_1", gormIgnorelist22_1},
 }
+
+var gormBlocklist22_1 = gormBlocklist21_2
 
 var gormBlocklist21_2 = gormBlocklist21_1
 
 var gormBlocklist21_1 = gormBlocklist20_2
 
 var gormBlocklist20_2 = blocklist{}
+
+var gormIgnorelist22_1 = gormIgnorelist21_2
 
 var gormIgnorelist21_2 = gormIgnorelist21_1
 

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -14,19 +14,25 @@ var hibernateBlocklists = blocklistsForVersion{
 	{"v20.2", "hibernateBlockList20_2", hibernateBlockList20_2, "", nil},
 	{"v21.1", "hibernateBlockList21_1", hibernateBlockList21_1, "hibernateIgnoreList21_1", hibernateIgnoreList21_1},
 	{"v21.2", "hibernateBlockList21_2", hibernateBlockList21_2, "hibernateIgnoreList21_2", hibernateIgnoreList21_2},
+	{"v22.1", "hibernateBlockList22_1", hibernateBlockList22_1, "hibernateIgnoreList22_1", hibernateIgnoreList22_1},
 }
 
 var hibernateSpatialBlocklists = blocklistsForVersion{
 	{"v21.1", "hibernateSpatialBlockList21_1", hibernateSpatialBlockList21_1, "", nil},
 	{"v21.2", "hibernateSpatialBlockList21_2", hibernateSpatialBlockList21_2, "", nil},
+	{"v22.1", "hibernateSpatialBlockList22_1", hibernateSpatialBlockList22_1, "", nil},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var hibernateSpatialBlockList22_1 = blocklist{}
+
 var hibernateSpatialBlockList21_2 = blocklist{}
 
 var hibernateSpatialBlockList21_1 = blocklist{}
+
+var hibernateBlockList22_1 = hibernateBlockList21_2
 
 var hibernateBlockList21_2 = blocklist{
 	"org.hibernate.jpa.test.graphs.FetchGraphTest.testCollectionEntityGraph":                                                "unknown",
@@ -208,6 +214,8 @@ var hibernateBlockList20_2 = blocklist{
 	"org.hibernate.test.naturalid.inheritance.cache.InheritedNaturalIdNoCacheTest.testLoadExtendedByNormal":                                                                                      "unknown",
 	"org.hibernate.test.where.annotations.EagerManyToOneFetchModeSelectWhereTest.testAssociatedWhereClause":                                                                                      "unknown",
 }
+
+var hibernateIgnoreList22_1 = hibernateIgnoreList21_2
 
 var hibernateIgnoreList21_2 = hibernateIgnoreList21_1
 

--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -14,7 +14,10 @@ var libPQBlocklists = blocklistsForVersion{
 	{"v20.2", "libPQBlocklist20_2", libPQBlocklist20_2, "libPQIgnorelist20_2", libPQIgnorelist20_2},
 	{"v21.1", "libPQBlocklist21_1", libPQBlocklist21_1, "libPQIgnorelist21_1", libPQIgnorelist21_1},
 	{"v21.2", "libPQBlocklist21_2", libPQBlocklist21_2, "libPQIgnorelist21_2", libPQIgnorelist21_2},
+	{"v22.1", "libPQBlocklist22_1", libPQBlocklist22_1, "libPQIgnorelist22_1", libPQIgnorelist22_1},
 }
+
+var libPQBlocklist22_1 = libPQBlocklist21_2
 
 var libPQBlocklist21_2 = blocklist{
 	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
@@ -89,6 +92,8 @@ var libPQBlocklist20_2 = blocklist{
 	"pq.TestRuntimeParameters":                       "12137",
 	"pq.TestStringWithNul":                           "26366",
 }
+
+var libPQIgnorelist22_1 = libPQIgnorelist21_2
 
 var libPQIgnorelist21_2 = libPQIgnorelist21_1
 

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -14,7 +14,10 @@ var liquibaseBlocklists = blocklistsForVersion{
 	{"v20.2", "liquibaseBlocklist20_2", liquibaseBlocklist20_2, "liquibaseIgnorelist20_2", liquibaseIgnorelist20_2},
 	{"v21.1", "liquibaseBlocklist21_1", liquibaseBlocklist21_1, "liquibaseIgnorelist21_1", liquibaseIgnorelist21_1},
 	{"v21.2", "liquibaseBlocklist21_2", liquibaseBlocklist21_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist21_2},
+	{"v22.1", "liquibaseBlocklist22_1", liquibaseBlocklist22_1, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_1},
 }
+
+var liquibaseBlocklist22_1 = liquibaseBlocklist21_2
 
 var liquibaseBlocklist21_2 = blocklist{
 	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2; verify generated SQL and DB snapshot": "",
@@ -23,6 +26,8 @@ var liquibaseBlocklist21_2 = blocklist{
 var liquibaseBlocklist21_1 = liquibaseBlocklist20_2
 
 var liquibaseBlocklist20_2 = blocklist{}
+
+var liquibaseIgnorelist22_1 = liquibaseIgnorelist21_2
 
 var liquibaseIgnorelist21_2 = liquibaseIgnorelist21_1
 

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -14,11 +14,14 @@ var pgjdbcBlocklists = blocklistsForVersion{
 	{"v20.2", "pgjdbcBlockList20_2", pgjdbcBlockList20_2, "pgjdbcIgnoreList20_2", pgjdbcIgnoreList20_2},
 	{"v21.1", "pgjdbcBlockList21_1", pgjdbcBlockList21_1, "pgjdbcIgnoreList21_1", pgjdbcIgnoreList21_1},
 	{"v21.2", "pgjdbcBlockList21_2", pgjdbcBlockList21_2, "pgjdbcIgnoreList21_2", pgjdbcIgnoreList21_2},
+	{"v22.1", "pgjdbcBlockList22_1", pgjdbcBlockList22_1, "pgjdbcIgnoreList22_1", pgjdbcIgnoreList22_1},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var pgjdbcBlockList22_1 = pgjdbcBlockList21_2
+
 var pgjdbcBlockList21_2 = blocklist{
 	"org.postgresql.jdbc.DeepBatchedInsertStatementTest.testDeepInternalsBatchedQueryDecorator":                                                                                                                      "26508",
 	"org.postgresql.jdbc.DeepBatchedInsertStatementTest.testUnspecifiedParameterType":                                                                                                                                "26508",
@@ -2526,6 +2529,8 @@ var pgjdbcBlockList20_2 = blocklist{
 	"org.postgresql.test.xa.XADataSourceTest.testTwoPhaseCommit":                                                                                                               "22329",
 	"org.postgresql.test.xa.XADataSourceTest.testWrapperEquals":                                                                                                                "22329",
 }
+
+var pgjdbcIgnoreList22_1 = pgjdbcIgnoreList21_2
 
 var pgjdbcIgnoreList21_2 = pgjdbcIgnoreList21_1
 

--- a/pkg/cmd/roachtest/tests/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgx_blocklist.go
@@ -14,16 +14,21 @@ var pgxBlocklists = blocklistsForVersion{
 	{"v20.2", "pgxBlocklist20_2", pgxBlocklist20_2, "pgxIgnorelist20_2", pgxIgnorelist20_2},
 	{"v21.1", "pgxBlocklist21_1", pgxBlocklist21_1, "pgxIgnorelist21_1", pgxIgnorelist21_1},
 	{"v21.2", "pgxBlocklist21_2", pgxBlocklist21_2, "pgxIgnorelist21_2", pgxIgnorelist21_2},
+	{"v22.1", "pgxBlocklist22_1", pgxBlocklist22_1, "pgxIgnorelist22_1", pgxIgnorelist22_1},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var pgxBlocklist22_1 = blocklist{}
+
 var pgxBlocklist21_2 = blocklist{}
 
 var pgxBlocklist21_1 = blocklist{}
 
 var pgxBlocklist20_2 = blocklist{}
+
+var pgxIgnorelist22_1 = pgxIgnorelist21_2
 
 var pgxIgnorelist21_2 = pgxIgnorelist21_1
 

--- a/pkg/cmd/roachtest/tests/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/psycopg_blocklist.go
@@ -14,6 +14,7 @@ var psycopgBlocklists = blocklistsForVersion{
 	{"v20.2", "psycopgBlockList20_2", psycopgBlockList20_2, "psycopgIgnoreList20_2", psycopgIgnoreList20_2},
 	{"v21.1", "psycopgBlockList21_1", psycopgBlockList21_1, "psycopgIgnoreList21_1", psycopgIgnoreList21_1},
 	{"v21.2", "psycopgBlockList21_2", psycopgBlockList21_2, "psycopgIgnoreList21_2", psycopgIgnoreList21_2},
+	{"v22.1", "psycopgBlockList22_1", psycopgBlockList22_1, "psycopgIgnoreList22_1", psycopgIgnoreList22_1},
 }
 
 // These are lists of known psycopg test errors and failures.
@@ -27,6 +28,8 @@ var psycopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var psycopgBlockList22_1 = psycopgBlockList21_2
+
 var psycopgBlockList21_2 = blocklist{
 	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
 	// The following two items can be removed once there is a new psycopg2 release.
@@ -43,6 +46,8 @@ var psycopgBlockList21_1 = blocklist{
 var psycopgBlockList20_2 = blocklist{
 	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
 }
+
+var psycopgIgnoreList22_1 = psycopgIgnoreList21_2
 
 var psycopgIgnoreList21_2 = psycopgIgnoreList21_1
 

--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -14,7 +14,10 @@ var rubyPGBlocklist = blocklistsForVersion{
 	{"v20.2", "rubyPGBlockList20_2", rubyPGBlockList20_2, "rubyPGIgnoreList20_2", rubyPGIgnoreList20_2},
 	{"v21.1", "rubyPGBlockList21_1", rubyPGBlockList21_1, "rubyPGIgnoreList21_1", rubyPGIgnoreList21_1},
 	{"v21.2", "rubyPGBlockList21_2", rubyPGBlockList21_2, "rubyPGIgnoreList21_2", rubyPGIgnoreList21_2},
+	{"v22.1", "rubyPGBlockList22_1", rubyPGBlockList22_1, "rubyPGIgnoreList21_2", rubyPGIgnoreList22_1},
 }
+
+var rubyPGBlockList22_1 = rubyPGBlockList21_2
 
 var rubyPGBlockList21_2 = blocklist{
 	"Basic type mapping PG::BasicTypeMapBasedOnResult with usage of result oids for bind params encoder selection can do JSON conversions":                                                                                      "unknown",
@@ -362,6 +365,8 @@ var rubyPGBlockList20_2 = blocklist{
 	"PG::Connection deprecated forms of methods should forward send_query to send_query_params":                                                                                                     "unknown",
 	"PG::Connection deprecated forms of methods should forward exec to exec_params":                                                                                                                 "unknown",
 }
+
+var rubyPGIgnoreList22_1 = rubyPGIgnoreList21_2
 
 var rubyPGIgnoreList21_2 = rubyPGIgnoreList21_1
 

--- a/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
@@ -14,13 +14,18 @@ var sqlAlchemyBlocklists = blocklistsForVersion{
 	{"v20.2", "sqlAlchemyBlocklist20_2", sqlAlchemyBlocklist20_2, "sqlAlchemyIgnoreList20_2", sqlAlchemyIgnoreList20_2},
 	{"v21.1", "sqlAlchemyBlocklist21_1", sqlAlchemyBlocklist21_1, "sqlAlchemyIgnoreList21_1", sqlAlchemyIgnoreList21_1},
 	{"v21.2", "sqlAlchemyBlocklist21_2", sqlAlchemyBlocklist21_2, "sqlAlchemyIgnoreList21_2", sqlAlchemyIgnoreList21_2},
+	{"v22.1", "sqlAlchemyBlocklist22_1", sqlAlchemyBlocklist22_1, "sqlAlchemyIgnoreList22_1", sqlAlchemyIgnoreList22_1},
 }
+
+var sqlAlchemyBlocklist22_1 = blocklist{}
 
 var sqlAlchemyBlocklist21_2 = blocklist{}
 
 var sqlAlchemyBlocklist21_1 = blocklist{}
 
 var sqlAlchemyBlocklist20_2 = blocklist{}
+
+var sqlAlchemyIgnoreList22_1 = sqlAlchemyIgnoreList21_2
 
 var sqlAlchemyIgnoreList21_2 = sqlAlchemyIgnoreList21_1
 


### PR DESCRIPTION
Shortly after [Creating a release branch](https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/187859111/Creating+a+release+branch) for release-21.2, we'll want to merge PRs as instructed by the [New major version checklist](https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/1522270228/New+major+version+checklist).

This PR is for Step 2c of the [New major version checklist](https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/1522270228/New+major+version+checklist), where we update the ORM tests. Specifically, adding block/ignore lists for the `vNEXT` major version for these files:
```
ls pkg/cmd/roachtest/tests/*_blocklist.go
```

This PR is one of the tasks detailed in #70751, which tracks all the steps relevant to creating a release branch for `${vBRANCH_CUT}` and preparing master for the `${vNEXT}` major version.

Release justification: Non-production code change.
Release note: None