### PR TITLE
cluster-ui: derive app name from route parameter in cluster-ui

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -17,7 +17,7 @@ import {
   ExecutionStatistics,
   flattenStatementStats,
   formatDate,
-  queryByName,
+  getMatchParamByName,
   statementKey,
   StatementStatistics,
   TimestampToMoment,
@@ -144,7 +144,7 @@ export const selectStatements = createSelector(
       return null;
     }
     let statements = flattenStatementStats(state.data.statements);
-    const app = queryByName(props.location, appAttr);
+    const app = getMatchParamByName(props.match, appAttr);
     const isInternal = (statement: ExecutionStatistics) =>
       statement.app.startsWith(state.data.internal_app_name_prefix);
 


### PR DESCRIPTION
Fixes: #70998

Release justification: category 2

Previously, we were deriving the selected app name from the
query string parameter in for the statements page in the
cluster-ui package. The selected app name should be derived from
the route parameter for the statements page.

Release note (bug fix): the selected app name in the statements page
is now derived from the route parameters.