### PR TITLE
ui: prevent statement/transaction page from sending infinite API

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -264,10 +264,6 @@ export class StatementsPage extends React.Component<
     if (this.state.search && this.state.search !== prevState.search) {
       this.props.onSearchComplete(this.filteredStatementsData());
     }
-    this.refreshStatements();
-    if (!this.props.isTenant) {
-      this.props.refreshStatementDiagnosticsRequests();
-    }
   };
 
   componentWillUnmount(): void {

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/sagaEffects/throttleWithReset.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/sagaEffects/throttleWithReset.ts
@@ -25,7 +25,7 @@ import { Action } from "redux";
  * Extended version of default `redux-saga/effects/throttle` effect implementation
  * with ability to provide actions that trigger reset on delay timer.
  *
- * For example, `initRequest` sata has to be throttled by specified amount of time and
+ * For example, `initRequest` saga has to be throttled by specified amount of time and
  * also `initRequest` call when specific action dispatched (even if timeout doesn't
  * occur).
  *

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -146,9 +146,6 @@ export class TransactionsPage extends React.Component<
   componentDidMount(): void {
     this.refreshData();
   }
-  componentDidUpdate(): void {
-    this.refreshData();
-  }
 
   syncHistory = (params: Record<string, string | undefined>) => {
     const { history } = this.props;


### PR DESCRIPTION
requests when the API requests fails

Previously, Statement Page and Transaction Page issues API requests
in conmponentDidUpdate() React lifecycle hook. However, when the
backend API returns an error, this lifecycle hook is constantly
triggered which resulted in infinite loop. This crashes the entire
frontend application.
This commit removes API calls from within the componentDidUpdate()
hooks.

Resolves #68602

Release note: None