### PR TITLE
[WIP] sql: make PAUSE JOB(S) a blocking query

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -81,7 +81,7 @@ type Job struct {
 	}
 }
 
-// CreatedByInfo encapsulates they type and the ID of the system which created
+// CreatedByInfo encapsulates the type and the ID of the system which created
 // this job.
 type CreatedByInfo struct {
 	Name string
@@ -595,9 +595,6 @@ func (j *Job) failed(
 				return err
 			}
 		}
-		// TODO (sajjad): We don't have any checks for state transitions here. Consequently,
-		// a pause-requested job can transition to failed, which may or may not be
-		// acceptable depending on the job.
 		ju.UpdateStatus(StatusFailed)
 		md.Payload.Error = err.Error()
 		md.Payload.FinishedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -113,6 +113,7 @@ func (n *controlJobsNode) startExec(params runParams) error {
 		switch n.desiredStatus {
 		case jobs.StatusPaused:
 			err = reg.PauseRequested(params.ctx, params.p.txn, jobspb.JobID(jobID), n.reason)
+			params.extendedEvalCtx.addPauseRequestedJob(jobspb.JobID(jobID))
 		case jobs.StatusRunning:
 			err = reg.Unpause(params.ctx, params.p.txn, jobspb.JobID(jobID))
 		case jobs.StatusCanceled:


### PR DESCRIPTION
Previously, PAUSE JOB(S) was not blocking. This commit makes PAUSE JOB(S)
queries to block until the given job(s) is/are effectively paused.

Release note (sql change): PAUSE JOB(S) queries were not blocking.
As a result, a PAUSE JOB(S) query was returning after submitting
a pause request and without waiting for the job(s) to be effectively
paused. This commit makes PAUSE JOB(S) block until the given jobs
are either paused. As a result, PAUSE JOB(S) is now a blocking query.

FIXES: #67453