### PR TITLE
release-21.1: changefeedccl: signal changeAggregator shutdown from the kvfeed

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -222,7 +222,7 @@ func createBenchmarkChangefeed(
 		Gossip:   gossip.MakeOptionalGossip(s.GossipI().(*gossip.Gossip)),
 		Spans:    spans,
 		Targets:  details.Targets,
-		Sink:     buf,
+		Writer:   buf,
 		LeaseMgr: leaseMgr,
 		EventBufferFactory: func() kvfeed.EventBuffer {
 			return kvfeed.MakeMemBuffer(mm.MakeBoundAccount(), &metrics.KVFeedMetrics)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1365,6 +1365,112 @@ func TestChangefeedFailOnTableOffline(t *testing.T) {
 	t.Run("enterprise", enterpriseTest(testFn))
 }
 
+// TODO(ssd): The following two test rely on test infrastructure that
+// has not been backported to this branch yet.
+//
+// func TestChangefeedRestartMutliNode(t *testing.T) {
+// 	defer leaktest.AfterTest(t)()
+// 	defer log.Scope(t).Close(t)
+//
+// 	cluster, db, cleanup := startTestCluster(t)
+// 	defer cleanup()
+//
+// 	sqlDB := sqlutils.MakeSQLRunner(db)
+// 	sqlDB.Exec(t, `CREATE TABLE test_tab (a INT PRIMARY KEY, b INT UNIQUE NOT NULL)`)
+// 	sqlDB.Exec(t, `INSERT INTO test_tab VALUES (0, 0)`)
+//
+// 	row := sqlDB.QueryRow(t, `SELECT range_id, lease_holder FROM [SHOW RANGES FROM TABLE test_tab] LIMIT 1`)
+// 	var rangeID, leaseHolder int
+// 	row.Scan(&rangeID, &leaseHolder)
+//
+// 	// Start the changefeed on a node other than the leaseholder
+// 	// so that it is likely that the changeAggregator and
+// 	// changeFrontier are on different nodes.
+// 	feedServerID := ((leaseHolder - 1) + 1) % 3
+// 	t.Logf("Range %d is on lease holder %d, running rangefeed on server %d (store id: %d)", rangeID, leaseHolder, feedServerID, cluster.Server(feedServerID).GetFirstStoreID())
+// 	db = cluster.ServerConn(feedServerID)
+// 	sqlDB = sqlutils.MakeSQLRunner(db)
+
+// 	f := makeKafkaFeedFactoryForCluster(cluster, db)
+// 	feed := feed(t, f, "CREATE CHANGEFEED FOR test_tab WITH updated")
+// 	defer closeFeed(t, feed)
+// 	assertPayloadsStripTs(t, feed, []string{
+// 		`test_tab: [0]->{"after": {"a": 0, "b": 0}}`,
+// 	})
+//
+// 	waitForSchemaChange(t, sqlDB, `ALTER TABLE test_tab ALTER PRIMARY KEY USING COLUMNS (b)`)
+// 	sqlDB.Exec(t, `INSERT INTO test_tab VALUES (1, 11)`)
+// 	// No backfill, but we should see the newly insert value
+// 	assertPayloadsStripTs(t, feed, []string{
+// 		`test_tab: [11]->{"after": {"a": 1, "b": 11}}`,
+// 	})
+//
+// 	waitForSchemaChange(t, sqlDB, `ALTER TABLE test_tab SET LOCALITY REGIONAL BY ROW`)
+// 	// schema-changer backfill for the ADD COLUMN
+// 	assertPayloadsStripTs(t, feed, []string{
+// 		`test_tab: [0]->{"after": {"a": 0, "b": 0}}`,
+// 		`test_tab: [11]->{"after": {"a": 1, "b": 11}}`,
+// 	})
+// 	// changefeed backfill for the ADD COLUMN
+// 	assertPayloadsStripTs(t, feed, []string{
+// 		`test_tab: ["us-east1", 0]->{"after": {"a": 0, "b": 0, "crdb_region": "us-east1"}}`,
+// 		`test_tab: ["us-east1", 11]->{"after": {"a": 1, "b": 11, "crdb_region": "us-east1"}}`,
+// 	})
+//
+// 	sqlDB.Exec(t, `INSERT INTO test_tab VALUES (2, 22)`)
+// 	// Newly inserted data works
+// 	assertPayloadsStripTs(t, feed, []string{
+// 		`test_tab: ["us-east1", 22]->{"after": {"a": 2, "b": 22, "crdb_region": "us-east1"}}`,
+// 	})
+// }
+//
+// func TestChangefeedStopPolicyMultiNode(t *testing.T) {
+// 	defer leaktest.AfterTest(t)()
+// 	defer log.Scope(t).Close(t)
+
+// 	skip.UnderRace(t)
+
+// 	cluster, db, cleanup := startTestCluster(t)
+// 	defer cleanup()
+
+// 	sqlDB := sqlutils.MakeSQLRunner(db)
+// 	sqlDB.Exec(t, `CREATE TABLE test_tab (a INT PRIMARY KEY)`)
+// 	sqlDB.Exec(t, `INSERT INTO test_tab VALUES (0)`)
+
+// 	row := sqlDB.QueryRow(t, `SELECT range_id, lease_holder FROM [SHOW RANGES FROM TABLE test_tab] LIMIT 1`)
+// 	var rangeID, leaseHolder int
+// 	row.Scan(&rangeID, &leaseHolder)
+
+// 	// Start the changefeed on a node other than the leaseholder
+// 	// so that it is likely that the changeAggregator and
+// 	// changeFrontier are on different nodes.
+// 	feedServerID := ((leaseHolder - 1) + 1) % 3
+// 	t.Logf("Range %d is on lease holder %d, running rangefeed on server %d (store id: %d)", rangeID, leaseHolder, feedServerID, cluster.Server(feedServerID).GetFirstStoreID())
+// 	db = cluster.ServerConn(feedServerID)
+// 	sqlDB = sqlutils.MakeSQLRunner(db)
+
+// 	f := makeKafkaFeedFactoryForCluster(cluster, db)
+// 	feed := feed(t, f, "CREATE CHANGEFEED FOR test_tab WITH schema_change_policy='stop'")
+// 	defer closeFeed(t, feed)
+// 	sqlDB.Exec(t, `INSERT INTO test_tab VALUES (1)`)
+// 	assertPayloads(t, feed, []string{
+// 		`test_tab: [0]->{"after": {"a": 0}}`,
+// 		`test_tab: [1]->{"after": {"a": 1}}`,
+// 	})
+// 	sqlDB.Exec(t, `ALTER TABLE test_tab ADD COLUMN b INT NOT NULL DEFAULT 0`)
+
+// 	waitForSchemaChangeError := func(t *testing.T, f cdctest.TestFeed) {
+// 		t.Helper()
+// 		for {
+// 			if _, err := f.Next(); err != nil {
+// 				require.Contains(t, err.Error(), "schema change occurred at")
+// 				break
+// 			}
+// 		}
+// 	}
+// 	waitForSchemaChangeError(t, feed)
+// }
+
 func TestChangefeedFailOnRBRChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -42,7 +42,7 @@ type Config struct {
 	Gossip             gossip.OptionalGossip
 	Spans              []roachpb.Span
 	Targets            jobspb.ChangefeedTargets
-	Sink               EventBufferWriter
+	Writer             EventBufferWriter
 	LeaseMgr           *lease.Manager
 	EventBufferFactory func() EventBuffer
 	WithDiff           bool
@@ -92,7 +92,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	f := newKVFeed(
-		cfg.Sink, cfg.Spans,
+		cfg.Writer, cfg.Spans,
 		cfg.SchemaChangeEvents, cfg.SchemaChangePolicy,
 		cfg.NeedsInitialScan, cfg.WithDiff,
 		cfg.InitialHighWater,
@@ -101,11 +101,19 @@ func Run(ctx context.Context, cfg Config) error {
 	g.GoCtx(f.run)
 	err := g.Wait()
 	// NB: The higher layers of the changefeed should detect the boundary and the
-	// policy and tear everything down. Returning before the higher layers tear
-	// down the changefeed exposes synchronization challenges.
+	// policy and tear everything down. Returning before the higher layers tear down
+	// the changefeed exposes synchronization challenges if the provided writer is
+	// buffered. Errors returned from this function will cause the
+	// changefeedAggregator to exit even if all values haven't been read out of the
+	// provided buffer.
 	var scErr schemaChangeDetectedError
 	if errors.As(err, &scErr) {
-		log.Infof(ctx, "stopping changefeed due to schema change at %v", scErr.ts)
+		log.Infof(ctx, "stopping kv feed due to schema change at %v", scErr.ts)
+		// Close the buffer so the consumer (changeAggregator) knows no more
+		// writes are expected and can transition to a draining state.
+		f.writer.Close(ctx)
+		// This context is canceled by the change aggregator when it receives
+		// ErrBufferClosed from the kv buffer that we closed above.
 		<-ctx.Done()
 		err = nil
 	}
@@ -160,7 +168,7 @@ type kvFeed struct {
 	withDiff            bool
 	withInitialBackfill bool
 	initialHighWater    hlc.Timestamp
-	sink                EventBufferWriter
+	writer              EventBufferWriter
 	codec               keys.SQLCodec
 
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass
@@ -174,7 +182,7 @@ type kvFeed struct {
 }
 
 func newKVFeed(
-	sink EventBufferWriter,
+	writer EventBufferWriter,
 	spans []roachpb.Span,
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass,
 	schemaChangePolicy changefeedbase.SchemaChangePolicy,
@@ -187,7 +195,7 @@ func newKVFeed(
 	bf func() EventBuffer,
 ) *kvFeed {
 	return &kvFeed{
-		sink:                sink,
+		writer:              writer,
 		spans:               spans,
 		withInitialBackfill: withInitialBackfill,
 		withDiff:            withDiff,
@@ -239,11 +247,12 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		if f.schemaChangePolicy != changefeedbase.OptSchemaChangePolicyNoBackfill ||
 			boundaryType == jobspb.ResolvedSpan_RESTART {
 			for _, span := range f.spans {
-				if err := f.sink.AddResolved(ctx, span, highWater, boundaryType); err != nil {
+				if err := f.writer.AddResolved(ctx, span, highWater, boundaryType); err != nil {
 					return err
 				}
 			}
 		}
+
 		// Exit if the policy says we should.
 		if boundaryType == jobspb.ResolvedSpan_RESTART || boundaryType == jobspb.ResolvedSpan_EXIT {
 			return schemaChangeDetectedError{highWater.Next()}
@@ -327,7 +336,7 @@ func (f *kvFeed) scanIfShould(
 		return nil
 	}
 
-	if err := f.scanner.Scan(ctx, f.sink, physicalConfig{
+	if err := f.scanner.Scan(ctx, f.writer, physicalConfig{
 		Spans:     spansToBackfill,
 		Timestamp: scanTime,
 		WithDiff:  !isInitialScan && f.withDiff,
@@ -356,7 +365,7 @@ func (f *kvFeed) runUntilTableEvent(
 	g := ctxgroup.WithContext(ctx)
 	physicalCfg := physicalConfig{Spans: f.spans, Timestamp: startFrom, WithDiff: f.withDiff}
 	g.GoCtx(func(ctx context.Context) error {
-		return copyFromSourceToSinkUntilTableEvent(ctx, f.sink, memBuf, physicalCfg, f.tableFeed)
+		return copyFromSourceToDestUntilTableEvent(ctx, f.writer, memBuf, physicalCfg, f.tableFeed)
 	})
 	g.GoCtx(func(ctx context.Context) error {
 		return f.physicalFeed.Run(ctx, memBuf, physicalCfg)
@@ -396,14 +405,14 @@ func (e *errUnknownEvent) Error() string {
 	return "unknown event type"
 }
 
-// copyFromSourceToSinkUntilTableEvents will pull read entries from source and
-// publish them to sink if there is no table event from the schemaFeed. If a
+// copyFromSourceToDestUntilTableEvents will pull read entries from source and
+// publish them to the destination if there is no table event from the SchemaFeed. If a
 // tableEvent occurs then the function will return once all of the spans have
 // been resolved up to the event. The first such event will be returned as
 // *errBoundaryReached. A nil error will never be returned.
-func copyFromSourceToSinkUntilTableEvent(
+func copyFromSourceToDestUntilTableEvent(
 	ctx context.Context,
-	sink EventBufferWriter,
+	dest EventBufferWriter,
 	source EventBufferReader,
 	cfg physicalConfig,
 	tables schemaFeed,
@@ -454,7 +463,7 @@ func copyFromSourceToSinkUntilTableEvent(
 		addEntry = func(e Event) error {
 			switch e.Type() {
 			case KVEvent:
-				return sink.AddKV(ctx, e.KV(), e.PrevValue(), e.BackfillTimestamp())
+				return dest.AddKV(ctx, e.KV(), e.PrevValue(), e.BackfillTimestamp())
 			case ResolvedEvent:
 				// TODO(ajwerner): technically this doesn't need to happen for most
 				// events - we just need to make sure we forward for events which are
@@ -462,7 +471,7 @@ func copyFromSourceToSinkUntilTableEvent(
 				// The logic currently doesn't make this clean.
 				resolved := e.Resolved()
 				frontier.Forward(resolved.Span, resolved.Timestamp)
-				return sink.AddResolved(ctx, resolved.Span, resolved.Timestamp, jobspb.ResolvedSpan_NONE)
+				return dest.AddResolved(ctx, resolved.Span, resolved.Timestamp, jobspb.ResolvedSpan_NONE)
 			default:
 				return &errUnknownEvent{e}
 			}

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util",
         "//pkg/util/fileutil",
         "//pkg/util/log",
         "//pkg/util/retry",


### PR DESCRIPTION
Backport 2/2 commits from #69234.

/cc @cockroachdb/release

---

During acceptance testing, we observed that changefeeds did not
correctly restart on primary key changes and did not correctly stop
when schema_change_policy was set to 'stop' when the changeFrontier
and changeAggregator were running on different nodes (most production
changefeeds).

The root cause of this was a bad assumption in the changeAggregator
shutdown logic. Namely, we assumed that the changeAggregator (and kv
feed) would see context cancellations as a result of the
changeFrontier moving to draining. However, this is not guaranteed.

When the changeFrontier moves to draining, all of its inputs will be
drained. But, a DrainRequest message is only sent to the input lazily
when the next message is received from that input.

In this case of a schema change, the kv feed would stop sending
messages to the changeAggregator and thus no further messages will be
sent to the changeFrontier and the drain request is not triggered.

With this change, we now shut down the changeAggregator when the
kvfeed indicates that no more messages will be returned.

Fixes #68791

Release note (enterprise change): Fixed a bug where CHANGEFEEDs would
fail to correctly handle a primary key change.

Release justification: Critical fix for previously released functionality.