### PR TITLE
roachtest/tests/kv: add missing admission control option

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -141,10 +141,11 @@ func registerKV(r registry.Registry) {
 		// Standard configs.
 		{nodes: 1, cpus: 8, readPercent: 0},
 		// CPU overload test, to stress admission control.
-		{nodes: 1, cpus: 8, readPercent: 50, concMultiplier: 8192, duration: 20 * time.Minute},
+		{nodes: 1, cpus: 8, readPercent: 50, concMultiplier: 8192, admissionControlEnabled: true,
+			duration: 20 * time.Minute},
 		// IO write overload test, to stress admission control.
 		{nodes: 1, cpus: 8, readPercent: 0, concMultiplier: 4096, blockSize: 1 << 16, /* 64 KB */
-			duration: 20 * time.Minute},
+		  admissionControlEnabled: true, duration: 20 * time.Minute},
 		{nodes: 1, cpus: 8, readPercent: 95},
 		{nodes: 1, cpus: 32, readPercent: 0},
 		{nodes: 1, cpus: 32, readPercent: 95},


### PR DESCRIPTION
IO and CPU overload tests were meant to run with admission control
enabled. For some reason it was omitted in the test spec.

Release note: None