### PR TITLE
xform: multiple MIN/MAX subqueries rewrite, filter support

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -453,7 +453,7 @@ SELECT count(*)
 1
 
 query I
-SELECT count(k) from kv
+SELECT count(k) FROM kv
 ----
 6
 
@@ -463,7 +463,7 @@ SELECT count(1)
 1
 
 query I
-SELECT count(1) from kv
+SELECT count(1) FROM kv
 ----
 6
 
@@ -760,7 +760,7 @@ SELECT min(x), max(z), sum(x) FROM xyz
 1  8  12
 
 query II
-SELECT min(y), max(y) FROM xyz WHERE x in (0, 4, 7)
+SELECT min(y), max(y) FROM xyz WHERE x IN (0, 4, 7)
 ----
 5  5
 
@@ -770,12 +770,27 @@ SELECT min(x), max(x) FROM xyz WHERE x = 1
 1  1
 
 query FI
-SELECT min(z), max(y) FROM xyz WHERE z in (3.0, 6.0, 8.0)
+SELECT min(z), max(y) FROM xyz WHERE z IN (3.0, 6.0, 8.0)
 ----
 3  5
 
+query FI
+SELECT max(z), min(x) FROM (SELECT x,y,z FROM xyz a) dt WHERE dt.y > 0
+----
+6  1
+
+query FI
+SELECT max(z), min(x) FROM xyz WHERE (z,x) = (SELECT max(z), min(x) FROM xyz)
+----
+NULL  NULL
+
+query FI
+SELECT max(z), min(x) FROM xyz HAVING (max(z), min(x)) = (SELECT max(z), min(x) FROM xyz)
+----
+8  1
+
 query I
-SELECT min(x) FROM xyz WHERE x in (0, 4, 7)
+SELECT min(x) FROM xyz WHERE x IN (0, 4, 7)
 ----
 4
 
@@ -894,15 +909,15 @@ VALUES (1, 1.1, 1.1),
        (18, 11.2, 11.2);
 
 query FRF
-select sqrdiff(i), round(sqrdiff(f), 12), sqrdiff(d)
-from ifd
+SELECT sqrdiff(i), round(sqrdiff(f), 12), sqrdiff(d)
+FROM ifd
 ----
 206.8333333333333333333334 86.248333333333 86.24833333333333333333333
 
 query FRF
 SELECT sqrdiff(i), round(sqrdiff(f), 2), sqrdiff(d)
 FROM ifd
-where i < 10
+WHERE i < 10
 ----
 8.666666666666666666666666 1.82 1.82
 
@@ -2855,7 +2870,7 @@ array_agg   array_agg
 {-3,-2,-1}  {-3,-2,-1,0,1,2}
 
 query IT
-SELECT count(1), concat_agg(col3 ORDER BY col1) from tab
+SELECT count(1), concat_agg(col3 ORDER BY col1) FROM tab
 ----
 6  aaabbb
 
@@ -3472,10 +3487,10 @@ SELECT json_object_agg(user_name, networks) FROM
 {"Bob": {"Facebook": "Bob_fb", "LinkedIn": "Bob The Builder"}}
 
 statement error pq: field name must not be null
-select json_object_agg(null, null)
+SELECT json_object_agg(null, null)
 
 statement error pq: field name must not be null
