### PR TITLE
changefeedccl: don't call encoder Ping() during validation

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -159,7 +159,7 @@ func newChangeAggregatorProcessor(
 	}
 
 	var err error
-	if ca.encoder, err = getEncoder(ctx, ca.spec.Feed.Opts, ca.spec.Feed.Targets); err != nil {
+	if ca.encoder, err = getEncoder(ca.spec.Feed.Opts, ca.spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 
@@ -1038,7 +1038,7 @@ func newChangeFrontierProcessor(
 		cf.freqEmitResolved = emitNoResolved
 	}
 
-	if cf.encoder, err = getEncoder(ctx, spec.Feed.Opts, spec.Feed.Targets); err != nil {
+	if cf.encoder, err = getEncoder(spec.Feed.Opts, spec.Feed.Targets); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -298,9 +298,10 @@ func changefeedPlanHook(
 			return err
 		}
 
-		if _, err := getEncoder(ctx, details.Opts, details.Targets); err != nil {
+		if _, err := getEncoder(details.Opts, details.Targets); err != nil {
 			return err
 		}
+
 		if isCloudStorageSink(parsedSink) || isWebhookSink(parsedSink) {
 			details.Opts[changefeedbase.OptKeyInValue] = ``
 		}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -215,7 +215,7 @@ func TestEncoders(t *testing.T) {
 			targets := jobspb.ChangefeedTargets{}
 			targets[tableDesc.GetID()] = target
 
-			e, err := getEncoder(context.Background(), o, targets)
+			e, err := getEncoder(o, targets)
 			if len(expected.err) > 0 {
 				require.EqualError(t, err, expected.err)
 				return
@@ -366,7 +366,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		targets := jobspb.ChangefeedTargets{}
 		targets[tableDesc.GetID()] = target
 
-		e, err := getEncoder(context.Background(), opts, targets)
+		e, err := getEncoder(opts, targets)
 		require.NoError(t, err)
 
 		rowInsert := encodeRow{
@@ -407,9 +407,11 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		defer noCertReg.Close()
 		opts[changefeedbase.OptConfluentSchemaRegistry] = noCertReg.URL()
 
-		_, err = getEncoder(context.Background(), opts, targets)
-		require.EqualError(t, err, fmt.Sprintf("schema registry unavailable: retryable changefeed error: "+
-			"Get \"%s/mode\": x509: certificate signed by unknown authority",
+		enc, err := getEncoder(opts, targets)
+		require.NoError(t, err)
+		_, err = enc.EncodeKey(context.Background(), rowInsert)
+		require.EqualError(t, err, fmt.Sprintf("retryable changefeed error: "+
+			`contacting confluent schema registry: Post "%s/subjects/foo-key/versions": x509: certificate signed by unknown authority`,
 			opts[changefeedbase.OptConfluentSchemaRegistry]))
 
 		wrongCert, _, err := cdctest.NewCACertBase64Encoded()
@@ -420,9 +422,11 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		defer wrongCertReg.Close()
 		opts[changefeedbase.OptConfluentSchemaRegistry] = wrongCertReg.URL()
 
-		_, err = getEncoder(context.Background(), opts, targets)
-		require.EqualError(t, err, fmt.Sprintf("schema registry unavailable: retryable changefeed error: "+
-			"Get \"%s/mode\": x509: certificate signed by unknown authority",
+		enc, err = getEncoder(opts, targets)
+		require.NoError(t, err)
+		_, err = enc.EncodeKey(context.Background(), rowInsert)
+		require.EqualError(t, err, fmt.Sprintf("retryable changefeed error: "+
+			`contacting confluent schema registry: Post "%s/subjects/foo-key/versions": x509: certificate signed by unknown authority`,
 			opts[changefeedbase.OptConfluentSchemaRegistry]))
 	})
 }

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -66,6 +66,10 @@ func newConfluentSchemaRegistry(baseURL string) (*confluentSchemaRegistry, error
 		return nil, errors.Wrap(err, "malformed schema registry url")
 	}
 
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, errors.Errorf("unsupported scheme: %q", u.Scheme)
+	}
+
 	query := u.Query()
 	var caCert []byte
 	if caCertString := query.Get(changefeedbase.RegistryParamCACert); caCertString != "" {


### PR DESCRIPTION
We don't want to make external calls when holding any locks. On the
first call to our PlanRowHookFn, we check the encoder before any jobs
table interaction. However, we are concerned that in the face of
retries, we may be holding a lock.

This PR removes the call to Ping() from getEncoder so that it is
always safe to call. It checks that we have a reasonable scheme in the
registry constructor so that we can provide feedback on a few error
cases.

I had considered still calling Ping() but protecting it with
sync.Once (so that it wouldn't be called again during retries).
However, it wasn't clear to be that this would be enough since we may
be getting called inside a transaction that is holding locks for other
reasons.

Release note: None