### PR TITLE
colexec: adjust the eager cancellation in parallel unordered sync a bit

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -71,7 +71,6 @@ go_library(
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
         "//pkg/util",
-        "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep
         "//pkg/util/encoding",  # keep
         "//pkg/util/humanizeutil",


### PR DESCRIPTION
This commit adjusts the logic for swallowing errors in the parallel
unordered synchronizer because of the eager cancellation when the
synchronizer transitions into the draining state to swallow all errors
coming from an input if the input's context has been canceled by the
synchronizer.

Fixes: #69419.

Release note: None

Release justification: update to the new functionality.