### PR TITLE
backupccl: Table schedule backup.

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -625,6 +625,13 @@ INSERT INTO t1 values (-1), (10), (-100);
 				dbTables{"other_db", []string{"t1"}},
 			),
 		},
+		{
+			name:     "table-backup-non-fully-qualified",
+			schedule: "CREATE SCHEDULE FOR BACKUP t2 INTO $1 RECURRING '@hourly' FULL BACKUP ALWAYS",
+			verifyTables: expectBackupTables(
+				dbTables{"db", []string{"t2"}},
+			),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Just a demo showing that scheduled backups of non fully qualified
tables do not work as expected.