### PR TITLE
cmd/roachtest: test automatic ballasts in disk-full roachtest

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -404,10 +404,6 @@ func DefaultPebbleOptions() *pebble.Options {
 	if diskHealthCheckInterval.Seconds() > maxSyncDurationDefault.Seconds() {
 		diskHealthCheckInterval = maxSyncDurationDefault
 	}
-	// If we encounter ENOSPC, exit with an informative exit code.
-	opts.FS = vfs.OnDiskFull(opts.FS, func() {
-		exit.WithCode(exit.DiskFull())
-	})
 	// Instantiate a file system with disk health checking enabled. This FS wraps
 	// vfs.Default, and can be wrapped for encryption-at-rest.
 	opts.FS = vfs.WithDiskHealthChecks(vfs.Default, diskHealthCheckInterval,
@@ -417,6 +413,10 @@ func DefaultPebbleOptions() *pebble.Options {
 				Duration: duration,
 			})
 		})
+	// If we encounter ENOSPC, exit with an informative exit code.
+	opts.FS = vfs.OnDiskFull(opts.FS, func() {
+		exit.WithCode(exit.DiskFull())
+	})
 	return opts
 }
 


### PR DESCRIPTION
Adjust the disk-full roachtest to test the automatic emergency ballast.
Additionally, fix a bug where a Cockroach node that ran out of disk
space during Pebble writes would not exit with the correct exit code.

Release note (bug fix): Fix a bug where CockroachDB did not exit with
the correct exit code when it ran out of disk space while the node was
running. This behavior was new in 21.2 and was not behaving as intended.