### PR TITLE
pgcode: use XC instead of CDB

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -268,10 +268,10 @@ SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', false) WHERE i = 2
 statement ok
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', false) WHERE i = 2
 
-statement error pgcode CDB00 bounded staleness read with minimum timestamp bound.*could not be satisfied by a local resolved timestamp
+statement error pgcode XCUBS bounded staleness read with minimum timestamp bound.*could not be satisfied by a local resolved timestamp
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', true) WHERE i = 2
 
-statement error pgcode CDB00 bounded staleness read with minimum timestamp bound.*could not be satisfied by a local resolved timestamp
+statement error pgcode XCUBS bounded staleness read with minimum timestamp bound.*could not be satisfied by a local resolved timestamp
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms', true) WHERE i = 2
 
 #

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -380,10 +380,10 @@ var (
 	// internally on a connection between different Cockroach nodes.
 	InternalConnectionFailure = MakeCode("58C01")
 
-	// Class CDB - cockroach extension.
+	// Class XC - cockroach extension.
 	// CockroachDB distributed system related errors.
 
 	// UnsatisfiableBoundedStaleness signals that the bounded staleness query
 	// cannot be satisfied.
-	UnsatisfiableBoundedStaleness = MakeCode("CDB00")
+	UnsatisfiableBoundedStaleness = MakeCode("XCUBS")
 )


### PR DESCRIPTION
Release note (sql change): Change the pgerror code XC instead of CD
for CockroachDB specific errors. This is because the "C" class is
reserved for the SQL standard. The pgcode `CDB00` used for
unsatisfiable bounded staleness is now `XCUBS`.