-select json_object_agg(null, 1)
+SELECT json_object_agg(null, 1)
 
 statement ok
 CREATE TABLE persons(

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -832,8 +832,67 @@ vectorized: true
       table: xyz@xy
       spans: [/1 - /1]
 
+# MULTIPLE MIN/MAX WITH FILTER
+
 query T
 EXPLAIN SELECT min(z), max(y) FROM xyz WHERE z in (3.0, 6.0, 8.0)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • values
+│     size: 2 columns, 1 row
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • scan
+│             missing stats
+│             table: xyz@zyx
+│             spans: [/3.0 - /3.0] [/6.0 - /6.0] [/8.0 - /8.0]
+│             limit: 1
+│
+└── • subquery
+    │ id: @S2
+    │ original sql: <unknown>
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • union all
+                │
+                ├── • union all
+                │   │
+                │   ├── • revscan
+                │   │     missing stats
+                │   │     table: xyz@zyx
+                │   │     spans: (/3.0/NULL - /3.0]
+                │   │     limit: 1
+                │   │
+                │   └── • revscan
+                │         missing stats
+                │         table: xyz@zyx
+                │         spans: (/6.0/NULL - /6.0]
+                │         limit: 1
+                │
+                └── • revscan
+                      missing stats
+                      table: xyz@zyx
+                      spans: (/8.0/NULL - /8.0]
+                      limit: 1
+
+# The COUNT disables ReplaceFilteredScalarMinMaxWithSubqueries.
+query T
+EXPLAIN SELECT min(z), max(y), count(x) FROM xyz WHERE z in (3.0, 6.0, 8.0)
 ----
 distribution: local
 vectorized: true
@@ -844,6 +903,174 @@ vectorized: true
       missing stats
       table: xyz@zyx
       spans: [/3.0 - /3.0] [/6.0 - /6.0] [/8.0 - /8.0]
+
+# Filter on derived table is supported.
+query T
+EXPLAIN SELECT max(z), min(x) FROM (SELECT x,y,z FROM xyz a) dt WHERE dt.y > 0
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • values
+│     size: 2 columns, 1 row
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • filter
+│               │ filter: y > 0
+│               │
+│               └── • revscan
+│                     missing stats
+│                     table: xyz@zyx
+│                     spans: (/NULL - ]
+│
+└── • subquery
+   │ id: @S2
+   │ original sql: <unknown>
+   │ exec mode: one row
+   │
+   └── • group (scalar)
+       │
+       └── • limit
+           │ count: 1
+           │
+           └── • filter
+               │ filter: y > 0
+               │
+               └── • scan
+                     missing stats
+                     table: xyz@xy
+                     spans: FULL SCAN
+
+# Scalar subquery in filter is supported.
+query T
+EXPLAIN SELECT max(z), min(x) FROM xyz WHERE (z,x) = (SELECT max(z), min(x) FROM xyz)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • values
+│     size: 2 columns, 1 row
+│
+├── • subquery
+│   │ id: @S1
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • revscan
+│             missing stats
+│             table: xyz@zyx
+│             spans: (/NULL - ]
+│             limit: 1
+│
+├── • subquery
+│   │ id: @S2
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • scan
+│             missing stats
+│             table: xyz@xy
+│             spans: LIMITED SCAN
+│             limit: 1
+│
+├── • subquery
+│   │ id: @S3
+│   │ original sql: (SELECT max(z), min(x) FROM xyz)
+│   │ exec mode: one row
+│   │
+│   └── • render
+│       │
+│       └── • values
+│             size: 2 columns, 1 row
+│
+├── • subquery
+│   │ id: @S4
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • limit
+│           │ count: 1
+│           │
+│           └── • filter
+│               │ filter: (z, x) = @S3
+│               │
+│               └── • revscan
+│                     missing stats
+│                     table: xyz@zyx
+│                     spans: (/NULL - ]
+│
+├── • subquery
+│   │ id: @S5
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • revscan
+│             missing stats
+│             table: xyz@zyx
+│             spans: (/NULL - ]
+│             limit: 1
+│
+├── • subquery
+│   │ id: @S6
+│   │ original sql: <unknown>
+│   │ exec mode: one row
+│   │
+│   └── • group (scalar)
+│       │
+│       └── • scan
+│             missing stats
+│             table: xyz@xy
+│             spans: LIMITED SCAN
+│             limit: 1
+│
+├── • subquery
+│   │ id: @S7
+│   │ original sql: (SELECT max(z), min(x) FROM xyz)
+│   │ exec mode: one row
+│   │
+│   └── • render
+│       │
+│       └── • values
+│             size: 2 columns, 1 row
+│
+└── • subquery
+    │ id: @S8
+    │ original sql: <unknown>
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • limit
+            │ count: 1
+            │
+            └── • filter
+                │ filter: (z, x) = @S7
+                │
+                └── • scan
+                      missing stats
+                      table: xyz@primary
+                      spans: FULL SCAN
 
 # VARIANCE/STDDEV
 

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -17,6 +17,28 @@
 =>
 (MakeMinMaxScalarSubqueries $scanPrivate $aggregations)
 
+# ReplaceFilteredScalarMinMaxWithSubqueries replaces a scalar group by from a
+# SelectExpr with a ScanExpr as input and n > 1 MIN/MAX expressions with n
+# scalar subqueries, so that each subquery may take advantage of the
+# ReplaceScalarMinMaxWithLimit rule.
+# NOTE: The input relation must be a select from a simple scan as currently no
+#       other cases, such as joins, can take advantage of this rewrite.
+[ReplaceFilteredScalarMinMaxWithSubqueries, Explore]
+(ScalarGroupBy
+    (Select
+        (Scan $scanPrivate:* & (IsCanonicalScan $scanPrivate))
+        $filters:*
+    )
+    $aggregations:* & (TwoOrMoreMinOrMax $aggregations)
+    $groupingPrivate:* & (IsCanonicalGroupBy $groupingPrivate)
+)
+=>
+(MakeMinMaxScalarSubqueriesWithFilter
+    $scanPrivate
+    $aggregations
+    $filters
+)
+
 # ReplaceScalarMinMaxWithLimit replaces a min or max group by aggregation with a
 # limit 1 on an ordered set. This rule may result in a lower cost plan if the
 # aggregated column (e.g. the "x" in min(x)) is indexed.

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -105,7 +105,7 @@ scalar-group-by
            └── b:2
 
 opt expect=ReplaceScalarMinMaxWithLimit
-SELECT min(y) FROM xyz where z=7
+SELECT min(y) FROM xyz WHERE z=7
 ----
 scalar-group-by
  ├── columns: min:6
@@ -125,7 +125,7 @@ scalar-group-by
 # ReplaceScalarMaxWithLimit has the same behavior with max() as
 # the previous min() query because z is the prefix of a unique key
 opt expect=ReplaceScalarMinMaxWithLimit
-SELECT max(y) FROM xyz where z=7
+SELECT max(y) FROM xyz WHERE z=7
 ----
 scalar-group-by
  ├── columns: max:6
@@ -142,7 +142,7 @@ scalar-group-by
       └── const-agg [as=max:6, outer=(2)]
            └── y:2
 
-# We expect ReplaceScalarMinWithLimit not to be preferred here.
+# We expect ReplaceScalarMinMaxWithLimit not to be preferred here.
 # This is because we know nothing about the ordering of y
 # on the index xy after a scan on xy with x>7.
 opt expect=ReplaceScalarMinMaxWithLimit
@@ -1184,29 +1184,8 @@ scalar-group-by
       └── sum [as=sum:8, outer=(3)]
            └── z:3
 
-# ReplaceScalarMinMaxWithScalarSubqueries can only be applied to canonical
-# scans.
-opt expect-not=ReplaceScalarMinMaxWithScalarSubqueries
-SELECT min(y), max(x) FROM xyz WHERE z > 0
-----
-scalar-group-by
- ├── columns: min:6 max:7
- ├── cardinality: [1 - 1]
- ├── key: ()
- ├── fd: ()-->(6,7)
- ├── scan xyz@zyx
- │    ├── columns: x:1!null y:2 z:3!null
- │    ├── constraint: /3/2/1: [/5e-324 - ]
- │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
- └── aggregations
-      ├── min [as=min:6, outer=(2)]
-      │    └── y:2
-      └── max [as=max:7, outer=(1)]
-           └── x:1
-
 # ReplaceScalarMinMaxWithScalarSubqueries cannot be applied on MIN/MAX
-# expressions which are not a simple variable expression.
+# expressions which are projections.
 opt expect-not=ReplaceScalarMinMaxWithScalarSubqueries
 SELECT min(y+1), max(x+1) FROM xyz
 ----
@@ -1231,6 +1210,362 @@ scalar-group-by
       │    └── column6:6
       └── max [as=max:9, outer=(8)]
            └── column8:8
+
+# Scalar subquery in having clause filter is supported.
+opt expect=ReplaceScalarMinMaxWithScalarSubqueries
+SELECT max(z), min(x) FROM xyz HAVING (max(z),min(x)) = (SELECT max(z), min(x) FROM xyz)
+----
+select
+ ├── columns: max:6 min:7
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ ├── values
+ │    ├── columns: max:6 min:7
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6,7)
+ │    └── tuple
+ │         ├── subquery
+ │         │    └── scalar-group-by
+ │         │         ├── columns: max:6
+ │         │         ├── cardinality: [1 - 1]
+ │         │         ├── key: ()
+ │         │         ├── fd: ()-->(6)
+ │         │         ├── scan xyz@zyx,rev
+ │         │         │    ├── columns: z:18!null
+ │         │         │    ├── constraint: /18/17/16: (/NULL - ]
+ │         │         │    ├── limit: 1(rev)
+ │         │         │    ├── key: ()
+ │         │         │    └── fd: ()-->(18)
+ │         │         └── aggregations
+ │         │              └── const-agg [as=max:6, outer=(18)]
+ │         │                   └── z:18
+ │         └── subquery
+ │              └── scalar-group-by
+ │                   ├── columns: min:7
+ │                   ├── cardinality: [1 - 1]
+ │                   ├── key: ()
+ │                   ├── fd: ()-->(7)
+ │                   ├── scan xyz@xy
+ │                   │    ├── columns: x:21!null
+ │                   │    ├── limit: 1
+ │                   │    ├── key: ()
+ │                   │    └── fd: ()-->(21)
+ │                   └── aggregations
+ │                        └── const-agg [as=min:7, outer=(21)]
+ │                             └── x:21
+ └── filters
+      └── eq [outer=(6,7), immutable, subquery]
+           ├── (max:6, min:7)
+           └── subquery
+                └── project
+                     ├── columns: column15:15
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(15)
+                     ├── values
+                     │    ├── columns: max:13 min:14
+                     │    ├── cardinality: [1 - 1]
+                     │    ├── key: ()
+                     │    ├── fd: ()-->(13,14)
+                     │    └── tuple
+                     │         ├── subquery
+                     │         │    └── scalar-group-by
+                     │         │         ├── columns: max:13
+                     │         │         ├── cardinality: [1 - 1]
+                     │         │         ├── key: ()
+                     │         │         ├── fd: ()-->(13)
+                     │         │         ├── scan xyz@zyx,rev
+                     │         │         │    ├── columns: z:28!null
+                     │         │         │    ├── constraint: /28/27/26: (/NULL - ]
+                     │         │         │    ├── limit: 1(rev)
+                     │         │         │    ├── key: ()
+                     │         │         │    └── fd: ()-->(28)
+                     │         │         └── aggregations
+                     │         │              └── const-agg [as=max:13, outer=(28)]
+                     │         │                   └── z:28
+                     │         └── subquery
+                     │              └── scalar-group-by
+                     │                   ├── columns: min:14
+                     │                   ├── cardinality: [1 - 1]
+                     │                   ├── key: ()
+                     │                   ├── fd: ()-->(14)
+                     │                   ├── scan xyz@xy
+                     │                   │    ├── columns: x:31!null
+                     │                   │    ├── limit: 1
+                     │                   │    ├── key: ()
+                     │                   │    └── fd: ()-->(31)
+                     │                   └── aggregations
+                     │                        └── const-agg [as=min:14, outer=(31)]
+                     │                             └── x:31
+                     └── projections
+                          └── (max:13, min:14) [as=column15:15, outer=(13,14)]
+
+# --------------------------------------------------
+# ReplaceFilteredScalarMinMaxWithSubqueries
+# --------------------------------------------------
+
+opt expect=ReplaceFilteredScalarMinMaxWithSubqueries
+SELECT min(z), max(x) FROM xyz WHERE y > 0
+----
+values
+ ├── columns: min:6 max:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ └── tuple
+      ├── subquery
+      │    └── scalar-group-by
+      │         ├── columns: min:6
+      │         ├── cardinality: [1 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(6)
+      │         ├── limit
+      │         │    ├── columns: y:9!null z:10!null
+      │         │    ├── internal-ordering: +10
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(9,10)
+      │         │    ├── select
+      │         │    │    ├── columns: y:9!null z:10!null
+      │         │    │    ├── ordering: +10
+      │         │    │    ├── limit hint: 1.00
+      │         │    │    ├── scan xyz@zyx
+      │         │    │    │    ├── columns: y:9 z:10!null
+      │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
+      │         │    │    │    ├── ordering: +10
+      │         │    │    │    └── limit hint: 2.97
+      │         │    │    └── filters
+      │         │    │         └── y:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
+      │         │    └── 1
+      │         └── aggregations
+      │              └── const-agg [as=min:6, outer=(10)]
+      │                   └── z:10
+      └── subquery
+           └── scalar-group-by
+                ├── columns: max:7
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7)
+                ├── limit
+                │    ├── columns: x:13!null y:14!null
+                │    ├── internal-ordering: -13
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(13,14)
+                │    ├── select
+                │    │    ├── columns: x:13!null y:14!null
+                │    │    ├── key: (13)
+                │    │    ├── fd: (13)-->(14)
+                │    │    ├── ordering: -13
+                │    │    ├── limit hint: 1.00
+                │    │    ├── scan xyz@xy,rev
+                │    │    │    ├── columns: x:13!null y:14
+                │    │    │    ├── key: (13)
+                │    │    │    ├── fd: (13)-->(14)
+                │    │    │    ├── ordering: -13
+                │    │    │    └── limit hint: 3.00
+                │    │    └── filters
+                │    │         └── y:14 > 0 [outer=(14), constraints=(/14: [/1 - ]; tight)]
+                │    └── 1
+                └── aggregations
+                     └── const-agg [as=max:7, outer=(13)]
+                          └── x:13
+
+opt expect=ReplaceFilteredScalarMinMaxWithSubqueries
+SELECT max(z), min(x) FROM xyz WHERE y IS NOT NULL
+----
+values
+ ├── columns: max:6 min:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ └── tuple
+      ├── subquery
+      │    └── scalar-group-by
+      │         ├── columns: max:6
+      │         ├── cardinality: [1 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(6)
+      │         ├── limit
+      │         │    ├── columns: y:9!null z:10!null
+      │         │    ├── internal-ordering: -10
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(9,10)
+      │         │    ├── select
+      │         │    │    ├── columns: y:9!null z:10!null
+      │         │    │    ├── ordering: -10
+      │         │    │    ├── limit hint: 1.00
+      │         │    │    ├── scan xyz@zyx,rev
+      │         │    │    │    ├── columns: y:9 z:10!null
+      │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
+      │         │    │    │    ├── ordering: -10
+      │         │    │    │    └── limit hint: 1.00
+      │         │    │    └── filters
+      │         │    │         └── y:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │         │    └── 1
+      │         └── aggregations
+      │              └── const-agg [as=max:6, outer=(10)]
+      │                   └── z:10
+      └── subquery
+           └── scalar-group-by
+                ├── columns: min:7
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7)
+                ├── limit
+                │    ├── columns: x:13!null y:14!null
+                │    ├── internal-ordering: +13
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(13,14)
+                │    ├── select
+                │    │    ├── columns: x:13!null y:14!null
+                │    │    ├── key: (13)
+                │    │    ├── fd: (13)-->(14)
+                │    │    ├── ordering: +13
+                │    │    ├── limit hint: 1.00
+                │    │    ├── scan xyz@xy
+                │    │    │    ├── columns: x:13!null y:14
+                │    │    │    ├── key: (13)
+                │    │    │    ├── fd: (13)-->(14)
+                │    │    │    ├── ordering: +13
+                │    │    │    └── limit hint: 1.01
+                │    │    └── filters
+                │    │         └── y:14 IS NOT NULL [outer=(14), constraints=(/14: (/NULL - ]; tight)]
+                │    └── 1
+                └── aggregations
+                     └── const-agg [as=min:7, outer=(13)]
+                          └── x:13
+
+# ReplaceFilteredScalarMinMaxWithSubqueries cannot be applied on MIN/MAX
+# expressions which are projections.
+opt expect-not=ReplaceFilteredScalarMinMaxWithSubqueries
+SELECT max(z+1), min(x) FROM xyz WHERE y IS NOT NULL
+----
+scalar-group-by
+ ├── columns: max:7 min:8
+ ├── cardinality: [1 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(7,8)
+ ├── project
+ │    ├── columns: column6:6 x:1!null
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(6)
+ │    ├── select
+ │    │    ├── columns: x:1!null y:2!null z:3
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan xyz
+ │    │    │    ├── columns: x:1!null y:2 z:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── filters
+ │    │         └── y:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │    └── projections
+ │         └── z:3 + 1.0 [as=column6:6, outer=(3), immutable]
+ └── aggregations
+      ├── max [as=max:7, outer=(6)]
+      │    └── column6:6
+      └── min [as=min:8, outer=(1)]
+           └── x:1
+
+# ORDER BY should not disable ReplaceFilteredScalarMinMaxWithSubqueries.
+opt expect=ReplaceFilteredScalarMinMaxWithSubqueries
+SELECT max(z), min(x) FROM xyz WHERE y IS NOT NULL ORDER BY 1
+----
+values
+ ├── columns: max:6 min:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ └── tuple
+      ├── subquery
+      │    └── scalar-group-by
+      │         ├── columns: max:6
+      │         ├── cardinality: [1 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(6)
+      │         ├── limit
+      │         │    ├── columns: y:9!null z:10!null
+      │         │    ├── internal-ordering: -10
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(9,10)
+      │         │    ├── select
+      │         │    │    ├── columns: y:9!null z:10!null
+      │         │    │    ├── ordering: -10
+      │         │    │    ├── limit hint: 1.00
+      │         │    │    ├── scan xyz@zyx,rev
+      │         │    │    │    ├── columns: y:9 z:10!null
+      │         │    │    │    ├── constraint: /10/9/8: (/NULL - ]
+      │         │    │    │    ├── ordering: -10
+      │         │    │    │    └── limit hint: 1.00
+      │         │    │    └── filters
+      │         │    │         └── y:9 IS NOT NULL [outer=(9), constraints=(/9: (/NULL - ]; tight)]
+      │         │    └── 1
+      │         └── aggregations
+      │              └── const-agg [as=max:6, outer=(10)]
+      │                   └── z:10
+      └── subquery
+           └── scalar-group-by
+                ├── columns: min:7
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7)
+                ├── limit
+                │    ├── columns: x:13!null y:14!null
+                │    ├── internal-ordering: +13
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(13,14)
+                │    ├── select
+                │    │    ├── columns: x:13!null y:14!null
+                │    │    ├── key: (13)
+                │    │    ├── fd: (13)-->(14)
+                │    │    ├── ordering: +13
+                │    │    ├── limit hint: 1.00
+                │    │    ├── scan xyz@xy
+                │    │    │    ├── columns: x:13!null y:14
+                │    │    │    ├── key: (13)
+                │    │    │    ├── fd: (13)-->(14)
+                │    │    │    ├── ordering: +13
+                │    │    │    └── limit hint: 1.01
+                │    │    └── filters
+                │    │         └── y:14 IS NOT NULL [outer=(14), constraints=(/14: (/NULL - ]; tight)]
+                │    └── 1
+                └── aggregations
+                     └── const-agg [as=min:7, outer=(13)]
+                          └── x:13
+
+# We expect the ReplaceFilteredScalarMinMaxWithSubqueries and
+# ReplaceScalarMinMaxWithLimit rules to fire, however, as we know nothing about
+# the ordering of y on the index zyx after a scan on xyz with z > 0, a sort is
+# required, making the new plan more expensive and therefore not selected.
+opt expect=(ReplaceFilteredScalarMinMaxWithSubqueries, ReplaceScalarMinMaxWithLimit)
+SELECT min(y), max(x) FROM xyz@zyx WHERE z > 0
+----
+scalar-group-by
+ ├── columns: min:6 max:7
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,7)
+ ├── scan xyz@zyx
+ │    ├── columns: x:1!null y:2 z:3!null
+ │    ├── constraint: /3/2/1: [/5e-324 - ]
+ │    ├── flags: force-index=zyx
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── aggregations
+      ├── min [as=min:6, outer=(2)]
+      │    └── y:2
+      └── max [as=max:7, outer=(1)]
+           └── x:1
 
 # --------------------------------------------------
 # GenerateStreamingGroupBy


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/70735

