### PR TITLE
util/tracing: fix an edge case for active span registration

### DIFF
--- a/pkg/util/tracing/context.go
+++ b/pkg/util/tracing/context.go
@@ -59,7 +59,7 @@ func maybeWrapCtx(ctx context.Context, octx *optimizedContext, sp *Span) (contex
 	}
 	// NB: we check sp != nil explicitly because some callers want to remove a
 	// Span from a Context, and thus pass nil.
-	if sp != nil && sp.i.isNoop() {
+	if sp != nil && sp.IsNoop() {
 		// If the context originally had the noop span, and we would now be wrapping
 		// the noop span in it again, we don't have to wrap at all and can save an
 		// allocation.
@@ -68,7 +68,7 @@ func maybeWrapCtx(ctx context.Context, octx *optimizedContext, sp *Span) (contex
 		// constitute a bug: A real, non-recording span might later start recording.
 		// Besides, the caller expects to get their own span, and will .Finish() it,
 		// leading to an extra, premature call to Finish().
-		if ctxSp := SpanFromContext(ctx); ctxSp != nil && ctxSp.i.isNoop() {
+		if ctxSp := SpanFromContext(ctx); ctxSp != nil && ctxSp.IsNoop() {
 			return ctx, sp
 		}
 	}

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -197,7 +197,7 @@ func (ss *tracingServerStream) Context() context.Context {
 //
 // See #17177.
 func spanInclusionFuncForClient(parent *Span) bool {
-	return parent != nil && !parent.i.isNoop()
+	return parent != nil && !parent.IsNoop()
 }
 
 func injectSpanMeta(ctx context.Context, tracer *Tracer, clientSpan *Span) context.Context {

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -121,7 +121,8 @@ type parentAndAutoCollectionOption Span
 // from a parent Span.
 //
 // WithParentAndAutoCollection can be called with a nil `sp`, in which case
-// it'll be a no-op.
+// it'll be a no-op. It can also be called with a "no-op span", in which case
+// the option will also be a no-op (i.e. the upcoming span will be a root).
 //
 // The child inherits the parent's log tags. The data collected in the
 // child trace will be retrieved automatically when the parent's data is
@@ -143,6 +144,9 @@ type parentAndAutoCollectionOption Span
 // WithParentAndManualCollection should be used, which incurs an
 // obligation to manually propagate the trace data to the parent Span.
 func WithParentAndAutoCollection(sp *Span) SpanOption {
+	if sp == nil || sp.IsNoop() {
+		return (*parentAndAutoCollectionOption)(nil)
+	}
 	return (*parentAndAutoCollectionOption)(sp)
 }
 

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -53,7 +53,7 @@ type spanOptions struct {
 }
 
 func (opts *spanOptions) parentTraceID() uint64 {
-	if opts.Parent != nil && !opts.Parent.i.isNoop() {
+	if opts.Parent != nil && !opts.Parent.IsNoop() {
 		return opts.Parent.i.crdb.traceID
 	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.traceID
@@ -62,7 +62,7 @@ func (opts *spanOptions) parentTraceID() uint64 {
 }
 
 func (opts *spanOptions) parentSpanID() uint64 {
-	if opts.Parent != nil && !opts.Parent.i.isNoop() {
+	if opts.Parent != nil && !opts.Parent.IsNoop() {
 		return opts.Parent.i.crdb.spanID
 	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.spanID
@@ -71,7 +71,7 @@ func (opts *spanOptions) parentSpanID() uint64 {
 }
 
 func (opts *spanOptions) deriveRootSpan() *crdbSpan {
-	if opts.Parent != nil && !opts.Parent.i.isNoop() {
+	if opts.Parent != nil && !opts.Parent.IsNoop() {
 		return opts.Parent.i.crdb.rootSpan
 	}
 	return nil
@@ -79,7 +79,7 @@ func (opts *spanOptions) deriveRootSpan() *crdbSpan {
 
 func (opts *spanOptions) recordingType() RecordingType {
 	recordingType := RecordingOff
-	if opts.Parent != nil && !opts.Parent.i.isNoop() {
+	if opts.Parent != nil && !opts.Parent.IsNoop() {
 		recordingType = opts.Parent.i.crdb.recordingType()
 	} else if !opts.RemoteParent.Empty() {
 		recordingType = opts.RemoteParent.recordingType

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -443,7 +443,7 @@ func (t *Tracer) startSpanGeneric(
 		opts.LogTags = logtags.FromContext(ctx)
 	}
 
-	if opts.LogTags == nil && opts.Parent != nil && !opts.Parent.i.isNoop() {
+	if opts.LogTags == nil && opts.Parent != nil && !opts.Parent.IsNoop() {
 		// If no log tags are specified in the options, use the parent
 		// span's, if any. This behavior is the reason logTags are
 		// fundamentally different from tags, which are strictly per span,
@@ -566,7 +566,7 @@ func (t *Tracer) startSpanGeneric(
 	//
 	// NB: this could be optimized.
 	if opts.Parent != nil {
-		if !opts.Parent.i.isNoop() {
+		if !opts.Parent.IsNoop() {
 			opts.Parent.i.crdb.mu.Lock()
 			m := opts.Parent.i.crdb.mu.baggage
 			opts.Parent.i.crdb.mu.Unlock()

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -431,6 +431,12 @@ func (t *Tracer) startSpanGeneric(
 		if !opts.RemoteParent.Empty() {
 			panic("can't specify both Parent and RemoteParent")
 		}
+		if opts.Parent.IsNoop() {
+			// This method relies on the parent, if any, not being a no-op. A no-op
+			// parent should have been optimized away by the
+			// WithParentAndAutoCollection option.
+			panic("invalid no-op parent")
+		}
 	}
 
 	// Are we tracing everything, or have a parent, or want a real span? Then
@@ -443,7 +449,7 @@ func (t *Tracer) startSpanGeneric(
 		opts.LogTags = logtags.FromContext(ctx)
 	}
 
-	if opts.LogTags == nil && opts.Parent != nil && !opts.Parent.IsNoop() {
+	if opts.LogTags == nil && opts.Parent != nil {
 		// If no log tags are specified in the options, use the parent
 		// span's, if any. This behavior is the reason logTags are
 		// fundamentally different from tags, which are strictly per span,
@@ -565,15 +571,15 @@ func (t *Tracer) startSpanGeneric(
 	// spans contained in Span.
 	//
 	// NB: this could be optimized.
-	if opts.Parent != nil {
-		if !opts.Parent.IsNoop() {
-			opts.Parent.i.crdb.mu.Lock()
-			m := opts.Parent.i.crdb.mu.baggage
-			opts.Parent.i.crdb.mu.Unlock()
+	// NB: (opts.Parent != nil && opts.Parent.i.crdb == nil) is not possible at
+	// the moment, but let's not rely on that.
+	if opts.Parent != nil && opts.Parent.i.crdb != nil {
+		opts.Parent.i.crdb.mu.Lock()
+		m := opts.Parent.i.crdb.mu.baggage
+		opts.Parent.i.crdb.mu.Unlock()
 
-			for k, v := range m {
-				s.SetBaggageItem(k, v)
-			}
+		for k, v := range m {
+			s.SetBaggageItem(k, v)
 		}
 	} else {
 		// Local root span - put it into the registry of active local root

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -35,17 +35,17 @@ func TestStartSpanAlwaysTrace(t *testing.T) {
 	require.True(t, nilMeta.Empty())
 	sp := tr.StartSpan("foo", WithParentAndManualCollection(nilMeta))
 	require.False(t, sp.IsVerbose()) // parent was not verbose, so neither is sp
-	require.False(t, sp.i.isNoop())
+	require.False(t, sp.IsNoop())
 	sp = tr.StartSpan("foo", WithParentAndAutoCollection(tr.noopSpan))
 	require.False(t, sp.IsVerbose()) // parent was not verbose
-	require.False(t, sp.i.isNoop())
+	require.False(t, sp.IsNoop())
 }
 
 func TestTracerRecording(t *testing.T) {
 	tr := NewTracer()
 
 	noop1 := tr.StartSpan("noop")
-	if !noop1.i.isNoop() {
+	if !noop1.IsNoop() {
 		t.Error("expected noop Span")
 	}
 	noop1.Record("hello")
@@ -54,14 +54,14 @@ func TestTracerRecording(t *testing.T) {
 	require.Equal(t, Recording(nil), noop1.GetRecording())
 
 	noop2 := tr.StartSpan("noop2", WithParentAndManualCollection(noop1.Meta()))
-	if !noop2.i.isNoop() {
+	if !noop2.IsNoop() {
 		t.Error("expected noop child Span")
 	}
 	noop2.Finish()
 	noop1.Finish()
 
 	s1 := tr.StartSpan("a", WithForceRealSpan())
-	if s1.i.isNoop() {
+	if s1.IsNoop() {
 		t.Error("WithForceRealSpan (but not recording) Span should not be noop")
 	}
 	if s1.IsVerbose() {
@@ -84,7 +84,7 @@ func TestTracerRecording(t *testing.T) {
 
 	// Real parent --> real child.
 	real3 := tr.StartSpan("noop3", WithParentAndManualCollection(s1.Meta()))
-	if real3.i.isNoop() {
+	if real3.IsNoop() {
 		t.Error("expected real child Span")
 	}
 	real3.Finish()
@@ -229,7 +229,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	// Verify that noop spans become noop spans on the remote side.
 
 	noop1 := tr.StartSpan("noop")
-	if !noop1.i.isNoop() {
+	if !noop1.IsNoop() {
 		t.Fatalf("expected noop Span: %+v", noop1)
 	}
 	carrier := metadataCarrier{metadata.MD{}}
@@ -248,7 +248,7 @@ func TestTracerInjectExtract(t *testing.T) {
 		t.Errorf("expected no-op span meta: %v", wireSpanMeta)
 	}
 	noop2 := tr2.StartSpan("remote op", WithParentAndManualCollection(wireSpanMeta))
-	if !noop2.i.isNoop() {
+	if !noop2.IsNoop() {
 		t.Fatalf("expected noop Span: %+v", noop2)
 	}
 	noop1.Finish()


### PR DESCRIPTION
Before this patch, a span with a no-op parent (as opposed to a span
with no parent), would not be present in the active spans registry. The
code was confused: the span didn't qualify as a "local root" because it
had a local parent, but of course it also wasn't really recorded by the
local parent cause a no-op span can't record anything. As such, the span
in question was missing from the registry.
This patch makes a span with a no-op parent behave like a root span.

Release note: None