### PR TITLE
sql: correct ZM coordinates for geometry_columns/geography_columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_extension
+++ b/pkg/sql/logictest/testdata/logic_test/pg_extension
@@ -15,38 +15,38 @@ CREATE TABLE pg_extension_test (
 query TTTTIIT rowsort
 SELECT * FROM pg_extension.geography_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  a    2     4326  POINT
-test  public  pg_extension_test  d    NULL  0     GEOMETRY
-test  public  pg_extension_test  az   3     4326  POINTZ
-test  public  pg_extension_test  am   3     4326  POINTM
-test  public  pg_extension_test  azm  4     4326  POINTZM
+test  public  pg_extension_test  a    2     4326  Point
+test  public  pg_extension_test  d    NULL  0     Geometry
+test  public  pg_extension_test  az   3     4326  PointZ
+test  public  pg_extension_test  am   3     4326  PointM
+test  public  pg_extension_test  azm  4     4326  PointZM
 
 query TTTTIIT rowsort
 SELECT * FROM pg_extension.geometry_columns WHERE f_table_name = 'pg_extension_test'
 ----
 test  public  pg_extension_test  b    2  3857  POLYGON
 test  public  pg_extension_test  c    2  0     GEOMETRY
-test  public  pg_extension_test  bz   3  3857  POLYGONZ
-test  public  pg_extension_test  bm   3  3857  POLYGONM
-test  public  pg_extension_test  bzm  4  3857  POLYGONZM
+test  public  pg_extension_test  bz   3  3857  POLYGON
+test  public  pg_extension_test  bm   3  3857  POLYGON
+test  public  pg_extension_test  bzm  4  3857  POLYGON
 
 query TTTTIIT rowsort
 SELECT * FROM geography_columns WHERE f_table_name = 'pg_extension_test'
 ----
-test  public  pg_extension_test  a    2     4326  POINT
-test  public  pg_extension_test  d    NULL  0     GEOMETRY
-test  public  pg_extension_test  az   3     4326  POINTZ
-test  public  pg_extension_test  am   3     4326  POINTM
-test  public  pg_extension_test  azm  4     4326  POINTZM
+test  public  pg_extension_test  a    2     4326  Point
+test  public  pg_extension_test  d    NULL  0     Geometry
+test  public  pg_extension_test  az   3     4326  PointZ
+test  public  pg_extension_test  am   3     4326  PointM
+test  public  pg_extension_test  azm  4     4326  PointZM
 
 query TTTTIIT rowsort
 SELECT * FROM geometry_columns WHERE f_table_name = 'pg_extension_test'
 ----
 test  public  pg_extension_test  b    2  3857  POLYGON
 test  public  pg_extension_test  c    2  0     GEOMETRY
-test  public  pg_extension_test  bz   3  3857  POLYGONZ
-test  public  pg_extension_test  bm   3  3857  POLYGONM
-test  public  pg_extension_test  bzm  4  3857  POLYGONZM
+test  public  pg_extension_test  bz   3  3857  POLYGON
+test  public  pg_extension_test  bm   3  3857  POLYGON
+test  public  pg_extension_test  bzm  4  3857  POLYGON
 
 query ITITT
 SELECT * FROM pg_extension.spatial_ref_sys WHERE srid IN (3857, 4326) ORDER BY srid ASC

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -82,12 +82,23 @@ func postgisColumnsTablePopulator(
 						default:
 							datumNDims = tree.NewDInt(2)
 						}
-
 					}
 
-					shapeName := m.ShapeType.String()
-					if m.ShapeType == geopb.ShapeType_Unset {
-						shapeName = geopb.ShapeType_Geometry.String()
+					// PostGIS is weird on this one! It has the following behavior:
+					//
+					// * For Geometry, it uses the 2D shape type, all uppercase.
+					// * For Geography, use the correct OGR case for the shape type.
+					shapeName := geopb.ShapeType_Geometry.String()
+					if matchingFamily == types.GeometryFamily {
+						if m.ShapeType == geopb.ShapeType_Unset {
+							shapeName = strings.ToUpper(shapeName)
+						} else {
+							shapeName = strings.ToUpper(m.ShapeType.To2D().String())
+						}
+					} else {
+						if m.ShapeType != geopb.ShapeType_Unset {
+							shapeName = m.ShapeType.String()
+						}
 					}
 
 					if err := addRow(
@@ -97,7 +108,7 @@ func postgisColumnsTablePopulator(
 						tree.NewDString(col.GetName()),
 						datumNDims,
 						tree.NewDInt(tree.DInt(m.SRID)),
-						tree.NewDString(strings.ToUpper(shapeName)),
+						tree.NewDString(shapeName),
 					); err != nil {
 						return err
 					}


### PR DESCRIPTION
Release note (bug fix): Correct how the `type` displays for ZM shapes
geometry_columns to match PostGIS output. This previously incorrectly
included the Z/M lettering.

Release note (bug fix): Correct how `type` displays in geography_columns
to better match PostGIS. This was previously in the wrong casing.