### PR TITLE
opt: fix LATERAL joins with NATURAL/USING

### DIFF
--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -97,7 +97,7 @@ func (b *Builder) buildJoin(
 		outScope = inScope.push()
 
 		var jb usingJoinBuilder
-		jb.init(b, joinType, flags, leftScope, rightScope, outScope)
+		jb.init(b, joinType, flags, isLateral, leftScope, rightScope, outScope)
 
 		switch t := cond.(type) {
 		case tree.NaturalJoinCond:
@@ -297,6 +297,7 @@ type usingJoinBuilder struct {
 	joinType   descpb.JoinType
 	joinFlags  memo.JoinFlags
 	filters    memo.FiltersExpr
+	isLateral  bool
 	leftScope  *scope
 	rightScope *scope
 	outScope   *scope
@@ -315,6 +316,7 @@ func (jb *usingJoinBuilder) init(
 	b *Builder,
 	joinType descpb.JoinType,
 	flags memo.JoinFlags,
+	isLateral bool,
 	leftScope, rightScope, outScope *scope,
 ) {
 	// This initialization pattern ensures that fields are not unwittingly
@@ -323,6 +325,7 @@ func (jb *usingJoinBuilder) init(
 		b:          b,
 		joinType:   joinType,
 		joinFlags:  flags,
+		isLateral:  isLateral,
 		leftScope:  leftScope,
 		rightScope: rightScope,
 		outScope:   outScope,
@@ -406,7 +409,7 @@ func (jb *usingJoinBuilder) finishBuild() {
 		jb.rightScope.expr.(memo.RelExpr),
 		jb.filters,
 		&memo.JoinPrivate{Flags: jb.joinFlags},
-		false, /* isLateral */
+		jb.isLateral,
 	)
 
 	if !jb.ifNullCols.Empty() {

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -10,6 +10,18 @@ exec-ddl
 CREATE TABLE z (c INT PRIMARY KEY)
 ----
 
+exec-ddl
+CREATE TABLE ax (a INT, x INT)
+----
+
+exec-ddl
+CREATE TABLE ay (a INT, y INT)
+----
+
+exec-ddl
+CREATE TABLE az (a INT, z INT)
+----
+
 build
 SELECT * FROM x, y, z
 ----
@@ -335,3 +347,72 @@ build
 SELECT * FROM x FULL OUTER JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
 ----
 error (42601): The combining JOIN type must be INNER or LEFT for a LATERAL reference
+
+
+build
+SELECT * FROM ax JOIN LATERAL (SELECT * FROM ay WHERE x=y) USING (a)
+----
+project
+ ├── columns: a:1 x:2 y:7!null
+ └── inner-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5 ay.a:6 y:7!null
+      ├── scan ax
+      │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5
+      ├── project
+      │    ├── columns: ay.a:6 y:7!null
+      │    └── select
+      │         ├── columns: ay.a:6 y:7!null ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │         ├── scan ay
+      │         │    └── columns: ay.a:6 y:7 ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │         └── filters
+      │              └── x:2 = y:7
+      └── filters
+           └── ax.a:1 = ay.a:6
+
+build
+SELECT * FROM ax NATURAL JOIN LATERAL (SELECT * FROM ay WHERE x=y)
+----
+project
+ ├── columns: a:1 x:2 y:7!null
+ └── inner-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5 ay.a:6 y:7!null
+      ├── scan ax
+      │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5
+      ├── project
+      │    ├── columns: ay.a:6 y:7!null
+      │    └── select
+      │         ├── columns: ay.a:6 y:7!null ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │         ├── scan ay
+      │         │    └── columns: ay.a:6 y:7 ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │         └── filters
+      │              └── x:2 = y:7
+      └── filters
+           └── ax.a:1 = ay.a:6
+
+build
+SELECT * FROM ax JOIN ay ON true LEFT JOIN LATERAL (SELECT a+z AS y FROM az WHERE x=z) USING (y)
+----
+project
+ ├── columns: y:7 a:1 x:2 a:6
+ └── left-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5 ay.a:6 ay.y:7 ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10 y:16
+      ├── inner-join (cross)
+      │    ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5 ay.a:6 ay.y:7 ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │    ├── scan ax
+      │    │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ax.tableoid:5
+      │    ├── scan ay
+      │    │    └── columns: ay.a:6 ay.y:7 ay.rowid:8!null ay.crdb_internal_mvcc_timestamp:9 ay.tableoid:10
+      │    └── filters
+      │         └── true
+      ├── project
+      │    ├── columns: y:16
+      │    ├── select
+      │    │    ├── columns: az.a:11 z:12!null az.rowid:13!null az.crdb_internal_mvcc_timestamp:14 az.tableoid:15
+      │    │    ├── scan az
+      │    │    │    └── columns: az.a:11 z:12 az.rowid:13!null az.crdb_internal_mvcc_timestamp:14 az.tableoid:15
+      │    │    └── filters
+      │    │         └── x:2 = z:12
+      │    └── projections
+      │         └── az.a:11 + z:12 [as=y:16]
+      └── filters
+           └── ay.y:7 = y:16


### PR DESCRIPTION
The code that builds joins for `NATURAL` and `USING` did not plumb
the `isLateral` flag correctly. This resulted in allowing lateral
references during resolution, but then building a non-apply join. In
test mode, this fails a check in CheckExpr. In production mode, this
results in an internal error in the execbuilder.

Fixes #61330.

Release note (bug fix): fixed internal error with joins that are both
LATERAL and NATURAL/USING.