### PR TITLE
release-21.2: clusterversion,storage: cluster version that uses Pebble's SetWithDelete

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -166,4 +166,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	21.1-1164	set the active cluster version in the format '<major>.<minor>'
+version	version	21.1-1166	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -171,6 +171,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.1-1164</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.1-1166</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -280,6 +280,11 @@ const (
 	// MarkerDataKeysRegistry switches to using an atomic marker file
 	// for denoting which data keys registry is active.
 	MarkerDataKeysRegistry
+	// PebbleSetWithDelete switches to a backwards incompatible Pebble version
+	// that provides SingleDelete semantics that are cleaner and robust to
+	// programming error. See https://github.com/cockroachdb/pebble/issues/1255
+	// and #69891.
+	PebbleSetWithDelete
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -472,6 +477,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     MarkerDataKeysRegistry,
 		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1164},
+	},
+	{
+		Key:     PebbleSetWithDelete,
+		Version: roachpb.Version{Major: 21, Minor: 1, Internal: 1166},
 	},
 	// *************************************************
 	// Step (2): Add new versions here.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -47,11 +47,12 @@ func _() {
 	_ = x[DateAndIntervalStyle-36]
 	_ = x[PebbleFormatVersioned-37]
 	_ = x[MarkerDataKeysRegistry-38]
+	_ = x[PebbleSetWithDelete-39]
 }
 
-const _Key_name = "Start21_1replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistry"
+const _Key_name = "Start21_1replacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationV21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsSQLStatsTableDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobPreventNewInterleavedTablesEnsureNoInterleavedTablesDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessSQLStatsCompactionScheduledJobDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDelete"
 
-var _Key_index = [...]uint16{0, 9, 55, 105, 143, 185, 190, 203, 212, 227, 256, 273, 290, 339, 353, 366, 386, 402, 419, 446, 481, 506, 535, 566, 586, 617, 644, 669, 686, 715, 748, 771, 790, 809, 832, 848, 878, 898, 919, 941}
+var _Key_index = [...]uint16{0, 9, 55, 105, 143, 185, 190, 203, 212, 227, 256, 273, 290, 339, 353, 366, 386, 402, 419, 446, 481, 506, 535, 566, 586, 617, 644, 669, 686, 715, 748, 771, 790, 809, 832, 848, 878, 898, 919, 941, 960}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -118,6 +118,12 @@ func TestSetMinVersion(t *testing.T) {
 	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleFormatVersioned))
 	require.NoError(t, err)
 	require.Equal(t, pebble.FormatVersioned, p.db.FormatMajorVersion())
+
+	// Advancing the store cluster version to PebbleSetWithDelete
+	// should also advance the store's format major version.
+	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleSetWithDelete))
+	require.NoError(t, err)
+	require.Equal(t, pebble.FormatSetWithDelete, p.db.FormatMajorVersion())
 }
 
 func TestMinVersion_IsNotEncrypted(t *testing.T) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1477,7 +1477,12 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 	// corresponding format major version, ratcheting Pebble's format
 	// major version if necessary.
 	formatVers := pebble.FormatMostCompatible
+	// Cases are ordered from newer to older versions.
 	switch {
+	case !version.Less(clusterversion.ByKey(clusterversion.PebbleSetWithDelete)):
+		if formatVers < pebble.FormatSetWithDelete {
+			formatVers = pebble.FormatSetWithDelete
+		}
 	case !version.Less(clusterversion.ByKey(clusterversion.PebbleFormatVersioned)):
 		if formatVers < pebble.FormatVersioned {
 			formatVers = pebble.FormatVersioned


### PR DESCRIPTION
Backport 1/1 commits from #70707.

/cc @cockroachdb/release

---

This is a backwards incompatible change in Pebble to provide
SingleDelete semantics that are clean and robust to programming
error.

This is being done post v21.2-beta but before GA since this
was deemed a GA blocker and not a release blocker. It allows
for upgrading beta clusters to the GA version. For more on these
discussions see the following threads
https://github.com/cockroachdb/pebble/issues/1255#issuecomment-915483527,
https://cockroachlabs.slack.com/archives/C4A9ALLRL/p1631213490022600
(Cockroach Labs internal link).

Informs https://github.com/cockroachdb/pebble/issues/1255
Informs #69891

Release note: None

Release justification: high-severity bug fix
