### PR TITLE
cluster-ui: fix statement filtering on aggregatedTs

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -105,7 +105,6 @@ function filterByRouterParamsPredicate(
 
   const filterByKeys = (stmt: ExecutionStatistics) =>
     stmt.statement === statement &&
-    aggregatedTs == null &&
     (aggregatedTs == null || stmt.aggregated_ts.toString() === aggregatedTs) &&
     stmt.implicit_txn === implicitTxn &&
     (stmt.database === database || database === null);


### PR DESCRIPTION
Fixes: cockroachdb#71023

This commit fixes a bug where the statement details page
for CC requires aggregated_ts to be null in the query param
string.

Release justification: category 2

Release note (bug fix): Statement details page in CC now
filters statements by the provided aggregated_ts in the query
param string.