### PR TITLE
spanconfig: fix an erroneous usage of timeutil.Timer

### DIFF
--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -154,12 +154,9 @@ func (m *Manager) run(ctx context.Context) {
 		timer.Reset(checkReconciliationJobInterval.Get(&m.settings.SV))
 		select {
 		case <-jobCheckCh:
-			timer.Read = true
-
 			checkJob()
 		case <-timer.C:
 			timer.Read = true
-
 			checkJob()
 		case <-m.stopper.ShouldQuiesce():
 			return


### PR DESCRIPTION
The contract for timeutil.Timer indicates that we should only be
setting .Read when reading from the timer channel, not unconditionally
before a call to .Reset().

Release note: None