### PR TITLE
sql: add summarized query formats for select, insert, and update statements

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3053,6 +3053,18 @@ func formatStatementHideConstants(ast tree.Statement) string {
 	return tree.AsStringWithFlags(ast, tree.FmtHideConstants)
 }
 
+// formatStatementSummary formats the statement using tree.FmtSummary
+// and tree.FmtHideConstants. This returns a summarized version of the
+// query. It does *not* anonymize the statement, since the result will
+// still contain names and identifiers.
+func formatStatementSummary(ast tree.Statement) string {
+	if ast == nil {
+		return ""
+	}
+	fmtFlags := tree.FmtSummary | tree.FmtHideConstants
+	return tree.AsStringWithFlags(ast, fmtFlags)
+}
+
 // DescsTxn is a convenient method for running a transaction on descriptors
 // when you have an ExecutorConfig.
 func DescsTxn(

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -13,6 +13,7 @@ package tree
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -143,11 +144,37 @@ const (
 	// FmtMarkRedactionNode instructs the pretty printer to redact datums,
 	// constants, and simples names (i.e. Name, UnrestrictedName) from statements.
 	FmtMarkRedactionNode
+
+	// FmtSummary instructs the pretty printer to produced a summarized version
+	// of the query, to pass to the frontend.
+	//
+	// Here are the following formats we support:
+	// SELECT: SELECT {columns} FROM {tables}
+	// - Show columns up to 15 characters.
+	// - Show tables up to 30 characters.
+	// - Hide column names in nested select queries.
+	// INSERT/UPSERT: INSERT/UPSERT INTO {table} {columns}
+	// - Show table up to 30 characters.
+	// - Show columns up to 15 characters.
+	// INSERT SELECT: INSERT INTO {table} SELECT {columns} FROM {table}
+	// - Show table up to 30 characters.
+	// - Show columns up to 15 characters.
+	// UPDATE: UPDATE {table} SET {columns} WHERE {condition}
+	// - Show table up to 30 characters.
+	// - Show columns up to 15 characters.
+	// - Show condition up to 15 characters.
+	FmtSummary
 )
 
 // PasswordSubstitution is the string that replaces
 // passwords unless FmtShowPasswords is specified.
 const PasswordSubstitution = "'*****'"
+
+// ColumnLimit is the max character limit for columns in summarized queries
+const ColumnLimit = 15
+
+// TableLimit is the max character limit for tables in summarized queries
+const TableLimit = 30
 
 // Composite/derived flag definitions follow.
 const (
@@ -459,11 +486,114 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 	}
 }
 
