### PR TITLE
sqlproxyccl: support secure connections to SQL backends

### DIFF
--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -71,6 +71,8 @@ This rule must include the port of the SQL pod.`,
 		Description: "Directory address of the service doing resolution from backend id to IP.",
 	}
 
+	// TODO(chrisseto): Remove skip-verify as a CLI option. It should only be
+	// set internally for testing, rather than being exposed to consumers.
 	SkipVerify = FlagInfo{
 		Name:        "skip-verify",
 		Description: "If true, skip identity verification of backend. For testing only.",


### PR DESCRIPTION
    Previously, when establishing a TLS connection to the SQL backend,
    the sqlproxy failed to set .ServerName on the tls.Config. The
    result was the error `tls: either ServerName or InsecureSkipVerify
    must be specified in the tls.Config` whenever .SkipVerify was false.
    This behavior made it impossible to establish verified secure
    connections to SQL backends. This commit properly sets .ServerName
    based on the outgoingAddress returned by the tenantdir service.

Release note: None