### PR TITLE
geo: simplify WKT conversion

### DIFF
--- a/pkg/geo/parse.go
+++ b/pkg/geo/parse.go
@@ -168,16 +168,12 @@ func parseEWKT(
 		}
 	}
 
-	geom, wktUnmarshalErr := wkt.Unmarshal(string(str))
+	g, wktUnmarshalErr := wkt.Unmarshal(string(str))
 	if wktUnmarshalErr != nil {
 		return geopb.SpatialObject{}, wktUnmarshalErr
 	}
-	AdjustGeomTSRID(geom, srid)
-	ewkb, ewkbMarshalErr := ewkb.Marshal(geom, DefaultEWKBEncodingFormat)
-	if ewkbMarshalErr != nil {
-		return geopb.SpatialObject{}, ewkbMarshalErr
-	}
-	return parseEWKBRaw(soType, ewkb)
+	AdjustGeomTSRID(g, srid)
+	return spatialObjectFromGeomT(g, soType)
 }
 
 // hasPrefixIgnoreCase returns whether a given str begins with a prefix, ignoring case.


### PR DESCRIPTION
Avoid the geom.T -> WKB -> geom.T hop to convert WKT. This was a relic
of using GEOS.

Release justification: risk free performance improvement
Release note (performance improvement): WKT conversion to a spatial type
is slightly improved.