### PR TITLE
kv: don't require raftMu in cleanupFailedProposalLocked

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -408,9 +408,6 @@ type Replica struct {
 		// to the *RaftCommand contained in its associated *ProposalData. This
 		// is because the *RaftCommand can be mutated during reproposals by
 		// Replica.tryReproposeWithNewLeaseIndex.
-		//
-		// TODO(ajwerner): move the proposal map and ProposalData entirely under
-		// the raftMu.
 		proposals map[kvserverbase.CmdIDKey]*ProposalData
 		// Indicates that the replica is in the process of applying log entries.
 		// Updated to true in handleRaftReady before entries are removed from
@@ -669,9 +666,8 @@ func (r *Replica) ReplicaID() roachpb.ReplicaID {
 
 // cleanupFailedProposal cleans up after a proposal that has failed. It
 // clears any references to the proposal and releases associated quota.
-// It requires that both Replica.mu and Replica.raftMu are exclusively held.
+// It requires that Replica.mu is exclusively held.
 func (r *Replica) cleanupFailedProposalLocked(p *ProposalData) {
-	r.raftMu.AssertHeld()
 	r.mu.AssertHeld()
 	delete(r.mu.proposals, p.idKey)
 	p.releaseQuota()

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -599,8 +599,8 @@ func (s *Store) processRaft(ctx context.Context) {
 	// spans in them, and we don't want to be leaking any.
 	s.stopper.AddCloser(stop.CloserFn(func() {
 		s.VisitReplicas(func(r *Replica) (more bool) {
-			r.mu.proposalBuf.FlushLockedWithoutProposing(ctx)
 			r.mu.Lock()
+			r.mu.proposalBuf.FlushLockedWithoutProposing(ctx)
 			for k, prop := range r.mu.proposals {
 				delete(r.mu.proposals, k)
 				prop.finishApplication(


### PR DESCRIPTION
Fixes #70742.

The method was asserting that the raftMu was held, but it did not
need to be. `r.mu.proposals` is protected under the replica mutex
and we already don't require accesses to `r.mu.proposals` to hold
the raftMu. For instance, `registerProposalLocked` only requires
the replica mutex.

A longer term goal is to pull all raft state under the raft mutex
and limit the interface between command evaluation and replication.
This will require reworking of how the propBuf handles inserts that
hit a size limit (see `flushRLocked`). Until then, there's no sense
asserting a condition that we know is not held.