### PR TITLE
workload: reduce logs from pgx

### DIFF
--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -12,6 +12,7 @@ package workload
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -58,6 +59,11 @@ var _ pgx.Logger = pgxLogger{}
 func (p pgxLogger) Log(
 	ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{},
 ) {
+	if strings.Contains(msg, "restart transaction") {
+		// Our workloads have a lot of contention, so "restart transaction" messages
+		// are expected and noisy.
+		return
+	}
 	log.Infof(ctx, "pgx logger [%s]: %s logParams=%v", level.String(), msg, data)
 }
 


### PR DESCRIPTION
Transaction restart errors are expected and produce a lot of noise, so
there's no good reason to log them.

Release note: None