### PR TITLE
sql: support preferred binary operators

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -821,6 +821,14 @@ func TestPGPreparedQuery(t *testing.T) {
 		{"TRUNCATE TABLE d.str", []preparedQueryTest{
 			baseTest.SetArgs(),
 		}},
+		{"SELECT '{\"field\": 12}'::JSON->$1", []preparedQueryTest{
+			baseTest.SetArgs("field").Results("12"),
+			baseTest.SetArgs(0).Results(gosql.NullString{}),
+		}},
+		{"SELECT '{\"field\": 12}'::JSON->>$1", []preparedQueryTest{
+			baseTest.SetArgs("field").Results("12"),
+			baseTest.SetArgs(0).Results(gosql.NullString{}),
+		}},
 
 		// TODO(nvanbenschoten): Same class of limitation as that in logic_test/typing:
 		//   Nested constants are not exposed to the same constant type resolution rules

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -284,12 +284,13 @@ type TwoArgFn func(*EvalContext, Datum, Datum) (Datum, error)
 
 // BinOp is a binary operator.
 type BinOp struct {
-	LeftType     *types.T
-	RightType    *types.T
-	ReturnType   *types.T
-	NullableArgs bool
-	Fn           TwoArgFn
-	Volatility   Volatility
+	LeftType          *types.T
+	RightType         *types.T
+	ReturnType        *types.T
+	NullableArgs      bool
+	Fn                TwoArgFn
+	Volatility        Volatility
+	PreferredOverload bool
 
 	types   TypeList
 	retType ReturnTyper
@@ -311,8 +312,8 @@ func (op *BinOp) returnType() ReturnTyper {
 	return op.retType
 }
 
-func (*BinOp) preferred() bool {
-	return false
+func (op *BinOp) preferred() bool {
+	return op.PreferredOverload
 }
 
 // AppendToMaybeNullArray appends an element to an array. If the first
@@ -1891,7 +1892,8 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				}
 				return &DJSON{j}, nil
 			},
-			Volatility: VolatilityImmutable,
+			PreferredOverload: true,
+			Volatility:        VolatilityImmutable,
 		},
 		&BinOp{
 			LeftType:   types.Jsonb,
@@ -1952,7 +1954,8 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				}
 				return NewDString(*text), nil
 			},
