### PR TITLE
[dnm] *: highlight unredacted uses of structured tracing payloads

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import "github.com/cockroachdb/redact"
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *BackupProcessorPlanningTraceEvent) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *BackupProgressTraceEvent) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *BackupExportTraceRequestEvent) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *BackupExportTraceResponseEvent) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -283,7 +283,7 @@ func backup(
 		return nil
 	}
 
-	resumerSpan.RecordStructured(&types.StringValue{Value: "starting DistSQL backup execution"})
+	resumerSpan.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "starting DistSQL backup execution"}))
 	runBackup := func(ctx context.Context) error {
 		return distBackup(
 			ctx,
@@ -303,7 +303,7 @@ func backup(
 	backupManifest.ID = backupID
 	// Write additional partial descriptors to each node for partitioned backups.
 	if len(storageByLocalityKV) > 0 {
-		resumerSpan.RecordStructured(&types.StringValue{Value: "writing partition descriptors for partitioned backup"})
+		resumerSpan.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "writing partition descriptors for partitioned backup"}))
 		filesByLocalityKV := make(map[string][]BackupManifest_File)
 		for _, file := range backupManifest.Files {
 			filesByLocalityKV[file.LocalityKV] = append(filesByLocalityKV[file.LocalityKV], file)
@@ -338,7 +338,7 @@ func backup(
 		}
 	}
 
-	resumerSpan.RecordStructured(&types.StringValue{Value: "writing backup manifest"})
+	resumerSpan.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "writing backup manifest"}))
 	if err := writeBackupManifest(ctx, settings, defaultStore, backupManifestName, encryption, backupManifest); err != nil {
 		return RowCount{}, err
 	}
@@ -368,7 +368,7 @@ func backup(
 		Statistics: tableStatistics,
 	}
 
-	resumerSpan.RecordStructured(&types.StringValue{Value: "writing backup table statistics"})
+	resumerSpan.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "writing backup table statistics"}))
 	if err := writeTableStatistics(ctx, defaultStore, backupStatisticsFileName, encryption, &statsTable); err != nil {
 		return RowCount{}, err
 	}
