### PR TITLE
server: share the table cache among stores

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -493,6 +494,13 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 
 	log.Event(ctx, "initializing engines")
 
+	var tableCache *pebble.TableCache
+	if physicalStores > 0 {
+		perStoreLimit := pebble.TableCacheSize(int(openFileLimitPerStore))
+		totalFileLimit := perStoreLimit * physicalStores
+		tableCache = pebble.NewTableCache(pebbleCache, runtime.GOMAXPROCS(0), totalFileLimit)
+	}
+
 	skipSizeCheck := cfg.TestingKnobs.Store != nil &&
 		cfg.TestingKnobs.Store.(*kvserver.StoreTestingKnobs).SkipMinSizeCheck
 	disableSeparatedIntents := cfg.TestingKnobs.Store != nil &&
@@ -579,6 +587,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				Opts:          storage.DefaultPebbleOptions(),
 			}
 			pebbleConfig.Opts.Cache = pebbleCache
+			pebbleConfig.Opts.TableCache = tableCache
 			pebbleConfig.Opts.MaxOpenFiles = int(openFileLimitPerStore)
 			// If the spec contains Pebble options, set those too.
 			if len(spec.PebbleOptions) > 0 {
@@ -595,6 +604,13 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				return Engines{}, err
 			}
 			engines = append(engines, eng)
+		}
+	}
+
+	if tableCache != nil {
+		// Unref the table cache now that the engines hold references to it.
+		if err := tableCache.Unref(); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Possible benefits of sharing the table cache are outlined
here: https://github.com/cockroachdb/pebble/issues/1178.

This PR creates a table cache which can be shared among many
stores.

Release note: None