### PR TITLE
ccl/backupccl: skip TestRestoreOldVersions

### DIFF
--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -60,6 +60,7 @@ import (
 //
 func TestRestoreOldVersions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 70154, "flaky test")
 	defer log.Scope(t).Close(t)
 	const (
 		testdataBase                = "testdata/restore_old_versions"


### PR DESCRIPTION
Refs: #70154

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None