### PR TITLE
cluster-ui: add tooltips to explain plan

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planTooltips.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planTooltips.tsx
@@ -1,0 +1,156 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Anchor } from "src/anchor";
+import {
+  distSql,
+  vectorizedExecution,
+  mergeJoin,
+  lookupJoin,
+  hashJoin,
+  invertedJoin,
+  indexJoin,
+  fullScan,
+  secondaryIndex,
+  lockingStrength,
+  transactionLayerOverview,
+} from "src/util/docs";
+
+type TooltipMap = Record<string, JSX.Element>;
+
+const attributeTooltips: TooltipMap = {
+  autoCommit: (
+    <span>
+      All statements are handled as transactions.{" "}
+      <Anchor href={transactionLayerOverview}>Autocommit</Anchor> indicates that
+      the single statement was implicitly committed.
+    </span>
+  ),
+  distribution: (
+    <span>
+      CockroachDB supports{" "}
+      <Anchor href={distSql}>two modes of execution </Anchor>
+      for SQL queries: local and distributed. In local execution, data is pulled
+      from where it is towards the one node that does the processing. In
+      distributed execution, the processing is shipped to run close to where the
+      data is stored, usually on multiple nodes simultaneously.
+    </span>
+  ),
+  lockingStrength: (
+    <span>
+      <Anchor href={lockingStrength}>Locking strength</Anchor> indicates that
+      additional locks were applied to rows during execution to improve
+      performance for workloads having high contention.
+    </span>
+  ),
+  vectorized: (
+    <span>
+      CockroachDB supports a{" "}
+      <Anchor href={vectorizedExecution}>vectorized execution engine.</Anchor>
+    </span>
+  ),
+};
+
+const operatorTooltips: TooltipMap = {
+  filter: (
+    <span>
+      The filter operator indicates the statement contains a WHERE clause.
+    </span>
+  ),
+  group: (
+    <span>
+      The group operator indicates the statement contains a GROUP BY clause.
+    </span>
+  ),
+  hashJoin: (
+    <span>
+      <Anchor href={hashJoin}>Hash join</Anchor> is used when merge join cannot
+      be used. CockroachDB will create a hash table based on the smaller table
+      and then scan the larger table, looking up each row in the hash table.
+    </span>
+  ),
+  indexJoin: (
+    <span>
+      <Anchor href={indexJoin}>Index join</Anchor> is suboptimal and indicates a
+      non-covering index where not all columns are present in the index to
+      satisfy the query. Index join requires columns to additionally be read
+      from the primary index.
+    </span>
+  ),
+  insertFastPath: (
+    <span>The insert operator indicates an INSERT statement.</span>
+  ),
+  invertedJoin: (
+    <span>
+      <Anchor href={invertedJoin}>Inverted join</Anchor> forces the optimizer to
+      use a join using an inverted index on the right side of the join. Inverted
+      joins can only be used with INNER and LEFT joins.
+    </span>
+  ),
+  lookupJoin: (
+    <span>
+      <Anchor href={lookupJoin}>Lookup join</Anchor> is used where there is a
+      large imbalance in size between the tables. The larger table must be
+      indexed on the equality column. Each row in the small table is read where
+      the rows are &apos;looked up&apos; in the larger table for matches.
+    </span>
+  ),
+  mergeJoin: (
+    <span>
+      <Anchor href={mergeJoin}>Merge join</Anchor> is selected when both tables
+      are indexed on the equality columns where indexes must have the same
+      ordering.
+    </span>
+  ),
+  scan: (
+    <span>
+      The scan (or reverse scan) operator indicates which and how the table(s)
+      in the statement&apos;s FROM clause and its index is read.
+    </span>
+  ),
+  sort: (
+    <span>
+      The sort operator indicates the statement contains an ORDER BY clause.
+    </span>
+  ),
+  update: <span>The update operator indicates an UPDATE statement.</span>,
+  window: (
+    <span>
+      The window operator indicates the statement contains a OVER or WINDOW
+      clause for window functions.
+    </span>
+  ),
+};
+
+const attributeValueTooltips: TooltipMap = {
+  fullScan: (
+    <span>
+      A <Anchor href={fullScan}>FULL SCAN</Anchor> indicates that{" "}
+      <strong>all</strong> rows were read from the table index.
+      <br />
+      <strong>Recommendation:</strong> Consider{" "}
+      <Anchor href={secondaryIndex}>adding a secondary index</Anchor> to the
+      table if the FULL SCAN is retrieving a relatively large number of rows.
+    </span>
+  ),
+};
+
+export function getOperatorTooltip(key: string): React.ReactElement {
+  return operatorTooltips[key] || null;
+}
+
+export function getAttributeTooltip(key: string): JSX.Element {
+  return attributeTooltips[key] || null;
+}
+
+export function getAttributeValueTooltip(key: string): JSX.Element {
+  return attributeValueTooltips[key] || null;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.module.scss
@@ -113,17 +113,34 @@
   .warn {
     color: $colors--functional-orange-4;
     text-transform: uppercase;
-    border-bottom: 1px dashed $adminui-white;
   }
 
-  .nodeDetails {
+  .underline-tooltip {
+    border-bottom: 1px dashed $adminui-white;
+
+    a {
+      text-decoration: underline;
+      font-size: inherit;
+      color: $chip-grey;
+    }
+  }
+
+  .node-attribute {
+    div {
+      display: inline-block;
+    }
+  }
+
+  .node-details {
     position: relative;
     padding: 6px 0;
     border: 1px solid transparent;
 
     b {
+      div {
+        display: inline-block;
+      }
       font-family: $font-family--monospace;
-      border-bottom: 1px dashed $adminui-white;
       font-size: 14px;
       font-weight: 500;
       line-height: 1.67;
@@ -132,24 +149,20 @@
     }
 
     &:only-child {
-      .nodeAttributes {
+      .node-attributes {
         border-left: 1px solid transparent;
       }
     }
   }
 
-  .nodeAttributes.globalAttributes {
+  .node-attributes.global-attributes {
     margin-bottom: 40px;
     padding: 0 0 40px 0;
     border-left: none;
     border-bottom: 1px solid $colors--neutral-5;
-
-    .nodeAttributeKey {
-      border-bottom: 1px dashed $adminui-white;
-    }
   }
 
-  .nodeAttributes {
+  .node-attributes {
     color: $chip-grey;
     padding: 3px 14px 12px 8px;
     margin-left: 2px;
@@ -159,7 +172,11 @@
     font-weight: 500;
     line-height: 1.83;
 
-    .nodeAttributeKey {
+    .node-attribute-key {
+      div {
+        display: inline-block;
+      }
+      position: relative;
       color: $colors--primary-blue-6;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -88,6 +88,27 @@ export const upgradeCockroachVersion =
 export const enterpriseLicensing =
   "https://www.cockroachlabs.com/docs/stable/enterprise-licensing.html";
 
+// Explain plan
+export const distSql = docsURL("architecture/sql-layer.html#distsql");
+export const vectorizedExecution = docsURL(
+  "vectorized-execution.html#configuring-vectorized-execution",
+);
+export const mergeJoin = docsURL("joins.html#merge-joins");
+export const lookupJoin = docsURL("joins.html#lookup-joins");
+export const hashJoin = docsURL("joins.html#hash-joins");
+export const invertedJoin = docsURL("joins.html#inverted-joins");
+export const indexJoin = docsURL("indexes.html#storing-columns");
+export const fullScan = docsURL(
+  "sql-tuning-with-explain.html#issue-full-table-scans",
+);
+export const secondaryIndex = docsURL("schema-design-indexes.html");
+export const lockingStrength = docsURL(
+  "explain.html#find-out-if-a-statement-is-using-select-for-update-locking",
+);
+export const transactionLayerOverview = docsURL(
+  "architecture/transaction-layer.html#overview",
+);
+
 // Not actually a docs URL.
 export const startTrial = "https://www.cockroachlabs.com/pricing/start-trial/";
 export const transactionsTable = docsURL("ui-transactions-page.html");


### PR DESCRIPTION
Resolves: #61764

This commit adds tooltips to explain plan operators and node
attributes, providing more information to explain plans.

Release justification: low-risk, high benefit changes to existing
functionality

Release note (ui change): On the explain plan tab in statement
details, Users will be able to hover over underlined explain
plan attributes to get tooltips with more information on the
attribute.

-----------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20136951/134358090-02d05792-9edb-4820-b476-41ab06d84282.png)

![image](https://user-images.githubusercontent.com/20136951/134358143-a75889d4-e300-4e5f-b42f-46a686f4fd70.png)
