### PR TITLE
sql: adding map to existing types for missing types in pg_catalog

### DIFF
--- a/pkg/cmd/generate-metadata-tables/rdbms/postgres.go
+++ b/pkg/cmd/generate-metadata-tables/rdbms/postgres.go
@@ -38,6 +38,12 @@ var unimplementedEquivalencies = map[oid.Oid]oid.Oid{
 	oid.Oid(13443): oid.T_text,        // sql_identifier
 	oid.Oid(13448): oid.T_timestamptz, // time_stamp
 
+	// pg_catalog
+	oid.Oid(2277): oid.T__text, // anyarray
+	oid.Oid(3361): oid.T_bytea, // pg_ndistinct
+	oid.Oid(3402): oid.T_bytea, // pg_dependencies
+	oid.Oid(5017): oid.T_bytea, // pg_mcv_list
+
 	// Other types
 	oid.T__aclitem:     oid.T__text,
 	oid.T_pg_node_tree: oid.T_text,

--- a/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
+++ b/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
@@ -374,8 +374,8 @@
         "expectedDataType": null
       },
       "attmissingval": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6270,32 +6270,32 @@
         "expectedDataType": null
       },
       "stavalues1": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stavalues2": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stavalues3": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stavalues4": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stavalues5": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6358,20 +6358,20 @@
     },
     "pg_statistic_ext_data": {
       "stxddependencies": {
-        "oid": 3402,
-        "dataType": "pg_dependencies",
+        "oid": 17,
+        "dataType": "BYTEA",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stxdmcv": {
-        "oid": 5017,
-        "dataType": "pg_mcv_list",
+        "oid": 17,
+        "dataType": "BYTEA",
         "expectedOid": null,
         "expectedDataType": null
       },
       "stxdndistinct": {
-        "oid": 3361,
-        "dataType": "pg_ndistinct",
+        "oid": 17,
+        "dataType": "BYTEA",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6408,8 +6408,8 @@
         "expectedDataType": null
       },
       "histogram_bounds": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6426,8 +6426,8 @@
         "expectedDataType": null
       },
       "most_common_elems": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6438,8 +6438,8 @@
         "expectedDataType": null
       },
       "most_common_vals": {
-        "oid": 2277,
-        "dataType": "anyarray",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6476,8 +6476,8 @@
         "expectedDataType": null
       },
       "dependencies": {
-        "oid": 3402,
-        "dataType": "pg_dependencies",
+        "oid": 17,
+        "dataType": "BYTEA",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6512,8 +6512,8 @@
         "expectedDataType": null
       },
       "n_distinct": {
-        "oid": 3361,
-        "dataType": "pg_ndistinct",
+        "oid": 17,
+        "dataType": "BYTEA",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -7419,10 +7419,5 @@
       }
     }
   },
-  "unimplementedTypes": {
-    "2277": "anyarray",
-    "3361": "pg_ndistinct",
-    "3402": "pg_dependencies",
-    "5017": "pg_mcv_list"
-  }
+  "unimplementedTypes": null
 }

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
@@ -5,7 +5,7 @@
     "TotalColumns": 1130,
     "MissingTables": 4,
     "MissingColumns": 1,
-    "DatatypeMismatches": 20
+    "DatatypeMismatches": 19
   },
   "pgMetadata": {
     "pg_am": {
@@ -150,20 +150,7 @@
     "pg_statistic": {},
     "pg_statistic_ext_data": {},
     "pg_stats": {},
-    "pg_stats_ext": {},
-    "pg_user": {
-      "valuntil": {
-        "oid": 1114,
-        "dataType": "timestamp",
-        "expectedOid": 1184,
-        "expectedDataType": "timestamptz"
-      }
-    }
+    "pg_stats_ext": {}
   },
-  "unimplementedTypes": {
-    "2277": "anyarray",
-    "3361": "pg_ndistinct",
-    "3402": "pg_dependencies",
-    "5017": "pg_mcv_list"
-  }
+  "unimplementedTypes": null
 }


### PR DESCRIPTION
Previously, there were 4 missing types at columns from postgres
pg_catalog
This was inadequate because we need to try to implement as much as
possible the columns that exists in postgres
To address this, this patch adds mapping for these missing types
using types that exists in cockroach db

Release note: None