### PR TITLE
ci: replace tmpdir-staging logic in `bazci` with `--test_tmpdir`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,8 @@ build:ci --host_crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
 test:ci --test_env=GO_TEST_WRAP_TESTV=1
 # Dump all output for failed tests to the build log.
 test:ci --test_output=errors
+# Put all tmp artifacts in /artifacts/tmp.
+test:ci --test_tmpdir=/artifacts/tmp
 
 # cross-compilation configurations. Add e.g. --config=crosslinux to turn these on
 # TODO(ricky): Having to specify both the `platform` and the `crosstool_top` is

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -29,7 +29,6 @@ const (
 
 var (
 	artifactsDir    string
-	tmpDir          string
 	configs         []string
 	compilationMode string
 
@@ -54,11 +53,6 @@ func init() {
 		"artifacts_dir",
 		"/artifacts",
 		"path where artifacts should be staged")
-	rootCmd.Flags().StringVar(
-		&tmpDir,
-		"tmp_dir",
-		"/tmp/bazelbuild",
-		"path to temporary directory to use for tests")
 	rootCmd.Flags().StringVar(
 		&compilationMode,
 		"compilation_mode",
@@ -237,9 +231,6 @@ func bazciImpl(cmd *cobra.Command, args []string) error {
 		processArgs = append(processArgs, configArgList()...)
 		processArgs = append(processArgs, "-c", compilationMode)
 		processArgs = append(processArgs, parsedArgs.additional...)
-		if parsedArgs.subcmd == "test" {
-			processArgs = append(processArgs, fmt.Sprintf("--test_tmpdir=%s", tmpDir))
-		}
 		fmt.Println("running bazel w/ args: ", processArgs)
 		cmd := exec.Command("bazel", processArgs...)
 		cmd.Stdout = os.Stdout

--- a/pkg/cmd/bazci/watch_test.go
+++ b/pkg/cmd/bazci/watch_test.go
@@ -39,9 +39,6 @@ func TestWatch(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 	artifactsDir = dir
-	dir, cleanup = testutils.TempDir(t)
-	defer cleanup()
-	tmpDir = dir
 	testdata := testutils.TestDataPath(t)
 	info := buildInfo{
 		binDir:      path.Join(testdata, "bazel-bin"),


### PR DESCRIPTION
This used to be necessary before #69666, but now that that's landed we
can just have the Bazel tests write directly to `/artifacts/tmp`.

Release note: None