### PR TITLE
reduce: show original test case output

### DIFF
--- a/pkg/testutils/reduce/reduce_test.go
+++ b/pkg/testutils/reduce/reduce_test.go
@@ -52,11 +52,11 @@ var (
 )
 
 func isInterestingGo(contains string) reduce.InterestingFn {
-	return func(ctx context.Context, f string) bool {
+	return func(ctx context.Context, f string) (bool, func()) {
 		_, err := parser.ParseExpr(f)
 		if err == nil {
-			return false
+			return false, nil
 		}
-		return strings.Contains(err.Error(), contains)
+		return strings.Contains(err.Error(), contains), nil
 	}
 }

--- a/pkg/testutils/reduce/reducesql/reducesql_test.go
+++ b/pkg/testutils/reduce/reducesql/reducesql_test.go
@@ -38,7 +38,7 @@ func TestReduceSQL(t *testing.T) {
 }
 
 func isInterestingSQL(contains string) reduce.InterestingFn {
-	return func(ctx context.Context, f string) bool {
+	return func(ctx context.Context, f string) (bool, func()) {
 		args := base.TestServerArgs{
 			Insecure: true,
 		}
@@ -67,8 +67,8 @@ func isInterestingSQL(contains string) reduce.InterestingFn {
 		}
 		_, err = db.Exec(ctx, f)
 		if err == nil {
-			return false
+			return false, nil
 		}
-		return strings.Contains(err.Error(), contains)
+		return strings.Contains(err.Error(), contains), nil
 	}
 }


### PR DESCRIPTION
The `reduce` tool now shows the original test case output in verbose
mode if it is not found to be interesting. This makes it easier for a
user to determine why a reproduction is not producing output that
matches the `--contains` regex.

Release note: None