### PR TITLE
execbuilder: restore auto commit for internal queries

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -157,7 +157,8 @@ func New(
 		// in such a scenario tableWriterBase.finalize is responsible for making
 		// sure that the rows written limit is not reached before the auto
 		// commit.
-		b.allowAutoCommit = b.allowAutoCommit && (sd.TxnRowsReadErr == 0 && !sd.Internal)
+		prohibitAutoCommit := sd.TxnRowsReadErr != 0 && !sd.Internal
+		b.allowAutoCommit = b.allowAutoCommit && !prohibitAutoCommit
 		b.initialAllowAutoCommit = b.allowAutoCommit
 		b.allowInsertFastPath = sd.InsertFastPath
 	}


### PR DESCRIPTION
We recently merged the guardrails on the number of rows written/read by
a single txn. This prohibited the auto commit when the erring "rows read"
guardrail is enabled. However, that change introduced a bug: we now
mistakenly prohibit the auto commit for all internal queries. This commit
fixes the regression so that we disallow the auto commit only in case of
non-internal queries when the erring "rows read" guardrail is enabled.

Fixes: #70176.

Release note: None (no release with this bug)