### PR TITLE
colexectestutils: use separate rand source for each input

### DIFF
--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -641,11 +641,11 @@ func RunTestsWithFn(
 			inputSources := make([]colexecop.Operator, len(tups))
 			var inputTypes []*types.T
 			if useSel {
-				rng, _ := randutil.NewTestRandFromGlobalSeed()
 				for i, tup := range tups {
 					if typs != nil {
 						inputTypes = typs[i]
 					}
+					rng, _ := randutil.NewTestRandFromGlobalSeed()
 					inputSources[i] = newOpTestSelInput(allocator, rng, batchSize, tup, inputTypes)
 				}
 			} else {


### PR DESCRIPTION
Multiple input operators could run concurrently, so we need to give them
a separate `rand.Rand`.

Fixes: #70816.

Release note: None