### PR TITLE
rpc: avoid network IO in `Dialer.ConnHealth`

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -685,6 +685,19 @@ func (ctx *Context) removeConn(conn *Connection, keys ...connKey) {
 	}
 }
 
+// ConnHealth returns nil if we have an open connection of the request
+// class to the given node that succeeded on its most recent heartbeat.
+func (ctx *Context) ConnHealth(target string, nodeID roachpb.NodeID, class ConnectionClass) error {
+	// The local client is always considered healthy.
+	if ctx.GetLocalInternalClientForAddr(target, nodeID) != nil {
+		return nil
+	}
+	if value, ok := ctx.conns.Load(connKey{target, nodeID, class}); ok {
+		return value.(*Connection).Health()
+	}
+	return ErrNoConnection
+}
+
 // GRPCDialOptions returns the minimal `grpc.DialOption`s necessary to connect
 // to a server created with `NewServer`.
 //
@@ -1133,6 +1146,10 @@ func (ctx *Context) NewBreaker(name string) *circuit.Breaker {
 // ErrNotHeartbeated is returned by ConnHealth when we have not yet performed
 // the first heartbeat.
 var ErrNotHeartbeated = errors.New("not yet heartbeated")
+
+// ErrNoConnection is returned by ConnHealth when no connection exists to
+// the node.
+var ErrNoConnection = errors.New("no connection found")
 
 func (ctx *Context) runHeartbeat(
 	conn *Connection, target string, redialChan <-chan struct{},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -165,7 +165,7 @@ func NewDistSQLPlanner(
 		nodeDialer:    nodeDialer,
 		nodeHealth: distSQLNodeHealth{
 			gossip:      gw,
-			connHealth:  nodeDialer.ConnHealth,
+			connHealth:  nodeDialer.ConnHealthTryDial,
 			isAvailable: isAvailable,
 		},
 		distSender:            distSender,


### PR DESCRIPTION
`Dialer.ConnHealth` is used to check whether a healthy RPC connection
exists to a given node, in order to avoid interacting with unavailable
nodes. However, this actually attempted to dial the node if no
connection was found, which can block for tens of seconds in the case of
an unresponsive node. This is problematic since it is used in
performance-critical code paths, including Raft command application.

This patch changes `Dialer.ConnHealth` to avoid dialing the node, and
adds a `Context.ConnHealth` helper with access to the RPC connection
registry. Because `DistSQLPlanner` relied on `ConnHealth` to dial the
remote node, it also adds `Dialer.ConnHealthTryDial` which retains
the old behavior for use in DistSQL until a better solution can be
implemented.

Resolves #69888.

Release note (bug fix): Avoid dialing nodes in performance-critical code
paths, which could cause substantial latency when encountering
unresponsive nodes (e.g. when a VM or server is shut down).