### PR TITLE
sql: add version gate to regrole type

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -49,6 +49,10 @@ func (p *planner) addColumnImpl(
 		)
 	}
 
+	if err := checkTypeIsSupported(params.ctx, params.ExecCfg().Settings, toType); err != nil {
+		return err
+	}
+
 	newDef, seqPrefix, seqName, seqOpts, err := params.p.processSerialLikeInColumnDef(params.ctx, d, tn)
 	if err != nil {
 		return err

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -83,6 +83,10 @@ func AlterColumnType(
 		return err
 	}
 
+	if err := checkTypeIsSupported(ctx, params.ExecCfg().Settings, typ); err != nil {
+		return err
+	}
+
 	// Special handling for STRING COLLATE xy to verify that we recognize the language.
 	if t.Collation != "" {
 		if types.IsStringType(typ) {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1641,6 +1641,9 @@ func NewTableDesc(
 					)
 				}
 			}
+			if err := checkTypeIsSupported(ctx, st, defType); err != nil {
+				return nil, err
+			}
 			if d.PrimaryKey.Sharded {
 				if !sessionData.HashShardedIndexesEnabled {
 					return nil, hashShardedIndexesDisabledError
@@ -2904,4 +2907,16 @@ func hashShardedIndexesOnRegionalByRowError() error {
 
 func interleaveOnRegionalByRowError() error {
 	return pgerror.New(pgcode.FeatureNotSupported, "interleaved tables are not compatible with REGIONAL BY ROW tables")
+}
+
+func checkTypeIsSupported(ctx context.Context, settings *cluster.Settings, typ *types.T) error {
+	version := settings.Version.ActiveVersionOrEmpty(ctx)
+	if supported := types.IsTypeSupportedInVersion(version, typ); !supported {
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"type %s is not supported until version upgrade is finalized",
+			typ.SQLString(),
+		)
+	}
+	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/regrole_type_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/regrole_type_mixed
@@ -1,0 +1,25 @@
+# LogicTest: local-mixed-21.1-21.2
+
+statement error pq: type REGROLE is not supported until version upgrade is finalized
+CREATE TABLE t(x REGROLE)
+
+statement error pq: type REGROLE\[\] is not supported until version upgrade is finalized
+CREATE TABLE t(x REGROLE[])
+
+statement ok
+CREATE TABLE t(x STRING)
+
+statement ok
+SET enable_experimental_alter_column_type_general = true
+
+statement error pq: type REGROLE is not supported until version upgrade is finalized
+ALTER TABLE t ALTER COLUMN x TYPE REGROLE
+
+statement error pq: type REGROLE\[\] is not supported until version upgrade is finalized
+ALTER TABLE t ALTER COLUMN x TYPE REGROLE[]
+
+statement error pq: type REGROLE is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN y REGROLE
+
+statement error pq: type REGROLE\[\] is not supported until version upgrade is finalized
+ALTER TABLE t ADD COLUMN y REGROLE[]

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
+        "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/types/BUILD.bazel
+++ b/pkg/sql/types/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     name = "types",
     srcs = [
         "alias.go",
+        "minimum_type_version.go",
         "oid.go",
         "testutils.go",
         "types.go",
@@ -15,6 +16,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/types",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/geo/geopb",
         "//pkg/sql/lex",
         "//pkg/sql/oidext",
@@ -31,11 +33,17 @@ go_library(
 go_test(
     name = "types_test",
     size = "small",
-    srcs = ["types_test.go"],
+    srcs = [
+        "minimum_type_version_test.go",
+        "types_test.go",
+    ],
     embed = [":types"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/geo/geopb",
         "//pkg/sql/oidext",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//assert",

--- a/pkg/sql/types/minimum_type_version.go
+++ b/pkg/sql/types/minimum_type_version.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package types
+
+import "github.com/cockroachdb/cockroach/pkg/clusterversion"
+
+// regroleTypeVersion is an alias for MarkerDataKeysRegistry to avoid
+// having to backport a new version.
+const regroleTypeVersion = clusterversion.MarkerDataKeysRegistry
+
+// minimumTypeUsageVersions defines the minimum version needed for a new
+// data type.
+// Note: please do not remove this map or IsTypeSupportedInVersion even
+// if the map becomes empty temporarily.
+var minimumTypeUsageVersions = map[*T]clusterversion.Key{
+	RegRole: regroleTypeVersion,
+}
+
+// IsTypeSupportedInVersion returns whether a given type is supported in the given version.
+func IsTypeSupportedInVersion(v clusterversion.ClusterVersion, t *T) bool {
+	// For these checks, if we have an array, we only want to find whether
+	// we support the array contents.
+	if t.Family() == ArrayFamily {
+		t = t.ArrayContents()
+	}
+
+	minVersion, ok := minimumTypeUsageVersions[t]
+	if !ok {
+		return true
+	}
+	return v.IsActive(minVersion)
+}

--- a/pkg/sql/types/minimum_type_version_test.go
+++ b/pkg/sql/types/minimum_type_version_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTypeSupportedInVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		v clusterversion.Key
+		t *T
+
+		ok bool
+	}{
+		{regroleTypeVersion, RegRole, true},
+		{regroleTypeVersion - 1, RegRole, false},
+		{regroleTypeVersion, MakeArray(RegRole), true},
+		{regroleTypeVersion - 1, MakeArray(RegRole), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s:%s", tc.v, tc.t.SQLString()), func(t *testing.T) {
+			ok := IsTypeSupportedInVersion(
+				clusterversion.ClusterVersion{Version: clusterversion.ByKey(tc.v)},
+				tc.t,
+			)
+			require.Equal(t, tc.ok, ok)
+		})
+	}
+}


### PR DESCRIPTION
Without the version gate, in a mixed cluster setting, creating
a table on the new binary version with type REGROLE can cause
errors when inserting on the old verison.

Errors can also happen on schema changes where the old binary uses
the new type.

Release justification: GA blocker, without a version gate this can
cause panics.
Release note: None. Not in production.