### PR TITLE
ui: fix reset sql stats not working on CC Console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlStatsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlStatsApi.ts
@@ -18,5 +18,6 @@ export const resetSQLStats = (): Promise<cockroach.server.serverpb.ResetSQLStats
     cockroach.server.serverpb.ResetSQLStatsResponse,
     RESET_SQL_STATS_PATH,
     cockroach.server.serverpb.ResetSQLStatsRequest,
+    new cockroach.server.serverpb.ResetSQLStatsRequest(),
   );
 };


### PR DESCRIPTION
Previously, CC Console's Reset SQL Stats button didn't work due to
the incorrect HTTP verb. It was sending a GET request to a POST
endpoint, which resulted in 405 response.
This commit address this issue by issuing the correct HTTP request.

Resolves #68604

Release note: None