### PR TITLE
roachprod: tag ssh keys in aws with IAMUserName and CreatedAt

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/cmd/roachprod/vm/aws/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/cmd/roachprod/vm/flagstub",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/cmd/roachprod/vm/aws/keys.go
+++ b/pkg/cmd/roachprod/vm/aws/keys.go
@@ -17,7 +17,9 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 )
@@ -62,11 +64,25 @@ func (p *Provider) sshKeyImport(keyName string, region string) error {
 		KeyName string
 	}
 	_ = data.KeyName // silence unused warning
+
+	user, err := p.FindActiveAccount()
+	if err != nil {
+		return err
+	}
+
+	timestamp := timeutil.Now()
+	createdAt := timestamp.Format(time.RFC3339)
+
+	IAMUserNameTag := fmt.Sprintf("{Key=IAMUserName,Value=%s}", user)
+	createdAtTag := fmt.Sprintf("{Key=CreatedAt,Value=%s}", createdAt)
+	tagSpecs := fmt.Sprintf("ResourceType=key-pair,Tags=[%s, %s]", IAMUserNameTag, createdAtTag)
+
 	args := []string{
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
 		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyFile),
+		"--tag-specifications", tagSpecs,
 	}
 	err = p.runJSONCommand(args, &data)
 	// If two roachprod instances run at the same time with the same key, they may


### PR DESCRIPTION
Previously, roachprod created ssh key pairs without any direct way
of mapping them to users, and without any way of knowing the
creation time.

This needed to change because we need to delete ssh key pairs of
previous users and we should have a way of finding those keys.

This patch ensures that any newly created ssh key pair will be
tagged with 'IAM-UserName' and 'CreatedAt' tags.

Informs: #70635

Release note: None