### PR TITLE
kvserver: make raft-snapshot queue logging less noisy

### DIFF
--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -108,6 +108,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 		return errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
 	snapType := SnapshotRequest_VIA_SNAPSHOT_QUEUE
+	skipSnapLogLimiter := log.Every(10 * time.Second)
 
 	if typ := repDesc.GetType(); typ == roachpb.LEARNER || typ == roachpb.NON_VOTER {
 		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
@@ -123,13 +124,11 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 				typ,
 				repDesc,
 			)
-			// TODO(knz): print the error instead when the error package
-			// knows how to expose redactable strings.
-			log.Infof(ctx,
-				"skipping snapshot; replica is likely a %s in the process of being added: %s",
-				typ,
-				repDesc,
-			)
+			if skipSnapLogLimiter.ShouldLog() {
+				log.Infof(ctx, "%v", err)
+			} else {
+				log.VEventf(ctx, 3, "%v", err)
+			}
 			// TODO(dan): This is super brittle and non-obvious. In the common case,
 			// this check avoids duplicate work, but in rare cases, we send the
 			// learner snap at an index before the one raft wanted here. The raft


### PR DESCRIPTION
Release justification: logging only

Release note: None