### PR TITLE
release-21.2: sql: gate declarative schema changer behind testing knob

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1302,6 +1302,11 @@ type ExecutorTestingKnobs struct {
 
 	// OnTxnRetry, if set, will be called if there is a transaction retry.
 	OnTxnRetry func(autoRetryReason error, evalCtx *tree.EvalContext)
+
+	// AllowDeclarativeSchemaChanger is used to allow enabling the new,
+	// declarative schema changer. It cannot be enabled without this testing knob
+	// in 21.2.
+	AllowDeclarativeSchemaChanger bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1372,7 +1372,8 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 					ForceProductionBatchSizes:       serverArgs.forceProductionBatchSizes,
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					DeterministicExplain: true,
+					DeterministicExplain:          true,
+					AllowDeclarativeSchemaChanger: true,
 				},
 				SQLStatsKnobs: &sqlstats.TestingKnobs{
 					AOSTClause: "AS OF SYSTEM TIME '-1us'",
@@ -1482,7 +1483,8 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 				AllowSettingClusterSettings: true,
 				TestingKnobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
-						DeterministicExplain: true,
+						DeterministicExplain:          true,
+						AllowDeclarativeSchemaChanger: true,
 					},
 					SQLStatsKnobs: &sqlstats.TestingKnobs{
 						AOSTClause: "AS OF SYSTEM TIME '-1us'",

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -47,7 +47,7 @@ func buildOpaque(
 	scalarProps.Require(stmt.StatementTag(), tree.RejectSubqueries)
 
 	var plan planNode
-	if tree.CanModifySchema(stmt) {
+	if tree.CanModifySchema(stmt) && p.execCfg.TestingKnobs.AllowDeclarativeSchemaChanger {
 		scPlan, usePlan, err := p.SchemaChange(ctx, stmt)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -49,7 +49,13 @@ func TestBuilderAlterTable(t *testing.T) {
 	ctx := context.Background()
 
 	datadriven.Walk(t, filepath.Join("testdata"), func(t *testing.T, path string) {
-		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					AllowDeclarativeSchemaChanger: true,
+				},
+			},
+		})
 		defer s.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -52,7 +52,16 @@ type testInfra struct {
 }
 
 func setupTestInfra(t testing.TB) *testInfra {
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	knobs := base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			AllowDeclarativeSchemaChanger: true,
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: knobs,
+		},
+	})
 	return &testInfra{
 		tc:       tc,
 		settings: tc.Server(0).ClusterSettings(),

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -68,6 +68,9 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 		var kvDB *kv.DB
 		params, _ := tests.CreateTestServerParams()
 		params.Knobs = base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				AllowDeclarativeSchemaChanger: true,
+			},
 			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 				RunBeforeResume: func(jobID jobspb.JobID) error {
 					// Only block in job 2.
@@ -197,6 +200,9 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 		var kvDB *kv.DB
 		params, _ := tests.CreateTestServerParams()
 		params.Knobs = base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				AllowDeclarativeSchemaChanger: true,
+			},
 			SQLNewSchemaChanger: &scexec.NewSchemaChangerTestingKnobs{
 				BeforeStage: func(ops scop.Ops, m scexec.TestingKnobMetadata) error {
 					// Verify that we never queue mutations for job 2 before finishing job
@@ -323,6 +329,9 @@ func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 	var kvDB *kv.DB
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			AllowDeclarativeSchemaChanger: true,
+		},
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeResume: func(jobID jobspb.JobID) error {
 				// Assert that old schema change jobs never run in this test.
@@ -405,7 +414,7 @@ func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 			_, err = conn.ExecContext(ctx, stmt)
 			assert.Truef(t,
 				testutils.IsError(err, `cannot perform a schema change on table "t"`),
-				"statement: %s, error: %s", stmt, err,
+				"statemnt: %s, error: %s", stmt, err,
 			)
 		}
 	}
@@ -428,6 +437,9 @@ func TestInsertDuringAddColumnNotWritingToCurrentPrimaryIndex(t *testing.T) {
 	var kvDB *kv.DB
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			AllowDeclarativeSchemaChanger: true,
+		},
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			RunBeforeResume: func(jobID jobspb.JobID) error {
 				// Assert that old schema change jobs never run in this test.
@@ -569,6 +581,9 @@ func TestDropJobCancelable(t *testing.T) {
 					}
 					return nil
 				},
+			}
+			params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+				AllowDeclarativeSchemaChanger: true,
 			}
 
 			s, sqlDB, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -50,7 +50,13 @@ func TestPlanAlterTable(t *testing.T) {
 	ctx := context.Background()
 
 	datadriven.Walk(t, filepath.Join("testdata"), func(t *testing.T, path string) {
-		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					AllowDeclarativeSchemaChanger: true,
+				},
+			},
+		})
 		defer s.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     size = "large",
     srcs = [
         "bank_test.go",
+        "declarative_schema_changer_knob_test.go",
         "enum_test.go",
         "hash_sharded_test.go",
         "impure_builtin_test.go",

--- a/pkg/sql/tests/declarative_schema_changer_knob_test.go
+++ b/pkg/sql/tests/declarative_schema_changer_knob_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewSchemaChangerKnob ensures that the new schema changer cannot be
+// enabled without a testing knob being set.
+func TestNewSchemaChangerKnob(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutils.RunTrueAndFalse(t, "knob", func(t *testing.T, enabled bool) {
+		ctx := context.Background()
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					AllowDeclarativeSchemaChanger: enabled,
+				},
+			},
+		})
+		defer s.Stopper().Stop(ctx)
+		tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+		tdb.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY, j INT)")
+		// The session variable is allowed but requires the knob to do anything.
+		tdb.Exec(t, "SET experimental_use_new_schema_changer = 'unsafe_always'")
+
+		_, err := sqlDB.Exec("ALTER TABLE t DROP COLUMN j")
+		if enabled {
+			require.Regexp(t,
+				`pq: \*tree.AlterTableDropColumn not implemented in the new schema changer`,
+				err)
+		} else {
+			require.NoError(t, err)
+		}
+	})
+}


### PR DESCRIPTION
There's no reason for us to support code that we really don't want an end-user
to enable. This gate is cheap and effective.

Fixes #70402.

Release note: None