### PR TITLE
update instructions to publish cluster-ui to npm

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/README.md
+++ b/pkg/ui/workspaces/cluster-ui/README.md
@@ -220,8 +220,7 @@ directory of CockroachDB.
 
 ```shell
 $ make ui-maintainer-clean
-$ make pkg/ui/yarn.protobuf.installed -B
-$ make pkg/ui/yarn.cluster-ui.installed -B
+$ make ui-generate -B
 ```
 
 ### 4. Publish


### PR DESCRIPTION
Update readme with the correct instructions to publish cluster-ui to npm