### PR TITLE
release-21.2:     sql: support for temporary table clean up for tenants

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -153,6 +153,7 @@ sql.stats.persisted_rows.max	integer	1000000	maximum number of rows of statement
 sql.stats.post_events.enabled	boolean	false	if set, an event is logged for every CREATE STATISTICS job
 sql.telemetry.query_sampling.enabled	boolean	false	when set to true, executed queries will emit an event on the telemetry logging channel
 sql.temp_object_cleaner.cleanup_interval	duration	30m0s	how often to clean up orphaned temporary objects
+sql.temp_object_cleaner.wait_interval	duration	30m0s	how long after creation a temporary object will be cleaned up
 sql.trace.log_statement_execute	boolean	false	set to true to enable logging of executed statements
 sql.trace.session_eventlog.enabled	boolean	false	set to true to enable session tracing. Note that enabling this may have a non-trivial negative performance impact.
 sql.trace.stmt.enable_threshold	duration	0s	duration beyond which all statements are traced (set to 0 to disable). This applies to individual statements within a transaction and is therefore finer-grained than sql.trace.txn.enable_threshold.

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -158,6 +158,7 @@
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.telemetry.query_sampling.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when set to true, executed queries will emit an event on the telemetry logging channel</td></tr>
 <tr><td><code>sql.temp_object_cleaner.cleanup_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how often to clean up orphaned temporary objects</td></tr>
+<tr><td><code>sql.temp_object_cleaner.wait_interval</code></td><td>duration</td><td><code>30m0s</code></td><td>how long after creation a temporary object will be cleaned up</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing. Note that enabling this may have a non-trivial negative performance impact.</td></tr>
 <tr><td><code>sql.trace.stmt.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>duration beyond which all statements are traced (set to 0 to disable). This applies to individual statements within a transaction and is therefore finer-grained than sql.trace.txn.enable_threshold.</td></tr>

