### PR TITLE
sql/delegate: pick up new 21.2 columns in `SHOW JOBS`

### DIFF
--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -32,10 +32,12 @@ SHOW JOBS SELECT id FROM system.jobs WHERE created_by_type='%s' and created_by_i
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Jobs)
 
 	const (
-		selectClause = `SELECT job_id, job_type, description, statement, user_name, status,
-				       running_status, created, started, finished, modified,
-				       fraction_completed, error, coordinator_id, trace_id
-				FROM crdb_internal.jobs`
+		selectClause = `
+SELECT job_id, job_type, description, statement, user_name, status,
+       running_status, created, started, finished, modified,
+       fraction_completed, error, coordinator_id, trace_id, last_run,
+       next_run, num_runs, execution_errors
+  FROM crdb_internal.jobs`
 	)
 	var typePredicate, whereClause, orderbyClause string
 	if n.Jobs == nil {

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -414,10 +414,10 @@ SELECT * FROM [SHOW COMPACT TRACE FOR SESSION] LIMIT 0
 ----
 age  message  tag  operation
 
-query ITTTTTTTTTTRTII colnames
+query ITTTTTTTTTTRTIITTIT colnames
 SELECT * FROM [SHOW JOBS] LIMIT 0
 ----
-job_id  job_type  description  statement  user_name  status  running_status  created  started  finished  modified  fraction_completed  error  coordinator_id  trace_id
+job_id  job_type  description  statement  user_name  status  running_status  created  started  finished  modified  fraction_completed  error  coordinator_id  trace_id  last_run  next_run  num_runs  execution_errors
 
 query TT colnames
 SELECT * FROM [SHOW SYNTAX 'select 1; select 2']


### PR DESCRIPTION
New columns were added to `crdb_internal.jobs` to expose retry and
exponential backoff state. This commit exposes them in `SHOW JOBS`.

No need for a version gate because the virtual table is local and will
just populate the columns with NULL in the mixed version state.

Fixes #70765.

Release note (sql change): `SHOW JOBS` will now include the newly added
columns from `crdb_internal.jobs` (`last_run`, `next_run`, `num_runs`,
and `execution_errors`). The columns capture state related to retries,
failures, and exponential backoff.