### PR TITLE
dev: various small tweaks

### DIFF
--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -46,6 +46,7 @@ func (d *dev) builder(cmd *cobra.Command, extraArgs []string) error {
 	if err != nil {
 		return err
 	}
+	logCommand("docker", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "docker", args...)
 }
 

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -44,15 +44,12 @@ func makeDevCmd() *dev {
 		Short:   "Dev is the general-purpose dev tool for working on cockroach/cockroachdb.",
 		Version: "v0.0",
 		Long: `
-Dev is the general-purpose dev tool for working cockroachdb/cockroach. It
-lets engineers do a few things:
+Dev is the general-purpose dev tool for working on cockroachdb/cockroach. With dev you can:
 
 - build various binaries (cockroach, optgen, ...)
 - run arbitrary tests (unit tests, logic tests, ...)
 - run tests under arbitrary configurations (under stress, using race builds, ...)
-- generate code (bazel files, protobufs, ...)
-
-...and much more.
+- generate code (bazel files, docs, ...)
 `,
 		// Disable automatic printing of usage information whenever an error
 		// occurs. We presume that most errors will not the result of bad
@@ -98,12 +95,6 @@ lets engineers do a few things:
 			}
 		}
 	}
-
-	// Hide the `help` sub-command.
-	ret.cli.SetHelpCommand(&cobra.Command{
-		Use:    "noop-help",
-		Hidden: true,
-	})
 
 	return &ret
 }

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -41,11 +42,17 @@ func (d *dev) doctor(cmd *cobra.Command, _ []string) error {
 		stdout, err := d.exec.CommandContextSilent(ctx, "/usr/bin/xcodebuild", "-version")
 		if err != nil {
 			success = false
-			log.Printf("Failed to run /usr/bin/xcodebuild -version. Got output: ")
-			log.Printf("stdout:   %s", string(stdout))
+			log.Printf("Failed to run `/usr/bin/xcodebuild -version`.")
+			stdoutStr := strings.TrimSpace(string(stdout))
+			if len(stdoutStr) > 0 {
+				log.Printf("stdout:   %s", stdoutStr)
+			}
 			var cmderr *exec.ExitError
 			if errors.As(err, &cmderr) {
-				log.Printf("stderr:   %s", string(cmderr.Stderr))
+				stderrStr := strings.TrimSpace(string(cmderr.Stderr))
+				if len(stderrStr) > 0 {
+					log.Printf("stderr:   %s", stderrStr)
+				}
 			}
 			log.Println(`You must have a full installation of XCode to build with Bazel.
 A command-line tools instance does not suffice.


### PR DESCRIPTION
* log the `docker` command before executing in `dev builder`
* update the `help` string and enable the `help` subcommand
* Don't print `xcodebuild -version` output if it's empty

Release note: None