### PR TITLE
server/diagnostics: fix a span name

### DIFF
--- a/pkg/server/diagnostics/update_checker.go
+++ b/pkg/server/diagnostics/update_checker.go
@@ -100,7 +100,7 @@ func (u *UpdateChecker) PeriodicallyCheckForUpdates(ctx context.Context, stopper
 // The returned boolean indicates if the check succeeded (and thus does not need
 // to be re-attempted by the scheduler after a retry-interval).
 func (u *UpdateChecker) CheckForUpdates(ctx context.Context) bool {
-	ctx, span := u.AmbientCtx.AnnotateCtxWithSpan(ctx, "usageReport")
+	ctx, span := u.AmbientCtx.AnnotateCtxWithSpan(ctx, "version update check")
 	defer span.Finish()
 
 	url := u.buildUpdatesURL(ctx)


### PR DESCRIPTION
A trace span had a copy-pasted bad name.

Release note: None