### PR TITLE
sqlliveness/slstorage: fix bug due to not using a transaction

### DIFF
--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -402,7 +402,7 @@ func (s *Storage) Update(
 ) (sessionExists bool, err error) {
 	err = s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		k := s.makeSessionKey(sid)
-		kv, err := s.db.Get(ctx, k)
+		kv, err := txn.Get(ctx, k)
 		if err != nil {
 			return err
 		}
@@ -410,7 +410,7 @@ func (s *Storage) Update(
 			return nil
 		}
 		v := encodeValue(expiration)
-		return s.db.Put(ctx, k, &v)
+		return txn.Put(ctx, k, &v)
 	})
 	if err != nil || !sessionExists {
 		s.metrics.WriteFailures.Inc(1)


### PR DESCRIPTION
We had a bug where updating a session was not using the transaction. This
exposed it to a problem whereby a concurrent removal of the session would
not be detected and the session could be resurrected.

Fortunately this code moved to using KV from SQL in the 21.2 cycle and
thus no released major release should experience this issue.

Fixes #71008.

Release note: None