### PR TITLE
tree: improve overload resolution with constants

### DIFF
--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -636,10 +636,16 @@ func typeCheckOverloadedExprs(
 			// become a homogeneous type, if all resolvable expressions became one.
 			// This is only possible if resolvable expressions were resolved
 			// homogeneously up to this point.
+			// We need to further make sure that, if we do have a homogeneous type,
+			// the constants can *actually* become that type - otherwise we'll
+			// accidentally pre-filter-out some overloads that we can't actually use
+			// later.
 			if homogeneousTyp != nil {
+				semaCtx := MakeSemaContext()
 				allConstantsAreHomogenous = true
 				for _, i := range s.constIdxs {
-					if !canConstantBecome(exprs[i].(Constant), homogeneousTyp) {
+					constExpr := exprs[i].(Constant)
+					if _, err := constExpr.ResolveAsType(ctx, &semaCtx, homogeneousTyp); err != nil {
 						allConstantsAreHomogenous = false
 						break
 					}


### PR DESCRIPTION
Closes #70698

When resolving overloads that have constant arguments, we previously
had a heuristic to throw away any overloads that didn't have
homogeneously typed parameters in ambiguous scenarios. However, this
could be problematic in the case where we have constants that might be
resolvable to a particular type, but can't actually *parse* into that
particular type. We have a heuristic that comes after the homogeneous
type heuristic that ensures that we only use overloads that are
compatible with the actual constant values, but since it came
afterwards, it was too late and we might have thrown away the only valid
overloads for a particular set of constants.

Now, we force an earlier check of "can-constant-become" to make sure
that we don't prematurely throw away the only valid overload for a
particular overload and constant pair.

Release note (sql change): fix overload resolution for cases like
`SELECT now() - '5h'`, where multiple binary operator overloads could
apply, but the constant isn't parseable into the same type as the left
hand side on the overload.