### PR TITLE
sql: throw pgerror instead of assertion error for bad OID strings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -521,3 +521,7 @@ query O
 SELECT $regression_62205_oid::regclass
 ----
 regression_62205
+
+# Check we error as appropriate if the OID type is not legit.
+statement error pgcode 22P02 invalid input syntax for type oid: "regression_69907"
+SELECT 'regression_69907'::oid

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -55,7 +55,12 @@ func resolveOID(
 ) (*tree.DOid, error) {
 	info, ok := regTypeInfos[resultType.Oid()]
 	if !ok {
-		return nil, errors.AssertionFailedf("illegal oid type %v", resultType)
+		return nil, pgerror.Newf(
+			pgcode.InvalidTextRepresentation,
+			"invalid input syntax for type %s: %q",
+			resultType,
+			tree.AsStringWithFlags(toResolve, tree.FmtBareStrings),
+		)
 	}
 	queryCol := info.nameCol
 	if _, isOid := toResolve.(*tree.DOid); isOid {


### PR DESCRIPTION
Resolves #69907

Release note (sql change): Return a pgerror with code 42704 when an
invalid cast to OID is made. This previously threw an assertion error.