### PR TITLE
ui: fix link color on tooltip for txn metric

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -142,7 +142,12 @@ export const TransactionRestartsToolTip: React.FC<{
   <div>
     The number of transactions restarted broken down by errors{" "}
     {tooltipSelection}. Refer to the transaction retry error reference{" "}
-    <Anchor href={docsURL.transactionRetryErrorReference}>documentation</Anchor>{" "}
+    <Anchor
+      href={docsURL.transactionRetryErrorReference}
+      className={"anchor-light"}
+    >
+      documentation
+    </Anchor>{" "}
     for more details.
   </div>
 );


### PR DESCRIPTION
On Metrics page, the link for the tooltip Transaction Retries
were being displayed as blue, instead of white with underline.
This PR updates the link class.

Before
<img width="275" alt="Screen Shot 2021-09-10 at 3 35 01 PM" src="https://user-images.githubusercontent.com/1017486/132907817-7c76865e-f47e-44b7-84b9-91de20221b34.png">

After
<img width="285" alt="Screen Shot 2021-09-10 at 3 34 19 PM" src="https://user-images.githubusercontent.com/1017486/132907835-d6a0abbd-c570-4f68-9eca-a367fa7ea430.png">


Release justification: Category 4

Release note (ui change): Fix color for link on tooltip
on Metrics page for chart Transaction Retries