### PR TITLE
cli: add unit test for disk full exit code

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -358,6 +358,7 @@ go_test(
         "//pkg/workload/examples",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Add a unit test verifying that a cli error with the appropriate exit
code is returned when the filesystem reports a full disk.

Release note: none