### PR TITLE
sql: Enable telemetry query_sampling by default

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -110,7 +111,13 @@ var adminAuditLogEnabled = settings.RegisterBoolSetting(
 var telemetryLoggingEnabled = settings.RegisterBoolSetting(
 	"sql.telemetry.query_sampling.enabled",
 	"when set to true, executed queries will emit an event on the telemetry logging channel",
-	false,
+	// Note: Usage of an env var here makes it possible to set a default without
+	// the execution of a cluster setting SQL query. This is particularly advantageous
+	// when cluster setting queries would be too inefficient or to slow to use. For
+	// example, in multi-tenant setups in CC, it is impractical to enable this
+	// setting directly after tenant creation without significant overhead in terms
+	// of time and code.
+	envutil.EnvOrDefaultBool("COCKROACH_SQL_TELEMETRY_QUERY_SAMPLING_ENABLED", false),
 ).WithPublic()
 
 type executorType int


### PR DESCRIPTION
  This commit changes the default for the
  "sql.telemetry.query_sampling.enabled" setting to true. The CC team
  would like this setting enabled by default as turning it on per tenant
  cluster during cluster creation and before any SQL is processed is
  inefficient in a number of ways.

Release note: None

Closes #70775 