### PR TITLE
vendor: bump Pebble to 9509dcb7a53a

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -651,8 +651,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:NBzearGbADR609fptc7ATDj14I2Gji7ne2mphj0j+r4=",
-        version = "v0.0.0-20210914174700-0f7e73483566",
+        sum = "h1:BV8fDvAogQeaAUCgx/8/6J/Sv/enyfkJ10l5bTAcQWI=",
+        version = "v0.0.0-20210921140715-9509dcb7a53a",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210914174700-0f7e73483566
+	github.com/cockroachdb/pebble v0.0.0-20210921140715-9509dcb7a53a
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210914174700-0f7e73483566 h1:NBzearGbADR609fptc7ATDj14I2Gji7ne2mphj0j+r4=
-github.com/cockroachdb/pebble v0.0.0-20210914174700-0f7e73483566/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210921140715-9509dcb7a53a h1:BV8fDvAogQeaAUCgx/8/6J/Sv/enyfkJ10l5bTAcQWI=
+github.com/cockroachdb/pebble v0.0.0-20210921140715-9509dcb7a53a/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
9509dcb compaction: fix nil pointer during errored compactions
d27f1d7 internal/base: add SetWithDelete key kind
971533d base: add `InternalKeyKindSeparator`
3f0c125 cmd/pebble: specify format major version
```

Informs #70443.

Release note: none