### PR TITLE
roachtest/sqlsmith: swallow "no volatility for cast" error

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -211,10 +211,11 @@ func registerSQLSmith(r registry.Registry) {
 				es := err.Error()
 				if strings.Contains(es, "internal error") {
 					// TODO(yuzefovich): we temporarily ignore internal errors
-					// that are because of #40929.
+					// that are because of #40929 and #70831.
 					var expectedError bool
 					for _, exp := range []string{
 						"could not parse \"0E-2019\" as type decimal",
+						"no volatility for cast tuple",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)
 					}


### PR DESCRIPTION
Touches: #70831.

Release note: None