### PR TITLE
ts: use 1-minute timeout when storing time series data

### DIFF
--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/storage",
         "//pkg/ts/catalog",
         "//pkg/ts/tspb",
+        "//pkg/util/contextutil",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/log",


### PR DESCRIPTION
`ts.poller.poll()`, which stores buffered in-memory timeseries data to
KV, did not use a context timeout. This could cause the KV RPCs to hang
indefinitely, e.g. in the case of stuck ranges.

This patch adds a 1-minute timeout when storing data.

Resolves #71004.

Release note: None