### PR TITLE
sql: improve casting from JSON types

### DIFF
--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -1133,9 +1133,19 @@ eval
 ----
 'hello t'
 
-# Test that numeric jsonb values can be cast to a numeric data type
+# Test that numeric jsonb values can be cast to a numeric data type.
 eval
 '1'::jsonb::int
+----
+1
+
+eval
+'1'::jsonb::int4
+----
+1
+
+eval
+'1'::jsonb::int2
 ----
 1
 
@@ -1160,6 +1170,11 @@ eval
 2
 
 eval
+'1.5'::jsonb::int
+----
+2
+
+eval
 '2.0'::jsonb::float
 ----
 2.0
@@ -1180,29 +1195,65 @@ eval
 3.14
 
 eval
+'3.14'::jsonb::float4
+----
+3.14
+
+eval
 '3.14'::jsonb::decimal
 ----
 3.14
 
 eval
+'9223372036854775808'::jsonb::int
+----
+integer out of range
+
+eval
+'"1"'::jsonb::int
+----
+cannot cast jsonb string to type int
+
+eval
 'true'::jsonb::float
 ----
-invalid cast: jsonb -> float
+cannot cast jsonb boolean to type float
 
 eval
 'null'::jsonb::float
 ----
-invalid cast: jsonb -> float
+cannot cast jsonb null to type float
 
 eval
 '{}'::jsonb::float
 ----
-invalid cast: jsonb -> float
+cannot cast jsonb object to type float
 
 eval
 '[]'::jsonb::float
 ----
-invalid cast: jsonb -> float
+cannot cast jsonb array to type float
+
+eval
+'"1"'::jsonb::decimal
+----
+cannot cast jsonb string to type decimal
+
+# Test that boolean jsonb values can be cast to a BOOL.
+eval
+'true'::jsonb::bool
+----
+true
+
+eval
+'false'::jsonb::bool
+----
+false
+
+eval
+'1'::jsonb::bool
+----
+cannot cast jsonb numeric to type bool
 
 # "char" is supposed to truncate long values
 eval

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -571,6 +571,18 @@ func (j *jsonEncoded) AsDecimal() (*apd.Decimal, bool) {
 	return decoded.AsDecimal()
 }
 
+func (j *jsonEncoded) AsBool() (bool, bool) {
+	if dec := j.alreadyDecoded(); dec != nil {
+		return dec.AsBool()
+	}
+
+	decoded, err := j.decode()
+	if err != nil {
+		return false, false
+	}
+	return decoded.AsBool()
+}
+
 func (j *jsonEncoded) Compare(other JSON) (int, error) {
 	if other == nil {
 		return -1, nil

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -49,6 +49,25 @@ const (
 	ObjectJSONType
 )
 
+func (t Type) String() string {
+	switch t {
+	case NullJSONType:
+		return "null"
+	case StringJSONType:
+		return "string"
+	case NumberJSONType:
+		return "numeric"
+	case FalseJSONType, TrueJSONType:
+		return "boolean"
+	case ArrayJSONType:
+		return "array"
+	case ObjectJSONType:
+		return "object"
+	default:
+		panic(errors.AssertionFailedf("unknown JSON type %d", int(t)))
+	}
+}
+
 const (
 	wordSize          = unsafe.Sizeof(big.Word(0))
 	decimalSize       = unsafe.Sizeof(apd.Decimal{})
@@ -154,8 +173,12 @@ type JSON interface {
 	AsText() (*string, error)
 
 	// AsDecimal returns the JSON document as a apd.Decimal if it is a numeric
-	// type, and a boolean inidicating if this JSON document is a numeric type.
+	// type, and a boolean indicating if this JSON value is a numeric type.
 	AsDecimal() (*apd.Decimal, bool)
+
+	// AsBool returns the JSON document as a boolean if it is a boolean type,
+	// and a boolean indicating if this JSON value is a bool type.
+	AsBool() (bool, bool)
 
 	// Exists implements the `?` operator: does the string exist as a top-level
 	// key within the JSON value?
@@ -450,6 +473,14 @@ func (j jsonNumber) AsDecimal() (*apd.Decimal, bool) {
 	d := apd.Decimal(j)
 	return &d, true
 }
+
+func (j jsonNull) AsBool() (bool, bool)   { return false, false }
+func (j jsonFalse) AsBool() (bool, bool)  { return false, true }
+func (j jsonTrue) AsBool() (bool, bool)   { return true, true }
+func (j jsonString) AsBool() (bool, bool) { return false, false }
+func (j jsonArray) AsBool() (bool, bool)  { return false, false }
+func (j jsonObject) AsBool() (bool, bool) { return false, false }
+func (j jsonNumber) AsBool() (bool, bool) { return false, false }
 
 func (j jsonNull) tryDecode() (JSON, error)   { return j, nil }
 func (j jsonFalse) tryDecode() (JSON, error)  { return j, nil }


### PR DESCRIPTION
This commit improves the behavior of casts from JSON types to other
types in three ways.

  1. Casting from a `JSON` boolean value to a `BOOL` is now possible.
  2. Casting a `JSON` numeric with a fraction to an INT now rounds the
     number to the closest integer. This matches Postgres's behavior.
  3. Error message for casting invalid JSON types to some type (e.g.
     `'"a"'::JSON::INT`) are now more clear. Instead of stating "invalid
     cast", it mentions that the cast failed. This is more accurate
     because the cast is valid, it just failed. It more closely matches
     Postgres's behavior.

This is preliminary work related to adding proper support for assignment
casts. See #45161 for more information.

Release note (sql change): It is now possible to cast JSON booleans to
the BOOL type, and to cast JSON numerics with fractions to rounded INT
types. Error messages are now more clear when a cast from a JSON value
to another type fails.