### PR TITLE
sql/catalog/lease: TestLeaseRenewedPeriodically failed

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -299,7 +299,7 @@ func (m *Manager) AcquireFreshestFromStore(ctx context.Context, id descpb.ID) er
 		// Acquire a fresh lease.
 		didAcquire, err := acquireNodeLease(ctx, m, id)
 		if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
-			m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(AcquireFreshestBlock)
+			m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(AcquireFreshestBlock, id)
 		}
 		if err != nil {
 			return err
@@ -814,7 +814,7 @@ func (m *Manager) Acquire(
 			}
 
 			if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
-				m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(AcquireBlock)
+				m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(AcquireBlock, id)
 			}
 
 		case errors.Is(err, errReadOlderVersion):

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -945,7 +945,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 					LeaseStoreTestingKnobs: StorageTestingKnobs{
 						RemoveOnceDereferenced: true,
 						LeaseReleasedEvent:     removalTracker.LeaseRemovedNotification,
-						LeaseAcquireResultBlockEvent: func(leaseBlockType AcquireBlockType) {
+						LeaseAcquireResultBlockEvent: func(leaseBlockType AcquireBlockType, _ descpb.ID) {
 							if leaseBlockType == AcquireBlock {
 								if count := atomic.LoadInt32(&acquireArrivals); (count < 1 && test.isSecondCallAcquireFreshest) ||
 									(count < 2 && !test.isSecondCallAcquireFreshest) {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1282,8 +1282,10 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 						atomic.AddInt32(&testAcquiredCount, 1)
 					}
 				},
-				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType) {
-					atomic.AddInt32(&testAcquisitionBlockCount, 1)
+				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
+					if id > keys.MaxReservedDescID {
+						atomic.AddInt32(&testAcquisitionBlockCount, 1)
+					}
 				},
 			},
 		},
@@ -1739,8 +1741,10 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 					defer mu.Unlock()
 					releasedIDs[id] = struct{}{}
 				},
-				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType) {
-					atomic.AddInt32(&testAcquisitionBlockCount, 1)
+				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
+					if id > keys.MaxReservedDescID {
+						atomic.AddInt32(&testAcquisitionBlockCount, 1)
+					}
 				},
 			},
 			TestingDescriptorUpdateEvent: func(_ *descpb.Descriptor) error {

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -30,7 +30,7 @@ type StorageTestingKnobs struct {
 	LeaseAcquiredEvent func(desc catalog.Descriptor, err error)
 	// Called before waiting on a results from a DoChan call of acquireNodeLease
 	// in descriptorState.acquire() and descriptorState.acquireFreshestFromStore().
-	LeaseAcquireResultBlockEvent func(leaseBlockType AcquireBlockType)
+	LeaseAcquireResultBlockEvent func(leaseBlockType AcquireBlockType, id descpb.ID)
 	// RemoveOnceDereferenced forces leases to be removed
 	// as soon as they are dereferenced.
 	RemoveOnceDereferenced bool


### PR DESCRIPTION
Fixes: #69737

Previously, the TestLeaseRenewedPeriodically was incorrectly counting
all blocked lease renewal requests, including non-user created descriptors.
This was inadequate because we would see intermittent failures in this
test. To address this, this patch detects if we are only blocked only
on user created descriptors.

Release note: None