### PR TITLE
sql: fix error message for anon tuple type derefs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -822,7 +822,7 @@ query error pq: column reference "unnest" is ambiguous
 SELECT ((unnest(ARRAY[1,2], ARRAY[1,2]))).unnest;
 
 # No labels
-query error pq: type tuple{int, int, int} is not composite
+query error pq: could not identify column "x" in record data type
 SELECT ((1,2,3)).x FROM tb
 
 query I colnames

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -600,7 +600,7 @@ project
 build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
 ----
-error (42804): could not identify column "other" in tuple{string AS x, int AS n}
+error (42703): could not identify column "other" in tuple{string AS x, int AS n}
 
 build
 SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).@4

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -317,6 +317,10 @@ func TestTypeCheckError(t *testing.T) {
 			`could not identify column "foo" in tuple{string AS word, string AS catcode, string AS catdesc}`,
 		},
 		{
+			`((1,2,3)).foo`,
+			`could not identify column "foo" in record data type`,
+		},
+		{
 			`1::d.notatype`,
 			`type "d.notatype" does not exist`,
 		},


### PR DESCRIPTION
Release note (sql change): improve error message when trying to select
a named field from an anonymous record that has no labels.