### PR TITLE
release-20.2: backupccl: set DropTime on descriptors dropped during restore cleanup

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1706,10 +1706,20 @@ func (r *restoreResumer) dropDescriptors(
 
 	// Drop the table descriptors that were created at the start of the restore.
 	tablesToGC := make([]descpb.ID, 0, len(details.TableDescs))
+	// Set the drop time as 1 (ns in Unix time), so that the table gets GC'd
+	// immediately.
+	dropTime := int64(1)
 	for i := range mutableTables {
 		tableToDrop := mutableTables[i]
 		tablesToGC = append(tablesToGC, tableToDrop.ID)
 		tableToDrop.State = descpb.DescriptorState_DROP
+		// If the DropTime is set, a table uses RangeClear for fast data removal. This
+		// operation starts at DropTime + the GC TTL. If we used now() here, it would
+		// not clean up data until the TTL from the time of the error. Instead, use 1
+		// (that is, 1ns past the epoch) to allow this to be cleaned up as soon as
+		// possible. This is safe since the table data was never visible to users,
+		// and so we don't need to preserve MVCC semantics.
+		tableToDrop.DropTime = dropTime
 		catalogkv.WriteObjectNamespaceEntryRemovalToBatch(
 			ctx,
 			b,
@@ -1763,9 +1773,6 @@ func (r *restoreResumer) dropDescriptors(
 	}
 
 	// Queue a GC job.
-	// Set the drop time as 1 (ns in Unix time), so that the table gets GC'd
-	// immediately.
-	dropTime := int64(1)
 	gcDetails := jobspb.SchemaChangeGCDetails{}
 	for _, tableID := range tablesToGC {
 		gcDetails.Tables = append(gcDetails.Tables, jobspb.SchemaChangeGCDetails_DroppedID{


### PR DESCRIPTION
Backport 1/1 commits from #70876.

/cc @cockroachdb/release

---

This change fixes a bug where restores' OnFailOrCancel cleanup
logic was not setting the DropTime on the table descriptors being
dropped and gc'ed.

Not setting the DropTime results in the underlying `ClearTableData` method
to use the slower DeleteRange on chunks of table rows instead of `ClearRange`.

Release note: None

Release justification: Fix for a bug that could result in garbage collection of data
from a failed RESTORE taking substantially longer than expected.

