### PR TITLE
tenantcostclient: restrict allowed configuration from the tenant side

### DIFF
--- a/pkg/multitenant/tenantcostmodel/settings.go
+++ b/pkg/multitenant/tenantcostmodel/settings.go
@@ -21,6 +21,10 @@ import (
 //
 // The KV operation parameters are set based on experiments, where 1000 Request
 // Units correspond to one CPU second of usage on the host cluster.
+//
+// TODO(radu): these settings are not currently used on the tenant side; there,
+// only the defaults are used. Ideally, the tenant would always get the values
+// from the host cluster.
 var (
 	readRequestCost = settings.RegisterFloatSetting(
 		"tenant_cost_model.kv_read_request_cost",


### PR DESCRIPTION
This change restricts the configuration of tenant cost control from
the tenant side. In the future, we will want to have settings where
the values come from the host cluster but we don't have that
infrastructure today.

With tenants being able to set their own settings, they could easily
sabotage the cost control mechanisms. This change restricts the
allowed values for the target period and the CPU usage allowance, and
fixes the cost model configuration to the default.

Release note: None

Release justification: Necessary fix for the distributed rate limiting
functionality, which is vital for the upcoming Serverless MVP release.
It allows CRDB to throttle clusters that have run out of free or paid
request units (which measure CPU and I/O usage). This functionality is
only enabled in multi-tenant scenarios and should have no impact on
our dedicated customers.