### PR TITLE
release-21.1: kv: use old retryable error reason

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -695,10 +695,10 @@ func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Err
 			})
 		if err != nil {
 			if errors.HasType(err, (*contextutil.TimeoutError)(nil)) {
-				if r.store.cfg.Settings.Version.IsActive(ctx, clusterversion.NewRetryableRangefeedErrors) {
-					err = &roachpb.RangeFeedRetryError{
-						Reason: roachpb.RangeFeedRetryError_REASON_NO_LEASEHOLDER,
-					}
+				err = &roachpb.RangeFeedRetryError{
+					// This is really RangeFeedRetryError_REASON_NO_LEASEHOLDER,
+					// but some 21.1 versions will crash on unrecognized reasons.
+					Reason: roachpb.RangeFeedRetryError_REASON_RANGE_SPLIT,
 				}
 			}
 			return roachpb.NewError(err)


### PR DESCRIPTION
This diff is needed to safely revert fd70104f88577a43d1bb40532566cede05fe1ca0

Release note: None