### PR TITLE
release-21.1: cli: fix the process exit status codes

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -67,14 +67,19 @@ func Main() {
 
 		// Finally, extract the error code, as optionally specified
 		// by the sub-command.
-		errCode = exit.UnspecifiedError()
-		var cliErr *cliError
-		if errors.As(err, &cliErr) {
-			errCode = cliErr.exitCode
-		}
+		errCode = getExitCode(err)
 	}
 
 	exit.WithCode(errCode)
+}
+
+func getExitCode(err error) (errCode exit.Code) {
+	errCode = exit.UnspecifiedError()
+	var cliErr *cliError
+	if errors.As(err, &cliErr) {
+		errCode = cliErr.exitCode
+	}
+	return errCode
 }
 
 func doMain(cmd *cobra.Command, cmdName string) error {

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -56,6 +56,10 @@ type formattedError struct {
 	showSeverity, verbose bool
 }
 
+func (f *formattedError) Unwrap() error {
+	return f.err
+}
+
 // Error implements the error interface.
 func (f *formattedError) Error() string {
 	// If we're applying recursively, ignore what's there and display the original error.

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -34,9 +34,9 @@ eexpect "shutdown completed"
 eexpect ":/# "
 end_test
 
-start_test "Check that Ctrl+C finishes with exit code 1. (#9051)"
+start_test "Check that Ctrl+C finishes with exit code 3. (#9051+#70673)"
 send "echo \$?\r"
-eexpect "1\r\n"
+eexpect "3\r\n"
 eexpect ":/# "
 end_test
 


### PR DESCRIPTION
Backport 1/1 commits from #70673.

/cc @cockroachdb/release

---

Found by @jbowens in #70637.
We'll want to backport this. cc @joshimhoff 

Release note (bug fix): The exit status of the `cockroach` command
did not follow the previously-documented table of exit status codes
when an error occurred during the command start-up. (Only errors
occuring after startup were reported using the correct code.)
This defect has been fixed. This bug had existed ever since reference
exit status codes had been introduced.

----

Release justification: bug fix needed for orchestration and monitoring
