### PR TITLE
sql: TestTenantTempTableCleanup design leads to stress failures

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -25,7 +25,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/stop",
-        "//pkg/util/timeutil",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],


### PR DESCRIPTION
Fixes: #70292

Previously, TestTenantTempTableCleanup was relying on
waiting on a certain amount of time to ensure that the
temporary object cleaner ran. This was inadequate because
there is potential for the temporary object cleaner to
run slower under stress. To address this, this patch
updates the test to ensure exact timing using channels
and testing knobs.

Release note: None