### PR TITLE
bazel,ci,dev: when running under `stress`/`race`, disable test sharding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss --experimental_proto_descriptor_sets_include_source_info
 test --config=test
 build:test --define gotags=bazel,crdb_test,gss --test_env=TZ=
-build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1
+build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -102,6 +102,8 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 	}
 	if race {
 		args = append(args, "--config=race")
+	} else if stress {
+		args = append(args, "--test_sharding_strategy=disabled")
 	}
 
 	for _, pkg := range pkgs {

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -165,7 +165,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -189,7 +189,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -53,7 +53,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
@@ -61,7 +61,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test //pkg/testutils --timeout=10s
 ----

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -258,6 +258,8 @@ func main() {
 				args = append(args, "--run_under", fmt.Sprintf("stress -stderr -maxfails 1 -maxtime %s -p %d", duration, parallelism))
 				if target == "stressrace" {
 					args = append(args, "--config=race")
+				} else {
+					args = append(args, "--test_sharding_strategy=disabled")
 				}
 				cmd := exec.Command("bazci", args...)
 				cmd.Stdout = os.Stdout


### PR DESCRIPTION
These two features add substantial overhead to tests. For example, w/
race detection:

> The cost of race detection varies by program, but for a typical
> program, memory usage may increase by 5-10x and execution time by
> 2-20x.

(Ref: https://golang.org/doc/articles/race_detector#Runtime_Overheads)

We've seen [timeouts under race detection in CI](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_GitHubCiOptional/3448162?expandedTest=build%3A%28id%3A3448161%29%2Cid%3A2871)
for sharded tests, so presumably these tests are buckling under the
weight of that additional overhead. Therefore we turn off test sharding
in these cases.

Release note: None