### PR TITLE
colexecop: harden CloseAndLogOnErr against panics

### DIFF
--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -160,11 +160,15 @@ type Closers []Closer
 // Note: this method should *only* be used when returning an error doesn't make
 // sense.
 func (c Closers) CloseAndLogOnErr(ctx context.Context, prefix string) {
-	prefix += ":"
-	for _, closer := range c {
-		if err := closer.Close(); err != nil && log.V(1) {
-			log.Infof(ctx, "%s error closing Closer: %v", prefix, err)
+	if err := colexecerror.CatchVectorizedRuntimeError(func() {
+		prefix += ":"
+		for _, closer := range c {
+			if err := closer.Close(); err != nil && log.V(1) {
+				log.Infof(ctx, "%s error closing Closer: %v", prefix, err)
+			}
 		}
+	}); err != nil && log.V(1) {
+		log.Infof(ctx, "%s runtime error closing the closers: %v", prefix, err)
 	}
 }
 


### PR DESCRIPTION
We have seen a few cases where closing the `Closer`s would lead to
a panic which wasn't caught because we're outside of the panic-catcher
scope. This commit adds a panic-catcher to `CloseAndLogOnErr` (which is
the "root" way of closing things) in order to increase the stability of
CRDB in face of edge case bugs.

Addresses: #70000.
Addresses: #70438.

Release note: None