### PR TITLE
backupccl: use FmtParsable when storing statement in scheduled backup

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -346,7 +346,7 @@ func doCreateBackupSchedules(
 		if err != nil {
 			return errors.Wrapf(err, "failed to evaluate backup encryption_passphrase")
 		}
-		backupNode.Options.EncryptionPassphrase = tree.NewDString(pw)
+		backupNode.Options.EncryptionPassphrase = tree.NewStrVal(pw)
 	}
 
 	// Evaluate encryption KMS URIs if set.
@@ -360,7 +360,7 @@ func doCreateBackupSchedules(
 		}
 		for _, kmsURI := range kmsURIs {
 			backupNode.Options.EncryptionKMSURI = append(backupNode.Options.EncryptionKMSURI,
-				tree.NewDString(kmsURI))
+				tree.NewStrVal(kmsURI))
 		}
 	}
 
@@ -371,7 +371,7 @@ func doCreateBackupSchedules(
 	}
 
 	for _, dest := range destinations {
-		backupNode.To = append(backupNode.To, tree.NewDString(dest))
+		backupNode.To = append(backupNode.To, tree.NewStrVal(dest))
 	}
 
 	backupNode.Targets = eval.Targets
@@ -600,10 +600,7 @@ func makeBackupSchedule(
 
 	// We do not set backupNode.AsOf: this is done when the scheduler kicks off the backup.
 	// Serialize backup statement and set schedule executor and its args.
-	//
-	// TODO(bulkio): this serialization is erroneous, see issue
-	// https://github.com/cockroachdb/cockroach/issues/63216
-	args.BackupStatement = tree.AsStringWithFlags(backupNode, tree.FmtSimple|tree.FmtShowPasswords)
+	args.BackupStatement = tree.AsStringWithFlags(backupNode, tree.FmtParsable|tree.FmtShowPasswords)
 	any, err := pbtypes.MarshalAny(args)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Previously, the executed backup statement for schedules was serialized and
stored using FmtSimple. This format can be lossy and the preferred format to
retain all information is FmtParsable. This patch switches the serialization to
use FmtParsable.

Resolves #63216

Release justification: change should have no impact on current backup schedules.

Release note: None