### PR TITLE
storage: override MVCCMetadata.TxnDidNotUpdateMeta in mixed version c…

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -247,6 +248,7 @@ func TestPebbleEncryption(t *testing.T) {
 			StorageConfig: base.StorageConfig{
 				Attrs:             roachpb.Attributes{},
 				MaxSize:           512 << 20,
+				Settings:          cluster.MakeTestingClusterSettings(),
 				UseFileRegistry:   true,
 				EncryptionOptions: encOptionsBytes,
 			},

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/base",
         "//pkg/keys",
         "//pkg/roachpb:with-mocks",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -184,7 +185,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 	peb, err := storage.NewPebble(
 		context.Background(),
 		storage.PebbleConfig{
-			StorageConfig: base.StorageConfig{Dir: dir},
+			StorageConfig: base.StorageConfig{Dir: dir, Settings: cluster.MakeTestingClusterSettings()},
 			Opts:          opts,
 		})
 	if err != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -248,7 +248,8 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 			storage.InMemory(),
 			storage.Attributes(roachpb.Attributes{Attrs: []string{"dc1", "mem"}}),
 			storage.MaxSize(1<<20),
-			storage.SetSeparatedIntents(disableSeparatedIntents))
+			storage.SetSeparatedIntents(disableSeparatedIntents),
+			storage.Settings(cfg.Settings))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -6430,9 +6431,9 @@ func TestRangeStatsComputation(t *testing.T) {
 	}
 	expMS = baseStats
 	expMS.Add(enginepb.MVCCStats{
-		LiveBytes:   103,
+		LiveBytes:   101,
 		KeyBytes:    28,
-		ValBytes:    75,
+		ValBytes:    73,
 		IntentBytes: 23,
 		LiveCount:   2,
 		KeyCount:    2,
@@ -6441,6 +6442,10 @@ func TestRangeStatsComputation(t *testing.T) {
 	})
 	if tc.engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 		expMS.SeparatedIntentCount++
+	}
+	if !tc.engine.OverrideTxnDidNotUpdateMetaToFalse(ctx) {
+		expMS.LiveBytes += 2
+		expMS.ValBytes += 2
 	}
 	if err := verifyRangeStats(tc.engine, tc.repl.RangeID, expMS); err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -676,6 +676,10 @@ func (s spanSetWriter) LogLogicalOp(
 	s.w.LogLogicalOp(op, details)
 }
 
+func (s spanSetWriter) OverrideTxnDidNotUpdateMetaToFalse(ctx context.Context) bool {
+	return s.w.OverrideTxnDidNotUpdateMetaToFalse(ctx)
+}
+
 // ReadWriter is used outside of the spanset package internally, in ccl.
 type ReadWriter struct {
 	spanSetReader

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -679,6 +679,31 @@ type Writer interface {
 	//
 	// It is safe to modify the contents of the arguments after it returns.
 	SingleClearEngineKey(key EngineKey) error
+
+	// OverrideTxnDidNotUpdateMetaToFalse is a temporary method that will be removed
+	// for 22.1.
+	//
+	// See #69891 for details on the bug related to usage of SingleDelete in
+	// separated intent resolution. The following is needed for correctly
+	// migrating from 21.1 to 21.2.
+	//
+	// We have fixed the intent resolution code path in 21.2-beta to use
+	// SingleDelete more conservatively. The 21.2-GA will also likely include
+	// Pebble changes to make the old buggy usage of SingleDelete correct.
+	// However, there is a problem if someone upgrades from 21.1 to
+	// 21.2-beta/21.2-GA:
+	// 21.1 nodes will not write separated intents while they are the
+	// leaseholder for a range. However they can become the leaseholder for a
+	// range after a separated intent was written (in a mixed version cluster).
+	// Hence they can resolve separated intents. The logic in 21.1 for using
+	// SingleDelete when resolving intents is similarly buggy, and the Pebble
+	// code included in 21.1 will not make this buggy usage correct. The
+	// solution is for 21.2 nodes to never set txnDidNotUpdateMeta=true when
+	// writing separated intents, until the cluster version is at the version
+	// when the buggy code was fixed in 21.2. So 21.1 code will never use
+	// SingleDelete when resolving these separated intents (since the only
+	// separated intents being written are by 21.2 nodes).
+	OverrideTxnDidNotUpdateMetaToFalse(ctx context.Context) bool
 }
 
 // ReadWriter is the read/write interface to an engine's data.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -20,8 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -109,7 +111,30 @@ func TestMVCCHistories(t *testing.T) {
 				"randomly setting enableSeparated: %t", enabledSeparated)
 		}
 		// We start from a clean slate in every test file.
