### PR TITLE
generate-test-suites: don't clear `pkg/BUILD.bazel` on failure

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
 
 # Even with --symlink_prefix, some sub-command somewhere hardcodes the
 # creation of a "bazel-out" symlink. This bazel-out symlink can only
@@ -8,5 +8,6 @@ set -exuo pipefail
 # invoked. For now, this is left as an exercise for the user.
 
 bazel run //:gazelle -- update-repos -from_file=go.mod -build_file_proto_mode=disable_global -to_macro=DEPS.bzl%go_deps -prune=true
-bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && " > pkg/BUILD.bazel
+CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")
+echo "$CONTENTS" > pkg/BUILD.bazel
 bazel run //:gazelle

--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -24,7 +25,12 @@ func main() {
 	buf, err := exec.Command("bazel", "query", "kind(go_test, //pkg/...)", "--output=label").Output()
 	if err != nil {
 		log.Printf("Could not query Bazel tests: got error %v", err)
-		log.Println("Run `bazel query 'kind(go_test, //pkg/...)'` to reproduce the failure")
+		var cmderr *exec.ExitError
+		if errors.As(err, &cmderr) {
+			log.Printf("Got error output: %s", string(cmderr.Stderr))
+		} else {
+			log.Println("Run `bazel query 'kind(go_test, //pkg/...)'` to reproduce the failure")
+		}
 		os.Exit(1)
 	}
 	labels := strings.Split(string(buf[:]), "\n")


### PR DESCRIPTION
Avoid using the redirection (`>`) because if the command fails this
results in `pkg/BUILD.bazel` being empty or containing garbage.

Also teach `generate-test-suites` how to say what the error was instead
of just asking the user to repro.

Release note: None