### PR TITLE
ui: remove link for stmt on sessions

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -24,8 +24,6 @@ type ISession = cockroach.server.serverpb.Session;
 
 import { TerminateSessionModalRef } from "./terminateSessionModal";
 import { TerminateQueryModalRef } from "./terminateQueryModal";
-
-import { StatementLink } from "src/statementsTable/statementsTableContent";
 import { ColumnDescriptor, SortedTable } from "src/sortedtable/sortedtable";
 
 import { Icon } from "antd";
@@ -35,6 +33,8 @@ import {
 } from "src/dropdown/dropdown";
 import { Button } from "src/button/button";
 import { Tooltip } from "@cockroachlabs/ui-components";
+import { summarize } from "../util";
+import { shortStatement } from "../statementsTable";
 
 const cx = classNames.bind(styles);
 
@@ -44,7 +44,7 @@ export interface SessionInfo {
 
 export class SessionsSortedTable extends SortedTable<SessionInfo> {}
 
-export function byteArrayToUuid(array: Uint8Array) {
+export function byteArrayToUuid(array: Uint8Array): string {
   const hexDigits: string[] = [];
   array.forEach(t => hexDigits.push(t.toString(16).padStart(2, "0")));
   return [
@@ -164,17 +164,8 @@ export function makeSessionsColumns(
           return "N/A";
         }
         const stmt = session.session.active_queries[0].sql;
-        const stmtNoConstants =
-          session.session.active_queries[0].sql_no_constants;
-        return (
-          <StatementLink
-            statement={stmt}
-            statementNoConstants={stmtNoConstants}
-            implicitTxn={session.session.active_txn?.implicit}
-            search={""}
-            app={""}
-          />
-        );
+        const summary = summarize(stmt);
+        return shortStatement(summary, stmt);
       },
     },
     {


### PR DESCRIPTION
When a statement is showing as active on the sessions
table, we don't have yet statistics about it, so it
doesn't make sense to have a link for Statement Details.
This commit removes the link and shows only the statement.

Fixes #70543

Release justification: Category 2

Release note (ui change): Remove link to Statement Details
on the Session table