### PR TITLE
cluster-ui: enable terminateSaga

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.spec.ts
@@ -1,0 +1,69 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import assert from "assert";
+import fetchMock from "jest-fetch-mock";
+import { applyMiddleware, createStore, Store } from "redux";
+import createSagaMiddleware, { SagaMiddleware } from "redux-saga";
+
+import { rootReducer, sagas } from "src/store";
+import {
+  actions,
+  ICancelQueryRequest,
+  ICancelSessionRequest,
+} from "src/store/terminateQuery";
+
+class TestDriver {
+  private readonly store: Store;
+
+  constructor() {
+    const sagaMiddleware = createSagaMiddleware();
+    this.store = createStore(rootReducer, {}, applyMiddleware(sagaMiddleware));
+    sagaMiddleware.run(sagas);
+  }
+
+  async cancelQuery(req: ICancelQueryRequest) {
+    return this.store.dispatch(actions.terminateQuery(req));
+  }
+
+  async cancelSession(req: ICancelSessionRequest) {
+    return this.store.dispatch(actions.terminateSession(req));
+  }
+}
+
+describe("SessionsPage Connections", () => {
+  beforeAll(fetchMock.enableMocks);
+  afterEach(fetchMock.resetMocks);
+  afterAll(fetchMock.disableMocks);
+
+  describe("cancelQuery", () => {
+    it("fires off an HTTP request", async () => {
+      const driver = new TestDriver();
+      assert.deepStrictEqual(fetchMock.mock.calls.length, 0);
+      await driver.cancelQuery({ node_id: "1" });
+      assert.deepStrictEqual(
+        fetchMock.mock.calls[0][0],
+        "/_status/cancel_query/1",
+      );
+    });
+  });
+
+  describe("cancelSession", () => {
+    it("fires off an HTTP request", async () => {
+      const driver = new TestDriver();
+      assert.deepStrictEqual(fetchMock.mock.calls.length, 0);
+      await driver.cancelSession({ node_id: "1" });
+      assert.deepStrictEqual(
+        fetchMock.mock.calls[0][0],
+        "/_status/cancel_session/1",
+      );
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -30,6 +30,7 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(livenessSaga, cacheInvalidationPeriod),
     fork(sessionsSaga),
     fork(transactionsSaga),
+    fork(terminateSaga),
     fork(notifificationsSaga),
     fork(sqlStatsSaga),
   ]);


### PR DESCRIPTION
Partially addresses #70832

Previously, we failed to make HTTP requests when clicking in the UI to
terminate queries and sessions. This patch includes the appropriate
redux saga in the right place to make sure we do.

Release note (bug fix): The terminate session and terminate query
buttons in cluster UI are now properly connected, so that they actually
make their HTTP requests.