### PR TITLE
testcat: make expression index column names consistent

### DIFF
--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -130,47 +130,47 @@ TABLE xyz
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
+ ├── crdb_internal_idx_expr string as (lower(z)) virtual [hidden]
  ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [hidden]
- ├── crdb_internal_idx_expr_2 string as (lower(z)) virtual [hidden]
- ├── crdb_internal_idx_expr_3 int as (y + 1) virtual [hidden]
- ├── crdb_internal_idx_expr_4 string as (lower(z)) virtual [hidden]
+ ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [hidden]
+ ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [hidden]
+ ├── crdb_internal_idx_expr_4 jsonb as (j->'a') virtual [hidden]
+ ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
  ├── crdb_internal_idx_expr_5 jsonb as (j->'a') virtual [hidden]
  ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
- ├── crdb_internal_idx_expr_6 jsonb as (j->'a') virtual [hidden]
- ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_6 int as (x + y) virtual [hidden]
  ├── crdb_internal_idx_expr_7 int as (x + y) virtual [hidden]
- ├── crdb_internal_idx_expr_8 int as (x + y) virtual [hidden]
- ├── crdb_internal_idx_expr_9 jsonb as (j->'a') virtual [hidden]
- ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_8 jsonb as (j->'a') virtual [hidden]
+ ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
  ├── PRIMARY INDEX primary
  │    └── x int not null
  ├── INDEX idx1
- │    ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [hidden]
+ │    ├── crdb_internal_idx_expr string as (lower(z)) virtual [hidden]
  │    └── x int not null
  ├── INDEX idx2
- │    ├── crdb_internal_idx_expr_2 string as (lower(z)) virtual [hidden]
+ │    ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [hidden]
  │    ├── y int
  │    └── x int not null
  ├── INDEX idx3
- │    ├── crdb_internal_idx_expr_3 int as (y + 1) virtual [hidden]
- │    ├── crdb_internal_idx_expr_4 string as (lower(z)) virtual [hidden]
+ │    ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [hidden]
+ │    ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [hidden]
  │    └── x int not null
  ├── INVERTED INDEX idx4
- │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INVERTED INDEX idx5
  │    ├── y int
  │    ├── z string
- │    ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INDEX idx6
- │    ├── crdb_internal_idx_expr_7 int as (x + y) virtual [hidden]
+ │    ├── crdb_internal_idx_expr_6 int as (x + y) virtual [hidden]
  │    ├── y int
  │    ├── x int not null
  │    ├── z string (storing)
  │    └── WHERE v > 1
  └── INVERTED INDEX idx7
-      ├── crdb_internal_idx_expr_8 int as (x + y) virtual [hidden]
-      ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [inverted]
+      ├── crdb_internal_idx_expr_7 int as (x + y) virtual [hidden]
+      ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
       ├── x int not null
       └── WHERE v > 1


### PR DESCRIPTION
Previously, the column names generated in the test catalog for virtual
columns that back expression indexes always included a numeric suffix.
The real catalog only adds a suffix to `crdb_internal_idx_expr` if there
is a name collision. This caused confusion when debugging a query with
both the real catalog and test catalog. This commit updates the test
catalog to produce column names consistent with the real catalog.

Release note: None