### PR TITLE
dev: remove dependency on `cockroachdb/errors`

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -20,8 +20,6 @@ go_library(
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
         "@com_github_alessio_shellescape//:shellescape",
-        "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +54,7 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 		pkg = strings.TrimRight(pkg, "/")
 
 		if !strings.HasPrefix(pkg, "pkg/") {
-			return errors.Newf("malformed package %q, expecting %q", pkg, "pkg/{...}")
+			return fmt.Errorf("malformed package %q, expecting %q", pkg, "pkg/{...}")
 		}
 
 		if strings.HasSuffix(pkg, "/...") {

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 
 	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
-	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/oserror"
 	"github.com/spf13/cobra"
 )
 
@@ -152,7 +150,7 @@ func (d *dev) stageArtifacts(ctx context.Context, targets []string, hoistGenerat
 		}
 
 		// Symlink from binaryPath -> symlinkPath
-		if err := d.os.Remove(symlinkPath); err != nil && !oserror.IsNotExist(err) {
+		if err := d.os.Remove(symlinkPath); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		if err := d.os.Symlink(binaryPath, symlinkPath); err != nil {
@@ -282,7 +280,7 @@ func getBasicBuildArgs(targets []string) (args, fullTargets []string, err error)
 		}
 		buildTarget, ok := buildTargetMapping[target]
 		if !ok {
-			err = errors.Newf("unrecognized target: %s", target)
+			err = fmt.Errorf("unrecognized target: %s", target)
 			return
 		}
 

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -12,13 +12,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -95,7 +95,7 @@ func (d *dev) getDockerRunArgs(
 		}
 	}
 	if bazelImage == "" {
-		err = errors.New("Could not find BAZEL_IMAGE in build/teamcity-bazel-support.sh")
+		err = errors.New("could not find BAZEL_IMAGE in build/teamcity-bazel-support.sh")
 		return
 	}
 

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -11,11 +11,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
-	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +64,7 @@ func (d *dev) generate(cmd *cobra.Command, targets []string) error {
 	for _, target := range targets {
 		generator, ok := generatorTargetMapping[target]
 		if !ok {
-			return errors.Newf("unrecognized target: %s", target)
+			return fmt.Errorf("unrecognized target: %s", target)
 		}
 
 		if err := generator(cmd); err != nil {
@@ -194,7 +195,7 @@ func (d *dev) generateGo(cmd *cobra.Command) error {
 }
 
 func (*dev) generateUnimplemented(*cobra.Command) error {
-	return errors.New("To hoist all generated code into the workspace, run " +
+	return errors.New("to hoist all generated code into the workspace, run " +
 		"`dev build` with the flag `--hoist-generated-code`; to build the generated Go " +
 		"code needed to pass CI, run `dev generate go`")
 }

--- a/pkg/cmd/dev/io/os/BUILD.bazel
+++ b/pkg/cmd/dev/io/os/BUILD.bazel
@@ -7,6 +7,5 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/dev/recording",
-        "@com_github_cockroachdb_errors//oserror",
     ],
 )

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/recording"
-	"github.com/cockroachdb/errors/oserror"
 )
 
 // OS is a convenience wrapper around the stdlib os package. It lets us
@@ -95,7 +94,7 @@ func (o *OS) Remove(path string) error {
 
 	if o.Recording == nil {
 		// Do the real thing.
-		if err := os.Remove(path); err != nil && !oserror.IsNotExist(err) {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		return nil

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -11,11 +11,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -111,7 +111,7 @@ func (d *dev) runUnitTest(cmd *cobra.Command, commandLine []string) error {
 		pkg = strings.TrimRight(pkg, "/")
 
 		if !strings.HasPrefix(pkg, "pkg/") {
-			return errors.Newf("malformed package %q, expecting %q", pkg, "pkg/{...}")
+			return fmt.Errorf("malformed package %q, expecting %q", pkg, "pkg/{...}")
 		}
 
 		if strings.HasSuffix(pkg, "...") {

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/alessio/shellescape"
-	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +83,7 @@ func parseAddr(addr string) (string, error) {
 
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return "", errors.Newf("invalid address %s", addr)
+		return "", fmt.Errorf("invalid address %s", addr)
 	}
 
 	return fmt.Sprintf("%s:%s", ip, port), nil
@@ -128,7 +127,7 @@ func addCommonTestFlags(cmd *cobra.Command) {
 func (d *dev) ensureBinaryInPath(bin string) error {
 	if !isTesting {
 		if _, err := d.exec.LookPath(bin); err != nil {
-			return errors.Newf("Could not find %s in PATH", bin)
+			return fmt.Errorf("could not find %s in PATH", bin)
 		}
 	}
 	return nil

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -762,6 +762,7 @@ func TestLint(t *testing.T) {
 			`\bos\.Is(Exist|NotExist|Timeout|Permission)`,
 			"--",
 			"*.go",
+			":!cmd/dev/**",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
`cockroachdb/errors` is a pretty heavyweight dependency, and since `dev`
is a bottleneck for development builds we'd like to remove as many
dependencies as possible. Bazel reports the "critical path" for a fresh
build of `dev` now takes <3s with this change. :)

Release note: None