### PR TITLE
ui: fix column display behaviour for nodes

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -248,6 +248,9 @@ export class DatabasesPage extends React.Component<
     this.columns.find(
       c => c.name === "nodeRegions",
     ).showByDefault = this.props.showNodeRegionsColumn;
+    const displayColumns = this.columns.filter(
+      col => col.showByDefault !== false,
+    );
     return (
       <div>
         <section className={baseHeadingClasses.wrapper}>
@@ -272,7 +275,7 @@ export class DatabasesPage extends React.Component<
           <DatabasesSortedTable
             className={cx("databases-table")}
             data={this.props.databases}
-            columns={this.columns}
+            columns={displayColumns}
             sortSetting={this.state.sortSetting}
             onChangeSortSetting={this.changeSortSetting.bind(this)}
             pagination={this.state.pagination}

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -246,21 +246,19 @@ export class SortedTable<T> extends React.Component<
       rollups: React.ReactNode[],
       columns: ColumnDescriptor<T>[],
     ) => {
-      return columns
-        .filter(col => col.alwaysShow || col.showByDefault !== false)
-        .map(
-          (cd, ii): SortableColumn => {
-            return {
-              name: cd.name,
-              title: cd.title,
-              cell: index => cd.cell(sorted[index]),
-              columnTitle: cd.sort ? cd.name : undefined,
-              rollup: rollups[ii],
-              className: cd.className,
-              titleAlign: cd.titleAlign,
-            };
-          },
-        );
+      return columns.map(
+        (cd, ii): SortableColumn => {
+          return {
+            name: cd.name,
+            title: cd.title,
+            cell: index => cd.cell(sorted[index]),
+            columnTitle: cd.sort ? cd.name : undefined,
+            rollup: rollups[ii],
+            className: cd.className,
+            titleAlign: cd.titleAlign,
+          };
+        },
+      );
     },
   );
 


### PR DESCRIPTION
A recent change made for the databases page broke the behaviour
of column display on Transaction and Statement page for
columns that were hidden by default. This commits fix this issue,
where now those columns are displayed if selected on the column
selector and also handle the right column on the database page.

Release justification: Category 3
Release note (bug fix): Columns that were hidden by default where not
being displayed when selected. This commits fixes the behaviour.