### PR TITLE
release-21.2: tenantcostclient: deflake TestDataDriven

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
@@ -38,6 +38,10 @@ wait-for-event
 tick
 ----
 
+timers
+----
+00:00:29.147
+
 advance
 10s
 ----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
@@ -44,6 +44,10 @@ wait-for-event
 low-ru
 ----
 
+timers
+----
+00:04:41.479
+
 advance
 2s
 ----
@@ -54,6 +58,10 @@ advance
 wait-for-event
 tick
 ----
+
+timers
+----
+00:00:38.947
 
 not-completed label=w2
 ----


### PR DESCRIPTION
Backport 1/1 commits from #70748.

/cc @cockroachdb/release

---

Deflaking test by adding more `timers` clauses - these ensure that
quotapool timers are set up before `advance`.

Release note: None

Release justification: test-only change.
