### PR TITLE
catalog: add comments to {Table,Type}Descriptor

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -135,23 +135,12 @@ func (desc *immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
-// IsMultiRegion returns whether the database has multi-region properties
-// configured. If so, desc.RegionConfig can be used.
+// IsMultiRegion implements the DatabaseDescriptor interface.
 func (desc *immutable) IsMultiRegion() bool {
 	return desc.RegionConfig != nil
 }
 
-// MultiRegionEnumID returns the ID of the multi-region enum if the database
-// is a multi-region database, and an error otherwise.
-func (desc *immutable) MultiRegionEnumID() (descpb.ID, error) {
-	if !desc.IsMultiRegion() {
-		return descpb.InvalidID, errors.AssertionFailedf(
-			"can not get multi-region enum ID of a non multi-region database")
-	}
-	return desc.RegionConfig.RegionEnumID, nil
-}
-
-// PrimaryRegionName returns the primary region for a multi-region database.
+// PrimaryRegionName implements the DatabaseDescriptor interface.
 func (desc *immutable) PrimaryRegionName() (descpb.RegionName, error) {
 	if !desc.IsMultiRegion() {
 		return "", errors.AssertionFailedf(
@@ -160,13 +149,21 @@ func (desc *immutable) PrimaryRegionName() (descpb.RegionName, error) {
 	return desc.RegionConfig.PrimaryRegion, nil
 }
 
+// MultiRegionEnumID implements the DatabaseDescriptor interface.
+func (desc *immutable) MultiRegionEnumID() (descpb.ID, error) {
+	if !desc.IsMultiRegion() {
+		return descpb.InvalidID, errors.AssertionFailedf(
+			"can not get multi-region enum ID of a non multi-region database")
+	}
+	return desc.RegionConfig.RegionEnumID, nil
+}
+
 // SetName sets the name on the descriptor.
 func (desc *Mutable) SetName(name string) {
 	desc.Name = name
 }
 
-// ForEachSchemaInfo iterates f over each schema info mapping in the descriptor.
-// iterutil.StopIteration is supported.
+// ForEachSchemaInfo implements the DatabaseDescriptor interface.
 func (desc *immutable) ForEachSchemaInfo(
 	f func(id descpb.ID, name string, isDropped bool) error,
 ) error {
@@ -181,8 +178,7 @@ func (desc *immutable) ForEachSchemaInfo(
 	return nil
 }
 
-// GetSchemaID returns the ID in the schema mapping entry for the
-// given name, 0 otherwise.
+// GetSchemaID implements the DatabaseDescriptor interface.
 func (desc *immutable) GetSchemaID(name string) descpb.ID {
 	info := desc.Schemas[name]
 	if info.Dropped {
@@ -191,8 +187,7 @@ func (desc *immutable) GetSchemaID(name string) descpb.ID {
 	return info.ID
 }
 
-// GetNonDroppedSchemaName returns the name in the schema mapping entry for the
-// given ID, if it's not marked as dropped, empty string otherwise.
+// GetNonDroppedSchemaName implements the DatabaseDescriptor interface.
 func (desc *immutable) GetNonDroppedSchemaName(schemaID descpb.ID) string {
 	for name, info := range desc.Schemas {
 		if !info.Dropped && info.ID == schemaID {

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -222,12 +222,12 @@ func (desc *TableDescriptor) Public() bool {
 	return desc.State == DescriptorState_PUBLIC
 }
 
-// Offline returns true if the table is importing.
+// Offline implements the Descriptor interface.
 func (desc *TableDescriptor) Offline() bool {
 	return desc.State == DescriptorState_OFFLINE
 }
 
-// Dropped returns true if the table is being dropped.
+// Dropped implements the Descriptor interface.
 func (desc *TableDescriptor) Dropped() bool {
 	return desc.State == DescriptorState_DROP
 }
@@ -237,49 +237,37 @@ func (desc *TableDescriptor) Adding() bool {
 	return desc.State == DescriptorState_ADD
 }
 
-// IsTable returns true if the TableDescriptor actually describes a
-// Table resource, as opposed to a different resource (like a View).
+// IsTable implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsTable() bool {
 	return !desc.IsView() && !desc.IsSequence()
 }
 
-// IsView returns true if the TableDescriptor actually describes a
-// View resource rather than a Table.
+// IsView implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsView() bool {
 	return desc.ViewQuery != ""
 }
 
-// MaterializedView returns whether or not this TableDescriptor is a
-// MaterializedView.
+// MaterializedView implements the TableDescriptor interface.
 func (desc *TableDescriptor) MaterializedView() bool {
 	return desc.IsMaterializedView
 }
 
-// IsPhysicalTable returns true if the TableDescriptor actually describes a
-// physical Table that needs to be stored in the kv layer, as opposed to a
-// different resource like a view or a virtual table. Physical tables have
-// primary keys, column families, and indexes (unlike virtual tables).
-// Sequences count as physical tables because their values are stored in
-// the KV layer.
+// IsPhysicalTable implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsPhysicalTable() bool {
 	return desc.IsSequence() || (desc.IsTable() && !desc.IsVirtualTable()) || desc.MaterializedView()
 }
 
-// IsAs returns true if the TableDescriptor actually describes
-// a Table resource with an As source.
+// IsAs implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsAs() bool {
 	return desc.CreateQuery != ""
 }
 
-// IsSequence returns true if the TableDescriptor actually describes a
-// Sequence resource rather than a Table.
+// IsSequence implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsSequence() bool {
 	return desc.SequenceOpts != nil
 }
 
-// IsVirtualTable returns true if the TableDescriptor describes a
-// virtual Table (like the information_schema tables) and thus doesn't
-// need to be physically stored.
+// IsVirtualTable implements the TableDescriptor interface.
 func (desc *TableDescriptor) IsVirtualTable() bool {
 	return IsVirtualTable(desc.ID)
 }

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -227,13 +227,12 @@ func GetShardColumnName(colNames []string, buckets int32) string {
 	)
 }
 
-// GetConstraintInfo returns a summary of all constraints on the table.
+// GetConstraintInfo implements the TableDescriptor interface.
 func (desc *wrapper) GetConstraintInfo() (map[string]descpb.ConstraintDetail, error) {
 	return desc.collectConstraintInfo(nil)
 }
 
-// GetConstraintInfoWithLookup returns a summary of all constraints on the
-// table using the provided function to fetch a TableDescriptor from an ID.
+// GetConstraintInfoWithLookup implements the TableDescriptor interface.
 func (desc *wrapper) GetConstraintInfoWithLookup(
 	tableLookup catalog.TableLookupFn,
 ) (map[string]descpb.ConstraintDetail, error) {

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -63,9 +63,7 @@ func (desc *wrapper) HasPostDeserializationChanges() bool {
 		desc.postDeserializationChanges.UpgradedPrivileges
 }
 
-// ActiveChecks returns a list of all check constraints that should be enforced
-// on writes (including constraints being added/validated). The columns
-// referenced by the returned checks are writable, but not necessarily public.
+// ActiveChecks implements the TableDescriptor interface.
 func (desc *wrapper) ActiveChecks() []descpb.TableDescriptor_CheckConstraint {
 	checks := make([]descpb.TableDescriptor_CheckConstraint, len(desc.Checks))
 	for i, c := range desc.Checks {
@@ -96,19 +94,19 @@ func (desc *immutable) IsUncommittedVersion() bool {
 	return desc.isUncommittedVersion
 }
 
-// DescriptorProto prepares desc for serialization.
+// DescriptorProto implements the Descriptor interface.
 func (desc *wrapper) DescriptorProto() *descpb.Descriptor {
 	return &descpb.Descriptor{
 		Union: &descpb.Descriptor_Table{Table: &desc.TableDescriptor},
 	}
 }
 
-// GetPrimaryIndexID returns the ID of the primary index.
+// GetPrimaryIndexID implements the TableDescriptor interface.
 func (desc *wrapper) GetPrimaryIndexID() descpb.IndexID {
 	return desc.PrimaryIndex.ID
 }
 
-// IsTemporary returns true if this is a temporary table.
+// IsTemporary implements the TableDescriptor interface.
 func (desc *wrapper) IsTemporary() bool {
 	return desc.GetTemporary()
 }
@@ -224,8 +222,7 @@ func UpdateIndexPartitioning(
 	return true
 }
 
-// GetPrimaryIndex returns the primary index in the form of a catalog.Index
-// interface.
+// GetPrimaryIndex implements the TableDescriptor interface.
 func (desc *wrapper) GetPrimaryIndex() catalog.Index {
 	return desc.getExistingOrNewIndexCache().primary
 }
@@ -359,83 +356,57 @@ func (desc *wrapper) getExistingOrNewColumnCache() *columnCache {
 	return newColumnCache(desc.TableDesc(), desc.getExistingOrNewMutationCache())
 }
 
-// AllColumns returns a slice of Column interfaces containing the
-// table's public columns and column mutations, in the canonical order:
-// - all public columns in the same order as in the underlying
-//   desc.TableDesc().Columns slice;
-// - all column mutations in the same order as in the underlying
-//   desc.TableDesc().Mutations slice.
-// - all system columns defined in colinfo.AllSystemColumnDescs.
+// AllColumns implements the TableDescriptor interface.
 func (desc *wrapper) AllColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().all
 }
 
-// PublicColumns returns a slice of Column interfaces containing the
-// table's public columns, in the canonical order.
+// PublicColumns implements the TableDescriptor interface.
 func (desc *wrapper) PublicColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().public
 }
 
-// WritableColumns returns a slice of Column interfaces containing the
-// table's public columns and DELETE_AND_WRITE_ONLY mutations, in the canonical
-// order.
+// WritableColumns implements the TableDescriptor interface.
 func (desc *wrapper) WritableColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().writable
 }
 
-// DeletableColumns returns a slice of Column interfaces containing the
-// table's public columns and mutations, in the canonical order.
+// DeletableColumns implements the TableDescriptor interface.
 func (desc *wrapper) DeletableColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().deletable
 }
 
-// NonDropColumns returns a slice of Column interfaces containing the
-// table's public columns and ADD mutations, in the canonical order.
+// NonDropColumns implements the TableDescriptor interface.
 func (desc *wrapper) NonDropColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().nonDrop
 }
 
-// VisibleColumns returns a slice of Column interfaces containing the table's
-// visible columns, in the canonical order. Visible columns are public columns
-// with Hidden=false and Inaccessible=false. See ColumnDescriptor.Hidden and
-// ColumnDescriptor.Inaccessible for more details.
+// VisibleColumns implements the TableDescriptor interface.
 func (desc *wrapper) VisibleColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().visible
 }
 
-// AccessibleColumns returns a slice of Column interfaces containing the table's
-// accessible columns, in the canonical order. Accessible columns are public
-// columns with Inaccessible=false. See ColumnDescriptor.Inaccessible for more
-// details.
+// AccessibleColumns implements the TableDescriptor interface.
 func (desc *wrapper) AccessibleColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().accessible
 }
 
