### PR TITLE
sql: preserve tuple types when decoding

### DIFF
--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -11,7 +11,6 @@
 package colencoding
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -40,7 +39,6 @@ func TestDecodeTableValueToCol(t *testing.T) {
 		typs[i] = ct
 		datums[i] = datum
 		var err error
-		fmt.Println(datum)
 		buf, err = rowenc.EncodeTableValue(buf, descpb.ColumnID(encoding.NoColumnID), datum, scratch)
 		if err != nil {
 			t.Fatal(err)
@@ -49,7 +47,6 @@ func TestDecodeTableValueToCol(t *testing.T) {
 	batch := coldata.NewMemBatchWithCapacity(typs, 1 /* capacity */, coldataext.NewExtendedColumnFactory(nil /*evalCtx */))
 	for i := 0; i < nCols; i++ {
 		typeOffset, dataOffset, _, typ, err := encoding.DecodeValueTag(buf)
-		fmt.Println(typ)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -1060,10 +1060,8 @@ func decodeTuple(a *DatumAlloc, tupTyp *types.T, b []byte) (tree.Datum, []byte, 
 		return nil, nil, err
 	}
 
-	result := tree.DTuple{
-		D: a.NewDatums(len(tupTyp.TupleContents())),
-	}
-
+	result := *(tree.NewDTuple(tupTyp))
+	result.D = a.NewDatums(len(tupTyp.TupleContents()))
 	var datum tree.Datum
 	for i := range tupTyp.TupleContents() {
 		datum, b, err = DecodeTableValue(a, tupTyp.TupleContents()[i], b)

--- a/pkg/sql/rowenc/column_type_encoding_test.go
+++ b/pkg/sql/rowenc/column_type_encoding_test.go
@@ -338,3 +338,22 @@ func TestDecodeTableValueOutOfRangeTimestamp(t *testing.T) {
 		})
 	}
 }
+
+// This test ensures that decoding a tuple value with a specific, labeled tuple
+// type preserves the labels.
+func TestDecodeTupleValueWithType(t *testing.T) {
+	tupleType := types.MakeLabeledTuple([]*types.T{types.Int, types.String}, []string{"a", "b"})
+	datum := tree.NewDTuple(tupleType, tree.NewDInt(tree.DInt(1)), tree.NewDString("foo"))
+	buf, err := rowenc.EncodeTableValue(nil, descpb.ColumnID(encoding.NoColumnID), datum, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	da := rowenc.DatumAlloc{}
+	var decoded tree.Datum
+	decoded, _, err = rowenc.DecodeTableValue(&da, tupleType, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, decoded, datum)
+}


### PR DESCRIPTION
Fixes #70360

Previously, when decoding tuples sent across the wire in DistSQL, tuple
labels were not preserved due to an oversight.

This oversight is now corrected, and tuple labels are now properly
preserved in all queries.

Release note (bug fix): fix a bug preventing tuple type labels from
being propagated across queries when run under DistSQL.