### PR TITLE
execbuilder/testdata: fix a rare recent flake

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scan_parallel
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan_parallel
@@ -84,7 +84,9 @@ vectorized: true
   table: data@primary
   spans: [/0 - /0] [/2 - /2] [/4 - /4] [/6 - /6] … (1 more)
 
-query T
+# We allow to retry because the concurrency limit on the semaphore might not be
+# updated right away.
+query T retry
 EXPLAIN (VEC) SELECT * FROM data WHERE a IN (0, 2, 4, 6, 8)
 ----
 │


### PR DESCRIPTION
Since there might be a delay between updating the cluster setting and
triggering the "OnUpdate" action, we currently can run into a rare flake
with the recent test that verifies that lowering the local scans
parallelism to 0 results in a single TableReader processor. This commit
allows for the test case to be retried.

Fixes: #69830.

Release note: None

Release justification: testing only change.