### PR TITLE
tenantcostserver: fix erroneous panic in tests

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/util",
+        "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
         "//pkg/util/syncutil",

--- a/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
@@ -79,7 +79,7 @@ func (s *instance) TokenBucketRequest(
 			return err
 		}
 
-		if err := h.maybeCheckInvariants(); err != nil {
+		if err := h.maybeCheckInvariants(ctx); err != nil {
 			panic(err)
 		}
 		consumption = tenant.Consumption


### PR DESCRIPTION
The test-only code that checks the invariants of the `tenant_usage`
table inadvertently panics if the query hits an error (such as one
that would be expected if the server is shutting down). We now just
log the error instead.

Fixes #70089.

Release note: None

Release justification: non-production code change to fix test failure.