### PR TITLE
serverccl: support ListContentionEvents RPC endpoint for Serverless

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1578,7 +1578,9 @@ Response object for ListContentionEvents and ListLocalContentionEvents.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1651,7 +1653,9 @@ Response object for ListContentionEvents and ListLocalContentionEvents.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1743,7 +1747,9 @@ Info contains an information about a single DistSQL remote flow.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1834,7 +1840,9 @@ Info contains an information about a single DistSQL remote flow.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -71,6 +71,12 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/ResetSQLStats":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/ListContentionEvents":
+		return a.authTenant(tenID)
+
+	case "/cockroach.server.serverpb.Status/ListLocalContentionEvents":
+		return a.authTenant(tenID)
+
 	case "/cockroach.server.serverpb.Status/ListSessions":
 		return a.authTenant(tenID)
 

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -2522,7 +2522,9 @@ func (m *ListContentionEventsRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_ListContentionEventsRequest proto.InternalMessageInfo
 
 // An error wrapper object for ListContentionEventsResponse and
-// ListDistSQLFlowsResponse.
+// ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+// implemented on a tenant, the `node_id` field refers to the instanceIDs that
+// identify individual tenant pods.
 type ListActivityError struct {
 	// ID of node that was being contacted when this error occurred.
 	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -690,7 +690,9 @@ message CancelSessionResponse {
 message ListContentionEventsRequest {}
 
 // An error wrapper object for ListContentionEventsResponse and
-// ListDistSQLFlowsResponse.
+// ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+// implemented on a tenant, the `node_id` field refers to the instanceIDs that
+// identify individual tenant pods.
 message ListActivityError {
   // ID of node that was being contacted when this error occurred.
   int32 node_id = 1 [

--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -243,6 +243,8 @@ func NewRegistry() *Registry {
 func (r *Registry) AddContentionEvent(c roachpb.ContentionEvent) {
 	r.globalLock.Lock()
 	defer r.globalLock.Unlock()
+	// Remove the tenant ID prefix if there is any.
+	c.Key, _, _ = keys.DecodeTenantPrefix(c.Key)
 	_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(c.Key)
 	if err != nil {
 		// The key is not a valid SQL key, so we store it in a separate cache.


### PR DESCRIPTION
Previously, ListContentionEvents RPC endpoint only returns node-local
contention events.
This commit introduces cluster RPC fanout for ListContentionEvents endpoint.
This commit also updated the ContentionRegistry to handle tenantID.

Resolves #68632

Release note (api change): ListContentionEvent RPC now returns cluster-wide
contention events.