### PR TITLE
release-21.1: colexec: fix IN operator with unsorted tuple

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1745,7 +1745,7 @@ func planSelectionOperators(
 					// the default comparison operator.
 					break
 				}
-				op, err = colexec.GetInOperator(lTyp, leftOp, leftIdx, datumTuple, negate)
+				op, err = colexec.GetInOperator(evalCtx, lTyp, leftOp, leftIdx, datumTuple, negate)
 			case tree.IsDistinctFrom, tree.IsNotDistinctFrom:
 				if constArg != tree.DNull {
 					// Optimized IsDistinctFrom and IsNotDistinctFrom are
@@ -2145,7 +2145,7 @@ func planProjectionExpr(
 					break
 				}
 				op, err = colexec.GetInProjectionOperator(
-					allocator, typs[leftIdx], input, leftIdx, resultIdx, datumTuple, negate,
+					evalCtx, allocator, typs[leftIdx], input, leftIdx, resultIdx, datumTuple, negate,
 				)
 			case tree.IsDistinctFrom, tree.IsNotDistinctFrom:
 				if right != tree.DNull {

--- a/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
@@ -31,8 +31,8 @@ func genSelectIn(inputFileContents string, wr io.Writer) error {
 	)
 	s := r.Replace(inputFileContents)
 
-	assignEq := makeFunctionRegex("_COMPARE", 5)
-	s = assignEq.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 5))
+	compare := makeFunctionRegex("_COMPARE", 5)
+	s = compare.ReplaceAllString(s, makeTemplateFunctionCall("Compare", 5))
 
 	s = replaceManipulationFuncs(s)
 

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -53,6 +53,7 @@ const (
 )
 
 func GetInProjectionOperator(
+	evalCtx *tree.EvalContext,
 	allocator *colmem.Allocator,
 	t *types.T,
 	input colexecop.Operator,
@@ -74,7 +75,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowBool(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowBool(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.BytesFamily:
@@ -88,7 +89,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowBytes(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowBytes(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.DecimalFamily:
@@ -102,7 +103,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.IntFamily:
@@ -115,7 +116,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt16(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt16(evalCtx, t, datumTuple)
 			return obj, nil
 		case 32:
 			obj := &projectInOpInt32{
@@ -125,7 +126,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt32(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt32(evalCtx, t, datumTuple)
 			return obj, nil
 		case -1:
 		default:
@@ -136,7 +137,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt64(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt64(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.FloatFamily:
@@ -150,7 +151,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.TimestampTZFamily:
@@ -164,7 +165,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.IntervalFamily:
@@ -178,7 +179,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInterval(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInterval(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case typeconv.DatumVecCanonicalTypeFamily:
@@ -192,7 +193,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowDatum(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowDatum(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	}
@@ -200,7 +201,12 @@ func GetInProjectionOperator(
 }
 
 func GetInOperator(
-	t *types.T, input colexecop.Operator, colIdx int, datumTuple *tree.DTuple, negate bool,
+	evalCtx *tree.EvalContext,
+	t *types.T,
+	input colexecop.Operator,
+	colIdx int,
+	datumTuple *tree.DTuple,
+	negate bool,
 ) (colexecop.Operator, error) {
 	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	case types.BoolFamily:
@@ -212,7 +218,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowBool(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowBool(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.BytesFamily:
@@ -224,7 +230,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowBytes(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowBytes(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.DecimalFamily:
@@ -236,7 +242,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.IntFamily:
@@ -247,7 +253,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt16(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt16(evalCtx, t, datumTuple)
 			return obj, nil
 		case 32:
 			obj := &selectInOpInt32{
@@ -255,7 +261,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt32(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt32(evalCtx, t, datumTuple)
 			return obj, nil
 		case -1:
 		default:
@@ -264,7 +270,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInt64(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInt64(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.FloatFamily:
@@ -276,7 +282,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.TimestampTZFamily:
@@ -288,7 +294,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case types.IntervalFamily:
@@ -300,7 +306,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowInterval(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowInterval(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	case typeconv.DatumVecCanonicalTypeFamily:
@@ -312,7 +318,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRowDatum(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRowDatum(evalCtx, t, datumTuple)
 			return obj, nil
 		}
 	}
@@ -341,7 +347,12 @@ type projectInOpBool struct {
 
 var _ colexecop.Operator = &projectInOpBool{}
 
-func fillDatumRowBool(t *types.T, datumTuple *tree.DTuple) ([]bool, bool) {
+func fillDatumRowBool(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]bool, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []bool
 	hasNulls := false
@@ -360,8 +371,8 @@ func fillDatumRowBool(t *types.T, datumTuple *tree.DTuple) ([]bool, bool) {
 func cmpInBool(
 	targetElem bool, targetCol coldata.Bools, filterRow []bool, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowBool, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -583,7 +594,12 @@ type projectInOpBytes struct {
 
 var _ colexecop.Operator = &projectInOpBytes{}
 
-func fillDatumRowBytes(t *types.T, datumTuple *tree.DTuple) ([][]byte, bool) {
+func fillDatumRowBytes(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([][]byte, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result [][]byte
 	hasNulls := false
@@ -602,8 +618,8 @@ func fillDatumRowBytes(t *types.T, datumTuple *tree.DTuple) ([][]byte, bool) {
 func cmpInBytes(
 	targetElem []byte, targetCol *coldata.Bytes, filterRow [][]byte, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowBytes, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -813,7 +829,12 @@ type projectInOpDecimal struct {
 
 var _ colexecop.Operator = &projectInOpDecimal{}
 
-func fillDatumRowDecimal(t *types.T, datumTuple *tree.DTuple) ([]apd.Decimal, bool) {
+func fillDatumRowDecimal(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]apd.Decimal, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []apd.Decimal
 	hasNulls := false
@@ -832,8 +853,8 @@ func fillDatumRowDecimal(t *types.T, datumTuple *tree.DTuple) ([]apd.Decimal, bo
 func cmpInDecimal(
 	targetElem apd.Decimal, targetCol coldata.Decimals, filterRow []apd.Decimal, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowDecimal, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -1047,7 +1068,12 @@ type projectInOpInt16 struct {
 
 var _ colexecop.Operator = &projectInOpInt16{}
 
-func fillDatumRowInt16(t *types.T, datumTuple *tree.DTuple) ([]int16, bool) {
+func fillDatumRowInt16(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]int16, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []int16
 	hasNulls := false
@@ -1066,8 +1092,8 @@ func fillDatumRowInt16(t *types.T, datumTuple *tree.DTuple) ([]int16, bool) {
 func cmpInInt16(
 	targetElem int16, targetCol coldata.Int16s, filterRow []int16, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowInt16, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -1292,7 +1318,12 @@ type projectInOpInt32 struct {
 
 var _ colexecop.Operator = &projectInOpInt32{}
 
-func fillDatumRowInt32(t *types.T, datumTuple *tree.DTuple) ([]int32, bool) {
+func fillDatumRowInt32(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]int32, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []int32
 	hasNulls := false
@@ -1311,8 +1342,8 @@ func fillDatumRowInt32(t *types.T, datumTuple *tree.DTuple) ([]int32, bool) {
 func cmpInInt32(
 	targetElem int32, targetCol coldata.Int32s, filterRow []int32, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowInt32, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -1537,7 +1568,12 @@ type projectInOpInt64 struct {
 
 var _ colexecop.Operator = &projectInOpInt64{}
 
-func fillDatumRowInt64(t *types.T, datumTuple *tree.DTuple) ([]int64, bool) {
+func fillDatumRowInt64(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]int64, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []int64
 	hasNulls := false
@@ -1556,8 +1592,8 @@ func fillDatumRowInt64(t *types.T, datumTuple *tree.DTuple) ([]int64, bool) {
 func cmpInInt64(
 	targetElem int64, targetCol coldata.Int64s, filterRow []int64, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowInt64, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -1782,7 +1818,12 @@ type projectInOpFloat64 struct {
 
 var _ colexecop.Operator = &projectInOpFloat64{}
 
-func fillDatumRowFloat64(t *types.T, datumTuple *tree.DTuple) ([]float64, bool) {
+func fillDatumRowFloat64(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]float64, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []float64
 	hasNulls := false
@@ -1801,8 +1842,8 @@ func fillDatumRowFloat64(t *types.T, datumTuple *tree.DTuple) ([]float64, bool) 
 func cmpInFloat64(
 	targetElem float64, targetCol coldata.Float64s, filterRow []float64, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowFloat64, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -2035,7 +2076,12 @@ type projectInOpTimestamp struct {
 
 var _ colexecop.Operator = &projectInOpTimestamp{}
 
-func fillDatumRowTimestamp(t *types.T, datumTuple *tree.DTuple) ([]time.Time, bool) {
+func fillDatumRowTimestamp(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]time.Time, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []time.Time
 	hasNulls := false
@@ -2054,8 +2100,8 @@ func fillDatumRowTimestamp(t *types.T, datumTuple *tree.DTuple) ([]time.Time, bo
 func cmpInTimestamp(
 	targetElem time.Time, targetCol coldata.Times, filterRow []time.Time, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowTimestamp, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -2276,7 +2322,12 @@ type projectInOpInterval struct {
 
 var _ colexecop.Operator = &projectInOpInterval{}
 
-func fillDatumRowInterval(t *types.T, datumTuple *tree.DTuple) ([]duration.Duration, bool) {
+func fillDatumRowInterval(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]duration.Duration, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []duration.Duration
 	hasNulls := false
@@ -2295,8 +2346,8 @@ func fillDatumRowInterval(t *types.T, datumTuple *tree.DTuple) ([]duration.Durat
 func cmpInInterval(
 	targetElem duration.Duration, targetCol coldata.Durations, filterRow []duration.Duration, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowInterval, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {
@@ -2510,7 +2561,12 @@ type projectInOpDatum struct {
 
 var _ colexecop.Operator = &projectInOpDatum{}
 
-func fillDatumRowDatum(t *types.T, datumTuple *tree.DTuple) ([]interface{}, bool) {
+func fillDatumRowDatum(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]interface{}, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []interface{}
 	hasNulls := false
@@ -2529,8 +2585,8 @@ func fillDatumRowDatum(t *types.T, datumTuple *tree.DTuple) ([]interface{}, bool
 func cmpInDatum(
 	targetElem interface{}, targetCol coldata.DatumVec, filterRow []interface{}, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRowDatum, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -78,6 +78,7 @@ const (
 )
 
 func GetInProjectionOperator(
+	evalCtx *tree.EvalContext,
 	allocator *colmem.Allocator,
 	t *types.T,
 	input colexecop.Operator,
@@ -100,7 +101,7 @@ func GetInProjectionOperator(
 				outputIdx:    resultIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(evalCtx, t, datumTuple)
 			return obj, nil
 			// {{end}}
 		}
@@ -110,7 +111,12 @@ func GetInProjectionOperator(
 }
 
 func GetInOperator(
-	t *types.T, input colexecop.Operator, colIdx int, datumTuple *tree.DTuple, negate bool,
+	evalCtx *tree.EvalContext,
+	t *types.T,
+	input colexecop.Operator,
+	colIdx int,
+	datumTuple *tree.DTuple,
+	negate bool,
 ) (colexecop.Operator, error) {
 	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
 	// {{range .}}
@@ -123,7 +129,7 @@ func GetInOperator(
 				colIdx:       colIdx,
 				negate:       negate,
 			}
-			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(t, datumTuple)
+			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(evalCtx, t, datumTuple)
 			return obj, nil
 			// {{end}}
 		}
@@ -157,7 +163,12 @@ type projectInOp_TYPE struct {
 
 var _ colexecop.Operator = &projectInOp_TYPE{}
 
-func fillDatumRow_TYPE(t *types.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool) {
+func fillDatumRow_TYPE(
+	evalCtx *tree.EvalContext, t *types.T, datumTuple *tree.DTuple,
+) ([]_GOTYPE, bool) {
+	// Sort the contents of the tuple, if they are not already sorted.
+	datumTuple.Normalize(evalCtx)
+
 	conv := colconv.GetDatumToPhysicalFn(t)
 	var result []_GOTYPE
 	hasNulls := false
@@ -176,8 +187,8 @@ func fillDatumRow_TYPE(t *types.T, datumTuple *tree.DTuple) ([]_GOTYPE, bool) {
 func cmpIn_TYPE(
 	targetElem _GOTYPE, targetCol _GOTYPESLICE, filterRow []_GOTYPE, hasNulls bool,
 ) comparisonResult {
-	// Filter row input is already sorted due to normalization, so we can use a
-	// binary search right away.
+	// Filter row input was already sorted in fillDatumRow_TYPE, so we can
+	// perform a binary search.
 	lo := 0
 	hi := len(filterRow)
 	for lo < hi {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1204,3 +1204,18 @@ query T
 SELECT c FROM t68040 WHERE c LIKE '%\\%'
 ----
 string with \ backslash
+
+# Regression test for #68979. The IN operator should evaluate correctly when the
+# tuple contents are not sorted by the optimizer.
+statement ok
+CREATE TABLE t68979 (
+  a INT
+)
+
+statement ok
+INSERT INTO t68979 VALUES (0)
+
+query B
+SELECT 'b' IN ('b', (SELECT NULL FROM t68979), 'a') FROM t68979
+----
+true

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3651,9 +3651,16 @@ func (d *DTuple) Normalize(ctx *EvalContext) {
 
 func (d *DTuple) sort(ctx *EvalContext) {
 	if !d.sorted {
-		sort.Slice(d.D, func(i, j int) bool {
+		lessFn := func(i, j int) bool {
 			return d.D[i].Compare(ctx, d.D[j]) < 0
-		})
+		}
+
+		// It is possible for the tuple to be sorted even though the sorted flag
+		// is not true. So before we perform the sort we check that it is not
+		// already sorted.
+		if !sort.SliceIsSorted(d.D, lessFn) {
+			sort.Slice(d.D, lessFn)
+		}
 		d.SetSorted()
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #69651.

/cc @cockroachdb/release 

Release justifcation: This commit fixes a critical correctness bug in
the vectorized execution engine.

---

The vectorized implementation of an `element IN tuple` expression
assumes that the contents of `tuple` are sorted by the optimizer. Based
on this assumption, it performs a binary search instead of a linear
search.

However, the assumption that the optimizer sorts all tuples is
incorrect. For example, there are cases where the contents of a tuple
are not known at planning-time, so the tuple cannot be sorted.
Performing a binary search with an unsorted tuple causes incorrect query
results.

Now, the vectorized engine sorts tuple contents if they are not already
sorted.

Fixes #68979

Release justification: This commit fixes a bug with the IN operator that
causes incorrect results.

Release note (bug fix): A bug has been fixed which caused incorrect
evaluation of the `IN` operator when the tuple on the right-hand-side
of the operator included a subquery, like
`a IN ('foo', (SELECT s FROM t), 'bar')`.
