### PR TITLE
gossip: avoid DNS lookups during bootstrapping

### DIFF
--- a/pkg/gossip/resolver/socket.go
+++ b/pkg/gossip/resolver/socket.go
@@ -34,10 +34,6 @@ func (sr *socketResolver) Addr() string { return sr.addr }
 func (sr *socketResolver) GetAddress() (net.Addr, error) {
 	switch sr.typ {
 	case "tcp":
-		_, err := net.ResolveTCPAddr("tcp", sr.addr)
-		if err != nil {
-			return nil, err
-		}
 		return util.NewUnresolvedAddr("tcp", sr.addr), nil
 	}
 	return nil, errors.Errorf("unknown address type: %q", sr.typ)


### PR DESCRIPTION
Gossip bootstrapping happens both during server startup and also when
the sentinel key expires (i.e. when the range 1 leaseholder is
unavailable). This performed DNS lookups as a way to validate bootstrap
addresses, although the resolved address was not actually used yet.

However, this was done while holding the gossip mutex, and an
unresponsive DNS server could cause this lookup to take tens of seconds
before failing. This would block other operations from acquiring the
mutex, notably `AddInfo()` which is called from several performance
critical code paths including Raft command application.

This patch simply removes this DNS lookup used for validation, since we
already do basic adress validation in `NewResolver()` and further
validation including DNS lookups will be done at dial time.

A better fix is to remove the `resolver.Resolver` concept entirely,
since it appears to be a historical vestige that doesn't actually do any
resolution, and instead use `util.UnresolvedAddr`. This should be
addressed in a separate PR, for backportability. Since this appears to
be the "correct" fix, no regression test is included here, as there will
be no way to incur a DNS lookup penalty when there are no resolvers.

Resolves #69890.

Release note (bug fix): DNS unavailability during range 1 leaseholder
loss will no longer cause significant latency increases for queries and
other operations.