### PR TITLE
release-21.1: jobs,changefeedccl: only load adopted jobs

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1020,7 +1020,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 
 	cf.highWaterAtStart = cf.spec.Feed.StatementTime
 	if cf.spec.JobID != 0 {
-		job, err := cf.flowCtx.Cfg.JobRegistry.LoadJob(ctx, cf.spec.JobID)
+		job, err := cf.flowCtx.Cfg.JobRegistry.LoadClaimedJob(ctx, cf.spec.JobID)
 		if err != nil {
 			cf.MoveToDraining(err)
 			return

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -635,7 +635,7 @@ func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) err
 		}
 		// Re-load the job in order to update our progress object, which may have
 		// been updated by the changeFrontier processor since the flow started.
-		reloadedJob, reloadErr := execCfg.JobRegistry.LoadJob(ctx, jobID)
+		reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2129,6 +2129,74 @@ func TestChangefeedRetryableError(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+// TODO(ssd): Requires test infrastructure that has not been backported.
+//
+// type alwaysAliveSession string
+
+// func (f alwaysAliveSession) ID() sqlliveness.SessionID                              { return sqlliveness.SessionID(f) }
+// func (f alwaysAliveSession) Expiration() hlc.Timestamp                              { return hlc.MaxTimestamp }
+// func (f alwaysAliveSession) RegisterCallbackForSessionExpiry(func(context.Context)) {}
+
+// func TestChangefeedJobUpdateFailsIfNotClaimed(t *testing.T) {
+// 	defer leaktest.AfterTest(t)()
+// 	defer log.Scope(t).Close(t)
+
+// 	// Set TestingKnobs to return a known session for easier
+// 	// comparison.
+// 	testSession := alwaysAliveSession("known-test-session")
+// 	adoptionInterval := 20 * time.Minute
+// 	sessionOverride := withKnobsFn(func(knobs *base.TestingKnobs) {
+// 		knobs.SQLLivenessKnobs = &sqlliveness.TestingKnobs{
+// 			SessionOverride: func(_ context.Context) (sqlliveness.Session, error) {
+// 				return testSession, nil
+// 			},
+// 		}
+// 		// This is a hack to avoid the job adoption loop from
+// 		// immediately re-adopting the job that is running. The job
+// 		// adoption loop basically just sets the claim ID, which will
+// 		// undo our deletion of the claim ID below.
+// 		knobs.JobsTestingKnobs.(*jobs.TestingKnobs).IntervalOverrides.Adopt = &adoptionInterval
+// 	})
+// 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+// 		knobs := f.Server().TestingKnobs().DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+// 		errChan := make(chan error, 1)
+// 		knobs.HandleDistChangefeedError = func(err error) error {
+// 			errChan <- err
+// 			return err
+// 		}
+
+// 		sqlDB := sqlutils.MakeSQLRunner(db)
+// 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b INT)`)
+// 		sqlDB.Exec(t, `INSERT INTO foo (a, b) VALUES (1, 1)`)
+
+// 		cf := feed(t, f, "CREATE CHANGEFEED FOR TABLE foo")
+// 		defer closeFeed(t, cf)
+
+// 		assertPayloads(t, cf, []string{
+// 			`foo: [1]->{"after": {"a": 1, "b": 1}}`,
+// 		})
+
+// 		// Mimic the claim dying and being cleaned up by
+// 		// another node.
+// 		jobID := cf.(cdctest.EnterpriseTestFeed).JobID()
+// 		sqlDB.Exec(t, `UPDATE system.jobs SET claim_session_id = NULL WHERE id = $1`, jobID)
+
+// 		// Expect that the distflow fails since it can't
+// 		// update the checkpoint.
+// 		select {
+// 		case err := <-errChan:
+// 			require.Error(t, err)
+// 			// TODO(ssd): Replace this error in the jobs system with
+// 			// an error type we can check against.
+// 			require.Contains(t, err.Error(), fmt.Sprintf("expected session '%s' but found NULL", testSession.ID().String()))
+// 		case <-time.After(5 * time.Second):
+// 			t.Fatal("expected distflow to fail but it hasn't after 5 seconds")
+// 		}
+
+// 	}
+// 	RunRandomSinkTest(t, "fails as expected", testFn, feedTestNoTenants, sessionOverride)
+// }
+
 // TestChangefeedDataTTL ensures that changefeeds fail with an error in the case
 // where the feed has fallen behind the GC TTL of the table data.
 func TestChangefeedDataTTL(t *testing.T) {

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -156,6 +157,8 @@ func (j *Job) update(ctx context.Context, txn *kv.Txn, useReadLock bool, updateF
 					"job %d: with status '%s': expected session '%s' but found '%s'",
 					j.ID(), statusString, j.sessionID, storedSession)
 			}
+		} else {
+			log.VInfof(ctx, 1, "job %s: update called with no session ID", j.sessionID.String())
 		}
 
 		status := Status(*statusString)


### PR DESCRIPTION
Backport 1/1 commits from #70612.

/cc @cockroachdb/release
  
---

The changeFrontier updates the job multiple times during its run. It
does this via a *job.Job object that it explicitly loads at startup
using a JobID that is passed to it via its distflow spec.

However, when loading the job in this way, the sessionID that was
associated with the initial adoption of the job is not set. This means
that this change frontier can continue updating the job without error
even long after the session from the original adoption is
expired. This can potentially lead to a single changefeed job running
twice.

This change addresses that by introducing a new method, LoadAdoptedJob
to the Registry, which consults the Registry's map of adopted job to
find the sessionID, and ensure that the sessionID is included in the
query to load the job.

Note that for this to be correct it _requires_ that the changeFrontier
is only ever scheduled on the sql instance that adopts the job.

This API should probably change further to make it much harder to
interact with jobs that haven't been adopted by your registry.
However, the goal of this change is to be backportable.

Release note (enterprise change): Fixes a bug that could have led to
duplicate instances of a single CHANGEFEED job running for a prolonged
period of time.

Release justification: Correctness bug in CHANGEFEEDs that could
result in multiple changefeeds running concurrently.