### PR TITLE
generate-test-suites: don't query `pkg/ui` directory for go tests

### DIFF
--- a/pkg/cmd/generate-test-suites/BUILD.bazel
+++ b/pkg/cmd/generate-test-suites/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/generate-test-suites",
     visibility = ["//visibility:private"],
+    deps = ["@com_github_alessio_shellescape//:shellescape"],
 )
 
 go_binary(


### PR DESCRIPTION
Closes #70398.

Release note: None