### PR TITLE
sql: skip reset sql stats in TestRandomSyntaxFunctions

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -298,6 +298,9 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					// Calculating the Frechet distance is slow and testing it here
 					// is not worth it.
 					continue
+				case "crdb_internal.reset_sql_stats":
+					// Skipped due to long execution time.
+					continue
 				}
 				_, variations := builtins.GetBuiltinProperties(name)
 				for _, builtin := range variations {


### PR DESCRIPTION
Previously, crdb_internal.reset_sql_stats() causes timeout
in TestRandomSyntaxFunctions. This is very unlikely due to
implementation of the function, and it is likely caused
by contentions.
This commit skip the tests for crdb_internal.reset_sql_stats()
to prevent nightly failures.

Related #69731

Release justification: Non-production code changes

Release note: None