### PR TITLE
sql: reduce TTL for tenant_usage

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -606,6 +606,7 @@ RANGE system                                                                  sy
 RANGE liveness                                                                liveness  NULL         NULL                          NULL       NULL
 TABLE system.public.replication_constraint_stats                              NULL      system       replication_constraint_stats  NULL       NULL
 TABLE system.public.replication_stats                                         NULL      system       replication_stats             NULL       NULL
+TABLE system.public.tenant_usage                                              NULL      system       tenant_usage                  NULL       NULL
 TABLE test.public.t                                                           NULL      test         t                             NULL       NULL
 INDEX test.public.t@secondary                                                 NULL      test         t                             secondary  NULL
 INDEX test.public.t@tertiary                                                  NULL      test         t                             tertiary   NULL

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -410,6 +410,9 @@ func runGossipRestartNodeOne(ctx context.Context, t test.Test, c cluster.Cluster
 		run(`ALTER TABLE system.replication_stats %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 		run(`ALTER TABLE system.replication_constraint_stats %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
 	}
+	if t.IsBuildVersion("v21.2.0") {
+		run(`ALTER TABLE system.tenant_usage %[1]s CONFIGURE ZONE %[2]s 'constraints: {"-rack=0"}'`)
+	}
 
 	var lastReplCount int
 	if err := retry.ForDuration(2*time.Minute, func() error {

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -331,6 +331,9 @@ func InitialZoneConfigKVs(
 	replicationStatsZoneConf := &zonepb.ZoneConfig{
 		GC: &zonepb.GCPolicy{TTLSeconds: int32(systemschema.ReplicationStatsTableTTL.Seconds())},
 	}
+	tenantUsageZoneConf := &zonepb.ZoneConfig{
+		GC: &zonepb.GCPolicy{TTLSeconds: int32(systemschema.TenantUsageTableTTL.Seconds())},
+	}
 
 	// Liveness zone config entry with a shorter GC time.
 	livenessZoneConf.GC.TTLSeconds = 10 * 60 // 10m
@@ -344,6 +347,8 @@ func InitialZoneConfigKVs(
 		createZoneConfigKV(keys.ReplicationConstraintStatsTableID, codec, replicationConstraintStatsZoneConf))
 	ret = append(ret,
 		createZoneConfigKV(keys.ReplicationStatsTableID, codec, replicationStatsZoneConf))
+	ret = append(ret,
+		createZoneConfigKV(keys.TenantUsageTableID, codec, tenantUsageZoneConf))
 
 	return ret
 }

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -2137,6 +2137,9 @@ var (
 			},
 		))
 
+	// The tenant_usage table receives periodic updates from all SQL pods. We want
+	// to limit the amount of clutter in the table.
+	TenantUsageTableTTL = 2 * time.Hour
 	// TenantUsageTable is the descriptor for the tenant_usage table. It is used
 	// to coordinate throttling of tenant SQL pods and to track consumption.
 	TenantUsageTable = registerSystemTable(

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -320,6 +320,7 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 22  RANGE liveness
 25  TABLE system.public.replication_constraint_stats
 27  TABLE system.public.replication_stats
+45  TABLE system.public.tenant_usage
 53  DATABASE testdb
 54  TABLE testdb.public.foo
 57  TABLE test.schema.bar

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -709,3 +709,15 @@ SET DATABASE = test
 # system is a database, not a schema.
 query error relation ".system.users" does not exist
 SELECT username FROM "".system.users WHERE username = 'root'
+
+# Verify that tenant_usage has a reduced TTL.
+query T
+SELECT raw_config_sql FROM [ SHOW ZONE CONFIGURATION FOR TABLE system.tenant_usage ]
+----
+ALTER TABLE system.public.tenant_usage CONFIGURE ZONE USING
+  range_min_bytes = 134217728,
+  range_max_bytes = 536870912,
+  gc.ttlseconds = 7200,
+  num_replicas = 5,
+  constraints = '[]',
+  lease_preferences = '[]'

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -31,6 +31,7 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 22  RANGE liveness
 25  TABLE system.public.replication_constraint_stats
 27  TABLE system.public.replication_stats
+45  TABLE system.public.tenant_usage
 53  TABLE test.public.t
 
 # The tests below test semantics around named zone for the system tenant. The

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -44,7 +44,7 @@ func TestInitialKeys(t *testing.T) {
 		var nonDescKeys int
 		if systemTenant {
 			codec = keys.SystemSQLCodec
-			nonDescKeys = 9
+			nonDescKeys = 10
 		} else {
 			codec = keys.MakeSQLCodec(roachpb.MakeTenantID(5))
 			nonDescKeys = 3

--- a/pkg/sql/tests/testdata/initial_keys
+++ b/pkg/sql/tests/testdata/initial_keys
@@ -1,6 +1,6 @@
 initial-keys tenant=system
 ----
-83 keys:
+84 keys:
  /System/"desc-idgen"
  /Table/3/1/1/2/1
  /Table/3/1/3/2/1
@@ -46,6 +46,7 @@ initial-keys tenant=system
  /Table/5/1/22/2/1
  /Table/5/1/25/2/1
  /Table/5/1/27/2/1
+ /Table/5/1/45/2/1
  /NamespaceTable/30/1/0/0/"system"/4/1
  /NamespaceTable/30/1/1/0/"public"/4/1
  /NamespaceTable/30/1/1/29/"comments"/4/1


### PR DESCRIPTION
This change reduces the TTL for the tenant_usage table. This is to
reduce unnecessary clutter in the table, given that we expect a steady
stream of updates.

Informs #68479.

Release note: None

Release justification: Necessary fix for the distributed rate limiting
functionality, which is vital for the upcoming Serverless MVP release.
It allows CRDB to throttle clusters that have run out of free or paid
request units (which measure CPU and I/O usage). This functionality is
only enabled in multi-tenant scenarios and should have no impact on
our dedicated customers.