### PR TITLE
roachtest: replace deprecated flags in `rapid-restart`

### DIFF
--- a/pkg/cmd/roachtest/tests/rapid_restart.go
+++ b/pkg/cmd/roachtest/tests/rapid_restart.go
@@ -52,7 +52,7 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 				err := c.RunE(ctx, nodes,
 					`mkdir -p {log-dir} && ./cockroach start-single-node --insecure --store={store-dir} `+
 						`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
-						`--listen-addr=:{pgport:1} --http-port=$[{pgport:1}+1] `+
+						`--listen-addr=:{pgport:1} --http-addr=$[{pgport:1}+1] `+
 						`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)
 				exitCh <- err
 			}()


### PR DESCRIPTION
Fixes [#63795](https://github.com/cockroachdb/cockroach/issues/63795).

The use of deprecated flags in `rapid-restart` is causing the test to fail. These 
flags are now replaced.

Release note: None