### PR TITLE
roachtest: add asyncpg test suite

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1724,17 +1724,17 @@ func (c *clusterImpl) GitClone(
 	ctx context.Context, l *logger.Logger, src, dest, branch string, node option.NodeListOption,
 ) error {
 	return c.RunL(ctx, l, node, "bash", "-e", "-c", fmt.Sprintf(`'
-if ! test -d %s; then
-  git clone -b %s --depth 1 %s %s
+if ! test -d %[1]s; then
+  git clone -b %[2]s --depth 1 %[3]s %[1]s
 else
-  cd %s
+  cd %[1]s
   git fetch origin
-  git checkout origin/%s
+  git checkout origin/%[2]s
 fi
 '`, dest,
-		branch, src, dest,
-		dest,
-		branch))
+		branch,
+		src,
+	))
 }
 
 func roachprodArgs(opts []option.Option) []string {

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "activerecord_blocklist.go",
         "allocator.go",
         "alterpk.go",
+        "asyncpg.go",
         "autoupgrade.go",
         "backup.go",
         "build_info.go",

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -1,0 +1,117 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+func registerAsyncpg(r registry.Registry) {
+	runAsyncpg := func(
+		ctx context.Context,
+		t test.Test,
+		c cluster.Cluster,
+	) {
+		if c.IsLocal() {
+			t.Fatal("cannot be run in local mode")
+		}
+		node := c.Node(1)
+		t.Status("setting up cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
+		c.Start(ctx, c.All())
+
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Status("cloning asyncpg and installing prerequisites")
+
+		if err := gitCloneWithRecurseSubmodules(
+			ctx,
+			c,
+			t.L(),
+			"https://github.com/MagicStack/asyncpg.git",
+			"/mnt/data1/asyncpg",
+			"master",
+			node,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"install python and pip",
+			`sudo apt-get -qq install python3.7 python3-pip libpq-dev python-dev`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		// Install postgresql for asyncpg requires pg_ctl and postgres executable to setup.
+		// See asyncpg's code here:
+		// https://github.com/MagicStack/asyncpg/blob/383c711eb68bc6a042c121e1fddfde0cdefb8068/asyncpg/cluster.py#L407-L419
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"install postgresql",
+			`sudo apt-get -y install postgresql`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"install asyncpg's dependencies",
+			"cd /mnt/data1/asyncpg && sudo pip3 install django && pip3 install -e ."); err != nil {
+			t.Fatal(err)
+		}
+
+		const cockroachPort = 26257
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"run setup.py test for asyncpg",
+			fmt.Sprintf("cd /mnt/data1/asyncpg && PGPORT=%d python3 setup.py test", cockroachPort),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r.Add(registry.TestSpec{
+		Name:    "asyncpg",
+		Owner:   registry.OwnerSQLExperience,
+		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
+		Tags:    []string{`default`, `orm`},
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runAsyncpg(ctx, t, c)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/logger"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -290,4 +291,28 @@ func repeatGetLatestTag(
 		return releaseTags[len(releaseTags)-1].tag, nil
 	}
 	return "", fmt.Errorf("could not get tags from %s, due to error: %s", url, lastError)
+}
+
+// gitCloneWithRecurseSubmodules clones a git repo from src into dest and checks out origin's
+// version of the given branch, but with a --recurse-submodules flag.
+// The src, dest, and branch arguments must not contain shell special characters.
+func gitCloneWithRecurseSubmodules(
+	ctx context.Context,
+	c cluster.Cluster,
+	l *logger.Logger,
+	src, dest, branch string,
+	node option.NodeListOption,
+) error {
+	return c.RunL(ctx, l, node, "bash", "-e", "-c", fmt.Sprintf(`'
+if ! test -d %[1]s; then
+  git clone --recurse-submodules -b %[2]s --depth 1 %[3]s %[1]s
+else
+  cd %[1]s
+  git fetch origin
+  git checkout origin/%[2]s
+fi
+'`, dest,
+		branch,
+		src,
+	))
 }

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -18,6 +18,7 @@ func RegisterTests(r registry.Registry) {
 	registerActiveRecord(r)
 	registerAllocator(r)
 	registerAlterPK(r)
+	registerAsyncpg(r)
 	registerAutoUpgrade(r)
 	registerBackup(r)
 	registerBackupNodeShutdown(r)


### PR DESCRIPTION
Fix #70209.

Add a new roachtest, asyncpg, that changes the connection port
to point at cockroachdb, and runs the original test suite from
the asyncpg package (`python3 setup.py test`).

Release note: None.