### PR TITLE
release-21.2: changefeedccl: Issue a flush request when waiting for more memory.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -496,6 +496,8 @@ func (ca *changeAggregator) tick() error {
 		if ca.knobs.ShouldSkipResolved == nil || !ca.knobs.ShouldSkipResolved(resolved) {
 			return ca.noteResolvedSpan(resolved)
 		}
+	case kvevent.TypeFlush:
+		return ca.sink.Flush(ca.Ctx)
 	}
 
 	return nil

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -95,7 +95,7 @@ func TestBlockingBuffer(t *testing.T) {
 		for {
 			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
 			if err != nil {
-				return nil
+				return err
 			}
 		}
 	})
@@ -110,4 +110,52 @@ func TestBlockingBuffer(t *testing.T) {
 		a.Release(context.Background())
 	}
 	stopProducers()
+}
+
+func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	metrics := kvevent.MakeMetrics(time.Minute)
+	ba, release := getBoundAccountWithBudget(4096)
+	defer release()
+
+	st := cluster.MakeTestingClusterSettings()
+	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)
+	defer func() {
+		require.NoError(t, buf.Close(context.Background()))
+	}()
+
+	producerCtx, stopProducer := context.WithCancel(context.Background())
+	wg := ctxgroup.WithContext(producerCtx)
+	defer func() {
+		_ = wg.Wait() // Ignore error -- this group returns context cancellation.
+	}()
+
+	// Start adding KVs to the buffer until we block.
+	wg.GoCtx(func(ctx context.Context) error {
+		rnd, _ := randutil.NewTestPseudoRand()
+		for {
+			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
+			if err != nil {
+				return err
+			}
+		}
+	})
+
+	// Consume events until we get a flush event.
+	var outstanding kvevent.Alloc
+	for i := 0; ; i++ {
+		e, err := buf.Get(context.Background())
+		require.NoError(t, err)
+		if e.Type() == kvevent.TypeFlush {
+			break
+		}
+
+		// detach alloc associated with an event and merge (but not release) it into outstanding.
+		a := e.DetachAlloc()
+		outstanding.Merge(&a)
+	}
+
+	stopProducer()
 }

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -62,6 +62,11 @@ const (
 	// meaningful.
 	TypeResolved
 
+	// TypeFlush indicates a request to flush buffered data.
+	// This request type is emitted by blocking buffer when it's blocked, waiting
+	// for more memory.
+	TypeFlush
+
 	// TypeUnknown indicates the event could not be parsed. Will fail the feed.
 	TypeUnknown
 )
@@ -71,6 +76,7 @@ const (
 type Event struct {
 	kv                 roachpb.KeyValue
 	prevVal            roachpb.Value
+	flush              bool
 	resolved           *jobspb.ResolvedSpan
 	backfillTimestamp  hlc.Timestamp
 	bufferGetTimestamp time.Time
@@ -85,6 +91,9 @@ func (b *Event) Type() Type {
 	}
 	if b.resolved != nil {
 		return TypeResolved
+	}
+	if b.flush {
+		return TypeFlush
 	}
 	return TypeUnknown
 }

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -467,7 +467,7 @@ func copyFromSourceToDestUntilTableEvent(
 		}
 		addEntry = func(e kvevent.Event) error {
 			switch e.Type() {
-			case kvevent.TypeKV:
+			case kvevent.TypeKV, kvevent.TypeFlush:
 				return dest.Add(ctx, e)
 			case kvevent.TypeResolved:
 				// TODO(ajwerner): technically this doesn't need to happen for most


### PR DESCRIPTION
Backport 1/1 commits from #70383.

/cc @cockroachdb/release

---

The blocking buffer enables changefeeds to limit the amount of
ingested messages based on the available memory.  The memory required
to process an event is allocated once the event has been admitted,
and is released once the message has been emitted to the sink.

Some sinks (e.g. cloud storage sinks) buffer user configurable
number of events.  While the sink has buffered events, it does not
release memory.  Thus, it is possible that all of the previously ingested
events are buffered (but the amount of buffered data is below user
defined threshold), while we cannot ingest any more events because
of memory pushback.  This results in changefeeds being stuck.

This change allows the blocking buffer to signal the event consumer
that it should flush its data.  The signaling is accomplished via a new
type of event -- the flush event.  The event consumer, upon seeing such event
flushes its sink, thus releasing memory and making it possible to make
forward progress.

Fixes #70248

Release Justification: Fix to a newly added functionality to prevent stuck
changefeeds.

Release Notes: None.
