### PR TITLE
release-21.1: sql: fix race condition with default_int_size

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -446,7 +446,7 @@ func (h ConnectionHandler) GetUnqualifiedIntSize() *types.T {
 	if h.ex != nil {
 		// The executor will be nil in certain testing situations where
 		// no server is actually present.
-		size = h.ex.sessionData.DefaultIntSize
+		size = atomic.LoadInt32(&h.ex.sessionData.DefaultIntSize)
 	}
 	return parser.NakedIntTypeFromDefaultIntSize(size)
 }

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -848,6 +848,36 @@ func TestTrimFlushedStatements(t *testing.T) {
 	require.NoError(t, tx.Commit())
 }
 
+// TestUnqualifiedIntSizeRace makes sure there is no data race using the
+// default_int_size session variable during statement parsing.
+// Regression test for https://github.com/cockroachdb/cockroach/issues/69451.
+func TestUnqualifiedIntSizeRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
+	})
+	defer s.Stopper().Stop(ctx)
+
+	// Connect to the cluster via the PGWire client.
+	p, err := pgtest.NewPGTest(ctx, s.SQLAddr(), security.RootUser)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "SET default_int_size = 8"}`))
+	require.NoError(t, p.SendOneLine(`Query {"String": "SET default_int_size = 4"}`))
+	require.NoError(t, p.SendOneLine(`Parse {"Query": "SELECT generate_series(1, 10)"}`))
+
+	// wait for ready
+	for i := 0; i < 2; i++ {
+		until := pgtest.ParseMessages("ReadyForQuery")
+		_, err = p.Until(false /* keepErrMsg */, until...)
+		require.NoError(t, err)
+	}
+}
+
 func TestTrimSuspendedPortals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/apd/v2"
@@ -2247,7 +2248,7 @@ func (m *sessionDataMutator) SetTemporarySchemaIDForDatabase(dbID uint32, tempSc
 }
 
 func (m *sessionDataMutator) SetDefaultIntSize(size int32) {
-	m.data.DefaultIntSize = size
+	atomic.StoreInt32(&m.data.DefaultIntSize, size)
 }
 
 func (m *sessionDataMutator) SetDefaultTransactionPriority(val tree.UserPriority) {


### PR DESCRIPTION
A much simpler version of https://github.com/cockroachdb/cockroach/pull/69543

---

fixes https://github.com/cockroachdb/cockroach/issues/69451

The default_int_size session variable needs to be read in a different
goroutine from the session itself. It's read at parsing time, when
reading from the pgwire stmtBuf, but is written inside the session.

This was a race condition. Now, the value is changed atomically.

Release justification: bug fix
Release note: None