### PR TITLE
release-21.2: workload: Fix TPC-C multi-region partition assignment

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -80,7 +80,7 @@ func newSkipResult(format string, args ...interface{}) auditResult {
 
 // runChecks runs the audit checks and prints warnings to stdout for those that
 // fail.
-func (a *auditor) runChecks() {
+func (a *auditor) runChecks(localWarehouses bool) {
 	type check struct {
 		name string
 		f    func(a *auditor) auditResult
@@ -89,11 +89,19 @@ func (a *auditor) runChecks() {
 		{"9.2.1.7", check9217},
 		{"9.2.2.5.1", check92251},
 		{"9.2.2.5.2", check92252},
-		{"9.2.2.5.3", check92253},
-		{"9.2.2.5.4", check92254},
 		{"9.2.2.5.5", check92255},
 		{"9.2.2.5.6", check92256},
 	}
+
+	// If we're keeping the workload local, these checks are expected to fail.
+	// Bypass them instead of allowing them to fail.
+	if !localWarehouses {
+		checks = append(checks,
+			check{"9.2.2.5.3", check92253},
+			check{"9.2.2.5.4", check92254},
+		)
+	}
+
 	for _, check := range checks {
 		result := check.f(a)
 		msg := fmt.Sprintf("Audit check %s: %s", check.name, result.status)

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -181,7 +181,12 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 		}
 		// 2.4.1.5.2: 1% of the time, an item is supplied from a remote warehouse.
-		item.remoteWarehouse = rng.Intn(100) == 0
+		// If we're in localWarehouses mode, keep all items local.
+		if n.config.localWarehouses {
+			item.remoteWarehouse = false
+		} else {
+			item.remoteWarehouse = rng.Intn(100) == 0
+		}
 		item.olSupplyWID = wID
 		if item.remoteWarehouse && n.config.activeWarehouses > 1 {
 			allLocal = 0

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -162,8 +162,11 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	}
 
 	// 2.5.1.2: 85% chance of paying through home warehouse, otherwise
-	// remote.
-	if rng.Intn(100) < 85 {
+	// remote. This only applies to the customer update below, and not the
+	// warehouse and district updates.
+	// NOTE: If localWarehouses is set, keep all transactions local. This is for
+	// testing only, as it violates the spec.
+	if p.config.localWarehouses || rng.Intn(100) < 85 {
 		d.cWID = wID
 		d.cDID = d.dID
 	} else {


### PR DESCRIPTION
Backport 1/1 commits from #70121.

/cc @cockroachdb/release

---

When the initial changes were made to allow the TPC-C
workload to leverage the new 21.1 multi-region syntax,
the partitioning was overlooked. TPC-C by default partitions
in consecutive blocks. For example, if there are 9 warehouses
and 3 partitions, the partition assignment would be as
follows [[0, 1, 2], [3, 4, 5], [6, 7, 8]]. This unfortunately
doesn't work for multi-region workload assignment, as the
warehouses are distributed to regions using a round-robin
algorithm ([0, 3, 6], [1, 4, 7], [2, 5, 8]]. The end result
is that when combined with the --partition-affinity flag, workers
won't be assigned to local partitions and the workload will
instead be fully cross-region.

This change creates a separate partitioning structure to be
used in multi-region setups and ensures that the workers will
operate on local warehouses.

Also adds a new flag (`--region-local`) which allows the user
to override the TPC-C spec and keep all transactions local to
a given region. This was introduced for testing only.

Release justification: High impact bug fix to new functionality.
Release note (bug fix): Fixes a problem where the TPC-C workload,
when used in a multi-region setup, will not properly assign workers
to the local partitions.
