### PR TITLE
dev: log the actual calls to `bazel` that `dev` makes

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/build/util",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
+        "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_cobra//:cobra",

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -114,6 +114,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		if short {
 			args = append(args, "-test.short", "-test.benchtime=1ns")
 		}
+		logCommand("bazel", args...)
 		err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 		if err != nil {
 			return err

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -90,6 +90,7 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 
 	if cross == "" {
 		args = append(args, getConfigFlags()...)
+		logCommand("bazel", args...)
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err
 		}

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -50,5 +50,6 @@ func (d *dev) lint(cmd *cobra.Command, _ []string) error {
 		args = append(args, "-test.run", filter)
 	}
 
+	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 }

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -182,6 +182,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_output", "errors")
 	}
 
+	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 }
 

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -205,4 +206,11 @@ func splitArgsAtDash(cmd *cobra.Command, args []string) (before, after []string)
 		after = args[argsLenAtDash:]
 	}
 	return
+}
+
+func logCommand(cmd string, args ...string) {
+	var fullArgs []string
+	fullArgs = append(fullArgs, cmd)
+	fullArgs = append(fullArgs, args...)
+	log.Printf("$ %s", shellescape.QuoteCommand(fullArgs))
 }


### PR DESCRIPTION
I think this is a low-friction way to encourage education about how
`dev` works "under the hood", and de-mystifies Bazel a bit.

Release note: None