### PR TITLE
sql: give a notice when SERIAL4 is upgraded to SERIAL8

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2576,6 +2576,7 @@ func (t *logicTest) unexpectedError(sql string, pos string, err error) bool {
 }
 
 func (t *logicTest) execStatement(stmt logicStatement) (bool, error) {
+	t.noticeBuffer = nil
 	if *showSQL {
 		t.outf("%s;", stmt.sql)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -618,4 +618,7 @@ statement notice NOTICE: using sequential values in a primary key does not perfo
 CREATE TABLE serial_test2 (id SERIAL PRIMARY KEY, temp string)
 
 statement notice NOTICE: using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/serial.html
-CREATE TABLE serial_test3 (id SERIAL , temp string, PRIMARY KEY (id))
+CREATE TABLE serial_test3 (id SERIAL, temp string, PRIMARY KEY (id))
+
+statement notice NOTICE: upgrading the column id to INT8 to utilize the session serial_normalization setting\nHINT: change the serial_normalization to sql_sequence or sql_sequence_cached if you wish to use a smaller sized serial column at the cost of performance. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/serial.html
+CREATE TABLE serial_test4 (id SERIAL4, temp string)

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -14,11 +14,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -130,6 +132,11 @@ func (p *planner) generateSerialInColumnDef(
 	// Clear the IsSerial bit now that it's been remapped.
 	newSpec.IsSerial = false
 
+	defType, err := tree.ResolveType(ctx, d.Type, p.semaCtx.GetTypeResolver())
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	// Find the integer type that corresponds to the specification.
 	switch serialNormalizationMode {
 	case sessiondatapb.SerialUsesRowID, sessiondatapb.SerialUsesVirtualSequences:
@@ -140,7 +147,22 @@ func (p *planner) generateSerialInColumnDef(
 		// TODO(bob): Follow up with https://github.com/cockroachdb/cockroach/issues/32534
 		// when the default is inverted to determine if we should also
 		// switch this behavior around.
-		newSpec.Type = types.Int
+		upgradeType := types.Int
+		if defType.Width() < upgradeType.Width() {
+			p.noticeSender.BufferNotice(
+				errors.WithHintf(
+					pgnotice.Newf(
+						"upgrading the column %s to %s to utilize the session serial_normalization setting",
+						d.Name.String(),
+						upgradeType.SQLString(),
+					),
+					"change the serial_normalization to sql_sequence or sql_sequence_cached if you wish "+
+						"to use a smaller sized serial column at the cost of performance. See %s",
+					docs.URL("serial.html"),
+				),
+			)
+		}
+		newSpec.Type = upgradeType
 
 	case sessiondatapb.SerialUsesSQLSequences, sessiondatapb.SerialUsesCachedSQLSequences:
 		// With real sequences we can use the requested type as-is.
@@ -148,11 +170,6 @@ func (p *planner) generateSerialInColumnDef(
 	default:
 		return nil, nil, nil, nil,
 			errors.AssertionFailedf("unknown serial normalization mode: %s", serialNormalizationMode)
-	}
-
-	defType, err := tree.ResolveType(ctx, d.Type, p.semaCtx.GetTypeResolver())
-	if err != nil {
-		return nil, nil, nil, nil, err
 	}
 	telemetry.Inc(sqltelemetry.SerialColumnNormalizationCounter(
 		defType.Name(), serialNormalizationMode.String()))


### PR DESCRIPTION
Also fix a statement notice buffer flush bug.

Release note (sql change): A hint is now provided when using a SERIAL4
type which gets upgraded to a SERIAL8 due to the serial_normalization
session variable requiring an INT8 to succeed.