### PR TITLE
tracing: don't expose span before fully initialized

### DIFF
--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_sdk//trace/tracetest",
+        "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",
         "@org_golang_x_net//trace",

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -171,13 +171,7 @@ func (s *crdbSpan) recordingType() RecordingType {
 
 // enableRecording start recording on the Span. From now on, log events and
 // child spans will be stored.
-//
-// If parent != nil, the Span will be registered as a child of the respective
-// parent. If nil, the parent's recording will not include this child.
-func (s *crdbSpan) enableRecording(parent *crdbSpan, recType RecordingType) {
-	if parent != nil {
-		parent.addChild(s)
-	}
+func (s *crdbSpan) enableRecording(recType RecordingType) {
 	if recType == RecordingOff || s.recordingType() == recType {
 		return
 	}
@@ -493,7 +487,7 @@ func (s *crdbSpan) addChild(child *crdbSpan) {
 // recurses on its list of children.
 func (s *crdbSpan) setVerboseRecursively(to bool) {
 	if to {
-		s.enableRecording(nil /* parent */, RecordingVerbose)
+		s.enableRecording(RecordingVerbose)
 	} else {
 		s.disableRecording()
 	}

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -60,7 +60,7 @@ func (s *spanInner) SetVerbose(to bool) {
 		panic(errors.AssertionFailedf("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
 	}
 	if to {
-		s.crdb.enableRecording(nil /* parent */, RecordingVerbose)
+		s.crdb.enableRecording(RecordingVerbose)
 	} else {
 		s.crdb.disableRecording()
 	}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -544,15 +544,15 @@ func (t *Tracer) startSpanGeneric(
 	s := &helper.span
 
 	{
-		// Link the newly created span to the parent, if necessary,
-		// and start recording, if requested.
-		// We inherit the recording type of the local parent, if any,
-		// over the remote parent, if any. If neither are specified, we're not recording.
-		var p *crdbSpan
-		if opts.Parent != nil {
-			p = opts.Parent.i.crdb
+		// If a parent is specified, link the newly created Span to the parent. This
+		// is done even when not recording because recording could be started later.
+		//
+		// We inherit the recording type of the local parent, if any, over the
+		// remote parent, if any. If neither are specified, we're not recording.
+		if opts.Parent != nil && opts.Parent.i.crdb != nil {
+			defer opts.Parent.i.crdb.addChild(s.i.crdb)
 		}
-		s.i.crdb.enableRecording(p, opts.recordingType())
+		s.i.crdb.enableRecording(opts.recordingType())
 	}
 
 	// Deal with opts.SpanKind. This needs to be done after we enable recording


### PR DESCRIPTION
By adding a Span to its parent's list of children, we were making it
accessible to `parent.GetRecording` prematurely. This only came to
our attention because we weren't reliably grabbing the right locks
during span creation (on the assumption that there wasn't any
concurrency yet).

This commit makes sure that registering with the parent is the last
thing we do and adds a regression test that immediately reproduced
the issue.

Fixes #70753.

Release note: None
