### PR TITLE
sql: remove the interleaved logic from fetchers

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -167,7 +167,6 @@ go_test(
         "//pkg/cloud/azure",
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/cloud/nodelocal",
-        "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/jobs",

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -19,10 +19,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -69,20 +67,8 @@ func TestRestoreOldVersions(t *testing.T) {
 		clusterDirs                 = testdataBase + "/cluster"
 		exceptionalDirs             = testdataBase + "/exceptional"
 		privilegeDirs               = testdataBase + "/privileges"
-		interleavedDirs             = testdataBase + "/interleaved"
 		multiRegionDirs             = testdataBase + "/multi-region"
 	)
-
-	t.Run("interleaved", func(t *testing.T) {
-		dirs, err := ioutil.ReadDir(interleavedDirs)
-		require.NoError(t, err)
-		for _, dir := range dirs {
-			require.True(t, dir.IsDir())
-			interleavedDirs, err := filepath.Abs(filepath.Join(interleavedDirs, dir.Name()))
-			require.NoError(t, err)
-			t.Run(dir.Name(), restoreInterleavedTest(interleavedDirs))
-		}
-	})
 
 	t.Run("table-restore", func(t *testing.T) {
 		dirs, err := ioutil.ReadDir(exportDirsWithoutInterleave)
@@ -252,70 +238,6 @@ ORDER BY object_type, object_name`, [][]string{
 			t.Run(dir.Name(), restoreV201ZoneconfigPrivilegeTest(exportDir))
 		}
 	})
-}
-
-func restoreInterleavedTest(exportDir string) func(t *testing.T) {
-	return func(t *testing.T) {
-		params := base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PreventNewInterleavedTables - 1),
-				},
-			},
-		}
-		const numAccounts = 1000
-		_, _, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
-			InitManualReplication, base.TestClusterArgs{ServerArgs: params})
-		defer cleanup()
-		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
-		require.NoError(t, err)
-		sqlDB.Exec(t, `CREATE DATABASE test`)
-		var unused string
-		var importedRows int
-		sqlDB.QueryRow(t, `RESTORE test.* FROM $1`, LocalFoo).Scan(
-			&unused, &unused, &unused, &importedRows, &unused, &unused,
-		)
-		// No rows in the imported table.
-		const totalRows = 4
-		if importedRows != totalRows {
-			t.Fatalf("expected %d rows, got %d", totalRows, importedRows)
-		}
-		// Validate an empty result set is generated.
-		orderResults := [][]string{
-			{"1", "1", "20.00000"},
-			{"2", "2", "30.00000"},
-		}
-		customerResults := [][]string{
-			{"1", "BOB"},
-			{"2", "BILL"},
-		}
-		sqlDB.CheckQueryResults(t, `SELECT * FROM test.orders`, orderResults)
-		sqlDB.CheckQueryResults(t, `SELECT * FROM test.customers`, customerResults)
-		// Result of show tables.
-		showTableResult := [][]string{
-			{"test.public.orders",
-				"CREATE TABLE public.orders (\n\tcustomer INT8 NOT NULL,\n\tid INT8 NOT NULL,\n\ttotal DECIMAL(20,5) NULL,\n\tCONSTRAINT \"primary\" PRIMARY KEY (customer ASC, id ASC),\n\tCONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES public.customers(id),\n\tFAMILY \"primary\" (customer, id, total)\n) INTERLEAVE IN PARENT public.customers (customer)"},
-		}
-		sqlDB.CheckQueryResults(t, "SHOW CREATE TABLE test.orders", showTableResult)
-		// We should still have interleaved tables.
-		interleavedResult := [][]string{
-			{"test", "public", "orders", "primary", "test", "public", "customers"}}
-		sqlDB.ExecSucceedsSoon(t, "SET DATABASE = test")
-		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.interleaved", interleavedResult)
-		// Next move to a version that blocks restores.
-		sqlDB.ExecSucceedsSoon(t,
-			"SET CLUSTER SETTING version = $1",
-			clusterversion.ByKey(clusterversion.PreventNewInterleavedTables).String())
-		// Clean up the old database.
-		sqlDB.ExecSucceedsSoon(t, "SET DATABASE = defaultdb")
-		sqlDB.ExecSucceedsSoon(t, "set sql_safe_updates=false")
-		sqlDB.ExecSucceedsSoon(t, "DROP DATABASE TEST")
-		// Restore should now fail.
-		sqlDB.ExpectErr(t,
-			"pq: restoring interleaved tables is no longer allowed. table customers was found to be interleaved",
-			`RESTORE test.* FROM $1`, LocalFoo)
-	}
 }
 
 func restoreOldVersionTestWithInterleave(exportDir string) func(t *testing.T) {

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -146,7 +146,7 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 	// guaranteed that the tables have the same version. Additionally, these
 	// fetchers are always initialized with a single tabledesc.Immutable.
 	if rf, ok := c.fetchers[idVer]; ok &&
-		catalog.UserDefinedTypeColsHaveSameVersion(tableDesc, rf.GetTables()[0].(catalog.TableDescriptor)) {
+		catalog.UserDefinedTypeColsHaveSameVersion(tableDesc, rf.GetTable().(catalog.TableDescriptor)) {
 		return rf, nil
 	}
 	// TODO(dan): Allow for decoding a subset of the columns.
@@ -159,7 +159,6 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 
 	var rf row.Fetcher
 	rfArgs := row.FetcherTableArgs{
-		Spans:            tableDesc.AllIndexSpans(c.codec),
 		Desc:             tableDesc,
 		Index:            tableDesc.GetPrimaryIndex(),
 		ColIdxMap:        colIdxMap,

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -586,7 +586,6 @@ func makeRowFetcher(
 	}
 
 	table := row.FetcherTableArgs{
-		Spans:            []roachpb.Span{entry.Span},
 		Desc:             entry.Desc,
 		Index:            entry.Desc.GetPrimaryIndex(),
 		ColIdxMap:        colIdxMap,

--- a/pkg/sql/colencoding/BUILD.bazel
+++ b/pkg/sql/colencoding/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/col/coldata",
         "//pkg/roachpb:with-mocks",
-        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -181,14 +181,6 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 		if spec.Core.JoinReader.LookupColumns != nil || !spec.Core.JoinReader.LookupExpr.Empty() {
 			return errLookupJoinUnsupported
 		}
-		for i := range spec.Core.JoinReader.Table.Indexes {
-			if spec.Core.JoinReader.Table.Indexes[i].IsInterleaved() {
-				// Interleaved indexes are going to be removed anyway, so there is no
-				// point in handling the extra complexity. Just let the row engine
-				// handle this.
-				return errInterleavedIndexJoin
-			}
-		}
 		return nil
 
 	case spec.Core.Filterer != nil:
@@ -263,7 +255,6 @@ var (
 	errExperimentalWrappingProhibited = errors.New("wrapping for non-JoinReader and non-LocalPlanNode cores is prohibited in vectorize=experimental_always")
 	errWrappedCast                    = errors.New("mismatched types in NewColOperator and unsupported casts")
 	errLookupJoinUnsupported          = errors.New("lookup join reader is unsupported in vectorized")
-	errInterleavedIndexJoin           = errors.New("vectorized join reader is unsupported for interleaved indexes")
 )
 
 func canWrap(mode sessiondatapb.VectorizeExecMode, spec *execinfrapb.ProcessorSpec) error {

--- a/pkg/sql/colfetcher/fetcherstate_string.go
+++ b/pkg/sql/colfetcher/fetcherstate_string.go
@@ -12,16 +12,15 @@ func _() {
 	_ = x[stateInitFetch-1]
 	_ = x[stateResetBatch-2]
 	_ = x[stateDecodeFirstKVOfRow-3]
-	_ = x[stateSeekPrefix-4]
-	_ = x[stateFetchNextKVWithUnfinishedRow-5]
-	_ = x[stateFinalizeRow-6]
-	_ = x[stateEmitLastBatch-7]
-	_ = x[stateFinished-8]
+	_ = x[stateFetchNextKVWithUnfinishedRow-4]
+	_ = x[stateFinalizeRow-5]
+	_ = x[stateEmitLastBatch-6]
+	_ = x[stateFinished-7]
 }
 
-const _fetcherState_name = "stateInvalidstateInitFetchstateResetBatchstateDecodeFirstKVOfRowstateSeekPrefixstateFetchNextKVWithUnfinishedRowstateFinalizeRowstateEmitLastBatchstateFinished"
+const _fetcherState_name = "stateInvalidstateInitFetchstateResetBatchstateDecodeFirstKVOfRowstateFetchNextKVWithUnfinishedRowstateFinalizeRowstateEmitLastBatchstateFinished"
 
-var _fetcherState_index = [...]uint8{0, 12, 26, 41, 64, 79, 112, 128, 146, 159}
+var _fetcherState_index = [...]uint8{0, 12, 26, 41, 64, 97, 113, 131, 144}
 
 func (i fetcherState) String() string {
 	if i < 0 || i >= fetcherState(len(_fetcherState_index)-1) {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3966,9 +3966,6 @@ func checkScanParallelizationIfLocal(
 				}
 				return true, nil
 			case *indexJoinNode:
-				// Vectorized index join is only supported for non-interleaved
-				// tables.
-				prohibitParallelization = n.table.desc.TableDesc().PrimaryIndex.IsInterleaved()
 				return true, nil
 			case *joinNode:
 				prohibitParallelization = n.pred.onCond != nil

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -921,7 +921,6 @@ func (e *distSQLSpecExecFactory) ConstructDeleteRange(
 	table cat.Table,
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
-	interleavedTables []cat.Table,
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete range")

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -390,7 +390,6 @@ INSERT INTO foo VALUES (1), (10), (100);
 			&alloc,
 			mm.Monitor(),
 			row.FetcherTableArgs{
-				Spans:            spans,
 				Desc:             table,
 				Index:            idx,
 				ColIdxMap:        colIdxMap,

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -559,23 +559,15 @@ define Delete {
 # true:
 #  - there are no secondary indexes;
 #  - the input to the delete is a scan (without limits);
-#  - the table is not involved in interleaving, or it is at the root of an
-#    interleaving hierarchy with cascading FKs such that a delete of a row
-#    cascades and deletes all interleaved rows corresponding to that row;
-#  - there are no inbound FKs to the table (other than within the
-#    interleaving as described above).
+#  - there are no inbound FKs to the table.
 #
 # See the comment for ConstructScan for descriptions of the needed and
 # indexConstraint parameters, since DeleteRange combines Delete + Scan into a
 # single operator.
-#
-# If any interleavedTables are passed, they are all the descendant tables in
-# an interleaving hierarchy we are deleting from.
 define DeleteRange {
     Table cat.Table
     Needed exec.TableColumnOrdinalSet
     IndexConstraint *constraint.Constraint
-    InterleavedTables []cat.Table
 
     # If set, the operator will commit the transaction as part of its execution.
     # This is false when executing inside an explicit transaction, or there are

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1728,7 +1728,6 @@ func (ef *execFactory) ConstructDeleteRange(
 	table cat.Table,
 	needed exec.TableColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
-	interleavedTables []cat.Table,
 	autoCommit bool,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
@@ -1746,19 +1745,11 @@ func (ef *execFactory) ConstructDeleteRange(
 	}
 
 	dr := &deleteRangeNode{
-		interleavedFastPath: false,
-		spans:               spans,
-		desc:                tabDesc,
-		autoCommitEnabled:   autoCommit,
+		spans:             spans,
+		desc:              tabDesc,
+		autoCommitEnabled: autoCommit,
 	}
 
-	if len(interleavedTables) > 0 {
-		dr.interleavedFastPath = true
-		dr.interleavedDesc = make([]catalog.TableDescriptor, len(interleavedTables))
-		for i := range dr.interleavedDesc {
-			dr.interleavedDesc[i] = interleavedTables[i].(*optTable).desc
-		}
-	}
 	return dr, nil
 }
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -61,15 +61,10 @@ type tableInfo struct {
 
 	// Used to determine whether a key retrieved belongs to the span we
 	// want to scan.
-	spans            roachpb.Spans
 	desc             catalog.TableDescriptor
 	index            catalog.Index
 	isSecondaryIndex bool
 	indexColumnDirs  []descpb.IndexDescriptor_Direction
-	// equivSignature is an equivalence class for each unique table-index
-	// pair. It allows us to check if an index key belongs to a given
-	// table-index.
-	equivSignature []byte
 
 	// The table columns to use for fetching, possibly including ones currently in
 	// schema changes.
@@ -144,11 +139,6 @@ type tableInfo struct {
 // FetcherTableArgs are the arguments passed to Fetcher.Init
 // for a given table that includes descriptors and row information.
 type FetcherTableArgs struct {
-	// The spans of keys to return for the given table. Fetcher
-	// ignores keys outside these spans.
-	// This is irrelevant if Fetcher is initialize with only one
-	// table.
-	Spans            roachpb.Spans
 	Desc             catalog.TableDescriptor
 	Index            catalog.Index
 	ColIdxMap        catalog.TableColMap
@@ -188,8 +178,7 @@ func (fta *FetcherTableArgs) InitCols(
 	}
 }
 
-// Fetcher handles fetching kvs and forming table rows for an
-// arbitrary number of tables.
+// Fetcher handles fetching kvs and forming table rows for a single table.
 // Usage:
 //   var rf Fetcher
 //   err := rf.Init(..)
@@ -209,28 +198,15 @@ type Fetcher struct {
 	// codec is used to encode and decode sql keys.
 	codec keys.SQLCodec
 
-	// tables is a slice of all the tables and their descriptors for which
-	// rows are returned.
-	tables []tableInfo
-
-	// allEquivSignatures is a map used for checking if an equivalence
-	// signature belongs to any table or table's ancestor. It also maps the
-	// string representation of every table's and every table's ancestors'
-	// signature to the table's index in 'tables' for lookup during decoding.
-	// If 2+ tables share the same ancestor signature, allEquivSignatures
-	// will map the signature to the largest 'tables' index.
-	// The full signature for a given table in 'tables' will always map to
-	// its own index in 'tables'.
-	allEquivSignatures map[string]int
+	table tableInfo
 
 	// reverse denotes whether or not the spans should be read in reverse
 	// or not when StartScan is invoked.
 	reverse bool
 
-	// maxKeysPerRow memoizes the maximum number of keys per row
-	// out of all the tables. This is used to calculate the kvBatchFetcher's
-	// firstBatchLimit.
-	maxKeysPerRow int
+	// numKeysPerRow is the number of keys per row of the table used to
+	// calculate the kvBatchFetcher's firstBatchLimit.
+	numKeysPerRow int
 
 	// True if the index key must be decoded.
 	// If there is more than one table, the index key must always be decoded.
@@ -256,8 +232,7 @@ type Fetcher struct {
 	traceKV bool
 
 	// mvccDecodeStrategy controls whether or not MVCC timestamps should
-	// be decoded from KV's fetched. It is set if any of the requested tables
-	// are required to produce an MVCC timestamp system column.
+	// be decoded from KV's fetched.
 	mvccDecodeStrategy MVCCDecodingStrategy
 
 	// -- Fields updated during a scan --
@@ -267,11 +242,6 @@ type Fetcher struct {
 	prettyValueBuf *bytes.Buffer
 
 	valueColsFound int // how many needed cols we've found so far in the value
-
-	rowReadyTable *tableInfo // the table for which a row was fully decoded and ready for output
-	currentTable  *tableInfo // the most recent table for which a key was decoded
-	keySigBuf     []byte     // buffer for the index key's signature
-	keyRestBuf    []byte     // buffer for the rest of the index key that is not part of the signature
 
 	// The current key/value, unless kvEnd is true.
 	kv                roachpb.KeyValue
@@ -300,7 +270,7 @@ type Fetcher struct {
 // reallocation of all of those slice fields.
 func (rf *Fetcher) Reset() {
 	*rf = Fetcher{
-		tables: rf.tables[:0],
+		table: rf.table,
 	}
 }
 
@@ -328,12 +298,8 @@ func (rf *Fetcher) Init(
 	isCheck bool,
 	alloc *rowenc.DatumAlloc,
 	memMonitor *mon.BytesMonitor,
-	tables ...FetcherTableArgs,
+	tableArgs FetcherTableArgs,
 ) error {
-	if len(tables) == 0 {
-		return errors.AssertionFailedf("no tables to fetch from")
-	}
-
 	rf.codec = codec
 	rf.reverse = reverse
 	rf.lockStrength = lockStrength
@@ -349,223 +315,153 @@ func (rf *Fetcher) Init(
 		rf.kvFetcherMemAcc = &memAcc
 	}
 
-	// We must always decode the index key if we need to distinguish between
-	// rows from more than one table.
-	nTables := len(tables)
-	multipleTables := nTables >= 2
-	rf.mustDecodeIndexKey = multipleTables
-	if multipleTables {
-		rf.allEquivSignatures = make(map[string]int, len(tables))
+	table := &rf.table
+	*table = tableInfo{
+		desc:             tableArgs.Desc,
+		colIdxMap:        tableArgs.ColIdxMap,
+		index:            tableArgs.Index,
+		isSecondaryIndex: tableArgs.IsSecondaryIndex,
+		cols:             tableArgs.Cols,
+		row:              make(rowenc.EncDatumRow, len(tableArgs.Cols)),
+		decodedRow:       make(tree.Datums, len(tableArgs.Cols)),
+
+		// These slice fields might get re-allocated below, so reslice them from
+		// the old table here in case they've got enough capacity already.
+		indexColIdx:        rf.table.indexColIdx[:0],
+		keyVals:            rf.table.keyVals[:0],
+		extraVals:          rf.table.extraVals[:0],
+		timestampOutputIdx: noOutputColumn,
+		oidOutputIdx:       noOutputColumn,
 	}
 
-	if cap(rf.tables) >= nTables {
-		rf.tables = rf.tables[:nTables]
+	var err error
+
+	// Scan through the entire columns map to see which columns are
+	// required.
+	for _, col := range table.cols {
+		idx := table.colIdxMap.GetDefault(col.GetID())
+		if tableArgs.ValNeededForCol.Contains(idx) {
+			// The idx-th column is required.
+			table.neededCols.Add(int(col.GetID()))
+
+			// Set up any system column metadata, if this column is a system column.
+			switch colinfo.GetSystemColumnKindFromColumnID(col.GetID()) {
+			case descpb.SystemColumnKind_MVCCTIMESTAMP:
+				table.timestampOutputIdx = idx
+				rf.mvccDecodeStrategy = MVCCDecodingRequired
+			case descpb.SystemColumnKind_TABLEOID:
+				table.oidOutputIdx = idx
+				table.tableOid = tree.NewDOid(tree.DInt(tableArgs.Desc.GetID()))
+			}
+		}
+	}
+
+	table.knownPrefixLength = len(
+		rowenc.MakeIndexKeyPrefix(codec, table.desc, table.index.GetID()),
+	)
+
+	var indexColumnIDs []descpb.ColumnID
+	indexColumnIDs, table.indexColumnDirs = catalog.FullIndexColumnIDs(table.index)
+
+	table.neededValueColsByIdx = tableArgs.ValNeededForCol.Copy()
+	neededIndexCols := 0
+	nIndexCols := len(indexColumnIDs)
+	if cap(table.indexColIdx) >= nIndexCols {
+		table.indexColIdx = table.indexColIdx[:nIndexCols]
 	} else {
-		rf.tables = make([]tableInfo, nTables)
+		table.indexColIdx = make([]int, nIndexCols)
 	}
-	for tableIdx, tableArgs := range tables {
-		oldTable := rf.tables[tableIdx]
-
-		table := tableInfo{
-			spans:            tableArgs.Spans,
-			desc:             tableArgs.Desc,
-			colIdxMap:        tableArgs.ColIdxMap,
-			index:            tableArgs.Index,
-			isSecondaryIndex: tableArgs.IsSecondaryIndex,
-			cols:             tableArgs.Cols,
-			row:              make(rowenc.EncDatumRow, len(tableArgs.Cols)),
-			decodedRow:       make(tree.Datums, len(tableArgs.Cols)),
-
-			// These slice fields might get re-allocated below, so reslice them from
-			// the old table here in case they've got enough capacity already.
-			indexColIdx:        oldTable.indexColIdx[:0],
-			keyVals:            oldTable.keyVals[:0],
-			extraVals:          oldTable.extraVals[:0],
-			timestampOutputIdx: noOutputColumn,
-			oidOutputIdx:       noOutputColumn,
-		}
-
-		var err error
-		if multipleTables {
-			// We produce references to every signature's reference.
-			equivSignatures, err := rowenc.TableEquivSignatures(table.desc, table.index)
-			if err != nil {
-				return err
+	for i, id := range indexColumnIDs {
+		colIdx, ok := table.colIdxMap.Get(id)
+		if ok {
+			table.indexColIdx[i] = colIdx
+			if table.neededCols.Contains(int(id)) {
+				neededIndexCols++
+				table.neededValueColsByIdx.Remove(colIdx)
 			}
-			for i, sig := range equivSignatures {
-				// We always map the table's equivalence signature (last
-				// 'sig' in 'equivSignatures') to its tableIdx.
-				// This allows us to overwrite previous "ancestor
-				// signatures" (see below).
-				if i == len(equivSignatures)-1 {
-					rf.allEquivSignatures[string(sig)] = tableIdx
-					break
-				}
-				// Map each table's ancestors' signatures to -1 so
-				// we know during ReadIndexKey if the parsed index
-				// key belongs to ancestor or one of our tables.
-				// We must check if the signature has already been set
-				// since it's possible for a later 'table' to have an
-				// ancestor that is a previous 'table', and we do not
-				// want to overwrite the previous table's tableIdx.
-				if _, exists := rf.allEquivSignatures[string(sig)]; !exists {
-					rf.allEquivSignatures[string(sig)] = -1
-				}
-			}
-			// The last signature is the given table's equivalence signature.
-			table.equivSignature = equivSignatures[len(equivSignatures)-1]
-		}
-
-		// Scan through the entire columns map to see which columns are
-		// required.
-		for _, col := range table.cols {
-			idx := table.colIdxMap.GetDefault(col.GetID())
-			if tableArgs.ValNeededForCol.Contains(idx) {
-				// The idx-th column is required.
-				table.neededCols.Add(int(col.GetID()))
-
-				// Set up any system column metadata, if this column is a system column.
-				switch colinfo.GetSystemColumnKindFromColumnID(col.GetID()) {
-				case descpb.SystemColumnKind_MVCCTIMESTAMP:
-					table.timestampOutputIdx = idx
-					rf.mvccDecodeStrategy = MVCCDecodingRequired
-				case descpb.SystemColumnKind_TABLEOID:
-					table.oidOutputIdx = idx
-					table.tableOid = tree.NewDOid(tree.DInt(tableArgs.Desc.GetID()))
-				}
-			}
-		}
-
-		table.knownPrefixLength = len(
-			rowenc.MakeIndexKeyPrefix(codec, table.desc, table.index.GetID()),
-		)
-
-		var indexColumnIDs []descpb.ColumnID
-		indexColumnIDs, table.indexColumnDirs = catalog.FullIndexColumnIDs(table.index)
-
-		table.neededValueColsByIdx = tableArgs.ValNeededForCol.Copy()
-		neededIndexCols := 0
-		nIndexCols := len(indexColumnIDs)
-		if cap(table.indexColIdx) >= nIndexCols {
-			table.indexColIdx = table.indexColIdx[:nIndexCols]
 		} else {
-			table.indexColIdx = make([]int, nIndexCols)
-		}
-		for i, id := range indexColumnIDs {
-			colIdx, ok := table.colIdxMap.Get(id)
-			if ok {
-				table.indexColIdx[i] = colIdx
-				if table.neededCols.Contains(int(id)) {
-					neededIndexCols++
-					table.neededValueColsByIdx.Remove(colIdx)
-				}
-			} else {
-				table.indexColIdx[i] = -1
-				if table.neededCols.Contains(int(id)) {
-					return errors.AssertionFailedf("needed column %d not in colIdxMap", id)
-				}
+			table.indexColIdx[i] = -1
+			if table.neededCols.Contains(int(id)) {
+				return errors.AssertionFailedf("needed column %d not in colIdxMap", id)
 			}
 		}
+	}
 
-		// In order to track #40410 more effectively, check that the contents of
-		// table.neededValueColsByIdx are valid.
-		for idx, ok := table.neededValueColsByIdx.Next(0); ok; idx, ok = table.neededValueColsByIdx.Next(idx + 1) {
-			if idx >= len(table.row) || idx < 0 {
-				return errors.AssertionFailedf(
-					"neededValueColsByIdx contains an invalid index. column %d requested, but table has %d columns",
-					idx,
-					len(table.row),
-				)
+	// In order to track #40410 more effectively, check that the contents of
+	// table.neededValueColsByIdx are valid.
+	for idx, ok := table.neededValueColsByIdx.Next(0); ok; idx, ok = table.neededValueColsByIdx.Next(idx + 1) {
+		if idx >= len(table.row) || idx < 0 {
+			return errors.AssertionFailedf(
+				"neededValueColsByIdx contains an invalid index. column %d requested, but table has %d columns",
+				idx,
+				len(table.row),
+			)
+		}
+	}
+
+	// - If there is more than one table, we have to decode the index key to
+	//   figure out which table the row belongs to.
+	// - If there are interleaves, we need to read the index key in order to
+	//   determine whether this row is actually part of the index we're scanning.
+	// - If there are needed columns from the index key, we need to read it.
+	//
+	// Otherwise, we can completely avoid decoding the index key.
+	if !rf.mustDecodeIndexKey && (neededIndexCols > 0 || table.index.NumInterleavedBy() > 0 || table.index.NumInterleaveAncestors() > 0) {
+		rf.mustDecodeIndexKey = true
+	}
+
+	// The number of columns we need to read from the value part of the key.
+	// It's the total number of needed columns minus the ones we read from the
+	// index key, except for composite columns.
+	table.neededValueCols = table.neededCols.Len() - neededIndexCols + table.index.NumCompositeColumns()
+
+	if table.isSecondaryIndex {
+		colIDs := table.index.CollectKeyColumnIDs()
+		colIDs.UnionWith(table.index.CollectSecondaryStoredColumnIDs())
+		colIDs.UnionWith(table.index.CollectKeySuffixColumnIDs())
+		for i := range table.cols {
+			if table.neededCols.Contains(int(table.cols[i].GetID())) && !colIDs.Contains(table.cols[i].GetID()) {
+				return errors.Errorf("requested column %s not in index", table.cols[i].GetName())
 			}
 		}
+	}
 
-		// - If there is more than one table, we have to decode the index key to
-		//   figure out which table the row belongs to.
-		// - If there are interleaves, we need to read the index key in order to
-		//   determine whether this row is actually part of the index we're scanning.
-		// - If there are needed columns from the index key, we need to read it.
-		//
-		// Otherwise, we can completely avoid decoding the index key.
-		if !rf.mustDecodeIndexKey && (neededIndexCols > 0 || table.index.NumInterleavedBy() > 0 || table.index.NumInterleaveAncestors() > 0) {
-			rf.mustDecodeIndexKey = true
+	// Prepare our index key vals slice.
+	table.keyValTypes, err = colinfo.GetColumnTypes(table.desc, indexColumnIDs, table.keyValTypes)
+	if err != nil {
+		return err
+	}
+	if cap(table.keyVals) >= nIndexCols {
+		table.keyVals = table.keyVals[:nIndexCols]
+	} else {
+		table.keyVals = make([]rowenc.EncDatum, nIndexCols)
+	}
+
+	if hasExtraCols(table) {
+		// Unique secondary indexes have a value that is the
+		// primary index key.
+		// Primary indexes only contain ascendingly-encoded
+		// values. If this ever changes, we'll probably have to
+		// figure out the directions here too.
+		table.extraTypes, err = colinfo.GetColumnTypes(table.desc, table.index.IndexDesc().KeySuffixColumnIDs, table.extraTypes)
+		nExtraColumns := table.index.NumKeySuffixColumns()
+		if cap(table.extraVals) >= nExtraColumns {
+			table.extraVals = table.extraVals[:nExtraColumns]
+		} else {
+			table.extraVals = make([]rowenc.EncDatum, nExtraColumns)
 		}
-
-		// The number of columns we need to read from the value part of the key.
-		// It's the total number of needed columns minus the ones we read from the
-		// index key, except for composite columns.
-		table.neededValueCols = table.neededCols.Len() - neededIndexCols + table.index.NumCompositeColumns()
-
-		if table.isSecondaryIndex {
-			colIDs := table.index.CollectKeyColumnIDs()
-			colIDs.UnionWith(table.index.CollectSecondaryStoredColumnIDs())
-			colIDs.UnionWith(table.index.CollectKeySuffixColumnIDs())
-			for i := range table.cols {
-				if table.neededCols.Contains(int(table.cols[i].GetID())) && !colIDs.Contains(table.cols[i].GetID()) {
-					return errors.Errorf("requested column %s not in index", table.cols[i].GetName())
-				}
-			}
-		}
-
-		// Prepare our index key vals slice.
-		table.keyValTypes, err = colinfo.GetColumnTypes(table.desc, indexColumnIDs, table.keyValTypes)
 		if err != nil {
 			return err
 		}
-		if cap(table.keyVals) >= nIndexCols {
-			table.keyVals = table.keyVals[:nIndexCols]
-		} else {
-			table.keyVals = make([]rowenc.EncDatum, nIndexCols)
-		}
-
-		if hasExtraCols(&table) {
-			// Unique secondary indexes have a value that is the
-			// primary index key.
-			// Primary indexes only contain ascendingly-encoded
-			// values. If this ever changes, we'll probably have to
-			// figure out the directions here too.
-			table.extraTypes, err = colinfo.GetColumnTypes(table.desc, table.index.IndexDesc().KeySuffixColumnIDs, table.extraTypes)
-			nExtraColumns := table.index.NumKeySuffixColumns()
-			if cap(table.extraVals) >= nExtraColumns {
-				table.extraVals = table.extraVals[:nExtraColumns]
-			} else {
-				table.extraVals = make([]rowenc.EncDatum, nExtraColumns)
-			}
-			if err != nil {
-				return err
-			}
-		}
-
-		// Keep track of the maximum keys per row to accommodate a
-		// limitHint when StartScan is invoked.
-		keysPerRow, err := table.desc.KeysPerRow(table.index.GetID())
-		if err != nil {
-			return err
-		}
-		if keysPerRow > rf.maxKeysPerRow {
-			rf.maxKeysPerRow = keysPerRow
-		}
-
-		rf.tables[tableIdx] = table
 	}
 
-	if len(tables) == 1 {
-		// If there is more than one table, currentTable will be
-		// updated every time NextKey is invoked and rowReadyTable
-		// will be updated when a row is fully decoded.
-		rf.currentTable = &(rf.tables[0])
-		rf.rowReadyTable = &(rf.tables[0])
-	}
-
-	return nil
+	rf.numKeysPerRow, err = table.desc.KeysPerRow(table.index.GetID())
+	return err
 }
 
-// GetTables returns all tables that this Fetcher was initialized with.
-func (rf *Fetcher) GetTables() []catalog.Descriptor {
-	ret := make([]catalog.Descriptor, len(rf.tables))
-	for i := range rf.tables {
-		ret[i] = rf.tables[i].desc
-	}
-	return ret
+// GetTable returns the table that this Fetcher was initialized with.
+func (rf *Fetcher) GetTable() catalog.Descriptor {
+	return rf.table.desc
 }
 
 // StartScan initializes and starts the key-value scan. Can be used multiple
@@ -733,7 +629,7 @@ func (rf *Fetcher) rowLimitToKeyLimit(rowLimitHint rowinfra.RowLimit) rowinfra.K
 	// rows we could potentially scan over.
 	//
 	// We add an extra key to make sure we form the last row.
-	return rowinfra.KeyLimit(int64(rowLimitHint)*int64(rf.maxKeysPerRow) + 1)
+	return rowinfra.KeyLimit(int64(rowLimitHint)*int64(rf.numKeysPerRow) + 1)
 }
 
 // StartScanFrom initializes and starts a scan from the given kvBatchFetcher. Can be
@@ -788,15 +684,12 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 
 		rf.kvEnd = !moreKVs
 		if rf.kvEnd {
-			// No more keys in the scan. We need to transition
-			// rf.rowReadyTable to rf.currentTable for the last
-			// row.
+			// No more keys in the scan.
 			//
 			// NB: this assumes that the KV layer will never split a range
 			// between column families, which is a brittle assumption.
 			// See:
 			// https://github.com/cockroachdb/cockroach/pull/42056
-			rf.rowReadyTable = rf.currentTable
 			return true, nil
 		}
 
@@ -824,18 +717,6 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 		// reading the index key.
 		if unchangedPrefix {
 			// Skip decoding!
-			// We must set the rowReadyTable to the currentTable like ReadIndexKey
-			// would do. This will happen when we see 2 rows in a row with the same
-			// prefix. If the previous prefix was from a different table, then we must
-			// update the ready table to the current table, updating the fetcher state
-			// machine to recognize that the next row that it outputs will be from
-			// rf.currentTable, which will be set to the table of the key that was
-			// last sent to ReadIndexKey.
-			//
-			// TODO(jordan): this is a major (but correct) mess. The fetcher is past
-			// due for a refactor, now that it's (more) clear what the state machine
-			// it's trying to model is.
-			rf.rowReadyTable = rf.currentTable
 		} else if rf.mustDecodeIndexKey || rf.traceKV {
 			rf.keyRemainingBytes, moreKVs, foundNull, err = rf.ReadIndexKey(rf.kv.Key)
 			if err != nil {
@@ -876,8 +757,8 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 		// them when processing the index. The difference with unique secondary indexes
 		// is that the extra columns are not always there, and are used to unique-ify
 		// the index key, rather than provide the primary key column values.
-		if foundNull && rf.currentTable.isSecondaryIndex && rf.currentTable.index.IsUnique() && len(rf.currentTable.desc.GetFamilies()) != 1 {
-			for i := 0; i < rf.currentTable.index.NumKeySuffixColumns(); i++ {
+		if foundNull && rf.table.isSecondaryIndex && rf.table.index.IsUnique() && len(rf.table.desc.GetFamilies()) != 1 {
+			for i := 0; i < rf.table.index.NumKeySuffixColumns(); i++ {
 				var err error
 				// Slice off an extra encoded column from rf.keyRemainingBytes.
 				rf.keyRemainingBytes, err = rowenc.SkipTableKey(rf.keyRemainingBytes)
@@ -888,16 +769,12 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 		}
 
 		switch {
-		case len(rf.currentTable.desc.GetFamilies()) == 1:
+		case len(rf.table.desc.GetFamilies()) == 1:
 			// If we only have one family, we know that there is only 1 k/v pair per row.
 			rowDone = true
 		case !unchangedPrefix:
 			// If the prefix of the key has changed, current key is from a different
 			// row than the previous one.
-			rowDone = true
-		case rf.rowReadyTable != rf.currentTable:
-			// For rowFetchers with more than one table, if the table changes the row
-			// is done.
 			rowDone = true
 		default:
 			rowDone = false
@@ -936,94 +813,26 @@ func (rf *Fetcher) prettyEncDatums(types []*types.T, vals []rowenc.EncDatum) str
 func (rf *Fetcher) ReadIndexKey(
 	key roachpb.Key,
 ) (remaining []byte, ok bool, foundNull bool, err error) {
-	// If there is only one table to check keys for, there is no need
-	// to go through the equivalence signature checks.
-	if len(rf.tables) == 1 {
-		return rowenc.DecodeIndexKeyWithoutTableIDIndexIDPrefix(
-			rf.currentTable.desc,
-			rf.currentTable.index,
-			rf.currentTable.keyValTypes,
-			rf.currentTable.keyVals,
-			rf.currentTable.indexColumnDirs,
-			key[rf.currentTable.knownPrefixLength:],
-		)
-	}
-
-	// Make a copy of the initial key for validating whether it's within
-	// the table's specified spans.
-	initialKey := key
-
-	key, err = rf.codec.StripTenantPrefix(key)
-	if err != nil {
-		return nil, false, false, err
-	}
-
-	// key now contains the bytes in the key (if match) that are not part
-	// of the signature in order.
-	tableIdx, key, match, err := rowenc.IndexKeyEquivSignature(key, rf.allEquivSignatures, rf.keySigBuf, rf.keyRestBuf)
-	if err != nil {
-		return nil, false, false, err
-	}
-	// The index key does not belong to our table because either:
-	// !match:	    part of the index key's signature did not match any of
-	//		    rf.allEquivSignatures.
-	// tableIdx == -1:  index key belongs to an ancestor.
-	if !match || tableIdx == -1 {
-		return nil, false, false, nil
-	}
-
-	// The index key is not within our specified span of keys for the
-	// particular table.
-	// TODO(richardwu): ContainsKey checks every span within spans. We
-	// can check that spans is ordered (or sort it) and memoize
-	// the last span we've checked for each table. We can pass in this
-	// information to ContainsKey as a hint for which span to start
-	// checking first.
-	if !rf.tables[tableIdx].spans.ContainsKey(initialKey) {
-		return nil, false, false, nil
-	}
-
-	// Either a new table is encountered or the rowReadyTable differs from
-	// the currentTable (the rowReadyTable was outputted in the previous
-	// read). We transition the references.
-	if &rf.tables[tableIdx] != rf.currentTable || rf.rowReadyTable != rf.currentTable {
-		rf.rowReadyTable = rf.currentTable
-		rf.currentTable = &rf.tables[tableIdx]
-
-		// rf.rowReadyTable is nil if this is the very first key.
-		// We want to ensure this does not differ from rf.currentTable
-		// to prevent another transition.
-		if rf.rowReadyTable == nil {
-			rf.rowReadyTable = rf.currentTable
-		}
-	}
-
-	// We can simply decode all the column values we retrieved
-	// when processing the ind
-	// ex key. The column values are at the
-	// front of the key.
-	if key, foundNull, err = rowenc.DecodeKeyVals(
-		rf.currentTable.keyValTypes,
-		rf.currentTable.keyVals,
-		rf.currentTable.indexColumnDirs,
-		key,
-	); err != nil {
-		return nil, false, false, err
-	}
-
-	return key, true, foundNull, nil
+	return rowenc.DecodeIndexKeyWithoutTableIDIndexIDPrefix(
+		rf.table.desc,
+		rf.table.index,
+		rf.table.keyValTypes,
+		rf.table.keyVals,
+		rf.table.indexColumnDirs,
+		key[rf.table.knownPrefixLength:],
+	)
 }
 
 // KeyToDesc implements the KeyToDescTranslator interface. The implementation is
 // used by ConvertFetchError.
 func (rf *Fetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
-	if rf.currentTable != nil && len(key) < rf.currentTable.knownPrefixLength {
+	if len(key) < rf.table.knownPrefixLength {
 		return nil, false
 	}
 	if _, ok, _, err := rf.ReadIndexKey(key); !ok || err != nil {
 		return nil, false
 	}
-	return rf.currentTable.desc, true
+	return rf.table.desc, true
 }
 
 // processKV processes the given key/value, setting values in the row
@@ -1032,7 +841,7 @@ func (rf *Fetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
 func (rf *Fetcher) processKV(
 	ctx context.Context, kv roachpb.KeyValue,
 ) (prettyKey string, prettyValue string, err error) {
-	table := rf.currentTable
+	table := &rf.table
 
 	if rf.traceKV {
 		prettyKey = fmt.Sprintf(
@@ -1361,7 +1170,7 @@ func (rf *Fetcher) NextRow(
 		}
 
 		if rf.isCheck {
-			rf.rowReadyTable.lastKV = rf.kv
+			rf.table.lastKV = rf.kv
 		}
 		rowDone, err := rf.NextKey(ctx)
 		if err != nil {
@@ -1369,7 +1178,7 @@ func (rf *Fetcher) NextRow(
 		}
 		if rowDone {
 			err := rf.finalizeRow()
-			return rf.rowReadyTable.row, rf.rowReadyTable.desc, rf.rowReadyTable.index, err
+			return rf.table.row, rf.table.desc, rf.table.index, err
 		}
 	}
 }
@@ -1393,22 +1202,22 @@ func (rf *Fetcher) NextRowDecoded(
 
 	for i, encDatum := range row {
 		if encDatum.IsUnset() {
-			rf.rowReadyTable.decodedRow[i] = tree.DNull
+			rf.table.decodedRow[i] = tree.DNull
 			continue
 		}
-		if err := encDatum.EnsureDecoded(rf.rowReadyTable.cols[i].GetType(), rf.alloc); err != nil {
+		if err := encDatum.EnsureDecoded(rf.table.cols[i].GetType(), rf.alloc); err != nil {
 			return nil, nil, nil, err
 		}
-		rf.rowReadyTable.decodedRow[i] = encDatum.Datum
+		rf.table.decodedRow[i] = encDatum.Datum
 	}
 
-	return rf.rowReadyTable.decodedRow, table, index, nil
+	return rf.table.decodedRow, table, index, nil
 }
 
 // RowLastModified may only be called after NextRow has returned a non-nil row
 // and returns the timestamp of the last modification to that row.
 func (rf *Fetcher) RowLastModified() hlc.Timestamp {
-	return rf.rowReadyTable.rowLastModified
+	return rf.table.rowLastModified
 }
 
 // RowIsDeleted may only be called after NextRow has returned a non-nil row and
@@ -1416,7 +1225,7 @@ func (rf *Fetcher) RowLastModified() hlc.Timestamp {
 // meaningful when the configured kvBatchFetcher returns deletion tombstones, which
 // the normal one (via `StartScan`) does not.
 func (rf *Fetcher) RowIsDeleted() bool {
-	return rf.rowReadyTable.rowIsDeleted
+	return rf.table.rowIsDeleted
 }
 
 // NextRowWithErrors calls NextRow to fetch the next row and also run
@@ -1447,13 +1256,13 @@ func (rf *Fetcher) NextRowWithErrors(ctx context.Context) (rowenc.EncDatumRow, e
 	// functions require that the table.row datums are decoded.
 	for i := range row {
 		if row[i].IsUnset() {
-			rf.rowReadyTable.decodedRow[i] = tree.DNull
+			rf.table.decodedRow[i] = tree.DNull
 			continue
 		}
-		if err := row[i].EnsureDecoded(rf.rowReadyTable.cols[i].GetType(), rf.alloc); err != nil {
+		if err := row[i].EnsureDecoded(rf.table.cols[i].GetType(), rf.alloc); err != nil {
 			return nil, err
 		}
-		rf.rowReadyTable.decodedRow[i] = row[i].Datum
+		rf.table.decodedRow[i] = row[i].Datum
 	}
 
 	if index.GetID() == table.GetPrimaryIndexID() {
@@ -1474,7 +1283,7 @@ func (rf *Fetcher) NextRowWithErrors(ctx context.Context) (rowenc.EncDatumRow, e
 // on all values in the buffered row. This check is specific to primary
 // index datums.
 func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
-	table := rf.rowReadyTable
+	table := &rf.table
 	scratch := make([]byte, 1024)
 	colIDToColumn := make(map[descpb.ColumnID]catalog.Column)
 	for _, col := range table.desc.PublicColumns() {
@@ -1533,7 +1342,7 @@ func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 // check on all values in the buffered row. This check is specific to
 // secondary index datums.
 func (rf *Fetcher) checkSecondaryIndexDatumEncodings(ctx context.Context) error {
-	table := rf.rowReadyTable
+	table := &rf.table
 	colToEncDatum := make(map[descpb.ColumnID]rowenc.EncDatum, len(table.row))
 	values := make(tree.Datums, len(table.row))
 	for i, col := range table.cols {
@@ -1551,14 +1360,14 @@ func (rf *Fetcher) checkSecondaryIndexDatumEncodings(ctx context.Context) error 
 	for _, indexEntry := range indexEntries {
 		// We ignore the first 4 bytes of the values. These bytes are a
 		// checksum which are not set by EncodeSecondaryIndex.
-		if !indexEntry.Key.Equal(rf.rowReadyTable.lastKV.Key) {
+		if !indexEntry.Key.Equal(rf.table.lastKV.Key) {
 			return scrub.WrapError(scrub.IndexKeyDecodingError, errors.Errorf(
 				"secondary index key failed to round-trip encode. expected %#v, got: %#v",
-				rf.rowReadyTable.lastKV.Key, indexEntry.Key))
+				rf.table.lastKV.Key, indexEntry.Key))
 		} else if !indexEntry.Value.EqualTagAndData(table.lastKV.Value) {
 			return scrub.WrapError(scrub.IndexValueDecodingError, errors.Errorf(
 				"secondary index value failed to round-trip encode. expected %#v, got: %#v",
-				rf.rowReadyTable.lastKV.Value, indexEntry.Value))
+				rf.table.lastKV.Value, indexEntry.Value))
 		}
 	}
 	return nil
@@ -1568,11 +1377,11 @@ func (rf *Fetcher) checkSecondaryIndexDatumEncodings(ctx context.Context) error 
 // have the same ordering as the encoded key.
 func (rf *Fetcher) checkKeyOrdering(ctx context.Context) error {
 	defer func() {
-		rf.rowReadyTable.lastDatums = append(tree.Datums(nil), rf.rowReadyTable.decodedRow...)
+		rf.table.lastDatums = append(tree.Datums(nil), rf.table.decodedRow...)
 	}()
 
-	if !rf.rowReadyTable.hasLast {
-		rf.rowReadyTable.hasLast = true
+	if !rf.table.hasLast {
+		rf.table.hasLast = true
 		return nil
 	}
 
@@ -1581,11 +1390,11 @@ func (rf *Fetcher) checkKeyOrdering(ctx context.Context) error {
 	// previous row in that column. When the first column with a differing value
 	// is found, compare the values to ensure the ordering matches the column
 	// ordering.
-	for i := 0; i < rf.rowReadyTable.index.NumKeyColumns(); i++ {
-		id := rf.rowReadyTable.index.GetKeyColumnID(i)
-		idx := rf.rowReadyTable.colIdxMap.GetDefault(id)
-		result := rf.rowReadyTable.decodedRow[idx].Compare(&evalCtx, rf.rowReadyTable.lastDatums[idx])
-		expectedDirection := rf.rowReadyTable.index.GetKeyColumnDirection(i)
+	for i := 0; i < rf.table.index.NumKeyColumns(); i++ {
+		id := rf.table.index.GetKeyColumnID(i)
+		idx := rf.table.colIdxMap.GetDefault(id)
+		result := rf.table.decodedRow[idx].Compare(&evalCtx, rf.table.lastDatums[idx])
+		expectedDirection := rf.table.index.GetKeyColumnDirection(i)
 		if rf.reverse && expectedDirection == descpb.IndexDescriptor_ASC {
 			expectedDirection = descpb.IndexDescriptor_DESC
 		} else if rf.reverse && expectedDirection == descpb.IndexDescriptor_DESC {
@@ -1608,7 +1417,7 @@ func (rf *Fetcher) checkKeyOrdering(ctx context.Context) error {
 }
 
 func (rf *Fetcher) finalizeRow() error {
-	table := rf.rowReadyTable
+	table := &rf.table
 
 	// Fill in any system columns if requested.
 	if table.timestampOutputIdx != noOutputColumn {
@@ -1677,11 +1486,11 @@ func (rf *Fetcher) PartialKey(nCols int) (roachpb.Key, error) {
 		return nil, nil
 	}
 	n, err := consumeIndexKeyWithoutTableIDIndexIDPrefix(
-		rf.currentTable.index, nCols, rf.kv.Key[rf.currentTable.knownPrefixLength:])
+		rf.table.index, nCols, rf.kv.Key[rf.table.knownPrefixLength:])
 	if err != nil {
 		return nil, err
 	}
-	return rf.kv.Key[:n+rf.currentTable.knownPrefixLength], nil
+	return rf.kv.Key[:n+rf.table.knownPrefixLength], nil
 }
 
 // GetBytesRead returns total number of bytes read by the underlying KVFetcher.


### PR DESCRIPTION
**row: simplify fetcher to only handle a single table**

Previously, `row.Fetcher` could handle multiple tables at the same time.
This was needed to support the interleaved tables efficiently, but since
the interleaved tables are no more, we can simplify the fetcher now.

There are more things that can be removed from the fetcher about
handling of the interleaved tables, but I chose to defer them to a later
commit. This commit's main focus is simplifying the fetcher to work
under the assumption that it will be fetching only from a single table.

Addresses: #69150

Release note: None

**colbuilder: remove the check for index join on the interleaved index**

Interleaved indexes are no more.

Release note: None

**sql: remove the interleaved logic from fetchers**

This commit removes the remaining bits of handling the interleaved
tables from both row fetcher and cFetcher. It also removes a test that
verifies that we can read from the interleaved table restored from
a backup.

Release note: None