### PR TITLE
bazel: bump the sizes of some tests

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
 
 go_test(
     name = "rttanalysisccl_test",
+    size = "large",
     srcs = [
         "bench_test.go",
         "multi_region_bench_test.go",

--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -62,7 +62,7 @@ go_library(
 
 go_test(
     name = "cliccl_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "debug_backup_test.go",
         "main_test.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -261,7 +261,7 @@ go_library(
 
 go_test(
     name = "server_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "addjoin_test.go",
         "admin_cluster_test.go",


### PR DESCRIPTION
These have all recently timed out in CI.

Release note: None