### PR TITLE
release-21.1: server: acceptance tests asserting backwards compatibility with recent patches

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -64,6 +64,7 @@ func registerTests(r *testRegistry) {
 	registerLibPQ(r)
 	registerNamespaceUpgradeMigration(r)
 	registerNetwork(r)
+	registerNonAcceptanceVersionUpgrade(r)
 	registerPebble(r)
 	registerPgjdbc(r)
 	registerPgx(r)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1234,6 +1234,20 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	return v, nil
 }
 
+// RecentPatchVersions returns up to n version strings (e.g. "21.1.2")
+// from the same minor release as buildVersion, in reverse chronological order.
+func RecentPatchVersions(buildVersion version.Version, n int) []string {
+	current := buildVersion.Patch()
+	if current < n {
+		n = current
+	}
+	versions := make([]string, n)
+	for i := 0; i < n; i++ {
+		versions[i] = fmt.Sprintf("%d.%d.%d", buildVersion.Major(), buildVersion.Minor(), current-i)
+	}
+	return versions
+}
+
 type workerErrors struct {
 	mu struct {
 		syncutil.Mutex


### PR DESCRIPTION
version-upgrade tests upgrading and downgrading across major/minor versions. This
pr adds a similar test upgrading and downgrading across patch versions, and therefore
allows upgrades to finalize before downgrading them.

It doesn't do any fixture management since the purpose isn't to test the whole upgrade
path, just recent-version interoperability, so we can start from a clean cluster.

Release note: None