### PR TITLE
[release-21.1] roachtest: Stop node in disk-full roachtest before restarting.

### DIFF
--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -62,6 +62,12 @@ func registerDiskFull(r *testRegistry) {
 						return nil
 					}
 					t.l.Printf("starting %d when disk is full\n", n)
+					// Pebble treats "no space left on device" as a background error. Kill
+					// cockroach if it is still running. Note that this is to kill the
+					// node that was started prior to this for loop, before the ballast
+					// was created. Now that the disk is full, any subsequent node starts
+					// must fail with an error for this test to succeed.
+					_ = c.StopE(ctx, c.Node(n))
 					// We expect cockroach to die during startup, though it might get far
 					// enough along that the monitor detects the death.
 					m.ExpectDeath()


### PR DESCRIPTION
Pebble doesn't have a distinction for fatal background
errors; so no space left on device during a flush/compaction
ends up being a suppressed background error. Seeing as this
isn't going to be fixed rightaway, this change updates
the disk-full roachtest to stop the node being stressed in
case it hasn't crashed on its own, before attempting to
restart it.

The test still checks for the restarts failing, so it's
still a useful roahctest with this change.

Fixes #61686. Backport of #61954.

Release note: None.