### PR TITLE
util/log: Fix log.Scope

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -73,7 +73,7 @@ type tShim interface {
 // restrictions.
 func Scope(t tShim) *TestLogScope {
 	if logging.showLogs {
-		return newLogScope(t, false /* mostlyInline */)
+		return newLogScope(t, true /* mostlyInline */)
 	}
 
 	scope := ScopeWithoutShowLogs(t)
@@ -97,7 +97,7 @@ func Scope(t tShim) *TestLogScope {
 // TestLogScope.
 func ScopeWithoutShowLogs(t tShim) (sc *TestLogScope) {
 	t.Helper()
-	return newLogScope(t, true /* mostlyInline */)
+	return newLogScope(t, false /* mostlyInline */)
 }
 
 func newLogScope(t tShim, mostlyInline bool) (sc *TestLogScope) {


### PR DESCRIPTION
A previous PR (#70052) flipped the meaning of a boolean
argument but forgot to flip the value passed for the argument,
resulting in the stderr behavior of log.Scope /
log.ScopeWithoutShowLogs to be inverted.

This patch fixes it.

Release note: None