### PR TITLE
roachtest: initialize prometheus scrapers by default for tpc-c

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -180,56 +180,22 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 	}
 
 	var ep *tpccChaosEventProcessor
-	if cfg := opts.PrometheusConfig; cfg != nil {
-		if c.IsLocal() {
+	promCfg, cleanupFunc := setupPrometheus(ctx, t, c, opts, workloadInstances)
+	defer cleanupFunc()
+	if opts.ChaosEventsProcessor != nil {
+		if promCfg == nil {
 			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
 			return
 		}
-		p, err := prometheus.Init(
-			ctx,
-			*cfg,
-			c,
-			func(ctx context.Context, nodes option.NodeListOption, operation string, args ...string) error {
-				return repeatRunE(
-					ctx,
-					t,
-					c,
-					nodes,
-					operation,
-					args...,
-				)
-			},
+		cep, err := opts.ChaosEventsProcessor(
+			promCfg.PrometheusNode,
+			workloadInstances,
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		defer func() {
-			// Use a context that will not time out to avoid the issue where
-			// ctx gets canceled if t.Fatal gets called.
-			snapshotCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			if err := p.Snapshot(
-				snapshotCtx,
-				c,
-				t.L(),
-				filepath.Join(t.ArtifactsDir(), "prometheus-snapshot.tar.gz"),
-			); err != nil {
-				t.L().Printf("failed to get prometheus snapshot: %v", err)
-			}
-		}()
-
-		if opts.ChaosEventsProcessor != nil {
-			cep, err := opts.ChaosEventsProcessor(
-				cfg.PrometheusNode,
-				workloadInstances,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			cep.listen(ctx, t.L())
-			ep = &cep
-		}
+		cep.listen(ctx, t.L())
+		ep = &cep
 	}
 
 	rampDuration := 5 * time.Minute
@@ -591,15 +557,6 @@ func registerTPCC(r registry.Registry) {
 						strings.Join(regions, ","),
 						len(regions),
 					)
-					workloadNode := c.Node(c.Spec().NodeCount)
-					workloadScrapeNodes := make([]prometheus.ScrapeNode, len(tc.workloadInstances))
-					for i, workloadInstance := range tc.workloadInstances {
-						workloadScrapeNodes[i] = prometheus.ScrapeNode{
-							Nodes: workloadNode,
-							Port:  workloadInstance.prometheusPort,
-						}
-					}
-
 					iter := 0
 					chaosEventCh := make(chan ChaosEvent)
 					runTPCC(ctx, t, c, tpccOptions{
@@ -664,16 +621,6 @@ func registerTPCC(r registry.Registry) {
 						},
 						SetupType:         usingInit,
 						WorkloadInstances: tc.workloadInstances,
-						PrometheusConfig: &prometheus.Config{
-							PrometheusNode: workloadNode,
-							ScrapeConfigs: []prometheus.ScrapeConfig{
-								prometheus.MakeInsecureCockroachScrapeConfig(
-									"cockroach",
-									c.Range(1, c.Spec().NodeCount-1),
-								),
-								prometheus.MakeWorkloadScrapeConfig("workload", workloadScrapeNodes),
-							},
-						},
 					})
 				},
 			})
@@ -1452,5 +1399,90 @@ func registerTPCCBench(r registry.Registry) {
 
 	for _, b := range specs {
 		registerTPCCBenchSpec(r, b)
+	}
+}
+
+// makeWorkloadScrapeNodes creates a ScrapeNode for every workloadInstance.
+func makeWorkloadScrapeNodes(
+	workloadNode option.NodeListOption, workloadInstances []workloadInstance,
+) []prometheus.ScrapeNode {
+	workloadScrapeNodes := make([]prometheus.ScrapeNode, len(workloadInstances))
+	for i, workloadInstance := range workloadInstances {
+		workloadScrapeNodes[i] = prometheus.ScrapeNode{
+			Nodes: workloadNode,
+			Port:  workloadInstance.prometheusPort,
+		}
+	}
+	return workloadScrapeNodes
+}
+
+// setupPrometheus initializes prometheus to run against the provided
+// PrometheusConfig. If no PrometheusConfig is provided, it creates a prometheus
+// scraper for all CockroachDB nodes in the TPC-C setup, as well as one for
+// each workloadInstance.
+// Returns the created PrometheusConfig if prometheus is initialized, as well
+// as a cleanup function which should be called in a defer statement.
+func setupPrometheus(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	opts tpccOptions,
+	workloadInstances []workloadInstance,
+) (*prometheus.Config, func()) {
+	cfg := opts.PrometheusConfig
+	if cfg == nil {
+		// Avoid setting prometheus automatically up for local clusters.
+		if c.IsLocal() {
+			return nil, func() {}
+		}
+		workloadNode := c.Node(c.Spec().NodeCount)
+		cfg = &prometheus.Config{
+			PrometheusNode: workloadNode,
+			// Scrape each CockroachDB node and the workload node.
+			ScrapeConfigs: []prometheus.ScrapeConfig{
+				prometheus.MakeInsecureCockroachScrapeConfig(
+					"cockroach",
+					c.Range(1, c.Spec().NodeCount-1),
+				),
+				prometheus.MakeWorkloadScrapeConfig("workload", makeWorkloadScrapeNodes(workloadNode, workloadInstances)),
+			},
+		}
+	}
+	if c.IsLocal() {
+		t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
+		return nil, func() {}
+	}
+	p, err := prometheus.Init(
+		ctx,
+		*cfg,
+		c,
+		func(ctx context.Context, nodes option.NodeListOption, operation string, args ...string) error {
+			return repeatRunE(
+				ctx,
+				t,
+				c,
+				nodes,
+				operation,
+				args...,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cfg, func() {
+		// Use a context that will not time out to avoid the issue where
+		// ctx gets canceled if t.Fatal gets called.
+		snapshotCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := p.Snapshot(
+			snapshotCtx,
+			c,
+			t.L(),
+			filepath.Join(t.ArtifactsDir(), "prometheus-snapshot.tar.gz"),
+		); err != nil {
+			t.L().Printf("failed to get prometheus snapshot: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
This commit enables TPC-C prometheus scraping by default. All cockroach
nodes and the workload instance will dump the prometheus snapshot into a
zip at the end of the test run.

This is a "trial by fire" - I expect nothing to go wrong, but if it does
we've caught it right at a branch cut.

Release note: None