### PR TITLE
sql: allow auto commit when rows written limit is reached, not exceeded

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
@@ -784,6 +784,10 @@ statement ok
 CREATE TABLE guardrails (i INT PRIMARY KEY);
 SET transaction_rows_written_err = 1
 
+# Get the range id.
+let $rangeid
+SELECT range_id FROM [ SHOW RANGES FROM TABLE guardrails ]
+
 query B
 SELECT count(*) > 0 FROM [
   EXPLAIN (VERBOSE) INSERT INTO guardrails VALUES (1)
@@ -793,7 +797,17 @@ true
 
 # Now verify that writing a single row succeeds, but writing two doesn't.
 statement ok
-INSERT INTO guardrails VALUES (1)
+SET tracing = on;
+  INSERT INTO guardrails VALUES (1);
+SET tracing = off;
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message     LIKE '%r$rangeid: sending batch%'
+  AND message NOT LIKE '%PushTxn%'
+  AND message NOT LIKE '%QueryTxn%'
+----
+dist sender send  r43: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 
 query error pq: txn has written 2 rows, which is above the limit
 INSERT INTO guardrails VALUES (2), (3)

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -210,9 +210,9 @@ func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 	// NB: unlike flushAndStartNewBatch, we don't bother with admission control
 	// for response processing when finalizing.
 	tb.rowsWritten += int64(tb.currentBatchSize)
-	if tb.autoCommit == autoCommitEnabled && (tb.rowsWrittenLimit == 0 || tb.rowsWritten < tb.rowsWrittenLimit) {
+	if tb.autoCommit == autoCommitEnabled && (tb.rowsWrittenLimit == 0 || tb.rowsWritten <= tb.rowsWrittenLimit) {
 		// We can only auto commit if the rows written guardrail is disabled or
-		// we haven't reached the specified limit (the optimizer is responsible
+		// we haven't exceeded the specified limit (the optimizer is responsible
 		// for making sure that there is exactly one mutation before enabling
 		// the auto commit).
 		log.Event(ctx, "autocommit enabled")


### PR DESCRIPTION
We recently added the support of the rows written/read guardrails.
Originally, those numbers meant that once reached, an error would be
emitted. In a0f68a17f935cbe1daf77a764f341adf01983ed2 we adjusted the
guardrails so that the numbers meant the largest allowed counts.
However, we forgot to update on place - namely, if "rows written"
erring guardrail is enabled, we have to check the count before allowing
the auto commit of all mutation operations. This meant that in case the
limit is reached but not exceeded, we would mistakenly lose the auto
commit optimization.

Release note: None