### PR TITLE
kvserver: fix & clarify placeholder removal assertions

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2693,11 +2693,11 @@ func TestStoreRangePlaceholders(t *testing.T) {
 	checkRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFilled))
 	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFailed))
 	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderDropped))
-	checkErr(`attempt to remove already removed placeholder`)(s.removePlaceholderLocked(
+	checkErr(`attempting to fill tainted placeholder`)(s.removePlaceholderLocked(
 		ctx, placeholder1, removePlaceholderFilled,
 	))
 	placeholder1.tainted = 0 // pretend it wasn't already deleted
-	checkErr(`expected placeholder to exist: true but found in store: false`)(s.removePlaceholderLocked(
+	checkErr(`expected placeholder .* to exist`)(s.removePlaceholderLocked(
 		ctx, placeholder1, removePlaceholderDropped,
 	))
 
@@ -2723,7 +2723,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 
 	// Test that Placeholder deletion doesn't delete replicas.
 	placeholder1.tainted = 0
-	checkErr(`expected placeholder to exist: true`)(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFilled))
+	checkErr(`expected placeholder .* to exist`)(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFilled))
 	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFailed))
 	check(`
 [] - [99] (/Min - "c")


### PR DESCRIPTION
We have assertions during the removal of replica placeholders that
recently fired in #69950. It turned out that this was a false positive,
owing to the fact once a placeholder is removed, a different placeholder
could be inserted.

This commit fixes (removes) the faulty assertions and streamlines
the remaining assertions. I believe they are now "more obviously
correct": when trying to fill a placeholder, it must exist. When
trying to clean up, the placeholder may or may not exist and there
isn't much that can meaningfully be asserted.

This is similar to how you can assert that you are holding a lock,
but you cannot hope to unlock and then assert that the lock is not
held (as someone else may have acquired it in the meantime).

Fixes #69950.

Release justification: fixes a (rare) crash
Release note: None
