### PR TITLE
democluster: shorten the scheduled jobs initial delay

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/cli/clierror",
         "//pkg/cli/cliflags",
         "//pkg/cli/democluster/api",
+        "//pkg/jobs",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb:with-mocks",
         "//pkg/rpc",

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierror"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -644,6 +645,12 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				StickyEngineRegistry: stickyEngineRegistry,
+			},
+			JobsTestingKnobs: &jobs.TestingKnobs{
+				// Allow the scheduler daemon to start earlier in demo.
+				SchedulerDaemonInitialScanDelay: func() time.Duration {
+					return time.Second * 15
+				},
 			},
 		},
 	}

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -126,6 +126,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			// We cannot compare these.
 			actual.Stopper = nil
 			actual.StoreSpecs = nil
+			actual.Knobs.JobsTestingKnobs = nil
 
 			assert.Equal(t, tc.expected, actual)
 		})


### PR DESCRIPTION
Release note (cli change): cockroach demo will now begin processing
scheduled jobs after 15s, instead of the 2-5min in a production
environment.