### PR TITLE
release-21.1: clusterversion: allow v21.1-124 to v21.1 downgrade

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -578,3 +578,19 @@ func listBetweenInternal(from, to ClusterVersion, vs keyedVersions) []ClusterVer
 	}
 	return cvs
 }
+
+var (
+	// V21Dot1 is used in tests.
+	V21Dot1 = ByKey(V21_1)
+	// V21Dot1Dot8 is used in tests.
+	V21Dot1Dot8 = roachpb.Version{Major: 21, Minor: 1, Internal: 124}
+)
+
+// Is21Dot1Dot8Equiv checks if the passed versions are the two cluster versions
+// used by released 21.1 versions, that is, v21.1 and v21.1-124, which was added
+// to the 21.1 branch in a backport and released in v21.1.8. This check is used
+// to allow later versions of 21.1 to treat this later 21.1 variant as if it is
+// 21.1 when checking for x-version compatibility and banning downgrades.
+func Is21Dot1Dot8Equiv(cv1, cv2 roachpb.Version) bool {
+	return (cv1 == V21Dot1 && cv2 == V21Dot1Dot8) || (cv1 == V21Dot1Dot8 && cv2 == V21Dot1)
+}

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -85,7 +85,7 @@ func (cv *clusterVersionSetting) initialize(
 		// It's also used in production code during bootstrap, where the version
 		// is first initialized to BinaryMinSupportedVersion and then
 		// re-initialized to BootstrapVersion (=BinaryVersion).
-		if version.Less(ver.Version) {
+		if version.Less(ver.Version) && !Is21Dot1Dot8Equiv(version, ver.Version) {
 			return errors.AssertionFailedf("cannot initialize version to %s because already set to: %s",
 				version, ver)
 		}
@@ -175,7 +175,7 @@ func (cv *clusterVersionSetting) Validate(
 	}
 
 	// Versions cannot be downgraded.
-	if newCV.Version.Less(oldCV.Version) {
+	if newCV.Version.Less(oldCV.Version) && !Is21Dot1Dot8Equiv(newCV.Version, oldCV.Version) {
 		return nil, errors.Errorf(
 			"versions cannot be downgraded (attempting to downgrade from %s to %s)",
 			oldCV.Version, newCV.Version)
@@ -225,7 +225,7 @@ func (cv *clusterVersionSetting) validateBinaryVersions(
 	if vh.BinaryMinSupportedVersion() == (roachpb.Version{}) {
 		panic("BinaryMinSupportedVersion not set")
 	}
-	if vh.BinaryVersion().Less(ver) {
+	if vh.BinaryVersion().Less(ver) && !Is21Dot1Dot8Equiv(vh.BinaryVersion(), ver) {
 		// TODO(tschottdorf): also ask gossip about other nodes.
 		return errors.Errorf("cannot upgrade to %s: node running %s",
 			ver, vh.BinaryVersion())

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -356,7 +356,7 @@ func SynthesizeClusterVersionFromEngines(
 
 		// Avoid running a binary with a store that is too new. For example,
 		// restarting into 1.1 after having upgraded to 1.2 doesn't work.
-		if binaryVersion.Less(cv.Version) {
+		if binaryVersion.Less(cv.Version) && !clusterversion.Is21Dot1Dot8Equiv(binaryVersion, cv.Version) {
 			return clusterversion.ClusterVersion{}, errors.Errorf(
 				"cockroach version v%s is incompatible with data in store %s; use version v%s or later",
 				binaryVersion, eng, cv.Version)
@@ -392,7 +392,7 @@ func SynthesizeClusterVersionFromEngines(
 	// We only verify this now because as we iterate through the stores, we
 	// may not yet have picked up the final versions we're actually planning
 	// to use.
-	if minStoreVersion.Version.Less(binaryMinSupportedVersion) {
+	if minStoreVersion.Version.Less(binaryMinSupportedVersion) && !clusterversion.Is21Dot1Dot8Equiv(minStoreVersion.Version, binaryMinSupportedVersion) {
 		return clusterversion.ClusterVersion{}, errors.Errorf("store %s, last used with cockroach version v%s, "+
 			"is too old for running version v%s (which requires data from v%s or later)",
 			minStoreVersion.origin, minStoreVersion.Version, binaryVersion, binaryMinSupportedVersion)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1236,7 +1236,7 @@ func (n *Node) Join(
 	defer span.Finish()
 
 	activeVersion := n.storeCfg.Settings.Version.ActiveVersion(ctx)
-	if req.BinaryVersion.Less(activeVersion.Version) {
+	if req.BinaryVersion.Less(activeVersion.Version) && !clusterversion.Is21Dot1Dot8Equiv(*req.BinaryVersion, activeVersion.Version) {
 		return nil, grpcstatus.Error(codes.PermissionDenied, ErrIncompatibleBinaryVersion.Error())
 	}
 

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -126,7 +126,7 @@ func setupMixedCluster(
 // eg. prev(20.1) = 19.2, prev(19.2) = 19.1, prev(19.1) = 2.1,
 // prev(2.0) = 1.0, prev(2.1) == 2.0, prev(2.1-5) == 2.1.
 func prev(version roachpb.Version) roachpb.Version {
-	if version.Internal != 0 {
+	if version.Internal != 0 && version != clusterversion.V21Dot1Dot8 {
 		return roachpb.Version{Major: version.Major, Minor: version.Minor}
 	}
 


### PR DESCRIPTION
This softens the hard rule that cluster versions must be greater than prior cluster versions,
when opening a store, joining a cluster, or changing the setting, to add a special-case
exemption for 21.1-124, which was backported to release-21.1 and released in v21.1.8.

This means a node with this change, if it were released as 21.1.9, would be happy to allow
reducing the cluster setting fro 21.1-124 to 21.1. It also means a subsequent change could
change the binary version back to 21.1 and still be able to start on stores or join clusters
where the cluster version was previously bumped to 21.1-124.

Release note (bug fix): add backwards compatibility between 21.1.x cluster version and 21.1.8 cluster version.