### PR TITLE
rowenc: error when encoding NULLs for PK columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -362,3 +362,11 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Regression test for #69867
+statement error pgcode 23502 null value in column "x" violates not-null constraint
+BEGIN;
+CREATE TABLE foo69867 (x PRIMARY KEY) AS VALUES (1), (NULL);
+
+statement ok
+ROLLBACK

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/lex",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/bitarray",

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -185,7 +185,7 @@ func TestIndexKey(t *testing.T) {
 		valuesLen := randutil.RandIntInRange(rng, len(t.primaryInterleaves)+1, len(t.primaryInterleaves)+10)
 		t.primaryValues = make([]tree.Datum, valuesLen)
 		for j := range t.primaryValues {
-			t.primaryValues[j] = randgen.RandDatum(rng, types.Int, true)
+			t.primaryValues[j] = randgen.RandDatum(rng, types.Int, false /* nullOk */)
 		}
 
 		t.secondaryInterleaves = make([]descpb.ID, rng.Intn(10))
@@ -195,7 +195,7 @@ func TestIndexKey(t *testing.T) {
 		valuesLen = randutil.RandIntInRange(rng, len(t.secondaryInterleaves)+1, len(t.secondaryInterleaves)+10)
 		t.secondaryValues = make([]tree.Datum, valuesLen)
 		for j := range t.secondaryValues {
-			t.secondaryValues[j] = randgen.RandDatum(rng, types.Int, true)
+			t.secondaryValues[j] = randgen.RandDatum(rng, types.Int, true /* nullOk */)
 		}
 
 		tests = append(tests, t)
@@ -1089,11 +1089,17 @@ func TestIndexKeyEquivSignature(t *testing.T) {
 			// Column values should be at the beginning of the
 			// remaining bytes of the key.
 			pkIndexDesc := desc.GetPrimaryIndex().IndexDesc()
-			colVals, null, err := EncodeColumns(pkIndexDesc.KeyColumnIDs, pkIndexDesc.KeyColumnDirections, colMap, tc.table.values, nil /*key*/)
+			colVals, nullColID, err := EncodeColumns(
+				pkIndexDesc.KeyColumnIDs,
+				pkIndexDesc.KeyColumnDirections,
+				colMap,
+				tc.table.values,
+				nil, /* keyPrefix */
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if null {
+			if nullColID != 0 {
 				t.Fatalf("unexpected null values when encoding expected column values")
 			}
 


### PR DESCRIPTION
This commit adds a validation check to rowenc.EncodeIndexKey to have it
return an error when it encodes a NULL value for a primary key column.

Fixes #69867.

Release note: None