--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = [
         "main_test.go",
         "run_control_test.go",
+        "temp_table_clean_test.go",
     ],
     deps = [
         "//pkg/base",
@@ -12,6 +13,9 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
+        "//pkg/sql",
+        "//pkg/sql/sqlliveness/slinstance",
         "//pkg/sql/sqltestutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
@@ -20,6 +24,8 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
+++ b/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
@@ -1,0 +1,185 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlccl_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+func TestTenantTempTableCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	t.Helper()
+	settings := cluster.MakeTestingClusterSettings()
+	sql.TempObjectCleanupInterval.Override(ctx, &settings.SV, time.Second)
+	sql.TempObjectWaitInterval.Override(ctx, &settings.SV, time.Second*0)
+	// Set up sessions to expire within 5 seconds of a
+	// nodes death.
+	slinstance.DefaultTTL.Override(ctx, &settings.SV, 5*time.Second)
+	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, time.Second)
+	// Knob state is used to track when temporary object clean up
+	// is executed.
+	var (
+		knobState struct {
+			syncutil.Mutex
+			paused   bool
+			finishCh chan struct{}
+		}
+		knobStateLocked = func(f func()) {
+			knobState.Lock()
+			defer knobState.Unlock()
+			f()
+		}
+		// Enables pausing of temp object cleanups
+		// until signaled.
+		pause = func() {
+			knobStateLocked(func() {
+				knobState.paused, knobState.finishCh = true, make(chan struct{})
+			})
+		}
+		// Disables pausing of temp object cleanups.
+		unpause = func() {
+			knobStateLocked(func() {
+				close(knobState.finishCh)
+				knobState.paused, knobState.finishCh = false, nil
+			})
+		}
+		getPaused = func() (paused bool) {
+			knobStateLocked(func() { paused = knobState.paused })
+			return paused
+		}
+		getFinishCh = func() (finishCh chan struct{}) {
+			knobStateLocked(func() { finishCh = knobState.finishCh })
+			return finishCh
+		}
+		// Waits for temp object cleanup, we intentionally
+		// wait for two cycles which will guarantee that any
+		// temp object is destroyed.
+		waitForCleanup = func() {
+			getFinishCh() <- struct{}{}
+			getFinishCh() <- struct{}{}
+		}
+	)
+	tenantTempKnobSettings := base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			OnTempObjectsCleanupDone: func() {
+				// If pausing is disabled, we don't need
+				// to inform anyone.
+				if !getPaused() {
+					return
+				}
+				// Indicate that a cleanup has occurred.
+				<-getFinishCh()
+			},
+		},
+	}
+	tc := serverutils.StartNewTestCluster(
+		t, 3 /* numNodes */, base.TestClusterArgs{ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				Settings: settings,
+			},
+		},
+	)
+	log.TestingClearServerIdentifiers()
+	tenantStoppers := []*stop.Stopper{stop.NewStopper(), stop.NewStopper()}
+	_, tenantPrimaryDB := serverutils.StartTenant(t, tc.Server(0),
+		base.TestTenantArgs{
+			TenantID:     serverutils.TestTenantID(),
+			Settings:     settings,
+			TestingKnobs: tenantTempKnobSettings,
+			Stopper:      tenantStoppers[0],
+		})
+	tenantSQL := sqlutils.MakeSQLRunner(tenantPrimaryDB)
+	pause()
+
+	// Sanity: Temporary table clean up works fine, we are going
+	// to start two nodes and close the kill one of
+	// them.
+	tenantSQL.Exec(t, "SET experimental_enable_temp_tables = 'on'")
+	tenantSQL.Exec(t, "set cluster setting sql.temp_object_cleaner.cleanup_interval='1 seconds'")
+	tenantSQL.Exec(t, "CREATE TEMP TABLE temp_table (x INT PRIMARY KEY, y INT);")
+	// Prevent a logging assertion that the server ID is initialized multiple times.
+	log.TestingClearServerIdentifiers()
+	_, tenantSecondDB := serverutils.StartTenant(t, tc.Server(1),
+		base.TestTenantArgs{
+			Existing: true,
+			TenantID: serverutils.TestTenantID(),
+			Settings: settings,
+			Stopper:  tenantStoppers[1],
+		})
+	log.TestingClearServerIdentifiers()
+	tenantSecondSQL := sqlutils.MakeSQLRunner(tenantSecondDB)
+	tenantSecondSQL.CheckQueryResults(t, "SELECT table_name FROM [SHOW TABLES]",
+		[][]string{
+			{"temp_table"},
+		})
+	tenantSecondSQL.Exec(t, "SET experimental_enable_temp_tables = 'on'")
+	tenantSecondSQL.Exec(t, "CREATE TEMP TABLE temp_table2 (x INT PRIMARY KEY, y INT);")
+	waitForCleanup()
+	tenantSecondSQL.CheckQueryResults(t, "SELECT table_name FROM [SHOW TABLES]",
+		[][]string{
+			{"temp_table"},
+			{"temp_table2"},
+		})
+	// Stop the second node, we should one be left with a single temp table.
+	tenantStoppers[1].Stop(ctx)
+	// Session should expire in 5 seconds, wait for
+	// two clean up cycles just in case, so that we have
+	// stable timing.
+	waitForCleanup()
+	tenantSQL.CheckQueryResults(t, "SELECT table_name FROM [SHOW TABLES]",
+		[][]string{
+			{"temp_table"},
+		})
+	// Disable our hook to allow the database to be
+	// brought down.
+	unpause()
+	// Close the primary DB, there should be no temporary
+	// tables left.
+	tenantStoppers[0].Stop(ctx)
+	// Enable our hook to allow the database to be
+	// brought up.
+	pause()
+	// Prevent a logging assertion that the server ID is initialized multiple times.
+	log.TestingClearServerIdentifiers()
+	// Once we restart the tenant, no sessions should exist
+	// so all temporary tables should be cleaned up.
+	tenantStoppers[0] = stop.NewStopper()
+	_, tenantPrimaryDB = serverutils.StartTenant(t, tc.Server(0),
+		base.TestTenantArgs{
+			Existing:     true,
+			TenantID:     serverutils.TestTenantID(),
+			Settings:     settings,
+			TestingKnobs: tenantTempKnobSettings,
+			Stopper:      tenantStoppers[0]})
+	tenantSQL = sqlutils.MakeSQLRunner(tenantPrimaryDB)
+	waitForCleanup()
+	tenantSQL.CheckQueryResultsRetry(t, "SELECT table_name FROM [SHOW TABLES]",
+		[][]string{})
+	// Disable our hook to allow the database to be
+	// brought stopped.
+	unpause()
+	// Bring down the tenants.
+	tenantStoppers[0].Stop(ctx)
+	tc.Stopper().Stop(ctx)
+}

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -71,6 +71,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/ListSessions":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/ListLocalSessions":
+		return a.authTenant(tenID)
+
 	case "/cockroach.roachpb.Internal/GetSpanConfigs":
 		return a.authGetSpanConfigs(tenID, req.(*roachpb.GetSpanConfigsRequest))
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -146,23 +146,28 @@ func StartTenant(
 	pgLAddr := pgL.Addr().String()
 	httpLAddr := httpL.Addr().String()
 	args.advertiseAddr = baseCfg.AdvertiseAddr
+	// The tenantStatusServer needs access to the sqlServer,
+	// but we also need the same object to set up the sqlServer.
+	// So construct the tenant status server with a nil sqlServer,
+	// and then assign it once an SQL server gets created. We are
+	// going to assume that the tenant status server won't require
+	// the SQL server object.
+	tenantStatusServer := newTenantStatusServer(
+		baseCfg.AmbientCtx, &adminPrivilegeChecker{ie: args.circularInternalExecutor},
+		args.sessionRegistry, args.contentionRegistry, args.flowScheduler, baseCfg.Settings, nil,
+		args.rpcContext, args.stopper,
+	)
+	args.sqlStatusServer = tenantStatusServer
 	s, err := newSQLServer(ctx, args)
+	tenantStatusServer.sqlServer = s
+
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	tenantStatusServer := newTenantStatusServer(
-		baseCfg.AmbientCtx, &adminPrivilegeChecker{ie: args.circularInternalExecutor},
-		args.sessionRegistry, args.contentionRegistry, args.flowScheduler, baseCfg.Settings, s,
-		args.rpcContext, args.stopper,
-	)
-
-	s.execCfg.SQLStatusServer = tenantStatusServer
-
 	// TODO(asubiotto): remove this. Right now it is needed to initialize the
 	// SpanResolver.
 	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: 0})
