### PR TITLE
sql: reduce default sampling QPS threshold for telemetry logging channel

### DIFF
--- a/pkg/sql/query_sampling.go
+++ b/pkg/sql/query_sampling.go
@@ -25,7 +25,7 @@ var telemetrySampleRate = settings.RegisterFloatSetting(
 
 // Default value for the QPS threshold used to determine whether telemetry logs
 // will be sampled.
-const defaultQPSThreshold = 2000
+const defaultQPSThreshold = 10
 
 var telemetryQPSThreshold = settings.RegisterIntSetting(
 	"sql.telemetry.query_sampling.qps_threshold",


### PR DESCRIPTION
Resolves #70393

Previously, we set 2000 QPS as the default QPS threshold at which to start
sampling events for the telemetry logging channel (based on a configurable
sampling rate). This value was far too high, as each node would be emitting
up to 2000 log lines per second. Most nodes reach saturation at
approximately 2000 QPS, and so downsampling would rarely even occur.

This commit lowers the QPS threshold to 10 queries per second, which is
a more manageable number of log lines. This is a merely temporary patch
before we can introduce an adaptive sampling rate in favour of this QPS
cutoff approach.

Release note (bug fix): The QPS threshold at which sampling should occur
for events emitted to the telemetry logging channel has been lowered
from 2000 QPS to 10 QPS.