### PR TITLE
colfetcher: make txnKVFetcher account for memory when used by cFetcher

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -105,7 +105,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	}
 	r1, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
-	defer r1.TestCleanup()
+	defer r1.TestCleanupNoError(t)
 
 	args = &colexecargs.NewColOperatorArgs{
 		Spec: &execinfrapb.ProcessorSpec{
@@ -119,7 +119,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	}
 	r, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
-	defer r.TestCleanup()
+	defer r.TestCleanupNoError(t)
 
 	m := colexec.NewMaterializer(
 		flowCtx,

--- a/pkg/sql/colexec/colexecargs/BUILD.bazel
+++ b/pkg/sql/colexec/colexecargs/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/mon",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_marusama_semaphore//:semaphore",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -13,6 +13,7 @@ package colexecargs
 import (
 	"context"
 	"sync"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewColOperator is a test helper that's always aliased to
@@ -133,13 +135,23 @@ func (r *NewColOperatorResult) AssertInvariants() {
 
 // TestCleanup releases the resources associated with this result. It should
 // only be used in tests.
-func (r *NewColOperatorResult) TestCleanup() {
+func (r *NewColOperatorResult) TestCleanup() error {
+	if err := r.ToClose.Close(); err != nil {
+		return err
+	}
 	for _, acc := range r.OpAccounts {
 		acc.Close(context.Background())
 	}
 	for _, m := range r.OpMonitors {
 		m.Stop(context.Background())
 	}
+	return nil
+}
+
+// TestCleanupNoError is the same as TestCleanup but asserts that no error is
+// returned.
+func (r *NewColOperatorResult) TestCleanupNoError(t testing.TB) {
+	require.NoError(t, r.TestCleanup())
 }
 
 var newColOperatorResultPool = sync.Pool{

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -339,6 +339,7 @@ func (s *ColBatchScan) Release() {
 
 // Close implements the colexecop.Closer interface.
 func (s *ColBatchScan) Close() error {
+	s.rf.Close(s.EnsureCtx())
 	if s.tracingSpan != nil {
 		s.tracingSpan.Finish()
 		s.tracingSpan = nil

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -528,6 +528,7 @@ func (s *ColIndexJoin) Release() {
 
 // Close implements the colexecop.Closer interface.
 func (s *ColIndexJoin) Close() error {
+	s.rf.Close(s.EnsureCtx())
 	if s.tracingSpan != nil {
 		s.tracingSpan.Finish()
 		s.tracingSpan = nil

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -90,7 +90,7 @@ func TestColBatchScanMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.TestCleanup()
+	defer res.TestCleanupNoError(t)
 	tr := res.Root
 	tr.Init(ctx)
 	meta := tr.(*colexecutils.CancelChecker).Input.(colexecop.DrainableOperator).DrainMeta()
@@ -169,7 +169,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 					}
 				}
 				b.StopTimer()
-				res.TestCleanup()
+				res.TestCleanupNoError(b)
 			}
 		})
 	}

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -119,6 +119,12 @@ func NewAllocator(
 	}
 }
 
+// GetMonitor returns the bytes monitor which the allocator's memory account is
+// bound to.
+func (a *Allocator) GetMonitor() *mon.BytesMonitor {
+	return a.acc.Monitor()
+}
+
 // NewMemBatchWithFixedCapacity allocates a new in-memory coldata.Batch with the
 // given vector capacity.
 // Note: consider whether you want the dynamic batch size behavior (in which


### PR DESCRIPTION
Previously, the cFetcher created the txnKVFetcher with a nil monitor
under the assumption that it (the cFetcher) performs the memory
accounting itself. I think the justification was that after receiving the
batch response into the txnKVFetcher, the cFetcher will quickly peel
things off and put into `coldata.Vec`s where it is accounted for. This,
however, isn't right because we always perform a deep copy of byte
slices when we set the values into `coldata.Vec`s. (This is the case for
bytes-like and other types, but bytes-like are likely to be affected the
most. I think previously - when we didn't have the flat bytes
representation - we might have skipped the deep copy.)

This results in the batch responses not being accounted for when the
txnKVFetcher is used by the cFetcher (which is the case for the
vectorized scans and index joins). Those batch responses can be on the
order of MBs which is quite large if we have hundred concurrent
cFetchers. This commit fixes the issue by providing the monitor in the
constructor.

Addresses: #64906.

Release note (bug fix): CockroachDB is now less likely to OOM when
queries reading a lot of data are issued with high concurrency (these
queries are likely to hit the memory budget determined by
`--max-sql-memory` startup parameter).