### PR TITLE
sql: implemented pg_statistic_ext on pg_catalog

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -5545,23 +5545,23 @@ CREATE TABLE pg_catalog.pg_statio_user_tables (
    tidx_blks_hit INT8 NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_statistic_ext (
-   stxrelid OID NULL,
-   stxstattarget INT4 NULL,
    oid OID NULL,
-   stxkeys INT2VECTOR NULL,
-   stxkind "char"[] NULL,
+   stxrelid OID NULL,
    stxname NAME NULL,
    stxnamespace OID NULL,
-   stxowner OID NULL
+   stxowner OID NULL,
+   stxstattarget INT4 NULL,
+   stxkeys INT2VECTOR NULL,
+   stxkind "char"[] NULL
 )  CREATE TABLE pg_catalog.pg_statistic_ext (
-   stxrelid OID NULL,
-   stxstattarget INT4 NULL,
    oid OID NULL,
-   stxkeys INT2VECTOR NULL,
-   stxkind "char"[] NULL,
+   stxrelid OID NULL,
    stxname NAME NULL,
    stxnamespace OID NULL,
-   stxowner OID NULL
+   stxowner OID NULL,
+   stxstattarget INT4 NULL,
+   stxkeys INT2VECTOR NULL,
+   stxkind "char"[] NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_subscription (
    subname NAME NULL,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3814,7 +3814,7 @@ objoid      classoid    objsubid  description
 4294967041  4294967133  0         pg_statio_user_indexes was created for compatibility and is currently unimplemented
 4294967040  4294967133  0         pg_statio_user_sequences was created for compatibility and is currently unimplemented
 4294967039  4294967133  0         pg_statio_user_tables was created for compatibility and is currently unimplemented
-4294967038  4294967133  0         pg_statistic_ext was created for compatibility and is currently unimplemented
+4294967038  4294967133  0         pg_statistic_ext has the statistics objects created with CREATE STATISTICS
 4294967036  4294967133  0         pg_subscription was created for compatibility and is currently unimplemented
 4294967037  4294967133  0         pg_subscription_rel was created for compatibility and is currently unimplemented
 4294967035  4294967133  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
@@ -5338,3 +5338,23 @@ WHERE usename = 'regression_70180'
 ----
 usename           valuntil
 regression_70180  NULL
+
+# Testing pg_statistic_ext
+statement ok
+CREATE TABLE stxtbl(a INT, b INT, c INT);
+CREATE STATISTICS stxobj ON b, c FROM stxtbl;
+
+query TTOOTTT colnames
+SELECT
+  relname,
+  stxname,
+  stxnamespace,
+  stxowner,
+  stxstattarget,
+  stxkeys,
+  stxkind
+FROM pg_statistic_ext
+JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
+----
+relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
+stxtbl   stxobj   NULL          NULL      NULL           {2,3}    NULL

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -1238,18 +1238,18 @@ CREATE TABLE pg_catalog.pg_hba_file_rules (
 	options STRING[]
 )`
 
-// PgCatalogStatisticExt is an empty table created by pg_catalog_test
-// and is currently unimplemented.
+// PgCatalogStatisticExt describes the schema of pg_catalog.pg_statistic_ext
+// https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html
 const PgCatalogStatisticExt = `
 CREATE TABLE pg_catalog.pg_statistic_ext (
-	stxrelid OID,
-	stxstattarget INT4,
 	oid OID,
+	stxrelid OID,
+  stxname NAME,
+  stxnamespace OID,
+	stxowner OID,
+	stxstattarget INT4,
 	stxkeys INT2VECTOR,
-	stxkind "char"[],
-	stxname NAME,
-	stxnamespace OID,
-	stxowner OID
+	stxkind "char"[]
 )`
 
 // PgCatalogReplicationOrigin is an empty table created by pg_catalog_test


### PR DESCRIPTION
Previously, pg_statistic_ext was unimplemented
This was inadequate because exists on postgres pg_catalog
and it is used by tools/ORMs
To address this, this patch implements what is relevant for
cockroach db on this table.

Release note (sql change): Implemented pg_statistic_ext on pg_catalog

Fixes #70579