### PR TITLE
roachtest: skip cli/node-status

### DIFF
--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -19,9 +19,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
+	skip.WithIssue(t, 70902, "flaky test")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Start(ctx, c.Range(1, 3))
 


### PR DESCRIPTION
Flaky test.

References #70902

Release note: None