### PR TITLE
sql: implement information_schema.{_pg_numeric_precision,_pg_numeric_precision_radix,_pg_numeric_scale}

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3152,6 +3152,12 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="has_type_privilege"></a><code>has_type_privilege(user: oid, type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for type.</p>
 </span></td></tr>
+<tr><td><a name="information_schema._pg_numeric_precision"></a><code>information_schema._pg_numeric_precision(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the precision of the given type with type modifier</p>
+</span></td></tr>
+<tr><td><a name="information_schema._pg_numeric_precision_radix"></a><code>information_schema._pg_numeric_precision_radix(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the radix of the given type with type modifier</p>
+</span></td></tr>
+<tr><td><a name="information_schema._pg_numeric_scale"></a><code>information_schema._pg_numeric_scale(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the scale of the given type with type modifier</p>
+</span></td></tr>
 <tr><td><a name="oid"></a><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
 </span></td></tr>
 <tr><td><a name="pg_collation_for"></a><code>pg_collation_for(str: anyelement) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the collation of the argument</p>

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -537,3 +537,44 @@ indexed_b_d_idx  {2,4}  1  NULL
 indexed_b_d_idx  {2,4}  2  1
 indexed_b_d_idx  {2,4}  3  NULL
 indexed_b_d_idx  {2,4}  4  2
+
+# information_schema._pg_numeric_precision and information_schema._pg_numeric_precision_radix
+# and information_schema._pg_numeric_scale
+
+statement ok
+CREATE TABLE numeric (
+  a SMALLINT,
+  b INT4,
+  c BIGINT,
+  d FLOAT(1),
+  e FLOAT4,
+  f FLOAT8,
+  g FLOAT(40),
+  h FLOAT,
+  i DECIMAL(12,2),
+  j DECIMAL(4,4)
+);
+
+query TTIII
+SELECT a.attname,
+       t.typname,
+       information_schema._pg_numeric_precision(a.atttypid,a.atttypmod),
+       information_schema._pg_numeric_precision_radix(a.atttypid,a.atttypmod),
+       information_schema._pg_numeric_scale(a.atttypid,a.atttypmod)
+FROM pg_attribute a
+JOIN pg_type t
+ON a.atttypid = t.oid
+WHERE a.attrelid = 'numeric'::regclass
+ORDER BY a.attname
+----
+a      int2     16  2   0
+b      int4     32  2   0
+c      int8     64  2   0
+d      float4   24  2   NULL
+e      float4   24  2   NULL
+f      float8   53  2   NULL
+g      float8   53  2   NULL
+h      float8   53  2   NULL
+i      numeric  12  10  2
+j      numeric  4   10  4
+rowid  int8     64  2   0


### PR DESCRIPTION
fixes #70872 

This commit adds implementation for the `information_schema._pg_numeric_precision`, `information_schema._pg_numeric_precision_radix` and `information_schema._pg_numeric_scale` builtin functions. 

These functions return the precision, and scale of an exact numeric type as well as the base the precision and scale are in.

Release note (sql change): The `information_schema._pg_numeric_precision`, `information_schema._pg_numeric_precision_radix` and `information_schema._pg_numeric_scale` builtin functions are nowsupported, which improves compatability with PostgreSQL.