### PR TITLE
release-21.2:  serverccl: ListContentionEvent RPC and IndexUsageStatistics RPC

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1578,7 +1578,9 @@ Response object for ListContentionEvents and ListLocalContentionEvents.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1651,7 +1653,9 @@ Response object for ListContentionEvents and ListLocalContentionEvents.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1743,7 +1747,9 @@ Info contains an information about a single DistSQL remote flow.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -1834,7 +1840,9 @@ Info contains an information about a single DistSQL remote flow.
 #### ListActivityError
 
 An error wrapper object for ListContentionEventsResponse and
-ListDistSQLFlowsResponse.
+ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+implemented on a tenant, the `node_id` field refers to the instanceIDs that
+identify individual tenant pods.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/idxusage",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -71,6 +71,12 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/ResetSQLStats":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/ListContentionEvents":
+		return a.authTenant(tenID)
+
+	case "/cockroach.server.serverpb.Status/ListLocalContentionEvents":
+		return a.authTenant(tenID)
+
 	case "/cockroach.server.serverpb.Status/ListSessions":
 		return a.authTenant(tenID)
 

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -83,6 +83,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/ListLocalSessions":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/IndexUsageStatistics":
+		return a.authTenant(tenID)
+
 	case "/cockroach.roachpb.Internal/GetSpanConfigs":
 		return a.authGetSpanConfigs(tenID, req.(*roachpb.GetSpanConfigsRequest))
 

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -2506,7 +2506,9 @@ func (m *ListContentionEventsRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_ListContentionEventsRequest proto.InternalMessageInfo
 
 // An error wrapper object for ListContentionEventsResponse and
-// ListDistSQLFlowsResponse.
+// ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+// implemented on a tenant, the `node_id` field refers to the instanceIDs that
+// identify individual tenant pods.
 type ListActivityError struct {
 	// ID of node that was being contacted when this error occurred.
 	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -684,7 +684,9 @@ message CancelSessionResponse {
 message ListContentionEventsRequest {}
 
 // An error wrapper object for ListContentionEventsResponse and
-// ListDistSQLFlowsResponse.
+// ListDistSQLFlowsResponse. Similar to the Statements endpoint, when
+// implemented on a tenant, the `node_id` field refers to the instanceIDs that
+// identify individual tenant pods.
 message ListActivityError {
   // ID of node that was being contacted when this error occurred.
   int32 node_id = 1 [

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -566,12 +566,68 @@ func (t *tenantStatusServer) ListDistSQLFlows(
 }
 
 func (t *tenantStatusServer) IndexUsageStatistics(
-	ctx context.Context, request *serverpb.IndexUsageStatisticsRequest,
+	ctx context.Context, req *serverpb.IndexUsageStatisticsRequest,
 ) (*serverpb.IndexUsageStatisticsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+
 	if _, err := t.privilegeChecker.requireViewActivityPermission(ctx); err != nil {
 		return nil, err
 	}
 
-	idxUsageStats := t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
-	return indexUsageStatsLocal(idxUsageStats)
+	localReq := &serverpb.IndexUsageStatisticsRequest{
+		NodeID: "local",
+	}
+
+	if len(req.NodeID) > 0 {
+		parsedInstanceID, local, err := t.parseInstanceID(req.NodeID)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		if local {
+			statsReader := t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
+			return indexUsageStatsLocal(statsReader)
+		}
+
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, parsedInstanceID)
+		if err != nil {
+			return nil, err
+		}
+		statusClient, err := t.dialPod(ctx, parsedInstanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		// We issue a localReq instead of the incoming req to other nodes. This is
+		// to instruct other nodes to only return us their node-local stats and
+		// do not further propagates the RPC call.
+		return statusClient.IndexUsageStatistics(ctx, localReq)
+	}
+
+	fetchIndexUsageStats := func(ctx context.Context, client interface{}, _ base.SQLInstanceID) (interface{}, error) {
+		statusClient := client.(serverpb.StatusClient)
+		return statusClient.IndexUsageStatistics(ctx, localReq)
+	}
+
+	resp := &serverpb.IndexUsageStatisticsResponse{}
+	aggFn := func(_ base.SQLInstanceID, nodeResp interface{}) {
+		stats := nodeResp.(*serverpb.IndexUsageStatisticsResponse)
+		resp.Statistics = append(resp.Statistics, stats.Statistics...)
+	}
+
+	var combinedError error
+	errFn := func(_ base.SQLInstanceID, nodeFnError error) {
+		combinedError = errors.CombineErrors(combinedError, nodeFnError)
+	}
+
+	if err := t.iteratePods(ctx, fmt.Sprintf("requesting index usage stats for instance %s", req.NodeID),
+		t.dialCallback,
+		fetchIndexUsageStats,
+		aggFn,
+		errFn,
+	); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -243,6 +243,8 @@ func NewRegistry() *Registry {
 func (r *Registry) AddContentionEvent(c roachpb.ContentionEvent) {
 	r.globalLock.Lock()
 	defer r.globalLock.Unlock()
+	// Remove the tenant ID prefix if there is any.
+	c.Key, _, _ = keys.DecodeTenantPrefix(c.Key)
 	_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(c.Key)
 	if err != nil {
 		// The key is not a valid SQL key, so we store it in a separate cache.

--- a/pkg/sql/idxusage/test_utils.go
+++ b/pkg/sql/idxusage/test_utils.go
@@ -11,8 +11,12 @@
 package idxusage
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // TestingKnobs is the testing knobs that provides callbacks that unit tests
@@ -27,3 +31,51 @@ var _ base.ModuleTestingKnobs = &TestingKnobs{}
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
 func (t *TestingKnobs) ModuleTestingKnobs() {}
+
+// CreateIndexStatsIngestedCallbackForTest creates a pair of callbacks and
+// notification channel for unit tests. The callback is injected into
+// IndexUsageStats struct through testing knobs and the channel can be used by
+// WaitForStatsIngestionForTest.
+func CreateIndexStatsIngestedCallbackForTest() (
+	func(key roachpb.IndexUsageKey),
+	chan roachpb.IndexUsageKey,
+) {
+	// Create a buffered channel so the callback is non-blocking.
+	notify := make(chan roachpb.IndexUsageKey, 100)
+
+	cb := func(key roachpb.IndexUsageKey) {
+		notify <- key
+	}
+
+	return cb, notify
+}
+
+// WaitForIndexStatsIngestionForTest waits for a map of expected events
+// to occur for expectedEventCnt number of times from the event channel.
+// If expected events did not occur, an error is returned.
+func WaitForIndexStatsIngestionForTest(
+	notify chan roachpb.IndexUsageKey,
+	expectedKeys map[roachpb.IndexUsageKey]struct{},
+	expectedEventCnt int,
+	timeout time.Duration,
+) error {
+	var timer timeutil.Timer
+	eventCnt := 0
+
+	timer.Reset(timeout)
+
+	for eventCnt < expectedEventCnt {
+		select {
+		case key := <-notify:
+			if _, ok := expectedKeys[key]; ok {
+				eventCnt++
+			}
+			continue
+		case <-timer.C:
+			timer.Read = true
+			return errors.New("failed to wait for index usage stats ingestion")
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/tests/server_params.go
+++ b/pkg/sql/tests/server_params.go
@@ -27,11 +27,7 @@ func CreateTestServerParams() (base.TestServerArgs, *CommandFilters) {
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(CheckEndTxnTrigger, true)
 	params := base.TestServerArgs{}
-	params.Knobs = base.TestingKnobs{
-		SQLStatsKnobs: &sqlstats.TestingKnobs{
-			AOSTClause: "AS OF SYSTEM TIME '-1us'",
-		},
-	}
+	params.Knobs = CreateTestingKnobs()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
 			TestingEvalFilter: cmdFilters.RunFilters,
@@ -43,11 +39,16 @@ func CreateTestServerParams() (base.TestServerArgs, *CommandFilters) {
 // CreateTestTenantParams creates a set of params suitable for SQL Tenant Tests.
 func CreateTestTenantParams(tenantID roachpb.TenantID) base.TestTenantArgs {
 	return base.TestTenantArgs{
-		TenantID: tenantID,
-		TestingKnobs: base.TestingKnobs{
-			SQLStatsKnobs: &sqlstats.TestingKnobs{
-				AOSTClause: "AS OF SYSTEM TIME '-1us'",
-			},
+		TenantID:     tenantID,
+		TestingKnobs: CreateTestingKnobs(),
+	}
+}
+
+// CreateTestingKnobs creates a testing knob in the unit tests.
+func CreateTestingKnobs() base.TestingKnobs {
+	return base.TestingKnobs{
+		SQLStatsKnobs: &sqlstats.TestingKnobs{
+			AOSTClause: "AS OF SYSTEM TIME '-1us'",
 		},
 	}
 }


### PR DESCRIPTION
---

serverccl: support ListContentionEvents RPC endpoint for Serverless

Previously, ListContentionEvents RPC endpoint only returns node-local
contention events.
This commit introduces cluster RPC fanout for ListContentionEvents endpoint.
This commit also updated the ContentionRegistry to handle tenantID.

Resolves cockroachdb#68632

Release note (api change): Serverless ListContentionEvent RPC now returns
cluster-wide contention events.

---
serverccl: support IndexUsageStatistics RPC fanout for tenant status server

Resolves #70878

Release note (api change): Serverless's IndexUsageStatistics RPC now
returns cluster-wide data.

---

Release justification: Bug fixes and low-risk updates to new functionality