### PR TITLE
dev: refactor `setupPath` test in `dev`

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -33,7 +33,10 @@ go_binary(
 
 go_test(
     name = "dev_test",
-    srcs = ["datadriven_test.go"],
+    srcs = [
+        "datadriven_test.go",
+        "dev_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":dev_lib"],
     deps = [

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	isTesting = true
-}
-
 // TestDatadriven makes use of datadriven to play back all operations executed
 // by individual `dev` invocations. The testcases are defined under testdata/*,
 // where each test files corresponds to a recording capture found in
@@ -88,7 +84,6 @@ func TestDatadriven(t *testing.T) {
 			dev := makeDevCmd()
 			dev.exec = devExec
 			dev.os = devOS
-			require.NoError(t, setupPath(dev))
 
 			if !verbose {
 				dev.cli.SetErr(ioutil.Discard)

--- a/pkg/cmd/dev/dev_test.go
+++ b/pkg/cmd/dev/dev_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/os"
+	"github.com/cockroachdb/cockroach/pkg/cmd/dev/recording"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	isTesting = true
+}
+
+func TestSetupPath(t *testing.T) {
+	rec := `getenv PATH
+----
+/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+
+which cc
+----
+/usr/local/opt/ccache/libexec/cc
+
+readlink /usr/local/opt/ccache/libexec/cc
+----
+../bin/ccache
+
+export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
+----
+
+`
+	r := recording.WithReplayFrom(strings.NewReader(rec), "TestSetupPath")
+	var logger io.ReadWriter = bytes.NewBufferString("")
+	var exopts []exec.Option
+	exopts = append(exopts, exec.WithRecording(r))
+	exopts = append(exopts, exec.WithLogger(log.New(logger, "", 0)))
+	var osopts []os.Option
+	osopts = append(osopts, os.WithRecording(r))
+	osopts = append(osopts, os.WithLogger(log.New(logger, "", 0)))
+	devExec := exec.New(exopts...)
+	devOS := os.New(osopts...)
+	dev := makeDevCmd()
+	dev.exec = devExec
+	dev.os = devOS
+
+	require.NoError(t, setupPath(dev))
+}

--- a/pkg/cmd/dev/testdata/bench.txt
+++ b/pkg/cmd/dev/testdata/bench.txt
@@ -1,17 +1,9 @@
 dev bench pkg/util/...
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 git grep -l ^func Benchmark -- pkg/util/*_test.go
 bazel run --config=test --test_sharding_strategy=disabled //pkg/util:util_test -- -test.run=- -test.bench=.
 bazel run --config=test --test_sharding_strategy=disabled //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
 
 dev bench pkg/sql/parser --filter=BenchmarkParse
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel run --config=test --test_sharding_strategy=disabled //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -1,9 +1,5 @@
 dev build cockroach-short
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -13,10 +9,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --cpus=12
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -26,10 +18,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build --debug cockroach-short
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -39,10 +27,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --remote-cache 127.0.0.1:9090
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -52,10 +36,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --hoist-generated-code
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build //pkg/cmd/cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -71,10 +51,6 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 
 dev build short -- -s
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build //pkg/cmd/cockroach-short -s
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
@@ -84,10 +60,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build -- --verbose_failures --sandbox_debug
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -1,9 +1,5 @@
 dev builder
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 id
 bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
@@ -13,10 +9,6 @@ docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --work
 
 dev builder echo hi
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 id
 bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -1,18 +1,10 @@
 dev gen bazel
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel info workspace --color=no
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh
 
 dev gen docs
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/docs/generated/bazel_targets.txt
 bazel build //docs/generated:gen-logging-md //docs/generated/sql
@@ -29,10 +21,6 @@ echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/gene
 
 dev gen go
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/bazelutil/checked_in_genfiles.txt
 bazel build //pkg/roachpb:gen-batch-generated //pkg/sql/opt/optgen/lang:gen-expr //pkg/sql/opt/optgen/lang:gen-operator

--- a/pkg/cmd/dev/testdata/lint.txt
+++ b/pkg/cmd/dev/testdata/lint.txt
@@ -1,15 +1,7 @@
 dev lint
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel run --config=test //build/bazelutil:lint -- -test.v
 
 dev lint --short --timeout=5m
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel run --config=test //build/bazelutil:lint -- -test.v -test.short -test.timeout 5m0s

--- a/pkg/cmd/dev/testdata/recording/bench.txt
+++ b/pkg/cmd/dev/testdata/recording/bench.txt
@@ -1,18 +1,3 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 git grep -l ^func Benchmark -- pkg/util/*_test.go
 ----
 pkg/util/topk_test.go
@@ -24,21 +9,6 @@ bazel run --config=test --test_sharding_strategy=disabled //pkg/util:util_test -
 ----
 
 bazel run --config=test --test_sharding_strategy=disabled //pkg/util/uuid:uuid_test -- -test.run=- -test.bench=.
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel run --config=test --test_sharding_strategy=disabled //pkg/sql/parser:parser_test -- -test.run=- -test.bench=BenchmarkParse

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -1,18 +1,3 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel build //pkg/cmd/cockroach-short
 ----
 
@@ -31,21 +16,6 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
@@ -68,21 +38,6 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel build //pkg/cmd/cockroach-short
 ----
 
@@ -103,21 +58,6 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
 ----
 
@@ -136,21 +76,6 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel build //pkg/cmd/cockroach-short
@@ -208,21 +133,6 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/operator-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator.og.go
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel build //pkg/cmd/cockroach-short -s
 ----
 
@@ -241,21 +151,6 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -1,18 +1,3 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 id
 ----
 1001:1002
@@ -32,21 +17,6 @@ mkdir go/src/github.com/cockroachdb/cockroach/artifacts
 ----
 
 docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --workdir=/cockroach -v go/src/github.com/cockroachdb/cockroach/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 1001:1002 mock_bazel_image:1234
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 id

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -1,38 +1,8 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel info workspace --color=no
@@ -130,21 +100,6 @@ go/src/github.com/cockroachdb/cockroach/build/bazelutil/generate_redact_safe.sh
 MOCK_REDACT_SAFE_OUTPUT
 
 echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/generated/redact_safe.md
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel info workspace --color=no

--- a/pkg/cmd/dev/testdata/recording/lint.txt
+++ b/pkg/cmd/dev/testdata/recording/lint.txt
@@ -1,34 +1,4 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel run --config=test //build/bazelutil:lint -- -test.v
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel run --config=test //build/bazelutil:lint -- -test.v -test.short -test.timeout 5m0s

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -1,18 +1,3 @@
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel test //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
@@ -20,21 +5,6 @@ bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 Executed 1 out of 1 test: 1 test passes.
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel query kind(go_test,  //pkg/util/tracing/...)
@@ -50,21 +20,6 @@ Executed 0 out of 1 test: 1 test passes.
 ----
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
@@ -72,21 +27,6 @@ bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --tes
 
 Executed 1 out of 1 test: 1 test passes.
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
@@ -102,21 +42,6 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 ----
 ----
@@ -124,21 +49,6 @@ bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experi
 
 Executed 0 out of 1 test: 1 test passes.
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel test //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
@@ -150,21 +60,6 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-----
-
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 ----
 ----
@@ -172,21 +67,6 @@ bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --r
 
 Executed 1 out of 1 test: 1 test passes.
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
@@ -202,21 +82,6 @@ SUCCESS
 
 Executed 1 out of 1 test: 1 test passes.
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
@@ -242,21 +107,6 @@ Executed 1 out of 1 test: 1 test passes.
 [32mINFO:[0m Build completed successfully, 3 total actions
 [0m
 ----
-----
-
-getenv PATH
-----
-/usr/local/opt/ccache/libexec:/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
-
-which cc
-----
-/usr/local/opt/ccache/libexec/cc
-
-readlink /usr/local/opt/ccache/libexec/cc
-----
-../bin/ccache
-
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 ----
 
 bazel test -s //pkg/util/tracing:tracing_test --test_output errors

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -1,80 +1,40 @@
 dev test pkg/util/tracing
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing/...
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel query kind(go_test,  //pkg/util/tracing/...)
 bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*'
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' -v
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test pkg/util/tracing -f 'TestStartChild*' --remote-cache 127.0.0.1:9092
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test --test_filter='TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f 'TestStartChild*' --ignore-cache
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test //pkg/util/tracing:tracing_test --nocache_test_results --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*'
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress  --test_filter='TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter 'TestStartChild*' --timeout=10s -v
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under @com_github_cockroachdb_stress//:stress -maxtime=10s  --test_timeout=11 --test_filter='TestStartChild*' --test_output all --test_arg -test.v
 
 dev test //pkg/testutils --timeout=10s
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
 
 dev test pkg/util/tracing -- -s
 ----
-getenv PATH
-which cc
-readlink /usr/local/opt/ccache/libexec/cc
-export PATH=/usr/local/opt/make/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin
 bazel test -s //pkg/util/tracing:tracing_test --test_output errors


### PR DESCRIPTION
We used to run this on every single test case in `dev`, which would
require copy-pasting a bunch of boilerplate every time you add a test
case. Instead refactor the `setupPath` test out on its own and test it
just once.

Release note: None