### PR TITLE
ui: fix tooltip text on statement and transaction table columns

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -163,7 +163,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               {"The bar indicates the ratio of runtime success (gray) to "}
@@ -194,7 +194,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
       <Tooltip
         placement="bottom"
         style="tableTitle"
-        content={<p>Database on which the ${contentModifier} was executed.</p>}
+        content={<p>Database on which the {contentModifier} was executed.</p>}
       >
         {getLabel("database")}
       </Tooltip>
@@ -232,7 +232,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               The gray bar indicates the mean number of rows read from disk. The
@@ -277,7 +277,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               The gray bar indicates the mean number of bytes read from disk.
@@ -322,7 +322,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={planningExecutionTime} target="_blank">
                 planning and execution time
               </Anchor>
-              {` of ${contentModifier} with this fingerprint${fingerprintModifier} within the last hour or specified time interval.`}
+              {` of ${contentModifier} with this fingerprint${fingerprintModifier} within the last hour or specified time interval. `}
             </p>
             <p>
               The gray bar indicates the mean latency. The blue bar indicates
@@ -367,7 +367,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               The gray bar indicates mean contention time. The blue bar
@@ -408,7 +408,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               The gray bar indicates the average max memory usage. The blue bar
@@ -453,7 +453,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               <Anchor href={statementsTimeInterval} target="_blank">
                 time interval
               </Anchor>
-              .
+              .&nbsp;
             </p>
             <p>
               If this value is 0, the statement was executed on a single node.
@@ -528,7 +528,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         style="tableTitle"
         content={
           <p>
-            % of runtime all ${contentModifier} with this fingerprint$
+            % of runtime all {contentModifier} with this fingerprint
             {fingerprintModifier} represent, compared to the cumulative runtime
             of all queries within the last hour or specified time interval.
           </p>
@@ -554,7 +554,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         placement="bottom"
         style="tableTitle"
         content={
-          <p>Regions/Nodes in which the ${contentModifier} was executed.</p>
+          <p>Regions/Nodes in which the {contentModifier} was executed.</p>
         }
       >
         {getLabel("regionNodes")}


### PR DESCRIPTION
Previously, there was a bug where some column tooltips included a '$'
before variable names. Also, some tooltip descriptions lacked a space
after a period.

To address this bug, this commit adds some simple styling changes by
inserting `&nbsp;` after some periods to add a space, and changing the way
we insert variables.

![image](https://user-images.githubusercontent.com/29153209/134581313-18d2d304-43a2-45a5-935b-cd1b54825df0.png)
![image](https://user-images.githubusercontent.com/29153209/134581387-69e4a3d0-a5d7-4ea5-9ca0-109164e7eb09.png)
![image](https://user-images.githubusercontent.com/29153209/134581432-bf3d37be-4159-4a65-9a6e-e988a4297359.png)

Release note (bug fix): fix styling issues in tooltip text on statement
and transaction table columns