+// formatLimitLength recurses into a node for pretty-printing, but limits the
+// number of characters to be printed.
+func (ctx *FmtCtx) formatLimitLength(n NodeFormatter, maxLength int) {
+	temp := NewFmtCtx(ctx.flags)
+	temp.FormatNodeSummary(n)
+	s := temp.CloseAndGetString()
+	if len(s) > maxLength {
+		truncated := s[:maxLength] + "..."
+		// close all open parentheses.
+		if strings.Count(truncated, "(") > strings.Count(truncated, ")") {
+			remaining := s[maxLength:]
+			for i, c := range remaining {
+				if c == ')' {
+					truncated += ")"
+					// add ellipses if there was more text after the parenthesis in
+					// the original string.
+					if i < len(remaining)-1 && string(remaining[i+1]) != ")" {
+						truncated += "..."
+					}
+					if strings.Count(truncated, "(") <= strings.Count(truncated, ")") {
+						break
+					}
+				}
+			}
+		}
+		s = truncated
+	}
+	ctx.WriteString(s)
+}
+
+// formatSummarySelect pretty-prints a summarized select statement.
+// See FmtSummary for supported formats.
+func (ctx *FmtCtx) formatSummarySelect(node *Select) {
+	if node.With == nil {
+		s := node.Select
+		if s, ok := s.(*SelectClause); ok {
+			ctx.WriteString("SELECT ")
+			ctx.formatLimitLength(&s.Exprs, ColumnLimit)
+			if len(s.From.Tables) > 0 {
+				ctx.WriteByte(' ')
+				ctx.formatLimitLength(&s.From, TableLimit+len("FROM "))
+			}
+		}
+	}
+}
+
+// formatSummaryInsert pretty-prints a summarized insert/upsert statement.
+// See FmtSummary for supported formats.
+func (ctx *FmtCtx) formatSummaryInsert(node *Insert) {
+	if node.OnConflict.IsUpsertAlias() {
+		ctx.WriteString("UPSERT")
+	} else {
+		ctx.WriteString("INSERT")
+	}
+	ctx.WriteString(" INTO ")
+	ctx.formatLimitLength(node.Table, TableLimit)
+	rows := node.Rows
+	expr := rows.Select
+	if _, ok := expr.(*SelectClause); ok {
+		ctx.WriteByte(' ')
+		ctx.FormatNodeSummary(rows)
+	} else if node.Columns != nil {
+		ctx.WriteByte('(')
+		ctx.formatLimitLength(&node.Columns, ColumnLimit)
+		ctx.WriteByte(')')
+	}
+}
+
+// formatSummaryUpdate pretty-prints a summarized update statement.
+// See FmtSummary for supported formats.
+func (ctx *FmtCtx) formatSummaryUpdate(node *Update) {
+	if node.With == nil {
+		ctx.WriteString("UPDATE ")
+		ctx.formatLimitLength(node.Table, TableLimit)
+		ctx.WriteString(" SET ")
+		ctx.formatLimitLength(&node.Exprs, ColumnLimit)
+		if node.Where != nil {
+			ctx.WriteByte(' ')
+			ctx.formatLimitLength(node.Where, ColumnLimit+len("WHERE "))
+		}
+	}
+}
+
+// FormatNodeSummary recurses into a node for pretty-printing a summarized version.
+func (ctx *FmtCtx) FormatNodeSummary(n NodeFormatter) {
+	switch node := n.(type) {
+	case *Insert:
+		ctx.formatSummaryInsert(node)
+		return
+	case *Select:
+		ctx.formatSummarySelect(node)
+		return
+	case *Update:
+		ctx.formatSummaryUpdate(node)
+		return
+	}
+	ctx.FormatNode(n)
+}
+
 // AsStringWithFlags pretty prints a node to a string given specific flags; only
 // flags that don't require Annotations can be used.
 func AsStringWithFlags(n NodeFormatter, fl FmtFlags, opts ...FmtCtxOption) string {
 	ctx := NewFmtCtx(fl, opts...)
-	ctx.FormatNode(n)
+	if fl.HasFlags(FmtSummary) {
+		ctx.FormatNodeSummary(n)
+	} else {
+		ctx.FormatNode(n)
+	}
 	return ctx.CloseAndGetString()
 }
 

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -430,6 +430,90 @@ func TestFormatPgwireText(t *testing.T) {
 	}
 }
 
