### PR TITLE
rpc: allow CombinedStatementStats RPC endpoint for tenant

### DIFF
--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -68,6 +68,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Statements":
 		return a.authTenant(tenID)
 
+	case "/cockroach.server.serverpb.Status/CombinedStatementStats":
+		return a.authTenant(tenID)
+
 	case "/cockroach.server.serverpb.Status/ResetSQLStats":
 		return a.authTenant(tenID)
 


### PR DESCRIPTION
Previously, /CombinedStatementStats endpoint is disabled for tenant.
This commit allows that RPC endpoint.

Release note (api change): CombinedStatementStats RPC is now allowed for
tenant.