### PR TITLE
logictest: attempt to deflake "disallow full scans" test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -725,8 +725,10 @@ true NULL
 
 # Tests for `disallow_full_table_scans`
 statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+
+statement ok
 CREATE TABLE t_disallow_scans(a INT, b INT, INDEX b_idx(b));
-INSERT INTO t_disallow_scans VALUES (1, 1), (2, 1), (3, 1)
 
 statement ok
 SELECT * FROM t_disallow_scans
@@ -741,11 +743,35 @@ SELECT * FROM t_disallow_scans
 statement error pq: query `SELECT \* FROM t_disallow_scans@b_idx` contains a full table/index scan which is explicitly disallowed
 SELECT * FROM t_disallow_scans@b_idx
 
-# Disable 'large_full_scan_rows' heuristic and analyze the table in order to
+# Disable 'large_full_scan_rows' heuristic and inject the stats in order to
 # test 'disallow_full_table_scans' in isolation.
 statement ok
 SET large_full_scan_rows = 0;
-ANALYZE t_disallow_scans
+
+statement ok
+ALTER TABLE t_disallow_scans INJECT STATISTICS '[
+  {
+    "columns": ["rowid"],
+    "created_at": "2021-09-15 19:38:46.017315",
+    "distinct_count": 3,
+    "null_count": 0,
+    "row_count": 3
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2021-09-15 19:38:46.017315",
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3
+  },
+  {
+    "columns": ["a"],
+    "created_at": "2021-09-15 19:38:46.017315",
+    "distinct_count": 3,
+    "null_count": 0,
+    "row_count": 3
+  }
+]'
 
 statement error pq: query `SELECT \* FROM t_disallow_scans` contains a full table/index scan which is explicitly disallowed
 SELECT * FROM t_disallow_scans
@@ -762,7 +788,7 @@ SELECT * FROM crdb_internal.jobs
 
 # Tests for 'large_full_scan_rows'.
 statement ok
-SET large_full_scan_rows = 4
+SET large_full_scan_rows = 1000
 
 # These queries succeed because the full table/index scans aren't considered
 # "large".
@@ -784,7 +810,8 @@ SELECT * FROM t_disallow_scans@b_idx
 # Cleanup
 statement ok
 SET disallow_full_table_scans = false;
-RESET large_full_scan_rows
+RESET large_full_scan_rows;
+RESET CLUSTER SETTING sql.stats.automatic_collection.enabled;
 
 # Regression test for #58104.
 statement ok


### PR DESCRIPTION
We've seen a couple of flakes on the testing of "disallow full scans"
feature although I couldn't reproduce it manually. In an attempt to
deflake the test, this commit increases the corresponding session
variable as well as injects the stats manually instead of analyzing the
table (to have more tight control over events).

Fixes: #70012.

Release note: None