### PR TITLE
changefeedccl: log create_changefeed usage to telemetry channel

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2261,6 +2261,64 @@ An event of type `drop_role` is recorded when a role is dropped.
 Events in this category are logged to the `TELEMETRY` channel.
 
 
+### `create_changefeed_query`
+
+An event of type `create_changefeed_query` is the CREATE CHANGEFEED query event logged to the
+telemetry channel. It contains usage details about the parameters the user
+passed in to define the changefeed
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on | no |
+| `TopicPrefix` | (Kafka/CloudStorage Query Param) Whether a custom prefix is being added to all topic names | no |
+| `TlsEnabled` | (Kafka Query Param) Whether TLS is enabled on the connection to Kafka | no |
+| `CaCert` | (Kafka Query Param) Whether a base64-encoded ca_cert file was specified | no |
+| `ClientCert` | (Kafka Query Param) Whether a Privacy Enhanced Email (PEM) certificate was specified | no |
+| `ClientKey` | (Kafka Query Param) Whether a private key for the PEM certificate was specified | no |
+| `SaslEnabled` | (Kafka Query Param) Whether SASL is enabled | no |
+| `SaslMechanism` | (Kafka Query Param) The SASL mechanism (ex: SASL-SCRAM-SHA-256, SASL-PLAIN) | no |
+| `SaslUser` | (Kafka Query Param) Whether a SASL username has been specified | no |
+| `SaslPassword` | (Kafka Query Param) Whether a SASL password has been specified | no |
+| `FileSize` | (CloudStorage Query Param) A custom maximum file size for files before they are flushed | no |
+| `InsecureTlsSkipVerify` | (Kafka Query Param) Whether client-side validation of responses has been disabled | no |
+| `Updated` | (Changefeed Option) Whether updated timestamps are emitted with each row | no |
+| `Resolved` | (Changefeed Option) The interval at which resolved timestamps are emitted | no |
+| `Envelope` | (Changefeed Option) Either key_only to emit only keys or wrapped for both key and value | no |
+| `Cursor` | (Changefeed Option) Whether a cursor timestamp has been specified to begin emitting events from | no |
+| `Format` | (Changefeed Option) The data format, either JSON or Avro, that the changefeed emits | no |
+| `ConfluentSchemaRegistry` | (Changefeed Option) Whether a schema registry address has been specified | no |
+| `KeyInValue` | (Changefeed Option) Whether to emit primary keys as the value for deleted rows | no |
+| `Diff` | (Changefeed Option) Whether a `before` field is to be emitted with each message | no |
+| `Compression` | (Changefeed Option) The compression format being used (ex: gzip) | no |
+| `ProtectDataFromGcOnPause` | (Changefeed Option) Whether data to resume a changefeed is protected from GC when paused | no |
+| `SchemaChangeEvents` | (Changefeed Option) The type of schema events that trigger the change policy | no |
+| `SchemaChangePolicy` | (Changefeed Option) The behavior to trigger from a schema change event (ex: backfill) | no |
+| `Scan` | Whether the initial_scan or no_initial_scan options have been specified | no |
+| `FullTableName` | (Changefeed Option) Whether fully-qualified table names are used for topic names | no |
+| `AvroSchemaPrefix` | (Changefeed Option) Whether a custom namespace for table schemas is specified | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `ChangefeedType` | The type of changefeed (ex: Enterprise) | no |
+| `CrdbVersion` | The CRDB version of the node that triggered the event | no |
+| `NodeID` | The ID of the node that triggered the event | no |
+| `InstanceID` | The Instance ID of the running SQL server | no |
+| `ClusterID` | The ID of the cluster containing the node that triggered the event | no |
+| `TenantID` | The ID of the tenant that triggered the event | no |
+| `OrganizationID` | The ID of the organization linked to the cluster | no |
+| `Internal` | Whether the event originates from within CRDB or an external service | no |
+| `SamplingRate` | How often this event is emitted to the channel per event that takes place | no |
+| `SeverityNumeric` | Numeric value for the severity of the event | no |
+| `Severity` | String value for the severity of the event | no |
+| `SinkType` | The scheme of sink being emitted to (ex: kafka, nodelocal, webhook-https) | no |
+| `JobID` | The ID of the job that triggered the event | no |
+
 ### `sampled_query`
 
 An event of type `sampled_query` is the SQL query event logged to the telemetry channel. It

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/build",
         "//pkg/ccl/backupccl/backupresolver",
         "//pkg/ccl/changefeedccl/cdcutils",
         "//pkg/ccl/changefeedccl/changefeedbase",
@@ -92,6 +93,7 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/json",
         "//pkg/util/log",
