### PR TITLE
storage: update mvcc metadata to conform to SafeFormatter interface

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -10,6 +10,7 @@ pkg/kv/kvserver/concurrency/lock/locking.go | `WaitPolicy`
 pkg/kv/kvserver/raft.go | `SnapshotRequest_Type`
 pkg/roachpb/data.go | `LeaseSequence`
 pkg/roachpb/data.go | `ReplicaChangeType`
+pkg/roachpb/data.go | `TransactionStatus`
 pkg/roachpb/metadata.go | `NodeID`
 pkg/roachpb/metadata.go | `RangeGeneration`
 pkg/roachpb/metadata.go | `RangeID`
@@ -31,9 +32,12 @@ pkg/sql/catalog/descpb/structured.go | `IndexID`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
 pkg/sql/sem/tree/table_ref.go | `ColumnID`
 pkg/sql/sem/tree/table_ref.go | `ID`
+pkg/storage/enginepb/mvcc.go | `TxnEpoch`
+pkg/storage/enginepb/mvcc.go | `TxnSeq`
 pkg/storage/enginepb/mvcc3.go | `*MVCCStats`
 pkg/storage/enginepb/mvcc3.go | `MVCCStatsDelta`
 pkg/util/hlc/timestamp.go | `ClockTimestamp`
+pkg/util/hlc/timestamp.go | `LegacyTimestamp`
 pkg/util/hlc/timestamp.go | `Timestamp`
 vendor/github.com/cockroachdb/pebble/internal/humanize/humanize.go | `FormattedString`
 pkg/util/log/redact.go | `reflect.TypeOf(123)`

--- a/pkg/roachpb/errors_test.go
+++ b/pkg/roachpb/errors_test.go
@@ -152,8 +152,8 @@ func TestErrorRedaction(t *testing.T) {
 		}
 		var s redact.StringBuilder
 		s.Print(r)
-		act := s.RedactableString()
-		const exp = "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered previous write with future timestamp 0.000000002,0 within uncertainty interval `t <= (local=0.000000002,2, global=0.000000003,0)`; observed timestamps: [{12 0.000000004,0}]: \"foo\" meta={id=00000000 pri=0.00005746 epo=0 ts=0.000000001,0 min=0.000000001,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false gul=0.000000002,0"
+		act := s.RedactableString().Redact()
+		const exp = "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered previous write with future timestamp 0.000000002,0 within uncertainty interval `t <= (local=0.000000002,2, global=0.000000003,0)`; observed timestamps: [{12 0.000000004,0}]: \"foo\" meta={id=00000000 key=‹×› pri=0.00005746 epo=0 ts=0.000000001,0 min=0.000000001,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false gul=0.000000002,0"
 		require.Equal(t, exp, string(act))
 	})
 }

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -152,6 +152,7 @@ go_test(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/storage",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/pkg/storage/enginepb/mvcc_test.go
+++ b/pkg/storage/enginepb/mvcc_test.go
@@ -11,13 +11,13 @@
 package enginepb_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,11 +64,11 @@ func TestFormatMVCCMetadata(t *testing.T) {
 			expStr, str)
 	}
 
-	const expV = `txn={id=d7aa0f5e key="a" pri=0.00000000 epo=1 ts=0,1 min=0,1 seq=0}` +
-		` ts=0,1 del=false klen=123 vlen=456 raw=/BYTES/foo ih={{11 /BYTES/bar}{22 /BYTES/baz}}` +
+	const expV = `txn={id=d7aa0f5e key=‹"a"› pri=0.00000000 epo=1 ts=0,1 min=0,1 seq=0}` +
+		` ts=0,1 del=false klen=123 vlen=456 raw=‹/BYTES/foo› ih={{11 ‹/BYTES/bar›}{22 ‹/BYTES/baz›}}` +
 		` mergeTs=<nil> txnDidNotUpdateMeta=true`
 
-	if str := fmt.Sprintf("%+v", meta); str != expV {
+	if str := redact.Sprintf("%+v", meta); str != expV {
 		t.Errorf(
 			"expected meta: %s\n"+
 				"got:           %s",

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -350,6 +350,9 @@ func (t LegacyTimestamp) String() string {
 	return t.ToTimestamp().String()
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (LegacyTimestamp) SafeValue() {}
+
 // ClockTimestamp is a Timestamp with the added capability of being able to
 // update a peer's HLC clock. It possesses this capability because the clock
 // timestamp itself is guaranteed to have come from an HLC clock somewhere in


### PR DESCRIPTION
This change updates our previous `MVCCMetadata` formatting methods from
using `fmt.Formatter` and `errors.SafeMessage` to a more streamlined and
redactable output following the `SafeFormatter` interface.

Release note: None