### PR TITLE
release-21.1: rpc: claim to be 21.1.8 in heartbeat responses

### DIFF
--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -174,6 +174,11 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 		}
 	}
 
+	version := hs.settings.Version.BinaryVersion()
+	if version.Equal(clusterversion.V21Dot1) {
+		version = clusterversion.V21Dot1Dot8
+	}
+
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
@@ -181,7 +186,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	return &PingResponse{
 		Pong:                           args.Ping,
 		ServerTime:                     hs.clock.PhysicalNow(),
-		ServerVersion:                  hs.settings.Version.BinaryVersion(),
+		ServerVersion:                  version,
 		ClusterName:                    hs.clusterName,
 		DisableClusterNameVerification: hs.disableClusterNameVerification,
 	}, nil


### PR DESCRIPTION
21.1.8 will eventually kill  RPC connections if it sees a 21.1 version
so lie and give 21.1.8 as the version in response

Release note: None