@@ -440,7 +440,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 	ptsID := details.ProtectedTimestampRecord
 	if ptsID != nil && !b.testingKnobs.ignoreProtectedTimestamps {
-		resumerSpan.RecordStructured(&types.StringValue{Value: "verifying protected timestamp"})
+		resumerSpan.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "verifying protected timestamp"}))
 		if err := p.ExecCfg().ProtectedTimestampProvider.Verify(ctx, *ptsID); err != nil {
 			if errors.Is(err, protectedts.ErrNotExists) {
 				// No reason to return an error which might cause problems if it doesn't

--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -25,13 +25,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +55,8 @@ func (r *traceSpanResumer) Resume(ctx context.Context, _ interface{}) error {
 	_, span := tracing.ChildSpan(ctx, "trace test")
 	defer span.Finish()
 	// Picked a random proto message that was simple to match output against.
-	span.RecordStructured(&serverpb.TableStatsRequest{Database: "foo", Table: "bar"})
+	span.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "foo bar"}))
+	// span.RecordStructured(&serverpb.TableStatsRequest{Database: "foo", Table: "bar"})
 	r.recordedSpanCh <- struct{}{}
 	<-r.completeResumerCh
 	return nil

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -394,7 +394,7 @@ func (s *s3Storage) Settings() *cluster.Settings {
 func (s *s3Storage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "s3.Writer")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.Writer: %s", path.Join(s.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("s3.Writer: %s", path.Join(s.prefix, basename))}))
 
 	uploader, err := s.getUploader(ctx)
 	if err != nil {
@@ -453,7 +453,7 @@ func (s *s3Storage) ReadFileAt(
 ) (io.ReadCloser, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "s3.ReadFileAt")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.ReadFileAt: %s", path.Join(s.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("s3.ReadFileAt: %s", path.Join(s.prefix, basename))}))
 
 	stream, err := s.openStreamAt(ctx, basename, offset)
 	if err != nil {
@@ -490,7 +490,7 @@ func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.Lis
 	defer sp.Finish()
 
 	dest := cloud.JoinPathPreservingTrailingSlash(s.prefix, prefix)
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.List: %s", dest)})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("s3.List: %s", dest)}))
 
 	client, err := s.getClient(ctx)
 	if err != nil {

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -118,8 +118,8 @@ func (s *azureStorage) Settings() *cluster.Settings {
 func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "azure.Writer")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("azure.Writer: %s",
-		path.Join(s.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("azure.Writer: %s",
+		path.Join(s.prefix, basename))}))
 
 	blob := s.getBlob(basename)
 	return cloud.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
@@ -143,8 +143,8 @@ func (s *azureStorage) ReadFileAt(
 ) (io.ReadCloser, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "azure.ReadFileAt")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("azure.ReadFileAt: %s",
-		path.Join(s.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("azure.ReadFileAt: %s",
+		path.Join(s.prefix, basename))}))
 
 	// https://github.com/cockroachdb/cockroach/issues/23859
 	blob := s.getBlob(basename)
@@ -180,7 +180,7 @@ func (s *azureStorage) List(ctx context.Context, prefix, delim string, fn cloud.
 	defer sp.Finish()
 
 	dest := cloud.JoinPathPreservingTrailingSlash(s.prefix, prefix)
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("azure.List: %s", dest)})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("azure.List: %s", dest)}))
 
 	var marker azblob.Marker
 	for marker.NotDone() {

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -156,8 +156,8 @@ func makeGCSStorage(
 func (g *gcsStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "gcs.Writer")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("gcs.Writer: %s",
-		path.Join(g.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("gcs.Writer: %s",
+		path.Join(g.prefix, basename))}))
 	w := g.bucket.Object(path.Join(g.prefix, basename)).NewWriter(ctx)
 	if !gcsChunkingEnabled.Get(&g.settings.SV) {
 		w.ChunkSize = 0
@@ -178,8 +178,8 @@ func (g *gcsStorage) ReadFileAt(
 
 	ctx, sp := tracing.ChildSpan(ctx, "gcs.ReadFileAt")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("gcs.ReadFileAt: %s",
-		path.Join(g.prefix, basename))})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("gcs.ReadFileAt: %s",
+		path.Join(g.prefix, basename))}))
 
 	r := &cloud.ResumingReader{
 		Ctx: ctx,
@@ -207,7 +207,7 @@ func (g *gcsStorage) List(ctx context.Context, prefix, delim string, fn cloud.Li
 	dest := cloud.JoinPathPreservingTrailingSlash(g.prefix, prefix)
 	ctx, sp := tracing.ChildSpan(ctx, "gcs.List")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("gcs.List: %s", dest)})
+	sp.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("gcs.List: %s", dest)}))
 
 	it := g.bucket.Objects(ctx, &gcs.Query{Prefix: dest, Delimiter: delim})
 

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -255,7 +255,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				if rts.traceRealSpan {
 					// Add a dummy recording so we actually see something in the trace.
 					span := tracing.SpanFromContext(ctx)
-					span.RecordStructured(&types.StringValue{Value: "boom"})
+					span.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "boom"}))
 				}
 				rts.mu.Lock()
 				rts.mu.a.ResumeStart = true
