### PR TITLE
sql: fixing panic on forEachRole function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5329,3 +5329,15 @@ usename       usesuper
 regular_user  false
 root          true
 super_user    true
+
+# Testing null valid until roles
+statement ok
+CREATE USER regression_70180 WITH password '123' VALID UNTIL null;
+
+query TT colnames
+SELECT usename, valuntil
+FROM pg_user
+WHERE usename = 'regression_70180'
+----
+usename           valuntil
+regression_70180  NULL


### PR DESCRIPTION
Previously, forEachRole function panics when having a role with a null
valid until value
This was inadequate because this should not panic
To address this, this patch add a nil check before trying to access the
memory.

Release note: None

Fixes #70180