### PR TITLE
clusterversion: add warning to not add new versions to a patch

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -300,7 +300,10 @@ const (
 	SQLStatsCompactionScheduledJob
 	// DateAndIntervalStyle enables DateStyle and IntervalStyle to be changed.
 	DateAndIntervalStyle
+	// *************************************************
 	// Step (1): Add new versions here.
+	// Do not add new versions to a patch release.
+	// *************************************************
 )
 
 // versionsSingleton lists all historical versions here in chronological order,
@@ -507,7 +510,10 @@ var versionsSingleton = keyedVersions{
 		Key:     DateAndIntervalStyle,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 160},
 	},
+	// *************************************************
 	// Step (2): Add new versions here.
+	// Do not add new versions to a patch release.
+	// *************************************************
 }
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version


### PR DESCRIPTION
This is an important warning to have as the eng team grows.

Release justification: comment-only change
Release note: None