### PR TITLE
ci,dev: build `cockroach` binary in ci, make sure `dev` knows how too

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,12 @@
+try-import %workspace%/.bazelrc.user
+
 build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off,gss --experimental_proto_descriptor_sets_include_source_info
 test --config=test
-build:test --define gotags=bazel,crdb_test,gss --test_env=TZ=
+build:with_ui --define cockroach_with_ui=y
+build:test --define gotags=bazel,crdb_test,gss
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
+test:test --test_env=TZ=
 query --ui_event_filters=-DEBUG
-
-try-import %workspace%/.bazelrc.user
 
 # CI should always run with `--config=ci`.
 build:ci --experimental_convenience_symlinks=ignore

--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -21,5 +21,6 @@ fi
 
 bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
-		       --config "$CONFIG" \
-		       build //pkg/cmd/cockroach-short //c-deps:libgeos $GENFILES_TARGETS
+		       --config "$CONFIG" --config with_ui \
+		       build //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
+		       //pkg/cmd/cockroach-oss //c-deps:libgeos $GENFILES_TARGETS

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -1,6 +1,6 @@
 dev build cockroach-short
 ----
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
@@ -9,16 +9,16 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --cpus=12
 ----
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
+bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 
-dev build --debug cockroach-short
+dev build --debug short
 ----
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
@@ -27,7 +27,7 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --remote-cache 127.0.0.1:9090
 ----
-bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short:cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
@@ -36,7 +36,7 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build cockroach-short --hoist-generated-code
 ----
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
@@ -51,7 +51,7 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 
 dev build short -- -s
 ----
-bazel build //pkg/cmd/cockroach-short -s
+bazel build //pkg/cmd/cockroach-short:cockroach-short -s
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
@@ -60,9 +60,19 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build -- --verbose_failures --sandbox_debug
 ----
-bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug
+bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach/cockroach_/cockroach go/src/github.com/cockroachdb/cockroach/cockroach
+
+dev build @com_github_cockroachdb_stress//:stress
+----
+bazel query @com_github_cockroachdb_stress//:stress --output=label_kind
+bazel build @com_github_cockroachdb_stress//:stress
+bazel info workspace --color=no
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no
+rm go/src/github.com/cockroachdb/cockroach/bin/stress
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress go/src/github.com/cockroachdb/cockroach/bin/stress

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -1,4 +1,4 @@
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 ----
 
 bazel info workspace --color=no
@@ -18,7 +18,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short
+bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short
 ----
 
 bazel info workspace --color=no
@@ -38,7 +38,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 ----
 
 bazel info workspace --color=no
@@ -58,7 +58,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short
+bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short:cockroach-short
 ----
 
 bazel info workspace --color=no
@@ -78,7 +78,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-bazel build //pkg/cmd/cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short
 ----
 
 bazel info workspace --color=no
@@ -133,7 +133,7 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/sql/opt/optgen/lang/operator-gen.og.go go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator.og.go
 ----
 
-bazel build //pkg/cmd/cockroach-short -s
+bazel build //pkg/cmd/cockroach-short:cockroach-short -s
 ----
 
 bazel info workspace --color=no
@@ -153,7 +153,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
-bazel build //pkg/cmd/cockroach --verbose_failures --sandbox_debug
+bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
 ----
 
 bazel info workspace --color=no
@@ -171,4 +171,28 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach
 ----
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach/cockroach_/cockroach go/src/github.com/cockroachdb/cockroach/cockroach
+----
+
+bazel query @com_github_cockroachdb_stress//:stress --output=label_kind
+----
+go_binary rule @com_github_cockroachdb_stress//:stress
+
+bazel build @com_github_cockroachdb_stress//:stress
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/bin/stress
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress go/src/github.com/cockroachdb/cockroach/bin/stress
 ----

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
 config_setting(
     name = "cockroach_with_ui",
     define_values = {
-        "cockroach_with_ui": "true",
+        "cockroach_with_ui": "y",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
* Add a new `with_ui` config for building with the UI enabled;
* Pass this config to `bazel build` in CI and build the full `cockroach`
  binaries;
* Look up proper target names w/ `bazel query` in `dev build` and add
  `with_ui` config when appropriate.

Release note: None