### PR TITLE
roachtest: fix up-replication in `node-status`

### DIFF
--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -110,9 +110,6 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Stop(ctx, c.Range(1, 3))
 	c.Start(ctx, c.Range(1, 2))
 
-	// Wait for the cluster to come back up.
-	WaitFor3XReplication(t, db)
-
 	waitUntil([]string{
 		"is_available is_live",
 		"true true",


### PR DESCRIPTION
Fixes [#70169](https://github.com/cockroachdb/cockroach/issues/70169).

This test was failing because it waits for up-replication on a node that was
killed. The up-replication step is unnecessary and has been removed.

Release note: none