### PR TITLE
sql: fix JSON deserialization for sql stats lastExecAt field

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/util/encoding",
         "//pkg/util/json",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -59,7 +59,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
          "cnt": {{.Int64}},
          "firstAttemptCnt": {{.Int64}},
          "maxRetries":      {{.Int64}},
-         "lastExecAt":      "0001-01-01T00:00:00Z",
+         "lastExecAt":      "{{stringifyTime .Time}}",
          "numRows": {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -334,7 +334,7 @@ func (t *jsonTime) decodeJSON(js json.JSON) error {
 		return err
 	}
 
-	tm := (time.Time)(*t)
+	tm := (*time.Time)(t)
 	if err := tm.UnmarshalText([]byte(s)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previsouly, lastExecAt field for roachpb.CollectedStatementStatistics
was not properly updated. This caused the status API to return
empty data for that field.
This commit fixes the deserialization and extended the randomize
testing framework to also test time.Time type.

Partially Resolves #69675

Release Justification: Bug fixes and low-risk updates to new
functionality

Release note (bug fix): Last Execution Timestamp is now properly
updating.