### PR TITLE
clusterversion,storage: cluster version that uses Pebble's SetWithDelete

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -165,4 +165,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-1164	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-1166	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -170,6 +170,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-1164</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-1166</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -281,6 +281,11 @@ const (
 	// MarkerDataKeysRegistry switches to using an atomic marker file
 	// for denoting which data keys registry is active.
 	MarkerDataKeysRegistry
+	// PebbleSetWithDelete switches to a backwards incompatible Pebble version
+	// that provides SingleDelete semantics that are cleaner and robust to
+	// programming error. See https://github.com/cockroachdb/pebble/issues/1255
+	// and #69891.
+	PebbleSetWithDelete
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -470,6 +475,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     MarkerDataKeysRegistry,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1164},
+	},
+	{
+		Key:     PebbleSetWithDelete,
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1166},
 	},
 	// *************************************************
 	// Step (2): Add new versions here.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -46,11 +46,12 @@ func _() {
 	_ = x[DateAndIntervalStyle-35]
 	_ = x[PebbleFormatVersioned-36]
 	_ = x[MarkerDataKeysRegistry-37]
+	_ = x[PebbleSetWithDelete-38]
 }
 
-const _Key_name = "replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistry"
+const _Key_name = "replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDelete"
 
-var _Key_index = [...]uint16{0, 46, 96, 134, 176, 181, 194, 203, 218, 247, 264, 281, 330, 344, 357, 377, 393, 410, 437, 472, 497, 526, 557, 577, 608, 635, 660, 677, 706, 739, 762, 781, 800, 823, 839, 869, 889, 910, 932}
+var _Key_index = [...]uint16{0, 46, 96, 134, 176, 181, 194, 203, 218, 247, 264, 281, 330, 344, 357, 377, 393, 410, 437, 472, 497, 526, 557, 577, 608, 635, 660, 677, 706, 739, 762, 781, 800, 823, 839, 869, 889, 910, 932, 951}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -118,6 +118,12 @@ func TestSetMinVersion(t *testing.T) {
 	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleFormatVersioned))
 	require.NoError(t, err)
 	require.Equal(t, pebble.FormatVersioned, p.db.FormatMajorVersion())
+
+	// Advancing the store cluster version to PebbleSetWithDelete
+	// should also advance the store's format major version.
+	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleSetWithDelete))
+	require.NoError(t, err)
+	require.Equal(t, pebble.FormatSetWithDelete, p.db.FormatMajorVersion())
 }
 
 func TestMinVersion_IsNotEncrypted(t *testing.T) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1477,7 +1477,12 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 	// corresponding format major version, ratcheting Pebble's format
 	// major version if necessary.
 	formatVers := pebble.FormatMostCompatible
+	// Cases are ordered from newer to older versions.
 	switch {
+	case !version.Less(clusterversion.ByKey(clusterversion.PebbleSetWithDelete)):
+		if formatVers < pebble.FormatSetWithDelete {
+			formatVers = pebble.FormatSetWithDelete
+		}
 	case !version.Less(clusterversion.ByKey(clusterversion.PebbleFormatVersioned)):
 		if formatVers < pebble.FormatVersioned {
 			formatVers = pebble.FormatVersioned


### PR DESCRIPTION
This is a backwards incompatible change in Pebble to provide
SingleDelete semantics that are clean and robust to programming
error.

This is being done post v21.2-beta but before GA since this
was deemed a GA blocker and not a release blocker. It allows
for upgrading beta clusters to the GA version. For more on these
discussions see the following threads
https://github.com/cockroachdb/pebble/issues/1255#issuecomment-915483527,
https://cockroachlabs.slack.com/archives/C4A9ALLRL/p1631213490022600
(Cockroach Labs internal link).

Informs https://github.com/cockroachdb/pebble/issues/1255
Informs #69891

Release note: None

Release justification: high-severity bug fix