### PR TITLE
build: don't install optional NPM dependencies with bazel build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,6 +69,9 @@ yarn_install(
     package_json = "//pkg/ui:package.json",
     yarn_lock = "//pkg/ui:yarn.lock",
     strict_visibility = False,
+    args = [
+        "--ignore-optional",
+    ]
 )
 
 # Load gazelle dependencies.


### PR DESCRIPTION
Initially Bazel build ran `yarn_install` rule to install required
dependencies for `ui` projects. But with default configuration, it
installs optional dependencies as well (that are needed only for
front-end development and not required to build entire project).
As result, it caused build failure on freeBSD platforms that don't
support one of optional dependencies (`cypress` test library).

To avoid this, `--ignore-optional` flag is provided to yarn_install
rule to follow the same behavior as defined in Make file for
`pkg/ui/yarn.installed` target.

Resolves #70398

Release note: none