### PR TITLE
sqlsmith, tests: Compare result sets in TLP testing

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -184,6 +184,7 @@ go_library(
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_golang_mock//gomock",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_jackc_pgtype//:pgtype",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",


### PR DESCRIPTION
Previously, only the result counts of the unpartitioned
and partitioned TLP queries were compared. This was inadequate
because it allowed for different rows values in the two result sets
to go undetected, as long as the row counts were the same.
To address this, the rows in the result sets are compared
directly to ensure they are the same, as expected.

Release note: None