### PR TITLE
roachprod: add stageurl command

### DIFF
--- a/pkg/cmd/roachprod/install/staging.go
+++ b/pkg/cmd/roachprod/install/staging.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -26,6 +27,55 @@ const (
 	releaseBinaryServer = "https://s3.amazonaws.com/binaries.cockroachdb.com/"
 )
 
+type archInfo struct {
+	// DebugArchitecture is the "target triple" string for debug
+	// builds on the given architecture.
+	DebugArchitecture string
+	// ReleaseArchitecture is the "target triple" string for debug
+	// builds on the given architecture.
+	ReleaseArchitecture string
+	// LibraryExtension is the extensions that dynamic libraries
+	// have on the given architecture.
+	LibraryExtension string
+}
+
+var (
+	linuxArchInfo = archInfo{
+		DebugArchitecture:   "linux-gnu-amd64",
+		ReleaseArchitecture: "linux-amd64",
+		LibraryExtension:    ".so",
+	}
+	darwinArchInfo = archInfo{
+		DebugArchitecture:   "darwin-amd64",
+		ReleaseArchitecture: "darwin-10.9-amd64",
+		LibraryExtension:    ".dylib",
+	}
+	windowsArchInfo = archInfo{
+		DebugArchitecture:   "windows-amd64",
+		ReleaseArchitecture: "windows-6.2-amd64",
+		LibraryExtension:    ".dll",
+	}
+
+	crdbLibraries = []string{"libgeos", "libgeos_c"}
+)
+
+// ArchInfoForOS returns an ArchInfo for the given OS if the OS is
+// currently supported.
+func archInfoForOS(os string) (archInfo, error) {
+	switch os {
+	case "linux":
+		return linuxArchInfo, nil
+	case "darwin":
+		return darwinArchInfo, nil
+	case "windows":
+		return windowsArchInfo, nil
+	default:
+		return archInfo{}, errors.Errorf("no release architecture information for %q", os)
+	}
+}
+
+// GetEdgeURL returns a URL from the edge binary archive. If no SHA is
+// given, the latest version is returned.
 func getEdgeURL(urlPathBase, SHA, arch string, ext string) (*url.URL, error) {
 	edgeBinaryLocation, err := url.Parse(edgeBinaryServer)
 	if err != nil {
@@ -53,6 +103,117 @@ func getEdgeURL(urlPathBase, SHA, arch string, ext string) (*url.URL, error) {
 	return edgeBinaryLocation, nil
 }
 
+// shaFromEdgeURL returns the SHA of the given URL. The SHA is based
+// on the current format of URLs.
+func shaFromEdgeURL(u *url.URL) string {
+	urlSplit := strings.Split(u.Path, ".")
+	return urlSplit[len(urlSplit)-1]
+}
+
+func cockroachReleaseURL(version string, arch string) (*url.URL, error) {
+	binURL, err := url.Parse(releaseBinaryServer)
+	if err != nil {
+		return nil, err
+	}
+	binURL.Path += fmt.Sprintf("cockroach-%s.%s.tgz", version, arch)
+	return binURL, nil
+}
+
+// StageApplication downloads the appropriate artifact for the given
+// application name into the specified directory on each node in the
+// cluster. If no version is specified, the latest artifact is used if
+// available.
+func StageApplication(
+	c *SyncedCluster, applicationName string, version string, os string, destDir string,
+) error {
+	archInfo, err := archInfoForOS(os)
+	if err != nil {
+		return err
+	}
+
+	switch applicationName {
+	case "cockroach":
+		sha, err := StageRemoteBinary(
+			c, applicationName, "cockroach/cockroach", version, archInfo.DebugArchitecture, destDir,
+		)
+		if err != nil {
+			return err
+		}
+		// NOTE: libraries may not be present in older versions.
+		// Use the sha for the binary to download the same remote library.
+		for _, library := range crdbLibraries {
+			if err := StageOptionalRemoteLibrary(
+				c,
+				library,
+				fmt.Sprintf("cockroach/lib/%s", library),
+				sha,
+				archInfo.DebugArchitecture,
+				archInfo.LibraryExtension,
+				destDir,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "workload":
+		_, err := StageRemoteBinary(
+			c, applicationName, "cockroach/workload", version, "" /* arch */, destDir,
+		)
+		return err
+	case "release":
+		return StageCockroachRelease(c, version, archInfo.ReleaseArchitecture, destDir)
+	default:
+		return fmt.Errorf("unknown application %s", applicationName)
+	}
+}
+
+// URLsForApplication returns a slice of URLs that should be
+// downloaded for the given application.
+func URLsForApplication(application string, version string, os string) ([]*url.URL, error) {
+	archInfo, err := archInfoForOS(os)
+	if err != nil {
+		return nil, err
+	}
+
+	switch application {
+	case "cockroach":
+		u, err := getEdgeURL("cockroach/cockroach", version, archInfo.DebugArchitecture, "" /* extension */)
+		if err != nil {
+			return nil, err
+		}
+
+		urls := []*url.URL{u}
+		sha := shaFromEdgeURL(u)
+		for _, library := range crdbLibraries {
+			u, err := getEdgeURL(
+				fmt.Sprintf("cockroach/lib/%s", library),
+				sha,
+				archInfo.DebugArchitecture,
+				archInfo.LibraryExtension,
+			)
+			if err != nil {
+				return nil, err
+			}
+			urls = append(urls, u)
+		}
+		return urls, nil
+	case "workload":
+		u, err := getEdgeURL("cockroach/workload", version, "" /* arch */, "" /* extension */)
+		if err != nil {
+			return nil, err
+		}
+		return []*url.URL{u}, nil
+	case "release":
+		u, err := cockroachReleaseURL(version, archInfo.ReleaseArchitecture)
+		if err != nil {
+			return nil, err
+		}
+		return []*url.URL{u}, nil
+	default:
+		return nil, fmt.Errorf("unknown application %s", application)
+	}
+}
+
 // StageRemoteBinary downloads a cockroach edge binary with the provided
 // application path to each specified by the cluster to the specified directory.
 // If no SHA is specified, the latest build of the binary is used instead.
@@ -65,12 +226,11 @@ func StageRemoteBinary(
 		return "", err
 	}
 	fmt.Printf("Resolved binary url for %s: %s\n", applicationName, binURL)
-	urlSplit := strings.Split(binURL.Path, ".")
 	target := filepath.Join(dir, applicationName)
 	cmdStr := fmt.Sprintf(
 		`curl -sfSL -o "%s" "%s" && chmod 755 %s`, target, binURL, target,
 	)
-	return urlSplit[len(urlSplit)-1], c.Run(
+	return shaFromEdgeURL(binURL), c.Run(
 		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
 }
@@ -110,11 +270,10 @@ func StageCockroachRelease(c *SyncedCluster, version, arch, dir string) error {
 			"release application cannot be staged without specifying a specific version",
 		)
 	}
-	binURL, err := url.Parse(releaseBinaryServer)
+	binURL, err := cockroachReleaseURL(version, arch)
 	if err != nil {
 		return err
 	}
-	binURL.Path += fmt.Sprintf("cockroach-%s.%s.tgz", version, arch)
 	fmt.Printf("Resolved release url for cockroach version %s: %s\n", version, binURL)
 
 	// This command incantation:

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1362,6 +1362,42 @@ var downloadCmd = &cobra.Command{
 	}),
 }
 
+var stageURLCmd = &cobra.Command{
+	Use:   "stageurl <application> [<sha/version>]",
+	Short: "print URL to cockroach binaries",
+	Long: `Prints URL for release and edge binaries.
+
+Currently available application options are:
+  cockroach - Cockroach Unofficial. Can provide an optional SHA, otherwise
+              latest build version is used.
+  workload  - Cockroach workload application.
+  release   - Official CockroachDB Release. Must provide a specific release
+              version.
+`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		applicationName := args[0]
+		versionArg := ""
+		if len(args) == 2 {
+			versionArg = args[1]
+		}
+
+		os := runtime.GOOS
+		if stageOS != "" {
+			os = stageOS
+		}
+
+		urls, err := install.URLsForApplication(applicationName, versionArg, os)
+		if err != nil {
+			return err
+		}
+		for _, u := range urls {
+			fmt.Println(u)
+		}
+		return nil
+	}),
+}
+
 var stageCmd = &cobra.Command{
 	Use:   "stage <cluster> <application> [<sha/version>]",
 	Short: "stage cockroach binaries",
@@ -1397,17 +1433,6 @@ Some examples of usage:
 		} else if c.IsLocal() {
 			os = runtime.GOOS
 		}