+func TestFormatNodeSummary(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testData := []struct {
+		stmt     string
+		expected string
+	}{
+		{
+			stmt:     `SELECT (SELECT count(*) FROM system.jobs) AS j, num_running, s.* FROM system.scheduled_jobs AS s WHERE next_run < current_timestamp() ORDER BY random() LIMIT 10 FOR UPDATE`,
+			expected: `SELECT (SELECT FROM sy...)... FROM system.scheduled_jobs AS s`,
+		},
+		{
+			stmt:     `SELECT status AS s, app_name FROM system.apps, system.transaction_statistics AS OF SYSTEM TIME follower_read_timestamp() WHERE crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8 = $1`,
+			expected: `SELECT status AS s, ap... FROM system.apps, system.transactio...`,
+		},
+		{
+			stmt:     `SELECT app_name, aggregated_ts, fingerprint_id, metadata, statistics FROM system.app_statistics JOIN system.transaction_statistics ON crdb_internal.transaction_statistics.app_name = system.transaction_statistics.app_name`,
+			expected: `SELECT app_name, aggre... FROM system.app_statistics JOIN sys...`,
+		},
+		{
+			stmt:     `SELECT id FROM system.jobs, (SELECT $3::TIMESTAMP AS ts, $4::FLOAT8 AS initial_delay, $5::FLOAT8 AS max_delay) AS args WHERE ((status IN ('_', '_')) AND ((claim_session_id = $1) AND (claim_instance_id = $2))) AND (args.ts >= (COALESCE(last_run, created) + least(IF((args.initial_delay * (power(_, least(_, COALESCE(num_runs, _))) - _)::FLOAT8) >= _, args.initial_delay * (power(_, least(_, COALESCE(num_runs, _))) - _)::FLOAT8, args.max_delay), args.max_delay)::INTERVAL))`,
+			expected: `SELECT id FROM system.jobs, (SELECT) AS args`,
+		},
+		{
+			stmt:     `INSERT INTO system.public.lease("descID", version, "nodeID", expiration) VALUES ('1232', '111', __more2__)`,
+			expected: `INSERT INTO system.public.lease("descID", versi...)`,
+		},
+		{
+			stmt:     `INSERT INTO vehicles VALUES ($1, $2, __more6__)`,
+			expected: `INSERT INTO vehicles`,
+		},
+		{
+			stmt:     `UPSERT INTO system.reports_meta(id, "generated") VALUES ($1, $2)`,
+			expected: `UPSERT INTO system.reports_meta(id, "generated")`,
+		},
+		{
+			stmt:     `INSERT INTO system.table_statistics("tableID", name) SELECT 'cockroach', app_names FROM system.apps`,
+			expected: `INSERT INTO system.table_statistics SELECT '_', app_names FROM system.apps`,
+		},
+		{
+			stmt:     `INSERT INTO system.settings(name, value, "lastUpdated", "valueType") SELECT 'unique_pear', value, "lastUpdated", "valueType" FROM system.settings JOIN system.internal_tables ON system.settings.id = system.internal_tables.id WHERE name = '_' ON CONFLICT (name) DO NOTHING`,
+			expected: `INSERT INTO system.settings SELECT '_', value, "la... FROM system.settings JOIN system.in...`,
+		},
+		{
+			stmt:     `UPDATE system.jobs SET progress = 'value' WHERE id = '12312'`,
+			expected: `UPDATE system.jobs SET progress = '_' WHERE id = '_'`,
+		},
+		{
+			stmt:     `UPDATE system.jobs SET status = $2, payload = $3, last_run = $4, num_runs = $5 WHERE internal_table_id = $1`,
+			expected: `UPDATE system.jobs SET status = $2, pa... WHERE internal_table_...`,
+		},
+		{
+			stmt:     `UPDATE system.extra_extra_long_table_name SET (schedule_state, next_run) = ($1, $2) WHERE schedule_id = 'name'`,
+			expected: `UPDATE system.extra_extra_long_table_... SET (schedule_state...)... WHERE schedule_id = '...`,
+		},
+		{
+			stmt:     `SELECT (SELECT job_id FROM (SELECT * FROM system.jobs)) AS j, name, app_name FROM system.apps`,
+			expected: `SELECT (SELECT FROM (S...))... FROM system.apps`,
+		},
+		{
+			stmt:     `SELECT (SELECT job_id FROM system.jobs) FROM system.apps`,
+			expected: `SELECT (SELECT FROM sy...) FROM system.apps`,
+		},
+		{
+			stmt:     `SELECT (SELECT job_id FROM (SELECT * FROM system.jobs) AS c) AS j, name, app_name FROM system.apps`,
+			expected: `SELECT (SELECT FROM (S...)...)... FROM system.apps`,
+		},
+	}
+
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("%d %s", i, test.stmt), func(t *testing.T) {
+			stmt, err := parser.ParseOne(test.stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fmtFlags := tree.FmtSummary | tree.FmtHideConstants
+			exprStr := tree.AsStringWithFlags(stmt.AST, fmtFlags)
+			if exprStr != test.expected {
+				t.Fatalf("expected %s, got %s", test.expected, exprStr)
+			}
+		})
+	}
+}
+
 // BenchmarkFormatRandomStatements measures the time needed to format
 // 1000 random statements.
 func BenchmarkFormatRandomStatements(b *testing.B) {

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -90,6 +90,15 @@ type SelectClause struct {
 
 // Format implements the NodeFormatter interface.
 func (node *SelectClause) Format(ctx *FmtCtx) {
+	f := ctx.flags
+	if f.HasFlags(FmtSummary) {
+		ctx.WriteString("SELECT")
+		if len(node.From.Tables) > 0 {
+			ctx.WriteByte(' ')
+			ctx.FormatNode(&node.From)
+		}
+		return
+	}
 	if node.TableSelect {
 		ctx.WriteString("TABLE ")
 		ctx.FormatNode(node.From.Tables[0])

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -20,6 +20,7 @@ type Statement struct {
 	parser.Statement
 
 	StmtNoConstants string
+	StmtSummary     string
 	QueryID         ClusterWideID
 
 	ExpectedTypes colinfo.ResultColumns
@@ -41,6 +42,7 @@ func makeStatement(parserStmt parser.Statement, queryID ClusterWideID) Statement
 	return Statement{
 		Statement:       parserStmt,
 		StmtNoConstants: formatStatementHideConstants(parserStmt.AST),
+		StmtSummary:     formatStatementSummary(parserStmt.AST),
 		QueryID:         queryID,
 	}
 }


### PR DESCRIPTION
Resolves #27021

Previously, statements on the statements page hid too much information.
There were complaints that it was difficult to disambiguate between
statements without having to view the full query on the tooltips.

To address this, this commit adds in new formatting functions for
creating summarized queries. Currently, this only applies to SELECT,
INSERT, and UPDATE statement types. We have also added a new FmtFlag,
FmtSummary, a new field, StmtSummary, in the Statement struct, and a
new field, QuerySummary, in app stats. A later commit will implement
these changes in the frontend.

Release note (sql change): Add new formatting functions to create
summarized queries for SELECT, INSERT, and UPDATE statements. Also
add new metadata fields, which will later be used to pass this
information to the front-end Statements page.