### PR TITLE
server: fix TestAdminAPIJobs failure

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1570,6 +1570,13 @@ func TestAdminAPIJobs(t *testing.T) {
 				expected = testCase.expectedIDsViaNonAdmin
 			}
 
+			sort.Slice(expected, func(i, j int) bool {
+				return expected[i] < expected[j]
+			})
+
+			sort.Slice(resIDs, func(i, j int) bool {
+				return resIDs[i] < resIDs[j]
+			})
 			if e, a := expected, resIDs; !reflect.DeepEqual(e, a) {
 				t.Errorf("%d: expected job IDs %v, but got %v", i, e, a)
 			}


### PR DESCRIPTION
This change sorts the expected job IDs before ensuring
that they are equal.

Fixes: #69401

Release note: None