### PR TITLE
build: fix incorrect argument name when checking container memory limits

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -200,7 +200,7 @@ docker run --init --privileged -i ${tty-} --rm \
 res=$?
 set -e
 
-if test $res -ne 0 -a \( ${1-x} = "make" -o ${1-x} = "xmkrelease" \) ; then
+if test $res -ne 0 -a \( ${1-x} = "make" -o ${1-x} = "mkrelease" \) ; then
    ram=$(docker run -i --rm \
          -u "$uid:$gid" \
          "${image}:${version}" awk '/MemTotal/{print $2}' /proc/meminfo)


### PR DESCRIPTION
This change fixes a typo where when checking if a build failed due to
the Docker container memory limits being too low, the script checked for
`xmkrelease` instead of `mkrelease`.  This caused developers to
potentially fail builds (for example, with MacOS Docker resource
defaults) without realizing the reason why.

Release note: None