### PR TITLE
roachtest: unskip `quit-all-nodes`

### DIFF
--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -422,7 +422,6 @@ func registerQuitAllNodes(r registry.Registry) {
 	// short --drain-wait for the remaining nodes under quorum.
 	r.Add(registry.TestSpec{
 		Name:    "quit-all-nodes",
-		Skip:    "flaky #68107",
 		Owner:   registry.OwnerServer,
 		Cluster: r.MakeClusterSpec(5),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
as it was skipped seemingly by accident

Informs #65637

Release justification: non-production code changes

Release note: None