### PR TITLE
row: improve the txnKVFetcher

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -639,6 +639,7 @@ func (rf *cFetcher) Init(
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
 func (rf *cFetcher) StartScan(
+	ctx context.Context,
 	txn *kv.Txn,
 	spans roachpb.Spans,
 	bsHeader *roachpb.BoundedStalenessHeader,
@@ -671,6 +672,7 @@ func (rf *cFetcher) StartScan(
 	// Note that we pass a nil memMonitor here, because the cfetcher does its own
 	// memory accounting.
 	f, err := row.NewKVFetcher(
+		ctx,
 		txn,
 		spans,
 		bsHeader,

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -92,6 +92,7 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchscan")
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
+		s.Ctx,
 		s.flowCtx.Txn,
 		s.spans,
 		s.bsHeader,

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -168,6 +168,7 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 			// Index joins will always return exactly one output row per input row.
 			s.rf.setEstimatedRowCount(uint64(rowCount))
 			if err := s.rf.StartScan(
+				s.Ctx,
 				s.flowCtx.Txn,
 				spans,
 				nil,   /* bsHeader */

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -596,6 +596,7 @@ func (rf *Fetcher) StartScan(
 
 	rf.traceKV = traceKV
 	f, err := makeKVBatchFetcher(
+		ctx,
 		makeKVBatchFetcherDefaultSendFunc(txn),
 		spans,
 		rf.reverse,
@@ -696,6 +697,7 @@ func (rf *Fetcher) StartInconsistentScan(
 
 	rf.traceKV = traceKV
 	f, err := makeKVBatchFetcher(
+		ctx,
 		sendFunc(sendFn),
 		spans,
 		rf.reverse,

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -46,6 +46,7 @@ type KVFetcher struct {
 // NewKVFetcher creates a new KVFetcher.
 // If mon is non-nil, this fetcher will track its fetches and must be Closed.
 func NewKVFetcher(
+	ctx context.Context,
 	txn *kv.Txn,
 	spans roachpb.Spans,
 	bsHeader *roachpb.BoundedStalenessHeader,
@@ -85,6 +86,7 @@ func NewKVFetcher(
 	}
 
 	kvBatchFetcher, err := makeKVBatchFetcher(
+		ctx,
 		sendFn,
 		spans,
 		reverse,


### PR DESCRIPTION
This commit improves the `txnKVFetcher` in the following manner:
- the fetcher is refactored to use only a single spans slice.
Previously, it was keeping track of the original request and the resume
spans separately; this commit makes it so that we reuse the same spans
slice by populating the resume spans while processing the responses one
at a time;
- the fetcher is now correctly reuses the spans slice it allocated in
the constructor. Previously, it was the intention to do so too, but it
wasn't working since we're slicing off for each response; now we're
keeping the reference to the largest allocated slice correctly;
- the commit adds the memory accounting for the now single spans slice
because these slices can be of non-trivial (in MBs and larger) size.

Release note: None