### PR TITLE
[CRDB-9016] ui: fix drag to zoom on custom charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -207,6 +207,7 @@ export class CustomChart extends React.Component<
         key={index}
         setTimeRange={this.props.setTimeRange}
         setTimeScale={this.props.setTimeScale}
+        history={this.props.history}
       >
         <LineGraph>
           <Axis units={units}>


### PR DESCRIPTION
This PR addresses the issue where a user creates a custom chart and selects an area to zoom into which leaves the grey highlight after the graph zooms in. This was due to the history prop not being passed into the linegraph component and caused an error to throw when updating the url params. This was resolved by passing in the history to propagate to the
linegraph component.

Release note (ui change): fix drag to zoom on custom charts

https://user-images.githubusercontent.com/17861665/133342585-d7b37e9b-7eb8-4a48-b2c5-814fed62556a.mp4

