### PR TITLE
testutils: deflake multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -174,6 +174,10 @@ func runMultiTenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster, 
 	const tenant11HTTPPort, tenant11SQLPort = 8081, 36357
 	const tenant11ID = 11
 	runner := sqlutils.MakeSQLRunner(c.Conn(ctx, 1))
+	// We'll sometimes have to wait out the backoff of the host cluster
+	// auto-update loop (at the time of writing 30s), plus some migrations may be
+	// genuinely long-running.
+	runner.SucceedsSoonDuration = 5 * time.Minute
 	runner.Exec(t, `SELECT crdb_internal.create_tenant($1)`, tenant11ID)
 
 	var initialVersion string

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )
 


### PR DESCRIPTION
- testutils: allow making SQLRunner more patient
- roachtest: wait longer in multitenant-upgrade
