### PR TITLE
[CC-4712] ui: fix drag-to-timerange specific window issue

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
@@ -127,7 +127,10 @@ export const availableTimeScales: TimeScaleCollection = _.mapValues(
   },
 );
 
-export const findClosestTimeScale = (seconds: number) => {
+export const findClosestTimeScale = (
+  seconds: number,
+  startSeconds?: number,
+) => {
   const data: TimeScale[] = [];
   Object.keys(availableTimeScales).forEach(val =>
     data.push(availableTimeScales[val]),
@@ -137,7 +140,23 @@ export const findClosestTimeScale = (seconds: number) => {
       Math.abs(seconds - a.windowSize.asSeconds()) -
       Math.abs(seconds - b.windowSize.asSeconds()),
   );
-  return data[0].windowSize.asSeconds() === seconds
+
+  const firstTimeScaleOptionSeconds = data[0].windowSize.asSeconds();
+
+  // This logic covers the edge case where drag-to-timerange on a linegraph is of a duration
+  // that exactly matches one of the standard available time scales e.g. selecting June 1 at
+  // 0:00 to June 2 at 0:00 when the date is July 1 at 0:00 should return a custom timescale
+  // instead of past day.
+  if (startSeconds && firstTimeScaleOptionSeconds === seconds) {
+    const startWindow = moment()
+      .subtract(firstTimeScaleOptionSeconds, "seconds")
+      .unix();
+    if (startSeconds < startWindow) {
+      return { ...data[0], key: "Custom" };
+    }
+  }
+
+  return firstTimeScaleOptionSeconds === seconds
     ? data[0]
     : { ...data[0], key: "Custom" };
 };
@@ -202,6 +221,7 @@ export function setTimeWindow(tw: TimeWindow): PayloadAction<TimeWindow> {
 }
 
 export function setTimeRange(tw: TimeWindow): PayloadAction<TimeWindow> {
+  console.log(tw);
   return {
     type: SET_RANGE,
     payload: tw,

--- a/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
@@ -221,7 +221,6 @@ export function setTimeWindow(tw: TimeWindow): PayloadAction<TimeWindow> {
 }
 
 export function setTimeRange(tw: TimeWindow): PayloadAction<TimeWindow> {
-  console.log(tw);
   return {
     type: SET_RANGE,
     payload: tw,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -409,7 +409,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       start: moment.unix(start),
       end: moment.unix(end),
     });
-    const newTimeScale = findClosestTimeScale(end - start);
+    const newTimeScale = findClosestTimeScale(end - start, start);
     this.props.setTimeScale(newTimeScale);
     const { pathname, search } = this.props.history.location;
     const urlParams = new URLSearchParams(search);


### PR DESCRIPTION
This PR fixes the issue where the user drags-to-timerange on a metrics page graph where the window is exactly 24 hours or 1 hour and the timewindow changes to the past day or past hour. This was due to a time scale function that determines the closes time scale returning a standard option instead of a custom option because the calculation only considers duration. Some additional logic was added to the function to handle this specific edge case.

Release note (ui change): fix drag-to-timerange for specific window issue

https://user-images.githubusercontent.com/17861665/133663386-8284d5c7-ca96-4d0b-8fbf-d62d4fd4a7e3.mp4



