### PR TITLE
.github: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,6 +215,8 @@
 /pkg/multitenant             @cockroachdb/unowned
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/                @cockroachdb/kv-prs
+/pkg/roachpb/app*            @cockroachdb/sql-observability
+/pkg/roachpb/index*          @cockroachdb/sql-observability
 /pkg/rpc/                    @cockroachdb/server-prs
 /pkg/scheduledjobs/          @cockroachdb/bulk-prs
 /pkg/security/               @cockroachdb/server-prs


### PR DESCRIPTION
Hand some files in `roachpb` to SQL-Observability.

Release note: None
