### PR TITLE
ui: update clear sql stats link

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -1,3 +1,5 @@
+@import "src/core/index.module";
+
 .flex-display {
   display: flex;
 }
@@ -5,4 +7,12 @@
 .tooltip-hover-area {
   padding-top: 3px;
   padding-right: 10px;
+}
+
+.action {
+  color: $colors--link;
+  &:hover {
+  color: $colors--link;
+    text-decoration: underline;
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -73,7 +73,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   );
 
   let toolTipText = ` history is cleared once an hour by default, which can be configured with 
-  the cluster setting diagnostics.sql_stat_reset.interval. Clicking ‘Clear SQL stats’ will reset SQL stats 
+  the cluster setting diagnostics.sql_stat_reset.interval. Clicking ‘clear SQL stats’ will reset SQL stats 
   on the statements and transactions pages.`;
 
   switch (tooltipType) {
@@ -104,7 +104,9 @@ export const TableStatistics: React.FC<TableStatistics> = ({
         <div className={lastCleared}>
           {renderLastCleared(lastReset)}
           {"  "}-{"  "}
-          <a onClick={resetSQLStats}>Clear SQL Stats</a>
+          <a className={cxStats("action")} onClick={resetSQLStats}>
+            clear SQL stats
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Update "clear SQL stats" on Statements and Transactions
page to match remaining action links (all lower case and
right blue tone"

Before
<img width="329" alt="Screen Shot 2021-09-10 at 12 43 54 PM" src="https://user-images.githubusercontent.com/1017486/132888427-9b9cba26-0c9c-4895-a8e8-9da2fd126ea7.png">

After
<img width="358" alt="Screen Shot 2021-09-10 at 12 42 55 PM" src="https://user-images.githubusercontent.com/1017486/132888444-aa3872e4-b626-4225-823e-6b986cda010c.png">
hover
<img width="243" alt="Screen Shot 2021-09-10 at 12 45 06 PM" src="https://user-images.githubusercontent.com/1017486/132888587-9b8cba3f-8c29-45e1-bbec-ba61ddc39115.png">



Release justification: Category 4
Release note (ui change): Update 'clear SQL stats' color and
change to lower case on Transaction and Statements page