### PR TITLE
tenantcostclient: tenant-side throttling

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -2,7 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tenantcostclient",
-    srcs = ["tenant_side.go"],
+    srcs = [
+        "limiter.go",
+        "tenant_side.go",
+        "test_utils.go",
+        "token_bucket.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl/tenantcostclient",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,10 +19,12 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/log",
+        "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//errorspb",
     ],
 )
 
@@ -26,6 +33,7 @@ go_test(
     srcs = [
         "main_test.go",
         "tenant_side_test.go",
+        "token_bucket_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":tenantcostclient"],
@@ -50,6 +58,8 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
@@ -1,0 +1,205 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import (
+	"context"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// limiter is used to rate-limit KV requests according to a local token bucket.
+//
+// The Wait() method is called when a KV request requires RUs. The other methods
+// are used to adjust/reconfigure/replenish the local token bucket.
+type limiter struct {
+	timeSource timeutil.TimeSource
+	tb         tokenBucket
+	qp         *quotapool.AbstractPool
+
+	// Total (rounded) RU needed for all currently waiting requests (or requests
+	// that are in the process of being fulfilled).
+	// Only accessed using atomics.
+	waitingRU int64
+}
+
+// Initial settings for the local token bucket. They are used only until the
+// first TokenBucket request returns. We allow immediate use of the initial RUs
+// (we essentially borrow them and pay them back in the first TokenBucket
+// request). The intention is to avoid any throttling during start-up in normal
+// circumstances.
+const initialRUs = 10000
+const initialRate = 100
+
+func (l *limiter) Init(timeSource timeutil.TimeSource, notifyChan chan struct{}) {
+	*l = limiter{
+		timeSource: timeSource,
+	}
+
+	l.tb.Init(timeSource.Now(), notifyChan, initialRate, initialRUs)
+
+	onWaitStartFn := func(ctx context.Context, poolName string, r quotapool.Request) {
+		req := r.(*waitRequest)
+		// Account for the RUs, unless we already did in waitRequest.Acquire.
+		// This is necessary because Acquire is only called for the head of the
+		// queue.
+		if !req.waitingRUAccounted {
+			req.waitingRUAccounted = true
+			atomic.AddInt64(&l.waitingRU, req.neededCeil())
+		}
+	}
+	// We use OnWaitStartLocked because otherwise we have a race between the token
+	// bucket noticing that it can't fulfill a request, and AvailableTokens()
+	// accounting for the RUs that are waiting.
+	//
+	// We have a similar problem on finish, but the consequences of overcounting
+	// waiting RUs are not very problematic.
+	l.qp = quotapool.New(
+		"tenant-side-limiter", l,
+		quotapool.WithTimeSource(timeSource),
+		quotapool.OnWaitStart(onWaitStartFn),
+	)
+}
+
+func (l *limiter) Close() {
+	l.qp.Close("shutting down")
+}
+
+// Wait removes the needed RUs from the bucket, waiting as necessary until it is
+// possible.
+func (l *limiter) Wait(ctx context.Context, needed tenantcostmodel.RU) error {
+	r := newWaitRequest(needed)
+	defer putWaitRequest(r)
+
+	return l.qp.Acquire(ctx, r)
+}
+
+// AdjustTokens adds or removes tokens from the bucket. Tokens are added when we
+// receive more tokens from the host cluster. Tokens are removed when
+// consumption has occurred without Wait(): accounting for CPU usage and the
+// number of read bytes.
+func (l *limiter) AdjustTokens(now time.Time, delta tenantcostmodel.RU) {
+	if delta == 0 {
+		return
+	}
+	l.qp.Update(func(res quotapool.Resource) (shouldNotify bool) {
+		l.tb.AdjustTokens(now, delta)
+		// We notify the head of the queue if we added RUs, in which case that
+		// request might be allowed to go through earlier.
+		return delta > 0
+	})
+}
+
+// Reconfigure is used to call tokenBucket.Reconfigure under the pool's lock.
+func (l *limiter) Reconfigure(now time.Time, args tokenBucketReconfigureArgs) {
+	l.qp.Update(func(quotapool.Resource) (shouldNotify bool) {
+		l.tb.Reconfigure(now, args)
+		// Notify the head of the queue; the new configuration might allow that
+		// request to go through earlier.
+		return true
+	})
+}
+
+// AvailableTokens returns the current number of available RUs. This can be
+// negative if we accumulated debt or we have waiting requests.
+func (l *limiter) AvailableTokens(now time.Time) tenantcostmodel.RU {
+	var result tenantcostmodel.RU
+	l.qp.Update(func(quotapool.Resource) (shouldNotify bool) {
+		result = l.tb.AvailableTokens(now)
+		return false
+	})
+	// Subtract the RUs for currently waiting requests.
+	result -= tenantcostmodel.RU(atomic.LoadInt64(&l.waitingRU))
+	return result
+}
+
+// SetupNotification is used to call tokenBucket.SetupNotification under the
+// pool's lock.
+func (l *limiter) SetupNotification(now time.Time, threshold tenantcostmodel.RU) {
+	l.qp.Update(func(quotapool.Resource) (shouldNotify bool) {
+		l.tb.SetupNotification(now, threshold)
+		// We return true so that if there is a request waiting, TryToFulfill gets
+		// called again which may produce a notification.
+		return true
+	})
+}
+
+// waitRequest is used to wait for adequate resources in the tokenBucket.
+type waitRequest struct {
+	needed tenantcostmodel.RU
+
+	// waitingRUAccounted is true if we counted the needed RUs as "waiting RU".
+	// This flag is necessary because we want to account f
+	waitingRUAccounted bool
+}
+
+var _ quotapool.Request = (*waitRequest)(nil)
+
+var waitRequestSyncPool = sync.Pool{
+	New: func() interface{} { return new(waitRequest) },
+}
+
+// newWaitRequest allocates a waitRequest from the sync.Pool.
+// It should be returned with putWaitRequest.
+func newWaitRequest(needed tenantcostmodel.RU) *waitRequest {
+	r := waitRequestSyncPool.Get().(*waitRequest)
+	*r = waitRequest{needed: needed}
+	return r
+}
+
+func putWaitRequest(r *waitRequest) {
+	*r = waitRequest{}
+	waitRequestSyncPool.Put(r)
+}
+
+// neededCeil returns the amount of needed RUs, rounded up to an integer.
+func (req *waitRequest) neededCeil() int64 {
+	return int64(math.Ceil(float64(req.needed)))
+}
+
+// Acquire is part of quotapool.Request.
+func (req *waitRequest) Acquire(
+	ctx context.Context, res quotapool.Resource,
+) (fulfilled bool, tryAgainAfter time.Duration) {
+	l := res.(*limiter)
+	now := l.timeSource.Now()
+	fulfilled, tryAgainAfter = l.tb.TryToFulfill(now, req.needed)
+
+	if !fulfilled {
+		// We want to account for the waiting RU here (under the quotapool lock)
+		// rather than in the OnWaitStart callback. This is to ensure that the
+		// waiting RUs for the head of the queue are reliably reflected in the next
+		// call to AvailableTokens(). If it is not reflected, a low RU notification
+		// might effectively be ignored because it looks like we have enough RUs.
+		//
+		// The waitingRUAccounted flag ensures we don't count the same request
+		// multiple times.
+		if !req.waitingRUAccounted {
+			req.waitingRUAccounted = true
+			atomic.AddInt64(&l.waitingRU, req.neededCeil())
+		}
+	} else {
+		if req.waitingRUAccounted {
+			req.waitingRUAccounted = false
+			atomic.AddInt64(&l.waitingRU, -req.neededCeil())
+		}
+	}
+	return fulfilled, tryAgainAfter
+}
+
+// ShouldWait is part of quotapool.Request.
+func (req *waitRequest) ShouldWait() bool {
+	return true
+}

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/errorspb"
 )
 
 // TargetPeriodSetting is exported for testing purposes.
@@ -44,27 +45,81 @@ var CPUUsageAllowance = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+// mainLoopUpdateInterval is the period at which we collect CPU usage and
+// evaluate whether we need to send a new token request.
+const mainLoopUpdateInterval = 1 * time.Second
+
+// movingAvgFactor is the weight applied to a new "sample" of RU usage (with one
+// sample per mainLoopUpdateInterval).
+//
+// If we want a factor of 0.5 per second, this should be:
+//   0.5^(1 second / mainLoopUpdateInterval)
+const movingAvgFactor = 0.5
+
+// We request more tokens when the available RUs go below a threshold. The
+// threshold is a fraction of the last granted RUs.
+const notifyFraction = 0.1
+
+// When we trickle RUs over a period of time, we request more tokens a bit
+// before that period runs out. This "anticipation" should be more than what we
+// expect the RTT of a token bucket request to be in practice.
+const anticipation = time.Second
+
+// If we have less than this many RUs to report, extend the reporting period to
+// reduce load on the host cluster.
+const consumptionReportingThreshold = 100
+
+// The extended reporting period is this factor times the normal period.
+const extendedReportingPeriodFactor = 4
+
+func newTenantSideCostController(
+	st *cluster.Settings,
+	tenantID roachpb.TenantID,
+	provider kvtenant.TokenBucketProvider,
+	timeSource timeutil.TimeSource,
+	testInstr TestInstrumentation,
+) (multitenant.TenantSideCostController, error) {
+	if tenantID == roachpb.SystemTenantID {
+		return nil, errors.AssertionFailedf("cost controller can't be used for system tenant")
+	}
+	c := &tenantSideCostController{
+		timeSource:      timeSource,
+		testInstr:       testInstr,
+		settings:        st,
+		tenantID:        tenantID,
+		provider:        provider,
+		responseChan:    make(chan *roachpb.TokenBucketResponse, 1),
+		lowRUNotifyChan: make(chan struct{}, 1),
+	}
+	c.limiter.Init(c.timeSource, c.lowRUNotifyChan)
+
+	// TODO(radu): support changing the tenant configuration at runtime.
+	c.costCfg = tenantcostmodel.ConfigFromSettings(&st.SV)
+	return c, nil
+}
+
 // NewTenantSideCostController creates an object which implements the
 // server.TenantSideCostController interface.
 func NewTenantSideCostController(
 	st *cluster.Settings, tenantID roachpb.TenantID, provider kvtenant.TokenBucketProvider,
 ) (multitenant.TenantSideCostController, error) {
-	if tenantID == roachpb.SystemTenantID {
-		return nil, errors.AssertionFailedf("cost controller can't be used for system tenant")
-	}
-	tc := &tenantSideCostController{
-		settings: st,
-		tenantID: tenantID,
-		provider: provider,
-	}
-	tc.mu.costCfg = tenantcostmodel.ConfigFromSettings(&st.SV)
-	sv := &st.SV
-	tenantcostmodel.SetOnChange(sv, func(context.Context) {
-		tc.mu.Lock()
-		defer tc.mu.Unlock()
-		tc.mu.costCfg = tenantcostmodel.ConfigFromSettings(sv)
-	})
-	return tc, nil
+	return newTenantSideCostController(
+		st, tenantID, provider,
+		timeutil.DefaultTimeSource{},
+		nil, /* testInstr */
+	)
+}
+
+// TestingTenantSideCostController is a testing variant of
+// NewTenantSideCostController which allows using a specified TimeSource.
+func TestingTenantSideCostController(
+	st *cluster.Settings,
+	tenantID roachpb.TenantID,
+	provider kvtenant.TokenBucketProvider,
+	timeSource timeutil.TimeSource,
+	testInstr TestInstrumentation,
+) (multitenant.TenantSideCostController, error) {
+	return newTenantSideCostController(st, tenantID, provider, timeSource, testInstr)
 }
 
 func init() {
@@ -72,15 +127,78 @@ func init() {
 }
 
 type tenantSideCostController struct {
-	settings *cluster.Settings
-	tenantID roachpb.TenantID
-	provider kvtenant.TokenBucketProvider
+	timeSource timeutil.TimeSource
+	testInstr  TestInstrumentation
+	settings   *cluster.Settings
+	costCfg    tenantcostmodel.Config
+	tenantID   roachpb.TenantID
+	provider   kvtenant.TokenBucketProvider
+	limiter    limiter
+	stopper    *stop.Stopper
+	cpuSecsFn  multitenant.CPUSecsFn
 
 	mu struct {
 		syncutil.Mutex
 
-		costCfg     tenantcostmodel.Config
 		consumption roachpb.TenantConsumption
+	}
+
+	// lowRUNotifyChan is used when the number of available RUs is running low and
+	// we need to send an early token bucket request.
+	lowRUNotifyChan chan struct{}
+
+	// responseChan is used to receive results from token bucket requests, which
+	// are run in a separate goroutine. A nil response indicates an error.
+	responseChan chan *roachpb.TokenBucketResponse
+
+	// run contains the state that is updated by the main loop.
+	run struct {
+		now         time.Time
+		cpuSecs     float64
+		consumption roachpb.TenantConsumption
+
+		// TargetPeriodSetting value at the last update.
+		targetPeriod time.Duration
+
+		// initialRequestCompleted is set to true when the first token bucket
+		// request completes successfully.
+		initialRequestCompleted bool
+
+		// requestInProgress is true if we are in the process of sending a request;
+		// it gets set to false when we process the response (in the main loop),
+		// even in error cases.
+		requestInProgress bool
+
+		// requestNeedsRetry is set if the last token bucket request encountered an
+		// error. This triggers a retry attempt on the next tick.
+		//
+		// Note: requestNeedsRetry and requestInProgress are never true at the same
+		// time.
+		requestNeedsRetry bool
+
+		// notificationReceivedDuringRequest is set if we received a "low RU"
+		// notification while a request was in progress.
+		notificationReceivedDuringRequest bool
+
+		lastRequestTime         time.Time
+		lastReportedConsumption roachpb.TenantConsumption
+
+		lastDeadline time.Time
+		lastRate     float64
+
+		// When we obtain tokens that are throttled over a period of time, we set up
+		// a low RU notification only when we get close to that period of time
+		// elapsing.
+		setupNotificationTimer     timeutil.TimerI
+		setupNotificationCh        <-chan time.Time
+		setupNotificationThreshold tenantcostmodel.RU
+
+		// avgRUPerSec is an exponentially-weighted moving average of the RU
+		// consumption per second; used to estimate the RU requirements for the next
+		// request.
+		avgRUPerSec float64
+		// lastSecRU is the consumption.RU value when avgRUPerSec was last updated.
+		avgRUPerSecLastRU float64
 	}
 }
 
@@ -90,60 +208,294 @@ var _ multitenant.TenantSideCostController = (*tenantSideCostController)(nil)
 func (c *tenantSideCostController) Start(
 	ctx context.Context, stopper *stop.Stopper, cpuSecsFn multitenant.CPUSecsFn,
 ) error {
+	c.stopper = stopper
+	c.cpuSecsFn = cpuSecsFn
 	return stopper.RunAsyncTask(ctx, "cost-controller", func(ctx context.Context) {
-		c.mainLoop(ctx, stopper, cpuSecsFn)
+		c.mainLoop(ctx)
 	})
 }
 
-func (c *tenantSideCostController) mainLoop(
-	ctx context.Context, stopper *stop.Stopper, cpuSecsFn multitenant.CPUSecsFn,
+func (c *tenantSideCostController) initRunState(ctx context.Context) {
+	c.run.targetPeriod = TargetPeriodSetting.Get(&c.settings.SV)
+
+	now := c.timeSource.Now()
+	c.run.now = now
+	c.run.cpuSecs = c.cpuSecsFn(ctx)
+	c.run.lastRequestTime = now
+	c.run.avgRUPerSec = initialRUs / c.run.targetPeriod.Seconds()
+}
+
+// updateRunState is called whenever the main loop awakens and accounts for the
+// CPU usage in the interim.
+func (c *tenantSideCostController) updateRunState(ctx context.Context) {
+	c.run.targetPeriod = TargetPeriodSetting.Get(&c.settings.SV)
+
+	newTime := c.timeSource.Now()
+	newCPUSecs := c.cpuSecsFn(ctx)
+
+	// Update CPU consumption.
+
+	deltaCPU := newCPUSecs - c.run.cpuSecs
+
+	// Subtract any allowance that we consider free background usage.
+	if deltaTime := newTime.Sub(c.run.now); deltaTime > 0 {
+		deltaCPU -= CPUUsageAllowance.Get(&c.settings.SV).Seconds() * deltaTime.Seconds()
+	}
+	if deltaCPU < 0 {
+		deltaCPU = 0
+	}
+	cpuRU := deltaCPU * float64(c.costCfg.PodCPUSecond)
+
+	c.mu.Lock()
+	c.mu.consumption.SQLPodsCPUSeconds += deltaCPU
+	c.mu.consumption.RU += cpuRU
+	newConsumption := c.mu.consumption
+	c.mu.Unlock()
+
+	c.run.now = newTime
+	c.run.cpuSecs = newCPUSecs
+	c.run.consumption = newConsumption
+
+	// TODO(radu): figure out how to "smooth out" this debt over a longer period
+	// (so we don't have periodic stalls).
+	c.limiter.AdjustTokens(newTime, -tenantcostmodel.RU(cpuRU))
+}
+
+// updateAvgRUPerSec is called exactly once per mainLoopUpdateInterval.
+func (c *tenantSideCostController) updateAvgRUPerSec() {
+	delta := c.run.consumption.RU - c.run.avgRUPerSecLastRU
+	c.run.avgRUPerSec = movingAvgFactor*c.run.avgRUPerSec + (1-movingAvgFactor)*delta
+	c.run.avgRUPerSecLastRU = c.run.consumption.RU
+}
+
+// shouldReportConsumption decides if it's time to send a token bucket request
+// to report consumption.
+func (c *tenantSideCostController) shouldReportConsumption() bool {
+	if c.run.requestInProgress {
+		return false
+	}
+
+	timeSinceLastRequest := c.run.now.Sub(c.run.lastRequestTime)
+	if timeSinceLastRequest >= c.run.targetPeriod {
+		consumptionToReport := c.run.consumption.RU - c.run.lastReportedConsumption.RU
+		if consumptionToReport >= consumptionReportingThreshold {
+			return true
+		}
+		if timeSinceLastRequest >= extendedReportingPeriodFactor*c.run.targetPeriod {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *tenantSideCostController) sendTokenBucketRequest(ctx context.Context) {
+	deltaConsumption := c.run.consumption
+	deltaConsumption.Sub(&c.run.lastReportedConsumption)
+
+	var requested float64
+
+	if !c.run.initialRequestCompleted {
+		requested = initialRUs
+	} else {
+		// Request what we expect to need over the next target period.
+		requested = c.run.avgRUPerSec * c.run.targetPeriod.Seconds()
+
+		// Adjust by the currently available amount. If we are in debt, we request
+		// more to cover the debt.
+		requested -= float64(c.limiter.AvailableTokens(c.run.now))
+		if requested < 0 {
+			// We don't need more RUs right now, but we still want to report
+			// consumption.
+			requested = 0
+		}
+	}
+
+	req := roachpb.TokenBucketRequest{
+		TenantID: c.tenantID.ToUint64(),
+		// TODO(radu): populate instance ID.
+		InstanceID:                  1,
+		ConsumptionSinceLastRequest: deltaConsumption,
+		RequestedRU:                 requested,
+		TargetRequestPeriod:         c.run.targetPeriod,
+	}
+
+	c.run.lastRequestTime = c.run.now
+	// TODO(radu): in case of an error, we undercount some consumption.
+	c.run.lastReportedConsumption = c.run.consumption
+	c.run.requestInProgress = true
+
+	ctx, _ = c.stopper.WithCancelOnQuiesce(ctx)
+	err := c.stopper.RunAsyncTask(ctx, "token-bucket-request", func(ctx context.Context) {
+		if log.V(1) {
+			log.Infof(ctx, "issuing TokenBucket: %s\n", req.String())
+		}
+		resp, err := c.provider.TokenBucket(ctx, &req)
+		if err != nil {
+			// Don't log any errors caused by the stopper canceling the context.
+			if !errors.Is(err, context.Canceled) {
+				log.Warningf(ctx, "TokenBucket RPC error: %v", err)
+			}
+			resp = nil
+		} else if (resp.Error != errorspb.EncodedError{}) {
+			// This is a "logic" error which indicates a configuration problem on the
+			// host side. We will keep retrying periodically.
+			err := errors.DecodeError(ctx, resp.Error)
+			log.Warningf(ctx, "TokenBucket error: %v", err)
+			resp = nil
+		}
+		c.responseChan <- resp
+	})
+	if err != nil {
+		// We are shutting down and could not send the request.
+		c.responseChan <- nil
+	}
+}
+
+func (c *tenantSideCostController) handleTokenBucketResponse(
+	ctx context.Context, resp *roachpb.TokenBucketResponse,
 ) {
-	ticker := time.NewTicker(TargetPeriodSetting.Get(&c.settings.SV))
+	if log.V(1) {
+		log.Infof(ctx, "TokenBucket response: %g RUs over %s", resp.GrantedRU, resp.TrickleDuration)
+	}
+
+	if !c.run.initialRequestCompleted {
+		c.run.initialRequestCompleted = true
+		// This is the first successful request. Take back the initial RUs that we
+		// used to pre-fill the bucket.
+		c.limiter.AdjustTokens(c.run.now, -initialRUs)
+	}
+
+	granted := resp.GrantedRU
+	if granted == 0 {
+		// We must have not requested any more RUs; nothing to do.
+		//
+		// It is possible that we got a low RU notification while the request was in
+		// flight. If that is the case, we must send another request.
+		if c.run.notificationReceivedDuringRequest {
+			c.run.notificationReceivedDuringRequest = false
+			c.sendTokenBucketRequest(ctx)
+		}
+		return
+	}
+	// It doesn't matter if we received a notification; we are going to
+	// reconfigure the bucket and set up a new notification as needed.
+	c.run.notificationReceivedDuringRequest = false
+
+	if !c.run.lastDeadline.IsZero() {
+		// If last request came with a trickle duration, we may have RUs that were
+		// not made available to the bucket yet; throw them together with the newly
+		// granted RUs.
+		if since := c.run.lastDeadline.Sub(c.run.now); since > 0 {
+			granted += c.run.lastRate * since.Seconds()
+		}
+	}
+
+	if c.run.setupNotificationTimer != nil {
+		c.run.setupNotificationTimer.Stop()
+		c.run.setupNotificationTimer = nil
+		c.run.setupNotificationCh = nil
+	}
+
+	notifyThreshold := tenantcostmodel.RU(granted * notifyFraction)
+	var cfg tokenBucketReconfigureArgs
+	if resp.TrickleDuration == 0 {
+		// We received a batch of tokens to use as needed. Set up the token bucket
+		// to notify us when the tokens are running low.
+		cfg.TokenAdjustment = tenantcostmodel.RU(granted)
+		// TODO(radu): if we don't get more tokens in time, fall back to a "backup"
+		// rate.
+		cfg.NewRate = 0
+		cfg.NotifyThreshold = notifyThreshold
+
+		c.run.lastDeadline = time.Time{}
+	} else {
+		// We received a batch of tokens that can only be used over the
+		// TrickleDuration. Set up the token bucket to notify us a bit before this
+		// period elapses (unless we accumulate enough unused tokens, in which case
+		// we get notified when the tokens are running low).
+		deadline := c.run.now.Add(resp.TrickleDuration)
+
+		cfg.NewRate = tenantcostmodel.RU(granted / resp.TrickleDuration.Seconds())
+
+		timerDuration := resp.TrickleDuration - anticipation
+		if timerDuration <= 0 {
+			timerDuration = (resp.TrickleDuration + 1) / 2
+		}
+
+		c.run.setupNotificationTimer = c.timeSource.NewTimer()
+		c.run.setupNotificationTimer.Reset(timerDuration)
+		c.run.setupNotificationCh = c.run.setupNotificationTimer.Ch()
+		c.run.setupNotificationThreshold = notifyThreshold
+
+		c.run.lastDeadline = deadline
+	}
+	c.run.lastRate = float64(cfg.NewRate)
+	c.limiter.Reconfigure(c.run.now, cfg)
+}
+
+func (c *tenantSideCostController) mainLoop(ctx context.Context) {
+	interval := mainLoopUpdateInterval
+	// Make sure the interval is never larger than the target request period. This
+	// is useful for tests which set a very small period.
+	if targetPeriod := TargetPeriodSetting.Get(&c.settings.SV); targetPeriod < interval {
+		interval = targetPeriod
+	}
+	ticker := c.timeSource.NewTicker(interval)
 	defer ticker.Stop()
+	tickerCh := ticker.Ch()
 
-	lastTime, lastCPUSecs := timeutil.Now(), cpuSecsFn(ctx)
-	var lastConsumption roachpb.TenantConsumption
+	c.initRunState(ctx)
+	c.sendTokenBucketRequest(ctx)
 
+	// The main loop should never block. The remote requests run in separate
+	// goroutines.
 	for {
 		select {
-		case <-ticker.C:
-			newTime, newCPUSecs := timeutil.Now(), cpuSecsFn(ctx)
-
-			c.mu.Lock()
-			newConsumption := c.mu.consumption
-			configPodCPUSecond := c.mu.costCfg.PodCPUSecond
-			c.mu.Unlock()
-
-			deltaConsumption := newConsumption
-			deltaConsumption.Sub(&lastConsumption)
-
-			deltaCPU := newCPUSecs - lastCPUSecs
-
-			// Subtract any allowance that we consider free background usage.
-			if deltaTime := newTime.Sub(lastTime); deltaTime > 0 {
-				deltaCPU -= CPUUsageAllowance.Get(&c.settings.SV).Seconds() * deltaTime.Seconds()
+		case <-tickerCh:
+			c.updateRunState(ctx)
+			c.updateAvgRUPerSec()
+			if c.run.requestNeedsRetry || c.shouldReportConsumption() {
+				c.run.requestNeedsRetry = false
+				c.sendTokenBucketRequest(ctx)
+			}
+			if c.testInstr != nil {
+				c.testInstr.Event(c.run.now, TickProcessed)
 			}
 
-			deltaConsumption.SQLPodsCPUSeconds = 0
-			if deltaCPU > 0 {
-				deltaConsumption.SQLPodsCPUSeconds = deltaCPU
-				deltaConsumption.RU += deltaCPU * float64(configPodCPUSecond)
+		case resp := <-c.responseChan:
+			c.run.requestInProgress = false
+			if resp != nil {
+				c.updateRunState(ctx)
+				c.handleTokenBucketResponse(ctx, resp)
+				if c.testInstr != nil {
+					c.testInstr.Event(c.run.now, TokenBucketResponseProcessed)
+				}
+			} else {
+				// A nil response indicates a failure (which would have been logged).
+				c.run.requestNeedsRetry = true
 			}
 
-			lastTime, lastCPUSecs, lastConsumption = newTime, newCPUSecs, newConsumption
+		case <-c.run.setupNotificationCh:
+			c.run.setupNotificationTimer = nil
+			c.run.setupNotificationCh = nil
 
-			req := roachpb.TokenBucketRequest{
-				TenantID: c.tenantID.ToUint64(),
-				// TODO(radu): populate instance ID.
-				InstanceID:                  1,
-				ConsumptionSinceLastRequest: deltaConsumption,
+			c.updateRunState(ctx)
+			c.limiter.SetupNotification(c.run.now, c.run.setupNotificationThreshold)
+
+		case <-c.lowRUNotifyChan:
+			c.updateRunState(ctx)
+			if !c.run.requestInProgress {
+				c.sendTokenBucketRequest(ctx)
+			} else {
+				c.run.notificationReceivedDuringRequest = true
 			}
-			_, err := c.provider.TokenBucket(ctx, &req)
-			if err != nil {
-				log.Warningf(ctx, "TokenBucket error: %v", err)
+			if c.testInstr != nil {
+				c.testInstr.Event(c.run.now, LowRUNotification)
 			}
 
-		case <-stopper.ShouldQuiesce():
+		case <-c.stopper.ShouldQuiesce():
+			c.limiter.Close()
 			// TODO(radu): send one last request to update consumption.
 			return
 		}
@@ -155,27 +507,31 @@ func (c *tenantSideCostController) mainLoop(
 func (c *tenantSideCostController) OnRequestWait(
 	ctx context.Context, info tenantcostmodel.RequestInfo,
 ) error {
-	return nil
+	return c.limiter.Wait(ctx, c.costCfg.RequestCost(info))
 }
 
 // OnResponse is part of the multitenant.TenantSideBatchInterceptor interface.
 //
-// TODO(radu): we don't get a callback in error cases (we should return the
-// RequestCost to the bucket).
+// TODO(radu): we don't get a callback in error cases (ideally we should return
+// the RequestCost to the bucket).
 func (c *tenantSideCostController) OnResponse(
 	ctx context.Context, req tenantcostmodel.RequestInfo, resp tenantcostmodel.ResponseInfo,
 ) {
+	if resp.ReadBytes() > 0 {
+		c.limiter.AdjustTokens(c.timeSource.Now(), -c.costCfg.ResponseCost(resp))
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if isWrite, writeBytes := req.IsWrite(); isWrite {
 		c.mu.consumption.WriteRequests++
 		c.mu.consumption.WriteBytes += uint64(writeBytes)
-		c.mu.consumption.RU += float64(c.mu.costCfg.KVWriteCost(writeBytes))
+		c.mu.consumption.RU += float64(c.costCfg.KVWriteCost(writeBytes))
 	} else {
 		c.mu.consumption.ReadRequests++
 		readBytes := resp.ReadBytes()
 		c.mu.consumption.ReadBytes += uint64(readBytes)
-		c.mu.consumption.RU += float64(c.mu.costCfg.KVReadCost(readBytes))
+		c.mu.consumption.RU += float64(c.costCfg.KVReadCost(readBytes))
 	}
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -10,9 +10,9 @@ package tenantcostclient_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,7 +32,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 // TestDataDriven tests the tenant-side cost controller in an isolated setting.
@@ -47,16 +49,18 @@ func TestDataDriven(t *testing.T) {
 		defer ts.stop()
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			args := parseArgs(t, d)
 			fn, ok := testStateCommands[d.Cmd]
 			if !ok {
 				d.Fatalf(t, "unknown command %s", d.Cmd)
 			}
-			return fn(&ts, t, d)
+			return fn(&ts, t, d, args)
 		})
 	})
 }
 
 type testState struct {
+	timeSrc    *timeutil.ManualTime
 	settings   *cluster.Settings
 	stopper    *stop.Stopper
 	provider   *testProvider
@@ -64,22 +68,60 @@ type testState struct {
 
 	// cpuUsage, accessed using atomic.
 	cpuUsage time.Duration
+
+	requestDoneCh map[string]chan struct{}
+
+	eventsCh chan event
 }
+
+type event struct {
+	time time.Time
+	typ  tenantcostclient.TestEventType
+}
+
+var _ tenantcostclient.TestInstrumentation = (*testState)(nil)
+
+// Event is part of tenantcostclient.TestInstrumentation.
+func (ts *testState) Event(now time.Time, typ tenantcostclient.TestEventType) {
+	ev := event{
+		time: now,
+		typ:  typ,
+	}
+	select {
+	case ts.eventsCh <- ev:
+	default:
+		panic("events channel full")
+	}
+}
+
+const timeFormat = "15:04:05.000"
+
+var t0 = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+const timeout = 10 * time.Second
 
 func (ts *testState) start(t *testing.T) {
 	ctx := context.Background()
 
+	ts.requestDoneCh = make(map[string]chan struct{})
+	ts.eventsCh = make(chan event, 10000)
+
+	ts.timeSrc = timeutil.NewManualTime(t0)
+
 	ts.settings = cluster.MakeTestingClusterSettings()
-	tenantcostclient.TargetPeriodSetting.Override(ctx, &ts.settings.SV, time.Millisecond)
+	// Fix settings so that the defaults can be changed without updating the test.
+	tenantcostclient.TargetPeriodSetting.Override(ctx, &ts.settings.SV, 10*time.Second)
 	tenantcostclient.CPUUsageAllowance.Override(ctx, &ts.settings.SV, 0)
 
 	ts.stopper = stop.NewStopper()
 	var err error
 	ts.provider = newTestProvider()
-	ts.controller, err = tenantcostclient.NewTenantSideCostController(
+	ts.controller, err = tenantcostclient.TestingTenantSideCostController(
 		ts.settings,
 		roachpb.MakeTenantID(5),
 		ts.provider,
+		ts.timeSrc,
+		ts,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -97,16 +139,16 @@ func (ts *testState) stop() {
 	ts.stopper.Stop(context.Background())
 }
 
-var testStateCommands = map[string]func(*testState, *testing.T, *datadriven.TestData) string{
-	"read":  (*testState).read,
-	"write": (*testState).write,
-	"cpu":   (*testState).cpu,
-	"usage": (*testState).usage,
+type cmdArgs struct {
+	bytes int64
+	label string
 }
 
-func bytesArg(t *testing.T, d *datadriven.TestData) int64 {
+func parseArgs(t *testing.T, d *datadriven.TestData) cmdArgs {
+	var res cmdArgs
 	for _, args := range d.CmdArgs {
-		if args.Key == "bytes" {
+		switch args.Key {
+		case "bytes":
 			if len(args.Vals) != 1 {
 				d.Fatalf(t, "expected one value for bytes")
 			}
@@ -114,34 +156,239 @@ func bytesArg(t *testing.T, d *datadriven.TestData) int64 {
 			if err != nil {
 				d.Fatalf(t, "invalid bytes value")
 			}
-			return int64(val)
+			res.bytes = int64(val)
+
+		case "label":
+			if len(args.Vals) != 1 || args.Vals[0] == "" {
+				d.Fatalf(t, "label requires a value")
+			}
+			res.label = args.Vals[0]
 		}
 	}
-	d.Fatalf(t, "bytes argument required")
-	return 0
+	return res
 }
 
-func (ts *testState) read(t *testing.T, d *datadriven.TestData) string {
-	reqInfo := tenantcostmodel.TestingRequestInfo(false /* isWrite */, 0 /* writeBytes */)
-	if err := ts.controller.OnRequestWait(context.Background(), reqInfo); err != nil {
-		d.Fatalf(t, "%v", err)
+var testStateCommands = map[string]func(
+	*testState, *testing.T, *datadriven.TestData, cmdArgs,
+) string{
+	"read":           (*testState).read,
+	"write":          (*testState).write,
+	"await":          (*testState).await,
+	"not-completed":  (*testState).notCompleted,
+	"advance":        (*testState).advance,
+	"wait-for-event": (*testState).waitForEvent,
+	"timers":         (*testState).timers,
+	"cpu":            (*testState).cpu,
+	"usage":          (*testState).usage,
+	"throttle":       (*testState).throttle,
+}
+
+func (ts *testState) fireRequest(
+	t *testing.T, reqInfo tenantcostmodel.RequestInfo, respInfo tenantcostmodel.ResponseInfo,
+) chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		ctx := context.Background()
+		if err := ts.controller.OnRequestWait(ctx, reqInfo); err != nil {
+			t.Errorf("OnRequestWait error: %v", err)
+		}
+		ts.controller.OnResponse(ctx, reqInfo, respInfo)
+		close(ch)
+	}()
+	return ch
+}
+
+func (ts *testState) syncRequest(
+	t *testing.T,
+	d *datadriven.TestData,
+	reqInfo tenantcostmodel.RequestInfo,
+	respInfo tenantcostmodel.ResponseInfo,
+) {
+	select {
+	case <-ts.fireRequest(t, reqInfo, respInfo):
+	case <-time.After(timeout):
+		d.Fatalf(t, "request timed out")
 	}
-	respInfo := tenantcostmodel.TestingResponseInfo(bytesArg(t, d))
-	ts.controller.OnResponse(context.Background(), reqInfo, respInfo)
+}
+
+func (ts *testState) asyncRequest(
+	t *testing.T,
+	d *datadriven.TestData,
+	reqInfo tenantcostmodel.RequestInfo,
+	respInfo tenantcostmodel.ResponseInfo,
+	label string,
+) {
+	if _, ok := ts.requestDoneCh[label]; ok {
+		d.Fatalf(t, "label %v already in use", label)
+	}
+
+	ts.requestDoneCh[label] = ts.fireRequest(t, reqInfo, respInfo)
+}
+
+// request simulates processing a read or write. If a label is provided, the
+// request is started in the background.
+func (ts *testState) request(
+	t *testing.T, d *datadriven.TestData, isWrite bool, args cmdArgs,
+) string {
+	var writeBytes, readBytes int64
+	if isWrite {
+		writeBytes = args.bytes
+	} else {
+		readBytes = args.bytes
+	}
+	reqInfo := tenantcostmodel.TestingRequestInfo(isWrite, writeBytes)
+	respInfo := tenantcostmodel.TestingResponseInfo(readBytes)
+	if args.label == "" {
+		ts.syncRequest(t, d, reqInfo, respInfo)
+	} else {
+		ts.asyncRequest(t, d, reqInfo, respInfo, args.label)
+	}
 	return ""
 }
 
-func (ts *testState) write(t *testing.T, d *datadriven.TestData) string {
-	reqInfo := tenantcostmodel.TestingRequestInfo(true /* isWrite */, bytesArg(t, d))
-	if err := ts.controller.OnRequestWait(context.Background(), reqInfo); err != nil {
-		d.Fatalf(t, "%v", err)
+// read simulates processing a read. If a label is provided, the request is
+// started in the background.
+func (ts *testState) read(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	return ts.request(t, d, false /* isWrite */, args)
+}
+
+// write simulates processing a write. If a label is provided, the request is
+// started in the background.
+func (ts *testState) write(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	return ts.request(t, d, true /* isWrite */, args)
+}
+
+// await waits until the given request completes.
+func (ts *testState) await(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	ch, ok := ts.requestDoneCh[args.label]
+	if !ok {
+		d.Fatalf(t, "unknown label %q", args.label)
 	}
-	respInfo := tenantcostmodel.TestingResponseInfo(0 /* readBytes */)
-	ts.controller.OnResponse(context.Background(), reqInfo, respInfo)
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		d.Fatalf(t, "await(%q) timed out", args.label)
+	}
+	delete(ts.requestDoneCh, args.label)
 	return ""
 }
 
-func (ts *testState) cpu(t *testing.T, d *datadriven.TestData) string {
+// notCompleted verifies that the request with the given label has not completed
+// yet.
+func (ts *testState) notCompleted(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	ch, ok := ts.requestDoneCh[args.label]
+	if !ok {
+		d.Fatalf(t, "unknown label %v", args.label)
+	}
+	// Sleep a bit to give a chance for a bug to manifest.
+	time.Sleep(1 * time.Millisecond)
+	select {
+	case <-ch:
+		d.Fatalf(t, "request %v completed unexpectedly", args.label)
+	default:
+	}
+	return ""
+}
+
+// advance advances the clock by the provided duration and returns the new
+// current time.
+//
+//  advance
+//  2s
+//  ----
+//  00:00:02.000
+//
+func (ts *testState) advance(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	dur, err := time.ParseDuration(d.Input)
+	if err != nil {
+		d.Fatalf(t, "failed to parse input as duration: %v", err)
+	}
+	ts.timeSrc.Advance(dur)
+	return ts.timeSrc.Now().Format(timeFormat)
+}
+
+// waitForEvent waits until the tenant controller reports the given event type,
+// at the current time.
+func (ts *testState) waitForEvent(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	typs := map[string]tenantcostclient.TestEventType{
+		"tick":                  tenantcostclient.TickProcessed,
+		"low-ru":                tenantcostclient.LowRUNotification,
+		"token-bucket-response": tenantcostclient.TokenBucketResponseProcessed,
+	}
+	typ, ok := typs[d.Input]
+	if !ok {
+		d.Fatalf(t, "unknown event type %s (supported types: %v)", d.Input, typs)
+	}
+
+	now := ts.timeSrc.Now()
+	for {
+		select {
+		case ev := <-ts.eventsCh:
+			if ev.time == now && ev.typ == typ {
+				return ""
+			}
+			// Drop the event.
+
+		case <-time.After(timeout):
+			d.Fatalf(t, "did not receive event %s", d.Input)
+		}
+	}
+}
+
+// timers waits for the set of open timers to match the expected output.
+// timers is critical to avoid synchronization problems in testing. The command
+// outputs the set of timers in increasing order with each timer's deadline on
+// its own line.
+//
+// The following example would wait for there to be two outstanding timers at
+// 00:00:01.000 and 00:00:02.000.
+//
+//  timers
+//  ----
+//  00:00:01.000
+//  00:00:02.000
+//
+func (ts *testState) timers(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	exp := strings.TrimSpace(d.Expected)
+	if err := testutils.SucceedsSoonError(func() error {
+		got := timesToStrings(ts.timeSrc.Timers())
+		gotStr := strings.Join(got, "\n")
+		if gotStr != exp {
+			return errors.Errorf("got: %q, exp: %q", gotStr, exp)
+		}
+		return nil
+	}); err != nil {
+		d.Fatalf(t, "failed to find expected timers: %v", err)
+	}
+	return d.Expected
+}
+
+func timesToStrings(times []time.Time) []string {
+	strs := make([]string, len(times))
+	for i, t := range times {
+		strs[i] = t.Format(timeFormat)
+	}
+	return strs
+}
+
+func (ts *testState) throttle(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	var rate float64
+	if d.Input != "disable" {
+		var err error
+		rate, err = strconv.ParseFloat(d.Input, 64)
+		if err != nil {
+			d.Fatalf(t, "expected float rate or 'disable'")
+		}
+	}
+	ts.provider.mu.Lock()
+	defer ts.provider.mu.Unlock()
+	ts.provider.mu.throttlingRate = rate
+	return ""
+}
+
+// cpu adds CPU usage which will be observed by the controller on the next main
+// loop tick.
+func (ts *testState) cpu(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
 	duration, err := time.ParseDuration(d.Input)
 	if err != nil {
 		d.Fatalf(t, "error parsing cpu duration: %v", err)
@@ -150,8 +397,24 @@ func (ts *testState) cpu(t *testing.T, d *datadriven.TestData) string {
 	return ""
 }
 
-func (ts *testState) usage(t *testing.T, d *datadriven.TestData) string {
-	c := ts.provider.waitForConsumption()
+// usage advances the clock until the latest consumption is reported and prints
+// out the latest consumption.
+func (ts *testState) usage(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	stopCh := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				ts.timeSrc.Advance(10 * time.Second)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+	defer close(stopCh)
+
+	c := ts.provider.waitForConsumption(t)
 	return fmt.Sprintf(""+
 		"RU:  %.2f\n"+
 		"Reads:  %d requests (%d bytes)\n"+
@@ -171,6 +434,10 @@ type testProvider struct {
 	mu struct {
 		syncutil.Mutex
 		consumption roachpb.TenantConsumption
+
+		// If zero, the provider always grants RUs immediately. If non-zero, the
+		// provider grants RUs at this rate.
+		throttlingRate float64
 	}
 	recvOnRequest chan struct{}
 }
@@ -184,20 +451,25 @@ func newTestProvider() *testProvider {
 }
 
 // waitForRequest waits until the next TokenBucket request.
-func (tp *testProvider) waitForRequest() {
-	// Try to send through the unbuffered channel. This will block until
-	// TokenBucket is called.
-	tp.recvOnRequest <- struct{}{}
+func (tp *testProvider) waitForRequest(t *testing.T) {
+	t.Helper()
+	// Try to send through the unbuffered channel, which blocks until TokenBucket
+	// is called.
+	select {
+	case tp.recvOnRequest <- struct{}{}:
+	case <-time.After(timeout):
+		t.Fatal("did not receive request")
+	}
 }
 
 // waitForConsumption waits for the next TokenBucket request and returns the
 // total consumption.
-func (tp *testProvider) waitForConsumption() roachpb.TenantConsumption {
-	tp.waitForRequest()
+func (tp *testProvider) waitForConsumption(t *testing.T) roachpb.TenantConsumption {
+	tp.waitForRequest(t)
 	// it is possible that the TokenBucket request was in the process of being
 	// prepared; we have to wait for another one to make sure the latest
 	// consumption is incorporated.
-	tp.waitForRequest()
+	tp.waitForRequest(t)
 	tp.mu.Lock()
 	defer tp.mu.Unlock()
 	return tp.mu.consumption
@@ -214,7 +486,18 @@ func (tp *testProvider) TokenBucket(
 	default:
 	}
 	tp.mu.consumption.Add(&in.ConsumptionSinceLastRequest)
-	return &roachpb.TokenBucketResponse{}, nil
+	res := &roachpb.TokenBucketResponse{}
+
+	res.GrantedRU = in.RequestedRU
+	if rate := tp.mu.throttlingRate; rate > 0 {
+		res.TrickleDuration = time.Duration(in.RequestedRU / rate * float64(time.Second))
+		if res.TrickleDuration > in.TargetRequestPeriod {
+			res.GrantedRU *= in.TargetRequestPeriod.Seconds() / res.TrickleDuration.Seconds()
+			res.TrickleDuration = in.TargetRequestPeriod
+		}
+	}
+
+	return res, nil
 }
 
 // TestConsumption verifies consumption reporting from a tenant server process.
@@ -248,11 +531,11 @@ func TestConsumption(t *testing.T) {
 	// test a few times, since background requests can trick the test into
 	// passing.
 	for repeat := 0; repeat < 5; repeat++ {
-		beforeWrite := testProvider.waitForConsumption()
+		beforeWrite := testProvider.waitForConsumption(t)
 		r.Exec(t, "INSERT INTO t SELECT repeat('1234567890', 1024) FROM generate_series(1, 10) AS g(i)")
 		const expectedBytes = 10 * 10 * 1024
 
-		afterWrite := testProvider.waitForConsumption()
+		afterWrite := testProvider.waitForConsumption(t)
 		delta := afterWrite
 		delta.Sub(&beforeWrite)
 		if delta.WriteRequests < 1 || delta.WriteBytes < expectedBytes {
@@ -261,7 +544,7 @@ func TestConsumption(t *testing.T) {
 
 		r.QueryStr(t, "SELECT min(v) FROM t")
 
-		afterRead := testProvider.waitForConsumption()
+		afterRead := testProvider.waitForConsumption(t)
 		delta = afterRead
 		delta.Sub(&afterWrite)
 		if delta.ReadRequests < 1 || delta.ReadBytes < expectedBytes {
@@ -271,7 +554,7 @@ func TestConsumption(t *testing.T) {
 	}
 	// Make sure some CPU usage is reported.
 	testutils.SucceedsSoon(t, func() error {
-		c := testProvider.waitForConsumption()
+		c := testProvider.waitForConsumption(t)
 		if c.SQLPodsCPUSeconds == 0 {
 			return errors.New("no CPU usage reported")
 		}

--- a/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import "time"
+
+// TestInstrumentation is used by tests to listen for tenant controller events.
+type TestInstrumentation interface {
+	Event(now time.Time, typ TestEventType)
+}
+
+// TestEventType indicates the type of an event reported through
+// TestInstrumentation.
+type TestEventType int
+
+const (
+	// TickProcessed indicates that the main loop completed the processing of a
+	// tick.
+	TickProcessed TestEventType = 1 + iota
+
+	// LowRUNotification indicates that the main loop handled a "low RU"
+	// notification from the token bucket.
+	LowRUNotification
+
+	// TokenBucketResponseProcessed indicates that we have processed a
+	// (successful) request to the global token bucket.
+	TokenBucketResponseProcessed
+)

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -7,27 +7,17 @@ Reads:  0 requests (0 bytes)
 Writes:  0 requests (0 bytes)
 SQL Pods CPU seconds:  0.00
 
-read-request
+read bytes=1024000
 ----
 
 usage
 ----
-RU:  0.70
-Reads:  1 requests (0 bytes)
+RU:  10.47
+Reads:  1 requests (1024000 bytes)
 Writes:  0 requests (0 bytes)
 SQL Pods CPU seconds:  0.00
 
-write-request bytes=1024
-----
-
-usage
-----
-RU:  2.09
-Reads:  1 requests (0 bytes)
-Writes:  1 requests (1024 bytes)
-SQL Pods CPU seconds:  0.00
-
-read-response bytes=1024000
+write bytes=1024
 ----
 
 usage
@@ -48,16 +38,13 @@ Reads:  1 requests (1024000 bytes)
 Writes:  1 requests (1024 bytes)
 SQL Pods CPU seconds:  1.00
 
-write-request bytes=4096
+write bytes=4096
 ----
 
-read-request
+read bytes=65536
 ----
 
-read-response bytes=65536
-----
-
-write-request bytes=4096
+write bytes=4096
 ----
 
 usage

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
@@ -1,0 +1,40 @@
+# This test verifies the following condition:
+#  - we have a large request blocked, requiring more RU than the "low RU"
+#    notification threshold.
+#  - the bucket has more RUs available than the notification threshold.
+
+wait-for-event
+token-bucket-response
+----
+
+throttle 
+1000
+----
+
+# Fire off a write that needs significantly more than the 10000 initial RUs.
+write bytes=100000000 label=w1
+----
+
+wait-for-event
+token-bucket-response
+----
+
+advance
+10s
+----
+00:00:10.000
+
+wait-for-event
+low-ru
+----
+
+not-completed label=w1
+----
+
+advance
+50s
+----
+00:01:00.000
+
+await label=w1
+----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
@@ -1,0 +1,19 @@
+# This test verifies the following condition:
+
+# Wait for the initial token bucket request.
+wait-for-event
+token-bucket-response
+----
+
+# Advance time enough for a "consumption reporting" request to go out, which
+# wouldn't request more RUs.
+advance
+40s
+----
+00:00:40.000
+
+# Fire off a big write. This will trigger a low RU notification, which may
+# happen while the token bucket request is still in progress. Verify that even
+# in this case, we can still satisfy the request without more time passing.
+write bytes=100000000
+----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
@@ -1,0 +1,97 @@
+# By default, the test provider grants all RUs immediately. Verify that
+# requests never block.
+
+wait-for-event
+token-bucket-response
+----
+
+read bytes=1024000
+----
+
+advance
+1s
+----
+00:00:01.000
+
+write bytes=1024
+----
+
+advance
+1s
+----
+00:00:02.000
+
+write bytes=1024
+----
+
+write bytes=1024
+----
+
+# Set up throttling at 1000 RU/s.
+throttle
+1000
+----
+
+# Fire off some writes that need significantly more than the 10000 initial RUs.
+write bytes=50000000 label=w1
+----
+
+wait-for-event
+token-bucket-response
+----
+
+timers
+----
+00:00:11.000
+00:00:11.089
+
+advance
+1s
+----
+00:00:03.000
+
+not-completed label=w1
+----
+
+write bytes=100000000 label=w2
+----
+
+# Advance time enough for w1 to complete.
+advance
+10s
+----
+00:00:13.000
+
+wait-for-event
+token-bucket-response
+----
+
+timers
+----
+00:00:22.000
+00:00:49.237
+
+advance
+20s
+----
+00:00:33.000
+
+await label=w1
+----
+
+timers
+----
+00:00:42.000
+00:00:49.237
+
+not-completed label=w2
+----
+
+# Advance time enough for w2 to complete.
+advance
+40s
+----
+00:01:13.000
+
+await label=w2
+----

--- a/pkg/ccl/multitenantccl/tenantcostclient/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/token_bucket.go
@@ -1,0 +1,160 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
+)
+
+// tokenBucket implements a token bucket. It is a more specialized form of
+// quotapool.TokenBucket. The main differences are:
+//  - it does not currently support a burst limit
+//  - it implements a "low tokens" notification mechanism.
+type tokenBucket struct {
+	// -- Static fields --
+
+	// Once the available RUs are below the notifyThreshold or a request cannot
+	// be immediately fulfilled, we do a (non-blocking) send on this channel.
+	notifyCh chan struct{}
+
+	// -- Dynamic fields --
+	// Protected by the AbstractPool's lock. All changes should happen either
+	// inside a Request.Acquire() method or under AbstractPool.Update().
+
+	// See notifyCh. A threshold of zero disables notifications.
+	notifyThreshold tenantcostmodel.RU
+
+	// Refill rate, in RU/s.
+	rate tenantcostmodel.RU
+	// Currently available RUs. Can be negative (indicating debt).
+	available tenantcostmodel.RU
+
+	lastUpdated time.Time
+}
+
+func (tb *tokenBucket) Init(
+	now time.Time, notifyCh chan struct{}, rate, available tenantcostmodel.RU,
+) {
+	*tb = tokenBucket{
+		notifyCh:        notifyCh,
+		notifyThreshold: 0,
+		rate:            rate,
+		available:       available,
+		lastUpdated:     now,
+	}
+}
+
+// update accounts for the passing of time.
+func (tb *tokenBucket) update(now time.Time) {
+	if since := now.Sub(tb.lastUpdated); since > 0 {
+		tb.available += tb.rate * tenantcostmodel.RU(since.Seconds())
+		tb.lastUpdated = now
+	}
+}
+
+// notify tries to send a non-blocking notification on notifyCh and disables
+// further notifications (until the next Reconfigure or StartNotification).
+func (tb *tokenBucket) notify() {
+	tb.notifyThreshold = 0
+	select {
+	case tb.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+// maybeNotify checks if it's time to send the notification and if so, performs
+// the notification.
+func (tb *tokenBucket) maybeNotify(now time.Time) {
+	if tb.notifyThreshold > 0 && tb.available < tb.notifyThreshold {
+		tb.notify()
+	}
+}
+
+// AdjustTokens changes the amount of tokens currently available, either
+// increasing or decreasing them. The amount can become negative (indicating
+// debt).
+func (tb *tokenBucket) AdjustTokens(now time.Time, delta tenantcostmodel.RU) {
+	tb.update(now)
+	tb.available += delta
+	tb.maybeNotify(now)
+}
+
+type tokenBucketReconfigureArgs struct {
+	TokenAdjustment tenantcostmodel.RU
+
+	NewRate tenantcostmodel.RU
+
+	NotifyThreshold tenantcostmodel.RU
+}
+
+// Reconfigure changes the rate, optionally adjusts the available tokens and
+// configures the next notification.
+func (tb *tokenBucket) Reconfigure(now time.Time, args tokenBucketReconfigureArgs) {
+	tb.update(now)
+	// If we already produced a notification that wasn't processed, drain it. This
+	// not racy as long as this code does not run in parallel with the code that
+	// receives from notifyCh.
+	select {
+	case <-tb.notifyCh:
+	default:
+	}
+	tb.available += args.TokenAdjustment
+	tb.rate = args.NewRate
+	tb.notifyThreshold = args.NotifyThreshold
+	tb.maybeNotify(now)
+}
+
+// SetupNotification enables the notification at the given threshold.
+func (tb *tokenBucket) SetupNotification(now time.Time, threshold tenantcostmodel.RU) {
+	tb.update(now)
+	tb.notifyThreshold = threshold
+}
+
+// TryToFulfill either removes the given amount if is available, or returns a
+// time after which the request should be retried.
+func (tb *tokenBucket) TryToFulfill(
+	now time.Time, amount tenantcostmodel.RU,
+) (fulfilled bool, tryAgainAfter time.Duration) {
+	tb.update(now)
+
+	if amount <= tb.available {
+		tb.available -= amount
+		tb.maybeNotify(now)
+		return true, 0
+	}
+
+	// We have run out of available tokens; notify if we haven't already. This is
+	// possible if we have more than the notifyThreshold available.
+	if tb.notifyThreshold > 0 {
+		tb.notify()
+	}
+
+	// Compute the time it will take to get to the needed capacity.
+	timeSeconds := float64((amount - tb.available) / tb.rate)
+	// Cap the number of seconds to avoid overflow; we want to tolerate even a
+	// rate of 0 (in which case we are really waiting for a token adjustment).
+	if timeSeconds > 1000 {
+		timeSeconds = 1000
+	}
+
+	timeDelta := time.Duration(timeSeconds * float64(time.Second))
+	if timeDelta < time.Nanosecond {
+		timeDelta = time.Nanosecond
+	}
+	return false, timeDelta
+}
+
+// AvailableTokens returns the current number of available RUs. This can be
+// negative if we accumulated debt.
+func (tb *tokenBucket) AvailableTokens(now time.Time) tenantcostmodel.RU {
+	tb.update(now)
+	return tb.available
+}

--- a/pkg/ccl/multitenantccl/tenantcostclient/token_bucket_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/token_bucket_test.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestTokenBucket(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	start := timeutil.Now()
+	ts := timeutil.NewManualTime(start)
+
+	ch := make(chan struct{}, 100)
+
+	var tb tokenBucket
+	tb.Init(ts.Now(), ch, 10 /* rate */, 100 /* available */)
+
+	check := func(expected float64) {
+		t.Helper()
+		available := float64(tb.AvailableTokens(ts.Now()))
+		delta := math.Abs(available - expected)
+		if delta > 1e-5 {
+			t.Errorf("expected %g tokens, got %g", expected, available)
+		}
+	}
+	check(100)
+
+	// Verify basic update.
+	ts.Advance(1 * time.Second)
+	check(110)
+
+	// Check AdjustTokens.
+	tb.AdjustTokens(ts.Now(), -200)
+	check(-90)
+
+	ts.Advance(1 * time.Second)
+	check(-80)
+	ts.Advance(15 * time.Second)
+	check(70)
+
+	fulfill := func(amount tenantcostmodel.RU) {
+		t.Helper()
+		if ok, _ := tb.TryToFulfill(ts.Now(), amount); !ok {
+			t.Fatalf("failed to fulfill")
+		}
+	}
+	fulfill(50)
+	check(20)
+	if ok, tryAgainAfter := tb.TryToFulfill(ts.Now(), 40); ok {
+		t.Fatalf("fulfilled incorrectly")
+	} else if exp := 2 * time.Second; tryAgainAfter.Round(time.Millisecond) != exp {
+		t.Fatalf("tryAgainAfter: expected %s, got %s", exp, tryAgainAfter)
+	}
+	check(20)
+
+	// Check notification.
+	checkNoNotification := func() {
+		t.Helper()
+		select {
+		case <-ch:
+			t.Error("unexpected notification")
+		default:
+		}
+	}
+
+	checkNotification := func() {
+		t.Helper()
+		select {
+		case <-ch:
+		default:
+			t.Error("expected notification")
+		}
+	}
+
+	checkNoNotification()
+	args := tokenBucketReconfigureArgs{
+		NewRate:         10,
+		NotifyThreshold: 5,
+	}
+	tb.Reconfigure(ts.Now(), args)
+
+	checkNoNotification()
+	ts.Advance(1 * time.Second)
+	check(30)
+	fulfill(20)
+	// No notification: we did not go below the threshold.
+	checkNoNotification()
+	// Now we should get a notification.
+	fulfill(8)
+	checkNotification()
+	check(2)
+
+	// We only get one notification (until we Reconfigure or StartNotification).
+	fulfill(1)
+	checkNoNotification()
+
+	// Verify that we get notified when we block, even if the current amount is
+	// above the threshold.
+	args = tokenBucketReconfigureArgs{
+		TokenAdjustment: 10,
+		NewRate:         10,
+		NotifyThreshold: 5,
+	}
+	tb.Reconfigure(ts.Now(), args)
+	check(11)
+	if ok, _ := tb.TryToFulfill(ts.Now(), 38); ok {
+		t.Fatalf("fulfilled incorrectly")
+	}
+	checkNotification()
+
+	args = tokenBucketReconfigureArgs{
+		TokenAdjustment: 80,
+		NewRate:         1,
+	}
+	tb.Reconfigure(ts.Now(), args)
+	check(91)
+	ts.Advance(1 * time.Second)
+
+	checkNoNotification()
+	tb.SetupNotification(ts.Now(), 50)
+	checkNoNotification()
+	fulfill(60)
+	checkNotification()
+}

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
@@ -12,12 +12,12 @@ inspect tenant=5
 empty state
 
 token-bucket-request tenant=5
-instance_id: 10 
+instance_id: 10
 ----
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 10
@@ -29,7 +29,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 10
@@ -41,7 +41,7 @@ instance_id: 20
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 10
@@ -54,7 +54,7 @@ instance_id: 15
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 10
@@ -68,7 +68,7 @@ instance_id: 1
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -46,7 +46,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=0  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
 Consumption: ru=1110  reads=2220 req/3330 bytes  writes=4440 req/5550 bytes  pod-cpu-usage: 6660
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
@@ -5,15 +5,22 @@
 create-tenant tenant=5
 ----
 
+# First drain all the initially available tokens.
 token-bucket-request tenant=5
-instance_id: 1 
+instance_id: 1
+ru: 10000000
+----
+10000000 RUs granted immediately.
+
+token-bucket-request tenant=5
+instance_id: 1
 ru: 10
 ----
-10 RUs granted over 50ms.
+10 RUs granted over 100ms.
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=-10  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:00.000
 First active instance: 1
@@ -25,24 +32,24 @@ advance
 00:00:10.000
 
 token-bucket-request tenant=5
-instance_id: 1 
+instance_id: 1
 ru: 500
 ----
 500 RUs granted immediately.
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=1490  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:10.000
 First active instance: 1
   Instance 1:  lease='\x'  seq=0  shares=0.0  next-instance=0  last-update=00:00:10.000
 
 token-bucket-request tenant=5
-instance_id: 2 
-ru: 500
+instance_id: 2
+ru: 250
 ----
-500 RUs granted immediately.
+250 RUs granted immediately.
 
 # Verify that if the time goes backward, the tenant's last_updated does not go
 # back (which would result in some tokens being doubly refilled). Note that in
@@ -55,7 +62,7 @@ advance
 00:00:09.000
 
 token-bucket-request tenant=5
-instance_id: 1 
+instance_id: 1
 ru: 10
 ----
 10 RUs granted immediately.
@@ -63,7 +70,7 @@ ru: 10
 # Last update time for the tenant is unchanged. The per-instance time does get updated.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=980  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:10.000
 First active instance: 1
@@ -76,13 +83,13 @@ advance
 00:00:10.000
 
 token-bucket-request tenant=5
-instance_id: 1 
+instance_id: 1
 ----
 
 # The current RU amount stays the same.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=980  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:10.000
 First active instance: 1
@@ -95,13 +102,13 @@ advance
 00:00:11.000
 
 token-bucket-request tenant=5
-instance_id: 1 
+instance_id: 1
 ----
 
 # RU refilling resumed.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=200  ru-current=1180  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  current-share-sum=0
 Consumption: ru=0  reads=0 req/0 bytes  writes=0 req/0 bytes  pod-cpu-usage: 0
 Last update: 00:00:11.000
 First active instance: 1

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -729,9 +729,10 @@ func (ds *DistSender) Send(
 	ctx, sp := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender send")
 	defer sp.Finish()
 
+	var reqInfo tenantcostmodel.RequestInfo
 	if ds.kvInterceptor != nil {
-		info := tenantcostmodel.MakeRequestInfo(&ba)
-		if err := ds.kvInterceptor.OnRequestWait(ctx, info); err != nil {
+		reqInfo = tenantcostmodel.MakeRequestInfo(&ba)
+		if err := ds.kvInterceptor.OnRequestWait(ctx, reqInfo); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 	}
@@ -829,8 +830,8 @@ func (ds *DistSender) Send(
 		reply.BatchResponse_Header = lastHeader
 
 		if ds.kvInterceptor != nil {
-			info := tenantcostmodel.MakeResponseInfo(reply)
-			ds.kvInterceptor.OnResponse(ctx, info)
+			respInfo := tenantcostmodel.MakeResponseInfo(reply)
+			ds.kvInterceptor.OnResponse(ctx, reqInfo, respInfo)
 		}
 	}
 

--- a/pkg/multitenant/cost_controller.go
+++ b/pkg/multitenant/cost_controller.go
@@ -43,5 +43,7 @@ type TenantSideKVInterceptor interface {
 	// OnResponse accounts for the portion of the cost that can only be determined
 	// after-the-fact. It does not block, but it can push the rate limiting into
 	// "debt", causing future requests to be blocked.
-	OnResponse(ctx context.Context, info tenantcostmodel.ResponseInfo)
+	OnResponse(
+		ctx context.Context, req tenantcostmodel.RequestInfo, resp tenantcostmodel.ResponseInfo,
+	)
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -508,6 +508,6 @@ func (noopTenantSideCostController) OnRequestWait(
 }
 
 func (noopTenantSideCostController) OnResponse(
-	ctx context.Context, info tenantcostmodel.ResponseInfo,
+	ctx context.Context, req tenantcostmodel.RequestInfo, resp tenantcostmodel.ResponseInfo,
 ) {
 }


### PR DESCRIPTION
#### tenantcostserver: start with 10M RUs by default

This change modifies the default initial values for the token bucket -
relevant when crdb_internal.update_tenant_resource_limits was not
called. Specifically, we now start with 10M RUs by default. This is
intended to prevent unit tests from being throttled.

We also decrease the default rate, so it is in line with the planned
refill rate.

Release note: None

Release justification: multi-tenant-only code.

#### util: add support for tickers in TimeSource and ManualTime

This change will allow tests to manually control tickers.

Release justification: new library functionality, no changes to
existing production code.

Release note: None

#### tenantcostclient: report consumption when requests complete

Consumption is now reported only when requests complete. This will
allow us to avoid charging for failed requests (at least for certain
error conditions).

Release justification: multi-tenant-only code.

Release note: None

#### tenantcostclient: tenant-side throttling

This commit implements the bulk of the tenant-side throttling library.

High level overview of how it works (more details are in the RFC):
 - we start with an initial number of RUs (1000) that we can use
   immediately; in the meantime, we make an initial request to the
   bucket.

 - we request the tokens we estimate we'll need over the next 10s,
   according to an exponentially-moving average of recent consumption.
   We also factor in any token bucket debt or waiting requests.

 - if we are granted tokens immediately, we request more tokens when
   we have less than 10% of the granted tokens (i.e. 1s worth of
   usage) remaining.

 - if we are granted tokens over a period of time (i.e. a rate), we
   request more when we get within 1s of the "deadline" (unless we
   accumulate unused tokens (more than 10% of last granted).

Other than the datadriven test, I did a manual end-to-end test with a
KV workload and verified that we can throttle and un-throttle the
workload using `crdb_internal.update_tenant_resource_limits`.

The biggest things not yet done:

 - reasonable "backup" behavior when we can't perform token bucket
   requests (e.g. `tenant_usage` table is unavailable); I have a plan
   to return a backup rate from the server that would allow reasonable
   behavior for both free tenants and tenants with lots of paid RUs.

 - an end-to-end roachtest;

 - we account for CPU usage once per second, and take out the RUs from
   the buckets immediately. This has the potential of blocking out
   everything for a fraction of each second. This could be improved by
   increasing the sampling rate or implementing a debt-repayment
   mechanism where the debt is repaid continuously over the next
   second rather than instantly.

Release note: None

Release justification: multi-tenant-only code.
