### PR TITLE
roachpb: remove comments referencing CPutInline version gate

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1068,9 +1068,6 @@ func NewConditionalPut(key Key, value Value, expValue []byte, allowNotExist bool
 // The callee takes ownership of value's underlying bytes and it will mutate
 // them. The caller retains ownership of expVal; NewConditionalPut will copy it
 // into the request.
-//
-// Callers should check the version gate clusterversion.CPutInline to make
-// sure this is supported.
 func NewConditionalPutInline(key Key, value Value, expValue []byte, allowNotExist bool) Request {
 	value.InitChecksum(key)
 	// Compatibility with 20.1 servers.

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -757,9 +757,6 @@ type ConditionalPutRequest struct {
 	// Specify as true to put the value without a corresponding
 	// timestamp. This option should be used with care as it precludes
 	// the use of this value with transactions.
-	//
-	// Callers should check the version gate clusterversion.CPutInline to make
-	// sure this is supported.
 	Inline bool `protobuf:"varint,7,opt,name=inline,proto3" json:"inline,omitempty"`
 }
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -223,9 +223,6 @@ message ConditionalPutRequest {
   // Specify as true to put the value without a corresponding
   // timestamp. This option should be used with care as it precludes
   // the use of this value with transactions.
-  //
-  // Callers should check the version gate clusterversion.CPutInline to make
-  // sure this is supported.
   bool inline = 7;
 }
 


### PR DESCRIPTION
The `clusterversion.CPutInline` version gate was removed in 99157d973a,
but some comments referencing it were left behind. This patch removes
those comments.

Release justification: non-production code changes
Release note: None