### PR TITLE
fmtsafe: allow string(RedactableString) as safe arg

### DIFF
--- a/pkg/testutils/lint/passes/fmtsafe/testdata/src/a/b.go
+++ b/pkg/testutils/lint/passes/fmtsafe/testdata/src/a/b.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
+)
+
+type someOtherType string
+
+func init() {
+	var ss1 redact.SafeString = "foo %d"
+	var ss2 interfaces.SafeString = "foo %d"
+	var os someOtherType = "foo %d"
+
+	errors.New(string(ss1))
+	errors.New(string(ss2))
+	errors.New(string(os)) // want `message argument is not a constant expression`
+}

--- a/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/redact/interfaces/safestring.go
+++ b/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/redact/interfaces/safestring.go
@@ -1,0 +1,13 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package interfaces
+
+type SafeString string

--- a/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/redact/safestring.go
+++ b/pkg/testutils/lint/passes/fmtsafe/testdata/src/github.com/cockroachdb/redact/safestring.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package redact
+
+import "github.com/cockroachdb/redact/interfaces"
+
+type SafeString interfaces.SafeString


### PR DESCRIPTION
It's safe to use a RedactableString as a format argument instead
of a constant string. This teaches the linter that.

Needed for #70485

Release note: None
