### PR TITLE
dev: allow passing extra arguments to `docker run` in `dev builder`

### DIFF
--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -31,17 +31,18 @@ func makeBuilderCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.C
 		Short:   "Run the Bazel builder image.",
 		Long:    "Run the Bazel builder image.",
 		Example: `dev builder`,
-		Args:    cobra.ExactArgs(0),
+		Args:    cobra.MinimumNArgs(0),
 		RunE:    runE,
 	}
 	builderCmd.Flags().String(volumeFlag, "bzlhome", "the Docker volume to use as the container home directory")
 	return builderCmd
 }
 
-func (d *dev) builder(cmd *cobra.Command, _ []string) error {
+func (d *dev) builder(cmd *cobra.Command, extraArgs []string) error {
 	ctx := cmd.Context()
 	volume := mustGetFlagString(cmd, volumeFlag)
 	args, err := d.getDockerRunArgs(ctx, volume, true)
+	args = append(args, extraArgs...)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -10,3 +10,16 @@ cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts
 docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234
+
+dev builder echo hi
+----
+getenv PATH
+which cc
+readlink /usr/local/opt/ccache/libexec/cc
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+id
+bazel info workspace --color=no --config=dev
+cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
+docker volume inspect bzlhome
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234 echo hi

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -33,3 +33,39 @@ mkdir go/src/github.com/cockroachdb/cockroach/artifacts
 
 docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234
 ----
+
+getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+id
+----
+1001:1002
+
+bazel info workspace --color=no --config=dev
+----
+go/src/github.com/cockroachdb/cockroach
+
+cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
+----
+BAZEL_IMAGE=mock_bazel_image:1234
+
+docker volume inspect bzlhome
+----
+
+mkdir go/src/github.com/cockroachdb/cockroach/artifacts
+----
+
+docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234 echo hi
+----


### PR DESCRIPTION
Now if you want to run a single command in the container you can do so,
just as `build/builder.sh` supports.

Release note: None