### PR TITLE
builtins: fix untyped NULL in array builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1746,6 +1746,48 @@ INSERT INTO t VALUES (
   '{0101, 11}',
   '{12.34, 45.67}');
 
+subtest array_builtin_uncasted_nulls
+
+query T
+SELECT array_prepend(1, NULL);
+----
+{1}
+
+query T
+SELECT array_append(NULL, 'cat');
+----
+{cat}
+
+query T
+SELECT array_cat(NULL, ARRAY[1]);
+----
+{1}
+
+query T
+SELECT array_cat(ARRAY[1], NULL);
+----
+{1}
+
+query T
+SELECT array_remove(NULL, 'cat');
+----
+NULL
+
+query T
+SELECT array_replace(NULL, 'cat', 'dog');
+----
+NULL
+
+query T
+SELECT array_position(NULL, 'cat');
+----
+NULL
+
+query T
+SELECT array_positions(NULL, 'cat');
+----
+NULL
+
 subtest array_tuples
 
 # Test for #32715: able to distribute queries with arrays of tuples.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3452,8 +3452,15 @@ value if you rely on the HLC for accuracy.`,
 
 	"array_append": setProps(arrayPropsNullableArgs(), arrayBuiltin(func(typ *types.T) tree.Overload {
 		return tree.Overload{
-			Types:      tree.ArgTypes{{"array", types.MakeArray(typ)}, {"elem", typ}},
-			ReturnType: tree.IdentityReturnType(0),
+			Types: tree.ArgTypes{{"array", types.MakeArray(typ)}, {"elem", typ}},
+			ReturnType: func(args []tree.TypedExpr) *types.T {
+				if len(args) > 0 {
+					if argTyp := args[0].ResolvedType(); argTyp.Family() != types.UnknownFamily {
+						return argTyp
+					}
+				}
+				return types.MakeArray(typ)
+			},
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return tree.AppendToMaybeNullArray(typ, args[0], args[1])
 			},
@@ -3464,8 +3471,15 @@ value if you rely on the HLC for accuracy.`,
 
 	"array_prepend": setProps(arrayPropsNullableArgs(), arrayBuiltin(func(typ *types.T) tree.Overload {
 		return tree.Overload{
-			Types:      tree.ArgTypes{{"elem", typ}, {"array", types.MakeArray(typ)}},
-			ReturnType: tree.IdentityReturnType(1),
+			Types: tree.ArgTypes{{"elem", typ}, {"array", types.MakeArray(typ)}},
+			ReturnType: func(args []tree.TypedExpr) *types.T {
+				if len(args) > 1 {
+					if argTyp := args[1].ResolvedType(); argTyp.Family() != types.UnknownFamily {
+						return argTyp
+					}
+				}
+				return types.MakeArray(typ)
+			},
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return tree.PrependToMaybeNullArray(typ, args[0], args[1])
 			},


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70661

A previous commit changed how return types were computed for these
builtins, but missed the case for NULL arrays. This is fixed and tested
now.

Release note: None