### PR TITLE
server: acceptance tests asserting backwards compatibility with recent patches

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -61,6 +61,23 @@ func registerAcceptance(r registry.Registry) {
 				minVersion: "v19.2.0",
 				timeout:    30 * time.Minute,
 			},
+			{
+				name: "patch-upgrade",
+				fn: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runPatchUpgrade(ctx, t, c, 0)
+				},
+				minVersion: "v21.1.9", // Regression test for 21.1.8
+
+				timeout: 30 * time.Minute,
+			},
+			{
+				name: "double-patch-upgrade",
+				fn: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runPatchUpgrade(ctx, t, c, 1)
+				},
+				minVersion: "v21.1.9", // Regression test for 21.1.8
+				timeout:    30 * time.Minute,
+			},
 		},
 		registry.OwnerServer: {
 			{name: "build-info", fn: RunBuildInfo},

--- a/pkg/cmd/roachtest/tests/predecessor_version.go
+++ b/pkg/cmd/roachtest/tests/predecessor_version.go
@@ -51,3 +51,16 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	}
 	return v, nil
 }
+
+// RecentPatchVersions returns up to n version strings from the same minor release as buildVersion
+func RecentPatchVersions(buildVersion version.Version, n int) []string {
+	current := buildVersion.Patch()
+	if current < n {
+		n = current
+	}
+	versions := make([]string, n)
+	for i := 0; i < n; i++ {
+		versions[i] = fmt.Sprintf("%d.%d.%d", buildVersion.Major(), buildVersion.Minor(), current-i)
+	}
+	return versions
+}

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -79,6 +79,15 @@ DROP TABLE test.t;
 	`),
 }
 
+// setupPersistentDB is a test step when running on a new cluster to
+// make it look like the fixtures.
+var setupPersistentDB = versionFeatureStep{
+	stmtFeatureTest("Create database and table", v201, `
+	create database persistent_db;
+	create table persistent_db.persistent_table(a int);
+	show tables from persistent_db;`),
+}
+
 func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	predecessorVersion, err := PredecessorVersion(*t.BuildVersion())
 	if err != nil {
@@ -375,6 +384,16 @@ func uploadAndStartFromCheckpointFixture(nodes option.NodeListOption, v string) 
 		args := u.uploadVersion(ctx, t, nodes, v)
 		// NB: can't start sequentially since cluster already bootstrapped.
 		u.c.Start(ctx, nodes, args, option.StartArgsDontEncrypt, option.RoachprodArgOption{"--sequential=false"})
+	}
+}
+
+func uploadAndStartEmptyCluster(nodes option.NodeListOption, v string) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		u.c.Run(ctx, nodes, "mkdir", "-p", "{store-dir}")
+
+		// Put and start the binary.
+		args := u.uploadVersion(ctx, t, nodes, v)
+		u.c.Start(ctx, nodes, args)
 	}
 }
 
@@ -691,4 +710,53 @@ func importLargeBankStep(oldV string, rows int, crdbNodes option.NodeListOption)
 		})
 		m.Wait()
 	}
+}
+
+func runPatchUpgrade(ctx context.Context, t test.Test, c cluster.Cluster, offset int) {
+	predecessorVersions := RecentPatchVersions(*t.BuildVersion(), offset+1)
+	if len(predecessorVersions) < offset+1 {
+		t.L().Printf("No recent patch versions for this version")
+		return
+	}
+
+	testFeaturesStep := versionUpgradeTestFeatures.step(c.All())
+
+	predecessorVersion := predecessorVersions[offset]
+
+	// The steps below start a cluster at predecessorVersion,
+	// then fully upgrade to the current version,
+	// then roll back, then roll one node forward again.
+	// Between each step, we run the feature tests defined in
+	// versionUpgradeTestFeatures (which aren't particularly
+	// appropriate here, but we just need arbitrary operations.)
+	u := newVersionUpgradeTest(c,
+		// Start a cluster from a previous patch version.
+		uploadAndStartEmptyCluster(c.All(), predecessorVersion),
+		setupPersistentDB.step(c.All().RandNode()),
+		uploadAndInitSchemaChangeWorkload(),
+		waitForUpgradeStep(c.All()),
+		testFeaturesStep,
+
+		// Roll nodes forward to the current build being tested.
+		binaryUpgradeStep(c.All(), ""),
+		testFeaturesStep,
+		// Since we've done nothing to stop it, the cluster version
+		// should be updated if it's going to, but let's make sure.
+		waitForUpgradeStep(c.All()),
+		// Roll back again. That this is allowed for patch versions
+		// is the key invariant being tested (and a regression test for 21.1.8).
+		binaryUpgradeStep(c.All(), predecessorVersion),
+		testFeaturesStep,
+		// Roll a single node forward so we can spend more time in a mixed state.
+		binaryUpgradeStep(c.All().RandNode(), ""),
+		testFeaturesStep,
+		// Turn tracing on globally to give it a fighting chance at exposing any
+		// crash-inducing incompatibilities or horrendous memory leaks. (It won't
+		// catch most memory leaks since this test doesn't run for too long or do
+		// too much work). Then, run the previous tests again.
+		enableTracingGloballyStep,
+		testFeaturesStep,
+	)
+
+	u.run(ctx, t)
 }


### PR DESCRIPTION
frontport of #70327. This is a no-op when run against master.

version-upgrade tests upgrading and downgrading across major/minor versions. This
pr adds a similar test upgrading and downgrading across patch versions, and therefore
allows upgrades to finalize before downgrading them.

It doesn't do any fixture management since the purpose isn't to test the whole upgrade
path, just recent-version interoperability, so we can start from a clean cluster.

Release note: None