### PR TITLE
jobs: add nil reference check when updating job run stats

### DIFF
--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -71,6 +71,12 @@ func (j *Job) Started(ctx context.Context) error {
 	return j.started(ctx, nil /* txn */)
 }
 
+// Reverted is a wrapper around the internal function that moves a job to the
+// reverting state.
+func (j *Job) Reverted(ctx context.Context, err error) error {
+	return j.reverted(ctx, nil /* txn */, err, nil)
+}
+
 // Paused is a wrapper around the internal function that moves a job to the
 // paused state.
 func (j *Job) Paused(ctx context.Context) error {

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -16,7 +16,6 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -263,7 +262,14 @@ func (j *Job) started(ctx context.Context, txn *kv.Txn) error {
 			md.Payload.StartedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 			ju.UpdatePayload(md.Payload)
 		}
-		if j.registry.settings.Version.IsActive(ctx, clusterversion.RetryJobsWithExponentialBackoff) {
+		// md.RunStats can be nil because of the timing of version-update when exponential-backoff
+		// gets activated. It may happen that backoff is not activated when Update() function was
+		// called, which will cause to not populate md.RunStats. However, when the code reaches this
+		// point, version update may have been updated to enable backoff. In this case, we can skip
+		// updating num_runs and last_run, treating this job run as if backoff was not activated.
+		//
+		// TODO (sajjad): Update this comment after version 22.2 has been released.
+		if md.RunStats != nil {
 			ju.UpdateRunStats(md.RunStats.NumRuns+1, j.registry.clock.Now().GoTime())
 		}
 		return nil
@@ -541,7 +547,12 @@ func (j *Job) reverted(
 			}
 			ju.UpdateStatus(StatusReverting)
 		}
-		if j.registry.settings.Version.IsActive(ctx, clusterversion.RetryJobsWithExponentialBackoff) {
+		// md.RunStats will be nil if clusterversion.RetryJobsWithExponentialBackoff
+		// was not active when Update was called above. In this case, we skip updating
+		// the runStats, treating this job run as if backoff is not active.
+		//
+		// TODO (sajjad): Update this comment after version 22.2 has been released.
+		if md.RunStats != nil {
 			// We can reach here due to a failure or due to the job being canceled.
 			// We should reset the exponential backoff parameters if the job was not
 			// canceled. Note that md.Status will be StatusReverting if the job


### PR DESCRIPTION
Previously, we didn't check for nil reference when updating job runs,
which results in a panic when exponential-backoff version bumps with
a particular timing. This commit adds nil reference checking.

Release note: None

Will fix #70243 after backport. 