### PR TITLE
colfetcher: optimize and simplify the cFetcher a bit

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1104,7 +1104,12 @@ func (rf *Fetcher) processKV(
 			// In this case, we don't need to decode the column family ID, because
 			// the ValueType_TUPLE encoding includes the column id with every encoded
 			// column value.
-			prettyKey, prettyValue, err = rf.processValueTuple(ctx, table, kv, prettyKey)
+			var tupleBytes []byte
+			tupleBytes, err = kv.Value.GetTuple()
+			if err != nil {
+				break
+			}
+			prettyKey, prettyValue, err = rf.processValueBytes(ctx, table, kv, tupleBytes, prettyKey)
 		default:
 			var familyID uint64
 			_, familyID, err = encoding.DecodeUvarintAscending(rf.keyRemainingBytes)
@@ -1317,18 +1322,6 @@ func (rf *Fetcher) processValueBytes(
 		prettyValue = rf.prettyValueBuf.String()
 	}
 	return prettyKey, prettyValue, nil
-}
-
-// processValueTuple processes the given values (of columns family.ColumnIDs),
-// setting values in the rf.row accordingly. The key is only used for logging.
-func (rf *Fetcher) processValueTuple(
-	ctx context.Context, table *tableInfo, kv roachpb.KeyValue, prettyKeyPrefix string,
-) (prettyKey string, prettyValue string, err error) {
-	tupleBytes, err := kv.Value.GetTuple()
-	if err != nil {
-		return "", "", err
-	}
-	return rf.processValueBytes(ctx, table, kv, tupleBytes, prettyKeyPrefix)
 }
 
 // NextRow processes keys until we complete one row, which is returned as an


### PR DESCRIPTION
This commit improves a few things about the `cFetcher`:
- it removes a conditional during the value part decoding (by
  pre-populating a slice of ASC directions)
- it encapsulates the tracing of the fetched KVs a little better
- it also removes a redundant `processValueTuple` method (which was
  simply calling another one).

This commit additionally applies the last simplification mentioned above
to the row fetcher too.

Release note: None