### PR TITLE
sql: refactored diff tool strucutres to remove JSON complexity

### DIFF
--- a/pkg/cmd/generate-metadata-tables/main.go
+++ b/pkg/cmd/generate-metadata-tables/main.go
@@ -15,11 +15,15 @@
 //
 // This accepts the following arguments:
 //
-// -user: to change default pg username of `postgres`
-// -addr: to change default pg address of `localhost:5432`
+// --user:    to change default pg username of `postgres`
+// --addr:    to change default pg address of `localhost:5432`
+// --catalog: can be pg_catalog or information_schema. Default is pg_catalog
+// --rdbms:   can be postgres or mysql. Default is postgres
+// --stdout:  for testing purposes, use this flag to send the output to the
+//            console
 //
-// Output of this file should generate:
-// pkg/sql/testdata/pg_catalog_tables
+// Output of this file should generate (If not using --stout):
+// pkg/sql/testdata/<catalog>_tables_from_<rdbms>.json
 package main
 
 import (
@@ -59,7 +63,7 @@ func main() {
 		panic(err)
 	}
 	pgCatalogFile := &sql.PGMetadataFile{
-		PGVersion:  dbVersion,
+		Version:    dbVersion,
 		PGMetadata: sql.PGMetadataTables{},
 	}
 
@@ -70,16 +74,13 @@ func main() {
 
 	rows.ForEachRow(func(tableName, columnName, dataTypeName string, dataTypeOid uint32) {
 		pgCatalogFile.PGMetadata.AddColumnMetadata(tableName, columnName, dataTypeName, dataTypeOid)
-		columnType := pgCatalogFile.PGMetadata[tableName][columnName]
-		if dataTypeOid != 0 && !columnType.IsImplemented() {
-			pgCatalogFile.AddUnimplementedType(columnType)
-		}
 	})
 
-	writer, err := getWriter()
+	writer, closeFn, err := getWriter()
 	if err != nil {
 		panic(err)
 	}
+	defer closeFn()
 	pgCatalogFile.Save(writer)
 }
 
@@ -102,11 +103,12 @@ func testdata() string {
 	return testdataDir
 }
 
-func getWriter() (io.Writer, error) {
+func getWriter() (io.Writer, func(), error) {
 	if *flagStdout {
-		return os.Stdout, nil
+		return os.Stdout, func() {}, nil
 	}
 
 	filename := sql.TablesMetadataFilename(testdata(), *flagRDBMS, *flagSchema)
-	return os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	return file, func() { file.Close() }, err
 }

--- a/pkg/sql/testdata/information_schema_tables_from_mysql.json
+++ b/pkg/sql/testdata/information_schema_tables_from_mysql.json
@@ -1,2965 +1,2005 @@
 {
-  "pgVersion": "8.0.25",
-  "diffSummary": {
-    "TotalTables": 0,
-    "TotalColumns": 0,
-    "MissingTables": 0,
-    "MissingColumns": 0,
-    "DatatypeMismatches": 0
-  },
-  "pgMetadata": {
+  "version": "8.0.25",
+  "tables": {
     "administrable_role_authorizations": {
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantee_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_default": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_mandatory": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "user": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "applicable_roles": {
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantee_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_default": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_mandatory": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "user": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "character_sets": {
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "default_collate_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "description": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "maxlen": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       }
     },
     "check_constraints": {
       "check_clause": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "collation_character_set_applicability": {
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "collations": {
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "id": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "is_compiled": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_default": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "pad_attribute": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "sortlen": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       }
     },
     "column_privileges": {
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "column_statistics": {
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "histogram": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "schema_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "columns": {
       "character_maximum_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_octet_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "column_comment": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "column_default": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "column_key": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "column_type": {
         "oid": 0,
-        "dataType": "mediumtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "mediumtext"
       },
       "data_type": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "datetime_precision": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "extra": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "generation_expression": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "is_nullable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "numeric_precision": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "numeric_scale": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "ordinal_position": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "privileges": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "srs_id": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "columns_extensions": {
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "secondary_engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "enabled_roles": {
       "is_default": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_mandatory": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "role_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "engines": {
       "comment": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "engine": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "savepoints": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "support": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "transactions": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "xa": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "events": {
       "character_set_client": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_connection": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "created": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "database_collation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "definer": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "ends": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "event_body": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_comment": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_definition": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "event_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "execute_at": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "interval_field": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "interval_value": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "last_altered": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "last_executed": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "on_completion": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "originator": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "sql_mode": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "starts": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "status": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "time_zone": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "files": {
       "autoextend_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "avg_row_length": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "check_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "checksum": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "create_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "creation_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "data_free": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "data_length": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "deleted_rows": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "engine": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "extent_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "extra": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "file_id": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "file_name": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "file_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "free_extents": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "fulltext_keys": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "index_length": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "initial_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "last_access_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "last_update_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "logfile_group_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "logfile_group_number": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "max_data_length": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "maximum_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "recover_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "row_format": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "status": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "table_rows": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "tablespace_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "total_extents": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "transaction_counter": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "update_count": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "update_time": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "version": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       }
     },
     "key_column_usage": {
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "ordinal_position": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "position_in_unique_constraint": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "referenced_column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "referenced_table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "referenced_table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "keywords": {
       "reserved": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "word": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "optimizer_trace": {
       "insufficient_privileges": {
         "oid": 0,
-        "dataType": "tinyint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "tinyint"
       },
       "missing_bytes_beyond_max_mem_size": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "query": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "trace": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "parameters": {
       "character_maximum_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_octet_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "data_type": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "datetime_precision": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "dtd_identifier": {
         "oid": 0,
-        "dataType": "mediumtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "mediumtext"
       },
       "numeric_precision": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "numeric_scale": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "ordinal_position": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "parameter_mode": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "parameter_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_type": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "specific_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "specific_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "specific_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "partitions": {
       "avg_row_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "check_time": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "checksum": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "create_time": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "data_free": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "data_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "index_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "max_data_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "nodegroup": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "partition_comment": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "partition_description": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "partition_expression": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "partition_method": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "partition_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "partition_ordinal_position": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "subpartition_expression": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "subpartition_method": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "subpartition_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "subpartition_ordinal_position": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_rows": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "tablespace_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "update_time": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       }
     },
     "plugins": {
       "load_option": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_author": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_description": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_library": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_library_version": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_license": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_status": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_type_version": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "plugin_version": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "processlist": {
       "command": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "db": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "id": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "info": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "state": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "time": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "user": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "profiling": {
       "block_ops_in": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "block_ops_out": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "context_involuntary": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "context_voluntary": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "cpu_system": {
         "oid": 0,
-        "dataType": "decimal",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "decimal"
       },
       "cpu_user": {
         "oid": 0,
-        "dataType": "decimal",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "decimal"
       },
       "duration": {
         "oid": 0,
-        "dataType": "decimal",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "decimal"
       },
       "messages_received": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "messages_sent": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "page_faults_major": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "page_faults_minor": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "query_id": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "seq": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "source_file": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "source_function": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "source_line": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "state": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "swaps": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       }
     },
     "referential_constraints": {
       "constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "delete_rule": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "match_option": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "referenced_table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "unique_constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "unique_constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "unique_constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "update_rule": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       }
     },
     "resource_groups": {
       "resource_group_enabled": {
         "oid": 0,
-        "dataType": "tinyint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "tinyint"
       },
       "resource_group_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "resource_group_type": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "thread_priority": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "vcpu_ids": {
         "oid": 0,
-        "dataType": "blob",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "blob"
       }
     },
     "role_column_grants": {
       "column_name": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantee": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantee_host": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantor": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantor_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "role_routine_grants": {
       "grantee": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantee_host": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantor": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantor_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "routine_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_name": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "routine_schema": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "specific_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "specific_name": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "specific_schema": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "role_table_grants": {
       "grantee": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantee_host": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "grantor": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "grantor_host": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "routines": {
       "character_maximum_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_octet_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "character_set_client": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_connection": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "created": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "data_type": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "database_collation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "datetime_precision": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "definer": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "dtd_identifier": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "external_language": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "external_name": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "is_deterministic": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "last_altered": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "numeric_precision": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "numeric_scale": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "parameter_style": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_body": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_comment": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "routine_definition": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "routine_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "routine_type": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "security_type": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "specific_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "sql_data_access": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "sql_mode": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "sql_path": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       }
     },
     "schema_privileges": {
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "schemata": {
       "catalog_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "default_character_set_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "default_collation_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "default_encryption": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "schema_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "sql_path": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       }
     },
     "schemata_extensions": {
       "catalog_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "options": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "schema_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "st_geometry_columns": {
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "geometry_type_name": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "srs_id": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "srs_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "st_spatial_reference_systems": {
       "definition": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "description": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "organization": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "organization_coordsys_id": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "srs_id": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "srs_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "st_units_of_measure": {
       "conversion_factor": {
         "oid": 0,
-        "dataType": "double",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "double"
       },
       "description": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "unit_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "unit_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "statistics": {
       "cardinality": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "collation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "column_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "comment": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "expression": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "index_comment": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "index_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "index_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "index_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_visible": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "non_unique": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "nullable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "packed": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "seq_in_index": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "sub_part": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "table_constraints": {
       "constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "enforced": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "table_constraints_extensions": {
       "constraint_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "constraint_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "secondary_engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "table_privileges": {
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "tables": {
       "auto_increment": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "avg_row_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "check_time": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "checksum": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "create_options": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "create_time": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "data_free": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "data_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "engine": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "index_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "max_data_length": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "row_format": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_collation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_comment": {
         "oid": 0,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_rows": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_type": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "update_time": {
         "oid": 0,
-        "dataType": "datetime",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "datetime"
       },
       "version": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       }
     },
     "tables_extensions": {
       "engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "secondary_engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "tablespaces": {
       "autoextend_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "engine": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "extent_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "logfile_group_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "maximum_size": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "nodegroup_id": {
         "oid": 0,
-        "dataType": "bigint",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bigint"
       },
       "tablespace_comment": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "tablespace_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "tablespace_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "tablespaces_extensions": {
       "engine_attribute": {
         "oid": 0,
-        "dataType": "json",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "json"
       },
       "tablespace_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "triggers": {
       "action_condition": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "action_order": {
         "oid": 0,
-        "dataType": "int",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int"
       },
       "action_orientation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "action_reference_new_row": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "action_reference_new_table": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "action_reference_old_row": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "action_reference_old_table": {
         "oid": 0,
-        "dataType": "binary",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "binary"
       },
       "action_statement": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "action_timing": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "character_set_client": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "collation_connection": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "created": {
         "oid": 0,
-        "dataType": "timestamp",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamp"
       },
       "database_collation": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "definer": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_manipulation": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "event_object_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_object_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "event_object_table": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "sql_mode": {
         "oid": 0,
-        "dataType": "set",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "set"
       },
       "trigger_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "trigger_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "trigger_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "user_attributes": {
       "attribute": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       },
       "host": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "user": {
         "oid": 0,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "user_privileges": {
       "grantee": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_grantable": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "privilege_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "view_routine_usage": {
       "specific_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "specific_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "specific_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "view_table_usage": {
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "view_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "view_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "view_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       }
     },
     "views": {
       "character_set_client": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "check_option": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "collation_connection": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "definer": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "is_updatable": {
         "oid": 0,
-        "dataType": "enum",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "enum"
       },
       "security_type": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_catalog": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_name": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "table_schema": {
         "oid": 0,
-        "dataType": "varchar",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "varchar"
       },
       "view_definition": {
         "oid": 0,
-        "dataType": "longtext",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "longtext"
       }
     }
-  },
-  "unimplementedTypes": null
+  }
 }

--- a/pkg/sql/testdata/information_schema_tables_from_postgres.json
+++ b/pkg/sql/testdata/information_schema_tables_from_postgres.json
@@ -1,3901 +1,2637 @@
 {
-  "pgVersion": "13.3",
-  "diffSummary": {
-    "TotalTables": 0,
-    "TotalColumns": 0,
-    "MissingTables": 0,
-    "MissingColumns": 0,
-    "DatatypeMismatches": 0
-  },
-  "pgMetadata": {
+  "version": "13.3",
+  "tables": {
     "administrable_role_authorizations": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "role_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "applicable_roles": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "role_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "attributes": {
       "attribute_default": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "attribute_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "attribute_udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "attribute_udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "attribute_udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_derived_reference_attribute": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_nullable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "ordinal_position": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "character_sets": {
       "character_repertoire": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_collate_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_collate_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_collate_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "form_of_use": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "check_constraint_routine_usage": {
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "check_constraints": {
       "check_clause": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "collation_character_set_applicability": {
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "collations": {
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "pad_attribute": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "column_column_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "dependent_column": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "column_domain_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "column_options": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "column_privileges": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "column_udt_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "columns": {
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "column_default": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "domain_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "generation_expression": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_cycle": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_generation": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_increment": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_maximum": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_minimum": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "identity_start": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_generated": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_identity": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_nullable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_self_referencing": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_updatable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "ordinal_position": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "constraint_column_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "constraint_table_usage": {
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "data_type_privileges": {
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "domain_constraints": {
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "initially_deferred": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_deferrable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "domain_udt_usage": {
       "domain_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "domains": {
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "domain_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_default": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "domain_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "element_types": {
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collection_type_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "domain_default": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "enabled_roles": {
       "role_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_data_wrapper_options": {
       "foreign_data_wrapper_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_data_wrappers": {
       "authorization_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_language": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "library_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_server_options": {
       "foreign_server_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_servers": {
       "authorization_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_data_wrapper_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_version": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_table_options": {
       "foreign_table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "foreign_tables": {
       "foreign_server_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "information_schema_catalog_name": {
       "catalog_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "key_column_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ordinal_position": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "position_in_unique_constraint": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "parameters": {
       "as_locator": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_result": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "ordinal_position": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "parameter_default": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "parameter_mode": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "parameter_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "referential_constraints": {
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "delete_rule": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "match_option": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "unique_constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "unique_constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "unique_constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "update_rule": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "role_column_grants": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "role_routine_grants": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "role_table_grants": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "with_hierarchy": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "role_udt_grants": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "role_usage_grants": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "routine_privileges": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "routines": {
       "as_locator": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "created": {
         "oid": 1184,
-        "dataType": "TIMESTAMPTZ",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TIMESTAMPTZ"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "external_language": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "external_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_deterministic": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_implicitly_invocable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_null_call": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_udt_dependent": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_user_defined_cast": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "last_altered": {
         "oid": 1184,
-        "dataType": "TIMESTAMPTZ",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TIMESTAMPTZ"
       },
       "max_dynamic_result_sets": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "module_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "module_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "module_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "new_savepoint_level": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "parameter_style": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_as_locator": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_char_max_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_char_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_char_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_char_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_char_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_from_data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_maximum_cardinality": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "result_cast_scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_type_udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_type_udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "result_cast_type_udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_body": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_definition": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "routine_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "schema_level_routine": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "scope_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "security_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sql_data_access": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sql_path": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "to_sql_specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "to_sql_specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "to_sql_specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "type_udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "type_udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "type_udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "schemata": {
       "catalog_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "default_character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "schema_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "schema_owner": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sql_path": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "sequences": {
       "cycle_option": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "increment": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "maximum_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "minimum_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "sequence_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sequence_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sequence_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "start_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "sql_features": {
       "comments": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "feature_id": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "feature_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_supported": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_verified_by": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sub_feature_id": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sub_feature_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "sql_implementation_info": {
       "character_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "comments": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "implementation_info_id": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "implementation_info_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "integer_value": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       }
     },
     "sql_parts": {
       "comments": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "feature_id": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "feature_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_supported": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_verified_by": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "sql_sizing": {
       "comments": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "sizing_id": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "sizing_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "supported_value": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       }
     },
     "table_constraints": {
       "constraint_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "constraint_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "enforced": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "initially_deferred": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_deferrable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "table_privileges": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "with_hierarchy": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "tables": {
       "commit_action": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_insertable_into": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_typed": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "reference_generation": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "self_referencing_column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "transforms": {
       "group_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "transform_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "triggered_update_columns": {
       "event_object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_column": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_table": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "triggers": {
       "action_condition": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_order": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "action_orientation": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_reference_new_row": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_reference_new_table": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_reference_old_row": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_reference_old_table": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_statement": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "action_timing": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "created": {
         "oid": 1184,
-        "dataType": "TIMESTAMPTZ",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TIMESTAMPTZ"
       },
       "event_manipulation": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "event_object_table": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "trigger_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "udt_privileges": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "udt_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "usage_privileges": {
       "grantee": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "grantor": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_grantable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "object_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "privilege_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "user_defined_types": {
       "character_maximum_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_octet_length": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "character_set_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "character_set_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "collation_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "data_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "datetime_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "interval_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_final": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_instantiable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "numeric_precision": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_precision_radix": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "numeric_scale": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "ordering_category": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ordering_form": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ordering_routine_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ordering_routine_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ordering_routine_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ref_dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "reference_type": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "source_dtd_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_category": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "user_defined_type_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "user_mapping_options": {
       "authorization_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "option_value": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "user_mappings": {
       "authorization_identifier": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "foreign_server_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "view_column_usage": {
       "column_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "view_routine_usage": {
       "specific_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "specific_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "view_table_usage": {
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "views": {
       "check_option": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_insertable_into": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_trigger_deletable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_trigger_insertable_into": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_trigger_updatable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "is_updatable": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_catalog": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_name": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "table_schema": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "view_definition": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     }
-  },
-  "unimplementedTypes": null
+  }
 }

--- a/pkg/sql/testdata/mysql_test_expected_diffs_on_information_schema.json
+++ b/pkg/sql/testdata/mysql_test_expected_diffs_on_information_schema.json
@@ -1,5 +1,5 @@
 {
-  "pgVersion": "8.0.25",
+  "version": "8.0.25",
   "diffSummary": {
     "TotalTables": 48,
     "TotalColumns": 476,
@@ -7,7 +7,7 @@
     "MissingColumns": 80,
     "DatatypeMismatches": 0
   },
-  "pgMetadata": {
+  "diffs": {
     "administrable_role_authorizations": {
       "grantee_host": null,
       "host": null,
@@ -125,5 +125,7 @@
       "security_type": null
     }
   },
-  "unimplementedTypes": null
+  "unimplementedTypes": {
+    "0": "varchar"
+  }
 }

--- a/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
+++ b/pkg/sql/testdata/pg_catalog_tables_from_postgres.json
@@ -1,7423 +1,5031 @@
 {
-  "pgVersion": "13.3",
-  "diffSummary": {
-    "TotalTables": 0,
-    "TotalColumns": 0,
-    "MissingTables": 0,
-    "MissingColumns": 0,
-    "DatatypeMismatches": 0
-  },
-  "pgMetadata": {
+  "version": "13.3",
+  "tables": {
     "pg_aggregate": {
       "aggcombinefn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggdeserialfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggfinalextra": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "aggfinalfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggfinalmodify": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "aggfnoid": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "agginitval": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "aggkind": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "aggmfinalextra": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "aggmfinalfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggmfinalmodify": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "aggminitval": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "aggminvtransfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggmtransfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggmtransspace": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "aggmtranstype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "aggnumdirectargs": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "aggserialfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggsortop": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "aggtransfn": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "aggtransspace": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "aggtranstype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_am": {
       "amhandler": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "amname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "amtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_amop": {
       "amopfamily": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amoplefttype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amopmethod": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amopopr": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amoppurpose": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "amoprighttype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amopsortfamily": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amopstrategy": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_amproc": {
       "amproc": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "amprocfamily": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amproclefttype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "amprocnum": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "amprocrighttype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_attrdef": {
       "adbin": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "adnum": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "adrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_attribute": {
       "attacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "attalign": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "attbyval": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "attcacheoff": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "attcollation": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "attfdwoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "attgenerated": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "atthasdef": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "atthasmissing": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "attidentity": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "attinhcount": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "attisdropped": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "attislocal": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "attlen": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "attmissingval": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "attname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "attndims": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "attnotnull": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "attnum": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "attoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "attrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "attstattarget": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "attstorage": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "atttypid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "atttypmod": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_auth_members": {
       "admin_option": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "grantor": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "member": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "roleid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_authid": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rolbypassrls": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolcanlogin": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolconnlimit": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "rolcreatedb": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolcreaterole": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolinherit": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "rolpassword": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "rolreplication": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolsuper": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolvaliduntil": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_available_extension_versions": {
       "comment": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "installed": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "name": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relocatable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "requires": {
         "oid": 1003,
-        "dataType": "_name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_name"
       },
       "schema": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "superuser": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "trusted": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "version": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_available_extensions": {
       "comment": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "default_version": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "installed_version": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "name": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_cast": {
       "castcontext": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "castfunc": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "castmethod": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "castsource": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "casttarget": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_class": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "relallvisible": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relam": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relchecks": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "relfilenode": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relforcerowsecurity": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relfrozenxid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "relhasindex": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relhasrules": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relhassubclass": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relhastriggers": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relispartition": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relispopulated": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relisshared": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "relkind": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "relminmxid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relnatts": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "reloftype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "reloptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "relowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relpages": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relpartbound": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "relpersistence": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "relreplident": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "relrewrite": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relrowsecurity": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "reltablespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "reltoastrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "reltuples": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "reltype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_collation": {
       "collcollate": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "collctype": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "collencoding": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "collisdeterministic": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "collname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "collnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "collowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "collprovider": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "collversion": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_config": {
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "setting": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_constraint": {
       "conbin": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "condeferrable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "condeferred": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "conexclop": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "confdeltype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "conffeqop": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "confkey": {
         "oid": 1005,
-        "dataType": "_int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_int2"
       },
       "confmatchtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "confrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "confupdtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "conindid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "coninhcount": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "conislocal": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "conkey": {
         "oid": 1005,
-        "dataType": "_int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_int2"
       },
       "conname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "connamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "connoinherit": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "conparentid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "conpfeqop": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "conppeqop": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "conrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "contype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "contypid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "convalidated": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_conversion": {
       "condefault": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "conforencoding": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "conname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "connamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "conowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "conproc": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "contoencoding": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_cursors": {
       "creation_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "is_binary": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "is_holdable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "is_scrollable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "statement": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_database": {
       "datacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "datallowconn": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "datcollate": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "datconnlimit": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "datctype": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "datdba": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datfrozenxid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "datistemplate": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "datlastsysoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datminmxid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "dattablespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "encoding": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_db_role_setting": {
       "setconfig": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "setdatabase": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "setrole": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_default_acl": {
       "defaclacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "defaclnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "defaclobjtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "defaclrole": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_depend": {
       "classid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "deptype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "objid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "refclassid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "refobjid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "refobjsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_description": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "description": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_enum": {
       "enumlabel": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "enumsortorder": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "enumtypid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_event_trigger": {
       "evtenabled": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "evtevent": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "evtfoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "evtname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "evtowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "evttags": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_extension": {
       "extcondition": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "extconfig": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "extname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "extnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "extowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "extrelocatable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "extversion": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_file_settings": {
       "applied": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "error": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "seqno": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "setting": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sourcefile": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sourceline": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_foreign_data_wrapper": {
       "fdwacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "fdwhandler": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "fdwname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "fdwoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "fdwowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "fdwvalidator": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_foreign_server": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srvacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "srvfdw": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srvname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "srvoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "srvowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srvtype": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "srvversion": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_foreign_table": {
       "ftoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "ftrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "ftserver": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_group": {
       "grolist": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "groname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "grosysid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_hba_file_rules": {
       "address": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "auth_method": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "database": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "error": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "line_number": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "netmask": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "options": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "type": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "user_name": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       }
     },
     "pg_index": {
       "indcheckxmin": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indclass": {
         "oid": 30,
-        "dataType": "oidvector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oidvector"
       },
       "indcollation": {
         "oid": 30,
-        "dataType": "oidvector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oidvector"
       },
       "indexprs": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indimmediate": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisclustered": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisexclusion": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indislive": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisprimary": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisready": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisreplident": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisunique": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indisvalid": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "indkey": {
         "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2vector"
       },
       "indnatts": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "indnkeyatts": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "indoption": {
         "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2vector"
       },
       "indpred": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "indrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_indexes": {
       "indexdef": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "indexname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablespace": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_inherits": {
       "inhparent": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "inhrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "inhseqno": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_init_privs": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "initprivs": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "privtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "pg_language": {
       "lanacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "laninline": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "lanispl": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "lanname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "lanowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "lanplcallfoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "lanpltrusted": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "lanvalidator": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_largeobject": {
       "data": {
         "oid": 17,
-        "dataType": "bytea",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bytea"
       },
       "loid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "pageno": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_largeobject_metadata": {
       "lomacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "lomowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_locks": {
       "classid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "database": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "fastpath": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "granted": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "locktype": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "mode": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "page": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relation": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "transactionid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "tuple": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "virtualtransaction": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "virtualxid": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_matviews": {
       "definition": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "hasindexes": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "ispopulated": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "matviewname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "matviewowner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablespace": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_namespace": {
       "nspacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "nspname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "nspowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_opclass": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opcdefault": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "opcfamily": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opcintype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opckeytype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opcmethod": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opcname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "opcnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opcowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_operator": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprcanhash": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "oprcanmerge": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "oprcode": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "oprcom": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprjoin": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "oprkind": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "oprleft": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "oprnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprnegate": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprrest": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "oprresult": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oprright": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_opfamily": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opfmethod": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opfname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "opfnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "opfowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_partitioned_table": {
       "partattrs": {
         "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2vector"
       },
       "partclass": {
         "oid": 30,
-        "dataType": "oidvector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oidvector"
       },
       "partcollation": {
         "oid": 30,
-        "dataType": "oidvector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oidvector"
       },
       "partdefid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "partexprs": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "partnatts": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "partrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "partstrat": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "pg_policies": {
       "cmd": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "permissive": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "policyname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "qual": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "roles": {
         "oid": 1003,
-        "dataType": "_name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "with_check": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_policy": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "polcmd": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "polname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "polpermissive": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "polqual": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "polrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "polroles": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "polwithcheck": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "pg_prepared_statements": {
       "from_sql": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "parameter_types": {
         "oid": 2211,
-        "dataType": "_regtype",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_regtype"
       },
       "prepare_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "statement": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_prepared_xacts": {
       "database": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "gid": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "owner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "prepared": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "transaction": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       }
     },
     "pg_proc": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "proacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "proallargtypes": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "proargdefaults": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "proargmodes": {
         "oid": 1002,
-        "dataType": "_char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_char"
       },
       "proargnames": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "proargtypes": {
         "oid": 30,
-        "dataType": "oidvector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oidvector"
       },
       "probin": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "proconfig": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "procost": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "proisstrict": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "prokind": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "prolang": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "proleakproof": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "proname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "pronamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "pronargdefaults": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "pronargs": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "proowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "proparallel": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "proretset": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "prorettype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "prorows": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "prosecdef": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "prosrc": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "prosupport": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "protrftypes": {
         "oid": 1028,
-        "dataType": "_oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_oid"
       },
       "provariadic": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "provolatile": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "pg_publication": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "puballtables": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pubdelete": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pubinsert": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pubname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "pubowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "pubtruncate": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pubupdate": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pubviaroot": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       }
     },
     "pg_publication_rel": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "prpubid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "prrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_publication_tables": {
       "pubname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_range": {
       "rngcanonical": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "rngcollation": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rngsubdiff": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "rngsubopc": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rngsubtype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rngtypid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_replication_origin": {
       "roident": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "roname": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_replication_origin_status": {
       "external_id": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "local_id": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "local_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "remote_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "pg_replication_slots": {
       "active": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "active_pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "catalog_xmin": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "confirmed_flush_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "database": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "datoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "plugin": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "restart_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "safe_wal_size": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "slot_name": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "slot_type": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "temporary": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "wal_status": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "xmin": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       }
     },
     "pg_rewrite": {
       "ev_action": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ev_class": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "ev_enabled": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "ev_qual": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "ev_type": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "is_instead": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rulename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_roles": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "rolbypassrls": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolcanlogin": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolconfig": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "rolconnlimit": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "rolcreatedb": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolcreaterole": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolinherit": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "rolpassword": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "rolreplication": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolsuper": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rolvaliduntil": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_rules": {
       "definition": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "rulename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_seclabel": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "label": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "provider": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_seclabels": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "label": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objname": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "objtype": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "provider": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_sequence": {
       "seqcache": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seqcycle": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "seqincrement": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seqmax": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seqmin": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seqrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "seqstart": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seqtypid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_sequences": {
       "cache_size": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "cycle": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "data_type": {
         "oid": 2206,
-        "dataType": "regtype",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regtype"
       },
       "increment_by": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "last_value": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "max_value": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "min_value": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "sequencename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "sequenceowner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "start_value": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_settings": {
       "boot_val": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "category": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "context": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "enumvals": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "extra_desc": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "max_val": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "min_val": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pending_restart": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "reset_val": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "setting": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "short_desc": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "source": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sourcefile": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sourceline": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "unit": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "vartype": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_shadow": {
       "passwd": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "usebypassrls": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "useconfig": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "usecreatedb": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "userepl": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usesuper": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usesysid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "valuntil": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_shdepend": {
       "classid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "dbid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "deptype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "objid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "objsubid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "refclassid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "refobjid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_shdescription": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "description": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_shmem_allocations": {
       "allocated_size": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "off": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "size": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_shseclabel": {
       "classoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "label": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "objoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "provider": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_stat_activity": {
       "application_name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "backend_start": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "backend_type": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "backend_xid": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "backend_xmin": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "client_addr": {
         "oid": 869,
-        "dataType": "inet",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "inet"
       },
       "client_hostname": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "client_port": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "leader_pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "query": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "query_start": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "state": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "state_change": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "usename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "usesysid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "wait_event": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "wait_event_type": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "xact_start": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_stat_all_indexes": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stat_all_tables": {
       "analyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autoanalyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autovacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "last_analyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autoanalyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autovacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_vacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "n_dead_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_ins_since_vacuum": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_live_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_mod_since_analyze": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "vacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_archiver": {
       "archived_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "failed_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "last_archived_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_archived_wal": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "last_failed_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_failed_wal": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "stats_reset": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_stat_bgwriter": {
       "buffers_alloc": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "buffers_backend": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "buffers_backend_fsync": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "buffers_checkpoint": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "buffers_clean": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "checkpoint_sync_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "checkpoint_write_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "checkpoints_req": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "checkpoints_timed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "maxwritten_clean": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "stats_reset": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_stat_database": {
       "blk_read_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "blk_write_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "checksum_failures": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "checksum_last_failure": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "conflicts": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "deadlocks": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "numbackends": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "stats_reset": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "temp_bytes": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "temp_files": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tup_deleted": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tup_fetched": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tup_inserted": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tup_returned": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tup_updated": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "xact_commit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "xact_rollback": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_database_conflicts": {
       "confl_bufferpin": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "confl_deadlock": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "confl_lock": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "confl_snapshot": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "confl_tablespace": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stat_gssapi": {
       "encrypted": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "gss_authenticated": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "principal": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_stat_progress_analyze": {
       "child_tables_done": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "child_tables_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "current_child_table_relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "ext_stats_computed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "ext_stats_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "phase": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "sample_blks_scanned": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "sample_blks_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_progress_basebackup": {
       "backup_streamed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "backup_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "phase": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "tablespaces_streamed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tablespaces_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_progress_cluster": {
       "cluster_index_relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "command": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "heap_blks_scanned": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_tuples_scanned": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_tuples_written": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "index_rebuild_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "phase": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_stat_progress_create_index": {
       "blocks_done": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blocks_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "command": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "current_locker_pid": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "index_relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "lockers_done": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "lockers_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "partitions_done": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "partitions_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "phase": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tuples_done": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tuples_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_progress_vacuum": {
       "datid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "datname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "heap_blks_scanned": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_total": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_vacuumed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "index_vacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "max_dead_tuples": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "num_dead_tuples": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "phase": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_stat_replication": {
       "application_name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "backend_start": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "backend_xmin": {
         "oid": 20,
-        "dataType": "INT8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "INT8"
       },
       "client_addr": {
         "oid": 869,
-        "dataType": "inet",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "inet"
       },
       "client_hostname": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "client_port": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "flush_lag": {
         "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "interval"
       },
       "flush_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "replay_lag": {
         "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "interval"
       },
       "replay_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "reply_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "sent_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "state": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sync_priority": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "sync_state": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "usename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "usesysid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "write_lag": {
         "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "interval"
       },
       "write_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "pg_stat_slru": {
       "blks_exists": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_written": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_zeroed": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "flushes": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "stats_reset": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "truncates": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_ssl": {
       "bits": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "cipher": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "client_dn": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "client_serial": {
         "oid": 1700,
-        "dataType": "numeric",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "numeric"
       },
       "compression": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "issuer_dn": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "ssl": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "version": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_stat_subscription": {
       "last_msg_receipt_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_msg_send_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "latest_end_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "latest_end_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "received_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "subid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "subname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stat_sys_indexes": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stat_sys_tables": {
       "analyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autoanalyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autovacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "last_analyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autoanalyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autovacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_vacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "n_dead_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_ins_since_vacuum": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_live_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_mod_since_analyze": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "vacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_user_functions": {
       "calls": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "funcid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "funcname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "self_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "total_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       }
     },
     "pg_stat_user_indexes": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stat_user_tables": {
       "analyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autoanalyze_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "autovacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "last_analyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autoanalyze": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_autovacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_vacuum": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "n_dead_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_ins_since_vacuum": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_live_tup": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_mod_since_analyze": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "vacuum_count": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_wal_receiver": {
       "conninfo": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "flushed_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "last_msg_receipt_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "last_msg_send_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "latest_end_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "latest_end_time": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       },
       "pid": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "receive_start_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "receive_start_tli": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "received_tli": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "sender_host": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "sender_port": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "slot_name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "status": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "written_lsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       }
     },
     "pg_stat_xact_all_tables": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_xact_sys_tables": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_stat_xact_user_functions": {
       "calls": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "funcid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "funcname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "self_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       },
       "total_time": {
         "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float8"
       }
     },
     "pg_stat_xact_user_tables": {
       "idx_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_tup_fetch": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_del": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_hot_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_ins": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "n_tup_upd": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "seq_scan": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "seq_tup_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_statio_all_indexes": {
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_all_sequences": {
       "blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_all_tables": {
       "heap_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tidx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tidx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_statio_sys_indexes": {
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_sys_sequences": {
       "blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_sys_tables": {
       "heap_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tidx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tidx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_statio_user_indexes": {
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "indexrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "indexrelname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_user_sequences": {
       "blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_statio_user_tables": {
       "heap_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "heap_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "idx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "relid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "relname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tidx_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "tidx_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_hit": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       },
       "toast_blks_read": {
         "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int8"
       }
     },
     "pg_statistic": {
       "staattnum": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stacoll1": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stacoll2": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stacoll3": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stacoll4": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stacoll5": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stadistinct": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "stainherit": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "stakind1": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stakind2": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stakind3": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stakind4": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stakind5": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "stanullfrac": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "stanumbers1": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "stanumbers2": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "stanumbers3": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "stanumbers4": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "stanumbers5": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "staop1": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "staop2": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "staop3": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "staop4": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "staop5": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "starelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stavalues1": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "stavalues2": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "stavalues3": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "stavalues4": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "stavalues5": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "stawidth": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_statistic_ext": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stxkeys": {
         "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2vector"
       },
       "stxkind": {
         "oid": 1002,
-        "dataType": "_char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_char"
       },
       "stxname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "stxnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stxowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stxrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "stxstattarget": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_statistic_ext_data": {
       "stxddependencies": {
         "oid": 17,
-        "dataType": "BYTEA",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "BYTEA"
       },
       "stxdmcv": {
         "oid": 17,
-        "dataType": "BYTEA",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "BYTEA"
       },
       "stxdndistinct": {
         "oid": 17,
-        "dataType": "BYTEA",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "BYTEA"
       },
       "stxoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_stats": {
       "attname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "avg_width": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "correlation": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "elem_count_histogram": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "histogram_bounds": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "inherited": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "most_common_elem_freqs": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "most_common_elems": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "most_common_freqs": {
         "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float4"
       },
       "most_common_vals": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "n_distinct": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "null_frac": {
         "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "float4"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_stats_ext": {
       "attnames": {
         "oid": 1003,
-        "dataType": "_name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_name"
       },
       "dependencies": {
         "oid": 17,
-        "dataType": "BYTEA",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "BYTEA"
       },
       "kinds": {
         "oid": 1002,
-        "dataType": "_char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_char"
       },
       "most_common_base_freqs": {
         "oid": 1022,
-        "dataType": "_float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float8"
       },
       "most_common_freqs": {
         "oid": 1022,
-        "dataType": "_float8",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_float8"
       },
       "most_common_val_nulls": {
         "oid": 1000,
-        "dataType": "_bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_bool"
       },
       "most_common_vals": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "n_distinct": {
         "oid": 17,
-        "dataType": "BYTEA",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "BYTEA"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "statistics_name": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "statistics_owner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "statistics_schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_subscription": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "subconninfo": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "subdbid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "subenabled": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "subname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "subowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "subpublications": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "subslotname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "subsynccommit": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       }
     },
     "pg_subscription_rel": {
       "srrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srsubid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srsublsn": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "srsubstate": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       }
     },
     "pg_tables": {
       "hasindexes": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "hasrules": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "hastriggers": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "rowsecurity": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tableowner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tablespace": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_tablespace": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "spcacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "spcname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "spcoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "spcowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_timezone_abbrevs": {
       "abbrev": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "is_dst": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "utc_offset": {
         "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "interval"
       }
     },
     "pg_timezone_names": {
       "abbrev": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "is_dst": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "name": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "utc_offset": {
         "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "interval"
       }
     },
     "pg_transform": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "trffromsql": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "trflang": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "trftosql": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "trftype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_trigger": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgargs": {
         "oid": 17,
-        "dataType": "bytea",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bytea"
       },
       "tgattr": {
         "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2vector"
       },
       "tgconstraint": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgconstrindid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgconstrrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgdeferrable": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "tgenabled": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "tgfoid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tginitdeferred": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "tgisinternal": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "tgname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tgnargs": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "tgnewtable": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tgoldtable": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tgparentid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgqual": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "tgrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tgtype": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       }
     },
     "pg_ts_config": {
       "cfgname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "cfgnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "cfgowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "cfgparser": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_ts_config_map": {
       "mapcfg": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "mapdict": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "mapseqno": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "maptokentype": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_ts_dict": {
       "dictinitoption": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "dictname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "dictnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "dictowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "dicttemplate": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_ts_parser": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "prsend": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "prsheadline": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "prslextype": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "prsname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "prsnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "prsstart": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "prstoken": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       }
     },
     "pg_ts_template": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "tmplinit": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "tmpllexize": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "tmplname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "tmplnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_type": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typacl": {
         "oid": 1009,
-        "dataType": "_TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_TEXT"
       },
       "typalign": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "typanalyze": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typarray": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typbasetype": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typbyval": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "typcategory": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "typcollation": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typdefault": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "typdefaultbin": {
         "oid": 25,
-        "dataType": "TEXT",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "TEXT"
       },
       "typdelim": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "typelem": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typinput": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typisdefined": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "typispreferred": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "typlen": {
         "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int2"
       },
       "typmodin": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typmodout": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "typnamespace": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typndims": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       },
       "typnotnull": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "typoutput": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typowner": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typreceive": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typrelid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "typsend": {
         "oid": 24,
-        "dataType": "regproc",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "regproc"
       },
       "typstorage": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "typtype": {
         "oid": 18,
-        "dataType": "char",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "char"
       },
       "typtypmod": {
         "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "int4"
       }
     },
     "pg_user": {
       "passwd": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "usebypassrls": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "useconfig": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "usecreatedb": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "userepl": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usesuper": {
         "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "bool"
       },
       "usesysid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "valuntil": {
         "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "timestamptz"
       }
     },
     "pg_user_mapping": {
       "oid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "umoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "umserver": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "umuser": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       }
     },
     "pg_user_mappings": {
       "srvid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "srvname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "umid": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "umoptions": {
         "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "_text"
       },
       "umuser": {
         "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "oid"
       },
       "usename": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     },
     "pg_views": {
       "definition": {
         "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "text"
       },
       "schemaname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "viewname": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       },
       "viewowner": {
         "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
+        "dataType": "name"
       }
     }
-  },
-  "unimplementedTypes": null
+  }
 }

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_information_schema.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_information_schema.json
@@ -1,5 +1,5 @@
 {
-  "pgVersion": "13.3",
+  "version": "13.3",
   "diffSummary": {
     "TotalTables": 60,
     "TotalColumns": 628,
@@ -7,7 +7,7 @@
     "MissingColumns": 12,
     "DatatypeMismatches": 0
   },
-  "pgMetadata": {
+  "diffs": {
     "routines": {
       "scope_schema": null
     },
@@ -29,5 +29,5 @@
       "user_defined_type_schema": null
     }
   },
-  "unimplementedTypes": null
+  "unimplementedTypes": {}
 }

--- a/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
+++ b/pkg/sql/testdata/postgres_test_expected_diffs_on_pg_catalog.json
@@ -1,5 +1,5 @@
 {
-  "pgVersion": "13.3",
+  "version": "13.3",
   "diffSummary": {
     "TotalTables": 129,
     "TotalColumns": 1192,
@@ -7,7 +7,7 @@
     "MissingColumns": 0,
     "DatatypeMismatches": 19
   },
-  "pgMetadata": {
+  "diffs": {
     "pg_am": {
       "amhandler": {
         "oid": 26,
@@ -145,5 +145,5 @@
       }
     }
   },
-  "unimplementedTypes": null
+  "unimplementedTypes": {}
 }


### PR DESCRIPTION
Previously, diff tool shared the same structures for table metadata
and diffs
This was inadequate because they have different concerns
To address this, this patch refactored the code so every concern or
process have their own data types

Release note: None