### PR TITLE
docs: update readme for cluster-ui

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/README.md
+++ b/pkg/ui/workspaces/cluster-ui/README.md
@@ -132,7 +132,7 @@ and install it from a local tarball. To view a local change to cluster-ui in Coc
 # in the root of cockroachdb/cockroach
 $ make pkg/ui/yarn.protobuf.installed -B
 $ make pkg/ui/yarn.cluster-ui.installed -B
-# in pkg/ui/cluster-ui
+# in pkg/ui/workspaces/cluster-ui
 $ yarn run build
 $ yarn pack --prod
 ```


### PR DESCRIPTION
Previsouly, README in cluster-ui points to an incorrect directory
to run yarn command.
This commit update the directory mentioned in the README.

Release note: None