### PR TITLE
dev: refactor common build flags

### DIFF
--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -33,6 +33,7 @@ func makeBenchCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 		Args: cobra.MinimumNArgs(0),
 		RunE: runE,
 	}
+	addCommonBuildFlags(benchCmd)
 	addCommonTestFlags(benchCmd)
 	return benchCmd
 }

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -50,6 +50,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
         build configuration specified in .bazelrc, minus the "cross" prefix.`)
 	buildCmd.Flags().Bool(hoistGeneratedCodeFlag, false, "hoist generated code out of the Bazel sandbox into the workspace")
 	buildCmd.Flags().Lookup(crossFlag).NoOptDefVal = "linux"
+	addCommonBuildFlags(buildCmd)
 	return buildCmd
 }
 

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -27,12 +27,6 @@ type dev struct {
 	exec *exec.Exec
 }
 
-var (
-	// Shared flags.
-	remoteCacheAddr string
-	numCPUs         int
-)
-
 func makeDevCmd() *dev {
 	var ret dev
 	ret.log = log.New(ioutil.Discard, "DEBUG: ", 0) // used for debug logging (see --debug)
@@ -80,13 +74,6 @@ Dev is the general-purpose dev tool for working on cockroachdb/cockroach. With d
 	var debugVar bool
 	for _, subCmd := range ret.cli.Commands() {
 		subCmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")
-		subCmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of cpu cores used")
-		// This points to the grpc endpoint of a running `buchr/bazel-remote`
-		// instance. We're tying ourselves to the one implementation, but that
-		// seems fine for now. It seems mature, and has (very experimental)
-		// support for the  Remote Asset API, which helps speed things up when
-		// the cache sits across the network boundary.
-		subCmd.Flags().StringVar(&remoteCacheAddr, "remote-cache", "", "remote caching grpc endpoint to use")
 	}
 	for _, subCmd := range ret.cli.Commands() {
 		subCmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -10,7 +10,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 // makeLintCmd constructs the subcommand used to run the specified linters.
 func makeLintCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
@@ -23,6 +27,7 @@ func makeLintCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comm
 		Args: cobra.NoArgs,
 		RunE: runE,
 	}
+	addCommonBuildFlags(lintCmd)
 	addCommonTestFlags(lintCmd)
 	return lintCmd
 }
@@ -38,6 +43,9 @@ func (d *dev) lint(cmd *cobra.Command, _ []string) error {
 	// appropriate stuff (gotags, etc.)
 	args = append(args, "run", "--config=test", "//build/bazelutil:lint")
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
+	if numCPUs != 0 {
+		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	}
 	args = append(args, "--", "-test.v")
 	if short {
 		args = append(args, "-test.short")

--- a/pkg/cmd/dev/logic.go
+++ b/pkg/cmd/dev/logic.go
@@ -40,6 +40,7 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 	testLogicCmd.Flags().String(filesFlag, "", "run logic tests for files matching this regex")
 	testLogicCmd.Flags().String(subtestsFlag, "", "run logic test subtests matching this regex")
 	testLogicCmd.Flags().String(configFlag, "", "run logic tests under the specified config")
+	addCommonBuildFlags(testLogicCmd)
 	return testLogicCmd
 }
 
@@ -100,7 +101,11 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		if timeout > 0 {
 			args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
 		}
+		if numCPUs != 0 {
+			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+		}
 		args = append(args, additionalBazelArgs...)
+		args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 		logCommand("bazel", args...)
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -43,6 +43,7 @@ func makeTestCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comm
 		RunE: runE,
 	}
 	// Attach flags for the test sub-command.
+	addCommonBuildFlags(testCmd)
 	addCommonTestFlags(testCmd)
 	testCmd.Flags().BoolP(vFlag, "v", false, "enable logging during test runs")
 	testCmd.Flags().Bool(stressFlag, false, "run tests under stress")

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -32,8 +32,14 @@ const (
 	shortFlag   = "short"
 )
 
-// To be turned on for tests. Turns off some deeper checks for reproducibility.
-var isTesting bool
+var (
+	// Shared flags.
+	remoteCacheAddr string
+	numCPUs         int
+
+	// To be turned on for tests. Turns off some deeper checks for reproducibility.
+	isTesting bool
+)
 
 func mustGetFlagString(cmd *cobra.Command, name string) string {
 	val, err := cmd.Flags().GetString(name)
@@ -104,6 +110,16 @@ func (d *dev) getWorkspace(ctx context.Context) (string, error) {
 
 func (d *dev) getBazelBin(ctx context.Context) (string, error) {
 	return d.getBazelInfo(ctx, "bazel-bin")
+}
+
+func addCommonBuildFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of cpu cores used")
+	// This points to the grpc endpoint of a running `buchr/bazel-remote`
+	// instance. We're tying ourselves to the one implementation, but that
+	// seems fine for now. It seems mature, and has (very experimental)
+	// support for the  Remote Asset API, which helps speed things up when
+	// the cache sits across the network boundary.
+	cmd.Flags().StringVar(&remoteCacheAddr, "remote-cache", "", "remote caching grpc endpoint to use")
 }
 
 func addCommonTestFlags(cmd *cobra.Command) {


### PR DESCRIPTION
These flags aren't actually applicable for every single `dev` command.
Instead only add it for the relevant commands, and make sure that where
we define the flags they're also being used.

Release note: None