### PR TITLE
release-20.1: roachtest: deflake autoupgrade

### DIFF
--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -248,8 +248,9 @@ func registerAutoUpgrade(r *testRegistry) {
 			t.Fatalf("cluster setting cluster.preserve_downgrade_option is %s, should be an empty string", downgradeVersion)
 		}
 
-		// Start n3 again to satisfy the dead node detector.
-		c.Start(ctx, t, c.Node(nodeDecommissioned))
+		// Wipe n3 to exclude it from the dead node check the roachtest harness
+		// will perform after the test.
+		c.Wipe(ctx, c.Node(nodeDecommissioned))
 	}
 
 	r.Add(testSpec{


### PR DESCRIPTION
Backport 1/1 commits from #70858.

/cc @cockroachdb/release

Fixes #70271.

---

roachtest: deflake autoupgrade

The test was decommissioning and then restarting n3, but a
decommissioned node is rejected from the cluster and may not boot up
successfully. Since the restart occurred only to satisfy the dead
node detector, exclude it by wiping it instead.

Touches #70271.

Release note: None

