### PR TITLE
multiregionccl: deflake TestMultiRegionDataDriven/regional_by_table

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/regional_by_table
+++ b/pkg/ccl/multiregionccl/testdata/regional_by_table
@@ -92,6 +92,11 @@ ALTER TABLE db.rbt SET LOCALITY REGIONAL BY TABLE IN "us-west-1";
 wait-for-zone-config-changes db-name=db table-name=rbt num-voters=3 num-non-voters=3 leaseholder=3 voter=4,5
 ----
 
+refresh-range-descriptor-cache idx=3 table-name=rbt
+SELECT * FROM db.rbt WHERE k = 2
+----
+LAG_BY_CLUSTER_SETTING
+
 # Reads from us-west-1 now should be local since we're homed in us-west-1.
 trace-sql idx=3
 SELECT * FROM db.rbt WHERE k = 1


### PR DESCRIPTION
This was missing a call to refresh the range descriptor cache before
issuing a request to a RBT table. We recenlty improved tracing around
range descriptor cache lookups, and as such, the "dist sender send"
message associated with this lookup was getting caught in the query
trace which made the test unhappy. We circumvent this problem by
refreshing the range descriptor cache before running the query we plan
on tracing.

Stressed this for 20 minutes and it ran fine.

Closes #70846 

Release note: None