### PR TITLE
storage: surface Pebble Close errors

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -51,6 +51,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) {
 			WithDiff: opts.withDiff,
 			Span:     span,
 		}, opts.useTBI, func() {})
+		defer iter.Close()
 		counter := 0
 		err := iter.CatchUpScan(storage.MakeMVCCMetadataKey(startKey), storage.MakeMVCCMetadataKey(endKey), opts.ts, opts.withDiff, func(*roachpb.RangeFeedEvent) error {
 			counter++

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -388,74 +388,75 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	func() {
 		opts := IterOptions{LowerBound: keys.MinKey}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalMax})
-		iter.Close()
 	}()
 	func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
 		require.Equal(t, constrainedToLocal, iter.constraint)
-		iter.Close()
 	}()
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		iter.SeekLT(MVCCKey{Key: keys.MaxKey})
 	})
 	// Boundary cases for constrainedToGlobal
 	func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
-		iter.Close()
 	}()
 	require.Panics(t, func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
-		iter.Close()
 	})
 	require.Panics(t, func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalMax})
-		iter.Close()
 	})
 	// Panics for using a local key that is above the lock table.
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()})
-		iter.Close()
 	})
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekGE(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()})
-		iter.Close()
 	})
 	// Prefix iteration does not affect the constraint if bounds are
 	// specified.
 	func() {
 		opts := IterOptions{Prefix: true, LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
-		iter.Close()
 	}()
 	// Prefix iteration with no bounds.
 	func() {
 		iter := newIntentInterleavingIterator(eng, IterOptions{Prefix: true}).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, notConstrained, iter.constraint)
-		iter.Close()
 	}()
 }
 
