### PR TITLE
log: add mutex locking for reading all entries from a file

### DIFF
--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -95,7 +95,7 @@ type fileSink struct {
 	// mu protects the remaining elements of this structure and is
 	// used to synchronize output to this file sink..
 	mu struct {
-		syncutil.Mutex
+		syncutil.RWMutex
 
 		// directory prefix where to store this logger's files. This is
 		// under "mu" because the test Scope can overwrite this

--- a/pkg/util/log/file_api.go
+++ b/pkg/util/log/file_api.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 )
@@ -210,15 +211,18 @@ func GetLogReader(filename string) (io.ReadCloser, error) {
 	if fs == nil || !fs.enabled.Get() {
 		return nil, errors.Newf("no log directory found for %s", filename)
 	}
-	fs.mu.Lock()
-	dir := fs.mu.logDir
-	fs.mu.Unlock()
+	dir := func() string {
+		fs.mu.RLock()
+		defer fs.mu.RUnlock()
+		return fs.mu.logDir
+	}()
 	if dir == "" {
 		// This error should never happen: .enabled should be unset in
 		// that case.
 		return nil, errors.Newf("no log directory found for %s", filename)
 	}
 
+	baseFileName := filename
 	filename = filepath.Join(dir, filename)
 
 	info, err := os.Lstat(filename)
@@ -236,7 +240,23 @@ func GetLogReader(filename string) (io.ReadCloser, error) {
 		return nil, errors.Errorf("not a regular file")
 	}
 
-	return os.Open(filename)
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	sb, ok := fs.mu.file.(*syncBuffer)
+	if ok && baseFileName == filepath.Base(sb.file.Name()) {
+		// If the file being read is also the file being written to, then we
+		// want mutual exclusion between the reader and the flusher.
+		lr := &lockedReader{}
+		lr.mu.RWMutex = &fs.mu.RWMutex
+		lr.mu.wrappedFile = file
+		return lr, nil
+	}
+	return file, nil
 }
 
 // sortablelogpb.FileInfoSlice is required so we can sort logpb.FileInfos.
@@ -346,6 +366,40 @@ func (a sortableEntries) Less(i, j int) bool {
 	return a[i].Time > a[j].Time
 }
 
+var _ io.ReadCloser = (*lockedReader)(nil)
+
+// lockedReader locks accesses to a wrapped io.ReadCloser,
+// using a RWMutex shared with another component.
+// We use this when reading log files (using the GetLogReader API)
+// that are concurrently being written to by the log flusher,
+// to ensure that read operations cannot observe partial flushes.
+type lockedReader struct {
+	mu struct {
+		// We use a mutex by reference, so that we can point this
+		// lockedReader to the same mutex as used by the corresponding
+		// fileSink.
+		// This mutex is only defined if the file being read from
+		// can also be written to concurrently.
+		*syncutil.RWMutex
+
+		wrappedFile io.ReadCloser
+	}
+}
+
+func (r *lockedReader) Read(b []byte) (int, error) {
+	if r.mu.RWMutex != nil {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+	}
+	return r.mu.wrappedFile.Read(b)
+}
+
+func (r *lockedReader) Close() error {
+	// We do not need to hold the mutex to call Close() since there is
+	// no flushing needed on read-only file access during Close() calls.
+	return r.mu.wrappedFile.Close()
+}
+
 // readAllEntriesFromFile reads in all log entries from a given file that are
 // between the 'startTimestamp' and 'endTimestamp' and match the 'pattern' if it
 // exists. It returns the entries in the reverse chronological order. It also
@@ -366,6 +420,7 @@ func readAllEntriesFromFile(
 		return nil, false, err
 	}
 	defer reader.Close()
+
 	entries := []logpb.Entry{}
 	decoder, err := NewEntryDecoderWithFormat(reader, editMode, format)
 	if err != nil {


### PR DESCRIPTION
Fixes #70672
Fixes #57625
Fixes #74409.

When all entries from a log file were read, the file was not locked. This resulted
in a race condition between log file reads and flushes, resulting in entries being
corrupted on read. This patch ensures a read-write-mutex in order to prevent log
entry corruption.

Release note (bug fix): It was previously possible for `cockroach
debug zip` and the log file viewer in the web UI to observe incomplete
log entries at the end of log files—especially the log file currently
being written to by the CockroachDB process. This bug had existed from
a very early version of CockroachDB. This bug has now been fixed.