### PR TITLE
ui: alignment of o11y pages with other pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
@@ -18,6 +18,12 @@
     }
     &__label {
         cursor: pointer;
+        display: initial;
+        font-family: $font-family--lato-regular;
+        font-size: $font-size--medium;
+        font-weight: normal;
+        -webkit-font-smoothing: initial;
+        -moz-osx-font-smoothing: initial;
     }
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -17,6 +17,7 @@ $colors--primary-blue-3: #0055ff;
 $colors--primary-blue-4: #005fb3;
 $colors--primary-blue-5: #00294d;
 $colors--primary-blue-6: #89b0ff;
+$colors--primary-blue-7: #b6ceff;
 
 $colors--primary-green-0: #daf8d4;
 $colors--primary-green-1: #b4f1aa;

--- a/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
@@ -15,13 +15,16 @@
 @include font-face("SFMono-Semibold");
 @include font-face("RobotoMono-Medium");
 @include font-face("RobotoMono-Regular");
+@include font-face("Lato-Regular");
 
 $font-family--base: SourceSansPro-Regular;
 $font-family--bold: SourceSansPro-Bold;
 $font-family--semi-bold: SourceSansPro-SemiBold;
+$font-family--sans-serif: "Source Sans Pro", sans-serif;
 $font-family--monospace: RobotoMono-Medium;
 $font-family--mono-regular: RobotoMono-Regular;
 $font-family--sf-mono: SFMono-Semibold;
+$font-family--lato-regular: Lato-Regular;
 
 $font-weight--extra-bold: 900;
 $font-weight--bold: 600;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -364,14 +364,14 @@ export class DatabaseDetailsPage extends React.Component<
             }
           />
 
-          <h1
+          <h3
             className={`${baseHeadingClasses.tableName} ${cx(
               "icon__container",
             )}`}
           >
             <StackIcon className={cx("icon--md", "icon--title")} />
             {this.props.name}
-          </h1>
+          </h3>
         </section>
 
         <PageConfig>

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -180,14 +180,14 @@ export class DatabaseTablePage extends React.Component<
             }
           />
 
-          <h1
+          <h3
             className={`${baseHeadingClasses.tableName} ${cx(
               "icon__container",
             )}`}
           >
             <StackIcon className={cx("icon--md", "icon--title")} />
             {this.props.name}
