### PR TITLE
kv: use correct reason for `TransactionStatusError`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -669,7 +669,11 @@ func (tc *TxnCoordSender) maybeRejectClientLocked(
 			"Trying to execute: %s", ba.Summary())
 		stack := string(debug.Stack())
 		log.Errorf(ctx, "%s. stack:\n%s", msg, stack)
-		return roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(msg), &tc.mu.txn)
+		reason := roachpb.TransactionStatusError_REASON_UNKNOWN
+		if tc.mu.txn.Status == roachpb.COMMITTED {
+			reason = roachpb.TransactionStatusError_REASON_TXN_COMMITTED
+		}
+		return roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(reason, msg), &tc.mu.txn)
 	}
 
 	// Check the transaction proto state, along with any finalized transaction

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -453,8 +453,8 @@ func TestTxnCoordSenderCommitCanceled(t *testing.T) {
 	_, pErr := txn.Send(ctx, ba)
 	require.NotNil(t, pErr)
 	require.IsType(t, &roachpb.TransactionStatusError{}, pErr.GetDetail())
-	// TODO(erikgrinaker): This should really assert REASON_TXN_COMMITTED, but
-	// we return REASON_TXN_UNKNOWN to preserve existing EndTxn behavior.
+	txnErr := pErr.GetDetail().(*roachpb.TransactionStatusError)
+	require.Equal(t, roachpb.TransactionStatusError_REASON_TXN_COMMITTED, txnErr.Reason)
 }
 
 // TestTxnCoordSenderAddLockOnError verifies that locks are tracked if the

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -238,7 +238,9 @@ func EndTxn(
 			// meantime. The TransactionStatusError is going to be handled by the
 			// txnCommitter interceptor.
 			log.VEventf(ctx, 2, "transaction found to be already committed")
-			return result.Result{}, roachpb.NewTransactionCommittedStatusError()
+			return result.Result{}, roachpb.NewTransactionStatusError(
+				roachpb.TransactionStatusError_REASON_TXN_COMMITTED,
+				"already committed")
 
 		case roachpb.ABORTED:
 			if !args.Commit {

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -61,6 +61,8 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 	restartedAndPushedHeaderTxn := txn.Clone()
 	restartedAndPushedHeaderTxn.Restart(-1, 0, ts2)
 	restartedAndPushedHeaderTxn.WriteTimestamp.Forward(ts3)
+	committedHeaderTxn := txn.Clone()
+	committedHeaderTxn.Status = roachpb.COMMITTED
 
 	pendingRecord := func() *roachpb.TransactionRecord {
 		record := txn.AsRecord()
@@ -829,6 +831,16 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expError: "TransactionStatusError: already committed (REASON_TXN_COMMITTED)",
 		},
 		{
+			name: "record and header committed, try rollback",
+			// Replica state.
+			existingTxn: committedRecord,
+			// Request state.
+			headerTxn: committedHeaderTxn,
+			commit:    false,
+			// Expected result.
+			expError: "TransactionStatusError: cannot perform EndTxn with txn status COMMITTED (REASON_TXN_COMMITTED)",
+		},
+		{
 			name: "record committed, try stage",
 			// Replica state.
 			existingTxn: committedRecord,
@@ -848,6 +860,16 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			commit:    true,
 			// Expected result.
 			expError: "TransactionStatusError: already committed (REASON_TXN_COMMITTED)",
+		},
+		{
+			name: "record and header committed, try commit",
+			// Replica state.
+			existingTxn: committedRecord,
+			// Request state.
+			headerTxn: committedHeaderTxn,
+			commit:    true,
+			// Expected result.
+			expError: "TransactionStatusError: cannot perform EndTxn with txn status COMMITTED (REASON_TXN_COMMITTED)",
 		},
 		{
 			name: "record aborted, try stage",

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -12,7 +12,6 @@ package batcheval
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -114,20 +113,20 @@ func RecoverTxn(
 			// harmless, but we now use the timestamp cache to avoid
 			// needing to ever do so. If this ever becomes possible again, we'll
 			// need to relax this check.
-			return result.Result{}, roachpb.NewTransactionStatusError(fmt.Sprintf(
+			return result.Result{}, errors.AssertionFailedf(
 				"programming error: found %s record for implicitly committed transaction: %v",
 				reply.RecoveredTxn.Status, reply.RecoveredTxn,
-			))
+			)
 		case roachpb.STAGING, roachpb.COMMITTED:
 			if was, is := args.Txn.Epoch, reply.RecoveredTxn.Epoch; was != is {
-				return result.Result{}, roachpb.NewTransactionStatusError(fmt.Sprintf(
+				return result.Result{}, errors.AssertionFailedf(
 					"programming error: epoch change by implicitly committed transaction: %v->%v", was, is,
-				))
+				)
 			}
 			if was, is := args.Txn.WriteTimestamp, reply.RecoveredTxn.WriteTimestamp; was != is {
-				return result.Result{}, roachpb.NewTransactionStatusError(fmt.Sprintf(
+				return result.Result{}, errors.AssertionFailedf(
 					"programming error: timestamp change by implicitly committed transaction: %v->%v", was, is,
-				))
+				)
 			}
 			if reply.RecoveredTxn.Status == roachpb.COMMITTED {
 				// The transaction commit was already made explicit.
@@ -135,9 +134,7 @@ func RecoverTxn(
 			}
 			// Continue with recovery.
 		default:
-			return result.Result{}, roachpb.NewTransactionStatusError(
-				fmt.Sprintf("bad txn status: %s", reply.RecoveredTxn),
-			)
+			return result.Result{}, errors.AssertionFailedf("bad txn status: %s", reply.RecoveredTxn)
 		}
 	} else {
 		// Did the transaction change its epoch or timestamp in such a
@@ -177,9 +174,9 @@ func RecoverTxn(
 			// We should never hit this. The transaction recovery process will only
 			// ever be launched for a STAGING transaction and it is not possible for
 			// a transaction to move back to the PENDING status in the same epoch.
-			return result.Result{}, roachpb.NewTransactionStatusError(fmt.Sprintf(
+			return result.Result{}, errors.AssertionFailedf(
 				"programming error: cannot recover PENDING transaction in same epoch: %s", reply.RecoveredTxn,
-			))
+			)
 		case roachpb.STAGING:
 			if legalChange {
 				// Recovery not immediately needed because the transaction is
@@ -188,9 +185,7 @@ func RecoverTxn(
 			}
 			// Continue with recovery.
 		default:
-			return result.Result{}, roachpb.NewTransactionStatusError(
-				fmt.Sprintf("bad txn status: %s", reply.RecoveredTxn),
-			)
+			return result.Result{}, errors.AssertionFailedf("bad txn status: %s", reply.RecoveredTxn)
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/transaction.go
+++ b/pkg/kv/kvserver/batcheval/transaction.go
@@ -45,9 +45,12 @@ func VerifyTransaction(
 		}
 	}
 	if !statusPermitted {
-		return roachpb.NewTransactionStatusError(
-			fmt.Sprintf("cannot perform %s with txn status %v", args.Method(), h.Txn.Status),
-		)
+		reason := roachpb.TransactionStatusError_REASON_UNKNOWN
+		if h.Txn.Status == roachpb.COMMITTED {
+			reason = roachpb.TransactionStatusError_REASON_TXN_COMMITTED
+		}
+		return roachpb.NewTransactionStatusError(reason,
+			fmt.Sprintf("cannot perform %s with txn status %v", args.Method(), h.Txn.Status))
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -609,7 +609,10 @@ func (q *Queue) MaybeWaitForPush(
 			switch updatedPusher.Status {
 			case roachpb.COMMITTED:
 				log.VEventf(ctx, 1, "pusher committed: %v", updatedPusher)
-				return nil, roachpb.NewErrorWithTxn(roachpb.NewTransactionCommittedStatusError(), updatedPusher)
+				return nil, roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(
+					roachpb.TransactionStatusError_REASON_TXN_COMMITTED,
+					"already committed"),
+					updatedPusher)
 			case roachpb.ABORTED:
 				log.VEventf(ctx, 1, "pusher aborted: %v", updatedPusher)
 				return nil, roachpb.NewErrorWithTxn(

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -805,21 +805,14 @@ func (*TransactionRetryError) canRestartTransaction() TransactionRestart {
 var _ ErrorDetailInterface = &TransactionRetryError{}
 var _ transactionRestartError = &TransactionRetryError{}
 
-// NewTransactionStatusError initializes a new TransactionStatusError from
-// the given message.
-func NewTransactionStatusError(msg string) *TransactionStatusError {
+// NewTransactionStatusError initializes a new TransactionStatusError with
+// the given message and reason.
+func NewTransactionStatusError(
+	reason TransactionStatusError_Reason, msg string,
+) *TransactionStatusError {
 	return &TransactionStatusError{
 		Msg:    msg,
-		Reason: TransactionStatusError_REASON_UNKNOWN,
-	}
-}
-
-// NewTransactionCommittedStatusError initializes a new TransactionStatusError
-// with a REASON_TXN_COMMITTED.
-func NewTransactionCommittedStatusError() *TransactionStatusError {
-	return &TransactionStatusError{
-		Msg:    "already committed",
-		Reason: TransactionStatusError_REASON_TXN_COMMITTED,
+		Reason: reason,
 	}
 }
 


### PR DESCRIPTION
The `TransactionStatusError.Reason` field was often left to its default
value `REASON_UNKNOWN`, even in cases where the txn had been committed
and the reason should have been `REASON_TXN_COMMITTED`.

Since we have code that branches based on the reason, this patch makes
the reason a required argument for `NewTransactionStatusError` and sets
an appropriate reason for all call sites. A few errors were also changed
to `AssertionFailedf` instead, where suitable, and
`NewTransactionCommittedStatusError` was replaced.

Resolves #69965.

Release note: None