### PR TITLE
sql: consolidate non drop database schema change calls

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -210,13 +210,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 
 		switch d := descriptor.(type) {
 		case *dbdesc.Mutable:
-			if err := p.writeDatabaseChangeToBatch(ctx, d, b); err != nil {
-				return err
-			}
-			if err := p.createNonDropDatabaseChangeJob(ctx, d.ID,
-				fmt.Sprintf("updating privileges for database %d", d.ID)); err != nil {
-				return err
-			}
+			p.writeNonDropDatabaseChange(ctx, d, fmt.Sprintf("updating privileges for database %d", d.ID))
 			for _, grantee := range n.grantees {
 				privs := eventDetails // copy the granted/revoked privilege list.
 				privs.Grantee = grantee.Normalized()


### PR DESCRIPTION
Release justification: None, waiting for 22.1
Release note: None

https://github.com/cockroachdb/cockroach/issues/32811#issuecomment-920366066

replaced two calls with writeNonDropDatabaseChange in grant_revoke.go and added tests