### PR TITLE
sql: TestDropColumnAfterMutations fails intermittently

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7201,6 +7201,7 @@ COMMIT;
 			// This transaction will not complete. Therefore, we don't check the returned error.
 			_, _ = conn2.DB.ExecContext(context.Background(),
 				`
+	   SET application_name='TestDropColumnAfterMutations';
 	   BEGIN;
 	   ALTER TABLE t ALTER COLUMN j SET NOT NULL;
 	   ALTER TABLE t ADD COLUMN k INT8 DEFAULT 42 NOT NULL UNIQUE;
@@ -7215,6 +7216,7 @@ COMMIT;
 			// This transaction will not complete. Therefore, we don't check the returned error.
 			_, _ = conn1.DB.ExecContext(context.Background(),
 				`
+	   SET application_name='TestDropColumnAfterMutations';
 	   SET sql_safe_updates = false;
 	   BEGIN;
 	   ALTER TABLE t DROP COLUMN j;
@@ -7251,7 +7253,8 @@ COMMIT;
 		conn1.CheckQueryResults(t, fmt.Sprintf("SELECT status from system.jobs WHERE id = %d", jobIDs[0]), [][]string{{string(jobs.StatusRunning)}})
 		// Both jobs should be stuck in COMMIT, waiting for jobs to complete.
 		conn1.CheckQueryResults(t,
-			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id])",
+			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id]) "+
+				"AND application_name='TestDropColumnAfterMutations'",
 			[][]string{{"2"}},
 		)
 
@@ -7281,6 +7284,7 @@ COMMIT;
 			// This transaction will not complete. Therefore, we don't check the returned error.
 			_, _ = conn2.DB.ExecContext(context.Background(),
 				`
+	   SET application_name='TestDropColumnAfterMutations';
 	   BEGIN;
 	   ALTER TABLE t ALTER COLUMN j SET NOT NULL;
 	   ALTER TABLE t ADD COLUMN k INT8 DEFAULT 42 NOT NULL;
@@ -7293,6 +7297,7 @@ COMMIT;
 			// This transaction will not complete. Therefore, we don't check the returned error.
 			_, _ = conn1.DB.ExecContext(context.Background(),
 				`
+	   SET application_name='TestDropColumnAfterMutations';
 	   SET sql_safe_updates = false;
 	   BEGIN;
 	   ALTER TABLE t DROP COLUMN j;
@@ -7343,7 +7348,8 @@ COMMIT;
 		)
 		// Both jobs should be stuck in COMMIT, waiting for jobs to complete.
 		conn1.CheckQueryResults(t,
-			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id])",
+			"SELECT count(*) FROM [SHOW SESSIONS] WHERE last_active_query LIKE '%COMMIT%' AND session_id != (SELECT * FROM [SHOW session_id]) "+
+				"AND application_name='TestDropColumnAfterMutations'",
 			[][]string{{"2"}},
 		)
 


### PR DESCRIPTION
Fixes: #70329

Previously, the TestDropColumnAfterMutations did not correctly
filter out unrelated applications when scanning sessions. This
was inadequate because the count of number of commits could vary
if internal applications also executed commits. To address this
this patch explicitly sets the application name on the connections
used for starting jobs so we can observe the COMMIT operation count
only from relevant connections.

Release note: None