### PR TITLE
serverccl: support IndexUsageStatistics RPC fanout for tenant status server

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/idxusage",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -83,6 +83,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/ListLocalSessions":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/IndexUsageStatistics":
+		return a.authTenant(tenID)
+
 	case "/cockroach.roachpb.Internal/GetSpanConfigs":
 		return a.authGetSpanConfigs(tenID, req.(*roachpb.GetSpanConfigsRequest))
 

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -582,12 +582,68 @@ func (t *tenantStatusServer) Profile(
 }
 
 func (t *tenantStatusServer) IndexUsageStatistics(
-	ctx context.Context, request *serverpb.IndexUsageStatisticsRequest,
+	ctx context.Context, req *serverpb.IndexUsageStatisticsRequest,
 ) (*serverpb.IndexUsageStatisticsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+
 	if _, err := t.privilegeChecker.requireViewActivityPermission(ctx); err != nil {
 		return nil, err
 	}
 
-	idxUsageStats := t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
-	return indexUsageStatsLocal(idxUsageStats)
+	localReq := &serverpb.IndexUsageStatisticsRequest{
+		NodeID: "local",
+	}
+
+	if len(req.NodeID) > 0 {
+		parsedInstanceID, local, err := t.parseInstanceID(req.NodeID)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		if local {
+			statsReader := t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
+			return indexUsageStatsLocal(statsReader)
+		}
+
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, parsedInstanceID)
+		if err != nil {
+			return nil, err
+		}
+		statusClient, err := t.dialPod(ctx, parsedInstanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		// We issue a localReq instead of the incoming req to other nodes. This is
+		// to instruct other nodes to only return us their node-local stats and
+		// do not further propagates the RPC call.
+		return statusClient.IndexUsageStatistics(ctx, localReq)
+	}
+
+	fetchIndexUsageStats := func(ctx context.Context, client interface{}, _ base.SQLInstanceID) (interface{}, error) {
+		statusClient := client.(serverpb.StatusClient)
+		return statusClient.IndexUsageStatistics(ctx, localReq)
+	}
+
+	resp := &serverpb.IndexUsageStatisticsResponse{}
+	aggFn := func(_ base.SQLInstanceID, nodeResp interface{}) {
+		stats := nodeResp.(*serverpb.IndexUsageStatisticsResponse)
+		resp.Statistics = append(resp.Statistics, stats.Statistics...)
+	}
+
+	var combinedError error
+	errFn := func(_ base.SQLInstanceID, nodeFnError error) {
+		combinedError = errors.CombineErrors(combinedError, nodeFnError)
+	}
+
+	if err := t.iteratePods(ctx, fmt.Sprintf("requesting index usage stats for instance %s", req.NodeID),
+		t.dialCallback,
+		fetchIndexUsageStats,
+		aggFn,
+		errFn,
+	); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/pkg/sql/idxusage/test_utils.go
+++ b/pkg/sql/idxusage/test_utils.go
@@ -11,8 +11,12 @@
 package idxusage
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // TestingKnobs is the testing knobs that provides callbacks that unit tests
@@ -27,3 +31,51 @@ var _ base.ModuleTestingKnobs = &TestingKnobs{}
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
 func (t *TestingKnobs) ModuleTestingKnobs() {}
+
+// CreateIndexStatsIngestedCallbackForTest creates a pair of callbacks and
+// notification channel for unit tests. The callback is injected into
+// IndexUsageStats struct through testing knobs and the channel can be used by
+// WaitForStatsIngestionForTest.
+func CreateIndexStatsIngestedCallbackForTest() (
+	func(key roachpb.IndexUsageKey),
+	chan roachpb.IndexUsageKey,
+) {
+	// Create a buffered channel so the callback is non-blocking.
+	notify := make(chan roachpb.IndexUsageKey, 100)
+
+	cb := func(key roachpb.IndexUsageKey) {
+		notify <- key
+	}
+
+	return cb, notify
+}
+
+// WaitForIndexStatsIngestionForTest waits for a map of expected events
+// to occur for expectedEventCnt number of times from the event channel.
+// If expected events did not occur, an error is returned.
+func WaitForIndexStatsIngestionForTest(
+	notify chan roachpb.IndexUsageKey,
+	expectedKeys map[roachpb.IndexUsageKey]struct{},
+	expectedEventCnt int,
+	timeout time.Duration,
+) error {
+	var timer timeutil.Timer
+	eventCnt := 0
+
+	timer.Reset(timeout)
+
+	for eventCnt < expectedEventCnt {
+		select {
+		case key := <-notify:
+			if _, ok := expectedKeys[key]; ok {
+				eventCnt++
+			}
+			continue
+		case <-timer.C:
+			timer.Read = true
+			return errors.New("failed to wait for index usage stats ingestion")
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/tests/server_params.go
+++ b/pkg/sql/tests/server_params.go
@@ -27,11 +27,7 @@ func CreateTestServerParams() (base.TestServerArgs, *CommandFilters) {
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(CheckEndTxnTrigger, true)
 	params := base.TestServerArgs{}
-	params.Knobs = base.TestingKnobs{
-		SQLStatsKnobs: &sqlstats.TestingKnobs{
-			AOSTClause: "AS OF SYSTEM TIME '-1us'",
-		},
-	}
+	params.Knobs = CreateTestingKnobs()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
 			TestingEvalFilter: cmdFilters.RunFilters,
@@ -43,11 +39,16 @@ func CreateTestServerParams() (base.TestServerArgs, *CommandFilters) {
 // CreateTestTenantParams creates a set of params suitable for SQL Tenant Tests.
 func CreateTestTenantParams(tenantID roachpb.TenantID) base.TestTenantArgs {
 	return base.TestTenantArgs{
-		TenantID: tenantID,
-		TestingKnobs: base.TestingKnobs{
-			SQLStatsKnobs: &sqlstats.TestingKnobs{
-				AOSTClause: "AS OF SYSTEM TIME '-1us'",
-			},
+		TenantID:     tenantID,
+		TestingKnobs: CreateTestingKnobs(),
+	}
+}
+
+// CreateTestingKnobs creates a testing knob in the unit tests.
+func CreateTestingKnobs() base.TestingKnobs {
+	return base.TestingKnobs{
+		SQLStatsKnobs: &sqlstats.TestingKnobs{
+			AOSTClause: "AS OF SYSTEM TIME '-1us'",
 		},
 	}
 }


### PR DESCRIPTION
Follow up to #70959

Resolves #70878

Release note (api change): Serverless's IndexUsageStatistics RPC now
returns cluster-wide data.