-// UserDefinedTypeColumns returns a slice of Column interfaces
-// containing the table's columns with user defined types, in the
-// canonical order.
+// UserDefinedTypeColumns implements the TableDescriptor interface.
 func (desc *wrapper) UserDefinedTypeColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().withUDTs
 }
 
-// ReadableColumns is a list of columns (including those undergoing a schema
-// change) which can be scanned. Columns in the process of a schema change
-// are all set to nullable while column backfilling is still in
-// progress, as mutation columns may have NULL values.
+// ReadableColumns implements the TableDescriptor interface.
 func (desc *wrapper) ReadableColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().readable
 }
 
-// SystemColumns returns a slice of Column interfaces
-// containing the table's system columns, as defined in
-// colinfo.AllSystemColumnDescs.
+// SystemColumns implements the TableDescriptor interface.
 func (desc *wrapper) SystemColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().system
 }
 
-// FindColumnWithID returns the first column found whose ID matches the
-// provided target ID, in the canonical order.
-// If no column is found then an error is also returned.
+// FindColumnWithID implements the TableDescriptor interface.
 func (desc *wrapper) FindColumnWithID(id descpb.ColumnID) (catalog.Column, error) {
 	for _, col := range desc.AllColumns() {
 		if col.GetID() == id {
@@ -446,9 +417,7 @@ func (desc *wrapper) FindColumnWithID(id descpb.ColumnID) (catalog.Column, error
 	return nil, pgerror.Newf(pgcode.UndefinedColumn, "column-id \"%d\" does not exist", id)
 }
 
-// FindColumnWithName returns the first column found whose name matches the
-// provided target name, in the canonical order.
-// If no column is found then an error is also returned.
+// FindColumnWithName implements the TableDescriptor interface.
 func (desc *wrapper) FindColumnWithName(name tree.Name) (catalog.Column, error) {
 	for _, col := range desc.AllColumns() {
 		if col.ColName() == name {
@@ -467,7 +436,7 @@ func (desc *wrapper) getExistingOrNewMutationCache() *mutationCache {
 	return newMutationCache(desc.TableDesc())
 }
 
-// AllMutations returns all of the table descriptor's mutations.
+// AllMutations implements the TableDescriptor interface.
 func (desc *wrapper) AllMutations() []catalog.Mutation {
 	return desc.getExistingOrNewMutationCache().all
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -177,7 +177,7 @@ func (desc *immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
-// PrimaryRegionName returns the primary region for a multi-region enum.
+// PrimaryRegionName implements the TypeDescriptor interface.
 func (desc *immutable) PrimaryRegionName() (descpb.RegionName, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return "", errors.AssertionFailedf(
@@ -186,8 +186,7 @@ func (desc *immutable) PrimaryRegionName() (descpb.RegionName, error) {
 	return desc.RegionConfig.PrimaryRegion, nil
 }
 
-// RegionNames returns all `PUBLIC` regions on the multi-region enum. Regions
-// that are in the process of being added/removed (`READ_ONLY`) are omitted.
+// RegionNames implements the TypeDescriptor interface.
 func (desc *immutable) RegionNames() (descpb.RegionNames, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return nil, errors.AssertionFailedf(
@@ -204,8 +203,7 @@ func (desc *immutable) RegionNames() (descpb.RegionNames, error) {
 	return regions, nil
 }
 
-// TransitioningRegionNames returns regions which are transitioning to PUBLIC
-// or are being removed.
+// TransitioningRegionNames implements the TypeDescriptor interface.
 func (desc *immutable) TransitioningRegionNames() (descpb.RegionNames, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return nil, errors.AssertionFailedf(
@@ -221,15 +219,7 @@ func (desc *immutable) TransitioningRegionNames() (descpb.RegionNames, error) {
 	return regions, nil
 }
 
-// RegionNamesForValidation returns all regions on the multi-region
-// enum to make validation with the public zone configs and partitons
-// possible.
-// Since the partitions and zone configs are only updated when a transaction
-// commits, this must ignore all regions being added (since they will not be
-// reflected in the zone configuration yet), but it must include all region
-// being dropped (since they will not be dropped from the zone configuration
-// until they are fully removed from the type descriptor, again, at the end
-// of the transaction).
+// RegionNamesForValidation implements the TypeDescriptor interface.
 func (desc *immutable) RegionNamesForValidation() (descpb.RegionNames, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return nil, errors.AssertionFailedf(
@@ -247,8 +237,7 @@ func (desc *immutable) RegionNamesForValidation() (descpb.RegionNames, error) {
 	return regions, nil
 }
 
-// RegionNamesIncludingTransitioning returns all the regions on a multi-region
-// enum, including `READ ONLY` regions which are in the process of transitioning.
+// RegionNamesIncludingTransitioning implements the TypeDescriptor interface.
 func (desc *immutable) RegionNamesIncludingTransitioning() (descpb.RegionNames, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return nil, errors.AssertionFailedf(
@@ -708,7 +697,7 @@ func (t TypeLookupFunc) GetTypeDescriptor(
 	return t(ctx, id)
 }
 
-// MakeTypesT creates a types.T from the input type descriptor.
+// MakeTypesT implements the TypeDescriptor interface.
 func (desc *immutable) MakeTypesT(
 	ctx context.Context, name *tree.TypeName, res catalog.TypeDescriptorResolver,
 ) (*types.T, error) {
@@ -770,12 +759,7 @@ func HydrateTypesInTableDescriptor(
 	return nil
 }
 
-// HydrateTypeInfoWithName fills in user defined type metadata for
-// a type and also sets the name in the metadata to the passed in name.
-// This is used when hydrating a type with a known qualified name.
-//
-// Note that if the passed type is already hydrated, regardless of the version
-// with which it has been hydrated, this is a no-op.
+// HydrateTypeInfoWithName implements the TypeDescriptor interface.
 func (desc *immutable) HydrateTypeInfoWithName(
 	ctx context.Context, typ *types.T, name *tree.TypeName, res catalog.TypeDescriptorResolver,
 ) error {
@@ -828,45 +812,37 @@ func (desc *immutable) HydrateTypeInfoWithName(
 	}
 }
 
-// NumEnumMembers returns the number of enum members if the type is an
-// enumeration type, 0 otherwise.
+// NumEnumMembers implements the TypeDescriptor interface.
 func (desc *immutable) NumEnumMembers() int {
 	return len(desc.EnumMembers)
 }
 
-// GetMemberPhysicalRepresentation returns the physical representation of the
-// enum member at ordinal enumMemberOrdinal.
+// GetMemberPhysicalRepresentation implements the TypeDescriptor interface.
 func (desc *immutable) GetMemberPhysicalRepresentation(enumMemberOrdinal int) []byte {
 	return desc.physicalReps[enumMemberOrdinal]
 }
 
-// GetMemberLogicalRepresentation returns the logical representation of the enum
-// member at ordinal enumMemberOrdinal.
+// GetMemberLogicalRepresentation implements the TypeDescriptor interface.
 func (desc *immutable) GetMemberLogicalRepresentation(enumMemberOrdinal int) string {
 	return desc.logicalReps[enumMemberOrdinal]
 }
 
-// IsMemberReadOnly returns true iff the enum member at ordinal
-// enumMemberOrdinal is read-only.
+// IsMemberReadOnly implements the TypeDescriptor interface.
 func (desc *immutable) IsMemberReadOnly(enumMemberOrdinal int) bool {
 	return desc.readOnlyMembers[enumMemberOrdinal]
 }
 
-// NumReferencingDescriptors returns the number of descriptors referencing this
-// type, directly or indirectly.
+// NumReferencingDescriptors implements the TypeDescriptor interface.
 func (desc *immutable) NumReferencingDescriptors() int {
 	return len(desc.ReferencingDescriptorIDs)
 }
 
-// GetReferencingDescriptorID returns the ID of the referencing descriptor at
-// ordinal refOrdinal.
+// GetReferencingDescriptorID implements the TypeDescriptor interface.
 func (desc *immutable) GetReferencingDescriptorID(refOrdinal int) descpb.ID {
 	return desc.ReferencingDescriptorIDs[refOrdinal]
 }
 
-// IsCompatibleWith returns whether the type "desc" is compatible with "other".
-// As of now "compatibility" entails that disk encoded data of "desc" can be
-// interpreted and used by "other".
+// IsCompatibleWith implements the TypeDescriptor interface.
 func (desc *immutable) IsCompatibleWith(other catalog.TypeDescriptor) error {
 
 	switch desc.Kind {
@@ -904,8 +880,7 @@ func (desc *immutable) IsCompatibleWith(other catalog.TypeDescriptor) error {
 	}
 }
 
-// HasPendingSchemaChanges returns whether or not this descriptor has schema
-// changes that need to be completed.
+// HasPendingSchemaChanges implements the TypeDescriptor interface.
 func (desc *immutable) HasPendingSchemaChanges() bool {
 	switch desc.Kind {
 	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
@@ -922,8 +897,7 @@ func (desc *immutable) HasPendingSchemaChanges() bool {
 	}
 }
 
-// GetIDClosure returns all type descriptor IDs that are referenced by this
-// type descriptor.
+// GetIDClosure implements the TypeDescriptor interface.
 func (desc *immutable) GetIDClosure() (map[descpb.ID]struct{}, error) {
 	ret := make(map[descpb.ID]struct{})
 	// Collect the descriptor's own ID.


### PR DESCRIPTION
This commit pulls comments up from the Table/TypeDescriptor
implementations into the Table/TypeDescriptor interfaces, when
available, and adds new comments when there were none previously.

Release note: None