### PR TITLE
release-21.2: vendor: bump Pebble to c6751b08960c

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -648,8 +648,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:LdrRwalGCnBc7GXqtzShgVvf7m02F7FK6YmziC+cs7M=",
-        version = "v0.0.0-20210909162603-6c12d67b83e6",
+        sum = "h1:YKDxrC/1iG0AYW7YTK0eVl1rVQqxeJEY1h5izK8pURA=",
+        version = "v0.0.0-20210923235227-c6751b08960c",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210909162603-6c12d67b83e6
+	github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210909162603-6c12d67b83e6 h1:LdrRwalGCnBc7GXqtzShgVvf7m02F7FK6YmziC+cs7M=
-github.com/cockroachdb/pebble v0.0.0-20210909162603-6c12d67b83e6/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c h1:YKDxrC/1iG0AYW7YTK0eVl1rVQqxeJEY1h5izK8pURA=
+github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
c6751b08 metamorphic: add keyManager abstraction and SetWithDelete bug fix
96dc1efe internal/base: add SetWithDelete key kind
5db9bf33 base: add `InternalKeyKindSeparator`
a2d58e95 db: improve use-after-free test coverage for compactions
a3b61ae3 testdata: remove values from deletes
99414d59 db: support nil logger in EventListener.EnsureDefaults
e0860f77 compaction: fix nil pointer during errored compactions

This is a backwards incompatible change in Pebble to provide
SingleDelete semantics that are clean and robust to programming
error.

This is being done post v21.2-beta but before GA since this
was deemed a GA blocker and not a release blocker. It allows
for upgrading beta clusters to the GA version. For more on these
discussions see the following threads
cockroachdb/pebble#1255 (comment),
https://cockroachlabs.slack.com/archives/C4A9ALLRL/p1631213490022600
(Cockroach Labs internal link).

Informs cockroachdb/pebble#1255
Informs #69891

Release note: none
Release justification: high-severity bug fix