### PR TITLE
build: use user-managed dependencies to build protobufjs client code

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,14 +2,6 @@
 # `@cockroach//...`.
 workspace(
     name = "cockroach",
-    managed_directories = {
-       "@npm": [
-          "pkg/ui/node_modules",
-          "pkg/ui/workspaces/cluster-ui/node_modules",
-          "pkg/ui/workspaces/db-console/node_modules",
-          "pkg/ui/workspaces/db-console/src/js/node_modules",
-       ],
-    },
 )
 
 # Load the things that let us load other things.
@@ -62,14 +54,6 @@ go_register_toolchains(go_version = "1.16.6")
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install", "node_repositories")
 
 node_repositories(package_json = ["//pkg/ui:package.json"])
-
-# install external dependencies for pkg/ui package
-yarn_install(
-    name = "npm",
-    package_json = "//pkg/ui:package.json",
-    yarn_lock = "//pkg/ui:yarn.lock",
-    strict_visibility = False,
-)
 
 # Load gazelle dependencies.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "ui",
@@ -13,18 +16,15 @@ go_library(
     ],
 )
 
-filegroup(
+js_library(
     name = "node_modules",
+    package_name = "$node_modules$",
     srcs = glob(
         include = [
-            "node_modules/**",
-        ],
-        exclude = [
-            "node_modules/db-console",
-            "node_modules/@cockroachlabs/cluster-ui",
+            "node_modules/**/*",
+            "node_modules/.bin/*",
         ],
     ),
-    visibility = ["//pkg/ui:__subpackages__"],
 )
 
 filegroup(
@@ -55,4 +55,15 @@ filegroup(
         ],
     ),
     visibility = ["//pkg/ui:__subpackages__"],
+)
+
+
+js_library(
+    name = "protobufjs",
+    package_name = "$node_modules$",
+    srcs = glob(
+        include = [
+            "node_modules/protobufjs/**/*",
+        ],
+    ),
 )

--- a/pkg/ui/build/protobufjs/BUILD.bazel
+++ b/pkg/ui/build/protobufjs/BUILD.bazel
@@ -1,0 +1,16 @@
+# Generated file from yarn_install rule.
+# See rules_nodejs/internal/npm_install/generate_build_file.ts
+
+package(default_visibility = ["//visibility:public"])
+
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+js_library(
+    name = "protobufjs",
+    package_name = "protobufjs",
+    package_path = "",
+    srcs = ["//pkg/ui:protobufjs"],
+    deps = [
+        "//pkg/ui:node_modules",
+    ],
+)

--- a/pkg/ui/build/protobufjs/bin/BUILD.bazel
+++ b/pkg/ui/build/protobufjs/bin/BUILD.bazel
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+nodejs_binary(
+    name = "pbjs",
+    entry_point = "//pkg/ui:node_modules/protobufjs/bin/pbjs",
+    data = ["//pkg/ui/build/protobufjs:protobufjs"],
+)
+
+nodejs_binary(
+    name = "pbts",
+    entry_point = "//pkg/ui:node_modules/protobufjs/bin/pbts",
+    data = ["//pkg/ui/build/protobufjs:protobufjs"],
+)

--- a/pkg/ui/build/protobufjs/index.bzl
+++ b/pkg/ui/build/protobufjs/index.bzl
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "npm_package_bin")
+
+def pbjs(**kwargs):
+    output_dir = kwargs.pop("output_dir", False)
+    if "outs" in kwargs or output_dir:
+        npm_package_bin(tool = "//pkg/ui/build/protobufjs/bin:pbjs", output_dir = output_dir, **kwargs)
+    else:
+        nodejs_binary(
+            entry_point = "//pkg/ui:node_modules/protobufjs/bin/pbjs",
+            data = ["//pkg/ui/build/protobufjs:protobufjs"] + kwargs.pop("data", []),
+            **kwargs
+        )
+
+def pbts(**kwargs):
+    output_dir = kwargs.pop("output_dir", False)
+    if "outs" in kwargs or output_dir:
+        npm_package_bin(tool = "//pkg/ui/build/protobufjs/bin:pbts", output_dir = output_dir, **kwargs)
+    else:
+        nodejs_binary(
+            entry_point = "//pkg/ui:node_modules/protobufjs/bin/pbts",
+            data = ["//pkg/ui/build/protobufjs:protobufjs"] + kwargs.pop("data", []),
+            **kwargs
+        )

--- a/pkg/ui/workspaces/db-console/src/js/defs.bzl
+++ b/pkg/ui/workspaces/db-console/src/js/defs.bzl
@@ -5,7 +5,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 
 # TODO switch to protobufjs-cli when its published
 # https://github.com/protobufjs/protobuf.js/commit/da34f43ccd51ad97017e139f137521782f5ef119
-load("@npm//protobufjs:index.bzl", "pbjs", "pbts")
+load("//pkg/ui/build/protobufjs:index.bzl", "pbjs", "pbts")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
 # protobuf.js relies on these packages, but does not list them as dependencies
@@ -17,18 +17,20 @@ load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 # Per Bazel semantics, all dependencies should be pre-declared.
 # Note, you'll also need to install all of these in your package.json!
 # (This should be fixed when we switch to protobufjs-cli)
-_PROTOBUFJS_CLI_DEPS = ["@npm//%s" % s for s in [
-    "chalk",
-    "escodegen",
-    "espree",
-    "estraverse",
-    "glob",
-    "jsdoc",
-    "minimist",
-    "semver",
-    "tmp",
-    "uglify-js",
-]]
+# _PROTOBUFJS_CLI_DEPS = ["//pkg/ui:node_modules/%s" % s for s in [
+#     "chalk",
+#     "escodegen",
+#     "espree",
+#     "estraverse",
+#     "glob",
+#     "jsdoc",
+#     "minimist",
+#     "semver",
+#     "tmp",
+#     "uglify-js",
+# ]]
+
+_PROTOBUFJS_CLI_DEPS = ["//pkg/ui:node_modules"]
 
 def _proto_sources_impl(ctx):
     return DefaultInfo(files = depset(


### PR DESCRIPTION
Main goal is to run `bazel build //pkg/ui/workspaces/db-console/src/js:db_console_oss_js_proto`
target that depends on bazel macros and need to be refactored to
avoid loading macros from "@npm" external workspace.

- it fails due to wrong node module path resolution.
- also it takes long time to copy all deps into sandbox because
most dependencies are simplified to include entire `node_modules` dir.

Release note: none