### PR TITLE
release-21.1: changefeedccl: allow changefeeds on regional by row tables

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -40,9 +40,6 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 	if tableDesc.IsSequence() {
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.GetName())
 	}
-	if tableDesc.IsLocalityRegionalByRow() {
-		return errors.Errorf(`CHANGEFEED cannot target REGIONAL BY ROW tables: %s`, tableDesc.GetName())
-	}
 	if len(tableDesc.GetFamilies()) != 1 {
 		return errors.Errorf(
 			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -307,7 +307,7 @@ func (f *kvFeed) scanIfShould(
 			// and returns early. This is important because a change to a primary
 			// index may occur in the same transaction as a change requiring a
 			// backfill.
-			if schemafeed.IsPrimaryIndexChange(ev) {
+			if schemafeed.IsOnlyPrimaryIndexChange(ev) {
 				continue
 			}
 			tablePrefix := f.codec.TablePrefix(uint32(ev.After.GetID()))

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -131,15 +131,6 @@ func (e schemaChangeDetectedError) Error() string {
 	return fmt.Sprintf("schema change detected at %v", e.ts)
 }
 
-type unsupportedSchemaChangeDetected struct {
-	desc string
-	ts   hlc.Timestamp
-}
-
-func (e unsupportedSchemaChangeDetected) Error() string {
-	return fmt.Sprintf("unsupported schema change %s detected at %s", e.desc, e.ts.AsOfSystemTime())
-}
-
 type schemaFeed interface {
 	Peek(ctx context.Context, atOrBefore hlc.Timestamp) (events []schemafeed.TableEvent, err error)
 	Pop(ctx context.Context, atOrBefore hlc.Timestamp) (events []schemafeed.TableEvent, err error)
@@ -227,17 +218,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		boundaryType := jobspb.ResolvedSpan_BACKFILL
 		if f.schemaChangePolicy == changefeedbase.OptSchemaChangePolicyStop {
 			boundaryType = jobspb.ResolvedSpan_EXIT
-		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isRegionalByRowChange(events) {
-			// NOTE(ssd): The user is unlikely to see this
-			// error. The schemafeed will fail with an
-			// non-retriable error, meaning we likely
-			// return right after runUntilTableEvent
-			// above.
-			return unsupportedSchemaChangeDetected{
-				desc: "SET REGIONAL BY ROW",
-				ts:   highWater.Next(),
-			}
-		} else if err == nil && isPrimaryKeyChange(events) {
+		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isPrimaryKeyChange(events) {
 			boundaryType = jobspb.ResolvedSpan_RESTART
 		} else if err != nil {
 			return err
@@ -263,15 +244,6 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 func isPrimaryKeyChange(events []schemafeed.TableEvent) bool {
 	for _, ev := range events {
 		if schemafeed.IsPrimaryIndexChange(ev) {
-			return true
-		}
-	}
-	return false
-}
-
-func isRegionalByRowChange(events []schemafeed.TableEvent) bool {
-	for _, ev := range events {
-		if schemafeed.IsRegionalByRowChange(ev) {
 			return true
 		}
 	}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -194,8 +194,8 @@ func TestKVFeed(t *testing.T) {
 				ts(3),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			expEvents: 2,
 		},
@@ -218,8 +218,8 @@ func TestKVFeed(t *testing.T) {
 				ts(2),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			expEvents: 4,
 		},
@@ -243,8 +243,8 @@ func TestKVFeed(t *testing.T) {
 				ts(2),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(4), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(4), 1, 1)),
 			},
 			expEvents: 2,
 			expErrRE:  "schema change ...",

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -23,7 +23,11 @@ import (
 
 // MakeTableDesc makes a generic table descriptor with the provided properties.
 func MakeTableDesc(
-	tableID descpb.ID, version descpb.DescriptorVersion, modTime hlc.Timestamp, cols int,
+	tableID descpb.ID,
+	version descpb.DescriptorVersion,
+	modTime hlc.Timestamp,
+	cols int,
+	primaryKeyIndex int,
 ) catalog.TableDescriptor {
 	td := descpb.TableDescriptor{
 		Name:             "foo",
@@ -31,6 +35,9 @@ func MakeTableDesc(
 		Version:          version,
 		ModificationTime: modTime,
 		NextColumnID:     1,
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID: descpb.IndexID(primaryKeyIndex),
+		},
 	}
 	for i := 0; i < cols; i++ {
 		td.Columns = append(td.Columns, *MakeColumnDesc(td.NextColumnID))
@@ -80,6 +87,39 @@ func AddNewColumnBackfillMutation(desc catalog.TableDescriptor) catalog.TableDes
 		Direction:   descpb.DescriptorMutation_ADD,
 		MutationID:  0,
 		Rollback:    false,
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddPrimaryKeySwapMutation adds a mutation to desc to do a primary key swap.
+// Yes, this does modify an immutable.
+func AddPrimaryKeySwapMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_ADD,
+		Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{PrimaryKeySwap: &descpb.PrimaryKeySwap{}},
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddNewIndexMutation adds a mutation to desc to add an index.
+// Yes, this does modify an immutable.
+func AddNewIndexMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_ADD,
+		Descriptor_: &descpb.DescriptorMutation_Index{Index: &descpb.IndexDescriptor{}},
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddDropIndexMutation adds a mutation to desc to drop an index.
+// Yes, this does modify an immutable.
+func AddDropIndexMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_DROP,
+		Descriptor_: &descpb.DescriptorMutation_Index{Index: &descpb.IndexDescriptor{}},
 	})
 	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
 }

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -25,9 +25,11 @@ func TestTableEventIsRegionalByRowChange(t *testing.T) {
 	ts := func(seconds int) hlc.Timestamp {
 		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
 	}
-	mkTableDesc := schematestutils.MakeTableDesc
-	addColBackfill := schematestutils.AddNewColumnBackfillMutation
-	setRBR := schematestutils.SetLocalityRegionalByRow
+	var (
+		mkTableDesc    = schematestutils.MakeTableDesc
+		addColBackfill = schematestutils.AddNewColumnBackfillMutation
+		setRBR         = schematestutils.SetLocalityRegionalByRow
+	)
 	for _, c := range []struct {
 		name string
 		e    TableEvent
@@ -36,25 +38,221 @@ func TestTableEventIsRegionalByRowChange(t *testing.T) {
 		{
 			name: "regional by row change",
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: true,
 		},
 		{
 			name: "add non-NULL column",
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
 			},
 			exp: false,
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.exp, IsRegionalByRowChange(c.e))
+			require.Equalf(t, c.exp, IsRegionalByRowChange(c.e), "event %v", c.e)
 		})
 	}
+}
 
+func TestTableEventIsPrimaryIndexChange(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	var (
+		mkTableDesc     = schematestutils.MakeTableDesc
+		addColBackfill  = schematestutils.AddNewColumnBackfillMutation
+		dropColBackfill = schematestutils.AddColumnDropBackfillMutation
+		addIdx          = schematestutils.AddNewIndexMutation
+		pkSwap          = schematestutils.AddPrimaryKeySwapMutation
+		dropIdx         = schematestutils.AddDropIndexMutation
+	)
+	for _, c := range []struct {
+		name string
+		e    TableEvent
+		exp  bool
+	}{
+		{
+			name: "primary index change",
+			e: TableEvent{
+				Before: pkSwap(addIdx(mkTableDesc(42, 1, ts(2), 2, 1))),
+				After:  dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "primary index change with column addition",
+			e: TableEvent{
+				Before: pkSwap(addIdx(addColBackfill(
+					mkTableDesc(42, 1, ts(2), 1, 1),
+				))),
+				After: dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "drop column",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+			},
+			exp: false,
+		},
+		{
+			name: "add non-NULL column",
+			e: TableEvent{
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "add NULL-able computed column",
+			e: TableEvent{
+				Before: func() catalog.TableDescriptor {
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
+					col := td.TableDesc().Mutations[0].GetColumn()
+					col.Nullable = true
+					col.ComputeExpr = proto.String("1")
+					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
+				}(),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equalf(t, c.exp, IsPrimaryIndexChange(c.e), "event %v", c.e)
+		})
+	}
+}
+
+func TestTableEventIsOnlyPrimaryIndexChange(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	var (
+		mkTableDesc     = schematestutils.MakeTableDesc
+		addColBackfill  = schematestutils.AddNewColumnBackfillMutation
+		dropColBackfill = schematestutils.AddColumnDropBackfillMutation
+		addIdx          = schematestutils.AddNewIndexMutation
+		pkSwap          = schematestutils.AddPrimaryKeySwapMutation
+		dropIdx         = schematestutils.AddDropIndexMutation
+	)
+	for _, c := range []struct {
+		name string
+		e    TableEvent
+		exp  bool
+	}{
+		{
+			name: "primary index change",
+			e: TableEvent{
+				Before: pkSwap(addIdx(mkTableDesc(42, 1, ts(2), 2, 1))),
+				After:  dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "primary index change with column addition",
+			e: TableEvent{
+				Before: pkSwap(addIdx(addColBackfill(
+					mkTableDesc(42, 1, ts(2), 1, 1),
+				))),
+				After: dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: false,
+		},
+		{
+			name: "drop column",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+			},
+			exp: false,
+		},
+		{
+			name: "add non-NULL column",
+			e: TableEvent{
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "add NULL-able computed column",
+			e: TableEvent{
+				Before: func() catalog.TableDescriptor {
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
+					col := td.TableDesc().Mutations[0].GetColumn()
+					col.Nullable = true
+					col.ComputeExpr = proto.String("1")
+					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
+				}(),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equalf(t, c.exp, IsOnlyPrimaryIndexChange(c.e), "event %v", c.e)
+		})
+	}
+}
+
+func TestTableEventFilterErrorsWithIncompletePolicy(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	mkTableDesc := schematestutils.MakeTableDesc
+	dropColBackfill := schematestutils.AddColumnDropBackfillMutation
+
+	incompleteFilter := tableEventFilter{
+		// tableEventTypeDropColumn:            false,
+		tableEventTypeAddColumnWithBackfill: false,
+		tableEventTypeAddColumnNoBackfill:   true,
+		// tableEventTypeUnknown:               true,
+		tableEventPrimaryKeyChange: false,
+	}
+	dropColEvent := TableEvent{
+		Before: mkTableDesc(42, 1, ts(2), 2, 1),
+		After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+	}
+	_, err := incompleteFilter.shouldFilter(context.Background(), dropColEvent)
+	require.Error(t, err)
+
+	unknownEvent := TableEvent{
+		Before: mkTableDesc(42, 1, ts(2), 2, 1),
+		After:  mkTableDesc(42, 1, ts(2), 2, 1),
+	}
+	_, err = incompleteFilter.shouldFilter(context.Background(), unknownEvent)
+	require.Error(t, err)
 }
 
 func TestTableEventFilter(t *testing.T) {
@@ -75,8 +273,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter drop column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			exp: false,
 		},
@@ -84,8 +282,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter first step of add non-NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 1),
-				After:  addColBackfill(mkTableDesc(42, 2, ts(4), 1)),
+				Before: mkTableDesc(42, 1, ts(2), 1, 1),
+				After:  addColBackfill(mkTableDesc(42, 2, ts(4), 1, 1)),
 			},
 			exp: true,
 		},
@@ -93,8 +291,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter rollback of add column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 1),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 1, 1),
 			},
 			exp: true,
 		},
@@ -102,8 +300,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter end of add non-NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -112,13 +310,13 @@ func TestTableEventFilter(t *testing.T) {
 			p:    defaultTableEventFilter,
 			e: TableEvent{
 				Before: func() catalog.TableDescriptor {
-					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1))
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
 					col := td.TableDesc().Mutations[0].GetColumn()
 					col.Nullable = true
 					col.ComputeExpr = proto.String("1")
 					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
 				}(),
-				After: mkTableDesc(42, 4, ts(4), 2),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -126,8 +324,17 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter end of add NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 3, ts(2), 1),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: mkTableDesc(42, 3, ts(2), 1, 1),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: true,
+		},
+		{
+			name: "filter unknown table event",
+			p:    defaultTableEventFilter,
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
 			},
 			exp: true,
 		},
