### PR TITLE
colexec: use unordered groups for hash aggregator benchmarks

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -935,6 +935,7 @@ func benchmarkAggregateFunction(
 	groupSize int,
 	distinctProb float64,
 	numInputRows int,
+	orderedGroup bool,
 ) {
 	defer log.Scope(b).Close(b)
 	if groupSize > numInputRows {
@@ -957,7 +958,7 @@ func benchmarkAggregateFunction(
 		cols[i] = testAllocator.NewMemColumn(typs[i], numInputRows)
 	}
 	groups := cols[0].Int64()
-	if agg.name == "hash" {
+	if !orderedGroup {
 		numGroups := numInputRows / groupSize
 		for i := 0; i < numInputRows; i++ {
 			groups[i] = int64(rng.Intn(numGroups))
@@ -1099,7 +1100,7 @@ func BenchmarkAggregator(b *testing.B) {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.Int}, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					agg.name == "ordered" /* orderedGroup */)
 			}
 		}
 	}
@@ -1136,7 +1137,7 @@ func BenchmarkAllOptimizedAggregateFunctions(b *testing.B) {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, aggInputTypes, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					agg.name == "ordered" /* orderedGroup */)
 			}
 		}
 	}
@@ -1158,8 +1159,8 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 						continue
 					}
 					benchmarkAggregateFunction(
-						b, agg, aggFn, []*types.T{types.Int}, groupSize, distinctProb, numInputRows,
-					)
+						b, agg, aggFn, []*types.T{types.Int}, groupSize, distinctProb,
+						numInputRows, agg.name == "ordered" /* orderedGroup */)
 				}
 			}
 		}

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -173,7 +173,7 @@ func BenchmarkDefaultAggregateFunction(b *testing.B) {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					agg.name == "ordered" /* orderedGroup */)
 			}
 		}
 	}

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -205,10 +205,9 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 							return colexecop.NewNoop(op), err
 						},
 						name: fmt.Sprintf("spilled=%t", spillForced),
-					},
-					aggFn, []*types.T{types.Int}, groupSize,
+					}, aggFn, []*types.T{types.Int}, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					false /* orderedGroup */)
 			}
 		}
 	}

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -199,7 +199,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.Int}, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					false /* orderedGroup */)
 			}
 		}
 	}


### PR DESCRIPTION
Before this change, aggregator benchmarking relied on the test's
`AggType` name to determine whether to order the input groups or not.
As a result, some hash aggregator benchmarks with different names were
using sorted input, when they should have used randomized input.

This change makes the choice between using an `orderedGroup` versus a
hash more explicit in the benchmark setup. Although this affects the
group ordering for some hash aggregator benchmarks, this change is not
expected to have performance impact.

Release note: None