### PR TITLE
opt: push group by into join

### DIFF
--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -605,3 +605,13 @@ func (c *CustomFuncs) MakeProjectionsFromValues(values *memo.ValuesExpr) memo.Pr
 	}
 	return projections
 }
+
+// IsCorrelatedFiltersAggs returns true if any column in the filter expression
+// is an output column of the aggregation. This is used to determine whether the
+// results of GroupBy aggregations are used in an InnerJoin predicate.
+func (c *CustomFuncs) IsCorrelatedFiltersAggs(
+	filters memo.FiltersExpr, aggs memo.AggregationsExpr,
+) bool {
+	aggCols := aggs.OutputCols()
+	return aggCols.Intersects(c.FilterOuterCols(filters))
+}

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -298,6 +298,41 @@
     $private
 )
 
+# PushJoinIntoGroupByRight matches on InnerJoins with a GroupBy in the right
+# relation. The GroupBy can be pushed into the join if the following 2
+# conditions are met:
+#
+# 1. The left relation has a key.
+# 2. The results of the GroupBy's aggregate functions are not used in the join
+#    predicate.
+#
+# Note that this normalization rule is not always an improvement. Its
+# purpose is to try and group InnerJoins together for further optimization. Thus
+# there is a corresponding optimization rule, PushGroupByIntoJoinRight, that
+# reverses this change if necessary.
+#
+# See this published paper for further context:
+# http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.563.8492&rep=rep1&type=pdf
+[PushJoinIntoGroupByRight, Normalize]
+(InnerJoin
+    $left:* & (HasStrictKey $left)
+    $right:(GroupBy | ScalarGroupBy
+        $input:*
+        $aggs:*
+        $groupingPrivate:(GroupingPrivate $groupingCols:* $ordering:*))
+    $on:* & ^(IsCorrelatedFiltersAggs $on $aggs)
+    $private:*
+)
+=>
+((OpName $right)
+    (InnerJoin $left $input $on $private)
+    $aggs
+    (MakeGrouping
+        (UnionCols $groupingCols (OutputCols $left))
+        $ordering
+    )
+)
+
 # SimplifyLeftJoin reduces a LeftJoin operator to an InnerJoin operator (or a
 # FullJoin to a RightJoin) when it's known that every row in the join's left
 # input will match at least one row in the right input. Since every row matches,

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2121,27 +2121,33 @@ left-join (cross)
  │    └── fd: (6)-->(7-10)
  └── filters (true)
 
-norm expect=SimplifyLeftJoin
+# LeftJoin simplified to InnerJoin
+# InnerJoin predicate does not use result of GroupBy aggregation
+norm expect=SimplifyLeftJoin expect=PushJoinIntoGroupByRight
 SELECT * FROM a LEFT JOIN (SELECT count(*) FROM b) ON True
 ----
-inner-join (cross)
+project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 count:12!null
- ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── cardinality: [1 - 1]
  ├── key: (1)
- ├── fd: ()-->(12), (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- ├── scalar-group-by
- │    ├── columns: count_rows:12!null
- │    ├── cardinality: [1 - 1]
- │    ├── key: ()
- │    ├── fd: ()-->(12)
- │    ├── scan b
- │    └── aggregations
- │         └── count-rows [as=count_rows:12]
- └── filters (true)
+ ├── fd: (1)-->(2-5,12)
+ └── scalar-group-by
+      ├── columns: k:1!null i:2 f:3!null s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7 count_rows:12!null
+      ├── grouping columns: k:1!null i:2 f:3!null s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7
+      ├── cardinality: [1 - 1]
+      ├── key: (1)
+      ├── fd: (1)-->(2-7,12)
+      ├── inner-join (cross)
+      │    ├── columns: k:1!null i:2 f:3!null s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7
+      │    ├── fd: (1)-->(2-7)
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3!null s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-7)
+      │    ├── scan b
+      │    └── filters (true)
+      └── aggregations
+           └── count-rows [as=count_rows:12]
 
 # Full-join.
 norm expect=SimplifyLeftJoin
@@ -3902,3 +3908,176 @@ sort
       │    └── fd: (1)-->(4)
       └── projections
            └── s:4 [as=column3:10, outer=(4)]
