### PR TITLE
workload: Allow multi-region TPC-C to use IMPORT

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -196,9 +196,9 @@ func TestImportFixture(t *testing.T) {
 
 	// Since we did not inject stats, the IMPORT should have triggered
 	// automatic stats collection.
-	sqlDB.CheckQueryResultsRetry(t,
-		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-           FROM [SHOW STATISTICS FOR TABLE ingest.fx]`,
+	statsQuery := fmt.Sprintf(`SELECT statistics_name, column_names, row_count, distinct_count, null_count
+           FROM [SHOW STATISTICS FOR TABLE ingest.fx] WHERE row_count = %d`, fixtureTestGenRows)
+	sqlDB.CheckQueryResultsRetry(t, statsQuery,
 		[][]string{
 			{"__auto__", "{key}", "10", "10", "0"},
 			{"__auto__", "{value}", "10", "1", "0"},


### PR DESCRIPTION
Previously, multi-region TPC-C could only leverage insert for data loading.
This commit enables the IMPORT path by adding the pre-create and post-load
steps to the fixtures. The commit also works around a problem in IMPORT where
for multi-region databases, if certain table types (REGIONAL BY ROW, REGIONAL
BY TABLE IN) are created during a running IMPORT, the IMPORT will fail due to
the fact that the crdb_internal_region type is modified under the covers (to
install back references). To work around this problem, we pre-create the
tables before running an IMPORT INTO.

Release note (bug fix): Fixes IMPORT in tpcc workload.