-
 	workersCtx := tenantStatusServer.AnnotateCtx(context.Background())
 
 	// Register and start gRPC service on pod. This is separate from the

--- a/pkg/sql/catalog/descs/kv_descriptors.go
+++ b/pkg/sql/catalog/descs/kv_descriptors.go
@@ -267,9 +267,13 @@ func (kd *kvDescriptors) getSchemasForDatabase(
 	}
 	if _, ok := kd.allSchemasForDatabase[dbID]; !ok {
 		var err error
-		kd.allSchemasForDatabase[dbID], err = resolver.GetForDatabase(ctx, txn, kd.codec, dbID)
+		allSchemas, err := resolver.GetForDatabase(ctx, txn, kd.codec, dbID)
 		if err != nil {
 			return nil, err
+		}
+		kd.allSchemasForDatabase[dbID] = make(map[descpb.ID]string)
+		for id, entry := range allSchemas {
+			kd.allSchemasForDatabase[dbID][id] = entry.Name
 		}
 	}
 	return kd.allSchemasForDatabase[dbID], nil

--- a/pkg/sql/catalog/resolver/BUILD.bazel
+++ b/pkg/sql/catalog/resolver/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
+        "//pkg/util/hlc",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -297,16 +298,24 @@ func ResolveSchemaNameByID(
 		return "", err
 	}
 	if schema, ok := schemas[schemaID]; ok {
-		return schema, nil
+		return schema.Name, nil
 	}
 	return "", errors.Newf("unable to resolve schema id %d for db %d", schemaID, dbID)
 }
 
+// SchemaEntryForDB entry for an individual schema,
+// which includes the name and modification timestamp.
+type SchemaEntryForDB struct {
+	Name      string
+	Timestamp hlc.Timestamp
+}
+
 // GetForDatabase looks up and returns all available
-// schema ids to names for a given database.
+// schema ids to SchemaEntryForDB structures for a
+//given database.
 func GetForDatabase(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, dbID descpb.ID,
-) (map[descpb.ID]string, error) {
+) (map[descpb.ID]SchemaEntryForDB, error) {
 	log.Eventf(ctx, "fetching all schema descriptor IDs for %d", dbID)
 
 	nameKey := catalogkeys.MakeSchemaNameKey(codec, dbID, "" /* name */)
@@ -318,9 +327,12 @@ func GetForDatabase(
 	// Always add public schema ID.
 	// TODO(solon): This can be removed in 20.2, when this is always written.
 	// In 20.1, in a migrating state, it may be not included yet.
-	ret := make(map[descpb.ID]string, len(kvs)+1)
-	ret[descpb.ID(keys.PublicSchemaID)] = tree.PublicSchema
-
+	ret := make(map[descpb.ID]SchemaEntryForDB, len(kvs)+1)
+	ret[descpb.ID(keys.PublicSchemaID)] =
+		SchemaEntryForDB{
+			Name:      tree.PublicSchema,
+			Timestamp: txn.ReadTimestamp(),
+		}
 	for _, kv := range kvs {
 		id := descpb.ID(kv.ValueInt())
 		if _, ok := ret[id]; ok {
@@ -330,7 +342,10 @@ func GetForDatabase(
 		if err != nil {
 			return nil, err
 		}
-		ret[id] = k.GetName()
+		ret[id] = SchemaEntryForDB{
+			Name:      k.GetName(),
+			Timestamp: kv.Value.Timestamp,
+		}
 	}
 	return ret, nil
 }

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -144,6 +145,8 @@ func TestTemporaryObjectCleaner(t *testing.T) {
 			},
 		},
 	}
+	settings := cluster.MakeTestingClusterSettings()
+	TempObjectWaitInterval.Override(context.Background(), &settings.SV, time.Microsecond)
 	tc := serverutils.StartNewTestCluster(
 		t,
 		numNodes,
@@ -151,6 +154,7 @@ func TestTemporaryObjectCleaner(t *testing.T) {
 			ServerArgs: base.TestServerArgs{
 				UseDatabase: "defaultdb",
 				Knobs:       knobs,
+				Settings:    settings,
 			},
 		},
 	)


### PR DESCRIPTION
Backport 1/2 commits from #69486.

/cc @cockroachdb/release

---

Fixes: #67401
Previously, the temporary table clean-up did not execute for
tenants. This was inadequate that temporary tables would last
longer than the life span of user sessions. To address this,
this patch adds support for cleaning up on a single tenant
pod. Specifically removing checks for meta1 lease when under
a tenant, and support for listing sessions.

Release justification: low risk and fixes a tenant-related bug
Release note (bug fix): Temporary tables were not properly cleaned up for
tenants.
