### PR TITLE
kvserver: QueryResolvedTimestamp should look for intents in LockTable

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
@@ -12,9 +12,9 @@ package batcheval
 
 import (
 	"context"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -30,7 +30,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	db := storage.NewDefaultInMemForTesting()
+	db := storage.NewDefaultInMemForStickyEngineTesting()
 	defer db.Close()
 
 	makeTS := func(ts int64) hlc.Timestamp {
@@ -128,7 +128,6 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			closedTS:              makeTS(4),
 			intentCleanupAge:      5,
 			expResolvedTS:         makeTS(2).Prev(),
-			// The test sets current clock to 10; collect intents with WriteTimestamp < 10 - intentCleanupAge
 			expEncounteredIntents: []string{"d"},
 		},
 		{

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -128,6 +128,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			closedTS:              makeTS(4),
 			intentCleanupAge:      5,
 			expResolvedTS:         makeTS(2).Prev(),
+			// The test sets current clock to 10; collect intents with WriteTimestamp < 10 - intentCleanupAge
 			expEncounteredIntents: []string{"d"},
 		},
 		{

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -52,3 +52,13 @@ func NewDefaultInMemForTesting(opts ...ConfigOption) Engine {
 	}
 	return eng
 }
+
+// NewDefaultInMemForStickyEngineTesting is just like NewDefaultInMemForTesting but uses
+// ForStickyEngineTesting to always separate intents from MVCC data, instead of randomizing this setting.
+func NewDefaultInMemForStickyEngineTesting(opts ...ConfigOption) Engine {
+	eng, err := Open(context.Background(), InMemory(), ForStickyEngineTesting, MaxSize(1<<20), CombineOptions(opts...))
+	if err != nil {
+		panic(err)
+	}
+	return eng
+}


### PR DESCRIPTION
Previously, a request called “QueryResolvedTimestamp” that is used to determine the “resolved timestamp” of a key range on a given replica cost O(num_keys_in_span), because it needed to find all intents in the span and intents were interleaved with key-value versions. A multi-release project to separate out intents from MVCC data is now far enough along that we can make this request more efficient by scanning only the lock-table keyspace, reducing its cost to O(num_locks_in_span).

Release note: None

Release justification: This is going into 22.1 where the migration to separated intents is complete

Fixes: https://github.com/cockroachdb/cockroach/issues/69717