@@ -135,8 +342,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter regional by row change",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: false,
 		},
@@ -144,8 +351,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "columnChange - don't filter end of add NULL column",
 			p:    columnChangeTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 3, ts(2), 1),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: mkTableDesc(42, 3, ts(2), 1, 1),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -153,10 +360,19 @@ func TestTableEventFilter(t *testing.T) {
 			name: "columnChange - don't filter regional by row change",
 			p:    columnChangeTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: false,
+		},
+		{
+			name: "columnChange - filter unknown table event",
+			p:    columnChangeTableEventFilter,
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: true,
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #68229.
Backport 1/1 commits from #63217.


/cc @cockroachdb/release

---

Previously we explicitly disallowed changefeeds on regional by row
tables because:

1) the Avro encoder lacked enum support,
2) the schema feed did not correctly identify RBR schema changes as
   both a column addition and a primary key change, and
3) we were unsure whether users would be OK seeing the new crdb_region
   column in their changefeed output.

Both (1) and (2) have been fixed.

For (3) we've decided that changefeeds should rather faithfully emit
what KV tells us about. Future work to support projections and
predicate filtering may allow _users_ to filter what gets output, but
until then we want to err on the side of avoiding ad-hoc modifications
to the changefeed output. Thus, we are OK emitting the crdb_region
column as-is both in the row data and as part of the primary key.

Release note (enterprise change): CHANGEFEEDs no longer fail when
started on REGIONAL BY ROW tables. Note that in REGION BY ROW tables,
the crdb_region column becomes part of the primary index. Thus,
changing an existing table to REGIONAL BY ROW will trigger a
changefeed backfill with new messages emitted using the new composite
primary key.

Release justification: Product-requested functionality backport to facilitiate
21.1 upgrades.