+        "//pkg/util/log/eventpb",
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -361,8 +362,10 @@ func changefeedPlanHook(
 		}
 
 		if details.SinkURI == `` {
+			jobID := jobspb.JobID(0)
 			telemetry.Count(`changefeed.create.core`)
-			err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, progress, resultsCh)
+			logChangefeedCreateTelemetry(ctx, p, changefeedStmt, opts, nil, jobID)
+			err := distChangefeedFlow(ctx, p, jobID, details, progress, resultsCh)
 			if err != nil {
 				telemetry.Count(`changefeed.core.error`)
 			}
@@ -474,6 +477,8 @@ func changefeedPlanHook(
 			return err
 		}
 
+		logChangefeedCreateTelemetry(ctx, p, changefeedStmt, opts, &sinkURL{URL: parsedSink}, jobID)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -485,6 +490,76 @@ func changefeedPlanHook(
 
 	}
 	return fn, header, nil, avoidBuffering, nil
+}
+
+func logChangefeedCreateTelemetry(
+	ctx context.Context,
+	p sql.PlanHookState,
+	changefeedStmt *tree.CreateChangefeed,
+	opts map[string]string,
+	sinkURL *sinkURL,
+	jobID jobspb.JobID,
+) {
+	changefeedType := "enterprise"
+	if sinkURL == nil {
+		changefeedType = "core"
+	}
+
+	changefeedEventDetails := eventpb.CommonChangefeedEventDetails{
+		ChangefeedType:  changefeedType,
+		Internal:        true,
+		SamplingRate:    1,
+		SeverityNumeric: 1,
+		Severity:        "INFO",
+		JobID:           int64(jobID),
+	}
+
+	scanValue := ""
+	if opts[changefeedbase.OptInitialScan] != "" {
+		scanValue = "initial_scan"
+	}
+	if opts[changefeedbase.OptNoInitialScan] != "" {
+		scanValue = "no_initial_scan"
+	}
+
+	createChangefeedEvent := &eventpb.CreateChangefeedQuery{
+		CommonChangefeedEventDetails: changefeedEventDetails,
+		NumTables:                    int32(len(changefeedStmt.Targets.Tables)),
+
+		// Changefeed Options
+		Updated:                  opts[changefeedbase.OptUpdatedTimestamps] != "",
+		Resolved:                 opts[changefeedbase.OptResolvedTimestamps],
+		Envelope:                 opts[changefeedbase.OptEnvelope],
+		Cursor:                   opts[changefeedbase.OptCursor] != "",
+		Format:                   opts[changefeedbase.OptFormat],
+		ConfluentSchemaRegistry:  opts[changefeedbase.OptConfluentSchemaRegistry] != "",
+		KeyInValue:               opts[changefeedbase.OptKeyInValue] != "",
+		Diff:                     opts[changefeedbase.OptDiff] != "",
+		Compression:              opts[changefeedbase.OptCompression],
+		ProtectDataFromGcOnPause: opts[changefeedbase.OptProtectDataFromGCOnPause] != "",
+		SchemaChangeEvents:       opts[changefeedbase.OptSchemaChangeEvents],
+		SchemaChangePolicy:       opts[changefeedbase.OptSchemaChangePolicy],
+		Scan:                     scanValue,
+		FullTableName:            opts[changefeedbase.OptFullTableName] != "",
+		AvroSchemaPrefix:         opts[changefeedbase.OptAvroSchemaPrefix] != "",
+	}
+
+	if sinkURL != nil {
+		// Fill in Sink parameters
+		createChangefeedEvent.TopicPrefix = sinkURL.consumeParam(changefeedbase.SinkParamTopicPrefix) != ""
+		createChangefeedEvent.TlsEnabled = sinkURL.consumeParam(changefeedbase.SinkParamTLSEnabled) != ""
+		createChangefeedEvent.CaCert = sinkURL.consumeParam(changefeedbase.SinkParamCACert) != ""
+		createChangefeedEvent.ClientCert = sinkURL.consumeParam(changefeedbase.SinkParamClientCert) != ""
+		createChangefeedEvent.ClientKey = sinkURL.consumeParam(changefeedbase.SinkParamClientKey) != ""
+		createChangefeedEvent.SaslEnabled = sinkURL.consumeParam(changefeedbase.SinkParamSASLEnabled) != ""
+		createChangefeedEvent.SaslMechanism = sinkURL.consumeParam(changefeedbase.SinkParamSASLMechanism)
+		createChangefeedEvent.SaslUser = sinkURL.consumeParam(changefeedbase.SinkParamSASLUser) != ""
+		createChangefeedEvent.SaslPassword = sinkURL.consumeParam(changefeedbase.SinkParamSASLPassword) != ""
+		createChangefeedEvent.FileSize = sinkURL.consumeParam(changefeedbase.SinkParamFileSize)
+		createChangefeedEvent.InsecureTlsSkipVerify = sinkURL.consumeParam(changefeedbase.SinkParamSkipTLSVerify) != ""
+	}
+
+	log.StructuredEvent(ctx, createChangefeedEvent)
 }
 
 func changefeedJobDescription(

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -261,6 +261,9 @@ func (m *CreateRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_
 func (m *DropRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_ADMIN }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *CreateChangefeedQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SampledQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -85,3 +85,28 @@ message CommonJobEventDetails {
   string status = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// CommonChangefeedEventDetails contains the fields common to all changefeed
+// events.
+message CommonChangefeedEventDetails {
+  // The type of changefeed (ex: Enterprise)
+  string changefeed_type = 1 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Whether the event originates from within CRDB or an external service
+  bool internal = 2 [(gogoproto.jsontag) = ",omitempty"];
+
+  // How often this event is emitted to the channel per event that takes place
+  float sampling_rate = 3 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Numeric value for the severity of the event
+  int32 severity_numeric = 4 [(gogoproto.jsontag) = ",omitempty"];
+
+  // String value for the severity of the event
+  string severity = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The scheme of sink being emitted to (ex: kafka, nodelocal, webhook-https)
+  string sink_type = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The ID of the job that triggered the event
+  int64 job_id = 7 [(gogoproto.customname) = "JobID", (gogoproto.jsontag) = ",omitempty"];
+}
+

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1084,6 +1084,77 @@ func (m *CommentOnTable) AppendJSONFields(printComma bool, b redact.RedactableBy
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	if m.ChangefeedType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ChangefeedType\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.ChangefeedType)))
+		b = append(b, '"')
+	}
+
+	if m.Internal {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Internal\":true"...)
+	}
+
+	if m.SamplingRate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SamplingRate\":"...)
+		b = strconv.AppendFloat(b, float64(m.SamplingRate), 'f', -1, 32)
+	}
+
+	if m.SeverityNumeric != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SeverityNumeric\":"...)
+		b = strconv.AppendInt(b, int64(m.SeverityNumeric), 10)
+	}
+
+	if m.Severity != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Severity\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Severity)))
+		b = append(b, '"')
+	}
+
+	if m.SinkType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SinkType\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SinkType)))
+		b = append(b, '"')
+	}
+
+	if m.JobID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobID\":"...)
+		b = strconv.AppendInt(b, int64(m.JobID), 10)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *CommonConnectionDetails) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	if m.InstanceID != 0 {
@@ -1764,6 +1835,251 @@ func (m *ConvertToSchema) AppendJSONFields(printComma bool, b redact.RedactableB
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.NewDatabaseParent)))))
 		b = append(b, redact.EndMarker()...)
 		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *CreateChangefeedQuery) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
