### PR TITLE
roachtest: unskip `rapid-restart`

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -67,10 +67,7 @@ func registerAcceptance(r registry.Registry) {
 			{name: "build-analyze", fn: RunBuildAnalyze},
 			{name: "cli/node-status", fn: runCLINodeStatus},
 			{name: "cluster-init", fn: runClusterInit},
-			{
-				name: "rapid-restart", fn: runRapidRestart,
-				skip: "https://github.com/cockroachdb/cockroach/issues/63795",
-			},
+			{name: "rapid-restart", fn: runRapidRestart},
 			{name: "status-server", fn: runStatusServer},
 		},
 	}


### PR DESCRIPTION
Informs [#63795]( https://github.com/cockroachdb/cockroach/issues/63795).

The rapid restart roachtest is getting unskipped in order to investigate CI failures.

Release note: None