### PR TITLE
roachtest: add cmd flags to helper script to run reproductions

### DIFF
--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -11,21 +11,97 @@ set -euo pipefail
 # to avoid computer going to standby.
 
 if [ -z "${BASH_VERSINFO}" ] || [ -z "${BASH_VERSINFO[0]}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
-  echo "This script requires Bash version >= 4"
-  echo "On OSX, 'brew install bash' should do the trick."
+  echo "Error: This script requires Bash version >= 4"
+  echo "Error: On OSX, 'brew install bash' should do the trick."
   exit 1
 fi
 
-# Read user input.
-if [ ! -v TEST ]; then read -r -e -p "Test regexp: " TEST; fi
-if [ ! -v COUNT ]; then read -r -e -i "10" -p "Count: " COUNT; fi
-if [ ! -v LOCAL ]; then read -r -e -i "n" -p "Local: " LOCAL; fi
-case $LOCAL in
-  [Nn]* | false | "") LOCAL="";;
-  *) LOCAL=".local";;
-esac
+function help {
+  cat <<EOF
+Build and stress run roachtest
+Usage:
+  $(basename ${0}) [flags] <test name> [-- <roachtest flags>]
 
-if [ -z "${LOCAL}" ] && [ "${GCE_PROJECT-cockroach-ephemeral}" == "cockroach-ephemeral" ]; then
+flags:
+  -c COUNT - number of test iterations to run
+  -l       - run test locally on host
+  -u       - build cockroach with ui (don't use buildshort)
+  -b       - do not rebuild binaries if they exist
+
+Roachstress will build artifacts inside artifacts/<commit-hash> directory
+for later reuse. This is eliminating the need to rebuild when comparing
+branches.
+If roachstress detects that there's an uncommitted change, it would always
+try to rebuild into artifacts/<commit-hash>-dirty to allow temporary test
+or cockroach changes for reproductions.
+Local change rebuilding behavior could be disabled by -b flag.
+EOF
+}
+
+function fail {
+  echo -e "Error: $1\n"
+  help
+  exit 1
+}
+
+# Process command line flags
+force_build=
+short=short
+local=
+count=10
+while getopts ":c:lubh" o ; do
+  case "$o" in
+    c)
+     count="${OPTARG}"
+     ;;
+    l)
+     local=.local
+     ;;
+    u)
+     short=
+     ;;
+    b)
+     force_build=n
+     ;;
+    h)
+     help
+     exit 0
+     ;;
+    :)
+     fail "Option -${OPTARG} requires argument"
+     ;;
+    *)
+     fail "Unknown option -${OPTARG}"
+     ;;
+  esac
+done
+
+# Some magic to ensure test name is present. We need special handling for the case where
+# test name was not provided but -- and roachtest arguments were. getopts makes it hard
+# to distinguish since cases where OPTIND points to test name or OPTIND points to the first
+# arg to roachtest look identical.
+
+# Check if we parsed beyond last arg already, then its an error.
+[ $# -lt "${OPTIND}" ] && fail "No test name provided"
+
+# We are at arg, but it may be test name or first roachtest arg.
+if [ $OPTIND -gt 1 ] ; then
+  # Check if arg to the left is '--' then we don't have test name.
+  shift $((OPTIND - 2))
+  [ "$1" = "--" ] && fail "No test name provided"
+  shift 1
+fi
+
+test="$1"
+# Finally extract roachprod params if present.
+shift 1
+if [ $# -gt 0 ] ; then
+  [ "$1" != "--" ] && fail "Can only provide single test name, did you forget -- before roachtest arguments"
+  shift 1
+fi
+
+# Sanity-check used GCE project. You still need to set non default for GCE even if running on AWS.
+if [ -z "${local}" ] && [ "${GCE_PROJECT-cockroach-ephemeral}" == "cockroach-ephemeral" ]; then
   cat <<EOF
 Please do not use roachstress on the cockroach-ephemeral project.
 This may compete over quota with scheduled roachtest builds.
@@ -41,31 +117,27 @@ fi
 # artifacts will be stored.
 sha=$(git rev-parse --short HEAD)
 abase="artifacts/${sha}"
+# If local changes are detected use separate artifacts dir and force rebuild.
+if [ -n "$(git status --porcelain --untracked-files=no)" ] ; then
+  abase="${abase}-dirty"
+  force_build=${force_build:-y}
+fi
+mkdir -p "${abase}"
+trap 'echo Build artifacts dir is ${abase}' EXIT
 
 # Locations of the binaries.
 rt="${abase}/roachtest"
 rp="${abase}/roachprod"
-wl="${abase}/workload${LOCAL}"
-cr="${abase}/cockroach${LOCAL}"
+wl="${abase}/workload${local}"
+cr="${abase}/cockroach${local}"
 
 # This is the artifacts dir we'll pass to the roachtest invocation. It's
 # disambiguated by a timestamp because one often ends up invoking roachtest on
 # the same SHA multiple times and artifacts shouldn't mix.
 a="${abase}/$(date '+%H%M%S')"
 
-short="short"
-if [ ! -f "${cr}" ]; then
-  yn="${SHORT-}"
-  if [ -z "${yn}" ]; then read -r -e -i "y" -p "Build cockroach without the UI: " yn; fi
-  case $yn in
-    [Nn]* | false | "") short=""
-  esac
-fi
-
-mkdir -p "${a}"
-
-if [ ! -f "${cr}" ]; then
-  if [ -z "${LOCAL}" ]; then
+if [ ! -f "${cr}" ] || [ "${force_build}" = "y" ]; then
+  if [ -z "${local}" ]; then
     ./build/builder.sh mkrelease amd64-linux-gnu "build${short}"
     cp "cockroach${short}-linux-2.6.32-gnu-amd64" "${cr}"
   else
@@ -74,8 +146,8 @@ if [ ! -f "${cr}" ]; then
   fi
 fi
 
-if [ ! -f "${wl}" ]; then
-  if [ -z "${LOCAL}" ]; then
+if [ ! -f "${wl}" ] || [ "${force_build}" = "y" ]; then
+  if [ -z "${local}" ]; then
     ./build/builder.sh mkrelease amd64-linux-gnu bin/workload
     cp bin.docker_amd64/workload "${wl}"
   else
@@ -87,20 +159,26 @@ if [ ! -f "${wl}" ]; then
   cp bin/roachtest "${rt}"
 fi
 
+# Creation of test data directory is deferred here to avoid spamming in
+# cases where build fails.
+mkdir -p "${a}"
+trap 'echo Find run artifacts in ${a}' EXIT
+
 args=(
-  "run" "${TEST}"
+  "run" "${test}"
   "--port" "$((8080+RANDOM % 1000))"
   "--roachprod" "${rp}"
   "--workload" "${wl}"
   "--cockroach" "${cr}"
   "--artifacts" "${a}"
-  "--count" "${COUNT}"
+  "--count" "${count}"
 )
-if [ -n "${LOCAL}" ]; then
+if [ -n "${local}" ]; then
   args+=("--local")
 fi
 args+=("$@")
 
+echo "Running ${rt} ${args[@]}"
 # Run roachtest. Use a random port so that multiple
 # tests can be stressed from the same workstation.
 "${rt}" "${args[@]}"


### PR DESCRIPTION
Script expects run parameters as environment variables.
When changing test or changing number of runs it is handy to quickly pass
new value or just use history without running interactively.
Changed script to rely on command line options to provide arguments and
control rebuilding.

Release note: None