### PR TITLE
sql: implement information_schema._pg_index_position

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -484,3 +484,56 @@ varchar  64
 bit      1
 varbit   16
 numeric  NULL
+
+# information_schema._pg_index_position
+
+statement ok
+CREATE TABLE indexed (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX (b, d),
+  INDEX (c, a)
+);
+
+# NOTE, we cast indkey to an INT2[], because an INT2VECTOR's formatting appears
+# to be dependent on whether the result set spilled to disk or not. It was being
+# formatted differently with the "local" test config (and others) than with the
+# "fakedist-disk" test config.
+statement ok
+CREATE TEMPORARY VIEW indexes AS
+  SELECT i.relname, indkey::INT2[], indexrelid
+    FROM pg_catalog.pg_index
+    JOIN pg_catalog.pg_class AS t ON indrelid   = t.oid
+    JOIN pg_catalog.pg_class AS i ON indexrelid = i.oid
+   WHERE t.relname = 'indexed'
+ORDER BY i.relname
+
+query TT
+SELECT relname, indkey FROM indexes ORDER BY relname DESC
+----
+primary          {1}
+indexed_c_a_idx  {3,1}
+indexed_b_d_idx  {2,4}
+
+query TTII
+SELECT relname,
+       indkey,
+       generate_series(1, 4) input,
+       information_schema._pg_index_position(indexrelid, generate_series(1, 4))
+FROM indexes
+ORDER BY relname DESC, input
+----
+primary          {1}    1  1
+primary          {1}    2  NULL
+primary          {1}    3  NULL
+primary          {1}    4  NULL
+indexed_c_a_idx  {3,1}  1  2
+indexed_c_a_idx  {3,1}  2  NULL
+indexed_c_a_idx  {3,1}  3  1
+indexed_c_a_idx  {3,1}  4  NULL
+indexed_b_d_idx  {2,4}  1  NULL
+indexed_b_d_idx  {2,4}  2  1
+indexed_b_d_idx  {2,4}  3  NULL
+indexed_b_d_idx  {2,4}  4  2


### PR DESCRIPTION
Needed for #69010.

This commit implements the `information_schema._pg_index_position` builtin
function. Given an index's OID and an underlying-table column number,
`information_schema._pg_index_position` return the column's position in the
index (or NULL if not there).

The function is implemented as a user-defined function in Postgres here:
https://github.com/postgres/postgres/blob/master/src/backend/catalog/information_schema.sql

Release note (sql change): The `information_schema._pg_index_position`
builtin function is now supported, which improves compatibility with
PostgreSQL.

Release justification: None, waiting for v22.1.