Previously, we only rewrote single-table queries with scalar
min and max aggregate expressions into separate subqueries
if there was no WHERE clause, for example:
```
    SELECT min(pk_col1), max(pk_col1) FROM t1;
```
becomes:
```
    SELECT (SELECT min(pk_col1) FROM t1),
           (SELECT max(pk_col1) FROM t1);
```
The purpose of this transformation was to allow each subquery 
to utilize a limited scan via the primary key.

This was inadequate because it is of limited value.
Many user queries use a WHERE clause, so WHERE clause
support is crucial to allow this optimization to be
applied in more cases.

To address this, this patch adds a new rewrite rule named
ReplaceFilteredScalarMinMaxWithSubqueries to detect a Select
as input to two or more scalar MIN or MAX expressions. If present,
a new Select is built for each MIN or MAX expression with the same
Filters (WHERE clause) as the original Select, but with mapped column
IDs in a copy of the tree. Each new Select is used as input
to a newly constructed subquery and combined via a values clause.
The values clause replaces the original ScalarGroupByExpr.

Example:
```
    CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
    
    EXPLAIN (OPT) SELECT min(a), max(a) FROM t1 WHERE b < 6;
    ---------------------------------------------
      values
       └── tuple
            ├── subquery
            │    └── scalar-group-by
            │         ├── limit
            │         │    ├── select
            │         │    │    ├── scan t1
            │         │    │    └── filters
            │         │    │         └── b < 6
            │         │    └── 1
            │         └── aggregations
            │              └── const-agg
            │                   └── a
            └── subquery
                 └── scalar-group-by
                      ├── limit
                      │    ├── select
                      │    │    ├── scan t1,rev
                      │    │    └── filters
                      │    │         └── b < 6
                      │    └── 1
                      └── aggregations
                           └── const-agg
                                └── a
```
Release note (performance improvement): A SELECT query from
a single table with more than one MIN or MAX scalar aggregate 
expression and a WHERE clause can now be performed with LIMITED SCANs, 
one per aggregate expression, instead of a single FULL SCAN.

Note: No other aggregate function, such as SUM, may be present
      in the query block in order for it to be eligible for
      this transformation. This optimization should occur when 
      each MIN or MAX expression involves a leading index column, 
      so that a sort is not required for the limit operation, and 
      the resulting query plan will appear cheapest to the optimizer.
