### PR TITLE
release-21.2: ui/cluster-ui: add 'Interval Start Time' column to stmts/txns tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -118,6 +118,8 @@ const statementStats: any = {
   exec_stats: execStats,
 };
 
+const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
+
 export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   history,
   location: {
@@ -146,6 +148,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
     byNode: [
       {
         label: "4",
+        aggregatedTs,
         implicitTxn: true,
         database: "defaultdb",
         fullScan: true,
@@ -153,6 +156,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
       },
       {
         label: "3",
+        aggregatedTs,
         implicitTxn: true,
         database: "defaultdb",
         fullScan: true,
@@ -160,6 +164,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
       },
       {
         label: "2",
+        aggregatedTs,
         implicitTxn: true,
         database: "defaultdb",
         fullScan: true,
@@ -167,6 +172,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
       },
       {
         label: "1",
+        aggregatedTs,
         implicitTxn: true,
         database: "defaultdb",
         fullScan: true,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -34,6 +34,7 @@ import {
   calculateTotalWorkload,
   unique,
   queryByName,
+  aggregatedTsAttr,
 } from "src/util";
 import { Loading } from "src/loading";
 import { Button } from "src/button";
@@ -517,6 +518,13 @@ export class StatementDetails extends React.Component<
         <span className={cx("tooltip-info")}>unavailable</span>
       </Tooltip>
     );
+
+    // If the aggregatedTs is unset, we are aggregating over the whole date range.
+    const aggregatedTs = queryByName(this.props.location, aggregatedTsAttr);
+    const intervalStartTime = aggregatedTs
+      ? moment.unix(parseInt(aggregatedTs)).utc()
+      : this.props.dateRange[0];
+
     return (
       <Tabs
         defaultActiveKey="1"
@@ -628,6 +636,11 @@ export class StatementDetails extends React.Component<
             <Col className="gutter-row" span={8}>
               <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Statement details</Heading>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Interval start time</Text>
+                  <Text>{intervalStartTime.format("MMM D, h:mm A (UTC)")}</Text>
+                </div>
+
                 {!isTenant && (
                   <div>
                     <div className={summaryCardStylesCx("summary--card__item")}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -239,6 +239,8 @@ const diagnosticsReportsInProgress: IStatementDiagnosticsReport[] = [
   },
 ];
 
+const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
+
 const statementsPagePropsFixture: StatementsPageProps = {
   history,
   location: {
@@ -264,6 +266,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -271,6 +274,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -279,6 +283,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -287,6 +292,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -294,6 +300,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -301,6 +308,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT city, id FROM vehicles WHERE city = $1",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: true,
@@ -309,6 +317,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -317,6 +326,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -325,6 +335,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -332,6 +343,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO users VALUES ($1, $2, __more3__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -340,6 +352,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: true,
@@ -347,6 +360,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -354,6 +368,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -362,6 +377,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -369,6 +385,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SHOW database",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -378,6 +395,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -385,6 +403,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE users SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -392,6 +411,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -400,6 +420,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -408,6 +429,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -415,6 +437,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -422,6 +445,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -429,6 +453,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: 'SET CLUSTER SETTING "cluster.organization" = $1',
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -437,6 +462,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -445,6 +471,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -453,6 +480,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -460,6 +488,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -467,6 +496,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -474,6 +504,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SET sql_safe_updates = _",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -482,6 +513,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -490,6 +522,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -497,6 +530,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT * FROM crdb_internal.node_build_info",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -505,6 +539,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label: "CREATE DATABASE movr",
       implicitTxn: true,
+      aggregatedTs,
       database: "defaultdb",
       fullScan: false,
       stats: statementStats,
@@ -513,6 +548,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -520,6 +556,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: 'SET CLUSTER SETTING "enterprise.license" = $1',
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -528,6 +565,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -536,6 +574,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -544,6 +583,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -551,6 +591,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -558,6 +599,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -566,6 +608,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,
@@ -573,6 +616,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
+      aggregatedTs,
       implicitTxn: true,
       database: "defaultdb",
       fullScan: false,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -33,6 +33,7 @@ import { AggregateStatistics } from "../statementsTable";
 type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 export interface StatementsSummaryData {
   statement: string;
+  aggregatedTs: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;
@@ -138,7 +139,8 @@ export const selectStatements = createSelector(
     props: RouteComponentProps<any>,
     diagnosticsReportsPerStatement,
   ): AggregateStatistics[] => {
-    if (!state.data) {
+    // State is valid if we successfully fetched data, and the data has not yet been invalidated.
+    if (!state.data || !state.valid) {
       return null;
     }
     let statements = flattenStatementStats(state.data.statements);
@@ -169,6 +171,7 @@ export const selectStatements = createSelector(
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
           statement: stmt.statement,
+          aggregatedTs: stmt.aggregated_ts,
           implicitTxn: stmt.implicit_txn,
           fullScan: stmt.full_scan,
           database: stmt.database,
@@ -182,6 +185,7 @@ export const selectStatements = createSelector(
       const stmt = statsByStatementKey[key];
       return {
         label: stmt.statement,
+        aggregatedTs: stmt.aggregatedTs,
         implicitTxn: stmt.implicitTxn,
         fullScan: stmt.fullScan,
         database: stmt.database,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -42,6 +42,7 @@ import {
   statisticsTableTitles,
   NodeNames,
   StatisticType,
+  formatStartIntervalColumn,
 } from "../statsTableUtil/statsTableUtil";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
@@ -87,6 +88,14 @@ function makeCommonColumns(
   const retryBar = retryBarChart(statements, defaultBarChartOptions);
 
   return [
+    {
+      name: "intervalStartTime",
+      title: statisticsTableTitles.intervalStartTime(statType),
+      className: cx("statements-table__interval_time"),
+      cell: (stmt: AggregateStatistics) =>
+        formatStartIntervalColumn(stmt.aggregatedTs),
+      sort: (stmt: AggregateStatistics) => stmt.aggregatedTs,
+    },
     {
       name: "executionCount",
       title: statisticsTableTitles.executionCount(statType),
@@ -181,6 +190,7 @@ function makeCommonColumns(
 export interface AggregateStatistics {
   // label is either shortStatement (StatementsPage) or nodeId (StatementDetails).
   label: string;
+  aggregatedTs: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -25,6 +25,7 @@ import { Tooltip } from "@cockroachlabs/ui-components";
 import {
   appAttr,
   databaseAttr,
+  aggregatedTsAttr,
   propsToQueryString,
   summarize,
   TimestampToMoment,
@@ -47,6 +48,7 @@ export const StatementTableCell = {
   ) => (stmt: any) => (
     <StatementLink
       statement={stmt.label}
+      aggregatedTs={stmt.aggregatedTs}
       database={stmt.database}
       implicitTxn={stmt.implicitTxn}
       search={search}
@@ -129,6 +131,7 @@ export const StatementTableCell = {
 
 type StatementLinkTargetProps = {
   statement: string;
+  aggregatedTs?: number;
   app: string;
   implicitTxn: boolean;
   statementNoConstants?: string;
@@ -146,12 +149,14 @@ export const StatementLinkTarget = (
   const searchParams = propsToQueryString({
     [databaseAttr]: props.database,
     [appAttr]: props.app,
+    [aggregatedTsAttr]: props.aggregatedTs,
   });
 
   return `${base}/${encodeURIComponent(linkStatement)}?${searchParams}`;
 };
 
 interface StatementLinkProps {
+  aggregatedTs?: number;
   statement: string;
   app: string;
   implicitTxn: boolean;
@@ -161,11 +166,17 @@ interface StatementLinkProps {
   onClick?: (statement: string) => void;
 }
 
-export const StatementLink = (
-  props: StatementLinkProps,
-): React.ReactElement => {
-  const summary = summarize(props.statement);
-  const { onClick, statement } = props;
+export const StatementLink = ({
+  aggregatedTs,
+  statement,
+  app,
+  implicitTxn,
+  search,
+  statementNoConstants,
+  database,
+  onClick,
+}: StatementLinkProps): React.ReactElement => {
+  const summary = summarize(statement);
   const onStatementClick = React.useCallback(() => {
     if (onClick) {
       onClick(statement);
@@ -173,11 +184,12 @@ export const StatementLink = (
   }, [onClick, statement]);
 
   const linkProps = {
-    statement: props.statement,
-    app: props.app,
-    implicitTxn: props.implicitTxn,
-    statementNoConstants: props.statementNoConstants,
-    database: props.database,
+    aggregatedTs,
+    statement,
+    app,
+    implicitTxn,
+    statementNoConstants,
+    database,
   };
 
   return (
@@ -187,14 +199,14 @@ export const StatementLink = (
           placement="bottom"
           content={
             <pre className={cx("cl-table-link__description")}>
-              {getHighlightedText(props.statement, props.search, true)}
+              {getHighlightedText(statement, search, true)}
             </pre>
           }
         >
           <div className="cl-table-link__tooltip-hover-area">
             {getHighlightedText(
-              shortStatement(summary, props.statement),
-              props.search,
+              shortStatement(summary, statement),
+              search,
               false,
               true,
             )}

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -10,6 +10,7 @@
 
 import React from "react";
 import { Anchor } from "src/anchor";
+import moment from "moment";
 
 import { Tooltip } from "@cockroachlabs/ui-components";
 import {
@@ -22,6 +23,7 @@ import {
   contentionTime,
   readsAndWrites,
 } from "src/util";
+import { AggregateStatistics } from "src/statementsTable";
 
 export type NodeNames = { [nodeId: string]: string };
 
@@ -32,6 +34,7 @@ export const statisticsColumnLabels = {
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",
+  intervalStartTime: "Interval Start Time (UTC)",
   maxMemUsage: "Max Memory",
   networkBytes: "Network",
   regionNodes: "Regions/Nodes",
@@ -91,7 +94,7 @@ export function getLabel(
 // of data the statistics are based on (e.g. statements, transactions, or transactionDetails). The
 // StatisticType is used to modify the content of the tooltip.
 export const statisticsTableTitles: StatisticTableTitleType = {
-  statements: (statType: StatisticType) => {
+  statements: () => {
     return (
       <Tooltip
         placement="bottom"
@@ -132,6 +135,28 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("transactions")}
+      </Tooltip>
+    );
+  },
+  intervalStartTime: () => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <div>
+            <p>
+              The time that the statement execution interval started. By
+              default, statements are configured to aggregate over an hour
+              interval.
+              <br />
+              For example, if a statement is executed at 1:23PM it will fall in
+              the 1:00PM - 2:00PM time interval.
+            </p>
+          </div>
+        }
+      >
+        {getLabel("intervalStartTime")}
       </Tooltip>
     );
   },
@@ -603,3 +628,10 @@ export const statisticsTableTitles: StatisticTableTitleType = {
     );
   },
 };
+
+export function formatStartIntervalColumn(aggregatedTs: number) {
+  return moment
+    .unix(aggregatedTs)
+    .utc()
+    .format("MMM D, h:mm A");
+}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -26,7 +26,6 @@ import { Button } from "../button";
 import { tableClasses } from "../transactionsTable/transactionsTableClasses";
 import { SqlBox } from "../sql";
 import { aggregateStatements } from "../transactionsPage/utils";
-import Long from "long";
 import { Loading } from "../loading";
 import { SummaryCard } from "../summaryCard";
 import { Bytes, Duration, formatNumberForDisplay } from "src/util";
@@ -42,6 +41,7 @@ import {
   populateRegionNodeForStatements,
   makeStatementFingerprintColumn,
 } from "src/statementsTable/statementsTable";
+import { TransactionInfo } from "src/transactionsTable";
 
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
@@ -58,10 +58,7 @@ interface TransactionDetailsProps {
   nodeRegions: { [nodeId: string]: string };
   transactionStats?: TransactionStats;
   lastReset?: string | Date;
-  handleDetails: (
-    statementFingerprintIds: Long[] | null,
-    transactionStats: TransactionStats | null,
-  ) => void;
+  handleDetails: (txn?: TransactionInfo) => void;
   error?: Error | null;
   resetSQLStats: () => void;
   isTenant: UIConfigState["isTenant"];
@@ -117,7 +114,7 @@ export class TransactionDetails extends React.Component<
       <div>
         <section className={baseHeadingClasses.wrapper}>
           <Button
-            onClick={() => handleDetails(null, null)}
+            onClick={() => handleDetails()}
             type="unstyled-link"
             size="small"
             icon={<ArrowLeft fontSize={"10px"} />}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -12,6 +12,7 @@ import { createMemoryHistory } from "history";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
 import moment from "moment";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -42,6 +43,9 @@ export const dateRange: [moment.Moment, moment.Moment] = [
   moment.utc("2021.08.08"),
   moment.utc("2021.08.12"),
 ];
+export const timestamp = new protos.google.protobuf.Timestamp({
+  seconds: new Long(Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3),
+});
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {
   statements: [
@@ -58,6 +62,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(557),
@@ -136,6 +141,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(70),
@@ -201,6 +207,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(1),
@@ -257,6 +264,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(280),
@@ -354,6 +362,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(1),
@@ -404,6 +413,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(1),
@@ -443,6 +453,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(1),
@@ -493,6 +504,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(24),
@@ -581,6 +593,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(141),
@@ -693,6 +706,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
           vec: false,
         },
         node_id: 5,
+        aggregated_ts: timestamp,
       },
       stats: {
         count: Long.fromInt(1),
@@ -748,6 +762,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(100)],
         app: "$ internal-select-running/get-claimed-jobs",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(93),
           max_retries: Long.fromInt(0),
@@ -769,6 +784,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(101)],
         app: "$ internal-stmt-diag-poll",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(281),
           max_retries: Long.fromInt(0),
@@ -790,6 +806,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(102)],
         app: "$ internal-get-tables",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(1),
           max_retries: Long.fromInt(0),
@@ -805,6 +822,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(103)],
         app: "$ internal-read orphaned leases",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(1),
           max_retries: Long.fromInt(0),
@@ -820,6 +838,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(104)],
         app: "$ internal-expire-sessions",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(280),
           max_retries: Long.fromInt(0),
@@ -838,6 +857,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(105)],
         app: "$ internal-show-version",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(1),
           max_retries: Long.fromInt(0),
@@ -853,6 +873,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(106), Long.fromInt(107)],
         app: "$ internal-delete-sessions",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(141),
           max_retries: Long.fromInt(0),
@@ -874,6 +895,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(108)],
         app: "$ TEST",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(278),
           max_retries: Long.fromInt(0),
@@ -892,6 +914,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(109)],
         app: "$ TEST",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(140),
           max_retries: Long.fromInt(0),
@@ -913,6 +936,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(107)],
         app: "$ TEST",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(280),
           max_retries: Long.fromInt(0),
@@ -934,6 +958,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       stats_data: {
         statement_fingerprint_ids: [Long.fromInt(107)],
         app: "$ TEST EXACT",
+        aggregated_ts: timestamp,
         stats: {
           count: Long.fromInt(280),
           max_retries: Long.fromInt(0),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -22,7 +22,9 @@ export const selectTransactionsSlice = createSelector(
 
 export const selectTransactionsData = createSelector(
   selectTransactionsSlice,
-  transactionsState => transactionsState.data,
+  transactionsState =>
+    // The state is valid if we have successfully fetched data, and it has not yet been invalidated.
+    transactionsState.valid ? transactionsState.data : null,
 );
 
 export const selectTransactionsLastError = createSelector(

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -11,22 +11,26 @@
 import { assert } from "chai";
 import {
   filterTransactions,
-  getStatementsByFingerprintId,
+  getStatementsByFingerprintIdAndTime,
   statementFingerprintIdsToText,
 } from "./utils";
 import { Filters } from "../queryFilter/filter";
-import { data, nodeRegions } from "./transactions.fixture";
+import { data, nodeRegions, timestamp } from "./transactions.fixture";
 import Long from "long";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 
-describe("getStatementsByFingerprintId", () => {
-  it("filters statements by fingerprint id", () => {
-    const selectedStatements = getStatementsByFingerprintId(
+describe("getStatementsByFingerprintIdAndTime", () => {
+  it("filters statements by fingerprint id and time", () => {
+    const selectedStatements = getStatementsByFingerprintIdAndTime(
       [Long.fromInt(4104049045071304794), Long.fromInt(3334049045071304794)],
+      timestamp,
       [
-        { id: Long.fromInt(4104049045071304794) },
+        {
+          id: Long.fromInt(4104049045071304794),
+          key: { aggregated_ts: timestamp },
+        },
         { id: Long.fromInt(5554049045071304794) },
       ],
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -23,11 +23,16 @@ import {
   aggregateNumericStats,
   FixLong,
   longToInt,
+  statementKey,
+  TimestampToNumber,
+  addStatementStats,
+  flattenStatementStats,
 } from "../util";
 
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+type Timestamp = protos.google.protobuf.ITimestamp;
 
 export const getTrxAppFilterOptions = (
   transactions: Transaction[],
@@ -51,12 +56,17 @@ export const getTrxAppFilterOptions = (
 export const collectStatementsText = (statements: Statement[]): string =>
   statements.map(s => s.key.key_data.query).join("\n");
 
-export const getStatementsByFingerprintId = (
+export const getStatementsByFingerprintIdAndTime = (
   statementFingerprintIds: Long[],
+  timestamp: Timestamp | null,
   statements: Statement[],
 ): Statement[] => {
-  return statements.filter(s =>
-    statementFingerprintIds.some(id => id.eq(s.id)),
+  return statements.filter(
+    s =>
+      (timestamp == null ||
+        (s.key?.aggregated_ts != null &&
+          timestamp.seconds.eq(s.key.aggregated_ts.seconds))) &&
+      statementFingerprintIds.some(id => id.eq(s.id)),
   );
 };
 
@@ -69,17 +79,30 @@ export const statementFingerprintIdsToText = (
     .join("\n");
 };
 
+// Aggregate transaction statements from different nodes.
 export const aggregateStatements = (
   statements: Statement[],
-): AggregateStatistics[] =>
-  statements.map((s: Statement) => ({
-    label: s.key.key_data.query,
-    implicitTxn: s.key.key_data.implicit_txn,
-    database: s.key.key_data.database,
-    fullScan: s.key.key_data.full_scan,
-    stats: s.stats,
-  }));
+): AggregateStatistics[] => {
+  const statsKey: { [key: string]: AggregateStatistics } = {};
 
+  flattenStatementStats(statements).forEach(s => {
+    const key = statementKey(s);
+    if (!(key in statsKey)) {
+      statsKey[key] = {
+        label: s.statement,
+        aggregatedTs: s.aggregated_ts,
+        implicitTxn: s.implicit_txn,
+        database: s.database,
+        fullScan: s.full_scan,
+        stats: s.stats,
+      };
+    } else {
+      statsKey[key].stats = addStatementStats(statsKey[key].stats, s.stats);
+    }
+  });
+
+  return Object.values(statsKey);
+};
 export const searchTransactionsData = (
   search: string,
   transactions: Transaction[],
@@ -88,8 +111,9 @@ export const searchTransactionsData = (
   return transactions.filter((t: Transaction) =>
     search.split(" ").every(val =>
       collectStatementsText(
-        getStatementsByFingerprintId(
+        getStatementsByFingerprintIdAndTime(
           t.stats_data.statement_fingerprint_ids,
+          t.stats_data.aggregated_ts,
           statements,
         ),
       )
@@ -144,8 +168,9 @@ export const filterTransactions = (
       let foundRegion: boolean = regions.length == 0;
       let foundNode: boolean = nodes.length == 0;
 
-      getStatementsByFingerprintId(
+      getStatementsByFingerprintIdAndTime(
         t.stats_data.statement_fingerprint_ids,
+        t.stats_data.aggregated_ts,
         statements,
       ).some(stmt => {
         stmt.stats.nodes &&
@@ -188,8 +213,9 @@ export const generateRegionNode = (
   // nodes and regions of all the statements to a single list of `region: nodes`
   // for the transaction.
   // E.g. {"gcp-us-east1" : [1,3,4]}
-  getStatementsByFingerprintId(
+  getStatementsByFingerprintIdAndTime(
     transaction.stats_data.statement_fingerprint_ids,
+    transaction.stats_data.aggregated_ts,
     statements,
   ).forEach(stmt => {
     stmt.stats.nodes &&
@@ -238,7 +264,7 @@ const withFingerprint = function(
 };
 
 // addTransactionStats adds together two stat objects into one using their counts to compute a new
-// average for the numeric statistics. It's modeled after the similar `addStatementStats` function
+// average for the numeric statistics. It's modeled after the similar `addStatementStats` functionj
 function addTransactionStats(
   a: TransactionStats,
   b: TransactionStats,
@@ -311,7 +337,12 @@ export const aggregateAcrossNodeIDs = function(
 ): Transaction[] {
   return _.chain(t)
     .map(t => withFingerprint(t, stmts))
-    .groupBy(t => t.fingerprint + t.stats_data.app)
+    .groupBy(
+      t =>
+        t.fingerprint +
+        t.stats_data.app +
+        TimestampToNumber(t.stats_data.aggregated_ts),
+    )
     .mapValues(mergeTransactionStats)
     .values()
     .value();

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -33,22 +33,15 @@ type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 
 interface TextCellProps {
   transactionText: string;
-  transactionFingerprintIds: Long[];
-  transactionStats: TransactionStats;
-  handleDetails: (
-    transactionFingerprintIds: Long[],
-    transactionStats: TransactionStats,
-  ) => void;
+  onClick: () => void;
   search: string;
 }
 
 export const textCell = ({
   transactionText,
-  transactionFingerprintIds,
-  transactionStats,
-  handleDetails,
+  onClick,
   search,
-}: TextCellProps) => {
+}: TextCellProps): React.ReactElement => {
   const summary = summarize(transactionText);
   return (
     <div>
@@ -61,12 +54,7 @@ export const textCell = ({
         }
       >
         <div className={textWrapper}>
-          <div
-            onClick={() =>
-              handleDetails(transactionFingerprintIds, transactionStats)
-            }
-            className={hoverAreaClassName}
-          >
+          <div onClick={onClick} className={hoverAreaClassName}>
             {getHighlightedText(
               limitText(shortStatement(summary, transactionText), 200),
               search,
@@ -78,41 +66,4 @@ export const textCell = ({
       </Tooltip>
     </div>
   );
-};
-
-export const titleCells = {
-  transactions: (
-    <Tooltip
-      placement="bottom"
-      content={
-        <div className={statementsCx("tooltip__table--content")}>
-          <p>
-            {"SQL statement "}
-            <Anchor href={statementsSql} target="_blank">
-              fingerprint.
-            </Anchor>
-          </p>
-          <p>
-            To view additional details of a SQL statement fingerprint, click
-            this to open the Statement Details page.
-          </p>
-        </div>
-      }
-    >
-      Transactions
-    </Tooltip>
-  ),
-
-  statements: (
-    <Tooltip
-      placement="bottom"
-      content={
-        <div className={statementsCx("tooltip__table--content")}>
-          <p>FILL THE TEXT</p>
-        </div>
-      }
-    >
-      Statements
-    </Tooltip>
-  ),
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -26,22 +26,23 @@ import {
   transactionsNetworkBytesBarChart,
   transactionsRetryBarChart,
 } from "./transactionsBarCharts";
-import { statisticsTableTitles } from "../statsTableUtil/statsTableUtil";
+import {
+  formatStartIntervalColumn,
+  statisticsTableTitles,
+} from "../statsTableUtil/statsTableUtil";
 import { tableClasses } from "./transactionsTableClasses";
 import { textCell } from "./transactionsCells";
-import { FixLong, longToInt } from "src/util";
+import { FixLong, longToInt, TimestampToNumber } from "src/util";
 import { SortSetting } from "../sortedtable";
 import {
-  getStatementsByFingerprintId,
+  getStatementsByFingerprintIdAndTime,
   collectStatementsText,
   statementFingerprintIdsToText,
 } from "../transactionsPage/utils";
-import Long from "long";
 import classNames from "classnames/bind";
 import statsTablePageStyles from "src/statementsTable/statementsTableContent.module.scss";
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
-type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
 interface TransactionsTable {
@@ -65,10 +66,7 @@ export function makeTransactionsColumns(
   transactions: TransactionInfo[],
   statements: Statement[],
   isTenant: boolean,
-  handleDetails: (
-    statementFingerprintIds: Long[] | null,
-    transactionStats: TransactionStats,
-  ) => void,
+  handleDetails: (txn?: TransactionInfo) => void,
   search?: string,
 ): ColumnDescriptor<TransactionInfo>[] {
   const defaultBarChartOptions = {
@@ -122,19 +120,28 @@ export function makeTransactionsColumns(
             item.stats_data.statement_fingerprint_ids,
             statements,
           ),
-          transactionFingerprintIds: item.stats_data.statement_fingerprint_ids,
-          transactionStats: item.stats_data.stats,
-          handleDetails,
+          onClick: () => handleDetails(item),
           search,
         }),
       sort: (item: TransactionInfo) =>
         collectStatementsText(
-          getStatementsByFingerprintId(
+          getStatementsByFingerprintIdAndTime(
             item.stats_data.statement_fingerprint_ids,
+            item.stats_data.aggregated_ts,
             statements,
           ),
         ),
       alwaysShow: true,
+    },
+    {
+      name: "intervalStartTime",
+      title: statisticsTableTitles.intervalStartTime("transaction"),
+      cell: (item: TransactionInfo) =>
+        formatStartIntervalColumn(
+          TimestampToNumber(item.stats_data?.aggregated_ts),
+        ),
+      sort: (item: TransactionInfo) =>
+        TimestampToNumber(item.stats_data?.aggregated_ts),
     },
     {
       name: "executionCount",

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -10,7 +10,7 @@
 
 import _ from "lodash";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { FixLong, uniqueLong } from "src/util";
+import { FixLong, TimestampToNumber, uniqueLong } from "src/util";
 
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
 export type ExecStats = protos.cockroach.sql.IExecStats;
@@ -21,15 +21,15 @@ export interface NumericStat {
   squared_diffs?: number;
 }
 
-export function variance(stat: NumericStat, count: number) {
+export function variance(stat: NumericStat, count: number): number {
   return (stat?.squared_diffs || 0) / (count - 1);
 }
 
-export function stdDev(stat: NumericStat, count: number) {
+export function stdDev(stat: NumericStat, count: number): number {
   return Math.sqrt(variance(stat, count)) || 0;
 }
 
-export function stdDevLong(stat: NumericStat, count: number | Long) {
+export function stdDevLong(stat: NumericStat, count: number | Long): number {
   return stdDev(stat, Number(FixLong(count)));
 }
 
@@ -40,7 +40,7 @@ export function aggregateNumericStats(
   b: NumericStat,
   countA: number,
   countB: number,
-) {
+): { mean: number; squared_diffs: number } {
   const total = countA + countB;
   const delta = b.mean - a.mean;
 
@@ -192,6 +192,7 @@ export function aggregateStatementStats(
 
 export interface ExecutionStatistics {
   statement: string;
+  aggregated_ts: number;
   app: string;
   database: string;
   distSQL: boolean;
@@ -209,6 +210,7 @@ export function flattenStatementStats(
 ): ExecutionStatistics[] {
   return statementStats.map(stmt => ({
     statement: stmt.key.key_data.query,
+    aggregated_ts: TimestampToNumber(stmt.key.aggregated_ts),
     app: stmt.key.key_data.app,
     database: stmt.key.key_data.database,
     distSQL: stmt.key.key_data.distSQL,
@@ -236,7 +238,9 @@ export const getSearchParams = (searchParams: string) => {
 
 // This function returns a key based on all parameters
 // that should be used to group statements.
-// Parameters being used: node_id, implicit_txn and database.
+// Parameters being used: query, implicit_txn, database, and aggregated_ts.
 export function statementKey(stmt: ExecutionStatistics): string {
-  return stmt.statement + stmt.implicit_txn + stmt.database;
+  return (
+    stmt.statement + stmt.implicit_txn + stmt.database + stmt.aggregated_ts
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -20,6 +20,7 @@ export const statementAttr = "statement";
 export const databaseAttr = "database";
 export const tableNameAttr = "table_name";
 export const sessionAttr = "session";
+export const aggregatedTsAttr = "aggregated_ts";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -51,6 +51,21 @@ export function TimestampToMoment(
 }
 
 /**
+ * TimestampToNumber converts a Timestamp$Properties object, as seen in wire.proto, to
+ * its unix time. If timestamp is null, it returns the `defaultIfNull` value which is
+ * by default is current time.
+ */
+export function TimestampToNumber(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultIfNull = moment.utc().unix(),
+): number {
+  if (!timestamp) {
+    return defaultIfNull;
+  }
+  return timestamp.seconds.toNumber() + NanoToMilli(timestamp.nanos) * 1e-3;
+}
+
+/**
  * LongToMoment converts a Long, representing nanos since the epoch, to a Moment
  * object. If timestamp is null, it returns the current time.
  */

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -74,6 +74,7 @@ export function* setCombinedStatementsDateRangeSaga(
     }),
   );
   const req = new CombinedStatementsRequest({
+    combined: true,
     start: Long.fromNumber(start.unix()),
     end: Long.fromNumber(end.unix()),
   });

--- a/pkg/ui/workspaces/db-console/src/util/appStats.ts
+++ b/pkg/ui/workspaces/db-console/src/util/appStats.ts
@@ -16,6 +16,7 @@ import _ from "lodash";
 import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
 import { uniqueLong } from "src/util/arrays";
+import { TimestampToNumber } from "src/util/convert";
 
 export type ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
@@ -181,6 +182,7 @@ export function aggregateStatementStats(
 
 export interface ExecutionStatistics {
   statement: string;
+  aggregated_ts: number;
   app: string;
   database: string;
   distSQL: boolean;
@@ -198,6 +200,7 @@ export function flattenStatementStats(
 ): ExecutionStatistics[] {
   return statementStats.map(stmt => ({
     statement: stmt.key.key_data.query,
+    aggregated_ts: TimestampToNumber(stmt.key.aggregated_ts),
     app: stmt.key.key_data.app,
     database: stmt.key.key_data.database,
     distSQL: stmt.key.key_data.distSQL,
@@ -219,7 +222,9 @@ export function combineStatementStats(
 
 // This function returns a key based on all parameters
 // that should be used to group statements.
-// Parameters being used: node_id, implicit_txn and database.
+// Parameters being used: query, implicit_txn, database, and aggregated_ts.
 export function statementKey(stmt: ExecutionStatistics): string {
-  return stmt.statement + stmt.implicit_txn + stmt.database;
+  return (
+    stmt.statement + stmt.implicit_txn + stmt.database + stmt.aggregated_ts
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -20,6 +20,7 @@ export const statementAttr = "statement";
 export const databaseAttr = "database";
 export const sessionAttr = "session";
 export const tableNameAttr = "table_name";
+export const aggregatedTsAttr = "aggregated_ts";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/util/convert.ts
+++ b/pkg/ui/workspaces/db-console/src/util/convert.ts
@@ -62,6 +62,21 @@ export function TimestampToMoment(
 }
 
 /**
+ * TimestampToNumber converts a Timestamp$Properties object, as seen in wire.proto, to
+ * its unix time. If timestamp is null, it returns the `defaultIfNull` value which is
+ * by default is current time.
+ */
+export function TimestampToNumber(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultIfNull = moment.utc().unix(),
+): number {
+  if (!timestamp) {
+    return defaultIfNull;
+  }
+  return timestamp.seconds.toNumber() + NanoToMilli(timestamp.nanos) * 1e-3;
+}
+
+/**
  * LongToMoment converts a Long, representing nanos since the epoch, to a Moment
  * object. If timestamp is null, it returns the current time.
  */

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -36,6 +36,7 @@ import {
   StatementStatistics,
 } from "src/util/appStats";
 import {
+  aggregatedTsAttr,
   appAttr,
   databaseAttr,
   implicitTxnAttr,
@@ -66,6 +67,7 @@ interface Fraction {
 
 interface StatementDetailsData {
   nodeId: number;
+  aggregatedTs: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;
@@ -82,6 +84,7 @@ function coalesceNodeStats(
     if (!(key in statsKey)) {
       statsKey[key] = {
         nodeId: stmt.node_id,
+        aggregatedTs: stmt.aggregated_ts,
         implicitTxn: stmt.implicit_txn,
         fullScan: stmt.full_scan,
         database: stmt.database,
@@ -95,6 +98,7 @@ function coalesceNodeStats(
     const stmt = statsKey[key];
     return {
       label: stmt.nodeId.toString(),
+      aggregatedTs: stmt.aggregatedTs,
       implicitTxn: stmt.implicitTxn,
       fullScan: stmt.fullScan,
       database: stmt.database,
@@ -130,9 +134,12 @@ function filterByRouterParamsPredicate(
   const implicitTxn = getMatchParamByName(match, implicitTxnAttr) === "true";
   const database = queryByName(location, databaseAttr);
   let app = queryByName(location, appAttr);
+  // If the aggregatedTs is unset, we will aggregate across the current date range.
+  const aggregatedTs = queryByName(location, aggregatedTsAttr);
 
   const filterByKeys = (stmt: ExecutionStatistics) =>
     stmt.statement === statement &&
+    (aggregatedTs == null || stmt.aggregated_ts.toString() === aggregatedTs) &&
     stmt.implicit_txn === implicitTxn &&
     (stmt.database === database || database === null);
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -162,6 +162,8 @@ const statementStats: IStatementStatistics = {
   },
 };
 
+const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
+
 const statementsPagePropsFixture: StatementsPageProps = {
   history,
   location: {
@@ -188,6 +190,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -195,6 +198,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -203,6 +207,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -211,6 +216,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -218,6 +224,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -225,6 +232,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT city, id FROM vehicles WHERE city = $1",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: true,
       stats: statementStats,
@@ -233,6 +241,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -241,6 +250,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM vehicles WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM vehicles WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -249,6 +259,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -256,6 +267,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO users VALUES ($1, $2, __more3__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -264,6 +276,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: true,
       stats: statementStats,
@@ -271,6 +284,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -278,6 +292,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -286,6 +301,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -293,6 +309,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SHOW database",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -301,6 +318,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -308,6 +326,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE users SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -315,6 +334,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -323,6 +343,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -331,6 +352,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -338,6 +360,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -345,6 +368,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -352,6 +376,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: 'SET CLUSTER SETTING "cluster.organization" = $1',
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -360,6 +385,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -368,6 +394,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -376,6 +403,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -383,6 +411,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -390,6 +419,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -397,6 +427,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SET sql_safe_updates = _",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -405,6 +436,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -413,6 +445,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -420,6 +453,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT * FROM crdb_internal.node_build_info",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -427,6 +461,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "CREATE DATABASE movr",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -435,6 +470,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -442,6 +478,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: 'SET CLUSTER SETTING "enterprise.license" = $1',
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -450,6 +487,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -458,6 +496,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -466,6 +505,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -473,6 +513,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -480,6 +521,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -488,6 +530,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       label:
         "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,
@@ -495,6 +538,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
+      aggregatedTs,
       implicitTxn: true,
       fullScan: false,
       stats: statementStats,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -57,6 +57,7 @@ type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDi
 
 interface StatementsSummaryData {
   statement: string;
+  aggregatedTs: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;
@@ -74,7 +75,7 @@ export const selectStatements = createSelector(
     props: RouteComponentProps<any>,
     diagnosticsReportsPerStatement,
   ): AggregateStatistics[] => {
-    if (!state.data) {
+    if (!state.data || state.inFlight) {
       return null;
     }
     let statements = flattenStatementStats(state.data.statements);
@@ -105,6 +106,7 @@ export const selectStatements = createSelector(
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
           statement: stmt.statement,
+          aggregatedTs: stmt.aggregated_ts,
           implicitTxn: stmt.implicit_txn,
           fullScan: stmt.full_scan,
           database: stmt.database,
@@ -118,6 +120,7 @@ export const selectStatements = createSelector(
       const stmt = statsByStatementKey[key];
       return {
         label: stmt.statement,
+        aggregatedTs: stmt.aggregatedTs,
         implicitTxn: stmt.implicitTxn,
         fullScan: stmt.fullScan,
         database: stmt.database,

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -32,7 +32,8 @@ import { LocalSetting } from "src/redux/localsettings";
 export const selectData = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
   (state: CachedDataReducerState<StatementsResponseMessage>) => {
-    return state.data || null;
+    if (!state.data || state.inFlight) return null;
+    return state.data;
   },
 );
 


### PR DESCRIPTION
Backport 1/1 commits from #70282.

/cc @cockroachdb/release

---

Resolves #69648, #70545

Release justification: category 4

This commit adds the `Interval Start Time (UTC)` column to stmt and txn
tables. Statements and transactions are now both grouped by their `aggregated_ts`
field in addition to the stmt / fingerprint id. On the statement details page,
the 'Interval Start Time' has also been added to the details panel.

To support viewing of statements grouped by aggregation interval start time,
a new query parameter has been added to statement details pages.
If `aggregated_ts` is set, it will display the statement details for statements
aggregated at that interval, using data from combined statements API response.
If unset, we will show data aggregated over the current date range.

Release note (ui change): A new column, 'Interval Start Time (UTC)', has
been added to both statement and transaction tables. The column represents
the start time in UTC of the stats aggregation interval for a statement.
By default, the aggregation interval is 1 hour. 'Interval Start Time' has
been added to the statement details page under 'Statement Details'.

A new query parameter has been added to statement details pages.
If the search param `aggregated_ts` is set, it will display the statement details
for statements aggregated at that interval. If unset, we will display the statement
details for the statement aggregated over the current date range.

--------------------------------------
Statements Table:
![image](https://user-images.githubusercontent.com/20136951/133510793-b8d3ad12-f1f1-442c-9f03-d19e1ba73739.png)

Transactions Table:
![image](https://user-images.githubusercontent.com/20136951/133510849-b8578f2c-165c-486f-a685-55a4c4b549d7.png)

details page:
![image](https://user-images.githubusercontent.com/20136951/134553530-7d9d1985-60b9-4d1b-80fa-c33e9654fe92.png)

