### PR TITLE
sql: implement pg_has_role

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3138,6 +3138,18 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="pg_get_serial_sequence"></a><code>pg_get_serial_sequence(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the name of the sequence used by the given column_name in the table table_name.</p>
 </span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(role: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for role.</p>
+</span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(role: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for role.</p>
+</span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(user: <a href="string.html">string</a>, role: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for role.</p>
+</span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(user: <a href="string.html">string</a>, role: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for role.</p>
+</span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(user: oid, role: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for role.</p>
+</span></td></tr>
+<tr><td><a name="pg_has_role"></a><code>pg_has_role(user: oid, role: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for role.</p>
+</span></td></tr>
 <tr><td><a name="pg_is_other_temp_schema"></a><code>pg_is_other_temp_schema(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the given OID is the OID of another session’s temporary schema. (This can be useful, for example, to exclude other sessions’ temporary tables from a catalog display.)</p>
 </span></td></tr>
 <tr><td><a name="pg_my_temp_schema"></a><code>pg_my_temp_schema() &rarr; oid</code></td><td><span class="funcdesc"><p>Returns the OID of the current session’s temporary schema, or zero if it has none (because it has not created any temporary tables).</p>

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -344,13 +344,12 @@ func (so *importSequenceOperators) IsTypeVisible(
 	return false, false, errors.WithStack(errSequenceOperators)
 }
 
-// HasTablePrivilege is part of the tree.EvalDatabase interface.
+// HasPrivilege is part of the tree.EvalDatabase interface.
 func (so *importSequenceOperators) HasPrivilege(
 	ctx context.Context,
 	specifier tree.HasPrivilegeSpecifier,
 	user security.SQLUsername,
 	kind privilege.Kind,
-	withGrantOpt bool,
 ) (bool, error) {
 	return false, errors.WithStack(errSequenceOperators)
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -85,7 +85,6 @@ func (so *DummySequenceOperators) HasPrivilege(
 	specifier tree.HasPrivilegeSpecifier,
 	user security.SQLUsername,
 	kind privilege.Kind,
-	withGrantOpt bool,
 ) (bool, error) {
 	return false, errors.WithStack(errEvalPlanner)
 }
@@ -311,7 +310,6 @@ func (ep *DummyEvalPlanner) HasPrivilege(
 	specifier tree.HasPrivilegeSpecifier,
 	user security.SQLUsername,
 	kind privilege.Kind,
-	withGrantOpt bool,
 ) (bool, error) {
 	return false, errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -230,6 +230,13 @@ func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// UserHasAdminRole is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) UserHasAdminRole(
+	ctx context.Context, user security.SQLUsername,
+) (bool, error) {
+	return false, errors.WithStack(errEvalPlanner)
+}
+
 // MemberOfWithAdminOption is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	ctx context.Context, member security.SQLUsername,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3524,8 +3524,8 @@ ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolreplication
 2310524507  admin     true      true        true           true         false         true         false
-1546506610  root      true      false       true           true         false         true         false
-2264919399  testuser  false     false       false          false        false         true         false
+1546506610  root      true      true        true           true         false         true         false
+2264919399  testuser  false     true        false          false        false         true         false
 
 query OTITTBT colnames
 SELECT oid, rolname, rolconnlimit, rolpassword, rolvaliduntil, rolbypassrls, rolconfig
@@ -5266,8 +5266,8 @@ ORDER BY rolname
 ----
 rolname    rolcreatedb  rolconfig                                          rolinherit  rolcanlogin  rolvaliduntil
 testrole1  false        NULL                                               true        false        NULL
-testuser1  true         {timezone=America/Los_Angeles,application_name=a}  false       true         NULL
-testuser2  false        NULL                                               false       true         3022-01-01 00:00:00 +0000 UTC
+testuser1  true         {timezone=America/Los_Angeles,application_name=a}  true        true         NULL
+testuser2  false        NULL                                               true        true         3022-01-01 00:00:00 +0000 UTC
 
 query TBBBBT colnames
 SELECT rolname, rolcreatedb, rolcreaterole, rolinherit, rolcanlogin, rolvaliduntil
@@ -5276,10 +5276,10 @@ WHERE rolname IN ('testuser1', 'testuser2', 'testrole1', 'root')
 ORDER BY rolname
 ----
 rolname    rolcreatedb  rolcreaterole  rolinherit  rolcanlogin  rolvaliduntil
-root       true         true           false       true         NULL
+root       true         true           true        true         NULL
 testrole1  false        false          true        false        NULL
-testuser1  true         false          false       true         NULL
-testuser2  false        true           false       true         3022-01-01 00:00:00 +0000 UTC
+testuser1  true         false          true        true         NULL
+testuser2  false        true           true        true         3022-01-01 00:00:00 +0000 UTC
 
 # Testing users that have admin role
 

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -469,7 +469,7 @@ false  false  false  false  false  false
 query B
 SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE')
 ----
-true
+NULL
 
 query error pgcode 42704 foreign-data wrapper 'does_not_exist' does not exist
 SELECT has_foreign_data_wrapper_privilege('does_not_exist', 'USAGE')
@@ -480,7 +480,7 @@ SELECT has_foreign_data_wrapper_privilege('does_not_exist'::Name, 'USAGE')
 query B
 SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE WITH GRANT OPTION')
 ----
-true
+NULL
 
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_foreign_data_wrapper_privilege(12345, 'UPDATE')
@@ -494,7 +494,7 @@ SELECT has_foreign_data_wrapper_privilege('no_user', 12345, 'USAGE')
 query B
 SELECT has_foreign_data_wrapper_privilege('bar', 12345, 'USAGE')
 ----
-true
+NULL
 
 
 ## has_function_privilege
@@ -801,7 +801,7 @@ false  false  false
 query B
 SELECT has_server_privilege(12345, 'USAGE')
 ----
-true
+NULL
 
 query error pgcode 42704 server 'does_not_exist' does not exist
 SELECT has_server_privilege('does_not_exist', 'USAGE')
@@ -812,7 +812,7 @@ SELECT has_server_privilege('does_not_exist'::Name, 'USAGE')
 query B
 SELECT has_server_privilege(12345, 'USAGE WITH GRANT OPTION')
 ----
-true
+NULL
 
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_server_privilege(12345, 'UPDATE')
@@ -826,7 +826,7 @@ SELECT has_server_privilege('no_user', 12345, 'USAGE')
 query B
 SELECT has_server_privilege('bar', 12345, 'USAGE')
 ----
-true
+NULL
 
 
 ## has_table_privilege
@@ -974,7 +974,7 @@ false  false  false  true  true  false  true  false  false
 query B
 SELECT has_tablespace_privilege(12345, 'CREATE')
 ----
-true
+NULL
 
 query B
 SELECT has_tablespace_privilege((SELECT oid FROM pg_tablespace LIMIT 1), 'CREATE')

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -86,14 +86,15 @@ true  true  true  true
 query error pgcode 42P01 relation "does_not_exist" does not exist
 SELECT has_any_column_privilege('does_not_exist', 'SELECT')
 
-query BBBBB
+query BBBBBB
 SELECT has_any_column_privilege('pg_type', 'SELECT'),
        has_any_column_privilege('pg_type', 'INSERT'),
        has_any_column_privilege('pg_type', 'UPDATE'),
        has_any_column_privilege('pg_type', 'REFERENCES'),
-       has_any_column_privilege('pg_type', 'SELECT, INSERT, UPDATE')
+       has_any_column_privilege('pg_type', 'SELECT, INSERT, UPDATE'),
+       has_any_column_privilege('pg_type', 'INSERT, UPDATE')
 ----
-true  false  false  true  false
+true  false  false  true  true  false
 
 query BBBBB
 SELECT has_any_column_privilege('t', 'SELECT'),
@@ -188,14 +189,15 @@ SELECT has_column_privilege('pg_type', 100, 'SELECT')
 query error pgcode 42703 column 100 of relation pg_type does not exist
 SELECT has_column_privilege('pg_type'::regclass, 100, 'SELECT')
 
-query BBBBB
+query BBBBBB
 SELECT has_column_privilege('pg_type', 1, 'SELECT'),
        has_column_privilege('pg_type', 1, 'INSERT'),
        has_column_privilege('pg_type', 1, 'UPDATE'),
        has_column_privilege('pg_type', 1, 'REFERENCES'),
-       has_column_privilege('pg_type', 1, 'SELECT, INSERT, UPDATE')
+       has_column_privilege('pg_type', 1, 'SELECT, INSERT, UPDATE'),
+       has_column_privilege('pg_type', 1, 'INSERT, UPDATE')
 ----
-true  false  false  true  false
+true  false  false  true  true  false
 
 query BBBBB
 SELECT has_column_privilege('t', 1, 'SELECT'),
@@ -272,14 +274,15 @@ SELECT has_column_privilege('pg_type', 'does not exist', 'SELECT')
 query error pgcode 42703 column "does not exist" does not exist
 SELECT has_column_privilege('pg_type'::regclass, 'does not exist', 'SELECT')
 
-query BBBBB
+query BBBBBB
 SELECT has_column_privilege('pg_type', 'typname', 'SELECT'),
        has_column_privilege('pg_type', 'typname', 'INSERT'),
        has_column_privilege('pg_type', 'typname', 'UPDATE'),
        has_column_privilege('pg_type', 'typname', 'REFERENCES'),
-       has_column_privilege('pg_type', 'typname', 'SELECT, INSERT, UPDATE')
+       has_column_privilege('pg_type', 'typname', 'SELECT, INSERT, UPDATE'),
+       has_column_privilege('pg_type', 'typname', 'INSERT, UPDATE')
 ----
-true  false  false  true  false
+true  false  false  true  true  false
 
 query BBBBB
 SELECT has_column_privilege('t', 'a', 'SELECT'),
@@ -443,7 +446,7 @@ SELECT has_database_privilege('bar', 'test', 'CREATE'),
        has_database_privilege('bar', 'test', 'CREATE, CONNECT'),
        has_database_privilege('bar', 'test', 'CREATE, TEMP')
 ----
-true  false  true  true  false  true
+true  false  true  true  true  true
 
 statement ok
 GRANT CONNECT ON DATABASE test TO bar
@@ -652,7 +655,7 @@ SELECT has_schema_privilege('bar', 'public', 'CREATE'),
        has_schema_privilege('bar', 'public', 'USAGE'),
        has_schema_privilege('bar', 'public', 'CREATE, USAGE')
 ----
-true  false  false
+true  false  true
 
 query BBB
 SELECT has_schema_privilege('bar', 'public', 'CREATE WITH GRANT OPTION'),
@@ -673,7 +676,7 @@ SELECT has_schema_privilege('bar', 'test_schema', 'CREATE'),
        has_schema_privilege('bar', 'test_schema', 'USAGE'),
        has_schema_privilege('bar', 'test_schema', 'CREATE, USAGE')
 ----
-true  false  false
+true  false  true
 
 query BBB
 SELECT has_schema_privilege('testuser', 'test_schema', 'CREATE'),
@@ -867,7 +870,7 @@ true  true  true  true  true  true  true
 query error pgcode 42P01 relation "does_not_exist" does not exist
 SELECT has_table_privilege('does_not_exist', 'SELECT')
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('pg_type', 'SELECT'),
        has_table_privilege('pg_type', 'INSERT'),
        has_table_privilege('pg_type', 'UPDATE'),
@@ -876,9 +879,10 @@ SELECT has_table_privilege('pg_type', 'SELECT'),
        has_table_privilege('pg_type', 'REFERENCES'),
        has_table_privilege('pg_type', 'TRIGGER'),
        has_table_privilege('pg_type', 'SELECT, INSERT, UPDATE'),
-       has_table_privilege('pg_type', 'SELECT, TRUNCATE')
+       has_table_privilege('pg_type', 'SELECT, TRUNCATE'),
+       has_table_privilege('pg_type', 'INSERT, UPDATE')
 ----
-true  false  false  false  false  true  false  false  false
+true  false  false  false  false  true  false  true  true  false
 
 query BBBBBBBBB
 SELECT has_table_privilege('t', 'SELECT'),
@@ -942,7 +946,7 @@ SELECT has_table_privilege('t', 'SELECT, USAGE')
 query error pgcode 42704 role 'no_user' does not exist
 SELECT has_table_privilege('no_user', 't', 'SELECT')
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('bar', 't', 'SELECT'),
        has_table_privilege('bar', 't', 'INSERT'),
        has_table_privilege('bar', 't', 'UPDATE'),
@@ -951,11 +955,12 @@ SELECT has_table_privilege('bar', 't', 'SELECT'),
        has_table_privilege('bar', 't', 'REFERENCES'),
        has_table_privilege('bar', 't', 'TRIGGER'),
        has_table_privilege('bar', 't', 'SELECT, INSERT, UPDATE'),
-       has_table_privilege('bar', 't', 'SELECT, TRUNCATE')
+       has_table_privilege('bar', 't', 'SELECT, TRUNCATE'),
+       has_table_privilege('bar', 't', 'INSERT, UPDATE')
 ----
-false  false  false  true  true  false  true  false  false
+false  false  false  true  true  false  true  false  true  false
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'UPDATE WITH GRANT OPTION'),
@@ -964,9 +969,10 @@ SELECT has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'REFERENCES WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'TRIGGER WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
-       has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION')
+       has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
 ----
-false  false  false  true  true  false  true  false  false
+false  false  false  true  true  false  true  false  true  false
 
 
 ## has_tablespace_privilege
@@ -1157,15 +1163,19 @@ SELECT pg_has_role('root', 'some_users', 'USAGE'),
 ----
 true  true  true  true  true  true
 
-query BBBBBB
+query BBBBBBBBBB
 SELECT pg_has_role('bar', 'some_users', 'USAGE'),
        pg_has_role('bar', 'some_users', 'USAGE WITH GRANT OPTION'),
        pg_has_role('bar', 'some_users', 'USAGE WITH ADMIN OPTION'),
        pg_has_role('bar', 'some_users', 'MEMBER'),
        pg_has_role('bar', 'some_users', 'MEMBER WITH GRANT OPTION'),
-       pg_has_role('bar', 'some_users', 'MEMBER WITH ADMIN OPTION')
+       pg_has_role('bar', 'some_users', 'MEMBER WITH ADMIN OPTION'),
+       pg_has_role('bar', 'some_users', 'USAGE, MEMBER'),
+       pg_has_role('bar', 'some_users', 'USAGE, MEMBER WITH GRANT OPTION'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH GRANT OPTION, MEMBER'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH GRANT OPTION, MEMBER WITH GRANT OPTION')
 ----
-true  false  false  true  false  false
+true  false  false  true  false  false  true  true  true  false
 
 statement ok
 GRANT some_users TO bar WITH ADMIN OPTION

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1066,6 +1066,157 @@ SELECT has_type_privilege('bar', 'text'::REGTYPE::OID, 'USAGE')
 ----
 true
 
+
+## pg_has_role
+
+query BBBBBB
+SELECT pg_has_role(12345, 'USAGE'),
+       pg_has_role(12345, 'USAGE WITH GRANT OPTION'),
+       pg_has_role(12345, 'USAGE WITH ADMIN OPTION'),
+       pg_has_role(12345, 'MEMBER'),
+       pg_has_role(12345, 'MEMBER WITH GRANT OPTION'),
+       pg_has_role(12345, 'MEMBER WITH ADMIN OPTION')
+----
+NULL  NULL  NULL  NULL  NULL  NULL
+
+query BBBBBB
+SELECT pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'USAGE'),
+       pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'USAGE WITH GRANT OPTION'),
+       pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'USAGE WITH ADMIN OPTION'),
+       pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'MEMBER'),
+       pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'MEMBER WITH GRANT OPTION'),
+       pg_has_role((SELECT oid FROM pg_roles WHERE rolname = 'root'), 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+query error pgcode 42704 role 'does_not_exist' does not exist
+SELECT pg_has_role('does_not_exist', 'USAGE')
+
+query BBBBBB
+SELECT pg_has_role('root', 'USAGE'),
+       pg_has_role('root', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('root', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('root', 'MEMBER'),
+       pg_has_role('root', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('root', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "SELECT"
+SELECT pg_has_role('root', 'SELECT')
+
+query error pgcode 22023 unrecognized privilege type: "SELECT"
+SELECT pg_has_role('root', 'SELECT, SELECT')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT pg_has_role('no_user', 'root', 'USAGE')
+
+query BBBBBB
+SELECT pg_has_role('root', 'root', 'USAGE'),
+       pg_has_role('root', 'root', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('root', 'root', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('root', 'root', 'MEMBER'),
+       pg_has_role('root', 'root', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('root', 'root', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+query BBBBBB
+SELECT pg_has_role('bar', 'root', 'USAGE'),
+       pg_has_role('bar', 'root', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('bar', 'root', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('bar', 'root', 'MEMBER'),
+       pg_has_role('bar', 'root', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('bar', 'root', 'MEMBER WITH ADMIN OPTION')
+----
+false  false  false  false  false  false
+
+statement ok
+CREATE ROLE some_users
+
+statement ok
+GRANT some_users TO bar
+
+query BBBBBB
+SELECT pg_has_role('testuser', 'some_users', 'USAGE'),
+       pg_has_role('testuser', 'some_users', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('testuser', 'some_users', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('testuser', 'some_users', 'MEMBER'),
+       pg_has_role('testuser', 'some_users', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('testuser', 'some_users', 'MEMBER WITH ADMIN OPTION')
+----
+false  false  false  false  false  false
+
+query BBBBBB
+SELECT pg_has_role('root', 'some_users', 'USAGE'),
+       pg_has_role('root', 'some_users', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('root', 'some_users', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('root', 'some_users', 'MEMBER'),
+       pg_has_role('root', 'some_users', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('root', 'some_users', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+query BBBBBB
+SELECT pg_has_role('bar', 'some_users', 'USAGE'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('bar', 'some_users', 'MEMBER'),
+       pg_has_role('bar', 'some_users', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('bar', 'some_users', 'MEMBER WITH ADMIN OPTION')
+----
+true  false  false  true  false  false
+
+statement ok
+GRANT some_users TO bar WITH ADMIN OPTION
+
+query BBBBBB
+SELECT pg_has_role('bar', 'some_users', 'USAGE'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('bar', 'some_users', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('bar', 'some_users', 'MEMBER'),
+       pg_has_role('bar', 'some_users', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('bar', 'some_users', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+# WITH ADMIN OPTION is session-user dependent.
+
+query BBBBBB
+SELECT pg_has_role('testuser', 'testuser', 'USAGE'),
+       pg_has_role('testuser', 'testuser', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('testuser', 'testuser', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('testuser', 'testuser', 'MEMBER'),
+       pg_has_role('testuser', 'testuser', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('testuser', 'testuser', 'MEMBER WITH ADMIN OPTION')
+----
+true  false  false  true  false  false
+
+user testuser
+
+query BBBBBB
+SELECT pg_has_role('testuser', 'testuser', 'USAGE'),
+       pg_has_role('testuser', 'testuser', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('testuser', 'testuser', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('testuser', 'testuser', 'MEMBER'),
+       pg_has_role('testuser', 'testuser', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('testuser', 'testuser', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+query BBBBBB
+SELECT pg_has_role('testuser', 'USAGE'),
+       pg_has_role('testuser', 'USAGE WITH GRANT OPTION'),
+       pg_has_role('testuser', 'USAGE WITH ADMIN OPTION'),
+       pg_has_role('testuser', 'MEMBER'),
+       pg_has_role('testuser', 'MEMBER WITH GRANT OPTION'),
+       pg_has_role('testuser', 'MEMBER WITH ADMIN OPTION')
+----
+true  true  true  true  true  true
+
+user root
+
+
 # Regression test for #39703.
 
 statement ok

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -295,7 +295,6 @@ func (p *planner) HasPrivilege(
 	specifier tree.HasPrivilegeSpecifier,
 	user security.SQLUsername,
 	kind privilege.Kind,
-	withGrantOpt bool,
 ) (bool, error) {
 	desc, err := p.ResolveDescriptorForPrivilegeSpecifier(
 		ctx,
@@ -323,16 +322,6 @@ func (p *planner) HasPrivilege(
 	}
 	if hasPrivilege {
 		return true, nil
-	}
-	// For WITH GRANT OPTION, check the roles also has the GRANT privilege.
-	if withGrantOpt {
-		hasPrivilege, err := hasPrivilegeFunc(privilege.GRANT)
-		if err != nil {
-			return false, err
-		}
-		if !hasPrivilege {
-			return false, nil
-		}
 	}
 	return hasPrivilegeFunc(kind)
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1541,19 +1541,24 @@ SELECT description
 			if err != nil {
 				return nil, err
 			}
+			retNull := false
 			if fdw == "" {
 				switch fdwArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.Newf(pgcode.UndefinedObject,
 						"foreign-data wrapper %s does not exist", fdwArg)
 				case *tree.DOid:
-					// Unlike most of the functions, Postgres does not return
-					// NULL when an OID does not match.
+					// Postgres returns NULL if no matching foreign data wrapper is found
+					// when given an OID.
+					retNull = true
 				}
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{
 				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
+					if retNull {
+						return tree.DNull, nil
+					}
 					// All users have USAGE privileges for all foreign-data wrappers.
 					return tree.DBoolTrue, nil
 				},
@@ -1758,19 +1763,24 @@ SELECT description
 			if err != nil {
 				return nil, err
 			}
+			retNull := false
 			if server == "" {
 				switch serverArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.Newf(pgcode.UndefinedObject,
 						"server %s does not exist", serverArg)
 				case *tree.DOid:
-					// Unlike most of the functions, Postgres does not return
-					// NULL when an OID does not match.
+					// Postgres returns NULL if no matching foreign server is found when
+					// given an OID.
+					retNull = true
 				}
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{
 				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
+					if retNull {
+						return tree.DNull, nil
+					}
 					// All users have USAGE privileges for all foreign servers.
 					return tree.DBoolTrue, nil
 				},
@@ -1823,19 +1833,24 @@ SELECT description
 			if err != nil {
 				return nil, err
 			}
+			retNull := false
 			if tablespace == "" {
 				switch tablespaceArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.Newf(pgcode.UndefinedObject,
 						"tablespace %s does not exist", tablespaceArg)
 				case *tree.DOid:
-					// Unlike most of the functions, Postgres does not return
-					// NULL when an OID does not match.
+					// Postgres returns NULL if no matching tablespace is found when given
+					// an OID.
+					retNull = true
 				}
 			}
 
 			return parsePrivilegeStr(args[1], pgPrivList{
 				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
+					if retNull {
+						return tree.DNull, nil
+					}
 					// All users have CREATE privileges in all tablespaces.
 					return tree.DBoolTrue, nil
 				},

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1894,6 +1894,66 @@ SELECT description
 		},
 	),
 
+	"pg_has_role": makePGPrivilegeInquiryDef(
+		"role",
+		argTypeOpts{{"role", strOrOidTypes}},
+		func(ctx *tree.EvalContext, args tree.Datums, user security.SQLUsername) (tree.Datum, error) {
+			roleArg := tree.UnwrapDatum(ctx, args[0])
+			roleS, err := getNameForArg(ctx, roleArg, "pg_roles", "rolname")
+			if err != nil {
+				return nil, err
+			}
+			// Note: the username in pg_roles is already normalized, so we can safely
+			// turn it into a SQLUsername without re-normalization.
+			role := security.MakeSQLUsernameFromPreNormalizedString(roleS)
+			retNull := false
+			if role.Undefined() {
+				switch roleArg.(type) {
+				case *tree.DString:
+					return nil, pgerror.Newf(pgcode.UndefinedObject,
+						"role %s does not exist", roleArg)
+				case *tree.DOid:
+					// Postgres returns NULL if no matching role is found when given an
+					// OID.
+					retNull = true
+				}
+			}
+
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				// From Postgres: We use USAGE to denote whether the privileges of the
+				// role are accessible (has_privs), MEMBER to denote is_member, and
+				// MEMBER WITH GRANT OPTION (or ADMIN OPTION) to denote is_admin. There
+				// is no ACL bit corresponding to MEMBER so we cheat and use CREATE for
+				// that. This convention is shared only with the switch statement below.
+				"USAGE": {privilege.USAGE},
+				// The following two are not a mistake. See Postgres.
+				"USAGE WITH GRANT OPTION":  {privilege.CREATE, privilege.GRANT},
+				"USAGE WITH ADMIN OPTION":  {privilege.CREATE, privilege.GRANT},
+				"MEMBER":                   {privilege.CREATE},
+				"MEMBER WITH GRANT OPTION": {privilege.CREATE, privilege.GRANT},
+				"MEMBER WITH ADMIN OPTION": {privilege.CREATE, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				switch priv {
+				case privilege.USAGE:
+					return hasPrivsOfRole(ctx, user, role)
+				case privilege.CREATE:
+					return isMemberOfRole(ctx, user, role)
+				case privilege.GRANT:
+					return isAdminOfRole(ctx, user, role)
+				default:
+					panic("unexpected")
+				}
+			})
+		},
+	),
+
 	// See https://www.postgresql.org/docs/10/functions-admin.html#FUNCTIONS-ADMIN-SET
 	"current_setting": makeBuiltin(
 		tree.FunctionProperties{
@@ -2301,4 +2361,104 @@ func pgTrueTypImpl(attrField, typField string, retType *types.T) builtinDefiniti
 			Volatility: tree.VolatilityImmutable,
 		},
 	)
+}
+
+// hasPrivsOfRole returns whether the user has the privileges of the
+// specified role (directly or indirectly).
+//
+// This is defined not to recurse through roles that don't have rolinherit
+// set; for such roles, membership implies the ability to do SET ROLE, but
+// the privileges are not available until you've done so.
+//
+// However, because we don't currently support NOINHERIT, a user being a
+// member of a role is equivalent to a user having the privileges of that
+// role, so this is currently equivalent to isMemberOfRole.
+// See https://github.com/cockroachdb/cockroach/issues/69583.
+func hasPrivsOfRole(ctx *tree.EvalContext, user, role security.SQLUsername) (tree.Datum, error) {
+	return isMemberOfRole(ctx, user, role)
+}
+
+// isMemberOfRole returns whether the user is a member of the specified role
+// (directly or indirectly).
+//
+// This is defined to recurse through roles regardless of rolinherit.
+func isMemberOfRole(ctx *tree.EvalContext, user, role security.SQLUsername) (tree.Datum, error) {
+	// Fast path for simple case.
+	if user == role {
+		return tree.DBoolTrue, nil
+	}
+
+	// Superusers have every privilege and are part of every role.
+	if isSuper, err := ctx.Planner.UserHasAdminRole(ctx.Context, user); err != nil {
+		return nil, err
+	} else if isSuper {
+		return tree.DBoolTrue, nil
+	}
+
+	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
+	if err != nil {
+		return nil, err
+	}
+	_, member := allRoleMemberships[role]
+	return tree.MakeDBool(tree.DBool(member)), nil
+}
+
+// isAdminOfRole returns whether the user is an admin of the specified role.
+//
+// That is, is member the role itself (subject to restrictions below), a
+// member (directly or indirectly) WITH ADMIN OPTION, or a superuser?
+func isAdminOfRole(ctx *tree.EvalContext, user, role security.SQLUsername) (tree.Datum, error) {
+	// Superusers are an admin of every role.
+	//
+	// NB: this is intentionally before the user == role check here.
+	if isSuper, err := ctx.Planner.UserHasAdminRole(ctx.Context, user); err != nil {
+		return nil, err
+	} else if isSuper {
+		return tree.DBoolTrue, nil
+	}
+
+	// Fast path for simple case.
+	if user == role {
+		// From Postgres:
+		//
+		// > A role can admin itself when it matches the session user and we're
+		// > outside any security-restricted operation, SECURITY DEFINER or
+		// > similar context. SQL-standard roles cannot self-admin. However,
+		// > SQL-standard users are distinct from roles, and they are not
+		// > grantable like roles: PostgreSQL's role-user duality extends the
+		// > standard. Checking for a session user match has the effect of
+		// > letting a role self-admin only when it's conspicuously behaving
+		// > like a user. Note that allowing self-admin under a mere SET ROLE
+		// > would make WITH ADMIN OPTION largely irrelevant; any member could
+		// > SET ROLE to issue the otherwise-forbidden command.
+		// >
+		// > Withholding self-admin in a security-restricted operation prevents
+		// > object owners from harnessing the session user identity during
+		// > administrative maintenance. Suppose Alice owns a database, has
+		// > issued "GRANT alice TO bob", and runs a daily ANALYZE. Bob creates
+		// > an alice-owned SECURITY DEFINER function that issues "REVOKE alice
+		// > FROM carol". If he creates an expression index calling that
+		// > function, Alice will attempt the REVOKE during each ANALYZE.
+		// > Checking InSecurityRestrictedOperation() thwarts that attack.
+		// >
+		// > Withholding self-admin in SECURITY DEFINER functions makes their
+		// > behavior independent of the calling user. There's no security or
+		// > SQL-standard-conformance need for that restriction, though.
+		// >
+		// > A role cannot have actual WITH ADMIN OPTION on itself, because that
+		// > would imply a membership loop. Therefore, we're done either way.
+		//
+		// Because CockroachDB does not have "security-restricted operation", so
+		// for compatibility, we just need to check whether the user matches the
+		// session user.
+		isSessionUser := user == ctx.SessionData().SessionUser()
+		return tree.MakeDBool(tree.DBool(isSessionUser)), nil
+	}
+
+	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
+	if err != nil {
+		return nil, err
+	}
+	isAdmin := allRoleMemberships[role]
+	return tree.MakeDBool(tree.DBool(isAdmin)), nil
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1577,7 +1577,7 @@ SELECT description
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = tree.PerformCast(ctx, t, types.RegProcedure)
+				oid, err = tree.ParseDOid(ctx, string(*t), types.RegProcedure)
 				if err != nil {
 					return nil, err
 				}
@@ -1869,7 +1869,7 @@ SELECT description
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = tree.PerformCast(ctx, t, types.RegType)
+				oid, err = tree.ParseDOid(ctx, string(*t), types.RegType)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -485,39 +485,43 @@ func getTableNameForArg(ctx *tree.EvalContext, arg tree.Datum) (*tree.TableName,
 	}
 }
 
-// TODO(nvanbenschoten): give this a comment.
-type pgPrivList map[string]func(withGrantOpt bool) (tree.Datum, error)
+// privMap maps a privilege string to a list of privileges.
+type privMap map[string]privilege.List
 
-// parsePrivilegeStr parses the provided privilege string and calls into the
-// privilege option map for each specified privilege.
-func parsePrivilegeStr(arg tree.Datum, availOpts pgPrivList) (tree.Datum, error) {
-	// Postgres allows WITH GRANT OPTION to be added to a privilege type to
-	// test whether the privilege is held with grant option.
-	for priv, fn := range availOpts {
-		fn := fn
-		availOpts[priv+" WITH GRANT OPTION"] = func(_ bool) (tree.Datum, error) {
-			return fn(true /* withGrantOpt */) // Override withGrantOpt
-		}
-	}
-
+// parsePrivilegeStr recognize privilege strings for has_foo_privilege builtins.
+//
+// The function accept a comma-separated list of case-insensitive privilege
+// names, producing a list of privileges. It is liberal about whitespace between
+// items, not so much about whitespace within items. The allowed privilege names
+// and their corresponding privileges are given as a privMap.
+func parsePrivilegeStr(arg tree.Datum, m privMap) (privilege.List, error) {
 	argStr := string(tree.MustBeDString(arg))
-	privs := strings.Split(argStr, ",")
-	for i, priv := range privs {
+	privStrs := strings.Split(argStr, ",")
+	var res privilege.List
+	for _, privStr := range privStrs {
 		// Privileges are case-insensitive.
-		priv = strings.ToUpper(priv)
+		privStr = strings.ToUpper(privStr)
 		// Extra whitespace is allowed between but not within privilege names.
-		privs[i] = strings.TrimSpace(priv)
-	}
-	// Check that all privileges are allowed.
-	for _, priv := range privs {
-		if _, ok := availOpts[priv]; !ok {
+		privStr = strings.TrimSpace(privStr)
+		// Check the privilege map.
+		privs, ok := m[privStr]
+		if !ok {
 			return nil, pgerror.Newf(pgcode.InvalidParameterValue,
-				"unrecognized privilege type: %q", priv)
+				"unrecognized privilege type: %q", privStr)
 		}
+		res = append(res, privs...)
 	}
-	// Perform all privilege checks.
-	for _, priv := range privs {
-		d, err := availOpts[priv](false /* withGrantOpt */)
+	return res, nil
+}
+
+// runPrivilegeChecks runs the provided function for each privilege in the list.
+// If any of the checks return False or NULL, the function short-circuits with
+// that result. Otherwise, it returns True.
+func runPrivilegeChecks(
+	privs privilege.List, check func(privilege.Kind) (tree.Datum, error),
+) (tree.Datum, error) {
+	for _, p := range privs {
+		d, err := check(p)
 		if err != nil {
 			return nil, err
 		}
@@ -537,9 +541,7 @@ func parsePrivilegeStr(arg tree.Datum, availOpts pgPrivList) (tree.Datum, error)
 // evalPrivilegeCheck performs a privilege check for the specified privilege.
 // The function takes an information_schema table name for which to run a query
 // against, along with an arbitrary predicate to run against the table and the
-// user to perform the check on. It also takes a flag as to whether the
-// privilege check should also test whether the privilege is held with grant
-// option.
+// user to perform the check on.
 func evalPrivilegeCheck(
 	ctx *tree.EvalContext,
 	schema string,
@@ -547,13 +549,7 @@ func evalPrivilegeCheck(
 	user security.SQLUsername,
 	pred string,
 	priv privilege.Kind,
-	withGrantOpt bool,
 ) (tree.Datum, error) {
-	privChecks := []privilege.Kind{priv}
-	if withGrantOpt {
-		privChecks = append(privChecks, privilege.GRANT)
-	}
-
 	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
 	if err != nil {
 		return nil, err
@@ -565,30 +561,20 @@ func evalPrivilegeCheck(
 		allRoles = append(allRoles, role.Normalized())
 	}
 
-	for _, p := range privChecks {
-		query := fmt.Sprintf(`
+	query := fmt.Sprintf(`
 			SELECT bool_or(privilege_type IN ('%s', '%s')) IS TRUE
 			FROM %s.%s WHERE grantee = ANY ($1) AND %s`,
-			privilege.ALL, p, schema, infoTable, pred)
-		r, err := ctx.InternalExecutor.QueryRow(
-			ctx.Ctx(), "eval-privilege-check", ctx.Txn, query, allRoles,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if r == nil {
-			return nil, errors.AssertionFailedf("failed to evaluate privilege check")
-		}
-		switch r[0] {
-		case tree.DBoolFalse:
-			return tree.DBoolFalse, nil
-		case tree.DBoolTrue:
-			continue
-		default:
-			return nil, errors.AssertionFailedf("unexpected privilege check result %v", r[0])
-		}
+		privilege.ALL, priv, schema, infoTable, pred)
+	r, err := ctx.InternalExecutor.QueryRow(
+		ctx.Ctx(), "eval-privilege-check", ctx.Txn, query, allRoles,
+	)
+	if err != nil {
+		return nil, err
 	}
-	return tree.DBoolTrue, nil
+	if r == nil {
+		return nil, errors.AssertionFailedf("failed to evaluate privilege check")
+	}
+	return r[0], nil
 }
 
 func makeCreateRegDef(typ *types.T) builtinDefinition {
@@ -1414,19 +1400,21 @@ SELECT description
 				return nil, err
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"SELECT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
-				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.INSERT, withGrantOpt)
-				},
-				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.UPDATE, withGrantOpt)
-				},
-				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"SELECT":                       {privilege.SELECT},
+				"SELECT WITH GRANT OPTION":     {privilege.SELECT, privilege.GRANT},
+				"INSERT":                       {privilege.INSERT},
+				"INSERT WITH GRANT OPTION":     {privilege.INSERT, privilege.GRANT},
+				"UPDATE":                       {privilege.UPDATE},
+				"UPDATE WITH GRANT OPTION":     {privilege.UPDATE, privilege.GRANT},
+				"REFERENCES":                   {privilege.SELECT},
+				"REFERENCES WITH GRANT OPTION": {privilege.SELECT, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return hasPrivilege(ctx, specifier, user, priv)
 			})
 		},
 	),
@@ -1455,19 +1443,21 @@ SELECT description
 				return nil, errors.AssertionFailedf("unexpected arg type %T", t)
 			}
 
-			return parsePrivilegeStr(args[2], pgPrivList{
-				"SELECT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
-				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.INSERT, withGrantOpt)
-				},
-				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.UPDATE, withGrantOpt)
-				},
-				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
+			privs, err := parsePrivilegeStr(args[2], privMap{
+				"SELECT":                       {privilege.SELECT},
+				"SELECT WITH GRANT OPTION":     {privilege.SELECT, privilege.GRANT},
+				"INSERT":                       {privilege.INSERT},
+				"INSERT WITH GRANT OPTION":     {privilege.INSERT, privilege.GRANT},
+				"UPDATE":                       {privilege.UPDATE},
+				"UPDATE WITH GRANT OPTION":     {privilege.UPDATE, privilege.GRANT},
+				"REFERENCES":                   {privilege.SELECT},
+				"REFERENCES WITH GRANT OPTION": {privilege.SELECT, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return hasPrivilege(ctx, specifier, user, priv)
 			})
 		},
 	),
@@ -1494,40 +1484,26 @@ SELECT description
 				}
 			}
 
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"CREATE":                      {privilege.CREATE},
+				"CREATE WITH GRANT OPTION":    {privilege.CREATE, privilege.GRANT},
+				"CONNECT":                     {privilege.CONNECT},
+				"CONNECT WITH GRANT OPTION":   {privilege.CONNECT, privilege.GRANT},
+				"TEMPORARY":                   {privilege.CREATE},
+				"TEMPORARY WITH GRANT OPTION": {privilege.CREATE, privilege.GRANT},
+				"TEMP":                        {privilege.CREATE},
+				"TEMP WITH GRANT OPTION":      {privilege.CREATE, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
 			databasePrivilegePred := fmt.Sprintf("database_name = '%s'", db)
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
-						"cluster_database_privileges", user, databasePrivilegePred,
-						privilege.CREATE, withGrantOpt)
-				},
-				"CONNECT": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
-						"cluster_database_privileges", user, databasePrivilegePred,
-						privilege.CONNECT, withGrantOpt)
-				},
-				"TEMPORARY": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
-						"cluster_database_privileges", user, databasePrivilegePred,
-						privilege.CREATE, withGrantOpt)
-				},
-				"TEMP": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, `"".crdb_internal`,
-						"cluster_database_privileges", user, databasePrivilegePred,
-						privilege.CREATE, withGrantOpt)
-				},
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return evalPrivilegeCheck(ctx, `"".crdb_internal`, "cluster_database_privileges",
+					user, databasePrivilegePred, priv)
 			})
 		},
 	),
@@ -1554,15 +1530,19 @@ SELECT description
 				}
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have USAGE privileges for all foreign-data wrappers.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"USAGE":                   {privilege.USAGE},
+				"USAGE WITH GRANT OPTION": {privilege.USAGE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have USAGE privileges for all foreign-data wrappers.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -1596,15 +1576,22 @@ SELECT description
 				retNull = true
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"EXECUTE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have access to all functions.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				// TODO(nvanbenschoten): this privilege is incorrect, but we don't
+				// currently have an EXECUTE privilege and we aren't even checking
+				// this down below, so it's fine for now.
+				"EXECUTE":                   {privilege.USAGE},
+				"EXECUTE WITH GRANT OPTION": {privilege.USAGE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have EXECUTE privileges for all functions.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -1630,15 +1617,19 @@ SELECT description
 				}
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have access to all languages.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"USAGE":                   {privilege.USAGE},
+				"USAGE WITH GRANT OPTION": {privilege.USAGE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have USAGE privileges for all languages.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -1668,25 +1659,23 @@ SELECT description
 				retNull = true
 			}
 
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"CREATE":                   {privilege.CREATE},
+				"CREATE WITH GRANT OPTION": {privilege.CREATE, privilege.GRANT},
+				"USAGE":                    {privilege.USAGE},
+				"USAGE WITH GRANT OPTION":  {privilege.USAGE, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
 			pred := fmt.Sprintf("table_catalog = '%s' AND table_schema = '%s'",
 				ctx.SessionData().Database, schema)
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"schema_privileges", user, pred,
-						privilege.CREATE, withGrantOpt)
-				},
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"schema_privileges", user, pred,
-						privilege.USAGE, withGrantOpt)
-				},
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return evalPrivilegeCheck(ctx, "information_schema", "schema_privileges",
+					user, pred, priv)
 			})
 		},
 	),
@@ -1725,31 +1714,25 @@ SELECT description
 					tn.CatalogName, tn.SchemaName, tn.ObjectName)
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"table_privileges", user, pred,
-						privilege.SELECT, withGrantOpt)
-				},
-				"SELECT": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"table_privileges", user, pred,
-						privilege.SELECT, withGrantOpt)
-				},
-				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					return evalPrivilegeCheck(ctx, "information_schema",
-						"table_privileges", user, pred,
-						privilege.UPDATE, withGrantOpt)
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				// Sequences and other table objects cannot be given a USAGE privilege,
+				// so we check for SELECT here instead. See privilege.TablePrivileges.
+				"USAGE":                    {privilege.SELECT},
+				"USAGE WITH GRANT OPTION":  {privilege.SELECT, privilege.GRANT},
+				"SELECT":                   {privilege.SELECT},
+				"SELECT WITH GRANT OPTION": {privilege.SELECT, privilege.GRANT},
+				"UPDATE":                   {privilege.UPDATE},
+				"UPDATE WITH GRANT OPTION": {privilege.UPDATE, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return evalPrivilegeCheck(ctx, "information_schema", "table_privileges",
+					user, pred, priv)
 			})
 		},
 	),
@@ -1776,15 +1759,19 @@ SELECT description
 				}
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have USAGE privileges for all foreign servers.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"USAGE":                   {privilege.USAGE},
+				"USAGE WITH GRANT OPTION": {privilege.USAGE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have USAGE privileges for all foreign servers.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -1798,28 +1785,27 @@ SELECT description
 				return nil, err
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"SELECT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
-				"INSERT": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.INSERT, withGrantOpt)
-				},
-				"UPDATE": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.UPDATE, withGrantOpt)
-				},
-				"DELETE": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.DELETE, withGrantOpt)
-				},
-				"TRUNCATE": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.DELETE, withGrantOpt)
-				},
-				"REFERENCES": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.SELECT, withGrantOpt)
-				},
-				"TRIGGER": func(withGrantOpt bool) (tree.Datum, error) {
-					return hasPrivilege(ctx, specifier, user, privilege.CREATE, withGrantOpt)
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"SELECT":                       {privilege.SELECT},
+				"SELECT WITH GRANT OPTION":     {privilege.SELECT, privilege.GRANT},
+				"INSERT":                       {privilege.INSERT},
+				"INSERT WITH GRANT OPTION":     {privilege.INSERT, privilege.GRANT},
+				"UPDATE":                       {privilege.UPDATE},
+				"UPDATE WITH GRANT OPTION":     {privilege.UPDATE, privilege.GRANT},
+				"DELETE":                       {privilege.DELETE},
+				"DELETE WITH GRANT OPTION":     {privilege.DELETE, privilege.GRANT},
+				"TRUNCATE":                     {privilege.DELETE},
+				"TRUNCATE WITH GRANT OPTION":   {privilege.DELETE, privilege.GRANT},
+				"REFERENCES":                   {privilege.SELECT},
+				"REFERENCES WITH GRANT OPTION": {privilege.SELECT, privilege.GRANT},
+				"TRIGGER":                      {privilege.CREATE},
+				"TRIGGER WITH GRANT OPTION":    {privilege.CREATE, privilege.GRANT},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return runPrivilegeChecks(privs, func(priv privilege.Kind) (tree.Datum, error) {
+				return hasPrivilege(ctx, specifier, user, priv)
 			})
 		},
 	),
@@ -1846,15 +1832,19 @@ SELECT description
 				}
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"CREATE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have CREATE privileges in all tablespaces.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"CREATE":                   {privilege.CREATE},
+				"CREATE WITH GRANT OPTION": {privilege.CREATE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have CREATE privileges in all tablespaces.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -1888,15 +1878,19 @@ SELECT description
 				retNull = true
 			}
 
-			return parsePrivilegeStr(args[1], pgPrivList{
-				"USAGE": func(withGrantOpt bool) (tree.Datum, error) {
-					if retNull {
-						return tree.DNull, nil
-					}
-					// All users have access to all types.
-					return tree.DBoolTrue, nil
-				},
+			privs, err := parsePrivilegeStr(args[1], privMap{
+				"USAGE":                   {privilege.USAGE},
+				"USAGE WITH GRANT OPTION": {privilege.USAGE, privilege.GRANT},
 			})
+			if err != nil {
+				return nil, err
+			}
+			if retNull {
+				return tree.DNull, nil
+			}
+			// All users have USAGE privileges to all types.
+			_ = privs
+			return tree.DBoolTrue, nil
 		},
 	),
 
@@ -2226,14 +2220,12 @@ func hasPrivilege(
 	specifier tree.HasPrivilegeSpecifier,
 	user security.SQLUsername,
 	kind privilege.Kind,
-	withGrantOpt bool,
 ) (tree.Datum, error) {
 	ret, err := ctx.Planner.HasPrivilege(
 		ctx.Context,
 		specifier,
 		user,
 		kind,
-		withGrantOpt,
 	)
 	if err != nil {
 		// When an OID is specified and the relation is not found, we return NULL.

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -113,7 +113,7 @@ func (t AlterDefaultPrivilegesTargetObject) String() string {
 	}
 }
 
-// AbbreviatedGrant represents an the GRANT part of an
+// AbbreviatedGrant represents the GRANT part of an
 // ALTER DEFAULT PRIVILEGES statement.
 type AbbreviatedGrant struct {
 	Privileges      privilege.List
@@ -144,7 +144,7 @@ func (n *AbbreviatedGrant) Format(ctx *FmtCtx) {
 	}
 }
 
-// AbbreviatedRevoke represents an the REVOKE part of an
+// AbbreviatedRevoke represents the REVOKE part of an
 // ALTER DEFAULT PRIVILEGES statement.
 type AbbreviatedRevoke struct {
 	Privileges     privilege.List

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3111,7 +3111,6 @@ type EvalDatabase interface {
 		specifier HasPrivilegeSpecifier,
 		user security.SQLUsername,
 		kind privilege.Kind,
-		withGrantOpt bool,
 	) (bool, error)
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3202,6 +3202,13 @@ type EvalPlanner interface {
 		force bool,
 	) error
 
+	// UserHasAdminRole returns tuple of bool and error:
+	// (true, nil) means that the user has an admin role (i.e. root or node)
+	// (false, nil) means that the user has NO admin role
+	// (false, err) means that there was an error running the query on
+	// the `system.users` table
+	UserHasAdminRole(ctx context.Context, user security.SQLUsername) (bool, error)
+
 	// MemberOfWithAdminOption is used to collect a list of roles (direct and
 	// indirect) that the member is part of. See the comment on the planner
 	// implementation in authorization.go


### PR DESCRIPTION
Needed for #69010.
Related to #22734.

This commit implements the `pg_has_role` builtin function. `pg_has_role`
returns whether the user has privileges for a specified role or not.
Allowable privilege types are MEMBER and USAGE. MEMBER denotes direct or
indirect membership in the role (that is, the right to do SET ROLE),
while USAGE denotes whether the privileges of the role are immediately
available without doing SET ROLE.

`pg_has_role` was the last remaining unimplemented "access privilege
inquiry functions", and was omitted from 94c25be because our role-based
access control system was not mature enough to support it at the time.

The commit also makes a small modification to `pg_catalog.pg_roles` and
`pg_catalog.pg_authid` to reflect that fact that all users and roles
inherit the privileges of roles they are members of.

Release note (sql change): The pg_has_role builtin function is now
supported, which returns whether a given user has privileges for a
specified role or not.

Release justification: None, waiting for v22.1.