### PR TITLE
sql: add telemetry for ON UPDATE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2842,6 +2842,9 @@ func incTelemetryForNewColumn(def *tree.ColumnTableDef, desc *descpb.ColumnDescr
 			telemetry.Inc(sqltelemetry.SchemaNewColumnTypeQualificationCounter("unique"))
 		}
 	}
+	if desc.HasOnUpdate() {
+		telemetry.Inc(sqltelemetry.SchemaNewColumnTypeQualificationCounter("on_update"))
+	}
 }
 
 func regionalByRowRegionDefaultExpr(oid oid.Oid, region tree.Name) tree.Expr {

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -94,3 +94,30 @@ feature-usage
 CREATE OR REPLACE VIEW cor_view AS SELECT 1
 ----
 sql.schema.create_or_replace_view
+
+feature-allowlist
+sql.schema.*
+----
+
+feature-usage
+CREATE TABLE on_update_t (a INT PRIMARY KEY, b INT8 DEFAULT 1 ON UPDATE 2)
+----
+sql.schema.create_table
+sql.schema.new_column.qualification.default_expr
+sql.schema.new_column.qualification.on_update
+sql.schema.new_column_type.int8
+
+feature-usage
+ALTER TABLE on_update_t ADD COLUMN c INT DEFAULT 1 ON UPDATE 2;
+----
+sql.schema.alter_table
+sql.schema.alter_table.add_column
+sql.schema.new_column.qualification.default_expr
+sql.schema.new_column.qualification.on_update
+sql.schema.new_column_type.int8
+
+feature-usage
+ALTER TABLE on_update_t ALTER COLUMN b SET ON UPDATE 3
+----
+sql.schema.alter_table
+sql.schema.alter_table.set_on_update


### PR DESCRIPTION
This commit is to add telemetry for a column
created / altered with `ON UPDATE` syntax.

Release Note: None