### PR TITLE
release-21.1: roachtest: ignore flaky hibernate test

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/hibernate_blocklist.go
@@ -202,4 +202,6 @@ var hibernateBlockList20_2 = blocklist{
 
 var hibernateIgnoreList21_2 = hibernateIgnoreList21_1
 
-var hibernateIgnoreList21_1 = blocklist{}
+var hibernateIgnoreList21_1 = blocklist{
+	"org.hibernate.userguide.pc.WhereTest.testLifecycle": "flaky",
+}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/69629

This test started flaking during setup, and doesn't cover an important
feature.

Release justification: test only change

Release note: None