### PR TITLE
importccl: allow changes to referencing set or privileges on UDT

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2306,9 +2306,10 @@ func (r *importResumer) publishSchemas(ctx context.Context, execCfg *sql.Executo
 }
 
 // checkForUDTModification checks whether any of the types referenced by the
-// table being imported into have been modified since they were read during
-// import planning. If they have, it may be unsafe to continue with the import
-// since we could be ingesting data that is no longer valid for the type.
+// table being imported into have been modified incompatibly since they were
+// read during import planning. If they have, it may be unsafe to continue
+// with the import since we could be ingesting data that is no longer valid
+// for the type.
 //
 // Egs: Renaming an enum value mid import could result in the import ingesting a
 // value that is no longer valid.
@@ -2316,7 +2317,11 @@ func (r *importResumer) publishSchemas(ctx context.Context, execCfg *sql.Executo
 // TODO(SQL Schema): This method might be unnecessarily aggressive in failing
 // the import. The semantics of what concurrent type changes are/are not safe
 // during an IMPORT still need to be ironed out. Once they are, we can make this
-// method more conservative in what it uses to deem a type change dangerous.
+// method more conservative in what it uses to deem a type change dangerous. At
+// the time of writing, changes to privileges and back-references are supported.
+// Additions of new values could be supported but are not. Renaming of logical
+// enum values or removal of enum values will need to forever remain
+// incompatible.
 func (r *importResumer) checkForUDTModification(
 	ctx context.Context, execCfg *sql.ExecutorConfig,
 ) error {
@@ -2324,23 +2329,76 @@ func (r *importResumer) checkForUDTModification(
 	if details.Types == nil {
 		return nil
 	}
-	return sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn,
-		col *descs.Collection) error {
+	// typeDescsAreEquivalent returns true if a and b are the same types save
+	// for the version, modification time, privileges, or the set of referencing
+	// descriptors.
+	typeDescsAreEquivalent := func(a, b *descpb.TypeDescriptor) (bool, error) {
+		clearIgnoredFields := func(d *descpb.TypeDescriptor) *descpb.TypeDescriptor {
+			d = protoutil.Clone(d).(*descpb.TypeDescriptor)
+			d.ModificationTime = hlc.Timestamp{}
+			d.Privileges = nil
+			d.Version = 0
+			d.ReferencingDescriptorIDs = nil
+			return d
+		}
+		aData, err := protoutil.Marshal(clearIgnoredFields(a))
+		if err != nil {
+			return false, err
+		}
+		bData, err := protoutil.Marshal(clearIgnoredFields(b))
+		if err != nil {
+			return false, err
+		}
+		return bytes.Equal(aData, bData), nil
+	}
+	// checkTypeIsEquivalent checks that the current version of the type as
+	// retrieved from the collection is equivalent to the previously saved
+	// type descriptor used by the import.
+	checkTypeIsEquivalent := func(
+		ctx context.Context, txn *kv.Txn, col *descs.Collection,
+		savedTypeDesc *descpb.TypeDescriptor,
+	) error {
+		typeDesc, err := catalogkv.MustGetTypeDescByID(
+			ctx, txn, execCfg.Codec, savedTypeDesc.GetID(),
+		)
+		if err != nil {
+			return errors.Wrap(err, "resolving type descriptor when checking version mismatch")
+		}
+		if typeDesc.GetModificationTime() == savedTypeDesc.GetModificationTime() {
+			return nil
+		}
+		equivalent, err := typeDescsAreEquivalent(typeDesc.TypeDesc(), savedTypeDesc)
+		if err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(
+				err, "failed to check for type descriptor equivalence for type %q (%d)",
+				typeDesc.GetName(), typeDesc.GetID())
+		}
+		if equivalent {
+			return nil
+		}
+		return errors.WithHint(
+			errors.Newf(
+				"type descriptor %q (%d) has been modified, potentially incompatibly,"+
+					" since import planning; aborting to avoid possible corruption",
+				typeDesc.GetName(), typeDesc.GetID(),
+			),
+			"retrying the IMPORT operation may succeed if the operation concurrently"+
+				" modifying the descriptor does not reoccur during the retry attempt",
+		)
+	}
+	checkTypesAreEquivalent := func(
+		ctx context.Context, txn *kv.Txn, col *descs.Collection,
+	) error {
 		for _, savedTypeDesc := range details.Types {
-			typeDesc, err := catalogkv.MustGetTypeDescByID(ctx, txn, execCfg.Codec,
-				savedTypeDesc.Desc.GetID())
-			if err != nil {
-				return errors.Wrap(err, "resolving type descriptor when checking version mismatch")
-			}
-			if typeDesc.GetModificationTime() != savedTypeDesc.Desc.GetModificationTime() {
-				return errors.Newf("type descriptor %d has a different modification time than what"+
-					" was saved during import planning; unsafe to import since the type"+
-					" has changed during the course of the import",
-					typeDesc.GetID())
+			if err := checkTypeIsEquivalent(
+				ctx, txn, col, savedTypeDesc.Desc,
+			); err != nil {
+				return err
 			}
 		}
 		return nil
-	})
+	}
+	return sql.DescsTxn(ctx, execCfg, checkTypesAreEquivalent)
 }
 
 // writeStubStatisticsForImportedTables writes "stub" statistics for new tables


### PR DESCRIPTION
In #69674 we enabled importing of tables which used UDTs. We added the caveat
that these types must not change during the import. In #70987, @ajstorm
uncovered that adding new usages of the type cause an illegal change. This is
a particularly painful limitation as all regional by row tables will use the
enum type of the database. That makes the limitation of import much more
extreme than just precluding renames or modifications of enums or their
members.

To fix this limitation, we permit changes to the referencing set which
occur during the import. We also permit changes to privileges as they
won't impact the correctness of the import.

Relates to #69706
Fixes #70987

Release note (enterprise change): Fixed a limitation of IMPORT for tables
using user-defined types whereby any change to the set of tables or views
which reference the type or any changes to privileges on the type during
the IMPORT would lead to failure. Now new references to the type or GRANT
or REVOKE operations performed while the IMPORT is ongoing will not cause
failure.