### PR TITLE
server: expect duplicate session cookies on HTTP requests

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -593,16 +593,29 @@ func makeCookieWithValue(value string, forHTTPSOnly bool) *http.Cookie {
 func (am *authenticationMux) getSession(
 	w http.ResponseWriter, req *http.Request,
 ) (string, *serverpb.SessionCookie, error) {
+	ctx := req.Context()
 	// Validate the returned cookie.
-	rawCookie, err := req.Cookie(SessionCookieName)
-	if err != nil {
-		return "", nil, err
+	cookies := req.Cookies()
+	found := false
+	var cookie *serverpb.SessionCookie
+	var err error
+	for _, c := range cookies {
+		if c.Name != SessionCookieName {
+			continue
+		}
+		found = true
+		cookie, err = decodeSessionCookie(c)
+		if err != nil {
+			// Multiple cookies with the same name may be included in the
+			// header. We continue searching even if we find a matching
+			// name with an invalid value
+			log.Infof(ctx, "found a matching cookie that failed decoding: %v", err)
+			continue
+		}
+		break
 	}
-
-	cookie, err := decodeSessionCookie(rawCookie)
-	if err != nil {
-		err = errors.Wrap(err, "a valid authentication cookie is required")
-		return "", nil, err
+	if !found {
+		return "", nil, http.ErrNoCookie
 	}
 
 	valid, username, err := am.server.verifySession(req.Context(), cookie)

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -654,9 +654,13 @@ func TestAuthenticationMux(t *testing.T) {
 	}
 
 	runRequest := func(
-		client http.Client, method string, path string, body []byte, expected int,
+		client http.Client, method string, path string, body []byte, cookieHeader string, expected int,
 	) error {
 		req, err := http.NewRequest(method, tsrv.AdminURL()+path, bytes.NewBuffer(body))
+		if cookieHeader != "" {
+			// The client still attaches its own cookies to this one.
+			req.Header.Set("cookie", cookieHeader)
+		}
 		if err != nil {
 			return err
 		}
@@ -688,22 +692,24 @@ func TestAuthenticationMux(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		method string
-		path   string
-		body   []byte
+		method       string
+		path         string
+		body         []byte
+		cookieHeader string
 	}{
-		{"GET", adminPrefix + "users", nil},
-		{"GET", statusPrefix + "sessions", nil},
-		{"POST", ts.URLPrefix + "query", tsReqBuffer.Bytes()},
+		{"GET", adminPrefix + "users", nil, ""},
+		{"GET", adminPrefix + "users", nil, "session=badcookie"},
+		{"GET", statusPrefix + "sessions", nil, ""},
+		{"POST", ts.URLPrefix + "query", tsReqBuffer.Bytes(), ""},
 	} {
 		t.Run("path="+tc.path, func(t *testing.T) {
 			// Verify normal client returns 401 Unauthorized.
-			if err := runRequest(normalClient, tc.method, tc.path, tc.body, http.StatusUnauthorized); err != nil {
+			if err := runRequest(normalClient, tc.method, tc.path, tc.body, "", http.StatusUnauthorized); err != nil {
 				t.Fatalf("request %s failed when not authorized: %s", tc.path, err)
 			}
 
 			// Verify authenticated client returns 200 OK.
-			if err := runRequest(authClient, tc.method, tc.path, tc.body, http.StatusOK); err != nil {
+			if err := runRequest(authClient, tc.method, tc.path, tc.body, tc.cookieHeader, http.StatusOK); err != nil {
 				t.Fatalf("request %s failed when authorized: %s", tc.path, err)
 			}
 		})


### PR DESCRIPTION
Previously, the golang HTTP library was used to retrieve a cookie with
the specific name we use to store our authentication token. This API
method retrieves the *first* matching cookie in the header and ignores
the rest. This can cause issues with requests that contain multiple
matching cookies with the same name (if other applications are
potentially running on the same domain).

This change adjusts the HTTP API we use to retrieve cookies (we now
prefer to call `req.Cookies()` and iterate through the entire list
ourselves, instead of relying on the API to give us the matching cookie
since it only supports returning a single result.

Resolves #70376.

Release note (security update): Authenticated HTTP requests to nodes can
now contain additional cookies with the same name as the one we use
("session"). Duplicates like this are permitted by the HTTP spec and our
code will now attempt to parse all cookies with a matching name before
giving up. This can resolve issues with customers who run other services
on the same domain as their CRDB nodes.