### PR TITLE
ui: remove `Last cleared` status on stmt and txn pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -39,10 +39,6 @@ interface TableStatistics {
   resetSQLStats: () => void;
 }
 
-const renderLastCleared = (lastReset: string | Date) => {
-  return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
-};
-
 export const TableStatistics: React.FC<TableStatistics> = ({
   pagination,
   totalCount,
@@ -72,23 +68,25 @@ export const TableStatistics: React.FC<TableStatistics> = ({
     </>
   );
 
-  let toolTipText = ` history is cleared once an hour by default, which can be configured with 
-  the cluster setting diagnostics.sql_stat_reset.interval. Clicking ‘clear SQL stats’ will reset SQL stats 
-  on the statements and transactions pages.`;
-
+  let statsType = "";
   switch (tooltipType) {
     case "transaction":
-      toolTipText = contentModifiers.transactionCapital + toolTipText;
+      statsType = contentModifiers.transactionCapital;
       break;
     case "statement":
-      toolTipText = contentModifiers.statementCapital + toolTipText;
+      statsType = contentModifiers.statementCapital;
       break;
     case "transactionDetails":
-      toolTipText = contentModifiers.statementCapital + toolTipText;
+      statsType = contentModifiers.statementCapital;
       break;
     default:
       break;
   }
+  const toolTipText = `${statsType} statistics are aggregated once an hour and organized by the start time. 
+  Statistics between two hourly intervals belong to the nearest hour rounded down. 
+  For example, a ${statsType} execution ending at 1:50 would have its statistics aggregated in the 1:00 interval 
+  start time. Clicking ‘clear SQL stats’ will reset SQL stats on the Statements and Transactions pages and 
+  crdb_internal tables.`;
 
   return (
     <div className={statistic}>
@@ -96,14 +94,12 @@ export const TableStatistics: React.FC<TableStatistics> = ({
         {activeFilters ? resultsCountAndClear : resultsPerPageLabel}
       </h4>
       <div className={cxStats("flex-display")}>
-        <Tooltip content={toolTipText}>
+        <Tooltip content={toolTipText} style="tableTitle">
           <div className={cxStats("tooltip-hover-area")}>
             <Icon iconName={"InfoCircle"} />
           </div>
         </Tooltip>
         <div className={lastCleared}>
-          {renderLastCleared(lastReset)}
-          {"  "}-{"  "}
           <a className={cxStats("action")} onClick={resetSQLStats}>
             clear SQL stats
           </a>


### PR DESCRIPTION
Previosuly we had a Last cleared status on Statements,
Transactions and Transactions Details pages, but with
persisted data this status doesn't make sense anymore.

This commit removes the status and updates the tooltip
of the clear sql stats to indicate that it will clear
in-memory and persisted data.

Fixes #70465

Before
<img width="572" alt="Screen Shot 2021-09-22 at 6 10 48 PM" src="https://user-images.githubusercontent.com/1017486/134428849-fb9e5b64-f37d-49b7-97c7-a1443f69f6df.png">


After
Statements page
<img width="478" alt="Screen Shot 2021-09-22 at 4 48 44 PM" src="https://user-images.githubusercontent.com/1017486/134428454-d7257141-0625-4033-850a-6e9e6c0ec648.png">

Transactions page
<img width="467" alt="Screen Shot 2021-09-22 at 4 48 58 PM" src="https://user-images.githubusercontent.com/1017486/134428468-69361259-ceb0-427a-a020-b0776f060643.png">

Release justification: Category 4
Release note (ui change): Remove last cleared status from
Statements, Transactions and Transaction Details page and
updates the tooltip on clear SQL stats to indicate it will clean
also the persisted data.