### PR TITLE
batcheval: remove span information from Export trace

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -86,11 +86,9 @@ func evalExport(
 
 	var evalExportTrace types.StringValue
 	if cArgs.EvalCtx.NodeID() == h.GatewayNodeID {
-		evalExportTrace.Value = fmt.Sprintf("evaluating Export [%s, %s) on local node %d",
-			args.Key, args.EndKey, cArgs.EvalCtx.NodeID())
+		evalExportTrace.Value = fmt.Sprintf("evaluating Export on local node %d", cArgs.EvalCtx.NodeID())
 	} else {
-		evalExportTrace.Value = fmt.Sprintf("evaluating Export [%s, %s) on remote node %d",
-			args.Key, args.EndKey, cArgs.EvalCtx.NodeID())
+		evalExportTrace.Value = fmt.Sprintf("evaluating Export on remote node %d", cArgs.EvalCtx.NodeID())
 	}
 	evalExportSpan.RecordStructured(&evalExportTrace)
 


### PR DESCRIPTION
This change removes the string representation of the span
being exported from the structured recording written to the
tracing span.

The change was motivated by discussions around redactabilty
and tenants being able to see unredacted traces from the KV
host server. More information can be found
https://github.com/cockroachdb/cockroach/issues/58610.

These traces are not very critical and so until there is a
larger change for structured recordings to support redactability
we can do away with them.

Informs: #58610

Release note: None