### PR TITLE
kvserver: add no-op safeguard to `TransferLeaseTarget`

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1451,7 +1451,7 @@ func (a *Allocator) TransferLeaseTarget(
 		leaseholderReplQPS, _ := stats.avgQPS()
 		currentDelta := getQPSDelta(storeQPSMap, existing)
 		bestOption := getCandidateWithMinQPS(storeQPSMap, existing)
-		if bestOption != (roachpb.ReplicaDescriptor{}) &&
+		if bestOption != (roachpb.ReplicaDescriptor{}) && bestOption.StoreID != leaseRepl.StoreID() &&
 			// It is always beneficial to transfer the lease to the coldest candidate
 			// if the range's own qps is smaller than the difference between the
 			// leaseholder store and the candidate store. This will always drive down

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1284,10 +1284,15 @@ const (
 )
 
 type transferLeaseOptions struct {
-	goal                     transferLeaseGoal
+	goal transferLeaseGoal
+	// checkTransferLeaseSource, when false, tells `TransferLeaseTarget` to
+	// exclude the current leaseholder from consideration as a potential target
+	// (i.e. when the caller explicitly wants to shed its lease away).
 	checkTransferLeaseSource bool
-	checkCandidateFullness   bool
-	dryRun                   bool
+	// checkCandidateFullness, when false, tells `TransferLeaseTarget`
+	// to disregard the existing lease counts on candidates.
+	checkCandidateFullness bool
+	dryRun                 bool
 }
 
 // leaseTransferOutcome represents the result of shedLease().


### PR DESCRIPTION
kvserver: add no-op safeguard to `TransferLeaseTarget`

Release justification: adds no-op safeguard

Release note: None