### PR TITLE
jobs: fix a flakey test by adopting SucceedsSoon

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -123,7 +123,6 @@ go_test(
         "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
-        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",


### PR DESCRIPTION
The test failed because the operation stopped retrying. The defaults
for the retrier were less than the duration of a KV lease.

Fixes #70664.

Release note: None