### PR TITLE
testutils: run roachvet on test files

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -318,12 +318,12 @@ func TestBackupRestoreDataDriven(t *testing.T) {
 				ret := ds.noticeBuffer
 				if err != nil {
 					ret = append(ds.noticeBuffer, err.Error())
-					if err, ok := err.(*pq.Error); ok {
-						if err.Detail != "" {
-							ret = append(ret, "DETAIL: "+err.Detail)
+					if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
+						if pqErr.Detail != "" {
+							ret = append(ret, "DETAIL: "+pqErr.Detail)
 						}
-						if err.Hint != "" {
-							ret = append(ret, "HINT: "+err.Hint)
+						if pqErr.Hint != "" {
+							ret = append(ret, "HINT: "+pqErr.Hint)
 						}
 					}
 				}
@@ -6632,7 +6632,7 @@ type exportResumePoint struct {
 	timestamp   hlc.Timestamp
 }
 
-var withTS = hlc.Timestamp{1, 0, false}
+var withTS = hlc.Timestamp{WallTime: 1}
 var withoutTS = hlc.Timestamp{}
 
 func TestPaginatedBackupTenant(t *testing.T) {
@@ -6734,7 +6734,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 		{[]byte("/Tenant/10/Table/53/1/410/0"), []byte("/Tenant/10/Table/53/2"), withoutTS},
 		{[]byte("/Tenant/10/Table/53/1/510/0"), []byte("/Tenant/10/Table/53/2"), withoutTS},
 	} {
-		expected = append(expected, requestSpanStr(roachpb.Span{resume.key, resume.endKey}, resume.timestamp))
+		expected = append(expected, requestSpanStr(roachpb.Span{Key: resume.key, EndKey: resume.endKey}, resume.timestamp))
 	}
 	require.Equal(t, expected, exportRequestSpans)
 	resetStateVars()
@@ -6761,7 +6761,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 		{[]byte("/Tenant/10/Table/57/1/410/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
 		{[]byte("/Tenant/10/Table/57/1/510/0"), []byte("/Tenant/10/Table/57/2"), withoutTS},
 	} {
-		expected = append(expected, requestSpanStr(roachpb.Span{resume.key, resume.endKey}, resume.timestamp))
+		expected = append(expected, requestSpanStr(roachpb.Span{Key: resume.key, EndKey: resume.endKey}, resume.timestamp))
 	}
 	require.Equal(t, expected, exportRequestSpans)
 	resetStateVars()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4283,8 +4283,8 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 
 		// Wait for the high water mark to be non-zero.
 		testutils.SucceedsSoon(t, func() error {
-			progress := loadProgress()
-			if p := progress.GetHighWater(); p != nil && !p.IsEmpty() {
+			prog := loadProgress()
+			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
 				return nil
 			}
 			return errors.New("waiting for highwater")

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -189,7 +189,7 @@ func assertPayloadsBaseErr(
 		// format again with timestamps stripped
 		actualFormatted, err = stripTsFromPayloads(actual)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -95,7 +95,7 @@ func TestBlockingBuffer(t *testing.T) {
 		for {
 			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
 			if err != nil {
-				return nil
+				return nil //nolint:returnerrcheck
 			}
 		}
 	})

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -253,7 +253,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			TestingKnobs: base.TestingKnobs{
 				MigrationManager: &migration.TestingKnobs{
 					ListBetweenOverride: func(from, to clusterversion.ClusterVersion) []clusterversion.ClusterVersion {
-						return []clusterversion.ClusterVersion{{v1}, {v2}}
+						return []clusterversion.ClusterVersion{{Version: v1}, {Version: v2}}
 					},
 					RegistryOverride: func(cv clusterversion.ClusterVersion) (migration.Migration, bool) {
 						switch cv.Version {
@@ -281,7 +281,6 @@ func TestTenantUpgradeFailure(t *testing.T) {
 						default:
 							panic("Unexpected version number observed.")
 						}
-						return nil, false
 					},
 				},
 			},

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -148,7 +148,7 @@ func (ts *testState) tokenBucketRequest(t *testing.T, d *datadriven.TestData) st
 		d.Fatalf(t, "failed to parse duration: %v", args.Period)
 	}
 	req := roachpb.TokenBucketRequest{
-		TenantID:   uint64(tenantID),
+		TenantID:   tenantID,
 		InstanceID: args.InstanceID,
 		ConsumptionSinceLastRequest: roachpb.TenantConsumption{
 			RU:                args.Consumption.RU,

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_crypto//bcrypt",
     ],
 )

--- a/pkg/ccl/serverccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/tenant_grpc_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 // TestTenantGRPCServices tests that the gRPC servers that are externally
@@ -67,9 +66,6 @@ func TestTenantGRPCServices(t *testing.T) {
 		nodeID := roachpb.NodeID(tenant.SQLInstanceID())
 		conn, err := rpcCtx.GRPCDialNode(grpcAddr, nodeID, rpc.DefaultClass).Connect(ctx)
 		require.NoError(t, err)
-		defer func(conn *grpc.ClientConn) {
-			_ = conn.Close()
-		}(conn)
 
 		client := serverpb.NewStatusClient(conn)
 
@@ -134,9 +130,6 @@ func TestTenantGRPCServices(t *testing.T) {
 		nodeID := roachpb.NodeID(tenant.SQLInstanceID())
 		conn, err := rpcCtx.GRPCDialNode(grpcAddr, nodeID, rpc.DefaultClass).Connect(ctx)
 		require.NoError(t, err)
-		defer func(conn *grpc.ClientConn) {
-			_ = conn.Close()
-		}(conn)
 
 		client := serverpb.NewStatusClient(conn)
 
@@ -151,9 +144,6 @@ func TestTenantGRPCServices(t *testing.T) {
 
 		conn, err := rpcCtx.GRPCDialNode(grpcAddr, server.NodeID(), rpc.DefaultClass).Connect(ctx)
 		require.NoError(t, err)
-		defer func(conn *grpc.ClientConn) {
-			_ = conn.Close()
-		}(conn)
 
 		client := serverpb.NewStatusClient(conn)
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -975,7 +975,7 @@ func newTester() *tester {
 	originalSendErrToClient := SendErrToClient
 	te.restoreSendErrToClient =
 		testutils.TestingHook(&SendErrToClient, func(conn net.Conn, err error) {
-			if codeErr, ok := err.(*codeError); ok {
+			if codeErr := (*codeError)(nil); errors.As(err, &codeErr) {
 				te.setErrToClient(codeErr)
 			}
 			originalSendErrToClient(conn, err)

--- a/pkg/ccl/sqlproxyccl/throttler/local_test.go
+++ b/pkg/ccl/sqlproxyccl/throttler/local_test.go
@@ -107,13 +107,13 @@ func TestPoolRefills(t *testing.T) {
 	}
 
 	// The bucket is initialized to its max size.
-	require.Equal(t, int(policy.Capacity), countSuccess())
+	require.Equal(t, policy.Capacity, countSuccess())
 
 	s.clock.advance(10 * time.Second)
 	require.Equal(t, 10, countSuccess())
 
 	s.clock.advance(time.Minute)
-	require.Equal(t, int(policy.Capacity), countSuccess())
+	require.Equal(t, policy.Capacity, countSuccess())
 }
 
 func TestReportSuccessDisablesThrottle(t *testing.T) {

--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -77,7 +77,9 @@ func TestDebugJobTrace(t *testing.T) {
 	c.omitArgs = true
 
 	registry := c.TestServer.JobRegistry().(*jobs.Registry)
-	jobCtx, _ := context.WithCancel(ctx)
+	jobCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	completeResumerCh := make(chan struct{})
 	recordedSpanCh := make(chan struct{})
 	defer close(completeResumerCh)

--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -141,7 +141,7 @@ func reduceSQL(
 		chunkReducer = reducesql.NewSQLChunkReducer(chunkReductions)
 	}
 
-	interesting := func(ctx context.Context, f string) bool {
+	interesting := func(ctx context.Context, sql string) bool {
 		// Disable telemetry and license generation.
 		cmd := exec.CommandContext(ctx, binary,
 			"demo",
@@ -149,7 +149,6 @@ func reduceSQL(
 			"--disable-demo-license",
 		)
 		cmd.Env = []string{"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING", "true"}
-		sql := string(f)
 		if !strings.HasSuffix(sql, ";") {
 			sql += ";"
 		}

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -91,7 +91,7 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 
 			for i := 1; i <= c.Spec().NodeCount; i++ {
 				if elapsed := timeutil.Since(start); elapsed >= 20*time.Second {
-					t.Fatalf("gossip did not stabilize in %.1fs", deadNode, elapsed.Seconds())
+					t.Fatalf("gossip did not stabilize (dead node %d) in %.1fs", deadNode, elapsed.Seconds())
 				}
 
 				if i == deadNode {

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -196,9 +196,9 @@ func makeKVLoadGroup(c cluster.Cluster, numRoachNodes, numLoadNodes int) loadGro
 // performance characteristics of using hash sharded indexes, for sequential workloads
 // which would've otherwise created a single-range hotspot.
 func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSpec) {
-	loadGroup := makeKVLoadGroup(c, b.Nodes, 1)
-	roachNodes := loadGroup.roachNodes
-	loadNodes := loadGroup.loadNodes
+	loadGrp := makeKVLoadGroup(c, b.Nodes, 1)
+	roachNodes := loadGrp.roachNodes
+	loadNodes := loadGrp.loadNodes
 
 	if err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", roachNodes); err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -38,9 +38,11 @@ func WaitFor3XReplication(t test.Test, db *gosql.DB) {
 			ctx,
 			"SELECT count(1) FROM crdb_internal.ranges WHERE array_length(replicas, 1) < 3 ",
 		).Scan(&n); err != nil {
+			cancel()
 			t.Fatal(err)
 		}
 		if n == 0 {
+			cancel()
 			return
 		}
 		cancel()

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -656,7 +656,7 @@ SELECT unnest(execution_errors)
 		tdb.Exec(t, "SET CLUSTER SETTING "+jobs.ExecutionErrorsMaxEntrySizeKey+" = $1", maxSize)
 		tdb.Exec(t, "SET CLUSTER SETTING "+jobs.ExecutionErrorsMaxEntriesKey+" = $1", 1)
 		err1 := strings.Repeat("a", largeSize)
-		firstRun.resume <- jobs.MarkAsRetryJobError(errors.New(err1))
+		firstRun.resume <- jobs.MarkAsRetryJobError(fmt.Errorf("%s", err1))
 
 		// Wait for the job to get restarted.
 		secondRun, secondStart := waitForEvent(t, id)
@@ -694,7 +694,7 @@ SELECT unnest(execution_errors)
 			executionErrorEqual(t, secondExecErr, execErrs[0])
 		}
 		err4 := strings.Repeat("b", largeSize)
-		fourthRun.resume <- jobs.MarkAsRetryJobError(errors.New(err4))
+		fourthRun.resume <- jobs.MarkAsRetryJobError(fmt.Errorf("%s", err4))
 		fifthRun, fifthStart := waitForEvent(t, id)
 		{
 			execErrs := getExecErrors(t, id)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3228,7 +3228,7 @@ func TestStrictGCEnforcement(t *testing.T) {
 						sysCfg.RaftLock()
 						require.NoError(t, sysCfg.MaybeGossipSystemConfigRaftMuLocked(ctx))
 						sysCfg.RaftUnlock()
-						return errors.Errorf("expected %d, got %d", exp, c.TTL().Seconds())
+						return errors.Errorf("expected %d, got %f", exp, c.TTL().Seconds())
 					}
 				}
 				return nil
@@ -3867,6 +3867,7 @@ func TestOptimisticEvalRetry(t *testing.T) {
 			require.True(t, removedLocks)
 			done = true
 		case <-timer.C:
+			timer.Read = true
 			require.NoError(t, txn1.Commit(ctx))
 			removedLocks = true
 		}

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -1169,7 +1169,7 @@ func TestGCQueueChunkRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not find span config for range %s", err)
 	}
-	tc.manualClock.Increment(int64(conf.TTL().Nanoseconds()) + 1)
+	tc.manualClock.Increment(conf.TTL().Nanoseconds() + 1)
 	gcQ := newGCQueue(tc.store)
 	processed, err := gcQ.process(ctx, tc.repl, confReader)
 	if err != nil {

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -422,7 +422,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 
 		// testTxnExecute executes a transaction for testTxn. It is a separate function
 		// so that any transaction errors can be retried as appropriate.
-		testTxnExecute := func(t *testing.T, spec testTxnSpec, txn *kv.Txn, txnKey roachpb.Key) error {
+		testTxnExecute := func(t *testing.T, ctx context.Context, spec testTxnSpec, txn *kv.Txn, txnKey roachpb.Key) error {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
@@ -445,7 +445,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 				// meanwhile, returning when heartbeat was aborted.
 				abortedC := abortHeartbeat(t, txnKey)
 				readyC := blockPut(t, txnKey)
-				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "unblock", func(ctx context.Context) {
+				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "unblock", func(_ context.Context) {
 					<-abortedC
 					unblockC := <-readyC
 					time.Sleep(100 * time.Millisecond)
@@ -492,7 +492,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			// evaluated in Raft.
 			if spec.finalize == "cancelAsync" {
 				readyC := blockPutEval(t, txnKey)
-				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "cancel", func(ctx context.Context) {
+				require.NoError(t, tc.Stopper().RunAsyncTask(ctx, "cancel", func(_ context.Context) {
 					unblockC := <-readyC
 					defer close(unblockC)
 					cancel()
@@ -559,16 +559,19 @@ func TestReliableIntentCleanup(t *testing.T) {
 			for attempt := 1; ; attempt++ {
 				txnKey := genKey(spec.singleRange)
 				txns[txn.ID()] = txnKey // before testTxnExecute, id may change on errors
-
-				err := testTxnExecute(t, spec, txn, txnKey)
+				retryErr := &roachpb.TransactionRetryWithProtoRefreshError{}
+				err := testTxnExecute(t, ctx, spec, txn, txnKey)
 				if err == nil {
 					break
 				} else if spec.abort != "" {
 					require.Error(t, err)
-					require.IsType(t, &roachpb.TransactionRetryWithProtoRefreshError{}, err, "err: %v", err)
-					require.True(t, err.(*roachpb.TransactionRetryWithProtoRefreshError).PrevTxnAborted())
+					if errors.As(err, retryErr) {
+						require.True(t, retryErr.PrevTxnAborted())
+					} else {
+						require.Fail(t, "expected TransactionRetryWithProtoRefreshError, got %v", err)
+					}
 					break
-				} else if retryErr, ok := err.(*roachpb.TransactionRetryWithProtoRefreshError); !ok {
+				} else if !errors.As(err, retryErr) {
 					require.NoError(t, err)
 				} else if attempt >= 3 {
 					require.Fail(t, "too many txn retries", "attempt %v errored: %v", attempt, err)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8453,8 +8453,8 @@ func TestReplicaReproposalWithNewLeaseIndexError(t *testing.T) {
 	tc.repl.mu.Lock()
 	tc.repl.mu.proposalBuf.testing.leaseIndexFilter = func(p *ProposalData) (indexOverride uint64) {
 		if v := p.ctx.Value(magicKey{}); v != nil {
-			curFlushAttempt := atomic.AddInt32(&curFlushAttempt, 1)
-			switch curFlushAttempt {
+			flushAttempts := atomic.AddInt32(&curFlushAttempt, 1)
+			switch flushAttempts {
 			case 1:
 				// This is the first time the command is being given a max lease
 				// applied index. Set the index to that of the recently applied

--- a/pkg/kv/kvserver/spanlatch/manager_test.go
+++ b/pkg/kv/kvserver/spanlatch/manager_test.go
@@ -553,9 +553,9 @@ func TestLatchManagerOptimistic(t *testing.T) {
 	waitUntilAcquiredCh := func(g *Guard) <-chan *Guard {
 		ch := make(chan *Guard)
 		go func() {
-			g, err := m.WaitUntilAcquired(context.Background(), g)
+			lg, err := m.WaitUntilAcquired(context.Background(), g)
 			require.NoError(t, err)
-			ch <- g
+			ch <- lg
 		}()
 		return ch
 	}

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -42,7 +42,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 1,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "a",
@@ -59,7 +59,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 2,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "a",
@@ -76,7 +76,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 3,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "a",
@@ -93,7 +93,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 4,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "b",
@@ -110,7 +110,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 5,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "b",
@@ -127,7 +127,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 6,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "b",
@@ -144,7 +144,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 7,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "c",
@@ -161,7 +161,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 8,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "c",
@@ -178,7 +178,7 @@ var (
 			Node: roachpb.NodeDescriptor{
 				NodeID: 9,
 				Locality: roachpb.Locality{
-					[]roachpb.Tier{
+					Tiers: []roachpb.Tier{
 						{
 							Key:   "region",
 							Value: "c",

--- a/pkg/migration/migrations/helpers_test.go
+++ b/pkg/migration/migrations/helpers_test.go
@@ -101,11 +101,11 @@ func ValidateSchemaExists(
 	for _, stmt := range stmts {
 		_, err := sqlDB.Exec(stmt)
 		if expectExists {
-			require.NoError(
+			require.NoErrorf(
 				t, err, "expected schema to exist, but unable to query it, using statement: %s", stmt,
 			)
 		} else {
-			require.Error(
+			require.Errorf(
 				t, err, "expected schema to not exist, but queried it successfully, using statement: %s", stmt,
 			)
 		}

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -167,7 +167,7 @@ func makeTestCert(
 func TestNamingScheme(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	permissionRequirement := ".* exceeds -rwx------"
+	permissionRequirementErr := errors.New(".* exceeds -rwx------")
 
 	// by default we only allow certificate keys owned by the same user
 	// as the running process (0700). In some environments, such as
@@ -180,7 +180,7 @@ func TestNamingScheme(t *testing.T) {
 	// Because this test creates certificate keys, when run as root we
 	// we have the less stringent permission requirement.
 	if os.Getuid() == 0 {
-		permissionRequirement = "exceeds -rwxr-----"
+		permissionRequirementErr = errors.New("exceeds -rwxr-----")
 	}
 
 	fullKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
@@ -284,9 +284,9 @@ func TestNamingScheme(t *testing.T) {
 			certs: []security.CertInfo{
 				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
-					Error: errors.New(permissionRequirement)},
+					Error: permissionRequirementErr},
 				{FileUsage: security.NodePem, Filename: "node.crt",
-					Error: errors.New(permissionRequirement)},
+					Error: permissionRequirementErr},
 			},
 			skipWindows: true,
 		},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1243,7 +1243,10 @@ func TestAssertEnginesEmpty(t *testing.T) {
 	require.NoError(t, assertEnginesEmpty([]storage.Engine{eng}))
 
 	batch := eng.NewBatch()
-	key := storage.MVCCKey{[]byte{0xde, 0xad, 0xbe, 0xef}, hlc.Timestamp{WallTime: 100}}
+	key := storage.MVCCKey{
+		Key:       []byte{0xde, 0xad, 0xbe, 0xef},
+		Timestamp: hlc.Timestamp{WallTime: 100},
+	}
 	require.NoError(t, batch.PutMVCC(key, []byte("foo")))
 	require.NoError(t, batch.Commit(false))
 	require.Error(t, assertEnginesEmpty([]storage.Engine{eng}))

--- a/pkg/server/statements_test.go
+++ b/pkg/server/statements_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 // TestStatements ensures that the Statements endpoint is accessible
@@ -41,9 +40,6 @@ func TestStatements(t *testing.T) {
 		testServer.RPCAddr(), testServer.NodeID(), rpc.DefaultClass,
 	).Connect(ctx)
 	require.NoError(t, err)
-	defer func(conn *grpc.ClientConn) {
-		_ = conn.Close()
-	}(conn)
 
 	client := serverpb.NewStatusClient(conn)
 

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -227,7 +227,6 @@ func TestCache(t *testing.T) {
 	byteSize.SetOnChange(sv, func(context.Context) { changes.byteSize++ })
 
 	t.Run("VersionSetting", func(t *testing.T) {
-		ctx := context.Background()
 		u := settings.NewUpdater(sv)
 		mB := settings.TestingRegisterVersionSetting("local.m", "foo", &dummyVersionSettingImpl{})
 		// Version settings don't have defaults, so we need to start by setting

--- a/pkg/sql/catalog/nstree/map_test.go
+++ b/pkg/sql/catalog/nstree/map_test.go
@@ -11,7 +11,6 @@
 package nstree
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -90,7 +89,7 @@ func testMapDataDriven(t *testing.T, d *datadriven.TestData, tr Map) string {
 			defer func() { i++ }()
 			if a.set&argStopAfter != 0 && i == a.stopAfter {
 				if d.Input != "" {
-					return errors.New(d.Input)
+					return fmt.Errorf("error: %s", d.Input)
 				}
 				return iterutil.StopIteration()
 			}
@@ -99,7 +98,7 @@ func testMapDataDriven(t *testing.T, d *datadriven.TestData, tr Map) string {
 			return nil
 		})
 		if err != nil {
-			fmt.Fprintf(&buf, "error: %v", err)
+			fmt.Fprintf(&buf, "%v", err)
 		}
 		return buf.String()
 	case "len":

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -277,7 +277,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 	// Choose a memory limit such that at most two batches can be kept in the
 	// in-memory buffer at a time (single batch is not enough because the queue
 	// delays the release of the memory by one batch).
-	memoryLimit := int64(2 * colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize()))
+	memoryLimit := 2 * colmem.EstimateBatchSizeBytes(typs, coldata.BatchSize())
 	if memoryLimit < mon.DefaultPoolAllocationSize {
 		memoryLimit = mon.DefaultPoolAllocationSize
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -118,7 +118,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 		inputIdx := i
 		inputs[i].MetadataSources = []colexecop.MetadataSource{
 			colexectestutils.CallbackMetadataSource{DrainMetaCb: func() []execinfrapb.ProducerMetadata {
-				return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d "+errSuffix, inputIdx)}}
+				return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d %s", inputIdx, errSuffix)}}
 			}},
 		}
 	}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -348,10 +348,10 @@ INSERT INTO t.t VALUES (1);
 	// The log messages we are looking for are structured like
 	// [....,txn=<txnID>], so search for those and extract the id.
 	row := sqlDB.QueryRow(`
-SELECT 
-	string_to_array(regexp_extract(tag, 'txn=[a-zA-Z0-9]*'), '=')[2] 
-FROM 
-	[SHOW KV TRACE FOR SESSION] 
+SELECT
+	string_to_array(regexp_extract(tag, 'txn=[a-zA-Z0-9]*'), '=')[2]
+FROM
+	[SHOW KV TRACE FOR SESSION]
 WHERE
   tag LIKE '%txn=%' LIMIT 1`)
 	var txnID string
@@ -536,12 +536,11 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	tc := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs:      params,
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer tc.Stopper().Stop(context.Background())
 
 	// Create a table with 3 rows, split them into 3 ranges with each node
 	// having one.
@@ -604,7 +603,7 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 			// maxRunningFlows is 0, the query eventually will error out because
 			// the remote flows don't connect in time; if maxRunningFlows is 1,
 			// the query will succeed once we close 'unblock' channel.
-			ctx, cancel := context.WithCancel(ctx)
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			g := ctxgroup.WithContext(ctx)
 			g.GoCtx(func(ctx context.Context) error {

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1328,7 +1328,7 @@ func TestCheckScanParallelizationIfLocal(t *testing.T) {
 		b := tabledesc.NewBuilder(&tableDesc)
 		err := b.RunPostDeserializationChanges(ctx, nil /* DescGetter */)
 		if err != nil {
-			log.Fatalf(ctx, "error when building a table descriptor", err)
+			log.Fatalf(ctx, "error when building a table descriptor: %v", err)
 		}
 		return b.BuildImmutableTable()
 	}

--- a/pkg/sql/query_sampling_test.go
+++ b/pkg/sql/query_sampling_test.go
@@ -46,8 +46,8 @@ func TestUpdateRollingQueryCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	stubTime := stubTime{}
-	stubTime.setTime(timeutil.Now())
+	st := stubTime{}
+	st.setTime(timeutil.Now())
 
 	type numUpdatesPerDelay struct {
 		numUpdates int
@@ -82,13 +82,13 @@ func TestUpdateRollingQueryCounts(t *testing.T) {
 	for _, tc := range testData {
 		freshMetrics := NewTelemetryLoggingMetrics(defaultSmoothingAlpha, int64(tc.intervalLength))
 		freshMetrics.Knobs = &TelemetryLoggingTestingKnobs{
-			getTimeNow: stubTime.TimeNow,
+			getTimeNow: st.TimeNow,
 		}
 
 		for i := 0; i < len(tc.updatesPerDelay); i++ {
 			secondsDelay := tc.updatesPerDelay[i].timeDelay
 			numUpdates := tc.updatesPerDelay[i].numUpdates
-			stubTime.setTime(stubTime.TimeNow().Add(time.Second * secondsDelay))
+			st.setTime(st.TimeNow().Add(time.Second * secondsDelay))
 			for j := 0; j < numUpdates; j++ {
 				freshMetrics.updateRollingQueryCounts()
 			}

--- a/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
+++ b/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
@@ -81,7 +81,7 @@ func TestInstanceProvider(t *testing.T) {
 		slInstance.ClearSessionForTest(ctx)
 		// Verify that the SQL instance is shutdown on session expiry.
 		testutils.SucceedsSoon(t, func() error {
-			if _, err = instanceProvider.Instance(ctx); err != stop.ErrUnavailable {
+			if _, err = instanceProvider.Instance(ctx); !errors.Is(err, stop.ErrUnavailable) {
 				return errors.Errorf("sql instance is not shutdown on session expiry")
 			}
 			return nil

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -170,27 +170,27 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 	helper, helperCleanup := newTestHelper(t)
 	defer helperCleanup()
 
-	sj := getSQLStatsCompactionSchedule(t, helper)
+	schedID := getSQLStatsCompactionSchedule(t, helper).ScheduleID()
 
 	t.Run("schedule_cannot_be_dropped", func(t *testing.T) {
-		_, err := helper.sqlDB.DB.ExecContext(ctx, "DROP SCHEDULE $1", sj.ScheduleID())
+		_, err := helper.sqlDB.DB.ExecContext(ctx, "DROP SCHEDULE $1", schedID)
 		require.True(t,
 			strings.Contains(err.Error(), persistedsqlstats.ErrScheduleUndroppable.Error()),
 			"expected to found ErrScheduleUndroppable, but found %+v", err)
 	})
 
 	t.Run("warn_schedule_paused", func(t *testing.T) {
-		helper.sqlDB.Exec(t, "PAUSE SCHEDULE $1", sj.ScheduleID())
-		defer helper.sqlDB.Exec(t, "RESUME SCHEDULE $1", sj.ScheduleID())
+		helper.sqlDB.Exec(t, "PAUSE SCHEDULE $1", schedID)
+		defer helper.sqlDB.Exec(t, "RESUME SCHEDULE $1", schedID)
 
 		helper.sqlDB.CheckQueryResults(
 			t,
-			fmt.Sprintf("SELECT schedule_status FROM [SHOW SCHEDULE %d]", sj.ScheduleID()),
+			fmt.Sprintf("SELECT schedule_status FROM [SHOW SCHEDULE %d]", schedID),
 			[][]string{{"PAUSED"}},
 		)
 
 		// Reload schedule from DB.
-		sj = getSQLStatsCompactionSchedule(t, helper)
+		sj := getSQLStatsCompactionSchedule(t, helper)
 		err := persistedsqlstats.CheckScheduleAnomaly(sj)
 		require.True(t, errors.Is(err, persistedsqlstats.ErrSchedulePaused),
 			"expected ErrSchedulePaused, but found %+v", err)
@@ -219,7 +219,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 			helper.sqlDB.CheckQueryResultsRetry(t,
 				fmt.Sprintf(`
 SELECT schedule_expr
-FROM system.scheduled_jobs WHERE schedule_id = %d`, sj.ScheduleID()),
+FROM system.scheduled_jobs WHERE schedule_id = %d`, schedID),
 				[][]string{{"@hourly"}},
 			)
 		})

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -78,8 +78,8 @@ func TestTelemetryLogging(t *testing.T) {
 	cleanup := installTelemetryLogFileSink(sc, t)
 	defer cleanup()
 
-	stubTime := stubTime{}
-	stubTime.setTime(timeutil.Now())
+	st := stubTime{}
+	st.setTime(timeutil.Now())
 	stubInterval := fakeInterval{}
 	stubInterval.setInterval(1)
 
@@ -87,7 +87,7 @@ func TestTelemetryLogging(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
 				getRollingIntervalLength: stubInterval.getInterval,
-				getTimeNow:               stubTime.TimeNow,
+				getTimeNow:               st.TimeNow,
 			},
 		},
 	})
@@ -187,13 +187,13 @@ func TestTelemetryLogging(t *testing.T) {
 	for _, tc := range testData {
 		telemetryQPSThreshold.Override(context.Background(), &s.ClusterSettings().SV, tc.stubQPSThreshold)
 		telemetrySampleRate.Override(context.Background(), &s.ClusterSettings().SV, tc.stubSamplingRate)
-		stubTime.setTime(stubTime.TimeNow().Add(time.Second))
+		st.setTime(st.TimeNow().Add(time.Second))
 		stubInterval.setInterval(tc.intervalLength)
 		for _, numExec := range tc.numExec {
 			for i := 0; i < numExec; i++ {
 				db.Exec(t, tc.query)
 			}
-			stubTime.setTime(stubTime.TimeNow().Add(time.Second))
+			st.setTime(st.TimeNow().Add(time.Second))
 		}
 	}
 

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -89,11 +89,6 @@ func TestFileRegistryOps(t *testing.T) {
 	bazFileEntry :=
 		&enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte("baz")}
 
-	require.NoError(t, mem.MkdirAll("/mydb", 0755))
-	registry := &PebbleFileRegistry{FS: mem, DBDir: "/mydb"}
-	require.NoError(t, registry.Load())
-	require.Nil(t, registry.GetFileEntry("file1"))
-
 	expected := make(map[string]*enginepb.FileEntry)
 
 	checkEquality := func() {
@@ -116,6 +111,11 @@ func TestFileRegistryOps(t *testing.T) {
 			t.Fatalf("%s\n%v", strings.Join(diff, "\n"), registry.mu.currProto.Files)
 		}
 	}
+
+	require.NoError(t, mem.MkdirAll("/mydb", 0755))
+	registry := &PebbleFileRegistry{FS: mem, DBDir: "/mydb"}
+	require.NoError(t, registry.Load())
+	require.Nil(t, registry.GetFileEntry("file1"))
 
 	// {file1 => foo}
 	require.NoError(t, registry.SetFileEntry("file1", fooFileEntry))

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2064,25 +2064,23 @@ func TestLint(t *testing.T) {
 		}, ",")
 
 		nakedGoroutineExceptions := `(` + strings.Join([]string{
-			`pkg/.*_test.go`,
-			`pkg/workload/`,
-			`pkg/cli/systembench/`,
-			`pkg/cmd/roachprod/`,
-			`pkg/cmd/roachtest/`,
-			`pkg/cmd/roachprod-stress/`,
-			`pkg/cmd/urlcheck/`,
-			`pkg/acceptance/`,
-			`pkg/cli/syncbench/`,
-			`pkg/workload/`,
-			`pkg/cmd/cmp-protocol/`,
-			`pkg/cmd/cr2pg/`,
-			`pkg/cmd/smithtest/`,
-			`pkg/cmd/reduce/`,
-			`pkg/cmd/zerosum/`,
-			`pkg/cmd/allocsim/`,
-			`pkg/testutils/`,
-		}, ")|(") + `)`
-
+			`pkg/.*_test\.go`,
+			`pkg/acceptance/.*\.go`,
+			`pkg/cli/syncbench/.*\.go`,
+			`pkg/cli/systembench/.*\.go`,
+			`pkg/cmd/allocsim/.*\.go`,
+			`pkg/cmd/cmp-protocol/.*\.go`,
+			`pkg/cmd/cr2pg/.*\.go`,
+			`pkg/cmd/reduce/.*\.go`,
+			`pkg/cmd/roachprod-stress/.*\.go`,
+			`pkg/cmd/roachprod/.*\.go`,
+			`pkg/cmd/roachtest/.*\.go`,
+			`pkg/cmd/smithtest/.*\.go`,
+			`pkg/cmd/urlcheck/.*\.go`,
+			`pkg/cmd/zerosum/.*\.go`,
+			`pkg/testutils/.*\.go`,
+			`pkg/workload/.*\.go`,
+		}, "|") + `)`
 		filters := []stream.Filter{
 			// Ignore generated files.
 			stream.GrepNot(`pkg/.*\.pb\.go:`),
@@ -2132,7 +2130,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: logfDepth\(\): format argument is not a constant expression`),
 			// roachtest is not collecting redactable logs so we don't care
 			// about printf hygiene there as much.
-			stream.GrepNot(`pkg/cmd/roachtest/log\.go:.*format argument is not a constant expression`),
+			stream.GrepNot(`pkg/cmd/roachtest/logger/log\.go:.*format argument is not a constant expression`),
 			// We purposefully produce nil dereferences in this file to test crash conditions
 			stream.GrepNot(`pkg/util/log/logcrash/crash_reporting_test\.go:.*nil dereference in type assertion`),
 			// Spawning naked goroutines is ok when it's not as part of the main CRDB

--- a/pkg/testutils/reduce/reduce_test.go
+++ b/pkg/testutils/reduce/reduce_test.go
@@ -53,7 +53,7 @@ var (
 
 func isInterestingGo(contains string) reduce.InterestingFn {
 	return func(ctx context.Context, f string) bool {
-		_, err := parser.ParseExpr(string(f))
+		_, err := parser.ParseExpr(f)
 		if err == nil {
 			return false
 		}

--- a/pkg/testutils/reduce/reducesql/reducesql_test.go
+++ b/pkg/testutils/reduce/reducesql/reducesql_test.go
@@ -65,7 +65,7 @@ func isInterestingSQL(contains string) reduce.InterestingFn {
 		if err != nil {
 			panic(err)
 		}
-		_, err = db.Exec(ctx, string(f))
+		_, err = db.Exec(ctx, f)
 		if err == nil {
 			return false
 		}

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -39,9 +39,7 @@ func TestGC(t *testing.T) {
 		t.Fatal("no file sink")
 	}
 
-	testLogGC(t, fs, func(ctx context.Context, msg string) {
-		Infof(ctx, msg)
-	})
+	testLogGC(t, fs, Info)
 }
 
 func TestSecondaryGC(t *testing.T) {

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -98,7 +98,7 @@ func testBase(
 		go func() {
 			defer func() { close(serverErrCh) }()
 			err := s.Serve(l)
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				select {
 				case serverErrCh <- err:
 				case <-cancelCh:

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -39,7 +39,7 @@ func columnByteSize(col coldata.Vec) int64 {
 		return int64(len(col.Float64()) * 8)
 	case types.BytesFamily:
 		// We subtract the overhead to be in line with Int64 and Float64 cases.
-		return int64(col.Bytes().Size() - coldata.FlatBytesOverhead)
+		return col.Bytes().Size() - coldata.FlatBytesOverhead
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, t))
 	}

--- a/pkg/workload/tpcc/checks.go
+++ b/pkg/workload/tpcc/checks.go
@@ -272,14 +272,14 @@ func check3325(db *gosql.DB, asOfSystemTime string) (retErr error) {
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 EXCEPT ALL
 (SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)`)
-	if err := firstQuery.Scan(); err != gosql.ErrNoRows {
+	if err := firstQuery.Scan(); !errors.Is(err, gosql.ErrNoRows) {
 		return errors.Errorf("left EXCEPT right returned nonzero results.")
 	}
 	secondQuery := txn.QueryRow(`
 (SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)
 EXCEPT ALL
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)`)
-	if err := secondQuery.Scan(); err != gosql.ErrNoRows {
+	if err := secondQuery.Scan(); !errors.Is(err, gosql.ErrNoRows) {
 		return errors.Errorf("right EXCEPT left returned nonzero results.")
 	}
 	return nil
@@ -302,7 +302,7 @@ EXCEPT ALL
 (SELECT ol_w_id, ol_d_id, ol_o_id, count(*) FROM order_line
   GROUP BY (ol_w_id, ol_d_id, ol_o_id)
   ORDER BY ol_w_id, ol_d_id, ol_o_id DESC)`)
-	if err := firstQuery.Scan(); err != gosql.ErrNoRows {
+	if err := firstQuery.Scan(); !errors.Is(err, gosql.ErrNoRows) {
 		return errors.Errorf("left EXCEPT right returned nonzero results")
 	}
 	secondQuery := txn.QueryRow(`
@@ -311,7 +311,7 @@ EXCEPT ALL
 EXCEPT ALL
 (SELECT o_w_id, o_d_id, o_id, o_ol_cnt FROM "order"
   ORDER BY o_w_id, o_d_id, o_id DESC)`)
-	if err := secondQuery.Scan(); err != gosql.ErrNoRows {
+	if err := secondQuery.Scan(); !errors.Is(err, gosql.ErrNoRows) {
 		return errors.Errorf("right EXCEPT left returned nonzero results")
 	}
 	return nil


### PR DESCRIPTION
The previously constructed extended regular expression would end up
looking like:

    (pkg/*_test.go)|(pkg/workload)|...|(pkg/testutil):.*Use of go keyword not allowed

As a result, roachvet was being skipped on all test files and all but
the last package in this list.

Fixes #70193

Release note: None