### PR TITLE
sql: add json{,b}_populate_record{,set}

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1121,6 +1121,10 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td></tr>
 <tr><td><a name="json_object_keys"></a><code>json_object_keys(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
+<tr><td><a name="json_populate_record"></a><code>json_populate_record(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
+</span></td></tr>
+<tr><td><a name="json_populate_recordset"></a><code>json_populate_recordset(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
+</span></td></tr>
 <tr><td><a name="jsonb_array_elements"></a><code>jsonb_array_elements(input: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
 <tr><td><a name="jsonb_array_elements_text"></a><code>jsonb_array_elements_text(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>
@@ -1130,6 +1134,10 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tr><td><a name="jsonb_each_text"></a><code>jsonb_each_text(input: jsonb) &rarr; tuple{string AS key, string AS value}</code></td><td><span class="funcdesc"><p>Expands the outermost JSON or JSONB object into a set of key/value pairs. The returned values will be of type text.</p>
 </span></td></tr>
 <tr><td><a name="jsonb_object_keys"></a><code>jsonb_object_keys(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
+</span></td></tr>
+<tr><td><a name="jsonb_populate_record"></a><code>jsonb_populate_record(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
+</span></td></tr>
+<tr><td><a name="jsonb_populate_recordset"></a><code>jsonb_populate_recordset(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
 </span></td></tr>
 <tr><td><a name="pg_get_keywords"></a><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -852,3 +852,82 @@ query T
 SELECT '{}'::JSONB[]
 ----
 {}
+
+# json_populate_record
+query FIII colnames
+SELECT *, c FROM json_populate_record(((1.01, 2, 3) AS d, c, a), '{"a": 3, "c": 10, "d": 11.001}')
+----
+d       c   a c
+11.001  10  3 10
+
+query BTT colnames
+SELECT * FROM json_populate_record(((true, ARRAY[1], ARRAY['f']) AS a, b, c), '{"a": true, "b": [1,2], "c": ["a", "b"]}')
+----
+a     b      c
+true  {1,2}  {a,b}
+
+query BT colnames
+SELECT * FROM json_populate_record(((true, ((1, 'bar', ARRAY['a']) AS x, y, z)) AS a, b), '{"a": true, "b": {"x": "3", "y": "foo", "z": ["a", "b"]}}')
+----
+a     b
+true  (3,foo,"{a,b}")
+
+query BI colnames
+SELECT * FROM json_populate_record(((true, 3) AS a, b), '{"a": null, "b": null}')
+----
+a     b
+NULL  NULL
+
+query T colnames
+SELECT json_populate_record(((1.01, 2, 3) AS d, c, a), '{"a": 3, "c": 10, "d": 11.001}')
+----
+json_populate_record
+(11.001,10,3)
+
+query T colnames
+SELECT json_populate_record(((1.01, 2) AS a, b), '{"a": "1.2345", "b": "33"}')
+----
+json_populate_record
+(1.2345,33)
+
+query F colnames
+SELECT (json_populate_record(((1.01, 2, 3) AS d, c, a), '{"a": 3, "c": 10, "d": 11.001}')).d
+----
+d
+11.001
+
+query error could not parse \"foo\" as type int
+SELECT json_populate_record(((3,) AS a), '{"a": "foo"}')
+
+query error anonymous records cannot be used with json_populate_record
+SELECT * FROM json_populate_record((1,2,3,4), '{"a": 3, "c": 10, "d": 11.001}')
+
+query error anonymous records cannot be used with json_populate_record
+SELECT * FROM json_populate_record(NULL, '{"a": 3, "c": 10, "d": 11.001}')
+
+query I
+SELECT * FROM json_populate_record(((3,) AS a), NULL)
+----
+3
+
+query FIII colnames
+SELECT *, c FROM json_populate_recordset(((1.01, 2, 3) AS d, c, a), '[{"a": 3, "c": 10, "d": 11.001}, {}]')
+----
+d       c   a  c
+11.001  10  3  10
+1.01    2   3  2
+
+query FITI colnames
+SELECT *, c FROM json_populate_recordset(((NULL::NUMERIC, 2::INT, 3::TEXT) AS d, c, a), '[{"a": 3, "c": 10, "d": 11.001}, {}]')
+----
+d       c   a  c
+11.001  10  3  10
+NULL    2   3  2
+
+query FIT
+SELECT * FROM json_populate_recordset(((NULL::NUMERIC, 2::INT, 3::TEXT) AS d, c, a), NULL)
+----
+
+query FIT
+SELECT * FROM json_populate_recordset(((NULL::NUMERIC, 2::INT, 3::TEXT) AS d, c, a), '[]')
+----

--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -53,6 +54,24 @@ func init() {
 			AllAggregateBuiltinNames = append(AllAggregateBuiltinNames, name)
 		} else if def.props.Class == tree.WindowClass {
 			AllWindowBuiltinNames = append(AllWindowBuiltinNames, name)
+		}
+		for _, overload := range def.overloads {
+			fnCount := 0
+			if overload.Fn != nil {
+				fnCount++
+			}
+			if overload.Generator != nil {
+				overload.Fn = unsuitableUseOfGeneratorFn
+				fnCount++
+			}
+			if overload.GeneratorWithExprs != nil {
+				overload.Fn = unsuitableUseOfGeneratorFn
+				fnCount++
+			}
+			if fnCount > 1 {
+				panic(fmt.Sprintf("builtin %s: at most 1 of Fn, Generator, and GeneratorWithExprs must be set on overloads; (found %d)",
+					name, fnCount))
+			}
 		}
 	}
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3704,10 +3704,8 @@ value if you rely on the HLC for accuracy.`,
 	// The behavior of both the JSON and JSONB data types in CockroachDB is
 	// similar to the behavior of the JSONB data type in Postgres.
 
-	"json_to_recordset":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
-	"jsonb_to_recordset":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
-	"json_populate_recordset":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
-	"jsonb_populate_recordset": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+	"json_to_recordset":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+	"jsonb_to_recordset": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
 
 	"jsonb_path_exists":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: categoryJSON}),
 	"jsonb_path_exists_opr":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: categoryJSON}),

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -303,6 +303,16 @@ var generators = map[string]builtinDefinition{
 	"jsonb_each":                makeBuiltin(genPropsWithLabels(jsonEachGeneratorLabels), jsonEachImpl),
 	"json_each_text":            makeBuiltin(genPropsWithLabels(jsonEachGeneratorLabels), jsonEachTextImpl),
 	"jsonb_each_text":           makeBuiltin(genPropsWithLabels(jsonEachGeneratorLabels), jsonEachTextImpl),
+	"json_populate_record": makeBuiltin(jsonPopulateProps, makeJSONPopulateImpl(makeJSONPopulateRecordGenerator,
+		"Expands the object in from_json to a row whose columns match the record type defined by base.",
+	)),
+	"jsonb_populate_record": makeBuiltin(jsonPopulateProps, makeJSONPopulateImpl(makeJSONPopulateRecordGenerator,
+		"Expands the object in from_json to a row whose columns match the record type defined by base.",
+	)),
+	"json_populate_recordset": makeBuiltin(jsonPopulateProps, makeJSONPopulateImpl(makeJSONPopulateRecordSetGenerator,
+		"Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base")),
+	"jsonb_populate_recordset": makeBuiltin(jsonPopulateProps, makeJSONPopulateImpl(makeJSONPopulateRecordSetGenerator,
+		"Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base")),
 
 	"crdb_internal.check_consistency": makeBuiltin(
 		tree.FunctionProperties{
@@ -404,8 +414,8 @@ func makeGeneratorOverload(
 	return makeGeneratorOverloadWithReturnType(in, tree.FixedReturnType(ret), g, info, volatility)
 }
 
-func newUnsuitableUseOfGeneratorError() error {
-	return errors.AssertionFailedf("generator functions cannot be evaluated as scalars")
+var unsuitableUseOfGeneratorFn = func(_ *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+	return nil, errors.AssertionFailedf("generator functions cannot be evaluated as scalars")
 }
 
 func makeGeneratorOverloadWithReturnType(
@@ -419,9 +429,6 @@ func makeGeneratorOverloadWithReturnType(
 		Types:      in,
 		ReturnType: retType,
 		Generator:  g,
-		Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-			return nil, newUnsuitableUseOfGeneratorError()
-		},
 		Info:       info,
 		Volatility: volatility,
 	}
@@ -1229,6 +1236,196 @@ func (g *jsonEachGenerator) Next(_ context.Context) (bool, error) {
 // Values implements the tree.ValueGenerator interface.
 func (g *jsonEachGenerator) Values() (tree.Datums, error) {
 	return tree.Datums{g.key, g.value}, nil
+}
+
+var jsonPopulateProps = tree.FunctionProperties{
+	Class:    tree.GeneratorClass,
+	Category: categoryGenerator,
+	// The typical way to call json_populate_record is to send NULL::atype as the
+	// first argument, so we have to accept nullable args.
+	NullableArgs: true,
+}
+
+func makeJSONPopulateImpl(gen tree.GeneratorWithExprsFactory, info string) tree.Overload {
+	return tree.Overload{
+		// The json{,b}_populate_record{,set} builtins all have a 2 argument
+		// structure. The first argument is an arbitrary tuple type, which is used
+		// to set the columns of the output when the builtin is used as a FROM
+		// source, or used as-is when it's used as an ordinary projection.
+		// The second argument is a JSON object or array of objects. The builtin
+		// transforms the JSON in the second argument into the tuple in the first
+		// argument, field by field, casting fields in key "k" to the type in the
+		// tuple slot "k". Any tuple fields that were missing in the JSON will be
+		// left as they are in the input argument.
+		// The first argument can be of the form NULL::<tupletype>, in which case
+		// the default values of each field will be NULL.
+		// The second argument can also be null, in which case the first argument
+		// is returned as-is.
+		Types: tree.ArgTypes{{"base", types.Any}, {"from_json", types.Jsonb}},
+		ReturnType: func(args []tree.TypedExpr) *types.T {
+			if len(args) != 2 {
+				return tree.UnknownReturnType
+			}
+			return args[0].ResolvedType()
+		},
+		GeneratorWithExprs: gen,
+		Info:               info,
+		Volatility:         tree.VolatilityStable,
+	}
+}
+
+func makeJSONPopulateRecordGenerator(
+	evalCtx *tree.EvalContext, args tree.Exprs,
+) (tree.ValueGenerator, error) {
+	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	if j != nil {
+		if j.Type() != json.ObjectJSONType {
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue, "argument of json_populate_record must be an object")
+		}
+	} else {
+		j = json.NewObjectBuilder(0).Build()
+	}
+	return &jsonPopulateRecordGenerator{
+		evalCtx: evalCtx,
+		input:   tuple,
+		target:  j,
+	}, nil
+}
+
+// jsonPopulateRecordEvalArgs evaluates the first 2 expression arguments to
+// one of the jsonPopulateRecord variants, and returns the correctly-typed
+// tuple of default values, and the JSON input or nil if it was SQL NULL.
+func jsonPopulateRecordEvalArgs(
+	evalCtx *tree.EvalContext, args tree.Exprs,
+) (tuple *tree.DTuple, jsonInputOrNil json.JSON, err error) {
+	evalled := make(tree.Datums, len(args))
+	for i := range args {
+		var err error
+		evalled[i], err = args[i].(tree.TypedExpr).Eval(evalCtx)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	tupleType := args[0].(tree.TypedExpr).ResolvedType()
+	var defaultElems tree.Datums
+	if evalled[0] == tree.DNull {
+		defaultElems = make(tree.Datums, len(tupleType.TupleLabels()))
+		for i := range defaultElems {
+			defaultElems[i] = tree.DNull
+		}
+	} else {
+		defaultElems = tree.MustBeDTuple(evalled[0]).D
+	}
+	var j json.JSON
+	if evalled[1] != tree.DNull {
+		j = tree.MustBeDJSON(evalled[1]).JSON
+	}
+	return tree.NewDTuple(tupleType, defaultElems...), j, nil
+}
+
+type jsonPopulateRecordGenerator struct {
+	input  *tree.DTuple
+	target json.JSON
+
+	wasCalled bool
+	evalCtx   *tree.EvalContext
+}
+
+// ResolvedType is part of the tree.ValueGenerator interface.
+func (j jsonPopulateRecordGenerator) ResolvedType() *types.T {
+	return j.input.ResolvedType()
+}
+
+// Start is part of the tree.ValueGenerator interface.
+func (j *jsonPopulateRecordGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
+
+// Close is part of the tree.ValueGenerator interface.
+func (j *jsonPopulateRecordGenerator) Close(_ context.Context) {}
+
+// Next is part of the tree.ValueGenerator interface.
+func (j *jsonPopulateRecordGenerator) Next(_ context.Context) (bool, error) {
+	if !j.wasCalled {
+		j.wasCalled = true
+		return true, nil
+	}
+	return false, nil
+}
+
+// Values is part of the tree.ValueGenerator interface.
+func (j jsonPopulateRecordGenerator) Values() (tree.Datums, error) {
+	if err := tree.PopulateRecordWithJSON(j.evalCtx, j.target, j.input.ResolvedType(), j.input); err != nil {
+		return nil, err
+	}
+	return j.input.D, nil
+}
+
+func makeJSONPopulateRecordSetGenerator(
+	evalCtx *tree.EvalContext, args tree.Exprs,
+) (tree.ValueGenerator, error) {
+	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	if j != nil {
+		if j.Type() != json.ArrayJSONType {
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue, "argument of json_populate_recordset must be an array")
+		}
+	} else {
+		j = json.NewArrayBuilder(0).Build()
+	}
+
+	return &jsonPopulateRecordSetGenerator{
+		jsonPopulateRecordGenerator: jsonPopulateRecordGenerator{
+			evalCtx: evalCtx,
+			input:   tuple,
+			target:  j,
+		},
+	}, nil
+}
+
+type jsonPopulateRecordSetGenerator struct {
+	jsonPopulateRecordGenerator
+
+	nextIdx int
+}
+
+// ResolvedType is part of the tree.ValueGenerator interface.
+func (j jsonPopulateRecordSetGenerator) ResolvedType() *types.T { return j.input.ResolvedType() }
+
+// Start is part of the tree.ValueGenerator interface.
+func (j jsonPopulateRecordSetGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
+
+// Close is part of the tree.ValueGenerator interface.
+func (j jsonPopulateRecordSetGenerator) Close(_ context.Context) {}
+
+// Next is part of the tree.ValueGenerator interface.
+func (j *jsonPopulateRecordSetGenerator) Next(_ context.Context) (bool, error) {
+	if j.nextIdx >= j.target.Len() {
+		return false, nil
+	}
+	j.nextIdx++
+	return true, nil
+}
+
+// Values is part of the tree.ValueGenerator interface.
+func (j *jsonPopulateRecordSetGenerator) Values() (tree.Datums, error) {
+	obj, err := j.target.FetchValIdx(j.nextIdx - 1)
+	if err != nil {
+		return nil, err
+	}
+	output := tree.NewDTupleWithLen(j.input.ResolvedType(), j.input.D.Len())
+	for i := range j.input.D {
+		output.D[i] = j.input.D[i]
+	}
+	if err := tree.PopulateRecordWithJSON(j.evalCtx, obj, j.input.ResolvedType(), output); err != nil {
+		return nil, err
+	}
+	return output.D, nil
 }
 
 type checkConsistencyGenerator struct {

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -6446,9 +6446,6 @@ The parent_only boolean is always ignored.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}},
 			ReturnType: tree.FixedReturnType(minimumBoundingRadiusReturnType),
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				return nil, newUnsuitableUseOfGeneratorError()
-			},
 			Generator:  makeMinimumBoundGenerator,
 			Info:       "Returns a record containing the center point and radius of the smallest circle that can fully contains the given geometry.",
 			Volatility: tree.VolatilityImmutable,

--- a/pkg/sql/sem/builtins/geo_builtins_test.go
+++ b/pkg/sql/sem/builtins/geo_builtins_test.go
@@ -84,7 +84,17 @@ func TestGeoBuiltinsPointEmptyArgs(t *testing.T) {
 								}
 								call.WriteByte(')')
 								t.Logf("calling: %s", call.String())
-								_, _ = overload.Fn(&tree.EvalContext{}, datums)
+								if overload.Fn != nil {
+									_, _ = overload.Fn(&tree.EvalContext{}, datums)
+								} else if overload.Generator != nil {
+									_, _ = overload.Generator(&tree.EvalContext{}, datums)
+								} else if overload.GeneratorWithExprs != nil {
+									exprs := make(tree.Exprs, len(datums))
+									for i := range datums {
+										exprs[i] = datums[i]
+									}
+									_, _ = overload.GeneratorWithExprs(&tree.EvalContext{}, exprs)
+								}
 							})
 						}
 					}

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -1477,4 +1478,87 @@ func performIntToOidCast(ctx *EvalContext, t *types.T, v DInt) (Datum, error) {
 		}
 		return oid, nil
 	}
+}
+
+// PopulateRecordWithJSON is used for the json to record function family, like
+// json_populate_record. Given a JSON object, a desired tuple type, and a tuple
+// of the same length as the desired type, this function will populate the tuple
+// by setting each named field in the tuple to the value of the key with the
+// same name in the input JSON object. Fields in the tuple that are not present
+// in the JSON will not be modified, and JSON keys that are not in the tuple
+// will be ignored.
+// Each field will be set by a best-effort coercion to its type from the JSON
+// field. The logic is more permissive than casts.
+func PopulateRecordWithJSON(
+	ctx *EvalContext, j json.JSON, desiredType *types.T, tup *DTuple,
+) error {
+	if j.Type() != json.ObjectJSONType {
+		return pgerror.Newf(pgcode.InvalidParameterValue, "expected JSON object")
+	}
+	tupleTypes := desiredType.TupleContents()
+	labels := desiredType.TupleLabels()
+	if labels == nil {
+		return pgerror.Newf(pgcode.InvalidParameterValue, "anonymous records cannot be used with json_populate_record")
+	}
+	for i := range tupleTypes {
+		val, err := j.FetchValKey(labels[i])
+		if err != nil || val == nil {
+			// No value? Use the value that was already in the tuple.
+			continue
+		}
+		tup.D[i], err = PopulateDatumWithJSON(ctx, val, tupleTypes[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PopulateDatumWithJSON is used for the json to record function family, like
+// json_populate_record. It's less restrictive than the casting system, which
+// is why it's implemented separately.
+func PopulateDatumWithJSON(ctx *EvalContext, j json.JSON, desiredType *types.T) (Datum, error) {
+	if j == json.NullJSONValue {
+		return DNull, nil
+	}
+	switch desiredType.Family() {
+	case types.ArrayFamily:
+		if j.Type() != json.ArrayJSONType {
+			return nil, pgerror.Newf(pgcode.InvalidTextRepresentation, "expected JSON array")
+		}
+		n := j.Len()
+		elementTyp := desiredType.ArrayContents()
+		d := NewDArray(elementTyp)
+		d.Array = make(Datums, n)
+		for i := 0; i < n; i++ {
+			elt, err := j.FetchValIdx(i)
+			if err != nil {
+				return nil, err
+			}
+			d.Array[i], err = PopulateDatumWithJSON(ctx, elt, elementTyp)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return d, nil
+	case types.TupleFamily:
+		tup := NewDTupleWithLen(desiredType, len(desiredType.TupleContents()))
+		for i := range tup.D {
+			tup.D[i] = DNull
+		}
+		err := PopulateRecordWithJSON(ctx, j, desiredType, tup)
+		return tup, err
+	}
+	var s string
+	switch j.Type() {
+	case json.StringJSONType:
+		t, err := j.AsText()
+		if err != nil {
+			return nil, err
+		}
+		s = *t
+	default:
+		s = j.String()
+	}
+	return PerformCast(ctx, NewDString(s), desiredType)
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4148,6 +4148,9 @@ func (expr *FuncExpr) EvalArgsAndGetGenerator(ctx *EvalContext) (ValueGenerator,
 	if expr.fn == nil || expr.fnProps.Class != GeneratorClass {
 		return nil, errors.AssertionFailedf("cannot call EvalArgsAndGetGenerator() on non-aggregate function: %q", ErrString(expr))
 	}
+	if expr.fn.GeneratorWithExprs != nil {
+		return expr.fn.GeneratorWithExprs(ctx, expr.Exprs)
+	}
 	nullArg, args, err := expr.evalArgs(ctx)
 	if err != nil || nullArg {
 		return nil, err

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1450,7 +1450,7 @@ func (node *FuncExpr) ResolvedOverload() *Overload {
 
 // IsGeneratorApplication returns true iff the function applied is a generator (SRF).
 func (node *FuncExpr) IsGeneratorApplication() bool {
-	return node.fn != nil && node.fn.Generator != nil
+	return node.fn != nil && (node.fn.Generator != nil || node.fn.GeneratorWithExprs != nil)
 }
 
 // IsWindowFunctionApplication returns true iff the function is being applied as a window function.

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -65,3 +65,8 @@ type ValueGenerator interface {
 // GeneratorFactory is the type of constructor functions for
 // ValueGenerator objects.
 type GeneratorFactory func(ctx *EvalContext, args Datums) (ValueGenerator, error)
+
+// GeneratorWithExprsFactory is an alternative constructor function type for
+// ValueGenerators that gives implementations the ability to see the builtin's
+// arguments before evaluation, as Exprs.
+type GeneratorWithExprsFactory func(ctx *EvalContext, args Exprs) (ValueGenerator, error)

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -67,8 +67,19 @@ type Overload struct {
 
 	AggregateFunc func([]*types.T, *EvalContext, Datums) AggregateFunc
 	WindowFunc    func([]*types.T, *EvalContext) WindowFunc
-	Fn            func(*EvalContext, Datums) (Datum, error)
-	Generator     GeneratorFactory
+
+	// Only one of the following three attributes can be set.
+
+	// Fn is the normal builtin implementation function. It's for functions that
+	// take in datums and return a datum.
+	Fn func(*EvalContext, Datums) (Datum, error)
+
+	// Generator is for SRFs. SRFs take datums and return multiple rows of datums.
+	Generator GeneratorFactory
+
+	// GeneratorWithExprs is for SRFs that need access to their arguments as Exprs
+	// and not pre-evaluated Datums, but is otherwise identical to Generator.
+	GeneratorWithExprs GeneratorWithExprsFactory
 
 	// SQLFn must be set for overloads of type SQLClass. It should return a SQL
 	// statement which will be executed as a common table expression in the query.


### PR DESCRIPTION
Updates #69010
Updates #70037

These generator builtins permit type-safe transformation of JSON to
table data. They're added for compatibility with PostgreSQL.

Release note (sql change): add the json_populate_record,
jsonb_populate_record functions, json_populate_recordset, and
jsonb_populate_recordset functions, which transform JSON into row tuples
based on the labels in a record type.