### PR TITLE
changefeedccl: add option to further shard cloudstorage folders

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -112,6 +112,7 @@ const (
 	SinkParamClientCert             = `client_cert`
 	SinkParamClientKey              = `client_key`
 	SinkParamFileSize               = `file_size`
+	SinkParamPartitionFormat        = `partition_format`
 	SinkParamSchemaTopic            = `schema_topic`
 	SinkParamTLSEnabled             = `tls_enabled`
 	SinkParamSkipTLSVerify          = `insecure_tls_skip_verify`

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -172,6 +172,13 @@ func (u *sinkURL) consumeParam(p string) string {
 	return v
 }
 
+func (u *sinkURL) addParam(p string, value string) {
+	if u.q == nil {
+		u.q = u.Query()
+	}
+	u.q.Add(p, value)
+}
+
 func (u *sinkURL) consumeBool(param string, dest *bool) (wasSet bool, err error) {
 	if paramVal := u.consumeParam(param); paramVal != "" {
 		wasSet, err := strToBool(paramVal, dest)


### PR DESCRIPTION
I initially wanted this to be a sinkURI query param, but that didn't allow me to have the "%" characters without them being escaped.

Resolves #63470

---

    changefeedccl: add query param to shard cloudstorage folders

    Previously we always bucketed cloudstorage paths into 'folders' delineated
    by date which described the earliest possible timestamp that could exist
    in that folder.  Ex: topic-name/2021-09-13/file.ndjson

    A customer with a ton of files wanted the folders to be separated hourly
    rather than just into dates.  Ex: topic-name/2021-0-13/04/file.ndjson

    This patch adds a `partition_format` query param which allows the
    user to elect to use the default behaviour with the "daily" value, split
    it by date/hour/ with the "hourly" value, or not partition at all with
    the "flat" value

    So to solve the customer's issue they would add the query parameter
    partition_format="hourly"

    Release justification: low risk new ux sink query param

    Release note (api change): CREATE CHANGEFEED on a CloudStorage sink now
    allows a new query parameter to specify how the file paths are
    partitioned, for example partition_format="daily" represents the default
    behavior of splitting into dates (2021-05-01/), while
    partition_format="hourly" will further partition them them by hour
    (2021-05-01/05/), and partition_format="flat" will not partition at all
