### PR TITLE
cluster-ui: enable persisted stats in serverless stmts/txns

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import moment from "moment";
 import Long from "long";
 import { createMemoryHistory } from "history";
 import { noop } from "lodash";
@@ -137,6 +138,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
       database: "defaultdb",
     },
   },
+  dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
   statement: {
     statement: "SELECT city, id FROM vehicles WHERE city = $1",
     stats: statementStats,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -146,7 +146,7 @@ export interface StatementDetailsDispatchProps {
 export interface StatementDetailsStateProps {
   statement: SingleStatementStatistics;
   statementsError: Error | null;
-  dateRange?: [Moment, Moment];
+  dateRange: [Moment, Moment];
   nodeNames: { [nodeId: string]: string };
   nodeRegions: { [nodeId: string]: string };
   diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
@@ -163,8 +163,7 @@ const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 
 function statementsRequestFromProps(
   props: StatementDetailsProps,
-): cockroach.server.serverpb.StatementsRequest | null {
-  if (props.isTenant || props.dateRange == null) return null;
+): cockroach.server.serverpb.StatementsRequest {
   return new cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(props.dateRange[0].unix()),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -45,7 +45,7 @@ const mapStateToProps = (state: AppState, props: StatementDetailsProps) => {
   return {
     statement,
     statementsError: state.adminUI.statements.lastError,
-    dateRange: selectIsTenant(state) ? null : selectDateRange(state),
+    dateRange: selectDateRange(state),
     nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
     nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
     diagnosticsReports: selectIsTenant(state)

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -95,7 +95,7 @@ export interface StatementsPageDispatchProps {
 
 export interface StatementsPageStateProps {
   statements: AggregateStatistics[];
-  dateRange?: [Moment, Moment];
+  dateRange: [Moment, Moment];
   statementsError: Error | null;
   apps: string[];
   databases: string[];
@@ -120,8 +120,7 @@ export type StatementsPageProps = StatementsPageDispatchProps &
 
 function statementsRequestFromProps(
   props: StatementsPageProps,
-): cockroach.server.serverpb.StatementsRequest | null {
-  if (props.isTenant || props.dateRange == null) return null;
+): cockroach.server.serverpb.StatementsRequest {
   return new cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(props.dateRange[0].unix()),
@@ -521,22 +520,18 @@ export class StatementsPage extends React.Component<
               showNodes={nodes.length > 1}
             />
           </PageConfigItem>
-          {this.props.dateRange && (
-            <>
-              <PageConfigItem>
-                <DateRange
-                  start={this.props.dateRange[0]}
-                  end={this.props.dateRange[1]}
-                  onSubmit={this.changeDateRange}
-                />
-              </PageConfigItem>
-              <PageConfigItem>
-                <button className={cx("reset-btn")} onClick={this.resetTime}>
-                  reset time
-                </button>
-              </PageConfigItem>
-            </>
-          )}
+          <PageConfigItem>
+            <DateRange
+              start={this.props.dateRange[0]}
+              end={this.props.dateRange[1]}
+              onSubmit={this.changeDateRange}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <button className={cx("reset-btn")} onClick={this.resetTime}>
+              reset time
+            </button>
+          </PageConfigItem>
         </PageConfig>
         <section className={sortableTableCx("cl-table-container")}>
           <div>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -56,7 +56,7 @@ export const ConnectedStatementsPage = withRouter(
       columns: selectColumns(state),
       nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
       isTenant: selectIsTenant(state),
-      dateRange: selectIsTenant(state) ? null : selectDateRange(state),
+      dateRange: selectDateRange(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -11,6 +11,7 @@
 import { createMemoryHistory } from "history";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
+import moment from "moment";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -36,6 +37,11 @@ export const nodeRegions: { [nodeId: string]: string } = {
   "3": "gcp-us-west1",
   "4": "gcp-europe-west1",
 };
+
+export const dateRange: [moment.Moment, moment.Moment] = [
+  moment.utc("2021.08.08"),
+  moment.utc("2021.08.12"),
+];
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {
   statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -12,7 +12,12 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import { cloneDeep, noop, extend } from "lodash";
-import { data, nodeRegions, routeProps } from "./transactions.fixture";
+import {
+  data,
+  nodeRegions,
+  routeProps,
+  dateRange,
+} from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
 import { RequestError } from "../util";
@@ -29,6 +34,7 @@ storiesOf("Transactions Page", module)
     <TransactionsPage
       {...routeProps}
       data={data}
+      dateRange={dateRange}
       nodeRegions={nodeRegions}
       refreshData={noop}
       resetSQLStats={noop}
@@ -39,6 +45,7 @@ storiesOf("Transactions Page", module)
       <TransactionsPage
         {...routeProps}
         data={getEmptyData()}
+        dateRange={dateRange}
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
@@ -56,6 +63,7 @@ storiesOf("Transactions Page", module)
       <TransactionsPage
         {...routeProps}
         data={getEmptyData()}
+        dateRange={dateRange}
         nodeRegions={nodeRegions}
         refreshData={noop}
         history={history}
@@ -68,6 +76,7 @@ storiesOf("Transactions Page", module)
       <TransactionsPage
         {...routeProps}
         data={undefined}
+        dateRange={dateRange}
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
@@ -79,6 +88,7 @@ storiesOf("Transactions Page", module)
       <TransactionsPage
         {...routeProps}
         data={undefined}
+        dateRange={dateRange}
         nodeRegions={nodeRegions}
         error={
           new RequestError(

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -81,7 +81,7 @@ interface TState {
 
 export interface TransactionsPageStateProps {
   data: IStatementsResponse;
-  dateRange?: [Moment, Moment];
+  dateRange: [Moment, Moment];
   nodeRegions: { [nodeId: string]: string };
   error?: Error | null;
   pageSize?: number;
@@ -102,8 +102,7 @@ export type TransactionsPageProps = TransactionsPageStateProps &
 
 function statementsRequestFromProps(
   props: TransactionsPageProps,
-): protos.cockroach.server.serverpb.StatementsRequest | null {
-  if (props.isTenant || props.dateRange == null) return null;
+): protos.cockroach.server.serverpb.StatementsRequest {
   return new protos.cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(props.dateRange[0].unix()),
@@ -394,25 +393,21 @@ export class TransactionsPage extends React.Component<
                       showNodes={nodes.length > 1}
                     />
                   </PageConfigItem>
-                  {this.props.dateRange && (
-                    <>
-                      <PageConfigItem>
-                        <DateRange
-                          start={this.props.dateRange[0]}
-                          end={this.props.dateRange[1]}
-                          onSubmit={this.changeDateRange}
-                        />
-                      </PageConfigItem>
-                      <PageConfigItem>
-                        <button
-                          className={cx("reset-btn")}
-                          onClick={this.resetTime}
-                        >
-                          reset time
-                        </button>
-                      </PageConfigItem>
-                    </>
-                  )}
+                  <PageConfigItem>
+                    <DateRange
+                      start={this.props.dateRange[0]}
+                      end={this.props.dateRange[1]}
+                      onSubmit={this.changeDateRange}
+                    />
+                  </PageConfigItem>
+                  <PageConfigItem>
+                    <button
+                      className={cx("reset-btn")}
+                      onClick={this.resetTime}
+                    >
+                      reset time
+                    </button>
+                  </PageConfigItem>
                 </PageConfig>
                 <section className={statisticsClasses.tableContainerClass}>
                   <ColumnsSelector

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -44,7 +44,7 @@ export const TransactionsPageConnected = withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       error: selectTransactionsLastError(state),
       isTenant: selectIsTenant(state),
-      dateRange: selectIsTenant(state) ? null : selectDateRange(state),
+      dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
     }),
     (dispatch: Dispatch) => ({


### PR DESCRIPTION
This commit enables viewing persisted statements in the statements
and transactions pages for tenants.

Part of #69930
Resolves #70214

Release justification: low risk, high benefit changes to existing
functionality

Release note (ui change): Persisted statements are now enabled for
tenants. In the statements and transactions pages, users now view the
aggregated statistics for statements and transactions over a date range.
A date range selector is present in both pages order to select the range
of persisted stats to view. Note that the two pages share a single date
range.