### PR TITLE
sql: reuse the spans in the txnKVFetcher

### DIFF
--- a/pkg/sql/colexec/colexecspan/span_assembler.eg.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler.eg.go
@@ -18,12 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/errors"
 )
 
 // NewColSpanAssembler returns a ColSpanAssembler operator that is able to
@@ -56,8 +58,8 @@ func NewColSpanAssembler(
 	}
 
 	// Account for the memory currently in use.
-	usedMem := int64(cap(base.spans) * int(spanSize))
-	base.allocator.AdjustMemoryUsage(usedMem)
+	base.spansBytes = int64(cap(base.spans)) * spanSize
+	base.allocator.AdjustMemoryUsage(base.spansBytes)
 
 	if len(base.colFamStartKeys) == 0 {
 		return &spanAssemblerNoColFamily{spanAssemblerBase: *base}
@@ -78,17 +80,27 @@ type ColSpanAssembler interface {
 
 	// ConsumeBatch generates lookup spans from input batches and stores them to
 	// later be returned by GetSpans. Spans are generated only for rows in the
-	// range [startIdx, endIdx). If startIdx >= endIdx, ConsumeBatch will perform
-	// no work.
+	// range [startIdx, endIdx). If startIdx >= endIdx, ConsumeBatch will
+	// perform no work. The memory of the newly accumulated spans is accounted
+	// for.
+	// Note: ConsumeBatch may invalidate the spans returned by the last call to
+	// GetSpans.
 	ConsumeBatch(batch coldata.Batch, startIdx, endIdx int)
 
 	// GetSpans returns the set of spans that have been generated so far. The
-	// returned Spans object is still owned by the SpanAssembler, so subsequent
-	// calls to GetSpans will invalidate the spans returned by previous calls. A
-	// caller that wishes to hold on to spans over the course of multiple calls
-	// should perform a shallow copy of the Spans. GetSpans will return an empty
-	// slice if it is called before ConsumeBatch.
+	// subsequent calls to GetSpans will invalidate the spans returned by the
+	// previous calls. A caller that wishes to hold on to spans over the course
+	// of multiple calls should perform a shallow copy of the Spans. GetSpans
+	// will return an empty slice if it is called before ConsumeBatch.
+	// The memory of the returned object is no longer accounted for by the
+	// ColSpanAssembler, so it is the caller's responsibility to do so.
 	GetSpans() roachpb.Spans
+
+	// AccountForSpans notifies the ColSpanAssembler that it is now responsible
+	// for accounting for the memory used by already allocated spans slice. This
+	// should be called after the result of the last call to GetSpans() is no
+	// longer accounted for by the caller.
+	AccountForSpans()
 
 	// Close closes the ColSpanAssembler operator.
 	Close()
@@ -102,6 +114,10 @@ type spanAssemblerBase struct {
 	// keys since the last call to GetSpans. It is reset each time GetSpans is
 	// called, since the SpanAssembler operator no longer owns the memory.
 	keyBytes int
+
+	// spansBytes tracks the number of bytes used by spans slice that we have
+	// accounted for so far. It doesn't include any of the keys in the spans.
+	spansBytes int64
 
 	// spans is the list of spans that have been assembled so far. spans is owned
 	// and reset upon each call to GetSpans by the SpanAssembler operator.
@@ -147,7 +163,7 @@ func (op *spanAssemblerNoColFamily) ConsumeBatch(batch coldata.Batch, startIdx, 
 	}
 
 	oldKeyBytes := op.keyBytes
-	oldSpansCap := cap(op.spans)
+	oldSpansBytes := op.spansBytes
 	for i := 0; i < (endIdx - startIdx); i++ {
 		op.scratchKey = op.scratchKey[:op.prefixLength]
 		for j := range op.spanCols {
@@ -175,9 +191,9 @@ func (op *spanAssemblerNoColFamily) ConsumeBatch(batch coldata.Batch, startIdx, 
 	}
 
 	// Account for the memory allocated for the span slice and keys.
-	keyBytesMem := op.keyBytes - oldKeyBytes
-	spanSliceMem := (cap(op.spans) - oldSpansCap) * int(spanSize)
-	op.allocator.AdjustMemoryUsage(int64(spanSliceMem + keyBytesMem))
+	keyBytesMem := int64(op.keyBytes - oldKeyBytes)
+	op.spansBytes = int64(cap(op.spans)) * spanSize
+	op.allocator.AdjustMemoryUsage((op.spansBytes - oldSpansBytes) + keyBytesMem)
 }
 
 type spanAssemblerWithColFamily struct {
@@ -197,7 +213,7 @@ func (op *spanAssemblerWithColFamily) ConsumeBatch(batch coldata.Batch, startIdx
 	}
 
 	oldKeyBytes := op.keyBytes
-	oldSpansCap := cap(op.spans)
+	oldSpansBytes := op.spansBytes
 	for i := 0; i < (endIdx - startIdx); i++ {
 		op.scratchKey = op.scratchKey[:op.prefixLength]
 		for j := range op.spanCols {
@@ -229,22 +245,34 @@ func (op *spanAssemblerWithColFamily) ConsumeBatch(batch coldata.Batch, startIdx
 	}
 
 	// Account for the memory allocated for the span slice and keys.
-	keyBytesMem := op.keyBytes - oldKeyBytes
-	spanSliceMem := (cap(op.spans) - oldSpansCap) * int(spanSize)
-	op.allocator.AdjustMemoryUsage(int64(spanSliceMem + keyBytesMem))
+	keyBytesMem := int64(op.keyBytes - oldKeyBytes)
+	op.spansBytes = int64(cap(op.spans)) * spanSize
+	op.allocator.AdjustMemoryUsage((op.spansBytes - oldSpansBytes) + keyBytesMem)
 }
 
-const spanSize = unsafe.Sizeof(roachpb.Span{})
+const spanSize = int64(unsafe.Sizeof(roachpb.Span{}))
 
 // GetSpans implements the ColSpanAssembler interface.
 func (b *spanAssemblerBase) GetSpans() roachpb.Spans {
-	// Even though the memory allocated for the span keys probably can't be GC'd
-	// yet, we release now because the memory will be owned by the caller.
-	b.allocator.ReleaseMemory(int64(b.keyBytes))
+	// The caller takes ownership of the returned spans, so we release all the
+	// memory.
+	b.allocator.ReleaseMemory(int64(b.keyBytes) + b.spansBytes)
 	b.keyBytes = 0
+	b.spansBytes = 0
 	spans := b.spans
 	b.spans = b.spans[:0]
 	return spans
+}
+
+// AccountForSpans implements the ColSpanAssembler interface.
+func (b *spanAssemblerBase) AccountForSpans() {
+	if b.spansBytes != 0 {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"unexpectedly non-zero spans bytes in AccountForSpans",
+		))
+	}
+	b.spansBytes = int64(cap(b.spans)) * spanSize
+	b.allocator.AdjustMemoryUsage(b.spansBytes)
 }
 
 // Close implements the ColSpanAssembler interface.
@@ -255,13 +283,9 @@ func (b *spanAssemblerBase) Close() {
 }
 
 // Release implements the ColSpanAssembler interface.
-// TODO(drewk): we account for the memory that is owned by the SpanAssembler
-// operator, but release it once the SpanAssembler loses its references even
-// though it can still be referenced elsewhere. The two cases are the spans
-// slice (it is put into a pool) and the underlying bytes for the keys (they are
-// referenced by the kv fetcher code). Ideally we would hand off memory
-// accounting to whoever ends up owning the memory, instead of just no longer
-// tracking it.
+// TODO(yuzefovich): once we put the spanAssembler into the pool, we no longer
+// account for the spans slice. Figure out how we can improve the accounting
+// here.
 func (b *spanAssemblerBase) Release() {
 	for i := range b.spanCols {
 		// Release references to input columns.

--- a/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
@@ -28,12 +28,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/errors"
 )
 
 // NewColSpanAssembler returns a ColSpanAssembler operator that is able to
@@ -66,8 +68,8 @@ func NewColSpanAssembler(
 	}
 
 	// Account for the memory currently in use.
-	usedMem := int64(cap(base.spans) * int(spanSize))
-	base.allocator.AdjustMemoryUsage(usedMem)
+	base.spansBytes = int64(cap(base.spans)) * spanSize
+	base.allocator.AdjustMemoryUsage(base.spansBytes)
 
 	if len(base.colFamStartKeys) == 0 {
 		return &spanAssemblerNoColFamily{spanAssemblerBase: *base}
@@ -88,17 +90,29 @@ type ColSpanAssembler interface {
 
 	// ConsumeBatch generates lookup spans from input batches and stores them to
 	// later be returned by GetSpans. Spans are generated only for rows in the
-	// range [startIdx, endIdx). If startIdx >= endIdx, ConsumeBatch will perform
-	// no work.
+	// range [startIdx, endIdx). If startIdx >= endIdx, ConsumeBatch will
+	// perform no work. The memory of the newly accumulated spans is accounted
+	// for.
+	//
+	// Note: ConsumeBatch may invalidate the spans returned by the last call to
+	// GetSpans.
 	ConsumeBatch(batch coldata.Batch, startIdx, endIdx int)
 
 	// GetSpans returns the set of spans that have been generated so far. The
-	// returned Spans object is still owned by the SpanAssembler, so subsequent
-	// calls to GetSpans will invalidate the spans returned by previous calls. A
-	// caller that wishes to hold on to spans over the course of multiple calls
-	// should perform a shallow copy of the Spans. GetSpans will return an empty
-	// slice if it is called before ConsumeBatch.
+	// subsequent calls to GetSpans will invalidate the spans returned by the
+	// previous calls. A caller that wishes to hold on to spans over the course
+	// of multiple calls should perform a shallow copy of the Spans. GetSpans
+	// will return an empty slice if it is called before ConsumeBatch.
+	//
+	// The memory of the returned object is no longer accounted for by the
+	// ColSpanAssembler, so it is the caller's responsibility to do so.
 	GetSpans() roachpb.Spans
+
+	// AccountForSpans notifies the ColSpanAssembler that it is now responsible
+	// for accounting for the memory used by already allocated spans slice. This
+	// should be called after the result of the last call to GetSpans() is no
+	// longer accounted for by the caller.
+	AccountForSpans()
 
 	// Close closes the ColSpanAssembler operator.
 	Close()
@@ -112,6 +126,10 @@ type spanAssemblerBase struct {
 	// keys since the last call to GetSpans. It is reset each time GetSpans is
 	// called, since the SpanAssembler operator no longer owns the memory.
 	keyBytes int
+
+	// spansBytes tracks the number of bytes used by spans slice that we have
+	// accounted for so far. It doesn't include any of the keys in the spans.
+	spansBytes int64
 
 	// spans is the list of spans that have been assembled so far. spans is owned
 	// and reset upon each call to GetSpans by the SpanAssembler operator.
@@ -159,7 +177,7 @@ func (op *_OP_STRING) ConsumeBatch(batch coldata.Batch, startIdx, endIdx int) {
 	}
 
 	oldKeyBytes := op.keyBytes
-	oldSpansCap := cap(op.spans)
+	oldSpansBytes := op.spansBytes
 	for i := 0; i < (endIdx - startIdx); i++ {
 		op.scratchKey = op.scratchKey[:op.prefixLength]
 		for j := range op.spanCols {
@@ -175,24 +193,36 @@ func (op *_OP_STRING) ConsumeBatch(batch coldata.Batch, startIdx, endIdx int) {
 	}
 
 	// Account for the memory allocated for the span slice and keys.
-	keyBytesMem := op.keyBytes - oldKeyBytes
-	spanSliceMem := (cap(op.spans) - oldSpansCap) * int(spanSize)
-	op.allocator.AdjustMemoryUsage(int64(spanSliceMem + keyBytesMem))
+	keyBytesMem := int64(op.keyBytes - oldKeyBytes)
+	op.spansBytes = int64(cap(op.spans)) * spanSize
+	op.allocator.AdjustMemoryUsage((op.spansBytes - oldSpansBytes) + keyBytesMem)
 }
 
 // {{end}}
 
-const spanSize = unsafe.Sizeof(roachpb.Span{})
+const spanSize = int64(unsafe.Sizeof(roachpb.Span{}))
 
 // GetSpans implements the ColSpanAssembler interface.
 func (b *spanAssemblerBase) GetSpans() roachpb.Spans {
-	// Even though the memory allocated for the span keys probably can't be GC'd
-	// yet, we release now because the memory will be owned by the caller.
-	b.allocator.ReleaseMemory(int64(b.keyBytes))
+	// The caller takes ownership of the returned spans, so we release all the
+	// memory.
+	b.allocator.ReleaseMemory(int64(b.keyBytes) + b.spansBytes)
 	b.keyBytes = 0
+	b.spansBytes = 0
 	spans := b.spans
 	b.spans = b.spans[:0]
 	return spans
+}
+
+// AccountForSpans implements the ColSpanAssembler interface.
+func (b *spanAssemblerBase) AccountForSpans() {
+	if b.spansBytes != 0 {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"unexpectedly non-zero spans bytes in AccountForSpans",
+		))
+	}
+	b.spansBytes = int64(cap(b.spans)) * spanSize
+	b.allocator.AdjustMemoryUsage(b.spansBytes)
 }
 
 // Close implements the ColSpanAssembler interface.
@@ -203,13 +233,9 @@ func (b *spanAssemblerBase) Close() {
 }
 
 // Release implements the ColSpanAssembler interface.
-// TODO(drewk): we account for the memory that is owned by the SpanAssembler
-// operator, but release it once the SpanAssembler loses its references even
-// though it can still be referenced elsewhere. The two cases are the spans
-// slice (it is put into a pool) and the underlying bytes for the keys (they are
-// referenced by the kv fetcher code). Ideally we would hand off memory
-// accounting to whoever ends up owning the memory, instead of just no longer
-// tracking it.
+// TODO(yuzefovich): once we put the spanAssembler into the pool, we no longer
+// account for the spans slice. Figure out how we can improve the accounting
+// here.
 func (b *spanAssemblerBase) Release() {
 	for i := range b.spanCols {
 		// Release references to input columns.

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -167,6 +167,12 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 
 			// Index joins will always return exactly one output row per input row.
 			s.rf.setEstimatedRowCount(uint64(rowCount))
+			// Note that the fetcher takes ownership of the spans slice - it
+			// will modify it and perform the memory accounting. We don't care
+			// about the modification here, but we want to be conscious about
+			// the memory accounting - we don't double count for any memory of
+			// spans because the spanAssembler released all of the relevant
+			// memory from its account in GetSpans().
 			if err := s.rf.StartScan(
 				s.Ctx,
 				s.flowCtx.Txn,
@@ -191,6 +197,11 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 			}
 			n := batch.Length()
 			if n == 0 {
+				// NB: the fetcher has just been closed automatically, so it
+				// released all of the resources. We now have to tell the
+				// ColSpanAssembler to account for the spans slice since it
+				// still has the references to it.
+				s.spanAssembler.AccountForSpans()
 				s.state = indexJoinConstructingSpans
 				continue
 			}
@@ -199,6 +210,11 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 			s.mu.Unlock()
 			return batch
 		case indexJoinDone:
+			// Eagerly close the index joiner. Note that Close() is idempotent,
+			// so it's ok if it'll be closed again.
+			if err := s.Close(); err != nil {
+				colexecerror.InternalError(err)
+			}
 			return coldata.ZeroBatch
 		}
 	}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -206,7 +206,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 
 	var spans roachpb.Spans
 	if params.InvertedConstraint != nil {
-		spans, err = sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint)
+		spans, err = sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint, nil /* scratch */)
 	} else {
 		spans, err = sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
 	}

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -95,3 +95,33 @@ func MisplannedRanges(
 
 	return misplannedRanges
 }
+
+// SpansWithCopy tracks a set of spans (which can be modified) along with the
+// copy of the original one if needed.
+type SpansWithCopy struct {
+	Spans     roachpb.Spans
+	SpansCopy roachpb.Spans
+}
+
+// MakeSpansCopy makes a copy of s.Spans (which are assumed to have already been
+// set).
+func (s *SpansWithCopy) MakeSpansCopy() {
+	if cap(s.SpansCopy) >= len(s.Spans) {
+		s.SpansCopy = s.SpansCopy[:len(s.Spans)]
+	} else {
+		s.SpansCopy = make(roachpb.Spans, len(s.Spans))
+	}
+	copy(s.SpansCopy, s.Spans)
+}
+
+// Reset deeply resets s.
+func (s *SpansWithCopy) Reset() {
+	for i := range s.Spans {
+		s.Spans[i] = roachpb.Span{}
+	}
+	for i := range s.SpansCopy {
+		s.SpansCopy[i] = roachpb.Span{}
+	}
+	s.Spans = s.Spans[:0]
+	s.SpansCopy = s.SpansCopy[:0]
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -149,7 +149,7 @@ func generateScanSpans(
 ) (roachpb.Spans, error) {
 	sb := span.MakeBuilder(evalCtx, codec, tabDesc, index)
 	if params.InvertedConstraint != nil {
-		return sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint)
+		return sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint, nil /* scratch */)
 	}
 	return sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
 }

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -45,6 +45,11 @@ type KVFetcher struct {
 
 // NewKVFetcher creates a new KVFetcher.
 // If mon is non-nil, this fetcher will track its fetches and must be Closed.
+//
+// The fetcher takes ownership of the spans slice - it can modify the slice and
+// will perform the memory accounting accordingly (if mon is non-nil). The
+// caller can only reuse the spans slice after the fetcher has been closed, and
+// if the caller does, it becomes responsible for the memory accounting.
 func NewKVFetcher(
 	ctx context.Context,
 	txn *kv.Txn,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -147,6 +147,13 @@ type invertedJoiner struct {
 	// columns are functionally dependent on the PK.
 	indexRows *rowcontainer.DiskBackedNumberedRowContainer
 
+	// indexSpans are the roachpb.Spans generated based on the inverted spans.
+	// The slice is reused between different input batches.
+	// NB: the row fetcher takes ownership of the slice and deeply resets each
+	// element of the slice once the fetcher is done with it, so we don't need
+	// to do ourselves.
+	indexSpans roachpb.Spans
+
 	// emitCursor contains information about where the next row to emit is within
 	// joinedRowIdx.
 	emitCursor struct {
@@ -487,16 +494,16 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 		return ijEmittingRows, nil
 	}
 	// NB: spans is already sorted, and that sorting is preserved when
-	// generating indexSpans.
-	indexSpans, err := ij.spanBuilder.SpansFromInvertedSpans(spans, nil /* constraint */)
+	// generating ij.indexSpans.
+	ij.indexSpans, err = ij.spanBuilder.SpansFromInvertedSpans(spans, nil /* constraint */, ij.indexSpans)
 	if err != nil {
 		ij.MoveToDraining(err)
 		return ijStateUnknown, ij.DrainHelper()
 	}
 
-	log.VEventf(ij.Ctx, 1, "scanning %d spans", len(indexSpans))
+	log.VEventf(ij.Ctx, 1, "scanning %d spans", len(ij.indexSpans))
 	if err = ij.fetcher.StartScan(
-		ij.Ctx, ij.FlowCtx.Txn, indexSpans, rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
+		ij.Ctx, ij.FlowCtx.Txn, ij.indexSpans, rowinfra.NoBytesLimit, rowinfra.NoRowLimit,
 		ij.FlowCtx.TraceKV, ij.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 	); err != nil {
 		ij.MoveToDraining(err)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -763,6 +763,11 @@ func (jr *joinReader) readInput() (
 			bytesLimit = rowinfra.DefaultBatchBytesLimit
 		}
 	}
+	// Note that the fetcher takes ownership of the spans slice - it will modify
+	// it and perform the memory accounting. We don't care about the
+	// modification here, but we want to be conscious about the memory
+	// accounting - we don't double count for any memory of spans because the
+	// joinReaderStrategy doesn't account for any memory used by the spans.
 	if err := jr.fetcher.StartScan(
 		jr.Ctx, jr.FlowCtx.Txn, spans, bytesLimit, rowinfra.NoRowLimit,
 		jr.FlowCtx.TraceKV, jr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -35,6 +35,10 @@ type joinReaderSpanGenerator interface {
 	// are returned in rows order, but there are no duplicates (i.e. if a 2nd row
 	// results in the same spans as a previous row, the results don't include them
 	// a second time).
+	//
+	// The returned spans are not accounted for, so it is the caller's
+	// responsibility to register the spans memory usage with our memory
+	// accounting system.
 	generateSpans(ctx context.Context, rows []rowenc.EncDatumRow) (roachpb.Spans, error)
 
 	// getMatchingRowIndices returns the indices of the input rows that desire
@@ -159,6 +163,8 @@ func (g *defaultSpanGenerator) maxLookupCols() int {
 
 // memUsage returns the size of the data structures in the defaultSpanGenerator
 // for memory accounting purposes.
+// NOTE: this does not account for scratchSpans because the joinReader passes
+// the ownership of spans to the fetcher which will account for it accordingly.
 func (g *defaultSpanGenerator) memUsage() int64 {
 	// Account for keyToInputRowIndices.
 	var size int64
@@ -167,9 +173,6 @@ func (g *defaultSpanGenerator) memUsage() int64 {
 		size += memsize.String + int64(len(k))
 		size += memsize.IntSliceOverhead + memsize.Int*int64(cap(v))
 	}
-
-	// Account for scratchSpans.
-	size += g.scratchSpans.MemUsage()
 	return size
 }
 
@@ -703,6 +706,8 @@ func (g *multiSpanGenerator) getMatchingRowIndices(key roachpb.Key) []int {
 
 // memUsage returns the size of the data structures in the multiSpanGenerator
 // for memory accounting purposes.
+// NOTE: this does not account for scratchSpans because the joinReader passes
+// the ownership of spans to the fetcher which will account for it accordingly.
 func (g *multiSpanGenerator) memUsage() int64 {
 	// Account for keyToInputRowIndices.
 	var size int64
@@ -714,9 +719,6 @@ func (g *multiSpanGenerator) memUsage() int64 {
 
 	// Account for spanToInputRowIndices.
 	size += g.spanToInputRowIndices.memUsage()
-
-	// Account for scratchSpans.
-	size += g.scratchSpans.MemUsage()
 	return size
 }
 

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -61,6 +61,10 @@ type joinReaderStrategy interface {
 	generatedRemoteSpans() bool
 	// processLookupRows consumes the rows the joinReader has buffered and returns
 	// the lookup spans.
+	//
+	// The returned spans are not accounted for, so it is the caller's
+	// responsibility to register the spans memory usage with our memory
+	// accounting system.
 	processLookupRows(rows []rowenc.EncDatumRow) (roachpb.Spans, error)
 	// processLookedUpRow processes a looked up row. A joinReaderState is returned
 	// to indicate the next state to transition to. If this next state is

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -134,10 +134,11 @@ func newScrubTableReader(
 	}
 	tr.fetcher = &fetcher
 
-	tr.spans = make(roachpb.Spans, len(spec.Spans))
+	tr.Spans = make(roachpb.Spans, len(spec.Spans))
 	for i, s := range spec.Spans {
-		tr.spans[i] = s.Span
+		tr.Spans[i] = s.Span
 	}
+	tr.MakeSpansCopy()
 
 	return tr, nil
 }
@@ -219,7 +220,7 @@ func (tr *scrubTableReader) Start(ctx context.Context) {
 	log.VEventf(ctx, 1, "starting")
 
 	if err := tr.fetcher.StartScan(
-		ctx, tr.FlowCtx.Txn, tr.spans, rowinfra.DefaultBatchBytesLimit, tr.limitHint,
+		ctx, tr.FlowCtx.Txn, tr.Spans, rowinfra.DefaultBatchBytesLimit, tr.limitHint,
 		tr.FlowCtx.TraceKV, tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 	); err != nil {
 		tr.MoveToDraining(err)

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -34,8 +34,8 @@ import (
 // See docs/RFCS/distributed_sql.md
 type tableReader struct {
 	execinfra.ProcessorBase
+	execinfra.SpansWithCopy
 
-	spans           roachpb.Spans
 	limitHint       rowinfra.RowLimit
 	parallelize     bool
 	batchBytesLimit rowinfra.BytesLimit
@@ -166,13 +166,18 @@ func newTableReader(
 	}
 
 	nSpans := len(spec.Spans)
-	if cap(tr.spans) >= nSpans {
-		tr.spans = tr.spans[:nSpans]
+	if cap(tr.Spans) >= nSpans {
+		tr.Spans = tr.Spans[:nSpans]
 	} else {
-		tr.spans = make(roachpb.Spans, nSpans)
+		tr.Spans = make(roachpb.Spans, nSpans)
 	}
 	for i, s := range spec.Spans {
-		tr.spans[i] = s.Span
+		tr.Spans[i] = s.Span
+	}
+	if !tr.ignoreMisplannedRanges {
+		// Make a copy of the spans so that we could get the misplanned ranges
+		// info.
+		tr.MakeSpansCopy()
 	}
 
 	if execinfra.ShouldCollectStats(flowCtx.EvalCtx.Ctx(), flowCtx) {
@@ -217,14 +222,14 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(
-			ctx, tr.FlowCtx.Txn, tr.spans, bytesLimit, tr.limitHint,
+			ctx, tr.FlowCtx.Txn, tr.Spans, bytesLimit, tr.limitHint,
 			tr.FlowCtx.TraceKV,
 			tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
 	} else {
 		initialTS := tr.FlowCtx.Txn.ReadTimestamp()
 		err = tr.fetcher.StartInconsistentScan(
-			ctx, tr.FlowCtx.Cfg.DB, initialTS, tr.maxTimestampAge, tr.spans,
+			ctx, tr.FlowCtx.Cfg.DB, initialTS, tr.maxTimestampAge, tr.Spans,
 			bytesLimit, tr.limitHint, tr.FlowCtx.TraceKV,
 			tr.EvalCtx.TestingKnobs.ForceProductionBatchSizes,
 		)
@@ -238,13 +243,11 @@ func (tr *tableReader) Release() {
 	tr.ProcessorBase.Reset()
 	tr.fetcher.Reset()
 	// Deeply reset the spans so that we don't hold onto the keys of the spans.
-	for i := range tr.spans {
-		tr.spans[i] = roachpb.Span{}
-	}
+	tr.SpansWithCopy.Reset()
 	*tr = tableReader{
 		ProcessorBase: tr.ProcessorBase,
+		SpansWithCopy: tr.SpansWithCopy,
 		fetcher:       tr.fetcher,
-		spans:         tr.spans[:0],
 		rowsRead:      0,
 	}
 	trPool.Put(tr)
@@ -335,7 +338,7 @@ func (tr *tableReader) generateMeta() []execinfrapb.ProducerMetadata {
 	if !tr.ignoreMisplannedRanges {
 		nodeID, ok := tr.FlowCtx.NodeID.OptionalNodeID()
 		if ok {
-			ranges := execinfra.MisplannedRanges(tr.Ctx, tr.spans, nodeID, tr.FlowCtx.Cfg.RangeCache)
+			ranges := execinfra.MisplannedRanges(tr.Ctx, tr.SpansCopy, nodeID, tr.FlowCtx.Cfg.RangeCache)
 			if ranges != nil {
 				trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
 			}


### PR DESCRIPTION
**sql: reuse the spans in the txnKVFetcher**

Previously, we would always make a copy of the spans to scan in the
`txnKVFetcher` because we might be modifying them. However, most callers
don't care about that - I think only the table reader and ColBatchScan
do need keep the copy of the original spans for the purposes of the
misplanned ranges. This commit takes advantage of this observation and
removes the copy in several cases (most notably for the lookup and index
joins).

Notable change is that now the `txnKVFetcher` is the only component
responsible for the memory accounting of the spans. This simplifies the
memory story but also seems like a good decision because
- `txnKVFetcher` is the component that might be holding onto the spans
slice for the longest amount of time
- it is also the place where we'd know about any modifications, so it
can update the memory accounting accordingly
- in case of `joinReader` - `StartScan` is called multiple times, we do
not close the fetcher until we're ready to perform the next scan, so the
old fetcher is holding onto and is accounting for the old spans until we
call `StartScan` again. Here `generateSpans` is very quick, so if
consequent scans had much more heavy-weight spans, we'll account for the
update very soon (when initializing the new fetcher).
- in case of the vectorized index joiner - here we're performing the
memory accounting as we are building the spans to scan, one batch at a
time. I think it makes sense to do so. Now, during the span generation
the spanAssembler is responsible for the memory accounting, but once
`GetSpans` is called, the ownership is passed to the `txnKVFetcher`.
Once the `cFetcher` emits the first zero batch for the current set of
spans, it closed the txnKVFetcher, and the vectorized index joiner
notifies the ColSpanAssembler to account for the spans. This makes sure
that we don't double count for the memory of `spans`, yet it is always
accounted for.

Addresses: #64906.

Release note: None

**rowexec: reuse the same spans slice in the inverted joiner**

Release note: None