### PR TITLE
base: optimize {NodeIDContainer,StoreIDContainer}.String()

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -2,6 +2,8 @@ The following types are considered always safe for reporting:
 
 File | Type
 --|--
+pkg/base/node_id.go | `*NodeIDContainer`
+pkg/base/node_id.go | `*StoreIDContainer`
 pkg/cli/exit/exit.go | `Code`
 pkg/jobs/jobspb/wrap.go | `Type`
 pkg/kv/kvserver/closedts/ctpb/service.go | `LAI`

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -777,7 +777,7 @@ func (ctx *Context) grpcDialOptions(
 		// is in setupSpanForIncomingRPC().
 		//
 		tagger := func(span *tracing.Span) {
-			span.SetTag("node", attribute.StringValue(ctx.NodeID.Get().String()))
+			span.SetTag("node", attribute.IntValue(int(ctx.NodeID.Get())))
 		}
 		unaryInterceptors = append(unaryInterceptors,
 			tracing.ClientInterceptor(tracer, tagger))

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -81,6 +81,11 @@ func (s *spanInner) GetRecording() Recording {
 	}
 	// If the span is not verbose, optimize by avoiding the tags.
 	// This span is likely only used to carry payloads around.
+	//
+	// TODO(andrei): The optimization for avoiding the tags was done back when
+	// stringifying a {NodeID,StoreID}Container (a very common tag) was expensive.
+	// That has become cheap since, so this optimization might not be worth it any
+	// more.
 	wantTags := s.crdb.recordingType() == RecordingVerbose
 	return s.crdb.getRecording(wantTags)
 }


### PR DESCRIPTION
These String() methods were implemented in terms of their respective
SafeFormat, which was pretty expensive: upwards of 750ns and between 4-7
allocations depending on the node id. This cost caused at least two
workarounds, that the patch annotates.

The patch makes stringifying cheap by precomputing the value and moving
from SafeFormatter to SafeValue. Moving away from SafeFormatter to a
more down-to-earth implementation brings the cost down to between 0 and
1 allocations. But I went further and precomputed the value because
these containers are used as logging tags and so can easily end up
being stringified very frequently.

Release note: None