### PR TITLE
builtins: tighten json*_populate_record to only accept AnyTuple

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1133,9 +1133,9 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td></tr>
 <tr><td><a name="json_object_keys"></a><code>json_object_keys(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
-<tr><td><a name="json_populate_record"></a><code>json_populate_record(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
+<tr><td><a name="json_populate_record"></a><code>json_populate_record(base: tuple, from_json: jsonb) &rarr; tuple</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
 </span></td></tr>
-<tr><td><a name="json_populate_recordset"></a><code>json_populate_recordset(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
+<tr><td><a name="json_populate_recordset"></a><code>json_populate_recordset(base: tuple, from_json: jsonb) &rarr; tuple</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
 </span></td></tr>
 <tr><td><a name="jsonb_array_elements"></a><code>jsonb_array_elements(input: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
@@ -1147,9 +1147,9 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td></tr>
 <tr><td><a name="jsonb_object_keys"></a><code>jsonb_object_keys(input: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
-<tr><td><a name="jsonb_populate_record"></a><code>jsonb_populate_record(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
+<tr><td><a name="jsonb_populate_record"></a><code>jsonb_populate_record(base: tuple, from_json: jsonb) &rarr; tuple</code></td><td><span class="funcdesc"><p>Expands the object in from_json to a row whose columns match the record type defined by base.</p>
 </span></td></tr>
-<tr><td><a name="jsonb_populate_recordset"></a><code>jsonb_populate_recordset(base: anyelement, from_json: jsonb) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
+<tr><td><a name="jsonb_populate_recordset"></a><code>jsonb_populate_recordset(base: tuple, from_json: jsonb) &rarr; tuple</code></td><td><span class="funcdesc"><p>Expands the outermost array of objects in from_json to a set of rows whose columns match the record type defined by base</p>
 </span></td></tr>
 <tr><td><a name="pg_get_keywords"></a><code>pg_get_keywords() &rarr; tuple{string AS word, string AS catcode, string AS catdesc}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -854,6 +854,13 @@ SELECT '{}'::JSONB[]
 {}
 
 # json_populate_record
+
+statement error unknown signature: json_populate_recordset\(oid, jsonb\)
+SELECT json_populate_recordset(3923269572::OID, '["regression_70475"]'::JSONB)
+
+statement error unknown signature: jsonb_populate_recordset\(oid, jsonb\)
+SELECT jsonb_populate_recordset(3923269572::OID, '["regression_70475"]'::JSONB)
+
 query FIII colnames
 SELECT *, c FROM json_populate_record(((1.01, 2, 3) AS d, c, a), '{"a": 3, "c": 10, "d": 11.001}')
 ----

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1261,7 +1261,7 @@ func makeJSONPopulateImpl(gen tree.GeneratorWithExprsFactory, info string) tree.
 		// the default values of each field will be NULL.
 		// The second argument can also be null, in which case the first argument
 		// is returned as-is.
-		Types: tree.ArgTypes{{"base", types.Any}, {"from_json", types.Jsonb}},
+		Types: tree.ArgTypes{{"base", types.AnyTuple}, {"from_json", types.Jsonb}},
 		ReturnType: func(args []tree.TypedExpr) *types.T {
 			if len(args) != 2 {
 				return tree.UnknownReturnType


### PR DESCRIPTION
`types.Any` would fail the `MustBeDTuple` check. As such, change the
typing to only allow `AnyTuple`.

Resolves #70475

Release note: None