### PR TITLE
release-21.1: roachtest: retry java install

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/codahale/hdrhistogram"
@@ -1111,9 +1112,24 @@ func (k kafkaManager) install(ctx context.Context) {
 	k.c.Run(ctx, k.nodes, downloadScriptPath, folder)
 	if !k.c.isLocal() {
 		k.c.Run(ctx, k.nodes, `mkdir -p logs`)
-		k.c.Run(ctx, k.nodes, `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)
-		k.c.Run(ctx, k.nodes, `yes | sudo apt-get -q install openssl default-jre 2>&1 > logs/apt-get-install.log`)
+		if err := k.installJRE(ctx); err != nil {
+			k.c.t.Fatal(err)
+		}
 	}
+}
+
+func (k kafkaManager) installJRE(ctx context.Context) error {
+	retryOpts := retry.Options{
+		InitialBackoff: 1 * time.Minute,
+		MaxBackoff:     5 * time.Minute,
+	}
+	return retry.WithMaxAttempts(ctx, retryOpts, 3, func() error {
+		err := k.c.RunE(ctx, k.nodes, `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)
+		if err != nil {
+			return err
+		}
+		return k.c.RunE(ctx, k.nodes, `sudo DEBIAN_FRONTEND=noninteractive apt-get -yq --no-install-recommends install openssl default-jre 2>&1 > logs/apt-get-install.log`)
+	})
 }
 
 func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {


### PR DESCRIPTION
Backport 1/1 commits from #70491.

/cc @cockroachdb/release

---

Occasionally, the apt mirrors in GCP return 503 Service
Unavailable.

Here, we retry the install attempt 3 times with some backoff between
attempts.

I've also added the --no-install-recommends flag, although it does
very little in this case.

Release justification: Test-only change to increase the reliability
of the nightly tests.

Release note: None