### PR TITLE
colexec: improve the test coverage of the hash aggregator a bit

### DIFF
--- a/pkg/sql/colexec/main_test.go
+++ b/pkg/sql/colexec/main_test.go
@@ -76,6 +76,7 @@ func TestMain(m *testing.M) {
 			if err := coldata.SetBatchSizeForTests(randomBatchSize); err != nil {
 				colexecerror.InternalError(err)
 			}
+			randomizeHashAggregatorMaxBuffered()
 		}
 		return m.Run()
 	}())


### PR DESCRIPTION
This commit enables the metamorphic randomization for the size of the
buffer in the hash aggregator. That size determines how many rows we're
aggregating over at once.

Release note: None