### PR TITLE
release-21.2: engineccl: use marker file for data keys registry

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -165,4 +165,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-1162	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-1164	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -170,6 +170,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-1162</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-1164</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -18,8 +18,10 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_pebble//vfs/atomicfs",
         "@com_github_gogo_protobuf//proto",
     ],
 )

--- a/pkg/ccl/storageccl/engineccl/testdata/data_key_manager
+++ b/pkg/ccl/storageccl/engineccl/testdata/data_key_manager
@@ -52,6 +52,9 @@ record-active-data-key
 check-all-recorded-data-keys
 ----
 
+close
+----
+
 # Test that starts with one active data and store key. Checks that data key is not rotated
 # until SetActiveStoreKeyInfo is called. Also tests key rotation and holding multiple store
 # and data keys.
@@ -154,6 +157,9 @@ check-all-recorded-data-keys
 ----
 
 check-exposed val=false
+----
+
+close
 ----
 
 # Test that keys transition to exposed.

--- a/pkg/ccl/storageccl/engineccl/testdata/data_key_manager_io
+++ b/pkg/ccl/storageccl/engineccl/testdata/data_key_manager_io
@@ -1,0 +1,143 @@
+load dir=nonexistent
+----
+error: open nonexistent/: file does not exist
+
+mkdir-all data-dir
+----
+mkdir-all("data-dir", 0777)
+OK
+
+load dir=data-dir
+----
+open-dir("data-dir")
+stat("data-dir/COCKROACHDB_DATA_KEYS")
+OK
+
+# Since there's no data keys registry file yet, use-marker should be a
+# noop.
+
+use-marker
+----
+OK
+
+# Setting the active store key should trigger initializing the registry
+# on disk. Since use-marker has already been called, the registry should
+# be initialized with a marker file.
+
+set-active-store-key id=foo
+----
+create("data-dir/COCKROACHDB_DATA_KEYS_000001_monolith")
+write("data-dir/COCKROACHDB_DATA_KEYS_000001_monolith", <...280 bytes...>)
+sync("data-dir/COCKROACHDB_DATA_KEYS_000001_monolith")
+create("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith")
+close("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith")
+sync("data-dir")
+close("data-dir/COCKROACHDB_DATA_KEYS_000001_monolith")
+
+# Rotating the store key should move the marker.
+
+set-active-store-key id=bar
+----
+create("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+write("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith", <...489 bytes...>)
+sync("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+create("data-dir/marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith")
+close("data-dir/marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith")
+remove("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith")
+sync("data-dir")
+remove("data-dir/COCKROACHDB_DATA_KEYS_000001_monolith")
+close("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+
+list data-dir
+----
+COCKROACHDB_DATA_KEYS_000002_monolith
+marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith
+
+close
+----
+close("data-dir")
+OK
+
+# Loading the registry again should load from the marked file.
+
+load dir=data-dir
+----
+open-dir("data-dir")
+open("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+close("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+OK
+
+# UseMarker should still be set, because we loaded from a marked file.
+
+set-active-store-key id=bax
+----
+create("data-dir/COCKROACHDB_DATA_KEYS_000003_monolith")
+write("data-dir/COCKROACHDB_DATA_KEYS_000003_monolith", <...698 bytes...>)
+sync("data-dir/COCKROACHDB_DATA_KEYS_000003_monolith")
+create("data-dir/marker.datakeys.000003.COCKROACHDB_DATA_KEYS_000003_monolith")
+close("data-dir/marker.datakeys.000003.COCKROACHDB_DATA_KEYS_000003_monolith")
+remove("data-dir/marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith")
+sync("data-dir")
+remove("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+close("data-dir/COCKROACHDB_DATA_KEYS_000003_monolith")
+
+close
+----
+close("data-dir")
+OK
+
+rm-all data-dir
+----
+OK
+
+mkdir-all data-dir
+----
+mkdir-all("data-dir", 0777)
+OK
+
+load dir=data-dir
+----
+open-dir("data-dir")
+stat("data-dir/COCKROACHDB_DATA_KEYS")
+OK
+
+# Since use-marker has not yet been called, the registry shouldn't use
+# it. Instead, it should replace the static COCKROACHDB_DATA_KEYS file.
+
+set-active-store-key id=foo
+----
+create("data-dir/COCKROACHDB_DATA_KEYS.crdbtmp")
+write("data-dir/COCKROACHDB_DATA_KEYS.crdbtmp", <...280 bytes...>)
+sync("data-dir/COCKROACHDB_DATA_KEYS.crdbtmp")
+close("data-dir/COCKROACHDB_DATA_KEYS.crdbtmp")
+rename("data-dir/COCKROACHDB_DATA_KEYS.crdbtmp", "data-dir/COCKROACHDB_DATA_KEYS")
+open-dir("data-dir")
+sync("data-dir")
+close("data-dir")
+
+# Calling use-marker should lay down a marker pointing to the existing
+# file.
+
+use-marker
+----
+create("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS")
+close("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS")
+sync("data-dir")
+OK
+
+set-active-store-key id=bar
+----
+create("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+write("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith", <...489 bytes...>)
+sync("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+create("data-dir/marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith")
+close("data-dir/marker.datakeys.000002.COCKROACHDB_DATA_KEYS_000002_monolith")
+remove("data-dir/marker.datakeys.000001.COCKROACHDB_DATA_KEYS")
+sync("data-dir")
+remove("data-dir/COCKROACHDB_DATA_KEYS")
+close("data-dir/COCKROACHDB_DATA_KEYS_000002_monolith")
+
+close
+----
+close("data-dir")
+OK

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -277,6 +277,10 @@ const (
 	// PebbleFormatVersioned ratchets Pebble's format major version to
 	// the version FormatVersioned.
 	PebbleFormatVersioned
+	// MarkerDataKeysRegistry switches to using an atomic marker file
+	// for denoting which data keys registry is active.
+	MarkerDataKeysRegistry
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -464,6 +468,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     PebbleFormatVersioned,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1162},
+	},
+	{
+		Key:     MarkerDataKeysRegistry,
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1164},
 	},
 	// *************************************************
 	// Step (2): Add new versions here.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -46,11 +46,12 @@ func _() {
 	_ = x[SQLStatsCompactionScheduledJob-35]
 	_ = x[DateAndIntervalStyle-36]
 	_ = x[PebbleFormatVersioned-37]
+	_ = x[MarkerDataKeysRegistry-38]
 }
 
-const _Key_name = "Start21_1replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersioned"
+const _Key_name = "Start21_1replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistry"
 
-var _Key_index = [...]uint16{0, 9, 55, 105, 143, 185, 190, 203, 212, 227, 256, 273, 290, 339, 353, 366, 386, 402, 419, 446, 481, 506, 535, 566, 586, 617, 644, 669, 686, 715, 748, 771, 790, 809, 832, 848, 878, 898, 919}
+var _Key_index = [...]uint16{0, 9, 55, 105, 143, 185, 190, 203, 212, 227, 256, 273, 290, 339, 353, 366, 386, 402, 419, 446, 481, 506, 535, 566, 586, 617, 644, 669, 686, 715, 748, 771, 790, 809, 832, 848, 878, 898, 919, 941}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -161,9 +161,17 @@ func TestMinVersion_IsNotEncrypted(t *testing.T) {
 
 func fauxNewEncryptedEnvFunc(
 	fs vfs.FS, fr *PebbleFileRegistry, dbDir string, readOnly bool, optionBytes []byte,
-) (vfs.FS, EncryptionStatsHandler, error) {
-	return fauxEncryptedFS{FS: fs}, nil, nil
+) (*EncryptionEnv, error) {
+	return &EncryptionEnv{
+		Closer:         nopCloser{},
+		FS:             fauxEncryptedFS{FS: fs},
+		UpgradeVersion: func() error { return nil },
+	}, nil
 }
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
 
 type fauxEncryptedFS struct {
 	vfs.FS


### PR DESCRIPTION
Use an atomic marker file for signaling which file to read for the data
keys registry. Previously, we replaced `COCKROACHDB_DATA_KEYS` on every
update. This relied on the filesystem rename operation being atomic.
However, when using an `encryptedFS`, renames are not atomic.

Informs #69861.

Release justification: high-severity bug fix

Release note: None

Backport 1/1 commits from #70156.