### PR TITLE
rpc,security: fix an incorrect code redundancy

### DIFF
--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -234,15 +234,6 @@ func (ctx *SecurityContext) GetHTTPClient() (http.Client, error) {
 	return ctx.lazy.httpClient.httpClient, ctx.lazy.httpClient.err
 }
 
-// getClientCertPaths returns the paths to the client cert and key. This uses
-// the node certs for the NodeUser, and the actual client certs for all others.
-func (ctx *SecurityContext) getClientCertPaths(user security.SQLUsername) (string, string) {
-	if user.IsNodeUser() {
-		return ctx.NodeCertPath(), ctx.NodeKeyPath()
-	}
-	return ctx.ClientCertPath(user), ctx.ClientKeyPath(user)
-}
-
 // CheckCertificateAddrs validates the addresses inside the configured
 // certificates to be compatible with the configured listen and
 // advertise addresses. This is an advisory function (to inform/educate

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -507,17 +507,19 @@ func TestUseSplitCACerts(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		pgUrl := makeSecurePGUrl(s.ServingSQLAddr(), tc.user, certsDir, tc.caName, tc.certPrefix+".crt", tc.certPrefix+".key")
-		goDB, err := gosql.Open("postgres", pgUrl)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer goDB.Close()
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			pgUrl := makeSecurePGUrl(s.ServingSQLAddr(), tc.user, certsDir, tc.caName, tc.certPrefix+".crt", tc.certPrefix+".key")
+			goDB, err := gosql.Open("postgres", pgUrl)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goDB.Close()
 
-		_, err = goDB.Exec("SELECT 1")
-		if !testutils.IsError(err, tc.expectedError) {
-			t.Errorf("#%d: expected error %v, got %v", i, tc.expectedError, err)
-		}
+			_, err = goDB.Exec("SELECT 1")
+			if !testutils.IsError(err, tc.expectedError) {
+				t.Errorf("#%d: expected error %v, got %v", i, tc.expectedError, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This patch removes `(*rpc.SecurityContext).getClientCertPaths()` which
was redundant.

Release justification: low risk, high benefit changes to existing functionality

Release note: None