-			Volatility: VolatilityImmutable,
+			PreferredOverload: true,
+			Volatility:        VolatilityImmutable,
 		},
 		&BinOp{
 			LeftType:   types.Jsonb,
@@ -2026,7 +2029,7 @@ type CmpOp struct {
 
 	Volatility Volatility
 
-	isPreferred bool
+	PreferredOverload bool
 }
 
 func (op *CmpOp) params() TypeList {
@@ -2044,7 +2047,7 @@ func (op *CmpOp) returnType() ReturnTyper {
 }
 
 func (op *CmpOp) preferred() bool {
-	return op.isPreferred
+	return op.PreferredOverload
 }
 
 func cmpOpFixups(
@@ -2319,9 +2322,9 @@ var CmpOps = cmpOpFixups(map[ComparisonOperatorSymbol]cmpOpOverload{
 			RightType:    types.Unknown,
 			Fn:           cmpOpScalarIsFn,
 			NullableArgs: true,
-			// Avoids ambiguous comparison error for NULL IS NOT DISTINCT FROM NULL>
-			isPreferred: true,
-			Volatility:  VolatilityLeakProof,
+			// Avoids ambiguous comparison error for NULL IS NOT DISTINCT FROM NULL.
+			PreferredOverload: true,
+			Volatility:        VolatilityLeakProof,
 		},
 		&CmpOp{
 			LeftType:     types.AnyArray,

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -156,13 +156,14 @@ func (b Overload) Signature(simplify bool) string {
 type overloadImpl interface {
 	params() TypeList
 	returnType() ReturnTyper
-	// allows manually resolving preference between multiple compatible overloads
+	// allows manually resolving preference between multiple compatible overloads.
 	preferred() bool
 }
 
 var _ overloadImpl = &Overload{}
 var _ overloadImpl = &UnaryOp{}
 var _ overloadImpl = &BinOp{}
+var _ overloadImpl = &CmpOp{}
 
 // GetParamsAndReturnType gets the parameters and return type of an
 // overloadImpl.
@@ -582,7 +583,8 @@ func typeCheckOverloadedExprs(
 		return typedExprs, fns, err
 	}
 
-	// The first heuristic is to prefer candidates that return the desired type.
+	// The first heuristic is to prefer candidates that return the desired type,
+	// if a desired type was provided.
 	if desired.Family() != types.AnyFamily {
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 			func(o overloadImpl) bool {
@@ -741,7 +743,17 @@ func typeCheckOverloadedExprs(
 		}
 	}
 
-	// The fifth heuristic is to prefer candidates where all placeholders can be
+	// The fifth heuristic is to defer to preferred candidates, if one has been
+	// specified in the overload list.
+	if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
+		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs, func(o overloadImpl) bool {
+			return o.preferred()
+		})
+	}); ok {
+		return typedExprs, fns, err
+	}
+
+	// The sixth heuristic is to prefer candidates where all placeholders can be
 	// given the same type as all constants and resolvable expressions. This is
 	// only possible if all constants and resolvable expressions were resolved
 	// homogeneously up to this point.
@@ -849,15 +861,6 @@ func typeCheckOverloadedExprs(
 		}); ok {
 			return typedExprs, fns, err
 		}
-	}
-
-	// The final heuristic is to defer to preferred candidates, if available.
-	if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs, func(o overloadImpl) bool {
-			return o.preferred()
-		})
-	}); ok {
-		return typedExprs, fns, err
 	}
 
 	if err := defaultTypeCheck(ctx, semaCtx, &s, len(s.overloads) > 0); err != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -123,7 +123,7 @@ const (
 	// (RejectAggregates notwithstanding).
 	RejectNestedAggregates
 
-	// RejectNestedWindows rejects any use of window functions inside the
+	// RejectNestedWindowFunctions rejects any use of window functions inside the
 	// argument list of another window function.
 	RejectNestedWindowFunctions
 


### PR DESCRIPTION
Needed for #69010.

This commit adds support for "preferred" overloads of binary operators. It then uses this new support to prefer the `(jsonb, text)` overload over the `(jsonb, int)` overload of the `->` (JSONFetchVal) and `->>` (JSONFetchText) operators. This allows the type system to properly type (according to Postgres) the following statements:
```sql
PREPARE x AS SELECT '{"field": 12}'->$1

PREPARE x AS SELECT '{"field": 12}'->>$1
```

Before this commit, each would return:
```sql
ERROR: unsupported binary operator: <jsonb> -> <jsonb>
```

This commit is helpful for PostgREST support. While this isn't a hard blocker, it is for use of JSON/JSONB data types with PostgREST. With this commit, and including the rest of the prototype in #69010, we can now handle requests like:
```
➜ curl -s 'http://localhost:3000/vehicles?status=eq.in_use&select=city,ext->brand&ext->>color=eq.blue' | jq
[
  {
    "brand": null,
    "city": "boston"
  },
  {
    "brand": "Pinarello",
    "city": "rome"
  },
  {
    "brand": null,
    "city": "san francisco"
  }
]
```

One of the more subtle parts of this change is the adjustment in `typeCheckOverloadedExprs` to consider overload preference before argument homogeneity. This was necessary to avoid type checking getting tricked into wanting a `(jsonb, jsonb)` overload (see above). I confirmed that no other overloaded function that has a `PreferredOverload` has more than one argument, so these two heuristic were operating independently to this point. This means that this change shouldn't be able to cause a regression in type checking. I think the change also makes sense, as an explicit preference should overrule what is effectively a guess.

Release note (sql change): Placeholder values can now be used as the right-hand operand of the JSONFetchVal (->) and JSONFetchText (->>) operators without ambiguity. This argument will be given the text type and the "object field lookup" variant of the operator will be used.

Release justification: None