### PR TITLE
release-21.1: sql: show indpred for partial indexes on pg_catalog

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3288,6 +3288,24 @@ indexes_include_idx  {a,c,d}    false        false         {ASC,ASC,ASC}  prefix
 primary              {id}       true         true          {ASC}          prefix  NULL     NULL
 
 statement ok
+CREATE TABLE partial_index (
+    a INT,
+    b INT,
+    INDEX (a, b) WHERE (a >= 0)
+)
+
+query OOBBTTTTTT colnames
+SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, indclass, indoption, indexprs, indpred
+FROM pg_catalog.pg_index
+WHERE indpred LIKE 'a >= 0%'
+----
+indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
+2955071326  113       true       false           1 2     0 0           0 0       2 2        NULL      a >= 0:::INT8
+
+statement ok
+DROP TABLE partial_index
+
+statement ok
 SET stub_catalog_tables=false
 
 statement error pq: unimplemented: virtual schema table not implemented: pg_catalog.pg_seclabel

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1576,6 +1576,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 					if err != nil {
 						return err
 					}
+					indpred := tree.DNull
+					if index.IsPartial() {
+						indpred = tree.NewDString(index.GetPredicate())
+					}
 					return addRow(
 						h.IndexOid(table.GetID(), index.GetID()),     // indexrelid
 						tableOid,                                     // indrelid
@@ -1595,7 +1599,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 						indclass,                                     // indclass
 						indoptionIntVector,                           // indoption
 						tree.DNull,                                   // indexprs
-						tree.DNull,                                   // indpred
+						indpred,                                      // indpred
 						tree.NewDInt(tree.DInt(indnkeyatts)),         // indnkeyatts
 					)
 				})


### PR DESCRIPTION
Backport 1/1 commits from #70808.

/cc @cockroachdb/release

Release justification: small info change

---

Release note (sql change): Show indpred on the pg_index table for
partial indexes. This was previously NULL, even for partial indexes.
