### PR TITLE
ui: increment cluster-ui version to 22.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "21.2.0-prerelease-4",
+  "version": "22.1.0-prerelease-1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After the release branch for 21.2 version is cut,
the version of `cluster-ui` NPM package is changed
to next major version 22.1.x on master branch

Resolves: https://github.com/cockroachdb/cockroach/issues/69784

Release note: none