### PR TITLE
kv/kvserver: skip TestTenantRateLimiter

### DIFF
--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -142,6 +143,7 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 // and report the correct metrics.
 func TestTenantRateLimiter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 70456, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// This test utilizes manual time to make the rate-limiting calculations more


### PR DESCRIPTION
Refs: #70456

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None