+
+# --------------------------------------------------
+# PushJoinIntoGroupByRight
+# --------------------------------------------------
+
+# InnerJoin predicate does not use result of ScalarGroupBy aggregation
+norm expect=PushJoinIntoGroupByRight
+SELECT uv.count
+FROM xy
+JOIN (SELECT COUNT(*) AS count FROM uv) uv
+ON xy.y = 1
+WHERE uv.count > 10
+----
+project
+ ├── columns: count:9!null
+ ├── cardinality: [0 - 1]
+ └── select
+      ├── columns: x:1!null y:2!null xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4 count_rows:9!null
+      ├── cardinality: [0 - 1]
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3,4,9)
+      ├── scalar-group-by
+      │    ├── columns: x:1!null y:2!null xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4 count_rows:9!null
+      │    ├── grouping columns: x:1!null y:2!null xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(2-4,9)
+      │    ├── inner-join (cross)
+      │    │    ├── columns: x:1!null y:2!null xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4
+      │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    ├── select
+      │    │    │    ├── columns: x:1!null y:2!null xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(2), (1)-->(3,4)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:1!null y:2 xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2-4)
+      │    │    │    └── filters
+      │    │    │         └── y:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    │    ├── scan uv
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         └── count-rows [as=count_rows:9]
+      └── filters
+           └── count_rows:9 > 10 [outer=(9), constraints=(/9: [/11 - ]; tight)]
+
+# InnerJoin predicate uses result of ScalarGroupBy aggregation
+norm expect-not=PushJoinIntoGroupByRight
+SELECT xy.x, xy.y
+FROM xy
+JOIN (SELECT COUNT(*) AS count FROM uv) uv
+ON uv.count = xy.y
+----
+project
+ ├── columns: x:1!null y:2!null
+ ├── key: (1)
+ ├── fd: ()-->(2)
+ └── inner-join (hash)
+      ├── columns: x:1!null y:2!null count_rows:9!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      ├── key: (1)
+      ├── fd: ()-->(2,9), (2)==(9), (9)==(2)
+      ├── scan xy
+      │    ├── columns: x:1!null y:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── scalar-group-by
+      │    ├── columns: count_rows:9!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(9)
+      │    ├── scan uv
+      │    └── aggregations
+      │         └── count-rows [as=count_rows:9]
+      └── filters
+           └── count_rows:9 = y:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+
+# InnerJoin predicate does not use result of GroupBy aggregation
+norm expect=PushJoinIntoGroupByRight
+SELECT uv.v
+FROM xy
+JOIN (SELECT COUNT(*) AS count, v FROM uv GROUP BY v) uv
+ON xy.y = uv.v
+----
+project
+ ├── columns: v:6!null
+ └── group-by
+      ├── columns: x:1!null v:6!null
+      ├── grouping columns: x:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(6)
+      ├── inner-join (hash)
+      │    ├── columns: x:1!null y:2!null v:6!null
+      │    ├── fd: (1)-->(2), (2)==(6), (6)==(2)
+      │    ├── scan xy
+      │    │    ├── columns: x:1!null y:2
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    ├── scan uv
+      │    │    └── columns: v:6
+      │    └── filters
+      │         └── y:2 = v:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── aggregations
+           └── const-agg [as=v:6, outer=(6)]
+                └── v:6
+
+# InnerJoin predicate uses result of GroupBy aggregation
+norm expect-not=PushJoinIntoGroupByRight
+SELECT *
+FROM xy
+JOIN (SELECT COUNT(*) AS count FROM uv GROUP BY v) uv
+ON xy.y = 1 AND uv.count = 2
+WHERE uv.count > 1
+----
+project
+ ├── columns: x:1!null y:2!null count:9!null
+ ├── fd: ()-->(2,9)
+ └── inner-join (cross)
+      ├── columns: x:1!null y:2!null v:6 count_rows:9!null
+      ├── key: (1,6)
+      ├── fd: ()-->(2,9)
+      ├── select
+      │    ├── columns: x:1!null y:2!null
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── scan xy
+      │    │    ├── columns: x:1!null y:2
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── filters
+      │         └── y:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      ├── select
+      │    ├── columns: v:6 count_rows:9!null
+      │    ├── key: (6)
+      │    ├── fd: ()-->(9)
+      │    ├── group-by
+      │    │    ├── columns: v:6 count_rows:9!null
+      │    │    ├── grouping columns: v:6
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(9)
+      │    │    ├── scan uv
+      │    │    │    └── columns: v:6
+      │    │    └── aggregations
+      │    │         └── count-rows [as=count_rows:9]
+      │    └── filters
+      │         └── count_rows:9 = 2 [outer=(9), constraints=(/9: [/2 - /2]; tight), fd=()-->(9)]
+      └── filters (true)
+
+# InnerJoin left relation does not have a key
+norm expect-not=PushJoinIntoGroupByRight
+SELECT *
+FROM (SELECT y from xy) xy
+JOIN (SELECT COUNT(*) AS count, v FROM uv GROUP BY v) uv
+ON xy.y = uv.v
+----
+inner-join (hash)
+ ├── columns: y:2!null count:9!null v:6!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── fd: (6)-->(9), (2)==(6), (6)==(2)
+ ├── scan xy
+ │    └── columns: y:2
+ ├── group-by
+ │    ├── columns: v:6 count_rows:9!null
+ │    ├── grouping columns: v:6
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(9)
+ │    ├── scan uv
+ │    │    └── columns: v:6
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:9]
+ └── filters
+      └── y:2 = v:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]


### PR DESCRIPTION
Previously, the optimizer did not support GROUP BY and JOIN
reordering. In this PR, support is added to push GROUP BY into
JOIN as a normalization rule. This is advantageous because it
can collect joins together for potential further optimization.
However, since this does not always lead to the best plan, a
corresponding optimization rule to push JOIN into GROUP BY
will be added in a future commit. Issue: [#47393](https://github.com/cockroachdb/cockroach/issues/47393)

Release note: None