### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,7 +126,7 @@
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
 /pkg/ccl/gssapiccl/          @cockroachdb/sql-queries
 /pkg/ccl/kvccl/              @cockroachdb/kv-noreview
-/pkg/ccl/migrationccl/       @cockroachdb/kv-prs
+/pkg/ccl/migrationccl/       @cockroachdb/kv-prs-noreview
 /pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/unowned
@@ -211,7 +211,7 @@
 /pkg/keys/                   @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 /pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
-/pkg/migration/              @cockroachdb/kv-prs @cockroachdb/sql-schema
+/pkg/migration/              @cockroachdb/kv-prs-noreview @cockroachdb/sql-schema
 /pkg/multitenant             @cockroachdb/unowned
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/                @cockroachdb/kv-prs


### PR DESCRIPTION
Don't solicit KV reviews for changes to the migration packages.