### PR TITLE
release-21.2: vendor: bump Pebble to c17bf6f57e8f

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -648,8 +648,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:YKDxrC/1iG0AYW7YTK0eVl1rVQqxeJEY1h5izK8pURA=",
-        version = "v0.0.0-20210923235227-c6751b08960c",
+        sum = "h1:/vjzZF57QxCg1y4Ue5GEkWxKQsGKHpSyQFHvXX87d24=",
+        version = "v0.0.0-20210930205914-c17bf6f57e8f",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c
+	github.com/cockroachdb/pebble v0.0.0-20210930205914-c17bf6f57e8f
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOF
 github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c h1:YKDxrC/1iG0AYW7YTK0eVl1rVQqxeJEY1h5izK8pURA=
-github.com/cockroachdb/pebble v0.0.0-20210923235227-c6751b08960c/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
+github.com/cockroachdb/pebble v0.0.0-20210930205914-c17bf6f57e8f h1:/vjzZF57QxCg1y4Ue5GEkWxKQsGKHpSyQFHvXX87d24=
+github.com/cockroachdb/pebble v0.0.0-20210930205914-c17bf6f57e8f/go.mod h1:JXfQr3d+XO4bL1pxGwKKo09xylQSdZ/mpZ9b2wfVcPs=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
c17bf6f5 db: disable table stats by default in TestCompactionDeleteOnlyHints
bec94536 db: set smallest / largest keys for elision-only compactions
```

Release note (bug fix): Addresses an issue in Pebble where a key can be
dropped from an LSM snapshot if the key was deleted by a range tombstone
after the snapshot was acquired.

Release justification: Fixes a serious, but rare issue that may cause
data to be dropped from the LSM.

Closes #70886