-		engine, err := Open(ctx, InMemory(), CacheSize(1<<20 /* 1 MiB */), SetSeparatedIntents(!enabledSeparated))
+		engine, err := Open(ctx, InMemory(), CacheSize(1<<20 /* 1 MiB */),
+			SetSeparatedIntents(!enabledSeparated),
+			func(cfg *engineConfig) error {
+				if !overridden {
+					// Latest cluster version, since these tests are not ones where we
+					// are examining differences related to separated intents.
+					cfg.Settings = cluster.MakeTestingClusterSettings()
+				} else {
+					if !enabledSeparated {
+						// 21.1, which has the old code that is unaware about the changes
+						// we have made for OverrideTxnDidNotUpdateMetaToFalse. By using
+						// the latest cluster version, we effectively undo these changes.
+						cfg.Settings = cluster.MakeTestingClusterSettings()
+					} else if strings.Contains(path, "mixed_cluster") {
+						v21_1 := clusterversion.ByKey(clusterversion.V21_1)
+						cfg.Settings =
+							cluster.MakeTestingClusterSettingsWithVersions(v21_1, v21_1, true)
+					} else {
+						// Latest cluster version.
+						cfg.Settings = cluster.MakeTestingClusterSettings()
+					}
+				}
+				return nil
+			})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -239,6 +239,11 @@ func (fw *SSTWriter) ClearEngineKey(key EngineKey) error {
 	return fw.fw.Delete(fw.scratch)
 }
 
