### PR TITLE
build: lose -x in roachtest nightly script

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
 


### PR DESCRIPTION
The `-x` makes it a lot harder to find the failures (since there is a
lot of output after the roachtest invocation returns, due to the
artifacts copying). The script is mature enough to run as-is.

Release note: None
