### PR TITLE
sql: change grant on database deprecation notice

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
@@ -114,8 +114,9 @@ CREATE DATABASE d;
 CREATE USER testuser;
 GRANT SELECT ON DATABASE d TO testuser;
 ----
-NOTICE: granting SELECT on databases is deprecated, please use ALTER DEFAULT PRIVILEGES FOR ALL ROLES.
-SELECT privileges were not granted, the statement was automatically translated to USE d; ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO testuser;
+NOTICE: GRANT SELECT ON DATABASE is deprecated.
+This statement was automatically converted to USE d; ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO testuser;
+Please use ALTER DEFAULT PRIVILEGES going forward
 
 exec-sql user=testuser
 BACKUP DATABASE d TO 'nodelocal://0/test3'

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -413,11 +413,10 @@ func convertPGIncompatibleDatabasePrivilegesToDefaultPrivileges(
 			}
 
 			p.BufferClientNotice(ctx, pgnotice.Newf(
-				"granting %s on databases is deprecated, "+
-					"please use ALTER DEFAULT PRIVILEGES FOR ALL ROLES.\n"+
-					"%s privileges were not granted, "+
-					"the statement was automatically translated to %s",
-				incompatiblePrivs, incompatiblePrivs, translatedStatement,
+				"GRANT %s ON DATABASE is deprecated.\n"+
+					"This statement was automatically converted to %s\n"+
+					"Please use ALTER DEFAULT PRIVILEGES going forward",
+				incompatiblePrivs, translatedStatement,
 			))
 		}
 	}


### PR DESCRIPTION
Release justification: Low risk change, only a change to a notice message.
Release note: None