### PR TITLE
cli: add \du USER metacommand

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -74,7 +74,7 @@ Informational
   \l                list all databases in the CockroachDB cluster.
   \dt               show the tables of the current schema in the current database.
   \dT               show the user defined types of the current database.
-  \du               list the users for all databases.
+  \du [USER]        list the specified user, or list the users for all databases if no user is specified.
   \d [TABLE]        show details about columns in the specified table, or alias for '\dt' if no table is specified.
 
 Formatting
@@ -1155,8 +1155,14 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return cliRunStatement
 
 	case `\du`:
-		c.concatLines = `SHOW USERS`
-		return cliRunStatement
+		if len(cmd) == 1 {
+			c.concatLines = `SHOW USERS`
+			return cliRunStatement
+		} else if len(cmd) == 2 {
+			c.concatLines = fmt.Sprintf(`SELECT * FROM [SHOW USERS] WHERE username = %s`, lexbase.EscapeSQLString(cmd[1]))
+			return cliRunStatement
+		}
+		return c.invalidSyntax(errState, `%s. Try \? for help.`, c.lastInputLine)
 
 	case `\d`:
 		if len(cmd) == 1 {

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -103,6 +103,7 @@ func TestHandleCliCmdSqlAlias(t *testing.T) {
 		{`\dt`, `SHOW TABLES`},
 		{`\dT`, `SHOW TYPES`},
 		{`\du`, `SHOW USERS`},
+		{`\du myuser`, `SELECT * FROM [SHOW USERS] WHERE username = 'myuser'`},
 		{`\d mytable`, `SHOW COLUMNS FROM mytable`},
 		{`\d`, `SHOW TABLES`},
 	}

--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -59,6 +59,8 @@ func Example_sql() {
 	// first batch consisting of 1 row has been returned to the client.
 	c.RunWithArgs([]string{`sql`, `-e`, `select 1/(@1-2) from generate_series(1,3)`})
 	c.RunWithArgs([]string{`sql`, `-e`, `SELECT '20:01:02+03:04:05'::timetz AS regression_65066`})
+	c.RunWithArgs([]string{`sql`, `-e`, `CREATE USER my_user WITH CREATEDB; GRANT admin TO my_user;`})
+	c.RunWithArgs([]string{`sql`, `-e`, `\du my_user`})
 
 	// Output:
 	// sql -e show application_name
@@ -120,6 +122,11 @@ func Example_sql() {
 	// sql -e SELECT '20:01:02+03:04:05'::timetz AS regression_65066
 	// regression_65066
 	// 20:01:02+03:04:05
+	// sql -e CREATE USER my_user WITH CREATEDB; GRANT admin TO my_user;
+	// GRANT
+	// sql -e \du my_user
+	// username	options	member_of
+	// my_user	CREATEDB	{admin}
 }
 
 func Example_sql_config() {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70445

Release note (cli change): The sql shell now supports the `\du USER`
command to show information for the current user.