### PR TITLE
[DNM] sql: index pg_catalog.pg_namespace.nspname

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1944,30 +1944,56 @@ var pgCatalogNamespaceTable = virtualSchemaTable{
 	comment: `available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
 https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 	schema: vtable.PGCatalogNamespace,
+	indexes: []virtualIndex{
+		{
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
+				if constraint == tree.DNull {
+					return false, nil
+				}
+				cs := constraint.(*tree.DString)
+				sc, err := p.Descriptors().GetSchemaByName(ctx, p.Txn(), db, *(*string)(cs), tree.SchemaLookupFlags{
+					Required: false,
+				})
+				if err != nil || sc == nil {
+					return false, err
+				}
+				return true, addNamespaceRow(makeOidHasher(), db, sc, addRow)
+			},
+		},
+	},
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, db, func(sc catalog.SchemaDescriptor) error {
-					ownerOID := tree.DNull
-					if sc.SchemaKind() == catalog.SchemaUserDefined {
-						ownerOID = getOwnerOID(sc)
-					} else if sc.SchemaKind() == catalog.SchemaPublic {
-						// admin is the owner of the public schema.
-						//
-						// TODO(ajwerner): The public schema effectively carries the privileges
-						// of the database so consider using the database's owner for public.
-						ownerOID = h.UserOid(security.MakeSQLUsernameFromPreNormalizedString("admin"))
-					}
-					return addRow(
-						h.NamespaceOid(db.GetID(), sc.GetName()), // oid
-						tree.NewDString(sc.GetName()),            // nspname
-						ownerOID,                                 // nspowner
-						tree.DNull,                               // nspacl
-					)
+					return addNamespaceRow(h, db, sc, addRow)
 				})
 			})
 	},
+}
+
+func addNamespaceRow(
+	h oidHasher,
+	db catalog.DatabaseDescriptor,
+	sc catalog.SchemaDescriptor,
+	addRow func(...tree.Datum) error,
+) error {
+	ownerOID := tree.DNull
+	if sc.SchemaKind() == catalog.SchemaUserDefined {
+		ownerOID = getOwnerOID(sc)
+	} else if sc.SchemaKind() == catalog.SchemaPublic {
+		// admin is the owner of the public schema.
+		//
+		// TODO(ajwerner): The public schema effectively carries the privileges
+		// of the database so consider using the database's owner for public.
+		ownerOID = h.UserOid(security.MakeSQLUsernameFromPreNormalizedString("admin"))
+	}
+	return addRow(
+		h.NamespaceOid(db.GetID(), sc.GetName()), // oid
+		tree.NewDString(sc.GetName()),            // nspname
+		ownerOID,                                 // nspowner
+		tree.DNull,                               // nspacl
+	)
 }
 
 var (

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -507,7 +507,8 @@ CREATE TABLE pg_catalog.pg_namespace (
 	oid OID,
 	nspname NAME NOT NULL,
 	nspowner OID,
-	nspacl STRING[]
+	nspacl STRING[],
+	INDEX (nspname)
 )`
 
 // PGCatalogOpclass describes the schema of the pg_catalog.pg_opclass table.


### PR DESCRIPTION
This adds a virtual index to enable point lookups against pg_namespace.

This approach is even better than just doing a point lookup, it also leverages
leases. That can run into other consistency problems that we aren't going to
think too hard about right now because there's some issues to fix thim in
this release. It's going to turn N lookups and descriptor constructions into
0.

Release note: None