### PR TITLE
release-21.1: roachprod: tag ssh keys in aws with IAMUserName and CreatedAt

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/cmd/roachprod/vm/aws/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/cmd/roachprod/vm/flagstub",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_pflag//:pflag",


### PR DESCRIPTION
Backport 1/1 commits from #70201.

/cc @cockroachdb/release

---

Previously, roachprod created ssh key pairs without any direct way
of mapping them to users, and without any way of knowing the
creation time.

This needed to change because we need to delete ssh key pairs of
previous users and we should have a way of finding those keys.

This patch ensures that any newly created ssh key pair will be
tagged with 'IAM-UserName' and 'CreatedAt' tags.

Informs: #70635

Release note: None
Release justification: non-production change