### PR TITLE
catalog: replace PrimaryKeyString table desc method with fn

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -402,9 +402,6 @@ type TableDescriptor interface {
 	// in preparation to add a new one. In CockroachDB, all tables have primary
 	// keys, even if they're not defined by the user.
 	HasPrimaryKey() bool
-	// PrimaryKeyString returns the pretty-printed primary key declaration for a
-	// table descriptor.
-	PrimaryKeyString() string
 
 	// AllColumns returns a slice of Column interfaces containing the
 	// table's public columns and column mutations, in the canonical order:

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -993,33 +993,6 @@ func (desc *wrapper) ValidateIndexNameIsUnique(indexName string) error {
 	return nil
 }
 
-// PrimaryKeyString implements the TableDescriptor interface.
-func (desc *wrapper) PrimaryKeyString() string {
-	primaryIdx := &desc.PrimaryIndex
-	f := tree.NewFmtCtx(tree.FmtSimple)
-	f.WriteString("PRIMARY KEY (")
-	startIdx := primaryIdx.ExplicitColumnStartIdx()
-	for i, n := startIdx, len(primaryIdx.KeyColumnNames); i < n; i++ {
-		if i > startIdx {
-			f.WriteString(", ")
-		}
-		// Primary key columns cannot be inaccessible computed columns, so it is
-		// safe to always print the column name. For secondary indexes, we have
-		// to print inaccessible computed column expressions. See
-		// catformat.FormatIndexElements.
-		f.FormatNameP(&primaryIdx.KeyColumnNames[i])
-		f.WriteByte(' ')
-		f.WriteString(primaryIdx.KeyColumnDirections[i].String())
-	}
-	f.WriteByte(')')
-	if desc.PrimaryIndex.IsSharded() {
-		f.WriteString(
-			fmt.Sprintf(" USING HASH WITH BUCKET_COUNT = %v", primaryIdx.Sharded.ShardBuckets),
-		)
-	}
-	return f.CloseAndGetString()
-}
-
 // FamilyHeuristicTargetBytes is the target total byte size of columns that the
 // current heuristic will assign to a family.
 const FamilyHeuristicTargetBytes = 256

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -511,3 +511,32 @@ func FindInvertedColumn(
 	*invertedColumn.ColumnDesc() = *invertedColDesc
 	return invertedColumn
 }
+
+// PrimaryKeyString returns the pretty-printed primary key declaration for a
+// table descriptor.
+func PrimaryKeyString(desc catalog.TableDescriptor) string {
+	primaryIdx := desc.GetPrimaryIndex()
+	f := tree.NewFmtCtx(tree.FmtSimple)
+	f.WriteString("PRIMARY KEY (")
+	startIdx := primaryIdx.ExplicitColumnStartIdx()
+	for i, n := startIdx, primaryIdx.NumKeyColumns(); i < n; i++ {
+		if i > startIdx {
+			f.WriteString(", ")
+		}
+		// Primary key columns cannot be inaccessible computed columns, so it is
+		// safe to always print the column name. For secondary indexes, we have
+		// to print inaccessible computed column expressions. See
+		// catformat.FormatIndexElements.
+		name := primaryIdx.GetKeyColumnName(i)
+		f.FormatNameP(&name)
+		f.WriteByte(' ')
+		f.WriteString(primaryIdx.GetKeyColumnDirection(i).String())
+	}
+	f.WriteByte(')')
+	if primaryIdx.IsSharded() {
+		f.WriteString(
+			fmt.Sprintf(" USING HASH WITH BUCKET_COUNT = %v", primaryIdx.GetSharded().ShardBuckets),
+		)
+	}
+	return f.CloseAndGetString()
+}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -839,7 +839,7 @@ func populateTableConstraints(
 			if conkey, err = colIDArrayToDatum(con.Index.KeyColumnIDs); err != nil {
 				return err
 			}
-			condef = tree.NewDString(table.PrimaryKeyString())
+			condef = tree.NewDString(tabledesc.PrimaryKeyString(table))
 
 		case descpb.ConstraintTypeFK:
 			oid = h.ForeignKeyConstraintOid(db.GetID(), scName, table.GetID(), con.FK)

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catformat"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -99,7 +100,7 @@ func ShowCreateTable(
 		f.WriteString(",\n\tCONSTRAINT ")
 		formatQuoteNames(&f.Buffer, desc.GetPrimaryIndex().GetName())
 		f.WriteString(" ")
-		f.WriteString(desc.PrimaryKeyString())
+		f.WriteString(tabledesc.PrimaryKeyString(desc))
 	}
 
 	// TODO (lucy): Possibly include FKs in the mutations list here, or else


### PR DESCRIPTION
This functionality doesn't need to be a method on the interface and
instead can be implemented as a function using the interface.

The table descriptor interface is heavy enough as it is.

Release note: None