### PR TITLE
colfetcher: fix the index join when an apply join is present

### DIFF
--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -144,6 +144,11 @@ type Closer interface {
 	// Close releases the resources associated with this Closer. If this Closer
 	// is an Operator, the implementation of Close must be safe to execute even
 	// if Operator.Init wasn't called.
+	//
+	// If this Closer is an execinfra.Releasable, the implementation must be
+	// safe to execute even after Release() was called.
+	// TODO(yuzefovich): refactor this because the Release()'d objects should
+	// not be used anymore.
 	Close() error
 }
 

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -532,7 +532,10 @@ func (s *ColIndexJoin) Close() error {
 		s.tracingSpan.Finish()
 		s.tracingSpan = nil
 	}
-	s.spanAssembler.Close()
+	if s.spanAssembler != nil {
+		// spanAssembler can be nil if Release() has already been called.
+		s.spanAssembler.Close()
+	}
 	s.batch = nil
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -428,3 +428,22 @@ EXPLAIN (VEC) SELECT 'b' IN ('b', a, 'a') FROM t_string
         └ *colexecbase.constBytesOp
           └ *colexecbase.constBytesOp
             └ *colfetcher.ColBatchScan
+
+# Regression test for calling Release() before Close() on a vectorized index
+# joiner (#70000).
+statement ok
+CREATE TABLE table70000_1 (i INT PRIMARY KEY);
+CREATE TABLE table70000_2 (f FLOAT, b BOOL, INDEX f_idx(f));
+
+query T
+EXPLAIN (VEC)
+  SELECT
+    CASE WHEN b THEN (SELECT f FROM table70000_1 LIMIT 1) ELSE f END
+  FROM
+    table70000_2@f_idx;
+----
+│
+└ Node 1
+  └ *sql.planNodeToRowSource
+    └ *colfetcher.ColIndexJoin
+      └ *colfetcher.ColBatchScan


### PR DESCRIPTION
Usually, `colexecop.Closer.Close` is called before
`execinfra.Releasable.Release`; however, in some edge cases (e.g. when
an apply join is present) this order might be reversed. Before this
commit, if these methods are called in the reverse order on the
vectorized index join, a NPE would occur, and this commit fixes the
issue and clarifies the `Closer` interface.

Note that I've audited other vectorized operators for this kind of
a problem and found none. Also, fixing this properly is not easy, so it
is left as a TODO.

Fixes: #70000.
Fixes: #69683.

Release note: None (no stable release with this bug)