@@ -643,6 +644,13 @@ func generateIterOps(rng *rand.Rand, mvcckv []MVCCKeyValue, isLocal bool) []stri
 
 func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings.Builder) {
 	var iter MVCCIterator
+	closeIter := func() {
+		if iter != nil {
+			iter.Close()
+			iter = nil
+		}
+	}
+	defer closeIter()
 	var d datadriven.TestData
 	var err error
 	for _, op := range ops {
@@ -650,6 +658,7 @@ func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings
 		require.NoError(t, err)
 		switch d.Cmd {
 		case "iter":
+			closeIter()
 			var opts IterOptions
 			if d.HasArg("lower") {
 				opts.LowerBound = scanRoachKey(t, &d, "lower")

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -555,6 +555,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 					EndTime:      tsMax,
 					InlinePolicy: MVCCIncrementalIterInlinePolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				_, err := iter.Valid()
 				assert.EqualError(t, err, "unexpected inline value found: \"/db1\"")
@@ -566,6 +567,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 					EndTime:      tsMax,
 					InlinePolicy: MVCCIncrementalIterInlinePolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectInlineKeyValue(t, iter, inline1_1_1)
 				iter.Next()
@@ -649,6 +651,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				for ; ; iter.Next() {
 					if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(keyMax) >= 0 {
@@ -665,6 +668,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectKeyValue(t, iter, kv1_3_3)
 				iter.Next()
@@ -679,6 +683,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				for _, kv := range []MVCCKeyValue{kv1_3_3, kv1_2_2, kv1_1_1} {
 					expectKeyValue(t, iter, kv)
@@ -698,6 +703,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectKeyValue(t, iter, kv1_3_3)
 				iter.Next()
@@ -1023,6 +1029,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 				// goroutine. A non-atomic Put can cause the strict invariant checking
 				// in intentInterleavingIter to be violated.
 				b := e.NewBatch()
+				defer b.Close()
 				if err := MVCCPut(ctx, b, nil, kA, ts1, vA2, txn); err != nil {
 					return err
 				}
@@ -1381,6 +1388,7 @@ func runIncrementalBenchmark(
 			StartTime:                           ts,
 			EndTime:                             hlc.MaxTimestamp,
 		})
+		defer it.Close()
 		it.SeekGE(MVCCKey{Key: startKey})
 		for {
 			if ok, err := it.Valid(); err != nil {

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -115,14 +115,17 @@ func (p *pebbleBatch) Close() {
 	}
 	p.closed = true
 
-	// Setting iter to nil is sufficient since it will be closed by one of the
-	// subsequent destroy calls.
-	p.iter = nil
 	// Destroy the iterators before closing the batch.
 	p.prefixIter.destroy()
 	p.normalIter.destroy()
 	p.prefixEngineIter.destroy()
 	p.normalEngineIter.destroy()
+	if p.iter != nil {
+		if err := p.iter.Close(); err != nil {
+			panic(err)
+		}
+		p.iter = nil
+	}
 
 	_ = p.batch.Close()
 	p.batch = nil

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -75,6 +75,7 @@ var pebbleIterPool = sync.Pool{
 
 type cloneableIter interface {
 	Clone() (*pebble.Iterator, error)
+	Close() error
 }
 
 type testingSetBoundsListener interface {

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -126,6 +126,7 @@ func TestPebbleIterReuse(t *testing.T) {
 	defer eng.Close()
 
 	batch := eng.NewBatch()
+	defer batch.Close()
 	for i := 0; i < 100; i++ {
 		key := MVCCKey{[]byte{byte(i)}, hlc.Timestamp{WallTime: 100}}
 		if err := batch.PutMVCC(key, []byte("foo")); err != nil {
@@ -460,10 +461,16 @@ func TestPebbleIterConsistency(t *testing.T) {
 	k1 := MVCCKey{[]byte("a"), ts1}
 	require.NoError(t, eng.PutMVCC(k1, []byte("a1")))
 
-	roEngine := eng.NewReadOnly()
-	batch := eng.NewBatch()
-	roEngine2 := eng.NewReadOnly()
-	batch2 := eng.NewBatch()
+	var (
+		roEngine  = eng.NewReadOnly()
+		batch     = eng.NewBatch()
+		roEngine2 = eng.NewReadOnly()
+		batch2    = eng.NewBatch()
+	)
+	defer roEngine.Close()
+	defer batch.Close()
+	defer roEngine2.Close()
+	defer batch2.Close()
 
 	require.False(t, eng.ConsistentIterators())
 	require.True(t, roEngine.ConsistentIterators())
@@ -485,6 +492,7 @@ func TestPebbleIterConsistency(t *testing.T) {
 	require.NoError(t, eng.PutMVCC(MVCCKey{[]byte("a"), ts2}, []byte("a2")))
 
 	checkMVCCIter := func(iter MVCCIterator) {
+		defer iter.Close()
 		iter.SeekGE(MVCCKey{Key: []byte("a")})
 		valid, err := iter.Valid()
 		require.Equal(t, true, valid)
@@ -495,9 +503,9 @@ func TestPebbleIterConsistency(t *testing.T) {
 		valid, err = iter.Valid()
 		require.False(t, valid)
 		require.NoError(t, err)
-		iter.Close()
 	}
 	checkEngineIter := func(iter EngineIterator) {
+		defer iter.Close()
 		valid, err := iter.SeekEngineKeyGE(EngineKey{Key: []byte("a")})
 		require.Equal(t, true, valid)
 		require.NoError(t, err)
@@ -511,7 +519,6 @@ func TestPebbleIterConsistency(t *testing.T) {
 		valid, err = iter.NextEngineKey()
 		require.False(t, valid)
 		require.NoError(t, err)
-		iter.Close()
 	}
 
 	checkMVCCIter(roEngine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
@@ -533,6 +540,7 @@ func TestPebbleIterConsistency(t *testing.T) {
 	checkEngineIter(batch2.NewEngineIterator(IterOptions{Prefix: true}))
 
 	checkIterSeesBothValues := func(iter MVCCIterator) {
+		defer iter.Close()
 		iter.SeekGE(MVCCKey{Key: []byte("a")})
 		count := 0
 		for ; ; iter.Next() {
@@ -544,7 +552,6 @@ func TestPebbleIterConsistency(t *testing.T) {
 			count++
 		}
 		require.Equal(t, 2, count)
-		iter.Close()
 	}
 	// The eng iterator will see both values.
 	checkIterSeesBothValues(eng.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: []byte("b")}))
@@ -601,6 +608,7 @@ func value(key roachpb.Key, val string, ts hlc.Timestamp) testValue {
 
 func fillInData(ctx context.Context, engine Engine, data []testValue) error {
 	batch := engine.NewBatch()
+	defer batch.Close()
 	for _, val := range data {
 		if err := MVCCPut(ctx, batch, nil, val.key, val.timestamp, val.value, val.txn); err != nil {
 			return err


### PR DESCRIPTION
If closing a Pebble engine errors, surface the error through a panic.

Release note: None