### PR TITLE
sql: disallow non-system tenants from running EXPLAIN ANALYZE (DEBUG)

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -65,3 +65,6 @@ ALTER TABLE kv EXPERIMENTAL_RELOCATE LEASE VALUES (1, 'k')
 
 statement error operation is unsupported in multi-tenancy mode
 SELECT crdb_internal.check_consistency(true, '', '')
+
+statement error operation is unsupported in multi-tenancy mode
+EXPLAIN ANALYZE (DEBUG) SELECT * FROM kv

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -374,6 +375,9 @@ func (ex *connExecutor) execStmtInOpenState(
 	if e, ok := ast.(*tree.ExplainAnalyze); ok {
 		switch e.Mode {
 		case tree.ExplainDebug:
+			if !p.ExecCfg().Codec.ForSystemTenant() {
+				return makeErrEvent(errorutil.UnsupportedWithMultiTenancy(70931))
+			}
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
 			ih.SetOutputMode(explainAnalyzeDebugOutput, explain.Flags{})
 

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -94,8 +94,3 @@ CREATE TABLE c (c INT8 PRIMARY KEY, p INT8 REFERENCES p (p))
 
 query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
 EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)
-
-# Regression test for the vectorized engine not playing nicely with
-# LocalPlanNodes (#62261).
-query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
-EXPLAIN ANALYZE (DEBUG) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_system_tenant
@@ -1,0 +1,12 @@
+# LogicTest: !3node-tenant
+# EXPLAIN ANALYZE logic tests that are only meant to work for the system tenant.
+
+# Regression test for #45099 (not running postqueries with EXPLAIN ANALYZE).
+statement ok
+CREATE TABLE p (p INT8 PRIMARY KEY);
+CREATE TABLE c (c INT8 PRIMARY KEY, p INT8 REFERENCES p (p))
+
+# Regression test for the vectorized engine not playing nicely with
+# LocalPlanNodes (#62261).
+query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
+EXPLAIN ANALYZE (DEBUG) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)


### PR DESCRIPTION
Until we can support `EXPLAIN ANALYZE (DEBUG)` correctly for non-system
tenants, this command is disallowed.

Fixes #70770
Informs #70931

Release note (sql change): `EXPLAIN ANALYZE (DEBUG)` now returns an error
for non-system tenants, since we cannot yet support it correctly.