### PR TITLE
release-21.2: backupccl: fix node shutdown roachtest flake

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -543,7 +543,7 @@ func restoreWithRetry(
 			break
 		}
 
-		if !utilccl.IsDistSQLRetryableError(err) {
+		if utilccl.IsPermanentBulkJobError(err) {
 			return RowCount{}, err
 		}
 

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -94,7 +94,7 @@ func jobSurvivesNodeShutdown(
 
 		// Shutdown a node after a bit, and keep it shutdown for the remainder
 		// of the job.
-		timeToWait := 10 * time.Second
+		timeToWait := 5 * time.Second
 		timer := timeutil.Timer{}
 		timer.Reset(timeToWait)
 		select {


### PR DESCRIPTION
Backport 1/1 commits from #70147.

/cc @cockroachdb/release

---

This change reduces the time we wait to shutdown the node
once the restore job has moved to a running state. Waiting
10 seconds often results in the job already having succeeded.

This change also fixes an oversight where restore was only
checking for a subset of the "bulk retryable" errors when
deciding whether or not to fail the job.

Fixes: #70072, #69078, #70090

Release note: None
