### PR TITLE
sql: interleaved tables notice was incorrectly labeled as an error

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -97,10 +97,10 @@ CREATE TABLE interleave_root (a INT PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p0 VALUES IN (0)
 )
 
-statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice NOTICE: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE TABLE interleave_child (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleave_root (a)
 
-statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice NOTICE: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE TABLE t (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleave_root (a) PARTITION BY LIST (a) (
     PARTITION p0 VALUES IN (0)
 )

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -117,7 +117,7 @@ LOCALITY REGIONAL BY ROW
 statement ok
 CREATE TABLE parent_table (pk INT PRIMARY KEY)
 
-statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice NOTICE: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE TABLE regional_by_row_table_int (
   pk INT NOT NULL PRIMARY KEY
 )
@@ -348,7 +348,7 @@ CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH BUCKET_COUNT = 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH BUCKET_COUNT = 8
 
-statement notice ERROR: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
+statement notice NOTICE: creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored. For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations
 CREATE INDEX bad_idx_int ON regional_by_row_table(pk) INTERLEAVE IN PARENT parent_table(pk)
 
 statement ok

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -614,12 +614,9 @@ var interleavedTableDisabledError = errors.WithIssueLink(
 	errors.IssueLink{IssueURL: build.MakeIssueURL(52009)},
 )
 
-var interleavedTableDisabledMigrationError = errors.WithIssueLink(
-	pgerror.New(pgcode.WarningDeprecatedFeature,
-		"creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored."+
-			" For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations"),
-	errors.IssueLink{IssueURL: build.MakeIssueURL(52009)},
-)
+var interleavedTableDisabledMigrationError = pgnotice.Newf(
+	"creation of new interleaved tables or interleaved indexes is no longer supported and will be ignored." +
+		" For details, see https://www.cockroachlabs.com/docs/releases/v20.2.0#deprecations")
 
 // interleavedTableDeprecationAction either returns an error, if interleaved
 // tables are disabled, or sends a notice, if they're not. Returns any error


### PR DESCRIPTION
Previously, interleaved tables were only deprecated, and
later on we fully dropped support for them returning a new
notice with the word "error" indicating they were no-ops. This
was inadequates because the message is not fatal and only a notice.
To address this, this patch will change them message type to notice.

Release note: None