### PR TITLE
keys,kvserver: Remove unused compactor-related code

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -147,9 +147,6 @@ var (
 	//
 	// LocalStorePrefix is the prefix identifying per-store data.
 	LocalStorePrefix = makeKey(LocalPrefix, roachpb.Key("s"))
-	// localStoreSuggestedCompactionSuffix stores suggested compactions to
-	// be aggregated and processed on the store.
-	localStoreSuggestedCompactionSuffix = []byte("comp")
 	// localStoreClusterVersionSuffix stores the cluster-wide version
 	// information for this store, updated any time the operator
 	// updates the minimum cluster version.

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -97,14 +97,6 @@ func DecodeNodeTombstoneKey(key roachpb.Key) (roachpb.NodeID, error) {
 	return roachpb.NodeID(nodeID), err
 }
 
-// StoreSuggestedCompactionKeyPrefix returns a store-local prefix for all
-// suggested compaction keys. These are unused in versions 21.1 and later.
-//
-// TODO(bilal): Delete this method along with any related uses of it after 21.1.
-func StoreSuggestedCompactionKeyPrefix() roachpb.Key {
-	return MakeStoreKey(localStoreSuggestedCompactionSuffix, nil)
-}
-
 // StoreCachedSettingsKey returns a store-local key for store's cached settings.
 func StoreCachedSettingsKey(settingKey roachpb.Key) roachpb.Key {
 	return MakeStoreKey(localStoreCachedSettingsSuffix, encoding.EncodeBytesAscending(nil, settingKey))

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -193,7 +193,6 @@ var constSubKeyDict = []struct {
 	{"/gossipBootstrap", localStoreGossipSuffix},
 	{"/clusterVersion", localStoreClusterVersionSuffix},
 	{"/nodeTombstone", localStoreNodeTombstoneSuffix},
-	{"/suggestedCompaction", localStoreSuggestedCompactionSuffix},
 	{"/cachedSettings", localStoreCachedSettingsSuffix},
 }
 
@@ -237,7 +236,6 @@ func localStoreKeyParse(input string) (remainder string, output roachpb.Key) {
 		if strings.HasPrefix(input, s.name) {
 			switch {
 			case
-				s.key.Equal(localStoreSuggestedCompactionSuffix),
 				s.key.Equal(localStoreNodeTombstoneSuffix),
 				s.key.Equal(localStoreCachedSettingsSuffix):
 				panic(&ErrUglifyUnsupported{errors.Errorf("cannot parse local store key with suffix %s", s.key)})

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1654,22 +1654,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		s.consistencyLimiter.UpdateLimit(quotapool.Limit(rate), rate*consistencyCheckRateBurstFactor)
 	})
 
-	// Storing suggested compactions in the store itself was deprecated with
-	// the removal of the Compactor in 21.1. See discussion in
-	// https://github.com/cockroachdb/cockroach/pull/55893
-	//
-	// TODO(bilal): Remove this code in versions after 21.1.
-	err = s.engine.MVCCIterate(
-		keys.StoreSuggestedCompactionKeyPrefix(),
-		keys.StoreSuggestedCompactionKeyPrefix().PrefixEnd(),
-		storage.MVCCKeyIterKind,
-		func(res storage.MVCCKeyValue) error {
-			return s.engine.ClearUnversioned(res.Key.Key)
-		})
-	if err != nil {
-		log.Warningf(ctx, "error when clearing compactor keys: %s", err)
-	}
-
 	// Set the started flag (for unittests).
 	atomic.StoreInt32(&s.started, 1)
 


### PR DESCRIPTION
In the RocksDB world, we had a manual out-of-RocksDB
compactor that would suggest compactions for range
deletions. These suggestions were stored in the storage
engine too, and this code was removed in #55893. The
only part left was some code to delete any stale
compaction suggestion keys.

Now that we are past the 21.1 release, this code can be removed;
any migration paths would have resulted in these keys getting
deleted in 21.1.

Release note: None.