### PR TITLE
storage: handle nonexistent monolithic file registry

### DIFF
--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -425,7 +425,10 @@ func (r *PebbleFileRegistry) upgradeToRecordsVersion() error {
 	if err := r.createNewRegistryFile(); err != nil {
 		return err
 	}
-	return r.FS.Remove(r.oldRegistryPath)
+	if err := r.FS.Remove(r.oldRegistryPath); err != nil && !oserror.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *PebbleFileRegistry) processBatchLocked(batch *enginepb.RegistryUpdateBatch) error {

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -60,6 +60,17 @@ func TestFileRegistryRelativePaths(t *testing.T) {
 	}
 }
 
+func TestFileRegistry_UpgradeEmpty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mem := vfs.NewMem()
+	registry := &PebbleFileRegistry{FS: mem, DBDir: ""}
+	require.NoError(t, registry.Load())
+	require.NoError(t, registry.StopUsingOldRegistry())
+	require.NoError(t, registry.Close())
+}
+
 func TestFileRegistryOps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
While upgrading to the records-based file registry, we remove the
old-style, monolithic file registry. However, the monolithic file
registry is not guaranteed to exist. This commit updates the removal to
ignore non-existence errors.

Release justification: bug fixes and low-risk updates to new
functionality

Release note: none