### PR TITLE
ui: revert yarn-vendor and node modules offline installation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/cockroachdb/jemalloc.git
 [submodule "pkg/ui/yarn-vendor"]
 	path = pkg/ui/yarn-vendor
-	url = https://github.com/cockroachdb/yarn-vendored
+	url = https://github.com/cockroachdb/yarn-vendored.git
 [submodule "c-deps/krb5"]
 	path = c-deps/krb5
 	url = https://github.com/cockroachdb/krb5.git

--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ pkg/ui/yarn.installed: pkg/ui/package.json pkg/ui/yarn.lock | bin/.submodules-in
 	@# and should not be installed for production builds.
 	@# Also some of linux distributives (that are used as development env) don't support some of
 	@# optional dependencies (i.e. cypress) so it is important to make these deps optional.
-	$(NODE_RUN) -C pkg/ui yarn install --ignore-optional
+	$(NODE_RUN) -C pkg/ui yarn install --ignore-optional --offline
 	@# We remove this broken dependency again in pkg/ui/webpack.config.js.
 	@# See the comment there for details.
 	rm -rf pkg/ui/node_modules/@types/node
@@ -1407,7 +1407,7 @@ pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(shell f
 	touch $@
 
 pkg/ui/yarn.opt.installed:
-	$(NODE_RUN) -C pkg/ui yarn install --check-files
+	$(NODE_RUN) -C pkg/ui yarn install --check-files --offline
 	touch $@
 
 .PHONY: ui-watch-secure

--- a/pkg/ui/.yarnrc
+++ b/pkg/ui/.yarnrc
@@ -1,0 +1,1 @@
+yarn-offline-mirror yarn-vendor


### PR DESCRIPTION
When ui project structure was refactored to use
yarn workspaces, support for offline node modules
installation and usage of `yarn-vendor` was removed.
Current change, reverts this change back to support
offline modules' installation.

Depends on: https://github.com/cockroachdb/yarn-vendored/pull/80

Following command can be used to install NPM modules for bazel build:
```
bazel run @nodejs//:yarn_node_repositories -- --ignore-optional --offline
```

Release note: none