### PR TITLE
ui: fixes clock offset rendering on multi-store nodes

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -18,11 +18,7 @@ import {
   AxisUnits,
 } from "src/views/shared/components/metricQuery";
 
-import {
-  GraphDashboardProps,
-  nodeDisplayName,
-  storeIDsForNode,
-} from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function(props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
@@ -158,7 +154,7 @@ export default function(props: GraphDashboardProps) {
             key={nid}
             name="cr.node.clock-offset.meannanos"
             title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            sources={[nid]}
           />
         ))}
       </Axis>


### PR DESCRIPTION
Previously, the clock offset metric was retrieved on a "per-store" basis
for each node which did not match its storage model in the tsdb which is
node-based. This would cause incorrect data to be displayed in the
Runtime dashboard's "Clock Offset" graph when a node contained multiple
stores. We would use `store_id`s to query when we should have been
asking for `node_id`s in the `sources` list in the query.

This change modifies the Clock Offset metric component to request
metrics by `node_id` instead which correctly renders the "Clock Offset"
graph for nodes with multiple stores.

Resolves #69652

Release note (ui change): fix bug where Clock Offset graph rendered
incorrectly on nodes with multiple stores.