### PR TITLE
randutil: use common seed for rand.Seed and rand.Rand for testing

### DIFF
--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -641,11 +641,11 @@ func RunTestsWithFn(
 			inputSources := make([]colexecop.Operator, len(tups))
 			var inputTypes []*types.T
 			if useSel {
+				rng, _ := randutil.NewTestRandFromGlobalSeed()
 				for i, tup := range tups {
 					if typs != nil {
 						inputTypes = typs[i]
 					}
-					rng, _ := randutil.NewPseudoRand()
 					inputSources[i] = newOpTestSelInput(allocator, rng, batchSize, tup, inputTypes)
 				}
 			} else {
@@ -929,7 +929,7 @@ func (s *opTestInput) Next() coldata.Batch {
 		}
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRandFromGlobalSeed()
 
 	for i := range s.typs {
 		vec := s.batch.ColVec(i)
@@ -1598,7 +1598,7 @@ const MinBatchSize = 3
 func GenerateBatchSize() int {
 	randomizeBatchSize := envutil.EnvOrDefaultBool("COCKROACH_RANDOMIZE_BATCH_SIZE", true)
 	if randomizeBatchSize {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRandFromGlobalSeed()
 		// sizesToChooseFrom specifies some predetermined and one random sizes
 		// that we will choose from. Such distribution is chosen due to the
 		// fact that most of our unit tests don't have a lot of data, so in

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -20,6 +20,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
+// globalSeed contains a pseudo random seed that should only be used in tests.
+var globalSeed int64
+
+// Initializes the global random seed. This value can be specified via an
+// environment variable COCKROACH_RANDOM_SEED=x.
+func init() {
+	globalSeed = envutil.EnvOrDefaultInt64("COCKROACH_RANDOM_SEED", NewPseudoSeed())
+}
+
 // NewPseudoSeed generates a seed from crypto/rand.
 func NewPseudoSeed() int64 {
 	var seed int64
@@ -45,6 +54,12 @@ func NewTestPseudoRand() (*rand.Rand, int64) {
 	rng, seed := NewPseudoRand()
 	log.Printf("random seed: %v", seed)
 	return rng, seed
+}
+
+// NewTestRandFromGlobalSeed returns an instance of math/rand.Rand seeded from
+// the seed set globally.
+func NewTestRandFromGlobalSeed() (*rand.Rand, int64) {
+	return rand.New(rand.NewSource(globalSeed)), globalSeed
 }
 
 // RandIntInRange returns a value in [min, max)
@@ -82,12 +97,9 @@ func ReadTestdataBytes(r *rand.Rand, arr []byte) {
 }
 
 // SeedForTests seeds the random number generator and prints the seed
-// value used. This value can be specified via an environment variable
-// COCKROACH_RANDOM_SEED=x to reuse the same value later. This function should
-// be called from TestMain; individual tests should not touch the seed
-// of the global random number generator.
+// value used. This function should be called from TestMain; individual tests
+// should not touch the seed of the global random number generator.
 func SeedForTests() {
-	seed := envutil.EnvOrDefaultInt64("COCKROACH_RANDOM_SEED", NewPseudoSeed())
-	rand.Seed(seed)
-	log.Printf("random seed: %v", seed)
+	rand.Seed(globalSeed)
+	log.Printf("random seed: %v", globalSeed)
 }

--- a/pkg/util/randutil/rand_test.go
+++ b/pkg/util/randutil/rand_test.go
@@ -32,6 +32,15 @@ func TestPseudoRand(t *testing.T) {
 	}
 }
 
+func TestNewTestRandFromGlobalSeed(t *testing.T) {
+	numbers := make(map[int]bool)
+	rand1, _ := randutil.NewTestRandFromGlobalSeed()
+	rand2, _ := randutil.NewTestRandFromGlobalSeed()
+	if numbers[rand1.Int()] != numbers[rand2.Int()] {
+		t.Errorf("expected numbers to be equal; got different")
+	}
+}
+
 func TestRandIntInRange(t *testing.T) {
 	rand, _ := randutil.NewPseudoRand()
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Previously, using the random seed logged at the beginning of tests as
`COCKROACH_RANDOM_SEED` did not necessarily produce the same test
results. This was because the seed printed in the log, used for
`rand.Seed` to seed the global rand functions, was different from the
seeds generated when tests create `rand.Rand`. As a result, it was
difficult to reproduce test failures.

This change introduces a common seed, set at initialization to
`COCKROACH_RANDOM_SEED` or a pseudo random seed. The common seed is
logged and used in `SeedForTests()` to seed rand, as well as in a new
randutil function `NewTestRandFromGlobalSeed()`, which returns a
`rand.Rand` for testing. Tests that use the function produce
deterministic results when the logged random seed is applied as
`COCKROACH_RANDOM_SEED`.

Release note: None