### PR TITLE
release-21.1: clusterversion: add warning to not add new versions to a patch

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -322,6 +322,10 @@ const (
 
 	// Can return new retryable rangefeed errors without crashing the client
 	NewRetryableRangefeedErrors
+	// *************************************************
+	// Step (1): Add new versions here.
+	// Do not add new versions to a patch release.
+	// *************************************************
 )
 
 // versionsSingleton lists all historical versions here in chronological order,
@@ -530,7 +534,10 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Key:     NewRetryableRangefeedErrors,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 124},
 	},
+	// *************************************************
 	// Step (2): Add new versions here.
+	// Do not add new versions to a patch release.
+	// *************************************************
 })
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version


### PR DESCRIPTION
Backport 1/1 commits from #69869.

/cc @cockroachdb/release

---

This is an important warning to have as the eng team grows.

Release justification: comment-only change
Release note: None
