### PR TITLE
build/deploy: add licenses to gitignore

### DIFF
--- a/build/deploy/.gitignore
+++ b/build/deploy/.gitignore
@@ -2,3 +2,4 @@
 # for reasoning and alternatives).
 cockroach
 libgeos*.so*
+licenses


### PR DESCRIPTION

Looks like the Docker image now includes licenses. Add it to the
.gitignore, since we don't want people to (potentially accidentally)
commit the licenses dir to the repo.

Release note: None