### PR TITLE
ui: add tooltip and make sql box scrollable on database page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -314,21 +314,33 @@ export class DatabaseDetailsPage extends React.Component<
         name: "name",
       },
       {
-        title: "Users",
+        title: (
+          <Tooltip placement="bottom" title="The number of users of the table.">
+            Users
+          </Tooltip>
+        ),
         cell: table => table.details.userCount,
         sort: table => table.details.userCount,
         className: cx("database-table__col-user-count"),
         name: "userCount",
       },
       {
-        title: "Roles",
+        title: (
+          <Tooltip placement="bottom" title="The list of roles of the table.">
+            Roles
+          </Tooltip>
+        ),
         cell: table => _.join(table.details.roles, ", "),
         sort: table => _.join(table.details.roles, ", "),
         className: cx("database-table__col-roles"),
         name: "roles",
       },
       {
-        title: "Grants",
+        title: (
+          <Tooltip placement="bottom" title="The list of grants of the table.">
+            Grants
+          </Tooltip>
+        ),
         cell: table => _.join(table.details.grants, ", "),
         sort: table => _.join(table.details.grants, ", "),
         className: cx("database-table__col-grants"),

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { Col, Row, Tabs } from "antd";
 import classNames from "classnames/bind";
 import _ from "lodash";
+import { Tooltip } from "antd";
 
 import { Breadcrumbs } from "src/breadcrumbs";
 import { CaretRight } from "src/icon/caretRight";
@@ -150,13 +151,21 @@ export class DatabaseTablePage extends React.Component<
   private columns: ColumnDescriptor<Grant>[] = [
     {
       name: "user",
-      title: "User",
+      title: (
+        <Tooltip placement="bottom" title="The user name.">
+          User
+        </Tooltip>
+      ),
       cell: grant => grant.user,
       sort: grant => grant.user,
     },
     {
       name: "privilege",
-      title: "Grants",
+      title: (
+        <Tooltip placement="bottom" title="The list of grants for the user.">
+          Grants
+        </Tooltip>
+      ),
       cell: grant => grant.privilege,
       sort: grant => grant.privilege,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -14,7 +14,7 @@
 	padding: 20px;
 	width: 100%;
 	margin-bottom: 29px;
-	min-height: 282px;
+	height: 282px;
 	white-space: pre-wrap;
   background-color: $colors--neutral-10;
   box-shadow: 0px 0px 1px rgba(67, 90, 111, 0.415);

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
@@ -16,7 +16,8 @@
   padding 20px
   width 100%
   margin-bottom 10px
-  min-height 282px;
+  height 282px;
+  overflow-y: auto;
   white-space pre-wrap
   background-color $colors--neutral-10
   .table-target


### PR DESCRIPTION
Add tooltip on the missing headers of all database pages (grants,
details, tables) and make the SQL box scrollable so it doesn't
push the remaining content.

Release justification: Category 4
Release note (ui change): Add tooltips on Databases pages and
make SQL Box scrollable.