### PR TITLE
changefeedccl: don't test non-error condition in error test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3303,11 +3303,6 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH webhook_sink_config='{"Retry": {"Max": -1}}'`,
 		`webhook-https://fake-host`,
 	)
-	sqlDB.ExpectErr(
-		t, ``,
-		`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, webhook_sink_config='{"Retry":{"Max":"inf"}}'`,
-		`webhook-https://fake-host`,
-	)
 
 	// Sanity check on_error option
 	sqlDB.ExpectErr(


### PR DESCRIPTION
This tested a successful statement in our TestChangefeedErrors test,
which left us in a somewhat unexpected state when investigating #70301.

Further, I think passing an empty string to ExpectErr is confusing, so
I've disallowed it.

Release note: None