-          </h1>
+          </h3>
         </section>
 
         <section className={baseHeadingClasses.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -250,10 +250,7 @@ export class DatabasesPage extends React.Component<
     ).showByDefault = this.props.showNodeRegionsColumn;
     return (
       <div>
-        <section className={baseHeadingClasses.wrapper}>
-          <h1 className={baseHeadingClasses.tableName}>Databases</h1>
-        </section>
-
+        <h3 className={baseHeadingClasses.tableName}>Databases</h3>
         <section className={sortableTableCx("cl-table-container")}>
           <div className={statisticsClasses.statistic}>
             <h4 className={statisticsClasses.countTitle}>

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.module.scss
@@ -1,6 +1,10 @@
 @import '../core/index.module';
 
 ._text-bold {
-  color: #87beff;
+  color: $colors--primary-blue-3;
   font-family: $font-family--monospace;
+
+  &-light {
+    color: $colors--primary-blue-7;
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -70,6 +70,7 @@ function rebaseText(text: string, highlight: string) {
 export function getHighlightedText(
   text: string,
   highlight: string,
+  hasDarkBkg: boolean,
   isOriginalText?: boolean,
 ) {
   if (!highlight || highlight.length === 0) {
@@ -91,10 +92,11 @@ export function getHighlightedText(
   const parts = isOriginalText
     ? text.split(new RegExp(`(${search})`, "gi"))
     : rebaseText(text, highlight).split(new RegExp(`(${search})`, "gi"));
+  const highlightClass = hasDarkBkg ? "_text-bold-light" : "_text-bold";
   return parts.map((part, i) => {
     if (search.includes(part.toLowerCase())) {
       return (
-        <span key={i} className={cx("_text-bold")}>
+        <span key={i} className={cx(highlightClass)}>
           {`${part}`}
         </span>
       );

--- a/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.module.scss
@@ -1,8 +1,16 @@
+@import "../core/index.module";
+
 .checkbox {
     &__input {
         margin-right: 5px;
     }
     &__label {
         cursor: pointer;
+        display: initial;
+        font-family: $font-family--lato-regular;
+        font-size: $font-size--medium;
+        font-weight: normal;
+        -webkit-font-smoothing: initial;
+        -moz-osx-font-smoothing: initial;
     }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -1,7 +1,6 @@
 @import '../core/index.module';
 
 .page-config {
-  padding-left: 24px;
   // Stick to the top.
   position: sticky;
   position: -webkit-sticky;

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -155,13 +155,13 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
             Sessions
           </Button>
           <div className={cx("heading-with-controls")}>
-            <h1
+            <h3
               className={`${statementsPageCx("base-heading")} ${cx(
                 "page--header__title",
               )}`}
             >
               Session details
-            </h1>
+            </h3>
             {showActionButtons && (
               <div className={cx("heading-controls-group")}>
                 <Button

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -228,11 +228,7 @@ export class SessionsPage extends React.Component<
     return (
       <div className={sessionsPageCx("sessions-page")}>
         <Helmet title={app ? `${app} App | Sessions` : "Sessions"} />
-
-        <section className={statementsPageCx("section")}>
-          <h1 className={statementsPageCx("base-heading")}>Sessions</h1>
-        </section>
-
+        <h3 className={statementsPageCx("base-heading")}>Sessions</h3>
         <Loading
           loading={isNil(this.props.sessions)}
           error={this.props.sessionsError}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.module.scss
@@ -16,24 +16,32 @@
 
 .sessionLink a {
   all: initial;
-  font-family: $font-family--base;
+  font-family: $font-family--semi-bold;
   font-size: $font-size--medium;
+  font-weight: $font-weight--bold;
   cursor: pointer;
+  color: $colors--link;
 }
 
-.cl-table__col-query-text a {
-  all: initial;
-  font-family: $font-family--monospace;
-  font-size: $font-size--small;
-  line-height: 1.83;
-  color: $adminui-grey-1;
-  width: 400px;
-  text-decoration: none;
-  cursor: pointer;
-  @include line-clamp(2);
-  &:hover {
+.cl-table__col-session {
+  color: $colors--neutral-8;
+  font-family: $font-family--base;
+  font-size: $font-size--medium;
+  font-weight: $font-weight--light;
+
+  & a {
+    all: initial;
+    font-family: $font-family--semi-bold;
+    font-weight: $font-weight--bold;
+    line-height: 1.83;
     color: $colors--link;
-    text-decoration: underline;
+    text-decoration: none;
+    cursor: pointer;
+    @include line-clamp(2);
+    &:hover {
+      color: $colors--link;
+      text-decoration: underline;
+    }
   }
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -105,7 +105,7 @@ export function makeSessionsColumns(
     {
       name: "sessionAge",
       title: SessionTableTitle.sessionAge,
-      className: cx("cl-table__col-session-age"),
+      className: cx("cl-table__col-session"),
       cell: session =>
         SessionLink({ session: session.session, onClick: onSessionClick }),
       sort: session => TimestampToMoment(session.session.start).valueOf(),
@@ -113,7 +113,7 @@ export function makeSessionsColumns(
     {
       name: "txnAge",
       title: SessionTableTitle.txnAge,
-      className: cx("cl-table__col-session-start"),
+      className: cx("cl-table__col-session"),
       cell: function(session: SessionInfo) {
         if (session.session.active_txn) {
           return AgeLabel({
@@ -128,7 +128,7 @@ export function makeSessionsColumns(
     {
       name: "statementAge",
       title: SessionTableTitle.statementAge,
-      className: cx("cl-table__col-session-start"),
+      className: cx("cl-table__col-session"),
       cell: function(session: SessionInfo) {
         if (session.session.active_queries?.length > 0) {
           return AgeLabel({
@@ -148,7 +148,7 @@ export function makeSessionsColumns(
     {
       name: "memUsage",
       title: SessionTableTitle.memUsage,
-      className: cx("cl-table__col-session-mem-usage"),
+      className: cx("cl-table__col-session"),
       cell: session =>
         BytesWithPrecision(session.session.alloc_bytes?.toNumber(), 0) +
         "/" +
@@ -158,7 +158,7 @@ export function makeSessionsColumns(
     {
       name: "statement",
       title: SessionTableTitle.statement,
-      className: cx("cl-table__col-query-text"),
+      className: cx("cl-table__col-session"),
       cell: session => {
         if (!(session.session.active_queries?.length > 0)) {
           return "N/A";

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -102,12 +102,12 @@
 }
 
 .cl-table-container {
-  padding: 18px 24px;
+  padding: 18px 24px 18px 0px;
 }
 .cl-table-wrapper {
   padding: 9.55px 20px 17px;
   background-color: $colors--white;
-  width: 100%;
+  width: fit-content;
 }
 
 .table__no-results {

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -3,7 +3,7 @@
 
 @mixin table-header-text {
   @include text--body-strong;
-  color: $colors--neutral-7;
+  color: $colors--neutral-6;
 }
 
 .head-wrapper {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -13,7 +13,7 @@
 
 .section {
   flex: 0 0 auto;
-  padding: 12px 24px;
+  padding: 12px 24px 12px 0px;
 
   &--heading {
     padding-top: 0;
@@ -47,6 +47,16 @@ h2.base-heading {
   padding: 12px 0;
   font-size: 24px;
   font-family: $font-family--base
+}
+
+h3.base-heading {
+  color: $colors--neutral-7;
+  font-family: $font-family--sans-serif;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  font-size: 20px;
+  padding-bottom: 12px;
 }
 
 .back-link {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -404,9 +404,9 @@ export class StatementDetails extends React.Component<
           >
             Statements
           </Button>
-          <h1 className={cx("base-heading", "page--header__title")}>
+          <h3 className={cx("base-heading", "page--header__title")}>
             Statement Details
-          </h1>
+          </h3>
         </div>
         <section className={cx("section", "section--container")}>
           <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -25,7 +25,7 @@
 
 .section {
   flex: 0 0 auto;
-  padding: 12px 24px;
+  padding: 12px 24px 12px 0px;
 
   &--heading {
     padding-top: 0;
@@ -46,6 +46,16 @@ h2.base-heading {
   padding: 12px 0;
   font-size: 24px;
   font-family: $font-family--base;
+}
+
+h3.base-heading {
+  color: $colors--neutral-7;
+  font-family: $font-family--sans-serif;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  font-size: 20px;
+  padding-bottom: 12px;
 }
 
 .root {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -593,11 +593,7 @@ export class StatementsPage extends React.Component<
     return (
       <div className={cx("root", "table-area")}>
         <Helmet title={app ? `${app} App | Statements` : "Statements"} />
-
-        <section className={cx("section")}>
-          <h1 className={cx("base-heading")}>Statements</h1>
-        </section>
-
+        <h3 className={cx("base-heading")}>Statements</h3>
         <Loading
           loading={isNil(this.props.statements)}
           error={this.props.statementsError}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -169,7 +169,7 @@ export const StatementLink = (props: StatementLinkProps) => {
           placement="bottom"
           content={
             <pre className={cx("cl-table-link__description")}>
-              {getHighlightedText(props.statement, props.search)}
+              {getHighlightedText(props.statement, props.search, true)}
             </pre>
           }
         >
@@ -177,6 +177,7 @@ export const StatementLink = (props: StatementLinkProps) => {
             {getHighlightedText(
               shortStatement(summary, props.statement),
               props.search,
+              false,
               true,
             )}
           </div>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -125,7 +125,7 @@ export class TransactionDetails extends React.Component<
           >
             Transactions
           </Button>
-          <h1 className={baseHeadingClasses.tableName}>Transaction Details</h1>
+          <h3 className={baseHeadingClasses.tableName}>Transaction Details</h3>
         </section>
         <Loading
           error={error}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -253,9 +253,7 @@ export class TransactionsPage extends React.Component<
   renderTransactionsList() {
     return (
       <div className={cx("table-area")}>
-        <section className={baseHeadingClasses.wrapper}>
-          <h1 className={baseHeadingClasses.tableName}>Transactions</h1>
-        </section>
+        <h3 className={baseHeadingClasses.tableName}>Transactions</h3>
         <Loading
           loading={!this.props?.data}
           error={this.props?.error}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -56,7 +56,7 @@ export const textCell = ({
         placement="bottom"
         content={
           <pre className={descriptionClassName}>
-            {getHighlightedText(transactionText, search)}
+            {getHighlightedText(transactionText, search, true)}
           </pre>
         }
       >
@@ -70,6 +70,7 @@ export const textCell = ({
             {getHighlightedText(
               limitText(shortStatement(summary, transactionText), 200),
               search,
+              false,
               true,
             )}
           </div>

--- a/pkg/ui/workspaces/db-console/src/components/core/typography.styl
+++ b/pkg/ui/workspaces/db-console/src/components/core/typography.styl
@@ -13,11 +13,13 @@ font-face('SourceSansPro-Regular')
 font-face('SFMono-Semibold')
 font-face('SFMono-Regular')
 font-face('RobotoMono-Medium')
+font-face("Lato-Regular")
 
 $font-family--base = SourceSansPro-Regular
 $font-family--bold = SourceSansPro-Bold
 $font-family--semi-bold = SourceSansPro-SemiBold
 $font-family--monospace = SFMono-Regular, RobotoMono-Medium
+$font-family--lato-regular = Lato-Regular
 
 $font-weight--extra-bold = 900
 $font-weight--bold = 600

--- a/pkg/ui/workspaces/db-console/src/util/highlightedText.module.styl
+++ b/pkg/ui/workspaces/db-console/src/util/highlightedText.module.styl
@@ -9,5 +9,9 @@
 // licenses/APL.txt.
 
 ._text-bold
-  color #87beff
+  color #0055FF
+  font-family RobotoMono-Bold
+
+._text-bold-light
+  color #B6CEFF
   font-family RobotoMono-Bold

--- a/pkg/ui/workspaces/db-console/src/util/highlightedText.tsx
+++ b/pkg/ui/workspaces/db-console/src/util/highlightedText.tsx
@@ -17,6 +17,7 @@ const cx = classNames.bind(styles);
 export default function getHighlightedText(
   text: string,
   highlight: string,
+  hasDarkBkg: boolean,
   isOriginalText?: boolean,
 ) {
   if (!highlight || highlight.length === 0) {
@@ -38,10 +39,11 @@ export default function getHighlightedText(
   const parts = isOriginalText
     ? text.split(new RegExp(`(${search})`, "gi"))
     : rebaseText(text, highlight).split(new RegExp(`(${search})`, "gi"));
+  const highlightClass = hasDarkBkg ? "_text-bold-light" : "_text-bold";
   return parts.map((part, i) => {
     if (search.includes(part.toLowerCase())) {
       return (
-        <span key={i} className={cx("_text-bold")}>
+        <span key={i} className={cx(highlightClass)}>
           {`${part}`}
         </span>
       );

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
@@ -28,7 +28,6 @@ $subnav-background  = $background-color
     clear both
 
 .page-config
-  padding-left 24px
   background-color $background-color
 
   &__list
@@ -65,7 +64,7 @@ $subnav-background  = $background-color
 
 .section
   flex 0 0 auto
-  padding 12px 24px
+  padding 12px 24px 12px 0px
   max-width $max-window-width
   clearfix()
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -256,4 +256,4 @@
   flex-grow 1
   max-width $max-window-width
   position relative
-  padding $spacing-smaller $spacing-medium
+  padding $spacing-smaller $spacing-medium $spacing-smaller 0

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -257,9 +257,7 @@ export class NodeGraphs extends React.Component<NodeGraphsProps> {
     return (
       <div style={{ paddingBottom }}>
         <Helmet title={title} />
-        <section className="section">
-          <h1 className="base-heading">{title}</h1>
-        </section>
+        <h3 className="base-heading">{title}</h3>
         <PageConfig>
           <PageConfigItem>
             <Dropdown

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeOverview/index.tsx
@@ -145,7 +145,7 @@ export class NodeOverview extends React.Component<NodeOverviewProps, {}> {
           >
             Overview
           </Button>
-          <h2 className="base-heading">{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
+          <h3 className="base-heading">{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h3>
         </div>
         <section className="section l-columns">
           <div className="l-columns__left">

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
@@ -142,9 +142,7 @@ export class JobsTable extends React.Component<JobsTableProps> {
     return (
       <div className="jobs-page">
         <Helmet title="Jobs" />
-        <section className="section">
-          <h1 className="base-heading">Jobs</h1>
-        </section>
+        <h3 className="base-heading">Jobs</h3>
         <div>
           <PageConfig>
             <PageConfigItem>

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -107,9 +107,9 @@ class JobDetails extends React.Component<JobsTableProps, {}> {
           >
             Jobs
           </Button>
-          <h1 className="page--header__title">{`Job ID: ${String(
+          <h3 className="page--header__title">{`Job ID: ${String(
             getMatchParamByName(match, "id"),
-          )}`}</h1>
+          )}`}</h3>
         </div>
         <section className="section section--container">
           <Loading loading={_.isNil(job)} render={this.renderContent} />

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -90,7 +90,7 @@ export default function Debug() {
   return (
     <div className="section">
       <Helmet title="Debug" />
-      <h1 className="base-heading">Advanced Debugging</h1>
+      <h3 className="base-heading">Advanced Debugging</h3>
       <div className="debug-header">
         <InfoBox>
           <p>

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/pageconfig/pageConfig.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/pageconfig/pageConfig.module.styl
@@ -12,7 +12,6 @@
 @require '~styl/base/layout-vars.styl'
 
 .page-config
-  padding-left 24px
   // Stick to the top.
   position sticky
   position -webkit-sticky

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sortabletable/index.tsx
@@ -349,6 +349,7 @@ export class SortableTable extends React.Component<TableProps> {
               {getHighlightedText(
                 drawerData.statement,
                 drawerData.search,
+                false,
                 true,
               )}
             </span>

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sortabletable/sortabletable.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sortabletable/sortabletable.styl
@@ -91,10 +91,11 @@
 
 
 .cl-table-container
-  padding 18px 24px
+  padding 18px 24px 18px 0px
 .cl-table-wrapper
   padding 20px
   background-color $adminui-white
+  width: fit-content
 
 .table__no-results
   display flex

--- a/pkg/ui/workspaces/db-console/styl/base/typography.styl
+++ b/pkg/ui/workspaces/db-console/styl/base/typography.styl
@@ -32,6 +32,14 @@ h2.base-heading
   font-size 24px
   font-family SourceSansPro-Regular
 
+h3.base-heading
+  color $colors--neutral-7
+  font-family $font-family--sans-serif
+  font-weight 600
+  font-style normal
+  font-stretch normal
+  font-size 20px
+  padding-bottom 12px
+
 code
   font-family $font-family--monospace
-  

--- a/pkg/ui/workspaces/db-console/styl/shame.styl
+++ b/pkg/ui/workspaces/db-console/styl/shame.styl
@@ -167,7 +167,7 @@
         line-height 24px
         ._text-bold
           font-family RobotoMono-Bold
-          color #8dbcff
+          color #0055ff
 
 .ant-input, .ant-time-picker-input
   height 40px
@@ -396,7 +396,7 @@
     font-size 12px
     line-height 24px
     ._text-bold
-      color #87beff
+      color #0055ff
       font-family RobotoMono-Bold
 
 .cockroach--tabs


### PR DESCRIPTION
- Update page title font and sizes
- Update spacing from main content area (removing
padding left)
- Update table headers
- On sessions page: update font, sizes of texts
and use color blue for links
- On search query results, update tone of blue on main
text and on tooltips

Partially #67774

Release justification: Category 4
Release note (ui change): Updating ui of o11y pages to match
remaning pages (e.g. spacing, colors, font sizes)