### PR TITLE
dev: allow passing additional arguments to `bazel` in `dev {build,test}`

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -76,7 +76,8 @@ var buildTargetMapping = map[string]string{
 	"roachtest":        "//pkg/cmd/roachtest",
 }
 
-func (d *dev) build(cmd *cobra.Command, targets []string) error {
+func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
+	targets, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
 	cross := mustGetFlagString(cmd, crossFlag)
 	hoistGeneratedCode := mustGetFlagBool(cmd, hoistGeneratedCodeFlag)
@@ -85,6 +86,7 @@ func (d *dev) build(cmd *cobra.Command, targets []string) error {
 	if err != nil {
 		return err
 	}
+	args = append(args, additionalBazelArgs...)
 
 	if cross == "" {
 		args = append(args, getConfigFlags()...)

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -69,15 +69,16 @@ func makeTestCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comm
 // TODO(irfansharif): Add tests for the various bazel commands that get
 // generated from the set of provided user flags.
 
-func (d *dev) test(cmd *cobra.Command, pkgs []string) error {
+func (d *dev) test(cmd *cobra.Command, args []string) error {
 	if logicTest := mustGetFlagBool(cmd, logicFlag); logicTest {
 		return d.runLogicTest(cmd)
 	}
 
-	return d.runUnitTest(cmd, pkgs)
+	return d.runUnitTest(cmd, args)
 }
 
-func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
+func (d *dev) runUnitTest(cmd *cobra.Command, commandLine []string) error {
+	pkgs, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
 	stress := mustGetFlagBool(cmd, stressFlag)
 	stressArgs := mustGetFlagString(cmd, stressArgsFlag)
@@ -96,6 +97,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, pkgs []string) error {
 	args = append(args, "--color=yes")
 	args = append(args, "--experimental_convenience_symlinks=ignore")
 	args = append(args, getConfigFlags()...)
+	args = append(args, additionalBazelArgs...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -81,3 +81,16 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/roachpb/batch_generated-gen.go go/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/expr-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/expr.og.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/operator-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator.og.go
+
+dev build short -- -s
+----
+getenv PATH
+which cc
+readlink /usr/local/opt/ccache/libexec/cc
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short -s --config=dev
+bazel info workspace --color=no --config=dev
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no --config=dev
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -242,3 +242,38 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/operator-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator.og.go
 ----
+
+getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+bazel build --color=yes --experimental_convenience_symlinks=ignore //pkg/cmd/cockroach-short -s --config=dev
+----
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no --config=dev
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -243,3 +243,27 @@ Executed 1 out of 1 test: 1 test passes.
 [0m
 ----
 ----
+
+getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev -s //pkg/util/tracing:tracing_test --test_output errors
+----
+----
+//pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.2s
+
+Executed 1 out of 1 test: 1 test passes.
+----
+----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -70,3 +70,11 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
+
+dev test pkg/util/tracing -- -s
+----
+getenv PATH
+which cc
+readlink /usr/local/opt/ccache/libexec/cc
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+bazel test --color=yes --experimental_convenience_symlinks=ignore --config=dev -s //pkg/util/tracing:tracing_test --test_output errors

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -194,3 +194,15 @@ func setupPathReal(dev *dev) error {
 	}
 	return nil
 }
+
+func splitArgsAtDash(cmd *cobra.Command, args []string) (before, after []string) {
+	argsLenAtDash := cmd.ArgsLenAtDash()
+	if argsLenAtDash < 0 {
+		// If there's no dash, the value of this is -1.
+		before = args
+	} else {
+		before = args[0:argsLenAtDash]
+		after = args[argsLenAtDash:]
+	}
+	return
+}


### PR DESCRIPTION
Just a convenience feature.

Release note: None