### PR TITLE
parser: change SESSION USER to use session_user

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -25,10 +25,10 @@ statement error pgcode 22023 role node does not exist
 SET ROLE node
 
 # Check root can reset and become itself.
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-root  root
+root  root  root  root
 
 query T
 SHOW ROLE
@@ -41,10 +41,10 @@ RESET ROLE
 statement error pgcode 22023 role non_existent_user does not exist
 SET ROLE non_existent_user
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-root  root
+root  root  root  root
 
 query T
 SHOW ROLE
@@ -54,10 +54,10 @@ root
 statement ok
 SET ROLE = root
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-root  root
+root  root  root  root
 
 query T
 SHOW ROLE
@@ -73,10 +73,10 @@ SELECT * FROM testuser_table
 statement ok
 SET ROLE = 'testuser'
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  root
+testuser  testuser  root  root
 
 query T
 SHOW is_superuser
@@ -111,10 +111,10 @@ CREATE USER testuser2
 statement ok
 SET ROLE testuser2
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser2  root
+testuser2  testuser2  root  root
 
 query T
 SHOW is_superuser
@@ -124,10 +124,10 @@ off
 statement ok
 SET ROLE = 'NoNe'
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-root  root
+root  root  root  root
 
 query T
 SHOW is_superuser
@@ -137,10 +137,10 @@ on
 # Check testuser cannot transition to other users as it has no privileges.
 user testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser
+testuser  testuser  testuser  testuser
 
 query T
 SHOW ROLE
@@ -150,10 +150,10 @@ none
 statement ok
 SET ROLE testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser
+testuser  testuser  testuser  testuser
 
 query T
 SHOW ROLE
@@ -183,10 +183,10 @@ SET ROLE root
 statement ok
 SET ROLE testuser2
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser2  testuser
+testuser2  testuser2  testuser  testuser
 
 query T
 SHOW is_superuser
@@ -202,10 +202,10 @@ SELECT * FROM no_priv_t
 statement ok
 RESET ROLE
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser
+testuser  testuser  testuser  testuser
 
 query T
 SHOW is_superuser
@@ -225,18 +225,18 @@ SET ROLE testuser
 statement ok
 SET ROLE testuser2
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser2  testuser2
+testuser2  testuser2  testuser2  testuser2
 
 statement ok
 RESET ROLE
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser2  testuser2
+testuser2  testuser2  testuser2  testuser2
 
 # Set testuser2 as admin, check testuser2 can become testuser
 user root
@@ -249,10 +249,10 @@ user testuser2
 statement ok
 SET ROLE testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser2
+testuser  testuser  testuser2  testuser2
 
 statement ok
 RESET ROLE
@@ -276,18 +276,18 @@ user testuser2
 statement ok
 SET ROLE testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser2
+testuser  testuser  testuser2  testuser2
 
 statement ok
 SET ROLE testrole
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testrole  testuser2
+testrole  testrole  testuser2  testuser2
 
 statement ok
 RESET ROLE
@@ -307,10 +307,10 @@ REVOKE admin FROM testuser
 
 user testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser2  testuser
+testuser2  testuser2  testuser  testuser
 
 statement error pgcode 42501 permission denied to set role "testuser2"
 SET ROLE testuser2
@@ -318,10 +318,10 @@ SET ROLE testuser2
 statement ok
 SET ROLE 'none'
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  testuser
+testuser  testuser  testuser  testuser
 
 
 # SET ROLE is specially cased in SET LOCAL as it uses SetWithPlanner,
@@ -335,10 +335,10 @@ GRANT ADMIN TO testuser;
 BEGIN;
 SET LOCAL ROLE testuser
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-testuser  root
+testuser  testuser  root  root
 
 query T
 SELECT user_name FROM crdb_internal.node_sessions
@@ -349,10 +349,10 @@ root
 statement ok
 ROLLBACK
 
-query TT
-SELECT current_user, session_user()
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
 ----
-root  root
+root  root  root  root
 
 statement ok
 SET ROLE testuser

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11744,7 +11744,7 @@ func_expr_common_subexpr:
   }
 | SESSION_USER
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("current_user")}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("session_user")}
   }
 | USER
   {

--- a/pkg/sql/parser/testdata/predefined_functions
+++ b/pkg/sql/parser/testdata/predefined_functions
@@ -113,10 +113,10 @@ SELECT current_user() -- identifiers removed
 parse
 SELECT SESSION_USER
 ----
-SELECT current_user() -- normalized!
-SELECT (current_user()) -- fully parenthesized
-SELECT current_user() -- literals removed
-SELECT current_user() -- identifiers removed
+SELECT session_user() -- normalized!
+SELECT (session_user()) -- fully parenthesized
+SELECT session_user() -- literals removed
+SELECT session_user() -- identifiers removed
 
 parse
 SELECT USER


### PR DESCRIPTION
Correct SESSION USER to actually use the session_user builtin. This
should not affect default expressions because they store the full
builtin name instead of the parsing syntax.


Resolves #69268

Release note (backward-incompatible change, sql change): Using `SESSION
USER` in a projection or where clause now actually returns the SESSION
USER instead of the CURRENT USER. If you require this to be backwards
compatible, use `session_user()` for SESSION USER and `current_user()`
or `CURRENT USER` if you need the CURRENT USER.