### PR TITLE
opt: autocommit when RETURNING expressions are leak-proof

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1047,12 +1047,11 @@ func (b *Builder) canAutoCommit(rel memo.RelExpr) bool {
 
 	case opt.ProjectOp:
 		// Allow Project on top, as long as the expressions are not side-effecting.
-		//
-		// TODO(radu): for now, we only allow passthrough projections because not all
-		// builtins that can error out are marked as side-effecting.
 		proj := rel.(*memo.ProjectExpr)
-		if len(proj.Projections) != 0 {
-			return false
+		for i := 0; i < len(proj.Projections); i++ {
+			if !proj.Projections[i].ScalarProps().VolatilitySet.IsLeakProof() {
+				return false
+			}
 		}
 		return b.canAutoCommit(proj.Input)
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit_nonmetamorphic
@@ -112,17 +112,16 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
 ----
 dist sender send  r43: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
-# TODO(radu): allow non-side-effecting projections.
 query B
 SELECT count(*) > 0 FROM [
-  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b
+  EXPLAIN (VERBOSE) INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a < b
 ] WHERE info LIKE '%auto commit%'
 ----
-false
+true
 
 statement ok
 SET TRACING=ON;
-  INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a + b;
+  INSERT INTO ab VALUES (8, 8), (9, 9) RETURNING a < b;
 SET TRACING=OFF
 
 query TT
@@ -132,8 +131,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%QueryTxn%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r43: sending batch 2 CPut to (n1,s1):1
-dist sender send  r43: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r43: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.


### PR DESCRIPTION
Previously, mutations under a Project could only be auto-committed when
the Project had only passthrough columns and no projection expressions.
Now, a mutation under a Project can auto-commit if all the projections
are leak-proof.

Release note (performance improvement): Mutation statements with a
RETURNING clause that are not inside an explicit transaction are faster
in some cases.