### PR TITLE
ci: add bazel SQL Logic Test High VModule Nightly job for CI

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run SQL Logic Test High VModule"
+run_bazel build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
+tc_end_block "Run SQL Logic Test High VModule"

--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+BAZEL_BIN=$(bazel info bazel-bin --config=ci)
+
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/sql/logictest:logictest_test -- \
+    --test_arg=--vmodule=*=10 \
+    --test_arg=-show-sql \
+    --test_filter='^TestLogic$' \
+    --test_timeout=7200


### PR DESCRIPTION
Adds wrappers to run Bazel-based SQL Logic Test High VModule Nightly CI
job.

Fixes #67150

Release note: None