@@ -289,7 +289,7 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				if rts.traceRealSpan {
 					// Add a dummy recording so we actually see something in the trace.
 					span := tracing.SpanFromContext(ctx)
-					span.RecordStructured(&types.StringValue{Value: "boom"})
+					span.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: "boom"}))
 				}
 				rts.mu.Lock()
 				rts.mu.a.OnFailOrCancelStart = true

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -182,7 +182,7 @@ func EvalAddSSTable(
 	ms.Add(stats)
 
 	if args.IngestAsWrites {
-		span.RecordStructured(&types.StringValue{Value: fmt.Sprintf("ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(args.Data))})
+		span.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(args.Data))}))
 		log.VEventf(ctx, 2, "ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(args.Data))
 		dataIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
 		for {

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -92,7 +92,7 @@ func evalExport(
 		evalExportTrace.Value = fmt.Sprintf("evaluating Export [%s, %s) on remote node %d",
 			args.Key, args.EndKey, cArgs.EvalCtx.NodeID())
 	}
-	evalExportSpan.RecordStructured(&evalExportTrace)
+	evalExportSpan.RecordStructured(roachpb.NeedsRedaction(&evalExportTrace))
 
 	if !args.ReturnSST {
 		return result.Result{}, errors.New("ReturnSST is required")

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1636,3 +1636,8 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 func (s *ScanStats) String() string {
 	return redact.StringWithoutMarkers(s)
 }
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *RetryTracingEvent) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}

--- a/pkg/roachpb/needs_redaction.go
+++ b/pkg/roachpb/needs_redaction.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachpb
+
+import (
+	"github.com/cockroachdb/redact"
+	"github.com/gogo/protobuf/types"
+)
+
+func NeedsRedaction(value *types.StringValue) *NeedsRedactionType {
+	return &NeedsRedactionType{StringValue: value}
+}
+
+// NeedsRedactionType ...
+type NeedsRedactionType struct {
+	*types.StringValue
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *NeedsRedactionType) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/types"
 )
@@ -69,6 +70,11 @@ const (
 	// ProcessorIDTagKey is the key used for processor id tags in tracing spans.
 	ProcessorIDTagKey = tracing.TagPrefix + "processorid"
 )
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *ComponentStats) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
+}
 
 // StatsForQueryPlan returns the statistics as a list of strings that can be
 // displayed in query plans and diagrams.

--- a/pkg/util/limit/limiter.go
+++ b/pkg/util/limit/limiter.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -54,7 +55,7 @@ func (l *ConcurrentRequestLimiter) Begin(ctx context.Context) (Reservation, erro
 		var span *tracing.Span
 		ctx, span = tracing.ChildSpan(ctx, l.spanName)
 		defer span.Finish()
-		span.RecordStructured(&types.StringValue{Value: fmt.Sprintf("%d requests are waiting", l.sem.Len())})
+		span.RecordStructured(roachpb.NeedsRedaction(&types.StringValue{Value: fmt.Sprintf("%d requests are waiting", l.sem.Len())}))
 		res, err = l.sem.Acquire(ctx, 1)
 	}
 	return res, err

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/collector"
+	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +32,11 @@ import (
 // testStructuredImpl is a testing implementation of Structured event.
 type testStructuredImpl struct {
 	*types.StringValue
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *testStructuredImpl) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
 }
 
 var _ tracing.Structured = &testStructuredImpl{}

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -32,6 +33,11 @@ import (
 // testStructuredImpl is a testing implementation of Structured event.
 type testStructuredImpl struct {
 	*types.StringValue
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (s *testStructuredImpl) SafeFormat(_ redact.SafePrinter, _ rune) {
+	// Needs implementation
 }
 
 var _ tracing.Structured = &testStructuredImpl{}

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/cockroachdb/redact"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -267,5 +268,6 @@ func (sm SpanMeta) String() string {
 // Structured is an opaque protobuf that can be attached to a trace via
 // `Span.RecordStructured`.
 type Structured interface {
+	redact.SafeFormatter
 	protoutil.Message
 }


### PR DESCRIPTION
This is a follow-up for #58610. I do not intend to get this PR to a
mergeable state. Instead, it highlights the remaining redactability
problems related to structured payloads so that the owners of that
issue can get a good overview quickly.

It turns out that we have started using raw strings
(`*types.StringValue`) for payloads in multiple places, which seems
problematic due to the frequent use of `Sprintf`.

These payloads, if sent to tenants, could leak PII. Also, just the
approach of putting Sprinted strings into structured payloads seems
ill-advised. We have verbose log messages for that.

There seems to be some mismatch between what people need and what people
are getting. But at a company-wide level, we need redactability or some
other means to guarantee that tenants cannot exfiltrate information they
are not privy to. Let's keep the discussion on that on #58610 as well.

Release note: None
