### PR TITLE
roachtest: make --workload optional

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -105,6 +105,8 @@ func (v *encryptValue) Type() string {
 	return "string"
 }
 
+var errBinaryOrLibraryNotFound = errors.New("binary or library not found")
+
 func filepathAbs(path string) (string, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
@@ -178,7 +180,7 @@ func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
 				return filepathAbs(path)
 			}
 		}
-		return "", fmt.Errorf("failed to find %q in $PATH or any of %s", name, dirs)
+		return "", errBinaryOrLibraryNotFound
 	}
 	return filepathAbs(path)
 }
@@ -205,7 +207,9 @@ func initBinariesAndLibraries() {
 	}
 
 	workload, err = findBinary(workload, "workload")
-	if err != nil {
+	if errors.Is(err, errBinaryOrLibraryNotFound) {
+		fmt.Fprintln(os.Stderr, "workload binary not provided, proceeding anyway")
+	} else if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This commit makes the `--workload` flag optional because some roachtests
do not require a workload binary.

Release note: None