### PR TITLE
sql: adding empty stubs for missing tables on pg_catalog

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -341,7 +341,11 @@ const (
 	PgCatalogStatioUserIndexesTableID
 	PgCatalogStatioUserSequencesTableID
 	PgCatalogStatioUserTablesTableID
+	PgCatalogStatisticExtDataTableID
 	PgCatalogStatisticExtTableID
+	PgCatalogStatisticTableID
+	PgCatalogStatsExtTableID
+	PgCatalogStatsTableID
 	PgCatalogSubscriptionRelTableID
 	PgCatalogSubscriptionTableID
 	PgCatalogTablesTableID

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -3367,7 +3367,8 @@ CREATE TABLE pg_catalog.pg_attribute (
    attoptions STRING[] NULL,
    attfdwoptions STRING[] NULL,
    atthasmissing BOOL NULL,
-   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing)
+   attmissingval STRING[] NULL,
+   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing, attmissingval)
 )  CREATE TABLE pg_catalog.pg_attribute (
    attrelid OID NOT NULL,
    attname NAME NULL,
@@ -3393,7 +3394,8 @@ CREATE TABLE pg_catalog.pg_attribute (
    attoptions STRING[] NULL,
    attfdwoptions STRING[] NULL,
    atthasmissing BOOL NULL,
-   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing)
+   attmissingval STRING[] NULL,
+   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing, attmissingval)
 )  {}  {}
 CREATE TABLE pg_catalog.pg_auth_members (
    roleid OID NULL,
@@ -5545,6 +5547,71 @@ CREATE TABLE pg_catalog.pg_statio_user_tables (
    schemaname NAME NULL,
    tidx_blks_hit INT8 NULL
 )  {}  {}
+CREATE TABLE pg_catalog.pg_statistic (
+   stakind2 INT2 NULL,
+   stanumbers2 FLOAT4[] NULL,
+   stanumbers3 FLOAT4[] NULL,
+   staop5 OID NULL,
+   stacoll3 OID NULL,
+   stainherit BOOL NULL,
+   stakind3 INT2 NULL,
+   stavalues5 STRING[] NULL,
+   staattnum INT2 NULL,
+   stacoll1 OID NULL,
+   stacoll4 OID NULL,
+   stanullfrac FLOAT4 NULL,
+   stavalues1 STRING[] NULL,
+   stawidth INT4 NULL,
+   stacoll2 OID NULL,
+   stanumbers4 FLOAT4[] NULL,
+   stanumbers5 FLOAT4[] NULL,
+   staop2 OID NULL,
+   stavalues3 STRING[] NULL,
+   stakind4 INT2 NULL,
+   staop1 OID NULL,
+   staop4 OID NULL,
+   stacoll5 OID NULL,
+   stakind5 INT2 NULL,
+   staop3 OID NULL,
+   stavalues2 STRING[] NULL,
+   stavalues4 STRING[] NULL,
+   stakind1 INT2 NULL,
+   stanumbers1 FLOAT4[] NULL,
+   starelid OID NULL,
+   stadistinct FLOAT4 NULL
+)  CREATE TABLE pg_catalog.pg_statistic (
+   stakind2 INT2 NULL,
+   stanumbers2 FLOAT4[] NULL,
+   stanumbers3 FLOAT4[] NULL,
+   staop5 OID NULL,
+   stacoll3 OID NULL,
+   stainherit BOOL NULL,
+   stakind3 INT2 NULL,
+   stavalues5 STRING[] NULL,
+   staattnum INT2 NULL,
+   stacoll1 OID NULL,
+   stacoll4 OID NULL,
+   stanullfrac FLOAT4 NULL,
+   stavalues1 STRING[] NULL,
+   stawidth INT4 NULL,
+   stacoll2 OID NULL,
+   stanumbers4 FLOAT4[] NULL,
+   stanumbers5 FLOAT4[] NULL,
+   staop2 OID NULL,
+   stavalues3 STRING[] NULL,
+   stakind4 INT2 NULL,
+   staop1 OID NULL,
+   staop4 OID NULL,
+   stacoll5 OID NULL,
+   stakind5 INT2 NULL,
+   staop3 OID NULL,
+   stavalues2 STRING[] NULL,
+   stavalues4 STRING[] NULL,
+   stakind1 INT2 NULL,
+   stanumbers1 FLOAT4[] NULL,
+   starelid OID NULL,
+   stadistinct FLOAT4 NULL
+)  {}  {}
 CREATE TABLE pg_catalog.pg_statistic_ext (
    oid OID NULL,
    stxrelid OID NULL,
@@ -5563,6 +5630,77 @@ CREATE TABLE pg_catalog.pg_statistic_ext (
    stxstattarget INT4 NULL,
    stxkeys INT2VECTOR NULL,
    stxkind "char"[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_ext_data (
+   stxddependencies BYTES NULL,
+   stxdmcv BYTES NULL,
+   stxdndistinct BYTES NULL,
+   stxoid OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_ext_data (
+   stxddependencies BYTES NULL,
+   stxdmcv BYTES NULL,
+   stxdndistinct BYTES NULL,
+   stxoid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stats (
+   histogram_bounds STRING[] NULL,
+   most_common_elem_freqs FLOAT4[] NULL,
+   most_common_elems STRING[] NULL,
+   most_common_vals STRING[] NULL,
+   attname NAME NULL,
+   inherited BOOL NULL,
+   n_distinct FLOAT4 NULL,
+   schemaname NAME NULL,
+   correlation FLOAT4 NULL,
+   null_frac FLOAT4 NULL,
+   elem_count_histogram FLOAT4[] NULL,
+   most_common_freqs FLOAT4[] NULL,
+   tablename NAME NULL,
+   avg_width INT4 NULL
+)  CREATE TABLE pg_catalog.pg_stats (
+   histogram_bounds STRING[] NULL,
+   most_common_elem_freqs FLOAT4[] NULL,
+   most_common_elems STRING[] NULL,
+   most_common_vals STRING[] NULL,
+   attname NAME NULL,
+   inherited BOOL NULL,
+   n_distinct FLOAT4 NULL,
+   schemaname NAME NULL,
+   correlation FLOAT4 NULL,
+   null_frac FLOAT4 NULL,
+   elem_count_histogram FLOAT4[] NULL,
+   most_common_freqs FLOAT4[] NULL,
+   tablename NAME NULL,
+   avg_width INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stats_ext (
+   kinds "char"[] NULL,
+   most_common_base_freqs FLOAT8[] NULL,
+   most_common_freqs FLOAT8[] NULL,
+   n_distinct BYTES NULL,
+   schemaname NAME NULL,
+   statistics_schemaname NAME NULL,
+   dependencies BYTES NULL,
+   most_common_val_nulls BOOL[] NULL,
+   most_common_vals STRING[] NULL,
+   statistics_name NAME NULL,
+   statistics_owner NAME NULL,
+   tablename NAME NULL,
+   attnames NAME[] NULL
+)  CREATE TABLE pg_catalog.pg_stats_ext (
+   kinds "char"[] NULL,
+   most_common_base_freqs FLOAT8[] NULL,
+   most_common_freqs FLOAT8[] NULL,
+   n_distinct BYTES NULL,
+   schemaname NAME NULL,
+   statistics_schemaname NAME NULL,
+   dependencies BYTES NULL,
+   most_common_val_nulls BOOL[] NULL,
+   most_common_vals STRING[] NULL,
+   statistics_name NAME NULL,
+   statistics_owner NAME NULL,
+   tablename NAME NULL,
+   attnames NAME[] NULL
 )  {}  {}
 CREATE TABLE pg_catalog.pg_subscription (
    subname NAME NULL,

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -423,7 +423,11 @@ test           pg_catalog          pg_statio_sys_tables                   public
 test           pg_catalog          pg_statio_user_indexes                 public   SELECT
 test           pg_catalog          pg_statio_user_sequences               public   SELECT
 test           pg_catalog          pg_statio_user_tables                  public   SELECT
+test           pg_catalog          pg_statistic                           public   SELECT
 test           pg_catalog          pg_statistic_ext                       public   SELECT
+test           pg_catalog          pg_statistic_ext_data                  public   SELECT
+test           pg_catalog          pg_stats                               public   SELECT
+test           pg_catalog          pg_stats_ext                           public   SELECT
 test           pg_catalog          pg_subscription                        public   SELECT
 test           pg_catalog          pg_subscription_rel                    public   SELECT
 test           pg_catalog          pg_tables                              public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -651,7 +651,11 @@ pg_catalog          pg_statio_sys_tables
 pg_catalog          pg_statio_user_indexes
 pg_catalog          pg_statio_user_sequences
 pg_catalog          pg_statio_user_tables
+pg_catalog          pg_statistic
 pg_catalog          pg_statistic_ext
+pg_catalog          pg_statistic_ext_data
+pg_catalog          pg_stats
+pg_catalog          pg_stats_ext
 pg_catalog          pg_subscription
 pg_catalog          pg_subscription_rel
 pg_catalog          pg_tables
@@ -963,7 +967,11 @@ pg_statio_sys_tables
 pg_statio_user_indexes
 pg_statio_user_sequences
 pg_statio_user_tables
+pg_statistic
 pg_statistic_ext
+pg_statistic_ext_data
+pg_stats
+pg_stats_ext
 pg_subscription
 pg_subscription_rel
 pg_tables
@@ -1312,7 +1320,11 @@ system         pg_catalog          pg_statio_sys_tables                   SYSTEM
 system         pg_catalog          pg_statio_user_indexes                 SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_statio_user_sequences               SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_statio_user_tables                  SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_statistic                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_statistic_ext                       SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_statistic_ext_data                  SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_stats                               SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_stats_ext                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_subscription                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_subscription_rel                    SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tables                              SYSTEM VIEW  NO                  1
@@ -2876,7 +2888,11 @@ NULL     public   system         pg_catalog          pg_statio_sys_tables       
 NULL     public   system         pg_catalog          pg_statio_user_indexes                 SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statio_user_sequences               SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statio_user_tables                  SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_statistic                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statistic_ext                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_statistic_ext_data                  SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stats                               SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stats_ext                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription_rel                    SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_tables                              SELECT          NULL          YES
@@ -3477,7 +3493,11 @@ NULL     public   system         pg_catalog          pg_statio_sys_tables       
 NULL     public   system         pg_catalog          pg_statio_user_indexes                 SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statio_user_sequences               SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statio_user_tables                  SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_statistic                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_statistic_ext                       SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_statistic_ext_data                  SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stats                               SELECT          NULL          YES
+NULL     public   system         pg_catalog          pg_stats_ext                           SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription                        SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_subscription_rel                    SELECT          NULL          YES
 NULL     public   system         pg_catalog          pg_tables                              SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -123,7 +123,11 @@ pg_catalog  pg_statio_sys_tables             table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_indexes           table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_sequences         table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_tables            table  NULL  NULL  NULL
+pg_catalog  pg_statistic                     table  NULL  NULL  NULL
 pg_catalog  pg_statistic_ext                 table  NULL  NULL  NULL
+pg_catalog  pg_statistic_ext_data            table  NULL  NULL  NULL
+pg_catalog  pg_stats                         table  NULL  NULL  NULL
+pg_catalog  pg_stats_ext                     table  NULL  NULL  NULL
 pg_catalog  pg_subscription                  table  NULL  NULL  NULL
 pg_catalog  pg_subscription_rel              table  NULL  NULL  NULL
 pg_catalog  pg_tables                        table  NULL  NULL  NULL
@@ -274,7 +278,11 @@ pg_catalog  pg_statio_sys_tables             table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_indexes           table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_sequences         table  NULL  NULL  NULL
 pg_catalog  pg_statio_user_tables            table  NULL  NULL  NULL
+pg_catalog  pg_statistic                     table  NULL  NULL  NULL
 pg_catalog  pg_statistic_ext                 table  NULL  NULL  NULL
+pg_catalog  pg_statistic_ext_data            table  NULL  NULL  NULL
+pg_catalog  pg_stats                         table  NULL  NULL  NULL
+pg_catalog  pg_stats_ext                     table  NULL  NULL  NULL
 pg_catalog  pg_subscription                  table  NULL  NULL  NULL
 pg_catalog  pg_subscription_rel              table  NULL  NULL  NULL
 pg_catalog  pg_tables                        table  NULL  NULL  NULL
@@ -1574,28 +1582,32 @@ oid         typname                                typnamespace  typowner    typ
 100074      _newtype1                              2332901747    1546506610  -1      false     b
 100075      newtype2                               2332901747    1546506610  -1      false     e
 100076      _newtype2                              2332901747    1546506610  -1      false     b
-4294967015  spatial_ref_sys                        3553698885    3233629770  -1      false     c
-4294967016  geometry_columns                       3553698885    3233629770  -1      false     c
-4294967017  geography_columns                      3553698885    3233629770  -1      false     c
-4294967019  pg_views                               1307062959    3233629770  -1      false     c
-4294967020  pg_user                                1307062959    3233629770  -1      false     c
-4294967021  pg_user_mappings                       1307062959    3233629770  -1      false     c
-4294967022  pg_user_mapping                        1307062959    3233629770  -1      false     c
-4294967023  pg_type                                1307062959    3233629770  -1      false     c
-4294967024  pg_ts_template                         1307062959    3233629770  -1      false     c
-4294967025  pg_ts_parser                           1307062959    3233629770  -1      false     c
-4294967026  pg_ts_dict                             1307062959    3233629770  -1      false     c
-4294967027  pg_ts_config                           1307062959    3233629770  -1      false     c
-4294967028  pg_ts_config_map                       1307062959    3233629770  -1      false     c
-4294967029  pg_trigger                             1307062959    3233629770  -1      false     c
-4294967030  pg_transform                           1307062959    3233629770  -1      false     c
-4294967031  pg_timezone_names                      1307062959    3233629770  -1      false     c
-4294967032  pg_timezone_abbrevs                    1307062959    3233629770  -1      false     c
-4294967033  pg_tablespace                          1307062959    3233629770  -1      false     c
-4294967034  pg_tables                              1307062959    3233629770  -1      false     c
-4294967035  pg_subscription                        1307062959    3233629770  -1      false     c
-4294967036  pg_subscription_rel                    1307062959    3233629770  -1      false     c
-4294967037  pg_statistic_ext                       1307062959    3233629770  -1      false     c
+4294967011  spatial_ref_sys                        3553698885    3233629770  -1      false     c
+4294967012  geometry_columns                       3553698885    3233629770  -1      false     c
+4294967013  geography_columns                      3553698885    3233629770  -1      false     c
+4294967015  pg_views                               1307062959    3233629770  -1      false     c
+4294967016  pg_user                                1307062959    3233629770  -1      false     c
+4294967017  pg_user_mappings                       1307062959    3233629770  -1      false     c
+4294967018  pg_user_mapping                        1307062959    3233629770  -1      false     c
+4294967019  pg_type                                1307062959    3233629770  -1      false     c
+4294967020  pg_ts_template                         1307062959    3233629770  -1      false     c
+4294967021  pg_ts_parser                           1307062959    3233629770  -1      false     c
+4294967022  pg_ts_dict                             1307062959    3233629770  -1      false     c
+4294967023  pg_ts_config                           1307062959    3233629770  -1      false     c
+4294967024  pg_ts_config_map                       1307062959    3233629770  -1      false     c
+4294967025  pg_trigger                             1307062959    3233629770  -1      false     c
+4294967026  pg_transform                           1307062959    3233629770  -1      false     c
+4294967027  pg_timezone_names                      1307062959    3233629770  -1      false     c
+4294967028  pg_timezone_abbrevs                    1307062959    3233629770  -1      false     c
+4294967029  pg_tablespace                          1307062959    3233629770  -1      false     c
+4294967030  pg_tables                              1307062959    3233629770  -1      false     c
+4294967031  pg_subscription                        1307062959    3233629770  -1      false     c
+4294967032  pg_subscription_rel                    1307062959    3233629770  -1      false     c
+4294967033  pg_stats                               1307062959    3233629770  -1      false     c
+4294967034  pg_stats_ext                           1307062959    3233629770  -1      false     c
+4294967035  pg_statistic                           1307062959    3233629770  -1      false     c
+4294967036  pg_statistic_ext                       1307062959    3233629770  -1      false     c
+4294967037  pg_statistic_ext_data                  1307062959    3233629770  -1      false     c
 4294967038  pg_statio_user_tables                  1307062959    3233629770  -1      false     c
 4294967039  pg_statio_user_sequences               1307062959    3233629770  -1      false     c
 4294967040  pg_statio_user_indexes                 1307062959    3233629770  -1      false     c
@@ -1952,28 +1964,32 @@ oid         typname                                typcategory  typispreferred  
 100074      _newtype1                              A            false           true          ,         0           100073   0
 100075      newtype2                               E            false           true          ,         0           0        100076
 100076      _newtype2                              A            false           true          ,         0           100075   0
-4294967015  spatial_ref_sys                        C            false           true          ,         4294967015  0        0
-4294967016  geometry_columns                       C            false           true          ,         4294967016  0        0
-4294967017  geography_columns                      C            false           true          ,         4294967017  0        0
-4294967019  pg_views                               C            false           true          ,         4294967019  0        0
-4294967020  pg_user                                C            false           true          ,         4294967020  0        0
-4294967021  pg_user_mappings                       C            false           true          ,         4294967021  0        0
-4294967022  pg_user_mapping                        C            false           true          ,         4294967022  0        0
-4294967023  pg_type                                C            false           true          ,         4294967023  0        0
-4294967024  pg_ts_template                         C            false           true          ,         4294967024  0        0
-4294967025  pg_ts_parser                           C            false           true          ,         4294967025  0        0
-4294967026  pg_ts_dict                             C            false           true          ,         4294967026  0        0
-4294967027  pg_ts_config                           C            false           true          ,         4294967027  0        0
-4294967028  pg_ts_config_map                       C            false           true          ,         4294967028  0        0
-4294967029  pg_trigger                             C            false           true          ,         4294967029  0        0
-4294967030  pg_transform                           C            false           true          ,         4294967030  0        0
-4294967031  pg_timezone_names                      C            false           true          ,         4294967031  0        0
-4294967032  pg_timezone_abbrevs                    C            false           true          ,         4294967032  0        0
-4294967033  pg_tablespace                          C            false           true          ,         4294967033  0        0
-4294967034  pg_tables                              C            false           true          ,         4294967034  0        0
-4294967035  pg_subscription                        C            false           true          ,         4294967035  0        0
-4294967036  pg_subscription_rel                    C            false           true          ,         4294967036  0        0
-4294967037  pg_statistic_ext                       C            false           true          ,         4294967037  0        0
+4294967011  spatial_ref_sys                        C            false           true          ,         4294967011  0        0
+4294967012  geometry_columns                       C            false           true          ,         4294967012  0        0
+4294967013  geography_columns                      C            false           true          ,         4294967013  0        0
+4294967015  pg_views                               C            false           true          ,         4294967015  0        0
+4294967016  pg_user                                C            false           true          ,         4294967016  0        0
+4294967017  pg_user_mappings                       C            false           true          ,         4294967017  0        0
+4294967018  pg_user_mapping                        C            false           true          ,         4294967018  0        0
+4294967019  pg_type                                C            false           true          ,         4294967019  0        0
+4294967020  pg_ts_template                         C            false           true          ,         4294967020  0        0
+4294967021  pg_ts_parser                           C            false           true          ,         4294967021  0        0
+4294967022  pg_ts_dict                             C            false           true          ,         4294967022  0        0
+4294967023  pg_ts_config                           C            false           true          ,         4294967023  0        0
+4294967024  pg_ts_config_map                       C            false           true          ,         4294967024  0        0
+4294967025  pg_trigger                             C            false           true          ,         4294967025  0        0
+4294967026  pg_transform                           C            false           true          ,         4294967026  0        0
+4294967027  pg_timezone_names                      C            false           true          ,         4294967027  0        0
+4294967028  pg_timezone_abbrevs                    C            false           true          ,         4294967028  0        0
+4294967029  pg_tablespace                          C            false           true          ,         4294967029  0        0
+4294967030  pg_tables                              C            false           true          ,         4294967030  0        0
+4294967031  pg_subscription                        C            false           true          ,         4294967031  0        0
+4294967032  pg_subscription_rel                    C            false           true          ,         4294967032  0        0
+4294967033  pg_stats                               C            false           true          ,         4294967033  0        0
+4294967034  pg_stats_ext                           C            false           true          ,         4294967034  0        0
+4294967035  pg_statistic                           C            false           true          ,         4294967035  0        0
+4294967036  pg_statistic_ext                       C            false           true          ,         4294967036  0        0
+4294967037  pg_statistic_ext_data                  C            false           true          ,         4294967037  0        0
 4294967038  pg_statio_user_tables                  C            false           true          ,         4294967038  0        0
 4294967039  pg_statio_user_sequences               C            false           true          ,         4294967039  0        0
 4294967040  pg_statio_user_indexes                 C            false           true          ,         4294967040  0        0
@@ -2330,28 +2346,32 @@ oid         typname                                typinput        typoutput    
 100074      _newtype1                              array_in        array_out        array_recv        array_send        0         0          0
 100075      newtype2                               enum_in         enum_out         enum_recv         enum_send         0         0          0
 100076      _newtype2                              array_in        array_out        array_recv        array_send        0         0          0
-4294967015  spatial_ref_sys                        record_in       record_out       record_recv       record_send       0         0          0
-4294967016  geometry_columns                       record_in       record_out       record_recv       record_send       0         0          0
-4294967017  geography_columns                      record_in       record_out       record_recv       record_send       0         0          0
-4294967019  pg_views                               record_in       record_out       record_recv       record_send       0         0          0
-4294967020  pg_user                                record_in       record_out       record_recv       record_send       0         0          0
-4294967021  pg_user_mappings                       record_in       record_out       record_recv       record_send       0         0          0
-4294967022  pg_user_mapping                        record_in       record_out       record_recv       record_send       0         0          0
-4294967023  pg_type                                record_in       record_out       record_recv       record_send       0         0          0
-4294967024  pg_ts_template                         record_in       record_out       record_recv       record_send       0         0          0
-4294967025  pg_ts_parser                           record_in       record_out       record_recv       record_send       0         0          0
-4294967026  pg_ts_dict                             record_in       record_out       record_recv       record_send       0         0          0
-4294967027  pg_ts_config                           record_in       record_out       record_recv       record_send       0         0          0
-4294967028  pg_ts_config_map                       record_in       record_out       record_recv       record_send       0         0          0
-4294967029  pg_trigger                             record_in       record_out       record_recv       record_send       0         0          0
-4294967030  pg_transform                           record_in       record_out       record_recv       record_send       0         0          0
-4294967031  pg_timezone_names                      record_in       record_out       record_recv       record_send       0         0          0
-4294967032  pg_timezone_abbrevs                    record_in       record_out       record_recv       record_send       0         0          0
-4294967033  pg_tablespace                          record_in       record_out       record_recv       record_send       0         0          0
-4294967034  pg_tables                              record_in       record_out       record_recv       record_send       0         0          0
-4294967035  pg_subscription                        record_in       record_out       record_recv       record_send       0         0          0
-4294967036  pg_subscription_rel                    record_in       record_out       record_recv       record_send       0         0          0
-4294967037  pg_statistic_ext                       record_in       record_out       record_recv       record_send       0         0          0
+4294967011  spatial_ref_sys                        record_in       record_out       record_recv       record_send       0         0          0
+4294967012  geometry_columns                       record_in       record_out       record_recv       record_send       0         0          0
+4294967013  geography_columns                      record_in       record_out       record_recv       record_send       0         0          0
+4294967015  pg_views                               record_in       record_out       record_recv       record_send       0         0          0
+4294967016  pg_user                                record_in       record_out       record_recv       record_send       0         0          0
+4294967017  pg_user_mappings                       record_in       record_out       record_recv       record_send       0         0          0
+4294967018  pg_user_mapping                        record_in       record_out       record_recv       record_send       0         0          0
+4294967019  pg_type                                record_in       record_out       record_recv       record_send       0         0          0
+4294967020  pg_ts_template                         record_in       record_out       record_recv       record_send       0         0          0
+4294967021  pg_ts_parser                           record_in       record_out       record_recv       record_send       0         0          0
+4294967022  pg_ts_dict                             record_in       record_out       record_recv       record_send       0         0          0
+4294967023  pg_ts_config                           record_in       record_out       record_recv       record_send       0         0          0
+4294967024  pg_ts_config_map                       record_in       record_out       record_recv       record_send       0         0          0
+4294967025  pg_trigger                             record_in       record_out       record_recv       record_send       0         0          0
+4294967026  pg_transform                           record_in       record_out       record_recv       record_send       0         0          0
+4294967027  pg_timezone_names                      record_in       record_out       record_recv       record_send       0         0          0
+4294967028  pg_timezone_abbrevs                    record_in       record_out       record_recv       record_send       0         0          0
+4294967029  pg_tablespace                          record_in       record_out       record_recv       record_send       0         0          0
+4294967030  pg_tables                              record_in       record_out       record_recv       record_send       0         0          0
+4294967031  pg_subscription                        record_in       record_out       record_recv       record_send       0         0          0
+4294967032  pg_subscription_rel                    record_in       record_out       record_recv       record_send       0         0          0
+4294967033  pg_stats                               record_in       record_out       record_recv       record_send       0         0          0
+4294967034  pg_stats_ext                           record_in       record_out       record_recv       record_send       0         0          0
+4294967035  pg_statistic                           record_in       record_out       record_recv       record_send       0         0          0
+4294967036  pg_statistic_ext                       record_in       record_out       record_recv       record_send       0         0          0
+4294967037  pg_statistic_ext_data                  record_in       record_out       record_recv       record_send       0         0          0
 4294967038  pg_statio_user_tables                  record_in       record_out       record_recv       record_send       0         0          0
 4294967039  pg_statio_user_sequences               record_in       record_out       record_recv       record_send       0         0          0
 4294967040  pg_statio_user_indexes                 record_in       record_out       record_recv       record_send       0         0          0
@@ -2708,28 +2728,32 @@ oid         typname                                typalign  typstorage  typnotn
 100074      _newtype1                              NULL      NULL        false       0            -1
 100075      newtype2                               NULL      NULL        false       0            -1
 100076      _newtype2                              NULL      NULL        false       0            -1
-4294967015  spatial_ref_sys                        NULL      NULL        false       0            -1
-4294967016  geometry_columns                       NULL      NULL        false       0            -1
-4294967017  geography_columns                      NULL      NULL        false       0            -1
-4294967019  pg_views                               NULL      NULL        false       0            -1
-4294967020  pg_user                                NULL      NULL        false       0            -1
-4294967021  pg_user_mappings                       NULL      NULL        false       0            -1
-4294967022  pg_user_mapping                        NULL      NULL        false       0            -1
-4294967023  pg_type                                NULL      NULL        false       0            -1
-4294967024  pg_ts_template                         NULL      NULL        false       0            -1
-4294967025  pg_ts_parser                           NULL      NULL        false       0            -1
-4294967026  pg_ts_dict                             NULL      NULL        false       0            -1
-4294967027  pg_ts_config                           NULL      NULL        false       0            -1
-4294967028  pg_ts_config_map                       NULL      NULL        false       0            -1
-4294967029  pg_trigger                             NULL      NULL        false       0            -1
-4294967030  pg_transform                           NULL      NULL        false       0            -1
-4294967031  pg_timezone_names                      NULL      NULL        false       0            -1
-4294967032  pg_timezone_abbrevs                    NULL      NULL        false       0            -1
-4294967033  pg_tablespace                          NULL      NULL        false       0            -1
-4294967034  pg_tables                              NULL      NULL        false       0            -1
-4294967035  pg_subscription                        NULL      NULL        false       0            -1
-4294967036  pg_subscription_rel                    NULL      NULL        false       0            -1
-4294967037  pg_statistic_ext                       NULL      NULL        false       0            -1
+4294967011  spatial_ref_sys                        NULL      NULL        false       0            -1
+4294967012  geometry_columns                       NULL      NULL        false       0            -1
+4294967013  geography_columns                      NULL      NULL        false       0            -1
+4294967015  pg_views                               NULL      NULL        false       0            -1
+4294967016  pg_user                                NULL      NULL        false       0            -1
+4294967017  pg_user_mappings                       NULL      NULL        false       0            -1
+4294967018  pg_user_mapping                        NULL      NULL        false       0            -1
+4294967019  pg_type                                NULL      NULL        false       0            -1
+4294967020  pg_ts_template                         NULL      NULL        false       0            -1
+4294967021  pg_ts_parser                           NULL      NULL        false       0            -1
+4294967022  pg_ts_dict                             NULL      NULL        false       0            -1
+4294967023  pg_ts_config                           NULL      NULL        false       0            -1
+4294967024  pg_ts_config_map                       NULL      NULL        false       0            -1
+4294967025  pg_trigger                             NULL      NULL        false       0            -1
+4294967026  pg_transform                           NULL      NULL        false       0            -1
+4294967027  pg_timezone_names                      NULL      NULL        false       0            -1
+4294967028  pg_timezone_abbrevs                    NULL      NULL        false       0            -1
+4294967029  pg_tablespace                          NULL      NULL        false       0            -1
+4294967030  pg_tables                              NULL      NULL        false       0            -1
+4294967031  pg_subscription                        NULL      NULL        false       0            -1
+4294967032  pg_subscription_rel                    NULL      NULL        false       0            -1
+4294967033  pg_stats                               NULL      NULL        false       0            -1
+4294967034  pg_stats_ext                           NULL      NULL        false       0            -1
+4294967035  pg_statistic                           NULL      NULL        false       0            -1
+4294967036  pg_statistic_ext                       NULL      NULL        false       0            -1
+4294967037  pg_statistic_ext_data                  NULL      NULL        false       0            -1
 4294967038  pg_statio_user_tables                  NULL      NULL        false       0            -1
 4294967039  pg_statio_user_sequences               NULL      NULL        false       0            -1
 4294967040  pg_statio_user_indexes                 NULL      NULL        false       0            -1
@@ -3086,28 +3110,32 @@ oid         typname                                typndims  typcollation  typde
 100074      _newtype1                              0         0             NULL           NULL        NULL
 100075      newtype2                               0         0             NULL           NULL        NULL
 100076      _newtype2                              0         0             NULL           NULL        NULL
-4294967015  spatial_ref_sys                        0         0             NULL           NULL        NULL
-4294967016  geometry_columns                       0         0             NULL           NULL        NULL
-4294967017  geography_columns                      0         0             NULL           NULL        NULL
-4294967019  pg_views                               0         0             NULL           NULL        NULL
-4294967020  pg_user                                0         0             NULL           NULL        NULL
-4294967021  pg_user_mappings                       0         0             NULL           NULL        NULL
-4294967022  pg_user_mapping                        0         0             NULL           NULL        NULL
-4294967023  pg_type                                0         0             NULL           NULL        NULL
-4294967024  pg_ts_template                         0         0             NULL           NULL        NULL
-4294967025  pg_ts_parser                           0         0             NULL           NULL        NULL
-4294967026  pg_ts_dict                             0         0             NULL           NULL        NULL
-4294967027  pg_ts_config                           0         0             NULL           NULL        NULL
-4294967028  pg_ts_config_map                       0         0             NULL           NULL        NULL
-4294967029  pg_trigger                             0         0             NULL           NULL        NULL
-4294967030  pg_transform                           0         0             NULL           NULL        NULL
-4294967031  pg_timezone_names                      0         0             NULL           NULL        NULL
-4294967032  pg_timezone_abbrevs                    0         0             NULL           NULL        NULL
-4294967033  pg_tablespace                          0         0             NULL           NULL        NULL
-4294967034  pg_tables                              0         0             NULL           NULL        NULL
-4294967035  pg_subscription                        0         0             NULL           NULL        NULL
-4294967036  pg_subscription_rel                    0         0             NULL           NULL        NULL
-4294967037  pg_statistic_ext                       0         0             NULL           NULL        NULL
+4294967011  spatial_ref_sys                        0         0             NULL           NULL        NULL
+4294967012  geometry_columns                       0         0             NULL           NULL        NULL
+4294967013  geography_columns                      0         0             NULL           NULL        NULL
+4294967015  pg_views                               0         0             NULL           NULL        NULL
+4294967016  pg_user                                0         0             NULL           NULL        NULL
+4294967017  pg_user_mappings                       0         0             NULL           NULL        NULL
+4294967018  pg_user_mapping                        0         0             NULL           NULL        NULL
+4294967019  pg_type                                0         0             NULL           NULL        NULL
+4294967020  pg_ts_template                         0         0             NULL           NULL        NULL
+4294967021  pg_ts_parser                           0         0             NULL           NULL        NULL
+4294967022  pg_ts_dict                             0         0             NULL           NULL        NULL
+4294967023  pg_ts_config                           0         0             NULL           NULL        NULL
+4294967024  pg_ts_config_map                       0         0             NULL           NULL        NULL
+4294967025  pg_trigger                             0         0             NULL           NULL        NULL
+4294967026  pg_transform                           0         0             NULL           NULL        NULL
+4294967027  pg_timezone_names                      0         0             NULL           NULL        NULL
+4294967028  pg_timezone_abbrevs                    0         0             NULL           NULL        NULL
+4294967029  pg_tablespace                          0         0             NULL           NULL        NULL
+4294967030  pg_tables                              0         0             NULL           NULL        NULL
+4294967031  pg_subscription                        0         0             NULL           NULL        NULL
+4294967032  pg_subscription_rel                    0         0             NULL           NULL        NULL
+4294967033  pg_stats                               0         0             NULL           NULL        NULL
+4294967034  pg_stats_ext                           0         0             NULL           NULL        NULL
+4294967035  pg_statistic                           0         0             NULL           NULL        NULL
+4294967036  pg_statistic_ext                       0         0             NULL           NULL        NULL
+4294967037  pg_statistic_ext_data                  0         0             NULL           NULL        NULL
 4294967038  pg_statio_user_tables                  0         0             NULL           NULL        NULL
 4294967039  pg_statio_user_sequences               0         0             NULL           NULL        NULL
 4294967040  pg_statio_user_indexes                 0         0             NULL           NULL        NULL
@@ -3819,28 +3847,32 @@ objoid      classoid    objsubid  description
 4294967040  4294967132  0         pg_statio_user_indexes was created for compatibility and is currently unimplemented
 4294967039  4294967132  0         pg_statio_user_sequences was created for compatibility and is currently unimplemented
 4294967038  4294967132  0         pg_statio_user_tables was created for compatibility and is currently unimplemented
-4294967037  4294967132  0         pg_statistic_ext has the statistics objects created with CREATE STATISTICS
-4294967035  4294967132  0         pg_subscription was created for compatibility and is currently unimplemented
-4294967036  4294967132  0         pg_subscription_rel was created for compatibility and is currently unimplemented
-4294967034  4294967132  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967033  4294967132  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967032  4294967132  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
-4294967031  4294967132  0         pg_timezone_names was created for compatibility and is currently unimplemented
-4294967030  4294967132  0         pg_transform was created for compatibility and is currently unimplemented
-4294967029  4294967132  0         triggers (empty - feature does not exist)
-4294967027  4294967132  0         pg_ts_config was created for compatibility and is currently unimplemented
-4294967028  4294967132  0         pg_ts_config_map was created for compatibility and is currently unimplemented
-4294967026  4294967132  0         pg_ts_dict was created for compatibility and is currently unimplemented
-4294967025  4294967132  0         pg_ts_parser was created for compatibility and is currently unimplemented
-4294967024  4294967132  0         pg_ts_template was created for compatibility and is currently unimplemented
-4294967023  4294967132  0         scalar types (incomplete)
-4294967020  4294967132  0         database users
-4294967022  4294967132  0         local to remote user mapping (empty - feature does not exist)
-4294967021  4294967132  0         pg_user_mappings was created for compatibility and is currently unimplemented
-4294967019  4294967132  0         view definitions (incomplete - see also information_schema.views)
-4294967017  4294967132  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967016  4294967132  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967015  4294967132  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967035  4294967132  0         pg_statistic was created for compatibility and is currently unimplemented
+4294967036  4294967132  0         pg_statistic_ext has the statistics objects created with CREATE STATISTICS
+4294967037  4294967132  0         pg_statistic_ext_data was created for compatibility and is currently unimplemented
+4294967033  4294967132  0         pg_stats was created for compatibility and is currently unimplemented
+4294967034  4294967132  0         pg_stats_ext was created for compatibility and is currently unimplemented
+4294967031  4294967132  0         pg_subscription was created for compatibility and is currently unimplemented
+4294967032  4294967132  0         pg_subscription_rel was created for compatibility and is currently unimplemented
+4294967030  4294967132  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967029  4294967132  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967028  4294967132  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
+4294967027  4294967132  0         pg_timezone_names was created for compatibility and is currently unimplemented
+4294967026  4294967132  0         pg_transform was created for compatibility and is currently unimplemented
+4294967025  4294967132  0         triggers (empty - feature does not exist)
+4294967023  4294967132  0         pg_ts_config was created for compatibility and is currently unimplemented
+4294967024  4294967132  0         pg_ts_config_map was created for compatibility and is currently unimplemented
+4294967022  4294967132  0         pg_ts_dict was created for compatibility and is currently unimplemented
+4294967021  4294967132  0         pg_ts_parser was created for compatibility and is currently unimplemented
+4294967020  4294967132  0         pg_ts_template was created for compatibility and is currently unimplemented
+4294967019  4294967132  0         scalar types (incomplete)
+4294967016  4294967132  0         database users
+4294967018  4294967132  0         local to remote user mapping (empty - feature does not exist)
+4294967017  4294967132  0         pg_user_mappings was created for compatibility and is currently unimplemented
+4294967015  4294967132  0         view definitions (incomplete - see also information_schema.views)
+4294967013  4294967132  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967012  4294967132  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967011  4294967132  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 
@@ -5026,7 +5058,7 @@ indoption
 query TTI
 SELECT database_name, descriptor_name, descriptor_id from test.crdb_internal.create_statements where descriptor_name = 'pg_views'
 ----
-test  pg_views  4294967019
+test  pg_views  4294967015
 
 # Verify INCLUDED columns appear in pg_index. See issue #59563
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -807,7 +807,11 @@ pg_statio_sys_tables                   NULL
 pg_statio_user_indexes                 NULL
 pg_statio_user_sequences               NULL
 pg_statio_user_tables                  NULL
+pg_statistic                           NULL
 pg_statistic_ext                       NULL
+pg_statistic_ext_data                  NULL
+pg_stats                               NULL
+pg_stats_ext                           NULL
 pg_subscription                        NULL
 pg_subscription_rel                    NULL
 pg_tables                              NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1058,7 +1058,7 @@ distribution: local
 vectorized: true
 ·
 • virtual table
-  columns: (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing)
+  columns: (attrelid, attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing, attmissingval)
   estimated row count: 10 (missing stats)
   table: pg_attribute@pg_attribute_attrelid_idx
   spans: [/t - /t]

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -147,12 +147,12 @@ vectorized: true
         └── • virtual table lookup join
             │ table: pg_attribute@pg_attribute_attrelid_idx
             │ equality: (oid) = (attrelid)
-            │ pred: column154 = attnum
+            │ pred: column156 = attnum
             │
             └── • render
                 │
                 └── • hash join
-                    │ equality: (attrelid, attnum) = (oid, column128)
+                    │ equality: (attrelid, attnum) = (oid, column129)
                     │
                     ├── • filter
                     │   │ filter: attrelid = 'b'::REGCLASS

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -920,34 +920,34 @@ WHERE
   a.attname IN ('descriptor_id', 'descriptor_name')
 ----
 project
- ├── columns: attname:3!null atttypid:4!null typbasetype:51 typtype:33
+ ├── columns: attname:3!null atttypid:4!null typbasetype:52 typtype:34
  ├── stats: [rows=198]
- ├── cost: 2901.01877
+ ├── cost: 2911.11877
  └── inner-join (merge)
-      ├── columns: attname:3!null atttypid:4!null oid:27!null typtype:33 typbasetype:51
-      ├── left ordering: +27
+      ├── columns: attname:3!null atttypid:4!null oid:28!null typtype:34 typbasetype:52
+      ├── left ordering: +28
       ├── right ordering: +4
-      ├── stats: [rows=198, distinct(4)=17.2927193, null(4)=0, distinct(27)=17.2927193, null(27)=0]
-      ├── cost: 2899.01877
-      ├── fd: (4)==(27), (27)==(4)
+      ├── stats: [rows=198, distinct(4)=17.2927193, null(4)=0, distinct(28)=17.2927193, null(28)=0]
+      ├── cost: 2909.11877
+      ├── fd: (4)==(28), (28)==(4)
       ├── scan pg_type@secondary [as=t]
-      │    ├── columns: oid:27!null typtype:33 typbasetype:51
-      │    ├── stats: [rows=1000, distinct(27)=100, null(27)=0]
+      │    ├── columns: oid:28!null typtype:34 typbasetype:52
+      │    ├── stats: [rows=1000, distinct(28)=100, null(28)=0]
       │    ├── cost: 1477.52
-      │    └── ordering: +27
+      │    └── ordering: +28
       ├── sort
       │    ├── columns: attname:3!null atttypid:4
       │    ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927193, null(4)=0.2]
-      │    ├── cost: 1409.29877
+      │    ├── cost: 1419.39877
       │    ├── ordering: +4
       │    └── select
       │         ├── columns: attname:3!null atttypid:4
       │         ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927193, null(4)=0.2]
-      │         ├── cost: 1406.75
+      │         ├── cost: 1416.85
       │         ├── scan pg_attribute [as=a]
       │         │    ├── columns: attname:3 atttypid:4
       │         │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
-      │         │    └── cost: 1396.72
+      │         │    └── cost: 1406.82
       │         └── filters
       │              └── attname:3 IN ('descriptor_id', 'descriptor_name') [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id'] [/'descriptor_name' - /'descriptor_name']; tight)]
       └── filters (true)
@@ -968,25 +968,25 @@ WHERE
   a.attname = 'descriptor_id'
 ----
 project
- ├── columns: attname:3!null atttypid:4!null typbasetype:51 typtype:33
+ ├── columns: attname:3!null atttypid:4!null typbasetype:52 typtype:34
  ├── stats: [rows=99]
- ├── cost: 2841.42
+ ├── cost: 2851.52
  ├── fd: ()-->(3)
  └── inner-join (lookup pg_type@secondary [as=t])
-      ├── columns: attname:3!null atttypid:4!null oid:27!null typtype:33 typbasetype:51
-      ├── key columns: [4] = [27]
-      ├── stats: [rows=99, distinct(4)=8.5617925, null(4)=0, distinct(27)=8.5617925, null(27)=0]
-      ├── cost: 2840.41
-      ├── fd: ()-->(3), (4)==(27), (27)==(4)
+      ├── columns: attname:3!null atttypid:4!null oid:28!null typtype:34 typbasetype:52
+      ├── key columns: [4] = [28]
+      ├── stats: [rows=99, distinct(4)=8.5617925, null(4)=0, distinct(28)=8.5617925, null(28)=0]
+      ├── cost: 2850.51
+      ├── fd: ()-->(3), (4)==(28), (28)==(4)
       ├── select
       │    ├── columns: attname:3!null atttypid:4
       │    ├── stats: [rows=10, distinct(3)=1, null(3)=0, distinct(4)=9.5617925, null(4)=0.1]
-      │    ├── cost: 1406.75
+      │    ├── cost: 1416.85
       │    ├── fd: ()-->(3)
       │    ├── scan pg_attribute [as=a]
       │    │    ├── columns: attname:3 atttypid:4
       │    │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
-      │    │    └── cost: 1396.72
+      │    │    └── cost: 1406.82
       │    └── filters
       │         └── attname:3 = 'descriptor_id' [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id']; tight), fd=()-->(3)]
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -157,46 +157,46 @@ ORDER BY
   nspname, c.relname, attnum;
 ----
 sort
- ├── columns: nspname:3!null relname:8!null attname:45!null atttypid:46!null attnotnull:154 atttypmod:52 attlen:48 typtypmod:94 attnum:153 attidentity:155 adsrc:156 description:110 typbasetype:93 typtype:75
+ ├── columns: nspname:3!null relname:8!null attname:45!null atttypid:46!null attnotnull:155 atttypmod:52 attlen:48 typtypmod:95 attnum:154 attidentity:156 adsrc:157 description:111 typbasetype:94 typtype:76
  ├── stable
- ├── fd: ()-->(3,155)
- ├── ordering: +8,+153 opt(3,155) [actual: +8,+153]
+ ├── fd: ()-->(3,156)
+ ├── ordering: +8,+154 opt(3,156) [actual: +8,+154]
  └── project
-      ├── columns: attnotnull:154 attidentity:155 adsrc:156 n.nspname:3!null c.relname:8!null attname:45!null atttypid:46!null attlen:48 atttypmod:52 typtype:75 typbasetype:93 typtypmod:94 description:110 row_number:153
+      ├── columns: attnotnull:155 attidentity:156 adsrc:157 n.nspname:3!null c.relname:8!null attname:45!null atttypid:46!null attlen:48 atttypmod:52 typtype:76 typbasetype:94 typtypmod:95 description:111 row_number:154
       ├── stable
-      ├── fd: ()-->(3,155)
+      ├── fd: ()-->(3,156)
       ├── select
-      │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45!null atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:69!null typtype:75 typnotnull:92 typbasetype:93 typtypmod:94 adrelid:102 adnum:103 adbin:104 objoid:107 classoid:108 objsubid:109 description:110 dc.oid:112 dc.relname:113 dc.relnamespace:114 dn.oid:149 dn.nspname:150 row_number:153
-      │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(69), (69)==(46)
+      │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45!null atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:70!null typtype:76 typnotnull:93 typbasetype:94 typtypmod:95 adrelid:103 adnum:104 adbin:105 objoid:108 classoid:109 objsubid:110 description:111 dc.oid:113 dc.relname:114 dc.relnamespace:115 dn.oid:150 dn.nspname:151 row_number:154
+      │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(70), (70)==(46)
       │    ├── window partition=(44) ordering=+49 opt(3,7,44,60)
-      │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:69!null typtype:75 typnotnull:92 typbasetype:93 typtypmod:94 adrelid:102 adnum:103 adbin:104 objoid:107 classoid:108 objsubid:109 description:110 dc.oid:112 dc.relname:113 dc.relnamespace:114 dn.oid:149 dn.nspname:150 row_number:153
-      │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(69), (69)==(46)
+      │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:70!null typtype:76 typnotnull:93 typbasetype:94 typtypmod:95 adrelid:103 adnum:104 adbin:105 objoid:108 classoid:109 objsubid:110 description:111 dc.oid:113 dc.relname:114 dc.relnamespace:115 dn.oid:150 dn.nspname:151 row_number:154
+      │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(70), (70)==(46)
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:69!null typtype:75 typnotnull:92 typbasetype:93 typtypmod:94 adrelid:102 adnum:103 adbin:104 objoid:107 classoid:108 objsubid:109 description:110 dc.oid:112 dc.relname:113 dc.relnamespace:114 dn.oid:149 dn.nspname:150
-      │    │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(69), (69)==(46)
+      │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46!null attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null t.oid:70!null typtype:76 typnotnull:93 typbasetype:94 typtypmod:95 adrelid:103 adnum:104 adbin:105 objoid:108 classoid:109 objsubid:110 description:111 dc.oid:113 dc.relname:114 dc.relnamespace:115 dn.oid:150 dn.nspname:151
+      │    │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7), (46)==(70), (70)==(46)
       │    │    │    ├── scan pg_type [as=t]
-      │    │    │    │    └── columns: t.oid:69!null typtype:75 typnotnull:92 typbasetype:93 typtypmod:94
+      │    │    │    │    └── columns: t.oid:70!null typtype:76 typnotnull:93 typbasetype:94 typtypmod:95
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null adrelid:102 adnum:103 adbin:104 objoid:107 classoid:108 objsubid:109 description:110 dc.oid:112 dc.relname:113 dc.relnamespace:114 dn.oid:149 dn.nspname:150
+      │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null adrelid:103 adnum:104 adbin:105 objoid:108 classoid:109 objsubid:110 description:111 dc.oid:113 dc.relname:114 dc.relnamespace:115 dn.oid:150 dn.nspname:151
       │    │    │    │    ├── fd: ()-->(3,60), (7)==(44), (44)==(7), (2)==(9), (9)==(2)
       │    │    │    │    ├── right-join (hash)
-      │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null adrelid:102 adnum:103 adbin:104 objoid:107 classoid:108 objsubid:109 description:110
+      │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null adrelid:103 adnum:104 adbin:105 objoid:108 classoid:109 objsubid:110 description:111
       │    │    │    │    │    ├── fd: ()-->(3,60), (7)==(44), (44)==(7), (2)==(9), (9)==(2)
       │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: adrelid:102!null adnum:103!null adbin:104
+      │    │    │    │    │    │    ├── columns: adrelid:103!null adnum:104!null adbin:105
       │    │    │    │    │    │    ├── scan pg_attrdef [as=def]
-      │    │    │    │    │    │    │    └── columns: adrelid:102!null adnum:103 adbin:104
+      │    │    │    │    │    │    │    └── columns: adrelid:103!null adnum:104 adbin:105
       │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── adnum:103 > 0 [outer=(103), constraints=(/103: [/1 - ]; tight)]
+      │    │    │    │    │    │         └── adnum:104 > 0 [outer=(104), constraints=(/104: [/1 - ]; tight)]
       │    │    │    │    │    ├── right-join (hash)
-      │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null objoid:107 classoid:108 objsubid:109 description:110
+      │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null objoid:108 classoid:109 objsubid:110 description:111
       │    │    │    │    │    │    ├── fd: ()-->(3,60), (7)==(44), (44)==(7), (2)==(9), (9)==(2)
       │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: objoid:107 classoid:108 objsubid:109!null description:110
+      │    │    │    │    │    │    │    ├── columns: objoid:108 classoid:109 objsubid:110!null description:111
       │    │    │    │    │    │    │    ├── scan pg_description [as=dsc]
-      │    │    │    │    │    │    │    │    └── columns: objoid:107 classoid:108 objsubid:109 description:110
+      │    │    │    │    │    │    │    │    └── columns: objoid:108 classoid:109 objsubid:110 description:111
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── objsubid:109 > 0 [outer=(109), constraints=(/109: [/1 - ]; tight)]
+      │    │    │    │    │    │    │         └── objsubid:110 > 0 [outer=(110), constraints=(/110: [/1 - ]; tight)]
       │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
       │    │    │    │    │    │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7)
@@ -235,39 +235,39 @@ sort
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── c.oid:7 = objoid:107 [outer=(7,107), constraints=(/7: (/NULL - ]; /107: (/NULL - ]), fd=(7)==(107), (107)==(7)]
-      │    │    │    │    │    │         └── attnum:49 = objsubid:109 [outer=(49,109), constraints=(/49: (/NULL - ]; /109: (/NULL - ]), fd=(49)==(109), (109)==(49)]
+      │    │    │    │    │    │         ├── c.oid:7 = objoid:108 [outer=(7,108), constraints=(/7: (/NULL - ]; /108: (/NULL - ]), fd=(7)==(108), (108)==(7)]
+      │    │    │    │    │    │         └── attnum:49 = objsubid:110 [outer=(49,110), constraints=(/49: (/NULL - ]; /110: (/NULL - ]), fd=(49)==(110), (110)==(49)]
       │    │    │    │    │    └── filters
-      │    │    │    │    │         ├── attrelid:44 = adrelid:102 [outer=(44,102), constraints=(/44: (/NULL - ]; /102: (/NULL - ]), fd=(44)==(102), (102)==(44)]
-      │    │    │    │    │         └── attnum:49 = adnum:103 [outer=(49,103), constraints=(/49: (/NULL - ]; /103: (/NULL - ]), fd=(49)==(103), (103)==(49)]
+      │    │    │    │    │         ├── attrelid:44 = adrelid:103 [outer=(44,103), constraints=(/44: (/NULL - ]; /103: (/NULL - ]), fd=(44)==(103), (103)==(44)]
+      │    │    │    │    │         └── attnum:49 = adnum:104 [outer=(49,104), constraints=(/49: (/NULL - ]; /104: (/NULL - ]), fd=(49)==(104), (104)==(49)]
       │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: dc.oid:112!null dc.relname:113!null dc.relnamespace:114 dn.oid:149 dn.nspname:150
-      │    │    │    │    │    ├── fd: ()-->(113)
+      │    │    │    │    │    ├── columns: dc.oid:113!null dc.relname:114!null dc.relnamespace:115 dn.oid:150 dn.nspname:151
+      │    │    │    │    │    ├── fd: ()-->(114)
       │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: dc.oid:112!null dc.relname:113!null dc.relnamespace:114
-      │    │    │    │    │    │    ├── fd: ()-->(113)
+      │    │    │    │    │    │    ├── columns: dc.oid:113!null dc.relname:114!null dc.relnamespace:115
+      │    │    │    │    │    │    ├── fd: ()-->(114)
       │    │    │    │    │    │    ├── scan pg_class [as=dc]
-      │    │    │    │    │    │    │    └── columns: dc.oid:112!null dc.relname:113!null dc.relnamespace:114
+      │    │    │    │    │    │    │    └── columns: dc.oid:113!null dc.relname:114!null dc.relnamespace:115
       │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── dc.relname:113 = 'pg_class' [outer=(113), constraints=(/113: [/'pg_class' - /'pg_class']; tight), fd=()-->(113)]
+      │    │    │    │    │    │         └── dc.relname:114 = 'pg_class' [outer=(114), constraints=(/114: [/'pg_class' - /'pg_class']; tight), fd=()-->(114)]
       │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: dn.oid:149 dn.nspname:150!null
-      │    │    │    │    │    │    ├── fd: ()-->(150)
+      │    │    │    │    │    │    ├── columns: dn.oid:150 dn.nspname:151!null
+      │    │    │    │    │    │    ├── fd: ()-->(151)
       │    │    │    │    │    │    ├── scan pg_namespace [as=dn]
-      │    │    │    │    │    │    │    └── columns: dn.oid:149 dn.nspname:150!null
+      │    │    │    │    │    │    │    └── columns: dn.oid:150 dn.nspname:151!null
       │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── dn.nspname:150 = 'pg_catalog' [outer=(150), constraints=(/150: [/'pg_catalog' - /'pg_catalog']; tight), fd=()-->(150)]
+      │    │    │    │    │    │         └── dn.nspname:151 = 'pg_catalog' [outer=(151), constraints=(/151: [/'pg_catalog' - /'pg_catalog']; tight), fd=()-->(151)]
       │    │    │    │    │    └── filters
-      │    │    │    │    │         └── dc.relnamespace:114 = dn.oid:149 [outer=(114,149), constraints=(/114: (/NULL - ]; /149: (/NULL - ]), fd=(114)==(149), (149)==(114)]
+      │    │    │    │    │         └── dc.relnamespace:115 = dn.oid:150 [outer=(115,150), constraints=(/115: (/NULL - ]; /150: (/NULL - ]), fd=(115)==(150), (150)==(115)]
       │    │    │    │    └── filters
-      │    │    │    │         └── dc.oid:112 = classoid:108 [outer=(108,112), constraints=(/108: (/NULL - ]; /112: (/NULL - ]), fd=(108)==(112), (112)==(108)]
+      │    │    │    │         └── dc.oid:113 = classoid:109 [outer=(109,113), constraints=(/109: (/NULL - ]; /113: (/NULL - ]), fd=(109)==(113), (113)==(109)]
       │    │    │    └── filters
-      │    │    │         └── atttypid:46 = t.oid:69 [outer=(46,69), constraints=(/46: (/NULL - ]; /69: (/NULL - ]), fd=(46)==(69), (69)==(46)]
+      │    │    │         └── atttypid:46 = t.oid:70 [outer=(46,70), constraints=(/46: (/NULL - ]; /70: (/NULL - ]), fd=(46)==(70), (70)==(46)]
       │    │    └── windows
-      │    │         └── row-number [as=row_number:153]
+      │    │         └── row-number [as=row_number:154]
       │    └── filters
       │         └── attname:45 LIKE '%' [outer=(45), constraints=(/45: (/NULL - ])]
       └── projections
-           ├── a.attnotnull:56 OR ((typtype:75 = 'd') AND typnotnull:92) [as=attnotnull:154, outer=(56,75,92)]
-           ├── NULL [as=attidentity:155]
-           └── pg_get_expr(adbin:104, adrelid:102) [as=adsrc:156, outer=(102,104), stable]
+           ├── a.attnotnull:56 OR ((typtype:76 = 'd') AND typnotnull:93) [as=attnotnull:155, outer=(56,76,93)]
+           ├── NULL [as=attidentity:156]
+           └── pg_get_expr(adbin:105, adrelid:103) [as=adsrc:157, outer=(103,105), stable]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -114,8 +114,6 @@ var pgCatalog = virtualSchema{
 		// select distinct '"'||table_name||'",' from information_schema.tables
 		//    where table_schema='pg_catalog' order by table_name;
 		"pg_pltemplate",
-		"pg_statistic",
-		"pg_stats",
 	),
 	tableDefs: map[descpb.ID]virtualSchemaDef{
 		catconstants.PgCatalogAggregateTableID:                  pgCatalogAggregateTable,
@@ -224,7 +222,11 @@ var pgCatalog = virtualSchema{
 		catconstants.PgCatalogStatioUserIndexesTableID:          pgCatalogStatioUserIndexesTable,
 		catconstants.PgCatalogStatioUserSequencesTableID:        pgCatalogStatioUserSequencesTable,
 		catconstants.PgCatalogStatioUserTablesTableID:           pgCatalogStatioUserTablesTable,
+		catconstants.PgCatalogStatisticExtDataTableID:           pgCatalogStatisticExtDataTable,
 		catconstants.PgCatalogStatisticExtTableID:               pgCatalogStatisticExtTable,
+		catconstants.PgCatalogStatisticTableID:                  pgCatalogStatisticTable,
+		catconstants.PgCatalogStatsExtTableID:                   pgCatalogStatsExtTable,
+		catconstants.PgCatalogStatsTableID:                      pgCatalogStatsTable,
 		catconstants.PgCatalogSubscriptionRelTableID:            pgCatalogSubscriptionRelTable,
 		catconstants.PgCatalogSubscriptionTableID:               pgCatalogSubscriptionTable,
 		catconstants.PgCatalogTablesTableID:                     pgCatalogTablesTable,
@@ -442,6 +444,8 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 				tree.DNull,                                       // attfdwoptions
 				// These columns were automatically created by pg_catalog_test's missing column generator.
 				tree.DNull, // atthasmissing
+				// These columns were automatically created by pg_catalog_test's missing column generator.
+				tree.DNull, // attmissingval
 			)
 		}
 
@@ -3854,6 +3858,42 @@ var pgCatalogStatioAllTablesTable = virtualSchemaTable{
 var pgCatalogStatProgressCreateIndexTable = virtualSchemaTable{
 	comment: "pg_stat_progress_create_index was created for compatibility and is currently unimplemented",
 	schema:  vtable.PgCatalogStatProgressCreateIndex,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
+}
+
+var pgCatalogStatisticTable = virtualSchemaTable{
+	comment: "pg_statistic was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStatistic,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
+}
+
+var pgCatalogStatsTable = virtualSchemaTable{
+	comment: "pg_stats was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStats,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
+}
+
+var pgCatalogStatsExtTable = virtualSchemaTable{
+	comment: "pg_stats_ext was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStatsExt,
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+	unimplemented: true,
+}
+
+var pgCatalogStatisticExtDataTable = virtualSchemaTable{
+	comment: "pg_statistic_ext_data was created for compatibility and is currently unimplemented",
+	schema:  vtable.PgCatalogStatisticExtData,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return nil
 	},

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
@@ -2,9 +2,9 @@
   "pgVersion": "13.3",
   "diffSummary": {
     "TotalTables": 129,
-    "TotalColumns": 1130,
-    "MissingTables": 4,
-    "MissingColumns": 1,
+    "TotalColumns": 1192,
+    "MissingTables": 0,
+    "MissingColumns": 0,
     "DatatypeMismatches": 19
   },
   "pgMetadata": {
@@ -15,9 +15,6 @@
         "expectedOid": 24,
         "expectedDataType": "regproc"
       }
-    },
-    "pg_attribute": {
-      "attmissingval": null
     },
     "pg_collation": {
       "collcollate": {
@@ -146,11 +143,7 @@
         "expectedOid": 23,
         "expectedDataType": "int4"
       }
-    },
-    "pg_statistic": {},
-    "pg_statistic_ext_data": {},
-    "pg_stats": {},
-    "pg_stats_ext": {}
+    }
   },
   "unimplementedTypes": null
 }

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -93,6 +93,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attoptions STRING[],
 	attfdwoptions STRING[],
 	atthasmissing BOOL,
+	attmissingval STRING[],
   INDEX(attrelid)
 )`
 
@@ -1921,4 +1922,86 @@ CREATE TABLE pg_catalog.pg_stat_progress_vacuum (
 	max_dead_tuples INT,
 	num_dead_tuples INT,
 	phase STRING
+)`
+
+//PgCatalogStatistic is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStatistic = `
+CREATE TABLE pg_catalog.pg_statistic (
+	stakind2 INT2,
+	stanumbers2 FLOAT4[],
+	stanumbers3 FLOAT4[],
+	staop5 OID,
+	stacoll3 OID,
+	stainherit BOOL,
+	stakind3 INT2,
+	stavalues5 STRING[],
+	staattnum INT2,
+	stacoll1 OID,
+	stacoll4 OID,
+	stanullfrac FLOAT4,
+	stavalues1 STRING[],
+	stawidth INT4,
+	stacoll2 OID,
+	stanumbers4 FLOAT4[],
+	stanumbers5 FLOAT4[],
+	staop2 OID,
+	stavalues3 STRING[],
+	stakind4 INT2,
+	staop1 OID,
+	staop4 OID,
+	stacoll5 OID,
+	stakind5 INT2,
+	staop3 OID,
+	stavalues2 STRING[],
+	stavalues4 STRING[],
+	stakind1 INT2,
+	stanumbers1 FLOAT4[],
+	starelid OID,
+	stadistinct FLOAT4
+)`
+
+//PgCatalogStats is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStats = `
+CREATE TABLE pg_catalog.pg_stats (
+	histogram_bounds STRING[],
+	most_common_elem_freqs FLOAT4[],
+	most_common_elems STRING[],
+	most_common_vals STRING[],
+	attname NAME,
+	inherited BOOL,
+	n_distinct FLOAT4,
+	schemaname NAME,
+	correlation FLOAT4,
+	null_frac FLOAT4,
+	elem_count_histogram FLOAT4[],
+	most_common_freqs FLOAT4[],
+	tablename NAME,
+	avg_width INT4
+)`
+
+//PgCatalogStatsExt is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStatsExt = `
+CREATE TABLE pg_catalog.pg_stats_ext (
+	kinds "char"[],
+	most_common_base_freqs FLOAT[],
+	most_common_freqs FLOAT[],
+	n_distinct BYTES,
+	schemaname NAME,
+	statistics_schemaname NAME,
+	dependencies BYTES,
+	most_common_val_nulls BOOL[],
+	most_common_vals STRING[],
+	statistics_name NAME,
+	statistics_owner NAME,
+	tablename NAME,
+	attnames NAME[]
+)`
+
+//PgCatalogStatisticExtData is an empty table in the pg_catalog that is not implemented yet
+const PgCatalogStatisticExtData = `
+CREATE TABLE pg_catalog.pg_statistic_ext_data (
+	stxddependencies BYTES,
+	stxdmcv BYTES,
+	stxdndistinct BYTES,
+	stxoid OID
 )`


### PR DESCRIPTION
    Previously, tables pg_statistic, pg_statistic_ext_data, pg_stats and
    pg_stats_ext; and column pg_attribute.attmissingval was missing in
    pg_catalog
    This was inadequate because they exists in postgres pg_catalog
    To address this, this patch adds empty stubs for the missing tables
    and column on cockroach pg_catalog
    
    Release note (sql change): Adding empty stubs for tables and columns:
    tables:
    - pg_statistic
    - pg_statistic_ext_data
    - pg_stats
    - pg_stats_ext
    columns:
    - pg_attribute.attmissingval
    
    Resolves #70780
