### PR TITLE
dev: implement `dev doctor`, remove `dev` config inference

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,6 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(":lint.bzl", "lint_binary")
 
+# Built by `dev doctor`. This target will fail to build iff the dev config
+# isn't being used.
+filegroup(
+    name = "dev_toolchain_being_used",
+    srcs = select({
+        "//build/toolchains:dev": [],
+        "//conditions:default": ["NONEXISTENT_FILE"],
+    }),
+)
+
 lint_binary(
     name = "lint",
     test = "//pkg/testutils/lint:lint_test",

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "build.go",
         "builder.go",
         "dev.go",
+        "doctor.go",
         "generate.go",
         "lint.go",
         "main.go",

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -85,7 +85,6 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 	// NOTE the --config=test here. It's very important we compile the test binary with the
 	// appropriate stuff (gotags, etc.)
 	argsBase = append(argsBase, "run", "--config=test", "--test_sharding_strategy=disabled")
-	argsBase = append(argsBase, getConfigFlags()...)
 	argsBase = append(argsBase, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
 		argsBase = append(argsBase, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -87,7 +87,6 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, additionalBazelArgs...)
 
 	if cross == "" {
-		args = append(args, getConfigFlags()...)
 		logCommand("bazel", args...)
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -31,7 +31,6 @@ var (
 	// Shared flags.
 	remoteCacheAddr string
 	numCPUs         int
-	skipDevConfig   bool
 )
 
 func makeDevCmd() *dev {
@@ -74,6 +73,7 @@ lets engineers do a few things:
 		makeBenchCmd(ret.bench),
 		makeBuildCmd(ret.build),
 		makeBuilderCmd(ret.builder),
+		makeDoctorCmd(ret.doctor),
 		makeGenerateCmd(ret.generate),
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),
@@ -89,7 +89,6 @@ lets engineers do a few things:
 		// support for the  Remote Asset API, which helps speed things up when
 		// the cache sits across the network boundary.
 		subCmd.Flags().StringVar(&remoteCacheAddr, "remote-cache", "", "remote caching grpc endpoint to use")
-		subCmd.Flags().BoolVar(&skipDevConfig, "skip-dev-config", false, "Don't infer an appropriate dev config to build with")
 	}
 	for _, subCmd := range ret.cli.Commands() {
 		subCmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"errors"
+	"log"
+	"os/exec"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// makeDoctorCmd constructs the subcommand used to build the specified binaries.
+func makeDoctorCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:     "doctor",
+		Short:   "Check whether your machine is ready to build.",
+		Long:    "Check whether your machine is ready to build.",
+		Example: "dev doctor",
+		Args:    cobra.ExactArgs(0),
+		RunE:    runE,
+	}
+}
+
+func (d *dev) doctor(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	success := true
+
+	// If we're running on macOS, we need to check whether XCode is installed.
+	d.log.Println("doctor: running xcode check")
+	if runtime.GOOS == "darwin" {
+		stdout, err := d.exec.CommandContextSilent(ctx, "/usr/bin/xcodebuild", "-version")
+		if err != nil {
+			success = false
+			log.Printf("Failed to run /usr/bin/xcodebuild -version. Got output: ")
+			log.Printf("stdout:   %s", string(stdout))
+			var cmderr *exec.ExitError
+			if errors.As(err, &cmderr) {
+				log.Printf("stderr:   %s", string(cmderr.Stderr))
+			}
+			log.Println(`You must have a full installation of XCode to build with Bazel.
+A command-line tools instance does not suffice.
+Please perform the following steps:
+  1. Install XCode from the App Store.
+  2. Launch Xcode.app at least once to perform one-time initialization of developer tools.
+  3. Run ` + "`xcode-select -switch /Applications/Xcode.app/`.")
+		}
+	}
+
+	// Check whether the dev config is active on a `bazel build`.
+	if _, err := d.exec.CommandContextSilent(ctx, "bazel", "build", "//build/bazelutil:dev_toolchain_being_used"); err != nil {
+		success = false
+		log.Printf(`Your machine should be configured to build using the "dev" config.
+Please add the following to your ~/.bazelrc:`)
+		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+			log.Printf("    build --config=devdarwinx86_64")
+		} else {
+			log.Printf("    build --config=dev")
+		}
+	}
+
+	if success {
+		log.Println("You are ready to build :)")
+		return nil
+	}
+	return errors.New("please address the errors described above and try again")
+}

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -106,7 +106,6 @@ func (d *dev) generateDocs(cmd *cobra.Command) error {
 	var args []string
 	args = append(args, "build")
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
-	args = append(args, getConfigFlags()...)
 	args = append(args, targets...)
 	err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	if err != nil {
@@ -168,7 +167,6 @@ func (d *dev) generateGo(cmd *cobra.Command) error {
 	var args []string
 	args = append(args, "build")
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
-	args = append(args, getConfigFlags()...)
 	args = append(args, targets...)
 	err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	if err != nil {

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -37,7 +37,6 @@ func (d *dev) lint(cmd *cobra.Command, _ []string) error {
 	// NOTE the --config=test here. It's very important we compile the test binary with the
 	// appropriate stuff (gotags, etc.)
 	args = append(args, "run", "--config=test", "//build/bazelutil:lint")
-	args = append(args, getConfigFlags()...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	args = append(args, "--", "-test.v")
 	if short {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -94,7 +94,6 @@ func (d *dev) runUnitTest(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test")
-	args = append(args, getConfigFlags()...)
 	args = append(args, additionalBazelArgs...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {

--- a/pkg/cmd/dev/testdata/bench.txt
+++ b/pkg/cmd/dev/testdata/bench.txt
@@ -5,8 +5,8 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 git grep -l ^func Benchmark -- pkg/util/*_test.go
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/util:util_test -- -test.run=- -test.bench=.
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
+bazel run --config=test --test_sharding_strategy=disabled //pkg/util:util_test -- -test.run=- -test.bench=.
+bazel run --config=test --test_sharding_strategy=disabled //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
 
 dev bench pkg/sql/parser --filter=BenchmarkParse
 ----
@@ -14,4 +14,4 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse
+bazel run --config=test --test_sharding_strategy=disabled //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -4,10 +4,10 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build //pkg/cmd/cockroach-short --config=dev
-bazel info workspace --color=no --config=dev
+bazel build //pkg/cmd/cockroach-short
+bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
@@ -17,40 +17,14 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short --config=dev
-bazel info workspace --color=no --config=dev
+bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
+bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 dev build --debug cockroach-short
-----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build //pkg/cmd/cockroach-short --config=dev
-bazel info workspace --color=no --config=dev
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-
-dev build cockroach-short --remote-cache 127.0.0.1:9090
-----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short --config=dev
-bazel info workspace --color=no --config=dev
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-
-dev build --skip-dev-config cockroach-short
 ----
 getenv PATH
 which cc
@@ -63,16 +37,29 @@ bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
+dev build cockroach-short --remote-cache 127.0.0.1:9090
+----
+getenv PATH
+which cc
+readlink /usr/local/opt/ccache/libexec/cc
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+bazel info workspace --color=no
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+
 dev build cockroach-short --hoist-generated-code
 ----
 getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build //pkg/cmd/cockroach-short --config=dev
-bazel info workspace --color=no --config=dev
+bazel build //pkg/cmd/cockroach-short
+bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 find /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg -name *.go
@@ -88,9 +75,9 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel build //pkg/cmd/cockroach-short -s --config=dev
-bazel info workspace --color=no --config=dev
+bazel build //pkg/cmd/cockroach-short -s
+bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -5,7 +5,7 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 id
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts
@@ -18,7 +18,7 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 id
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -4,7 +4,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh
 
 dev gen docs
@@ -13,10 +13,10 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/docs/generated/bazel_targets.txt
-bazel build --config=dev //docs/generated:gen-logging-md //docs/generated/sql
-bazel info bazel-bin --color=no --config=dev
+bazel build //docs/generated:gen-logging-md //docs/generated/sql
+bazel info bazel-bin --color=no
 bazel query --output=xml //docs/generated:gen-logging-md
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/docs/generated/logging.md go/src/github.com/cockroachdb/cockroach/docs/generated/logging.md
 bazel query --output=xml //docs/generated/sql
@@ -33,10 +33,10 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/bazelutil/checked_in_genfiles.txt
-bazel build --config=dev //pkg/roachpb:gen-batch-generated //pkg/sql/opt/optgen/lang:gen-expr //pkg/sql/opt/optgen/lang:gen-operator
-bazel info bazel-bin --color=no --config=dev
+bazel build //pkg/roachpb:gen-batch-generated //pkg/sql/opt/optgen/lang:gen-expr //pkg/sql/opt/optgen/lang:gen-operator
+bazel info bazel-bin --color=no
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/roachpb/batch_generated-gen.go go/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/expr-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/expr.og.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/operator-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator.og.go

--- a/pkg/cmd/dev/testdata/lint.txt
+++ b/pkg/cmd/dev/testdata/lint.txt
@@ -4,7 +4,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel run --config=test //build/bazelutil:lint --config=dev -- -test.v
+bazel run --config=test //build/bazelutil:lint -- -test.v
 
 dev lint --short --timeout=5m
 ----
@@ -12,4 +12,4 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel run --config=test //build/bazelutil:lint --config=dev -- -test.v -test.short -test.timeout 5m0s
+bazel run --config=test //build/bazelutil:lint -- -test.v -test.short -test.timeout 5m0s

--- a/pkg/cmd/dev/testdata/recording/bench.txt
+++ b/pkg/cmd/dev/testdata/recording/bench.txt
@@ -20,10 +20,10 @@ pkg/util/uuid/benchmark_fast_test.go
 pkg/util/uuid/codec_test.go
 pkg/util/uuid/generator_test.go
 
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/util:util_test -- -test.run=- -test.bench=.
+bazel run --config=test --test_sharding_strategy=disabled //pkg/util:util_test -- -test.run=- -test.bench=.
 ----
 
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
+bazel run --config=test --test_sharding_strategy=disabled //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
 ----
 
 getenv PATH
@@ -41,5 +41,5 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel run --config=test --test_sharding_strategy=disabled --config=dev //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse
+bazel run --config=test --test_sharding_strategy=disabled //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse
 ----

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -13,17 +13,17 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel build //pkg/cmd/cockroach-short --config=dev
+bazel build //pkg/cmd/cockroach-short
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 
@@ -48,87 +48,17 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short --config=dev
+bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
 ----
 
-bazel info workspace --color=no --config=dev
-----
-go/src/github.com/cockroachdb/cockroach
-
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-----
-
-bazel info bazel-bin --color=no --config=dev
-----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
-
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
-bazel build //pkg/cmd/cockroach-short --config=dev
-----
-
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
-bazel info bazel-bin --color=no --config=dev
-----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
-
-rm go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
-bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short --config=dev
-----
-
-bazel info workspace --color=no --config=dev
-----
-go/src/github.com/cockroachdb/cockroach
-
-mkdir go/src/github.com/cockroachdb/cockroach/bin
-----
-
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 
@@ -188,17 +118,52 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel build //pkg/cmd/cockroach-short --config=dev
+bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+----
+
+getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+bazel build //pkg/cmd/cockroach-short
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 
@@ -258,17 +223,17 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel build //pkg/cmd/cockroach-short -s --config=dev
+bazel build //pkg/cmd/cockroach-short -s
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -17,7 +17,7 @@ id
 ----
 1001:1002
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
@@ -53,7 +53,7 @@ id
 ----
 1001:1002
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -13,7 +13,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
@@ -35,7 +35,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
@@ -49,10 +49,10 @@ This line is ignored.
 ----
 ----
 
-bazel build --config=dev //docs/generated:gen-logging-md //docs/generated/sql
+bazel build //docs/generated:gen-logging-md //docs/generated/sql
 ----
 
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 
@@ -147,7 +147,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel info workspace --color=no --config=dev
+bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
@@ -161,10 +161,10 @@ cat go/src/github.com/cockroachdb/cockroach/build/bazelutil/checked_in_genfiles.
 ----
 ----
 
-bazel build --config=dev //pkg/roachpb:gen-batch-generated //pkg/sql/opt/optgen/lang:gen-expr //pkg/sql/opt/optgen/lang:gen-operator
+bazel build //pkg/roachpb:gen-batch-generated //pkg/sql/opt/optgen/lang:gen-expr //pkg/sql/opt/optgen/lang:gen-operator
 ----
 
-bazel info bazel-bin --color=no --config=dev
+bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
 

--- a/pkg/cmd/dev/testdata/recording/lint.txt
+++ b/pkg/cmd/dev/testdata/recording/lint.txt
@@ -13,7 +13,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel run --config=test //build/bazelutil:lint --config=dev -- -test.v
+bazel run --config=test //build/bazelutil:lint -- -test.v
 ----
 
 getenv PATH
@@ -31,5 +31,5 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel run --config=test //build/bazelutil:lint --config=dev -- -test.v -test.short -test.timeout 5m0s
+bazel run --config=test //build/bazelutil:lint -- -test.v -test.short -test.timeout 5m0s
 ----

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -13,7 +13,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.2s
@@ -41,7 +41,7 @@ bazel query kind(go_test,  //pkg/util/tracing/...)
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                 [0m[32m(cached) PASSED[0m in 0.2s
@@ -65,7 +65,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.1s
@@ -89,7 +89,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:
@@ -117,7 +117,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                 [0m[32m(cached) PASSED[0m in 0.0s
@@ -141,7 +141,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
+bazel test //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.1s
@@ -165,7 +165,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -189,7 +189,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:
@@ -219,7 +219,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
+bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
 ----
 ----
 [32mLoading:[0m 
@@ -259,7 +259,7 @@ readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
-bazel test --config=dev -s //pkg/util/tracing:tracing_test --test_output errors
+bazel test -s //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.2s

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -4,7 +4,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing/...
 ----
@@ -13,7 +13,7 @@ which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel query kind(go_test,  //pkg/util/tracing/...)
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*'
 ----
@@ -21,7 +21,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' -v
 ----
@@ -29,7 +29,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test pkg/util/tracing -f 'TestStartChild*' --remote-cache 127.0.0.1:9092
 ----
@@ -37,7 +37,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
+bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' --ignore-cache
 ----
@@ -45,7 +45,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
+bazel test //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*'
 ----
@@ -53,7 +53,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
@@ -61,7 +61,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test //pkg/testutils --timeout=10s
 ----
@@ -69,7 +69,7 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
+bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
 
 dev test pkg/util/tracing -- -s
 ----
@@ -77,4 +77,4 @@ getenv PATH
 which cc
 readlink /usr/local/opt/ccache/libexec/cc
 export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-bazel test --config=dev -s //pkg/util/tracing:tracing_test --test_output errors
+bazel test -s //pkg/util/tracing:tracing_test --test_output errors

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -17,7 +17,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -91,7 +90,6 @@ func parseAddr(addr string) (string, error) {
 
 func (d *dev) getBazelInfo(ctx context.Context, key string) (string, error) {
 	args := []string{"info", key, "--color=no"}
-	args = append(args, getConfigFlags()...)
 	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
 		return "", err
@@ -106,16 +104,6 @@ func (d *dev) getWorkspace(ctx context.Context) (string, error) {
 
 func (d *dev) getBazelBin(ctx context.Context) (string, error) {
 	return d.getBazelInfo(ctx, "bazel-bin")
-}
-
-func getConfigFlags() []string {
-	if skipDevConfig {
-		return []string{}
-	}
-	if !isTesting && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
-		return []string{"--config=devdarwinx86_64"}
-	}
-	return []string{"--config=dev"}
 }
 
 func addCommonTestFlags(cmd *cobra.Command) {


### PR DESCRIPTION
For a while `dev` has been automatically inserting
`--config=devdarwinx86_64` in `bazel` calls, but really this is the
sort of thing that makes the most sense for people to put into a
`bazelrc`. Instead of doing it the other way, implement a `dev doctor`
command that checks whether your machine is up-to-snuff, and perform
that check in `dev doctor`. Then the `--config=devdarwinx86_64` can be
removed from every `bazel` invocation.

For macOS we also check whether XCode is installed and provide clear
instructions on how to fix it.

Release note: None