### PR TITLE
server: Fix query profiler panic for serverless.

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -245,6 +245,7 @@ func StartTenant(
 		goroutineDumpDirName: args.GoroutineDumpDirName,
 		heapProfileDirName:   args.HeapProfileDirName,
 		runtime:              args.runtime,
+		sessionRegistry:      args.sessionRegistry,
 	}); err != nil {
 		return nil, "", "", err
 	}


### PR DESCRIPTION
The Query Profiler would panic for serverless clusters under memory
pressure as the session registry was not set. This PR updates the
serverless code to pass in the session registry to the Query Profiler.


Fixes: https://github.com/cockroachdb/cockroach/issues/70945

Release note (bug fix): The SQL server no longer panics under
memory pressure when the query profiler is enabled.
