### PR TITLE
release-20.2: grpcutil: Return true from RequestDidNotStart on open circuit breaker error

### DIFF
--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"strings"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
@@ -111,7 +112,8 @@ func IsAuthenticationError(err error) bool {
 // https://github.com/grpc/grpc-go/issues/1443 is resolved.
 func RequestDidNotStart(err error) bool {
 	if errors.HasType(err, connectionNotReadyError{}) ||
-		errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) {
+		errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) ||
+		errors.Is(err, circuit.ErrBreakerOpen) {
 		return true
 	}
 	s, ok := status.FromError(errors.Cause(err))

--- a/pkg/util/grpcutil/grpc_util_test.go
+++ b/pkg/util/grpcutil/grpc_util_test.go
@@ -16,11 +16,13 @@ import (
 	"strings"
 	"testing"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -117,4 +119,10 @@ func TestRequestDidNotStart(t *testing.T) {
 	} else if !grpcutil.RequestDidNotStart(err) {
 		t.Fatalf("request should not have started, but got %s", err)
 	}
+}
+
+func TestRequestDidNotStart_OpenBreaker(t *testing.T) {
+	err := errors.Wrapf(circuit.ErrBreakerOpen, "unable to dial n%d", 42)
+	res := grpcutil.RequestDidNotStart(err)
+	assert.True(t, res)
 }


### PR DESCRIPTION
Backport 1/1 commits from #59309.

/cc @cockroachdb/release

---

grpcutil: Return true from RequestDidNotStart on open circuit breaker error

Previously, the gRPC error check returned false on open circuit breaker error
that led to the request retries. Returning true instead should prevent
needless retries.

Fixes: #55869

Release note: None

Release justification: fixes known bug
