### PR TITLE
dev: various improvements

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -290,6 +290,7 @@ func (d *dev) getBasicBuildArgs(
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 
+	shouldBuildWithTestConfig := false
 	for _, target := range targets {
 		target = strings.TrimPrefix(target, "./")
 		target = strings.TrimRight(target, "/")
@@ -307,6 +308,9 @@ func (d *dev) getBasicBuildArgs(
 			typ := fields[0]
 			args = append(args, fullTargetName)
 			buildTargets = append(buildTargets, buildTarget{fullName: fullTargetName, isGoBinary: typ == "go_binary"})
+			if typ == "go_test" {
+				shouldBuildWithTestConfig = true
+			}
 			continue
 		}
 		aliased, ok := buildTargetMapping[target]
@@ -325,6 +329,9 @@ func (d *dev) getBasicBuildArgs(
 			args = append(args, "--config=with_ui")
 			break
 		}
+	}
+	if shouldBuildWithTestConfig {
+		args = append(args, "--config=test")
 	}
 
 	return

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -72,7 +72,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test")
-	args = append(args, additionalBazelArgs...)
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	if numCPUs != 0 {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
@@ -85,13 +84,14 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 
 	for _, pkg := range pkgs {
 		pkg = strings.TrimPrefix(pkg, "//")
+		pkg = strings.TrimPrefix(pkg, "./")
 		pkg = strings.TrimRight(pkg, "/")
 
 		if !strings.HasPrefix(pkg, "pkg/") {
 			return fmt.Errorf("malformed package %q, expecting %q", pkg, "pkg/{...}")
 		}
 
-		if strings.HasSuffix(pkg, "...") {
+		if strings.HasSuffix(pkg, "/...") {
 			// Similar to `go test`, we implement `...` expansion to allow
 			// callers to use the following pattern to test all packages under a
 			// named one:
@@ -124,10 +124,15 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 				targets := strings.TrimSpace(string(out))
 				args = append(args, strings.Split(targets, "\n")...)
 			}
+		} else if strings.Contains(pkg, ":") {
+			args = append(args, pkg)
 		} else {
-			components := strings.Split(pkg, "/")
-			pkgName := components[len(components)-1]
-			args = append(args, fmt.Sprintf("//%s:%s_test", pkg, pkgName))
+			out, err := d.exec.CommandContextSilent(ctx, "bazel", "query", fmt.Sprintf("kind(go_test, //%s:all)", pkg))
+			if err != nil {
+				return err
+			}
+			tests := strings.Split(strings.TrimSpace(string(out)), "\n")
+			args = append(args, tests...)
 		}
 	}
 
@@ -156,6 +161,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	} else {
 		args = append(args, "--test_output", "errors")
 	}
+	args = append(args, additionalBazelArgs...)
 
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -76,3 +76,11 @@ mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/bin/stress
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress go/src/github.com/cockroachdb/cockroach/bin/stress
+
+dev build pkg/roachpb:roachpb_test
+----
+bazel query pkg/roachpb:roachpb_test --output=label_kind
+bazel build //pkg/roachpb:roachpb_test --config=test
+bazel info workspace --color=no
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -196,3 +196,21 @@ rm go/src/github.com/cockroachdb/cockroach/bin/stress
 
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/external/com_github_cockroachdb_stress/stress_/stress go/src/github.com/cockroachdb/cockroach/bin/stress
 ----
+
+bazel query pkg/roachpb:roachpb_test --output=label_kind
+----
+go_test rule //pkg/roachpb:roachpb_test
+
+bazel build //pkg/roachpb:roachpb_test --config=test
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -1,3 +1,7 @@
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
+
 bazel test //pkg/util/tracing:tracing_test --test_output errors
 ----
 ----
@@ -20,6 +24,10 @@ Executed 0 out of 1 test: 1 test passes.
 ----
 ----
 
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
+
 bazel test //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output errors
 ----
 ----
@@ -28,6 +36,10 @@ bazel test //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --tes
 Executed 1 out of 1 test: 1 test passes.
 ----
 ----
+
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
 
 bazel test //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
 ----
@@ -42,6 +54,10 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
+
 bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output errors
 ----
 ----
@@ -50,6 +66,10 @@ bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experi
 Executed 0 out of 1 test: 1 test passes.
 ----
 ----
+
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
 
 bazel test //pkg/util/tracing:tracing_test --nocache_test_results '--test_filter=TestStartChild*' --test_output errors
 ----
@@ -60,6 +80,10 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
+
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output errors
 ----
 ----
@@ -68,6 +92,10 @@ bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --r
 Executed 1 out of 1 test: 1 test passes.
 ----
 ----
+
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
 
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=11 '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
 ----
@@ -83,6 +111,10 @@ SUCCESS
 Executed 1 out of 1 test: 1 test passes.
 ----
 ----
+
+bazel query 'kind(go_test, //pkg/testutils:all)'
+----
+//pkg/testutils:testutils_test
 
 bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
 ----
@@ -109,11 +141,29 @@ Executed 1 out of 1 test: 1 test passes.
 ----
 ----
 
-bazel test -s //pkg/util/tracing:tracing_test --test_output errors
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+----
+//pkg/util/tracing:tracing_test
+
+bazel test //pkg/util/tracing:tracing_test --test_output errors -s
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 0.2s
 
 Executed 1 out of 1 test: 1 test passes.
 ----
+----
+
+bazel query 'kind(go_test, //pkg/roachpb:all)'
+----
+----
+//pkg/roachpb:roachpb_test
+//pkg/roachpb:string_test
+----
+----
+
+bazel test //pkg/roachpb:roachpb_test //pkg/roachpb:string_test --test_output errors
+----
+
+bazel test pkg/roachpb:string_test --test_output errors
 ----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -1,5 +1,6 @@
 dev test pkg/util/tracing
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing/...
@@ -9,32 +10,49 @@ bazel test //pkg/util/tracing:tracing_test --test_output errors
 
 dev test pkg/util/tracing -f TestStartChild*
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f TestStartChild* -v
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
 
 dev test pkg/util/tracing -f TestStartChild* --remote-cache 127.0.0.1:9092
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test --remote_local_fallback --remote_cache=grpc://127.0.0.1:9092 --experimental_remote_downloader=grpc://127.0.0.1:9092 //pkg/util/tracing:tracing_test '--test_filter=TestStartChild*' --test_output errors
 
 dev test pkg/util/tracing -f TestStartChild* --ignore-cache
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test //pkg/util/tracing:tracing_test --nocache_test_results '--test_filter=TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter TestStartChild*
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output errors
 
 dev test --stress pkg/util/tracing --filter TestStartChild* --timeout=10s -v
 ----
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=11 '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
 
 dev test //pkg/testutils --timeout=10s
 ----
+bazel query 'kind(go_test, //pkg/testutils:all)'
 bazel test //pkg/testutils:testutils_test --test_timeout=10 --test_output errors
 
 dev test pkg/util/tracing -- -s
 ----
-bazel test -s //pkg/util/tracing:tracing_test --test_output errors
+bazel query 'kind(go_test, //pkg/util/tracing:all)'
+bazel test //pkg/util/tracing:tracing_test --test_output errors -s
+
+dev test ./pkg/roachpb
+----
+bazel query 'kind(go_test, //pkg/roachpb:all)'
+bazel test //pkg/roachpb:roachpb_test //pkg/roachpb:string_test --test_output errors
+
+dev test pkg/roachpb:string_test
+----
+bazel test pkg/roachpb:string_test --test_output errors


### PR DESCRIPTION
* force building w/ the `test` config if the target to `dev build` is a
  `go_test`
* in `dev test`, query for all tests in a package rather than assuming
  the name of the test
* also allow passing actual bazel target names to `dev test`

Release note: None