### PR TITLE
kvserver: de-flake TestBackpressureNotAppliedWhenReducingRangeSize

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -302,6 +302,9 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		case err := <-upsertErrCh:
 			t.Fatalf("expected no error because the request should hang, got %v", err)
 		}
-		require.Equal(t, context.Canceled, errors.Unwrap(<-upsertErrCh))
+		// Unfortunately we can't match on the error (context canceled) here since we can also
+		// get random other errors such as:
+		// "write failed: write tcp 127.0.0.1:37720->127.0.0.1:44313: i/o timeout"
+		require.Error(t, <-upsertErrCh)
 	})
 }


### PR DESCRIPTION
Fallout from the pgx bump, I think. We're now receiving
`context.Canceled` with some extra wrapping, but also entirely new
errors related to the connection being torn down. Realistically
speaking it's game over, we just have to stop checking the type
of the error.

Release justification: testing-only fix
Release note: None
