### PR TITLE
release-21.2: jobs: allow create table as select jobs to be canceled

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -150,7 +150,10 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 			Progress: jobspb.SchemaChangeProgress{},
 			// Mark jobs without a mutation ID as non-cancellable,
 			// since we expect these to be trivial.
-			NonCancelable: mutationID == descpb.InvalidMutationID,
+			//
+			// The job should be cancelable when we are adding a table that doesn't
+			// have mutations, e.g., in CREATE TABLE AS VALUES.
+			NonCancelable: mutationID == descpb.InvalidMutationID && !tableDesc.Adding(),
 		}
 		p.extendedEvalCtx.SchemaChangeJobRecords[tableDesc.ID] = &newRecord
 		// Only add a MutationJob if there's an associated mutation.


### PR DESCRIPTION
Backport 1/2 commits from #69300.

/cc @cockroachdb/release

---

Previously, non-cancelable jobs were retried in running state
only if their errors were marked as retryable. Moreover,  only 
non-cancelable reverting jobs were retried by default. This 
commit makes non-cancelable jobs always retry in running 
state unless their error is marked as a permanent error. In
addition, this commit makes all reverting jobs to retry when
they fail. As a result, non-cancelable running jobs and all
reverting jobs do not fail due to transient errors.

Release justification: low-risk updates to new functionality.

Release note (general change): Non-cancelable jobs, such as
schema-change GC jobs, now do not fail unless they fail with
a permanent error. They retry with exponential-backoff if
they fail due to a transient error. Furthermore, Jobs that 
perform reverting tasks do not fail. Instead, they are retried 
with exponential-backoff if an error is encountered while 
reverting. As a result, transient errors do not impact the jobs 
that are reverting.

Fixes: #66685
