### PR TITLE
sql: fix ZM dimensions for pg_extension

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_extension
+++ b/pkg/sql/logictest/testdata/logic_test/pg_extension
@@ -1,34 +1,52 @@
 statement ok
 CREATE TABLE pg_extension_test (
   a geography(point, 4326),
-  b geometry(linestring, 3857),
+  b geometry(polygon, 3857),
   c geometry,
-  d geography
+  d geography,
+  az geography(pointz, 4326),
+  bz geometry(polygonz, 3857),
+  am geography(pointm, 4326),
+  bm geometry(polygonm, 3857),
+  azm geography(pointzm, 4326),
+  bzm geometry(polygonzm, 3857)
 )
 
 query TTTTIIT rowsort
 SELECT * FROM pg_extension.geography_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  a  2     4326  POINT
-test  public  pg_extension_test  d  NULL  0     GEOMETRY
+test  public  pg_extension_test  a    2     4326  POINT
+test  public  pg_extension_test  d    NULL  0     GEOMETRY
+test  public  pg_extension_test  az   3     4326  POINTZ
+test  public  pg_extension_test  am   3     4326  POINTM
+test  public  pg_extension_test  azm  4     4326  POINTZM
 
 query TTTTIIT rowsort
 SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  b  2  3857  LINESTRING
-test  public  pg_extension_test  c  2  0     GEOMETRY
+test  public  pg_extension_test  b    2  3857  POLYGON
+test  public  pg_extension_test  c    2  0     GEOMETRY
+test  public  pg_extension_test  bz   3  3857  POLYGONZ
+test  public  pg_extension_test  bm   3  3857  POLYGONM
+test  public  pg_extension_test  bzm  4  3857  POLYGONZM
 
 query TTTTIIT rowsort
 SELECT * FROM geography_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  a  2     4326  POINT
-test  public  pg_extension_test  d  NULL  0     GEOMETRY
+test  public  pg_extension_test  a    2     4326  POINT
+test  public  pg_extension_test  d    NULL  0     GEOMETRY
+test  public  pg_extension_test  az   3     4326  POINTZ
+test  public  pg_extension_test  am   3     4326  POINTM
+test  public  pg_extension_test  azm  4     4326  POINTZM
 
 query TTTTIIT rowsort
 SELECT * FROM geometry_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  b  2  3857  LINESTRING
-test  public  pg_extension_test  c  2  0     GEOMETRY
+test  public  pg_extension_test  b    2  3857  POLYGON
+test  public  pg_extension_test  c    2  0     GEOMETRY
+test  public  pg_extension_test  bz   3  3857  POLYGONZ
+test  public  pg_extension_test  bm   3  3857  POLYGONM
+test  public  pg_extension_test  bzm  4  3857  POLYGONZM
 
 query ITITT
 SELECT * FROM pg_extension.spatial_ref_sys WHERE srid IN (3857, 4326) ORDER BY srid ASC

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -64,10 +64,6 @@ func postgisColumnsTablePopulator(
 
 					var datumNDims tree.Datum
 					switch m.ShapeType {
-					case geopb.ShapeType_Point, geopb.ShapeType_LineString, geopb.ShapeType_Polygon,
-						geopb.ShapeType_MultiPoint, geopb.ShapeType_MultiLineString, geopb.ShapeType_MultiPolygon,
-						geopb.ShapeType_GeometryCollection:
-						datumNDims = tree.NewDInt(2)
 					case geopb.ShapeType_Geometry, geopb.ShapeType_Unset:
 						// For geometry_columns, the query in PostGIS COALESCES the value to 2.
 						// Otherwise, the value is NULL.
@@ -76,6 +72,17 @@ func postgisColumnsTablePopulator(
 						} else {
 							datumNDims = tree.DNull
 						}
+					default:
+						zm := m.ShapeType & (geopb.ZShapeTypeFlag | geopb.MShapeTypeFlag)
+						switch zm {
+						case geopb.ZShapeTypeFlag | geopb.MShapeTypeFlag:
+							datumNDims = tree.NewDInt(4)
+						case geopb.ZShapeTypeFlag, geopb.MShapeTypeFlag:
+							datumNDims = tree.NewDInt(3)
+						default:
+							datumNDims = tree.NewDInt(2)
+						}
+
 					}
 
 					shapeName := m.ShapeType.String()


### PR DESCRIPTION
Resolves #70776

Release note (bug fix): Fix Z and M coordinate columns causing a panic
for geometry_columns and geography_columns.