### PR TITLE
sql: make diff tool to fail when no diff and there is an expected diff

### DIFF
--- a/pkg/sql/pg_metadata_diff.go
+++ b/pkg/sql/pg_metadata_diff.go
@@ -125,28 +125,48 @@ func (p PGMetadataTables) addDiff(
 	})
 }
 
-// isDiffOid verifies if there is a datatype mismatch or if the diff is an expected diff
-func (p PGMetadataTables) isDiffOid(
+// Not using error interface because message is not relevant
+type compareResult int
+
+const (
+	success compareResult = 1 + iota
+	expectedDiffError
+	diffError
+)
+
+// compareColumns verifies if there is a datatype mismatch or if the diff is an expected diff
+func (p PGMetadataTables) compareColumns(
 	tableName string, columnName string, expected *PGMetadataColumnType, actual *PGMetadataColumnType,
-) bool {
+) compareResult {
 	// MySQL don't have oid as they are in postgres so we can't compare oids.
-	if expected.Oid == 0 || expected.Oid == actual.Oid {
-		return false
+	if expected.Oid == 0 {
+		return 0
 	}
 
+	expectedDiff := p.getExpectedDiff(tableName, columnName)
+
+	if actual.Oid == expected.Oid {
+		if expectedDiff != nil {
+			// Need to update JSON file
+			return expectedDiffError
+		}
+	} else if expectedDiff == nil || expectedDiff.Oid != actual.Oid ||
+		*expectedDiff.ExpectedOid != expected.Oid {
+		// This diff is not expected
+		return diffError
+	}
+
+	return success
+}
+
+// If there is an expected diff for a table.column it will return it
+func (p PGMetadataTables) getExpectedDiff(tableName, columnName string) *PGMetadataColumnType {
 	columns, ok := p[tableName]
 	if !ok {
-		return true
+		return nil
 	}
 
-	// For columns that are expected to be missing, the diff is stored as nil
-	// and is present in the map.
-	diff, ok := columns[columnName]
-	if !ok || diff == nil {
-		return true
-	}
-
-	return !(diff.Oid == actual.Oid && *diff.ExpectedOid == expected.Oid)
+	return columns[columnName]
 }
 
 // isExpectedMissingTable is used by the diff PGMetadataTables to verify whether missing a table in cockroach is expected


### PR DESCRIPTION
Previously, diff tool didn't fail when there was an expected diff but
the diff was fixed
This was inadequate because, we need to keep the expected diffs
up-to-date
To address this, this patch enforces to run with --rewrite-diffs to
update expected diffs JSON when needed

Release note: None