### PR TITLE
kv: lock mutexes for `TxnCoordSender.Epoch()` and `Txn.status()`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1081,6 +1081,8 @@ func (tc *TxnCoordSender) IsSerializablePushAndRefreshNotPossible() bool {
 
 // Epoch is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) Epoch() enginepb.TxnEpoch {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
 	return tc.mu.txn.Epoch
 }
 


### PR DESCRIPTION
### kvcoord: lock mutex in `TxnCoordSender.Epoch()`

Methods that access `TxnCoordSender.mu` fields must lock the mutex
first. `Epoch()` didn't.

Resolves #70071.

Release note: None

### kv: fix mutex locking for `Txn.status`

`Txn.status()` fetches the transaction status from the mutex-protected
`Txn.mu.sender` field, but callers did not take out the mutex lock when
calling it.

This patch renames the method to `Txn.statusLocked()`, and updates all
callers to take out the lock before calling it.

Release note: None