### PR TITLE
dev: fix bug when doing `dev build -- extra_arg1 [extra_arg2 ...]`

### DIFF
--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -81,3 +81,16 @@ mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
+
+dev build -- --verbose_failures --sandbox_debug
+----
+getenv PATH
+which cc
+readlink /usr/local/opt/ccache/libexec/cc
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug
+bazel info workspace --color=no
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no
+rm go/src/github.com/cockroachdb/cockroach/cockroach
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach/cockroach_/cockroach go/src/github.com/cockroachdb/cockroach/cockroach

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -242,3 +242,38 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
+
+getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/cockroach
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach/cockroach_/cockroach go/src/github.com/cockroachdb/cockroach/cockroach
+----

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -187,10 +187,12 @@ func splitArgsAtDash(cmd *cobra.Command, args []string) (before, after []string)
 	argsLenAtDash := cmd.ArgsLenAtDash()
 	if argsLenAtDash < 0 {
 		// If there's no dash, the value of this is -1.
-		before = args
+		before = args[:len(args):len(args)]
 	} else {
-		before = args[0:argsLenAtDash]
-		after = args[argsLenAtDash:]
+		// NB: Have to do this verbose slicing to force Go to copy the
+		// memory. Otherwise later `append`s will break stuff.
+		before = args[0:argsLenAtDash:argsLenAtDash]
+		after = args[argsLenAtDash : len(args) : len(args)-argsLenAtDash+1]
 	}
 	return
 }


### PR DESCRIPTION
A quirk of how `append` works was making this case break. Updating the
slice syntax slightly fixes it.

Release note: None