### PR TITLE
distsql: update evalCtx.Txn early if possible

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -300,8 +300,10 @@ func (ds *ServerImpl) setupFlow(
 		// the whole evalContext, but that isn't free, so we choose to restore
 		// the original state in order to avoid performance regressions.
 		origMon := evalCtx.Mon
+		origTxn := evalCtx.Txn
 		onFlowCleanup = func() {
 			evalCtx.Mon = origMon
+			evalCtx.Txn = origTxn
 		}
 		evalCtx.Mon = monitor
 		if localState.HasConcurrency {
@@ -310,6 +312,9 @@ func (ds *ServerImpl) setupFlow(
 			if err != nil {
 				return nil, nil, nil, err
 			}
+			// Update the Txn field early (before f.SetTxn() below) since some
+			// processors capture the field in their constructor (see #41992).
+			evalCtx.Txn = leafTxn
 		}
 	} else {
 		if localState.IsLocal {


### PR DESCRIPTION
We recently introduced the support for multiple parallel processors
within a single stage of a local plan. This forces us to use the LeafTxn
which we instantiate eagerly. This commit adjusts the code to update
`EvalCtx.Txn` right away too as well as to restore the value to its
original.

Release note: None

Release justification: low-risk adjustment to the new functionality.