### PR TITLE
backupccl: unskip TestRestoreOldVersions

### DIFF
--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -60,7 +60,6 @@ import (
 //
 func TestRestoreOldVersions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 70154, "flaky test")
 	defer log.Scope(t).Close(t)
 	const (
 		testdataBase                = "testdata/restore_old_versions"


### PR DESCRIPTION
This test was skipped because of #70154. Although we saw two recent
failures, we do expect this to be very infrequent and a long-existing
bug that may affect any unit test with an engine. There's no need to
keep this test skipped until we resolve it.

Release note: None