### PR TITLE
release-21.1: sql: fix interaction between stmt bundles and tracing

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -119,6 +119,16 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 			base, plans, "stats-defaultdb.public.abc.sql", "distsql.html",
 		)
 	})
+
+	t.Run("basic when tracing already enabled", func(t *testing.T) {
+		r.Exec(t, "SET CLUSTER SETTING sql.trace.txn.enable_threshold='100ms';")
+		defer r.Exec(t, "SET CLUSTER SETTING sql.trace.txn.enable_threshold='0ms';")
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM abc WHERE c=1")
+		checkBundle(
+			t, fmt.Sprint(rows), "public.abc",
+			base, plans, "stats-defaultdb.public.abc.sql", "distsql.html",
+		)
+	})
 }
 
 // checkBundle searches text strings for a bundle URL and then verifies that the


### PR DESCRIPTION
Backport 1/1 commits from #69975.

/cc @cockroachdb/release

---

Previously, we wouldn't generate the bundle if the verbose tracing was
already enabled on the cluster because we wouldn't call
`instrumentationHelper.Finish` where we actually generate the bundle.
This would result in empty responses for `EXPLAIN ANALYZE (DEBUG)` as
well as the requests for stmt diagnostics being stuck in "waiting"
state.

Fixes: #69398.

Release note (bug fix): Previously, if the tracing
(`sql.trace.txn.enable_threshold` cluster setting) was enabled on the
cluster, the statement diagnostics collection (`EXPLAIN ANALYZE
(DEBUG)`) wouldn't work. This is now fixed.

Release justification: low-risk fix to a long-standing bug.
