### PR TITLE
ui: add unavailable message to statement details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -168,3 +168,7 @@ h3.base-heading {
   flex-grow: 0;
   width: 100%;
 }
+
+.tooltip-info {
+  border-bottom: 1px dashed $colors--neutral-5;
+}


### PR DESCRIPTION
Some metrics are part of the statement execution and will
only be available once the statement is sampled.
Previously the values for those metrics were showing as 0
if not yet sampled, causing confusion on their real value.
This commit intruduces an "unavailable" state that will be
displayed when the statement was not yet sampled.

Resolves #69675

With sampled statement
<img width="371" alt="Screen Shot 2021-09-21 at 5 40 28 PM" src="https://user-images.githubusercontent.com/1017486/134251702-bc6ab94d-f3d7-43d2-ad60-4dde79a4d45f.png">

Without sampled
<img width="437" alt="Screen Shot 2021-09-21 at 5 41 48 PM" src="https://user-images.githubusercontent.com/1017486/134251716-a45872c2-c625-4a47-9057-a6adfb124137.png">


Release justification: Category 4
Release note (ui change): Show info not yet sampled on Statement
Details page as unavailable, instead of value 0.