### PR TITLE
release-21.1: rpc: claim to be 21.1.8 in join/heartbeat rpcs

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -25,6 +25,7 @@ import (
 
 	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1151,6 +1152,9 @@ func (ctx *Context) runHeartbeat(
 				ClusterID:            &clusterID,
 				TargetNodeID:         conn.remoteNodeID,
 				ServerVersion:        ctx.Settings.Version.BinaryVersion(),
+			}
+			if request.ServerVersion.Equal(clusterversion.V21Dot1) {
+				request.ServerVersion = clusterversion.V21Dot1Dot8 // support talking to 21.1.8 clusters that demand their version.
 			}
 
 			interceptor := func(*PingRequest) error { return nil }

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -457,6 +457,9 @@ func (s *initServer) attemptJoinTo(
 	}()
 
 	binaryVersion := s.config.binaryVersion
+	if clusterversion.V21Dot1.Equal(binaryVersion) {
+		binaryVersion = clusterversion.V21Dot1Dot8 // claim to be 21.1.8 so any .8 nodes allow us in.
+	}
 	req := &roachpb.JoinNodeRequest{
 		BinaryVersion: &binaryVersion,
 	}


### PR DESCRIPTION
21.1.8 will consider 21.1 to be smaller than it and not let nodes claiming that version to join,
including 21.1.9 now that it has reset its binary version to 21.1. Instead, 21.1.9+ will lie when
sending Join and Heartbeat RPCs, and rather than use their actual binary version (21.1), can send
the 21.1.8 version (-124) to make 21.1.8 nodes allow them in. This allows adding 21.1.9 nodes to a
21.1.8 cluster, as well as upgradig nodes in a 21.1.8 cluster to 21.1.9 in place, i.e. as part of a
rolling upgrade.

Release note: none.