+
+	if m.NumTables != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NumTables\":"...)
+		b = strconv.AppendInt(b, int64(m.NumTables), 10)
+	}
+
+	if m.TopicPrefix {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TopicPrefix\":true"...)
+	}
+
+	if m.TlsEnabled {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TlsEnabled\":true"...)
+	}
+
+	if m.CaCert {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"CaCert\":true"...)
+	}
+
+	if m.ClientCert {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ClientCert\":true"...)
+	}
+
+	if m.ClientKey {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ClientKey\":true"...)
+	}
+
+	if m.SaslEnabled {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SaslEnabled\":true"...)
+	}
+
+	if m.SaslMechanism != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SaslMechanism\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SaslMechanism)))
+		b = append(b, '"')
+	}
+
+	if m.SaslUser {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SaslUser\":true"...)
+	}
+
+	if m.SaslPassword {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SaslPassword\":true"...)
+	}
+
+	if m.FileSize != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"FileSize\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.FileSize)))
+		b = append(b, '"')
+	}
+
+	if m.InsecureTlsSkipVerify {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"InsecureTlsSkipVerify\":true"...)
+	}
+
+	if m.Updated {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Updated\":true"...)
+	}
+
+	if m.Resolved != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Resolved\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Resolved)))
+		b = append(b, '"')
+	}
+
+	if m.Envelope != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Envelope\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Envelope)))
+		b = append(b, '"')
+	}
+
+	if m.Cursor {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Cursor\":true"...)
+	}
+
+	if m.Format != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Format\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Format)))
+		b = append(b, '"')
+	}
+
+	if m.ConfluentSchemaRegistry {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ConfluentSchemaRegistry\":true"...)
+	}
+
+	if m.KeyInValue {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KeyInValue\":true"...)
+	}
+
+	if m.Diff {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Diff\":true"...)
+	}
+
+	if m.Compression != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Compression\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Compression)))
+		b = append(b, '"')
+	}
+
+	if m.ProtectDataFromGcOnPause {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ProtectDataFromGcOnPause\":true"...)
+	}
+
+	if m.SchemaChangeEvents != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SchemaChangeEvents\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SchemaChangeEvents)))
+		b = append(b, '"')
+	}
+
+	if m.SchemaChangePolicy != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SchemaChangePolicy\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SchemaChangePolicy)))
+		b = append(b, '"')
+	}
+
+	if m.Scan != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Scan\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Scan)))
+		b = append(b, '"')
+	}
+
+	if m.FullTableName {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"FullTableName\":true"...)
+	}
+
+	if m.AvroSchemaPrefix {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"AvroSchemaPrefix\":true"...)
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -45,3 +45,95 @@ message SampledQuery {
   string distribution = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+
+// CreateChangefeedQuery is the CREATE CHANGEFEED query event logged to the
+// telemetry channel. It contains usage details about the parameters the user
+// passed in to define the changefeed
+message CreateChangefeedQuery {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonChangefeedEventDetails changefeed = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The number of tables listed in the query that the changefeed is to run on
+  int32 num_tables = 3 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Changefeed Sink Params
+
+  // (Kafka/CloudStorage Query Param) Whether a custom prefix is being added to all topic names
+  bool topic_prefix = 4 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) Whether TLS is enabled on the connection to Kafka
+  bool tls_enabled = 5 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) Whether a base64-encoded ca_cert file was specified
+  bool ca_cert = 6 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) Whether a Privacy Enhanced Email (PEM) certificate was specified
+  bool client_cert = 7 [(gogoproto.jsontag) = ",omitempty"];
+  // (Kafka Query Param) Whether a private key for the PEM certificate was specified
+  bool client_key = 8 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) Whether SASL is enabled
+  bool sasl_enabled = 9 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) The SASL mechanism (ex: SASL-SCRAM-SHA-256, SASL-PLAIN)
+  string sasl_mechanism = 10 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Kafka Query Param) Whether a SASL username has been specified
+  bool sasl_user = 11 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Kafka Query Param) Whether a SASL password has been specified
+  bool sasl_password = 12 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (CloudStorage Query Param) A custom maximum file size for files before they are flushed
+  string file_size = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Kafka Query Param) Whether client-side validation of responses has been disabled
+  bool insecure_tls_skip_verify = 14 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Changefeed Options
+
+  // (Changefeed Option) Whether updated timestamps are emitted with each row
+  bool updated = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) The interval at which resolved timestamps are emitted
+  string resolved = 16 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) Either key_only to emit only keys or wrapped for both key and value
+  string envelope = 17 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) Whether a cursor timestamp has been specified to begin emitting events from
+  bool cursor = 18 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) The data format, either JSON or Avro, that the changefeed emits
+  string format = 19 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) Whether a schema registry address has been specified
+  bool confluent_schema_registry = 20 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) Whether to emit primary keys as the value for deleted rows
+  bool key_in_value = 21 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) Whether a `before` field is to be emitted with each message
+  bool diff = 22 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) The compression format being used (ex: gzip)
+  string compression = 23 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) Whether data to resume a changefeed is protected from GC when paused
+  bool protect_data_from_gc_on_pause = 24 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) The type of schema events that trigger the change policy
+  string schema_change_events = 25 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) The behavior to trigger from a schema change event (ex: backfill)
+  string schema_change_policy = 26 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // Whether the initial_scan or no_initial_scan options have been specified
+  string scan = 27 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\"" ];
+
+  // (Changefeed Option) Whether fully-qualified table names are used for topic names
+  bool full_table_name = 28 [(gogoproto.jsontag) = ",omitempty"];
+
+  // (Changefeed Option) Whether a custom namespace for table schemas is specified
+  bool avro_schema_prefix = 29 [(gogoproto.jsontag) = ",omitempty"];
+}


### PR DESCRIPTION
Resolves #69721

Previously we had no information on how changefeeds were being used in
the wild.  This left us with less hard data to base decisions on.

This patch adds logging for CREATE CHANGEFEED commands such as number of
tables, sink type, sink parameters, sink options, and node information
to the eventpb TELEMETRY channel. This provides us with the information
on what the user specified and the environment in which they specified
it. Values with sensitive information are simply emitted as booleans
describing whether a custom value was set or not.

Note that this only describes what the user told us, not what was
actually used, as the TELEMETRY channel is just for usage, compared to
the OPS channel which would better suit a "changefeed has been created"
event.  It also doesn't log failed commands, as it only sends out an
event once we have a job_id.

Release note (ops change): CREATE CHANGEFEED statements now log usage
data to the TELEMETRY channel