### PR TITLE
build: use release branch instead of "master" for docs issue generation

### DIFF
--- a/build/teamcity-docs-issue-generation.sh
+++ b/build/teamcity-docs-issue-generation.sh
@@ -57,6 +57,11 @@ process_pr_commits() {
       body="${body//$'\"'/'\''"'}"
       # Get merge branch
       merge_branch=$(curl -s --retry 5 -s -H "Authorization: token $GITHUB_API_TOKEN" https://api.github.com/repos/cockroachdb/cockroach/pulls/"$1" | jq .base.ref)
+      # If merge branch is master, use the release version instead
+      if [ "$merge_branch" = "master" ]
+      then
+        merge_branch="release-22.1"
+      fi
       # Create issue
       echo "Creating issue for PR $prnum"
       curl -s --retry 5 -X POST -H "Authorization: token $GITHUB_API_TOKEN" \


### PR DESCRIPTION
When a commit including a release note text that is not a bug fix gets merged,
the teamcity docs issue genereation script generates a corresponding issue
in the docs repo and assigns a label based on the branch the commit was
merged into. When syncing the docs issue to Jira, that label is then used
to set the Target Fix Version.

In cases where the commit is merged into master, to make this work, we
now have the script replace master with the name of the branch that
will eventually be cut for the upcoming release (e.g., release-22.1).

Once a new branch is cut, we will need to update this script to map
"master" to the next version.

Release note: None