### PR TITLE
rowexec: fix a ctx NPE in couple of processors in edge cases

### DIFF
--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -883,11 +883,6 @@ func (jr *joinReader) ConsumerClosed() {
 }
 
 func (jr *joinReader) close() {
-	// Make sure to clone any tracing span so that stats can pick it up later.
-	// Stats are only collected after we finish closing the processor.
-	if !jr.Closed {
-		jr.scanStats = execinfra.GetScanStats(jr.Ctx)
-	}
 	if jr.InternalClose() {
 		if jr.fetcher != nil {
 			jr.fetcher.Close(jr.Ctx)
@@ -918,6 +913,7 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 
 	// TODO(asubiotto): Add memory and disk usage to EXPLAIN ANALYZE.
+	jr.scanStats = execinfra.GetScanStats(jr.Ctx)
 	ret := &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -299,9 +299,6 @@ func (tr *tableReader) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 
 func (tr *tableReader) close() {
 	if tr.InternalClose() {
-		// scanStats is collected from the trace after we finish doing work for this
-		// join.
-		tr.scanStats = execinfra.GetScanStats(tr.Ctx)
 		if tr.fetcher != nil {
 			tr.fetcher.Close(tr.Ctx)
 		}
@@ -319,6 +316,7 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	if !ok {
 		return nil
 	}
+	tr.scanStats = execinfra.GetScanStats(tr.Ctx)
 	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BytesRead:      optional.MakeUint(uint64(tr.fetcher.GetBytesRead())),


### PR DESCRIPTION
We recently extended the statistics that are collected during EXPLAIN
ANALYZE runs to include the "scan stats". However, in the joinReader and
the tableReader those are collected when closing the processor based on
the context argument, and in some edge cases (like when `Start` was
never called) might be nil leading to a NPE. This commit fixes the
problem by unifying all processors to collect all execution stats in
`execStatsForTrace` (which isn't called in the edge case mentioned
above).

Fixes: #70075.
Fixes: #70107.

Release note: None (no release with this bug)