-		var debugArch, releaseArch, libExt string
-		switch os {
-		case "linux":
-			debugArch, releaseArch, libExt = "linux-gnu-amd64", "linux-amd64", ".so"
-		case "darwin":
-			debugArch, releaseArch, libExt = "darwin-amd64", "darwin-10.9-amd64", ".dylib"
-		case "windows":
-			debugArch, releaseArch, libExt = "windows-amd64", "windows-6.2-amd64", ".dll"
-		default:
-			return errors.Errorf("cannot stage binary on %s", os)
-		}
 
 		dir := "."
 		if stageDir != "" {
@@ -1419,40 +1444,7 @@ Some examples of usage:
 		if len(args) == 3 {
 			versionArg = args[2]
 		}
-		switch applicationName {
-		case "cockroach":
-			sha, err := install.StageRemoteBinary(
-				c, applicationName, "cockroach/cockroach", versionArg, debugArch, dir,
-			)
-			if err != nil {
-				return err
-			}
-			// NOTE: libraries may not be present in older versions.
-			// Use the sha for the binary to download the same remote library.
-			for _, library := range []string{"libgeos", "libgeos_c"} {
-				if err := install.StageOptionalRemoteLibrary(
-					c,
-					library,
-					fmt.Sprintf("cockroach/lib/%s", library),
-					sha,
-					debugArch,
-					libExt,
-					dir,
-				); err != nil {
-					return err
-				}
-			}
-			return nil
-		case "workload":
-			_, err := install.StageRemoteBinary(
-				c, applicationName, "cockroach/workload", versionArg, "" /* arch */, dir,
-			)
-			return err
-		case "release":
-			return install.StageCockroachRelease(c, versionArg, releaseArch, dir)
-		default:
-			return fmt.Errorf("unknown application %s", applicationName)
-		}
+		return install.StageApplication(c, applicationName, versionArg, os, dir)
 	}),
 }
 
@@ -1841,6 +1833,7 @@ func main() {
 		putCmd,
 		getCmd,
 		stageCmd,
+		stageURLCmd,
 		downloadCmd,
 		sqlCmd,
 		ipCmd,
@@ -2004,6 +1997,8 @@ func main() {
 
 	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
 	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
+
+	stageURLCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
 
 	logsCmd.Flags().StringVar(
 		&logsFilter, "filter", "", "re to filter log messages")


### PR DESCRIPTION
Sometimes it is useful to be able to download these artifacts
directly. For example, when trying to bisect a problem. But, the URL
can take a second to remember the format of.

The stageurl command prints the staging URL of the given application.

I've reorganized some of the code to reduce duplication between the
stage and stageurl command. There is still more duplication than I
would like. But I figured I would see if this seems useful to others
before further refactoring.

Release note: None