### PR TITLE
util/log: prevent duplicate entries in registries

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -105,6 +105,9 @@ type loggingT struct {
 		syncutil.RWMutex
 		idPayload
 	}
+
+	allSinkInfos sinkInfoRegistry
+	allLoggers   loggerRegistry
 }
 
 type idPayload struct {

--- a/pkg/util/log/file_api.go
+++ b/pkg/util/log/file_api.go
@@ -92,7 +92,7 @@ var errNoFileLogging = errors.New("log: file logging is not configured")
 // listLogGroups returns slices of logpb.FileInfo structs.
 // There is one logpb.FileInfo slice per file sink.
 func listLogGroups() (logGroups [][]logpb.FileInfo, err error) {
-	err = allSinkInfos.iterFileSinks(func(l *fileSink) error {
+	err = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		_, thisLoggerFiles, err := l.listLogFiles()
 		if err != nil {
 			return err
@@ -116,7 +116,7 @@ func ListLogFiles() (logFiles []logpb.FileInfo, err error) {
 		return fileSink.mu.logDir
 	}()
 
-	err = allSinkInfos.iterFileSinks(func(l *fileSink) error {
+	err = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		// For now, only gather logs from the main log directory.
 		// This is because the other APIs don't yet understand
 		// secondary log directories, and we don't want

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -75,7 +75,7 @@ func TestSecondaryGC(t *testing.T) {
 
 	// Find our "gctest" file sink
 	var fs *fileSink
-	require.NoError(t, allSinkInfos.iterFileSinks(
+	require.NoError(t, logging.allSinkInfos.iterFileSinks(
 		func(p *fileSink) error {
 			if strings.HasSuffix(p.prefix, "gctest") {
 				fs = p

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -114,10 +114,10 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 		fd2CaptureCleanupFn()
 		secLoggersCancel()
 		for _, l := range secLoggers {
-			allLoggers.del(l)
+			logging.allLoggers.del(l)
 		}
 		for _, l := range sinkInfos {
-			allSinkInfos.del(l)
+			logging.allSinkInfos.del(l)
 		}
 	}
 
@@ -138,7 +138,7 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 		// file header at the beginning of the file (which will contain
 		// a timestamp, command-line arguments, etc.).
 		secLogger := &loggerT{}
-		allLoggers.put(secLogger)
+		logging.allLoggers.put(secLogger)
 		secLoggers = append(secLoggers, secLogger)
 
 		// A pseudo file sink. Again, for convenience, so we don't need
@@ -172,7 +172,7 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 			return nil, err
 		}
 		sinkInfos = append(sinkInfos, fileSinkInfo)
-		allSinkInfos.put(fileSinkInfo)
+		logging.allSinkInfos.put(fileSinkInfo)
 
 		if fileSink.logFilesCombinedMaxSize > 0 {
 			// Do a start round of GC, so clear up past accumulated files.
@@ -252,7 +252,7 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 
 	attachSinkInfo := func(si *sinkInfo, chs []logpb.Channel) {
 		sinkInfos = append(sinkInfos, si)
-		allSinkInfos.put(si)
+		logging.allSinkInfos.put(si)
 
 		// Connect the channels for this sink.
 		for _, ch := range chs {
@@ -461,7 +461,7 @@ func DescribeAppliedConfig() string {
 
 	// Describe the file sinks.
 	config.Sinks.FileGroups = make(map[string]*logconfig.FileSinkConfig)
-	_ = allSinkInfos.iter(func(l *sinkInfo) error {
+	_ = logging.allSinkInfos.iter(func(l *sinkInfo) error {
 		if cl := logging.testingFd2CaptureLogger; cl != nil && cl.sinkInfos[0] == l {
 			// Not a real sink. Omit.
 			return nil
@@ -506,7 +506,7 @@ func DescribeAppliedConfig() string {
 	// Describe the fluent sinks.
 	config.Sinks.FluentServers = make(map[string]*logconfig.FluentSinkConfig)
 	sIdx := 1
-	_ = allSinkInfos.iter(func(l *sinkInfo) error {
+	_ = logging.allSinkInfos.iter(func(l *sinkInfo) error {
 		fluentSink, ok := l.sink.(*fluentSink)
 		if !ok {
 			return nil

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -128,6 +128,11 @@ func ApplyConfig(config logconfig.Config) (cleanupFn func(), err error) {
 		}
 	}()
 
+	// We're going to re-define loggers and sinks, so start with a fresh
+	// registry.
+	logging.allLoggers.clear()
+	logging.allSinkInfos.clear()
+
 	// If capture of internal fd2 writes is enabled, set it up here.
 	if config.CaptureFd2.Enable {
 		if logging.testingFd2CaptureLogger != nil {

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -31,7 +31,7 @@ type flushSyncWriter interface {
 // flushes, and signalFlusher() that manages flushes in reaction to a
 // user signal.
 func Flush() {
-	_ = allSinkInfos.iterFileSinks(func(l *fileSink) error {
+	_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.lockAndFlushAndMaybeSync(true /*doSync*/)
 		return nil
 	})
@@ -83,7 +83,7 @@ func flushDaemon() {
 
 		if !disableDaemons {
 			// Flush the loggers.
-			_ = allSinkInfos.iterFileSinks(func(l *fileSink) error {
+			_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 				l.lockAndFlushAndMaybeSync(doSync)
 				return nil
 			})

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -19,6 +19,13 @@ type loggerRegistry struct {
 	}
 }
 
+// clear erases the registry.
+func (r *loggerRegistry) clear() {
+	r.mu.Lock()
+	r.mu.loggers = nil
+	r.mu.Unlock()
+}
+
 // put adds a logger into the registry.
 func (r *loggerRegistry) put(l *loggerT) {
 	r.mu.Lock()
@@ -47,6 +54,13 @@ type sinkInfoRegistry struct {
 		syncutil.Mutex
 		sinkInfos []*sinkInfo
 	}
+}
+
+// clear erases the registry.
+func (r *sinkInfoRegistry) clear() {
+	r.mu.Lock()
+	r.mu.sinkInfos = nil
+	r.mu.Unlock()
 }
 
 // iter iterates over all the sinks infos and stops at the first error

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -19,8 +19,6 @@ type loggerRegistry struct {
 	}
 }
 
-var allLoggers = loggerRegistry{}
-
 // put adds a logger into the registry.
 func (r *loggerRegistry) put(l *loggerT) {
 	r.mu.Lock()
@@ -50,8 +48,6 @@ type sinkInfoRegistry struct {
 		sinkInfos []*sinkInfo
 	}
 }
-
-var allSinkInfos = sinkInfoRegistry{}
 
 // iter iterates over all the sinks infos and stops at the first error
 // encountered.

--- a/pkg/util/log/stderr_redirect.go
+++ b/pkg/util/log/stderr_redirect.go
@@ -129,7 +129,7 @@ func (l *fileSink) relinquishInternalStderr() error {
 // Used by takeOverInternalStderr() to enforce its invariant.
 func anySinkHasInternalStderrOwnership() bool {
 	hasOwnership := false
-	_ = allSinkInfos.iterFileSinks(func(l *fileSink) error {
+	_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 		hasOwnership = hasOwnership || l.mu.redirectInternalStderrWrites

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -106,6 +106,13 @@ func newLogScope(t tShim, useFiles bool) (sc *TestLogScope) {
 	// logic work properly.
 	sc.previous.appliedConfig = DescribeAppliedConfig()
 
+	logging.allSinkInfos.mu.Lock()
+	sc.previous.allSinkInfos = logging.allSinkInfos.mu.sinkInfos
+	logging.allSinkInfos.mu.Unlock()
+	logging.allLoggers.mu.Lock()
+	sc.previous.allLoggers = logging.allLoggers.mu.loggers
+	logging.allLoggers.mu.Unlock()
+
 	sc.previous.stderrSinkInfoTemplate = logging.stderrSinkInfoTemplate
 	logging.rmu.RLock()
 	sc.previous.stderrSinkInfo = logging.rmu.currentStderrSinkInfo
@@ -298,6 +305,13 @@ func (l *TestLogScope) Close(t tShim) {
 	logging.mu.exitOverride.f = l.previous.exitOverrideFn
 	logging.mu.exitOverride.hideStack = l.previous.exitOverrideHideStack
 	logging.mu.Unlock()
+
+	logging.allSinkInfos.mu.Lock()
+	logging.allSinkInfos.mu.sinkInfos = l.previous.allSinkInfos
+	logging.allSinkInfos.mu.Unlock()
+	logging.allLoggers.mu.Lock()
+	logging.allLoggers.mu.loggers = l.previous.allLoggers
+	logging.allLoggers.mu.Unlock()
 
 	// Sanity check: if the restore logic is complete, the applied
 	// configuration should be the same as when the scope started.

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -41,6 +41,9 @@ type TestLogScope struct {
 		testingFd2CaptureLogger *loggerT
 		exitOverrideFn          func(exit.Code, error)
 		exitOverrideHideStack   bool
+
+		allSinkInfos []*sinkInfo
+		allLoggers   []*loggerT
 	}
 }
 
@@ -231,7 +234,7 @@ func (l *TestLogScope) Rotate(t tShim) {
 	// Ensure remaining logs are written.
 	Flush()
 
-	if err := allSinkInfos.iterFileSinks(func(l *fileSink) error {
+	if err := logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 		return l.closeFileLocked()

--- a/pkg/util/log/testdata/config
+++ b/pkg/util/log/testdata/config
@@ -86,16 +86,6 @@ sinks:
       redact: false
       redactable: true
       exit-on-error: true
-    default:
-      dir: TMPDIR
-      max-file-size: 10MiB
-      max-group-size: 100MiB
-      buffered-writes: true
-      filter: INFO
-      format: crdb-v2
-      redact: false
-      redactable: true
-      exit-on-error: true
   stderr:
     channels: all
     filter: NONE


### PR DESCRIPTION
Needed for #69715.

Prior to this patch, the "all sinks" and "all loggers" registries were
not reset during `ApplyConfig`. The result is that when a log
configuration "stacks" on top of another via `log.Scope`, the sinks
from the default (base) config, set up during `init`, are still
visible when iterating through the registry.

This does not impact most tests as the sinks in that case become
"inactive" (they are not connected to any channel during the duration
of the Scope).

However, we already have tests that assert that there are no more file
sinks defined than specified in configuration. Since these tests
use `DescribeAppliedConfig` and that in turns uses the registry, we
get extraneous file sinks in the output. In fact, one such test
already exists (`util/log/testdata/config`) and its expected
output was blatantly wrong, even though nobody had noticed so far.

Release justification: non-production code changes
