### PR TITLE
cli: add --read-only flag to `cockroach sql`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -318,6 +318,12 @@ accidents. This can also be overridden in a session with SET
 sql_safe_updates = FALSE.`,
 	}
 
+	ReadOnly = FlagInfo{
+		Name: "read-only",
+		Description: `
+Set the session variable default_transaction_read_only to on.`,
+	}
+
 	Set = FlagInfo{
 		Name: "set",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -695,6 +695,7 @@ func init() {
 		stringFlag(f, &sqlCtx.InputFile, cliflags.File)
 		durationFlag(f, &sqlCtx.ShellCtx.RepeatDelay, cliflags.Watch)
 		varFlag(f, &sqlCtx.SafeUpdates, cliflags.SafeUpdates)
+		boolFlag(f, &sqlCtx.ReadOnly, cliflags.ReadOnly)
 		// The "safe-updates" flag is tri-valued (true, false, not-specified).
 		// If the flag is specified on the command line, but is not given a value,
 		// then use the value "true".

--- a/pkg/cli/interactive_tests/test_read_only.tcl
+++ b/pkg/cli/interactive_tests/test_read_only.tcl
@@ -1,0 +1,35 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+send "$argv sql -e 'CREATE TABLE foo (i INT PRIMARY KEY);'\r"
+eexpect "CREATE TABLE"
+eexpect ":/# "
+
+start_test "Check that the read-only flag works non-interactively"
+send "$argv sql --read-only -e 'delete from foo where i = 1'\r"
+eexpect "ERROR: cannot execute DELETE in a read-only transaction"
+eexpect ":/# "
+end_test
+
+start_test "Check that the read-only flag works interactively"
+send "$argv sql --read-only | cat\r"
+# We can't immediately send input, because the shell will eat stdin just before it's ready.
+eexpect "brief introduction"
+sleep 0.4
+send "show default_transaction_read_only;\r"
+eexpect "on"
+eexpect "\r\n"
+send "delete from foo where i = 0;\r"
+eexpect "ERROR: cannot execute DELETE in a read-only transaction"
+send "\\q\r"
+eexpect ":/# "
+end_test
+
+stop_server $argv

--- a/pkg/cmd/cockroach-sql/main.go
+++ b/pkg/cmd/cockroach-sql/main.go
@@ -60,6 +60,7 @@ func main() {
 	f.StringVarP(&cfg.InputFile, cliflags.File.Name, cliflags.File.Shorthand, cfg.InputFile, cliflags.File.Description)
 	f.DurationVar(&cfg.ShellCtx.RepeatDelay, cliflags.Watch.Name, cfg.ShellCtx.RepeatDelay, cliflags.Watch.Description)
 	f.Var(&cfg.SafeUpdates, cliflags.SafeUpdates.Name, cliflags.SafeUpdates.Description)
+	f.BoolVar(&cfg.ReadOnly, cliflags.ReadOnly.Name, cfg.ReadOnly, cliflags.ReadOnly.Description)
 	f.Lookup(cliflags.SafeUpdates.Name).NoOptDefVal = "true" // allow the flag to not be given any value
 	f.BoolVar(&cfg.ConnCtx.DebugMode, cliflags.CliDebugMode.Name, cfg.ConnCtx.DebugMode, cliflags.CliDebugMode.Description)
 	f.BoolVar(&cfg.ConnCtx.Echo, cliflags.EchoSQL.Name, cfg.ConnCtx.Echo, cliflags.EchoSQL.Description)


### PR DESCRIPTION
Release note (cli change): Added a `--read-only` flag to `cockroach sql`
which will set the `default_session_read_only` variable upon connecting.
This is effectively equivalent to the `PGTARGETSESSIONATTRS=read-only`
option added to libpq and `psql` in postgres 13.