### PR TITLE
release-20.2: opt: fix LATERAL joins with NATURAL/USING

### DIFF
--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -84,7 +84,7 @@ func (b *Builder) buildJoin(
 		outScope = inScope.push()
 
 		var jb usingJoinBuilder
-		jb.init(b, joinType, flags, leftScope, rightScope, outScope)
+		jb.init(b, joinType, flags, isLateral, leftScope, rightScope, outScope)
 
 		switch t := cond.(type) {
 		case tree.NaturalJoinCond:
@@ -284,6 +284,7 @@ type usingJoinBuilder struct {
 	joinType   descpb.JoinType
 	joinFlags  memo.JoinFlags
 	filters    memo.FiltersExpr
+	isLateral  bool
 	leftScope  *scope
 	rightScope *scope
 	outScope   *scope
@@ -307,11 +308,13 @@ func (jb *usingJoinBuilder) init(
 	b *Builder,
 	joinType descpb.JoinType,
 	flags memo.JoinFlags,
+	isLateral bool,
 	leftScope, rightScope, outScope *scope,
 ) {
 	jb.b = b
 	jb.joinType = joinType
 	jb.joinFlags = flags
+	jb.isLateral = isLateral
 	jb.leftScope = leftScope
 	jb.rightScope = rightScope
 	jb.outScope = outScope
@@ -395,7 +398,7 @@ func (jb *usingJoinBuilder) finishBuild() {
 		jb.rightScope.expr.(memo.RelExpr),
 		jb.filters,
 		&memo.JoinPrivate{Flags: jb.joinFlags},
-		false, /* isLateral */
+		jb.isLateral,
 	)
 
 	if !jb.ifNullCols.Empty() {

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -10,6 +10,18 @@ exec-ddl
 CREATE TABLE z (c INT PRIMARY KEY)
 ----
 
+exec-ddl
+CREATE TABLE ax (a INT, x INT)
+----
+
+exec-ddl
+CREATE TABLE ay (a INT, y INT)
+----
+
+exec-ddl
+CREATE TABLE az (a INT, z INT)
+----
+
 build
 SELECT * FROM x, y, z
 ----
@@ -335,3 +347,72 @@ build
 SELECT * FROM x FULL OUTER JOIN LATERAL (SELECT * FROM y WHERE b = x.a) ON true
 ----
 error (42601): The combining JOIN type must be INNER or LEFT for a LATERAL reference
+
+
+build
+SELECT * FROM ax JOIN LATERAL (SELECT * FROM ay WHERE x=y) USING (a)
+----
+project
+ ├── columns: a:1 x:2 y:6!null
+ └── inner-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ay.a:5 y:6!null
+      ├── scan ax
+      │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4
+      ├── project
+      │    ├── columns: ay.a:5 y:6!null
+      │    └── select
+      │         ├── columns: ay.a:5 y:6!null ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │         ├── scan ay
+      │         │    └── columns: ay.a:5 y:6 ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │         └── filters
+      │              └── x:2 = y:6
+      └── filters
+           └── ax.a:1 = ay.a:5
+
+build
+SELECT * FROM ax NATURAL JOIN LATERAL (SELECT * FROM ay WHERE x=y)
+----
+project
+ ├── columns: a:1 x:2 y:6!null
+ └── inner-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ay.a:5 y:6!null
+      ├── scan ax
+      │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4
+      ├── project
+      │    ├── columns: ay.a:5 y:6!null
+      │    └── select
+      │         ├── columns: ay.a:5 y:6!null ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │         ├── scan ay
+      │         │    └── columns: ay.a:5 y:6 ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │         └── filters
+      │              └── x:2 = y:6
+      └── filters
+           └── ax.a:1 = ay.a:5
+
+build
+SELECT * FROM ax JOIN ay ON true LEFT JOIN LATERAL (SELECT a+z AS y FROM az WHERE x=z) USING (y)
+----
+project
+ ├── columns: y:6 a:1 x:2 a:5
+ └── left-join-apply
+      ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ay.a:5 ay.y:6 ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8 y:13
+      ├── inner-join (cross)
+      │    ├── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4 ay.a:5 ay.y:6 ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │    ├── scan ax
+      │    │    └── columns: ax.a:1 x:2 ax.rowid:3!null ax.crdb_internal_mvcc_timestamp:4
+      │    ├── scan ay
+      │    │    └── columns: ay.a:5 ay.y:6 ay.rowid:7!null ay.crdb_internal_mvcc_timestamp:8
+      │    └── filters
+      │         └── true
+      ├── project
+      │    ├── columns: y:13
+      │    ├── select
+      │    │    ├── columns: az.a:9 z:10!null az.rowid:11!null az.crdb_internal_mvcc_timestamp:12
+      │    │    ├── scan az
+      │    │    │    └── columns: az.a:9 z:10 az.rowid:11!null az.crdb_internal_mvcc_timestamp:12
+      │    │    └── filters
+      │    │         └── x:2 = z:10
+      │    └── projections
+      │         └── az.a:9 + z:10 [as=y:13]
+      └── filters
+           └── ay.y:6 = y:13


### PR DESCRIPTION
Backport 1/1 commits from #70721.

/cc @cockroachdb/release

---

The code that builds joins for `NATURAL` and `USING` did not plumb
the `isLateral` flag correctly. This resulted in allowing lateral
references during resolution, but then building a non-apply join. In
test mode, this fails a check in CheckExpr. In production mode, this
results in an internal error in the execbuilder.

Fixes #61330.

Release note (bug fix): fixed internal error with joins that are both
LATERAL and NATURAL/USING.
