### PR TITLE
build: improve frontend build a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1375,10 +1375,10 @@ UI_OSS_MANIFESTS := $(subst .ccl,.oss,$(UI_CCL_MANIFESTS))
 # [1]: http://savannah.gnu.org/bugs/?19108
 .SECONDARY: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS)
 
-pkg/ui/workspaces/db-console/dist/%.oss.dll.js pkg/ui/workspaces/db-console/%.oss.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(CLUSTER_UI_JS) $(UI_PROTOS_OSS)
+pkg/ui/workspaces/db-console/dist/%.oss.dll.js pkg/ui/workspaces/db-console/%.oss.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(UI_PROTOS_OSS)
 	$(NODE_RUN) -C pkg/ui/workspaces/db-console $(WEBPACK) -p --config webpack.$*.js --env.dist=oss
 
-pkg/ui/workspaces/db-console/dist/%.ccl.dll.js pkg/ui/workspaces/db-console/%.ccl.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(CLUSTER_UI_JS) $(UI_PROTOS_CCL)
+pkg/ui/workspaces/db-console/dist/%.ccl.dll.js pkg/ui/workspaces/db-console/%.ccl.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(UI_PROTOS_CCL)
 	$(NODE_RUN) -C pkg/ui/workspaces/db-console $(WEBPACK) -p --config webpack.$*.js --env.dist=ccl
 
 .PHONY: ui-test
@@ -1398,7 +1398,7 @@ ui-test-debug: $(UI_DLLS) $(UI_MANIFESTS)
 .SECONDARY: pkg/ui/assets.ccl.installed pkg/ui/assets.oss.installed
 pkg/ui/assets.ccl.installed: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_JS_CCL) $(shell find pkg/ui/workspaces/db-console/ccl -type f)
 pkg/ui/assets.oss.installed: $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS) $(UI_JS_OSS)
-pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(shell find pkg/ui/workspaces/db-console/src pkg/ui/workspaces/db-console/styl -type f) | bin/.bootstrap
+pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(CLUSTER_UI_JS) $(shell find pkg/ui/workspaces/db-console/src pkg/ui/workspaces/db-console/styl -type f) | bin/.bootstrap
 	find pkg/ui/dist$*/assets -mindepth 1 -not -name index.html -delete
 	for dll in $(shell find pkg/ui/workspaces/db-console/dist -name '*.dll.js' -type f); do \
 		echo $$dll | sed -E "s/.oss.dll.js|.ccl.dll.js/.dll.js/" | sed -E "s|^.*\/|pkg/ui/dist$*/assets/|" | xargs -I{} cp $$dll {};\

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -81,10 +81,6 @@ module.exports = {
         test: /\.(ts|js)x?$/,
         use: [
           "babel-loader",
-          {
-            loader: "astroturf/loader",
-            options: {extension: ".module.scss"},
-          },
         ],
         exclude: [
           /node_modules/,


### PR DESCRIPTION
make: improve frontend dep ordering
Previously, the protos and vendor bundles were marked as depending on
cluster ui, which is not true.

Now, only the main db console bundle is marked as depending on cluster
ui.

This makes it so that changes to cluster ui do not have to rebuild
protos and vendor bundles unnecessarily.

cluster-ui: improve build speed
1. Remove astroturf loader which was slow but unused
2. Treat antd and protobuf client as external dependencies

Step 2 especially really speeds up the build. We should avoid bundling
the protobuf client at all costs - it is by far the slowest part of the
build.

Release note: None