+// OverrideTxnDidNotUpdateMetaToFalse implements the Writer interface.
+func (fw *SSTWriter) OverrideTxnDidNotUpdateMetaToFalse(ctx context.Context) bool {
+	panic("OverrideTxnDidNotUpdateMetaToFalse is unsupported")
+}
+
 // An error is returned if it is not greater than any previous point key
 // passed to this Writer (according to the comparator configured during writer
 // creation). `Close` cannot have been called.

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated_mixed_cluster
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated_mixed_cluster
@@ -1,0 +1,113 @@
+# In this mixed cluster test, where v21.2 is writing separated intents, the
+# value of txnDidNotUpdateMeta will always be false.
+
+run ok
+txn_begin t=A ts=123
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+
+# Write value1.
+
+run ok
+with t=A
+  txn_step
+  cput k=k v=v
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/123.000000000,0 -> /BYTES/v
+
+# Now, overwrite value1 with value2 from same txn; should see value1
+# as pre-existing value.
+
+run ok
+with t=A
+  txn_step
+  cput k=k v=v2 cond=v
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/123.000000000,0 -> /BYTES/v2
+
+# Writing value3 from a new epoch should see nil again.
+
+run ok
+with t=A
+  txn_restart
+  txn_step
+  cput k=k v=v3
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/123.000000000,0 -> /BYTES/v3
+
+# Commit value3 at a later timestamp.
+
+run ok
+with t=A
+  txn_advance    ts=124
+  resolve_intent k=k
+  txn_remove
+----
+>> at end:
+data: "k"/124.000000000,0 -> /BYTES/v3
+
+# Write value4 with an old timestamp without txn...should get a write
+# too old error.
+
+run error
+cput k=k v=v4 cond=v3 ts=123
+----
+>> at end:
+data: "k"/124.000000000,1 -> /BYTES/v4
+data: "k"/124.000000000,0 -> /BYTES/v3
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
+
+# Reset for next test
+
+run ok
+clear_range k=k end=-k
+----
+>> at end:
+<no data>
+
+# From TxnCoordSenderRetries,
+# "multi-range batch with forwarded timestamp and cput and delete range"
+
+# First txn attempt
+
+run ok
+# Before txn start:
+put k=c v=value ts=1
+with t=A
+  txn_begin ts=2
+  txn_step
+  cput k=c v=cput cond=value
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "c"/2.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value
+
+# Restart and retry cput. It should succeed.
+
+run trace ok
+with t=A
+  txn_restart ts=3
+  txn_step
+  cput k=c v=cput cond=value
+----
+>> txn_restart ts=3 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+>> txn_step t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+>> cput k=c v=cput cond=value t=A
+called PutIntent("c", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "c"/3.000000000,0 -> /BYTES/cput
+data: "c"/1.000000000,0 -> /BYTES/value

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated_mixed_cluster
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated_mixed_cluster
@@ -1,0 +1,61 @@
+# In this mixed cluster test, where v21.2 is writing separated intents, the
+# value of txnDidNotUpdateMeta will always be false.
+
+## Write the base (default) value.
+
+run ok
+with t=A
+  txn_begin  ts=1
+  put   k=a v=default resolve
+  txn_remove
+----
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/default
+
+## See how the intent history evolves throughout the test.
+
+run trace ok
+with t=A
+  txn_begin  ts=2
+  with       k=a
+  put        v=first
+  txn_step
+  put        v=second
+  txn_step   n=2
+  del
+  txn_step   n=6
+  put        v=first
+  resolve_intent
+----
+>> txn_begin ts=2 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> put v=first k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> put v=second k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/2.000000000,0 -> /BYTES/second
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step n=2 k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> del k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/2.000000000,0 -> /<empty>
+data: "a"/1.000000000,0 -> /BYTES/default
+>> txn_step n=6 k=a t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> put v=first k=a t=A
+called PutIntent("a", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default
+>> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+data: "a"/2.000000000,0 -> /BYTES/first
+data: "a"/1.000000000,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated_mixed_cluster
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated_mixed_cluster
@@ -1,0 +1,90 @@
+# In this mixed cluster test, where v21.2 is writing separated intents, the
+# value of txnDidNotUpdateMeta will always be false.
+
+run trace ok
+with t=A
+  txn_begin ts=2
+  put k=k1 v=v1
+----
+>> txn_begin ts=2 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/2.000000000,0 -> /BYTES/v1
+
+run trace ok
+with t=A
+  txn_advance ts=3
+  txn_step
+  put k=k1 v=v1
+  put k=k2 v=v2
+----
+>> txn_advance ts=3 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> txn_step t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+>> put k=k1 v=v1 t=A
+called PutIntent("k1", _, ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/3.000000000,0 -> /BYTES/v1
+>> put k=k2 v=v2 t=A
+called PutIntent("k2", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/3.000000000,0 -> /BYTES/v2
+
+run trace ok
+put k=k3 v=v3 ts=1
+----
+>> put k=k3 v=v3 ts=1
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/3.000000000,0 -> /BYTES/v2
+data: "k3"/1.000000000,0 -> /BYTES/v3
+
+run trace ok
+with t=A
+  put k=k3 v=v33
+----
+>> put k=k3 v=v33 t=A
+called PutIntent("k3", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "k1"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+
+# transactionDidNotUpdateMeta (TDNUM) is false below for k2 and k3 since
+# disallowSeparatedIntents=true causes mvcc.go to always set it to false to maintain
+# consistency in a mixed version cluster.
+run trace ok
+with t=A
+  resolve_intent k=k1
+  resolve_intent k=k2 status=ABORTED
+  resolve_intent k=k3 status=ABORTED
+  txn_remove
+----
+>> resolve_intent k=k1 t=A
+called ClearIntent("k1", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k2"/3.000000000,0 -> /BYTES/v2
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> resolve_intent k=k2 status=ABORTED t=A
+called ClearIntent("k2", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k3"/3.000000000,0 -> /BYTES/v33
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> resolve_intent k=k3 status=ABORTED t=A
+called ClearIntent("k3", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+data: "k1"/3.000000000,0 -> /BYTES/v1
+data: "k3"/1.000000000,0 -> /BYTES/v3
+>> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated_mixed_cluster
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated_mixed_cluster
@@ -1,0 +1,33 @@
+# In this mixed cluster test, where v21.2 is writing separated intents, the
+# value of txnDidNotUpdateMeta will always be false.
+
+## Simple txn that aborts.
+
+run trace ok
+with t=A k=a
+  txn_begin      ts=22
+  put            v=cde
+  resolve_intent status=ABORTED
+  txn_remove
+----
+>> txn_begin ts=22 t=A k=a
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false gul=0,0
+>> put v=cde t=A k=a
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/22.000000000,0 -> /BYTES/cde
+>> resolve_intent status=ABORTED t=A k=a
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+<no data>
+>> txn_remove t=A k=a
+
+# Cannot read aborted value.
+
+run ok
+with t=A
+  txn_begin  ts=23
+  get   k=a
+  txn_remove
+----
+get: "a" -> <no data>
+>> at end:

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated_mixed_cluster
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated_mixed_cluster
@@ -1,0 +1,94 @@
+# In this mixed cluster test, where v21.2 is writing separated intents, the
+# value of txnDidNotUpdateMeta will always be false.
+
+## A simple txn that commits.
+
+run trace ok
+with t=A
+  txn_begin  ts=11
+  with       k=a
+    put      v=abc
+    get
+    resolve_intent
+----
+>> txn_begin ts=11 t=A
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+>> put v=abc k=a t=A
+called PutIntent("a", _, NoExistingIntent, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/11.000000000,0 -> /BYTES/abc
+>> get k=a t=A
+get: "a" -> /BYTES/abc @11.000000000,0
+>> resolve_intent k=a t=A
+called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+data: "a"/11.000000000,0 -> /BYTES/abc
+
+run ok
+with t=A resolve
+  put   k=a/1 v=eee
+  put   k=b   v=fff
+  put   k=b/2 v=ggg
+  put   k=c   v=hhh
+  txn_remove
+----
+>> at end:
+data: "a"/11.000000000,0 -> /BYTES/abc
+data: "a/1"/11.000000000,0 -> /BYTES/eee
+data: "b"/11.000000000,0 -> /BYTES/fff
+data: "b/2"/11.000000000,0 -> /BYTES/ggg
+data: "c"/11.000000000,0 -> /BYTES/hhh
+
+# Reads previous writes, transactional.
+
+run ok
+with t=A
+  txn_begin  ts=11
+  get   k=a
+----
+get: "a" -> /BYTES/abc @11.000000000,0
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+
+run trace ok
+with t=A
+  scan k=a end==b
+  scan k=a end=+a
+  scan k=a end=-a
+  scan k=a end=+b
+  scan k=a end==b
+  scan k=a end=-b
+  txn_remove
+----
+>> scan k=a end==b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=+a t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+>> scan k=a end=-a t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=+b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
+>> scan k=a end==b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+>> scan k=a end=-b t=A
+scan: "a" -> /BYTES/abc @11.000000000,0
+scan: "a/1" -> /BYTES/eee @11.000000000,0
+scan: "b" -> /BYTES/fff @11.000000000,0
+scan: "b/2" -> /BYTES/ggg @11.000000000,0
+>> txn_remove t=A
+
+
+## A simple txn anchored at some arbitrary key.
+
+run trace ok
+with t=A k=a
+  txn_begin ts=1
+  txn_remove
+----
+>> txn_begin ts=1 t=A k=a
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+>> txn_remove t=A k=a


### PR DESCRIPTION
…luster

Specifically, if the cluster version indicates that there can
be nodes with the broken SingleDelete logic for separated
intent resolution, the MVCCMetadata.TxnDidNotUpdateMeta
field will never be set to true.

See code comments and https://github.com/cockroachdb/cockroach/issues/69891#issuecomment-916452800

Informs #69891

Release justification: fix for a release blocker that causes incorrect
behavior for transactional writes.

Release note: None