### PR TITLE
release-21.2: migration: Retry no-op Migrate in separated intents migration

### DIFF
--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/migration/migrations",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/jobs",
@@ -52,6 +53,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",


### PR DESCRIPTION
Backport 1/1 commits from #69937.

/cc @cockroachdb/release

---

Occasionally, we see that replica membership can be quite in flux
after the main part of the separated intents migration. This
could cause one of the post-migration no-op Migrate commands
to fail. There's no fine-grained retry logic around that
command; if any of the Migrate commands fail on even one
range, it'll cause the entire post-migration migration to
be retried, which could then fail again if replica membership
is in flux, and so on.

This change reduces the chances of that happening by
retrying 5x in case of error(s) from the Migrate command
before failing the post-migration migration.

Release justification: Category 2: Bug fixes and low-risk updates to new functionality
Release note: None.
