### PR TITLE
workload: use the same ctx for ramp and main load

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -464,14 +464,11 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		for i, workFn := range ops.WorkerFns {
 			go func(i int, workFn func(context.Context) error) {
 				// If a ramp period was specified, start all of the workers
-				// gradually with a new context.
+				// gradually.
 				if rampCtx != nil {
 					rampPerWorker := *ramp / time.Duration(len(ops.WorkerFns))
 					time.Sleep(time.Duration(i) * rampPerWorker)
-					workerRun(rampCtx, errCh, nil /* wg */, limiter, workFn)
 				}
-
-				// Start worker again, this time with the main context.
 				workerRun(workersCtx, errCh, &wg, limiter, workFn)
 			}(i, workFn)
 		}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70019
fixes https://github.com/cockroachdb/cockroach/issues/69545
fixes https://github.com/cockroachdb/cockroach/issues/69523

We have seen issues where a worker returns ErrBadConn immediately after
the ramp period is done. It comes down to the fact that connections in
the pool are marked as "bad" when a context is canceled.

The underlying issue might be a race condition in how lib/pq cancels the
context and then marks the connection as "bad." But I'm not really sure
how to fix that and it's hard to reproduce, so I'm working around the
problem instead.

Release note: None