### PR TITLE
jobs,schedule: Restrict the set of executors in test environment.

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -199,7 +199,6 @@ go_test(
         "//pkg/sql/rowflow",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sqlstats",
         "//pkg/sql/stats",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -67,7 +66,8 @@ func newTestHelper(t *testing.T) (*testHelper, func()) {
 	dir, dirCleanupFn := testutils.TempDir(t)
 
 	th := &testHelper{
-		env:   jobstest.NewJobSchedulerTestEnv(jobstest.UseSystemTables, timeutil.Now()),
+		env: jobstest.NewJobSchedulerTestEnv(
+			jobstest.UseSystemTables, timeutil.Now(), tree.ScheduledBackupExecutor),
 		iodir: dir,
 	}
 
@@ -91,9 +91,6 @@ func newTestHelper(t *testing.T) (*testHelper, func()) {
 		ExternalIODir: dir,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: knobs,
-			SQLStatsKnobs: &sqlstats.TestingKnobs{
-				AOSTClause: "AS OF SYSTEM TIME '-1us'",
-			},
 		},
 	}
 	s, db, _ := serverutils.StartServer(t, args)

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -300,6 +300,12 @@ func (s *jobScheduler) executeSchedules(
 			continue
 		}
 
+		if !s.env.IsExecutorEnabled(schedule.ExecutorType()) {
+			log.Infof(ctx, "Ignoring schedule %d: %s executor disabled",
+				schedule.ScheduleID(), schedule.ExecutorType())
+			continue
+		}
+
 		if processErr := withSavePoint(ctx, txn, func() error {
 			return s.processSchedule(ctx, schedule, numRunning, stats, txn)
 		}); processErr != nil {

--- a/pkg/jobs/jobstest/BUILD.bazel
+++ b/pkg/jobs/jobstest/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/scheduledjobs",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/sem/tree",
         "//pkg/util/syncutil",
     ],
 )

--- a/pkg/jobs/jobstest/utils.go
+++ b/pkg/jobs/jobstest/utils.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -33,7 +34,9 @@ const UseSystemTables EnvTablesType = true
 
 // NewJobSchedulerTestEnv creates JobSchedulerTestEnv and initializes environments
 // current time to initial time.
-func NewJobSchedulerTestEnv(whichTables EnvTablesType, t time.Time) *JobSchedulerTestEnv {
+func NewJobSchedulerTestEnv(
+	whichTables EnvTablesType, t time.Time, allowedExecutors ...tree.ScheduledJobExecutorType,
+) *JobSchedulerTestEnv {
 	var env *JobSchedulerTestEnv
 	if whichTables == UseTestTables {
 		env = &JobSchedulerTestEnv{
@@ -47,6 +50,13 @@ func NewJobSchedulerTestEnv(whichTables EnvTablesType, t time.Time) *JobSchedule
 		}
 	}
 	env.mu.now = t
+	if len(allowedExecutors) > 0 {
+		env.allowedExecutors = make(map[string]struct{}, len(allowedExecutors))
+		for _, e := range allowedExecutors {
+			env.allowedExecutors[e.InternalName()] = struct{}{}
+		}
+	}
+
 	return env
 }
 
@@ -55,6 +65,7 @@ func NewJobSchedulerTestEnv(whichTables EnvTablesType, t time.Time) *JobSchedule
 type JobSchedulerTestEnv struct {
 	scheduledJobsTableName string
 	jobsTableName          string
+	allowedExecutors       map[string]struct{}
 	mu                     struct {
 		syncutil.Mutex
 		now time.Time
@@ -101,6 +112,15 @@ func (e *JobSchedulerTestEnv) NowExpr() string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return fmt.Sprintf("TIMESTAMPTZ '%s'", e.mu.now.Format(timestampTZLayout))
+}
+
+// IsExecutorEnabled implements scheduledjobs.JobSchedulerEnv
+func (e *JobSchedulerTestEnv) IsExecutorEnabled(name string) bool {
+	enabled := e.allowedExecutors == nil
+	if !enabled {
+		_, enabled = e.allowedExecutors[name]
+	}
+	return enabled
 }
 
 // GetScheduledJobsTableSchema returns schema for the scheduled jobs table.

--- a/pkg/scheduledjobs/env.go
+++ b/pkg/scheduledjobs/env.go
@@ -34,6 +34,9 @@ type JobSchedulerEnv interface {
 	// NowExpr returns expression representing current time when
 	// used in the database queries.
 	NowExpr() string
+	// IsExecutorEnabled returns true if the scheduled jobs for the
+	// specified executor type are allowed to run.
+	IsExecutorEnabled(name string) bool
 }
 
 // JobExecutionConfig encapsulates external components needed for scheduled job execution.
@@ -72,6 +75,10 @@ func (e *prodJobSchedulerEnvImpl) Now() time.Time {
 
 func (e *prodJobSchedulerEnvImpl) NowExpr() string {
 	return "current_timestamp()"
+}
+
+func (e *prodJobSchedulerEnvImpl) IsExecutorEnabled(name string) bool {
+	return true
 }
 
 // ScheduleControllerEnv is an environment for controlling (DROP, PAUSE)

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlutil",

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -64,7 +65,8 @@ WHERE
 
 func newTestHelper(t *testing.T) (helper *testHelper, cleanup func()) {
 	helper = &testHelper{
-		env: jobstest.NewJobSchedulerTestEnv(jobstest.UseSystemTables, timeutil.Now()),
+		env: jobstest.NewJobSchedulerTestEnv(
+			jobstest.UseSystemTables, timeutil.Now(), tree.ScheduledSQLStatsCompactionExecutor),
 	}
 
 	knobs := jobs.NewTestingKnobsWithShortIntervals()


### PR DESCRIPTION
Recent additions to scheduled jobs (i.e. SQL stats schedule job) resulted
in a state where scheduled jobs might have multiple scheduled job tests.
In general, the scheduled job tests (i.e. the tests that actually test
the ScheduledJobs implementations) need to setup their test state in specific
ways, and they also force execute schedules -- including the schedules
that the test itself did not create.  This results in unintented
effects, and requires adding some unrelated testing knobs in order to
make other scheduled job executors behave well under test environment.

This PR extends the `JobSchedulerEnv` to support whitelisting
the set of executors that are enabled, so that the tests can explicitly
restrict the execution only to the executors that they care about.

Release Justification: No functionality change, test only PR.
Release Notes: None