### PR TITLE
[CRDB-9062] ui: add presizing calc for metrics page graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -54,6 +54,7 @@ export interface LineGraphProps extends MetricsDataComponentProps {
   hoverOn?: typeof hoverOn;
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
+  preCalcGraphSize?: boolean;
 }
 
 interface LineGraphStateOld {
@@ -517,7 +518,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    const { title, subtitle, tooltip, data } = this.props;
+    const { title, subtitle, tooltip, data, preCalcGraphSize } = this.props;
 
     return (
       <Visualization
@@ -525,6 +526,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
         subtitle={subtitle}
         tooltip={tooltip}
         loading={!data}
+        preCalcGraphSize={preCalcGraphSize}
       >
         <div className="linegraph">
           <div ref={this.el} />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/index.tsx
@@ -27,6 +27,7 @@ interface VisualizationProps {
   stale?: boolean;
   // If loading is true a spinner is shown instead of the graph.
   loading?: boolean;
+  preCalcGraphSize?: boolean;
 }
 
 /**
@@ -36,9 +37,10 @@ interface VisualizationProps {
  */
 export default class extends React.Component<VisualizationProps, {}> {
   render() {
-    const { title, subtitle, tooltip, stale } = this.props;
+    const { title, subtitle, tooltip, stale, preCalcGraphSize } = this.props;
     const vizClasses = classNames("visualization", {
       "visualization--faded": stale || false,
+      "visualization__graph-sizing": preCalcGraphSize,
     });
     const contentClasses = classNames("visualization__content", {
       "visualization--loading": this.props.loading,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/visualizations.styl
@@ -55,6 +55,11 @@ $viz-sides = 62px
     width 40px
     height 40px
 
+  &__graph-sizing
+    height calc(30% - 200px)
+    min-height 300px
+    width 100%
+
   .icon-warning
     color $warning-color
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -40,6 +40,7 @@ export default function(props: GraphDashboardProps) {
       sources={nodeSources}
       tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
+      preCalcGraphSize={true}
     >
       <Axis label="queries">
         <Metric
@@ -77,6 +78,7 @@ export default function(props: GraphDashboardProps) {
           </em>
         </div>
       }
+      preCalcGraphSize={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
         {_.map(nodeIDs, node => (
@@ -95,6 +97,7 @@ export default function(props: GraphDashboardProps) {
       title="SQL Statement Contention"
       sources={nodeSources}
       tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
+      preCalcGraphSize={true}
     >
       <Axis label="queries">
         <Metric
@@ -116,6 +119,7 @@ export default function(props: GraphDashboardProps) {
           </em>
         </div>
       }
+      preCalcGraphSize={true}
     >
       <Axis label="replicas">
         {_.map(nodeIDs, nid => (
@@ -133,6 +137,7 @@ export default function(props: GraphDashboardProps) {
       title="Capacity"
       sources={storeSources}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
+      preCalcGraphSize={true}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
         <Metric name="cr.store.capacity" title="Max" />


### PR DESCRIPTION
This PR adresses the issue of graph containers changing size on refresh or tab switch after the graph loads in which causes the height to expand by a lot every time these events occur. This issue is resolved by passing in a boolean prop from the overview to the graph visualization which indicates whether specific height calc styling should be applied to the container. This ensures the size of the container for the loading state and rendering the graph stays a constant size.

Release note (ui change): add presizing calc for metrics page graphs

Video showing result of changes:

https://user-images.githubusercontent.com/17861665/135162097-cb62eecb-a0b3-451f-901d-5635d35f4587.mp4



