### PR TITLE
opt, parser: add support for nulls first, nulls last

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -438,3 +438,78 @@ query B
 SELECT usage_count > 0 FROM crdb_internal.feature_usage WHERE feature_name = 'sql.plan.opt.node.sort'
 ----
 true
+
+# ------------------------------------------------------------------------------
+# NULLS FIRST, NULLS LAST test cases.
+# ------------------------------------------------------------------------------
+subtest nulls_ordering
+
+statement ok
+CREATE TABLE xy(x INT, y INT)
+
+statement ok
+INSERT INTO xy VALUES (2, NULL), (NULL, 6), (2, 5), (4, 8)
+
+query II
+SELECT x, y FROM xy ORDER BY y NULLS FIRST
+----
+2     NULL
+2     5
+NULL  6
+4     8
+
+query II
+SELECT x, y FROM xy ORDER BY y NULLS LAST
+----
+2     5
+NULL  6
+4     8
+2     NULL
+
+query II
+SELECT x, y FROM xy ORDER BY y DESC NULLS FIRST
+----
+2     NULL
+4     8
+NULL  6
+2     5
+
+query II
+SELECT x, y FROM xy ORDER BY y DESC NULLS LAST
+----
+4     8
+NULL  6
+2     5
+2     NULL
+
+statement ok
+CREATE INDEX y_idx ON xy(y);
+
+query II
+SELECT x, y FROM xy ORDER BY y NULLS LAST
+----
+2     5
+NULL  6
+4     8
+2     NULL
+
+statement ok
+INSERT INTO xy VALUES (NULL, NULL)
+
+query II
+SELECT x, y FROM xy ORDER BY x NULLS FIRST, y NULLS LAST
+----
+NULL  6
+NULL  NULL
+2     5
+2     NULL
+4     8
+
+query II
+SELECT x, y FROM xy ORDER BY x NULLS LAST, y DESC NULLS FIRST
+----
+2     NULL
+2     5
+4     8
+NULL  NULL
+NULL  6

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -1192,3 +1192,164 @@ vectorized: true
           estimated row count: 10 (missing stats)
           table: xyz@xyz_z_y_idx
           spans: /1/!NULL-/2
+
+# ------------------------------------------------------------------------------
+# NULLS FIRST, NULLS LAST test cases.
+# ------------------------------------------------------------------------------
+# subtest nulls_ordering
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b NULLS FIRST
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b)
+│ ordering: +b
+│ estimated row count: 1,000 (missing stats)
+│ order: +b
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1,000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b NULLS LAST
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • sort
+    │ columns: (nulls_ordering_b, a, b)
+    │ ordering: +nulls_ordering_b,+b
+    │ estimated row count: 1,000 (missing stats)
+    │ order: +nulls_ordering_b,+b
+    │
+    └── • render
+        │ columns: (nulls_ordering_b, a, b)
+        │ estimated row count: 1,000 (missing stats)
+        │ render nulls_ordering_b: b IS NULL
+        │ render a: a
+        │ render b: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1,000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b DESC NULLS FIRST
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • sort
+    │ columns: (nulls_ordering_b, a, b)
+    │ ordering: -nulls_ordering_b,-b
+    │ estimated row count: 1,000 (missing stats)
+    │ order: -nulls_ordering_b,-b
+    │
+    └── • render
+        │ columns: (nulls_ordering_b, a, b)
+        │ estimated row count: 1,000 (missing stats)
+        │ render nulls_ordering_b: b IS NULL
+        │ render a: a
+        │ render b: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1,000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b DESC NULLS LAST
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b)
+│ ordering: -b
+│ estimated row count: 1,000 (missing stats)
+│ order: -b
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1,000 (missing stats)
+      table: t@primary
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b DESC NULLS FIRST, c NULLS LAST
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • sort
+    │ columns: (nulls_ordering_b, nulls_ordering_c, a, b, c)
+    │ ordering: -nulls_ordering_b,-b,+nulls_ordering_c,+c
+    │ estimated row count: 1,000 (missing stats)
+    │ order: -nulls_ordering_b,-b,+nulls_ordering_c,+c
+    │
+    └── • render
+        │ columns: (nulls_ordering_b, nulls_ordering_c, a, b, c)
+        │ estimated row count: 1,000 (missing stats)
+        │ render nulls_ordering_b: b IS NULL
+        │ render nulls_ordering_c: c IS NULL
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              estimated row count: 1,000 (missing stats)
+              table: t@primary
+              spans: FULL SCAN
+
+statement ok
+CREATE INDEX b_idx ON t(b);
+
+# TODO(nehageorge): Right now the optimizer does a sort even though there is an
+# index on column b. In the future, null-reordering for indexes can be added to
+# mitigate this as per #6224. Consider: "CREATE INDEX b_idx ON t(b NULLS LAST)."
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b NULLS LAST
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b)
+│
+└── • sort
+    │ columns: (nulls_ordering_b, a, b)
+    │ ordering: +nulls_ordering_b,+b
+    │ estimated row count: 1,000 (missing stats)
+    │ order: +nulls_ordering_b,+b
+    │
+    └── • render
+        │ columns: (nulls_ordering_b, a, b)
+        │ estimated row count: 1,000 (missing stats)
+        │ render nulls_ordering_b: b IS NULL
+        │ render a: a
+        │ render b: b
+        │
+        └── • scan
+              columns: (a, b)
+              estimated row count: 1,000 (missing stats)
+              table: t@b_idx
+              spans: FULL SCAN

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -192,7 +192,13 @@ func (b *Builder) analyzeDistinctOnArgs(
 	inScope.context = exprKindDistinctOn
 
 	for i := range distinctOn {
-		b.analyzeExtraArgument(distinctOn[i], inScope, projectionsScope, distinctOnScope)
+		b.analyzeExtraArgument(
+			distinctOn[i],
+			inScope,
+			projectionsScope,
+			distinctOnScope,
+			true, /* nullsDefaultOrder */
+		)
 	}
 	return distinctOnScope
 }

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -114,9 +116,7 @@ func (b *Builder) addOrderByOrDistinctOnColumn(
 
 // analyzeOrderByIndex appends to the orderByScope a column for each indexed
 // column in the specified index, including the implicit primary key columns.
-func (b *Builder) analyzeOrderByIndex(
-	order *tree.Order, inScope, projectionsScope, orderByScope *scope,
-) {
+func (b *Builder) analyzeOrderByIndex(order *tree.Order, inScope, orderByScope *scope) {
 	tab, tn := b.resolveTable(&order.Table, privilege.SELECT)
 	index, err := b.findIndexByName(tab, order.Index)
 	if err != nil {
@@ -154,13 +154,22 @@ func (b *Builder) analyzeOrderByArg(
 	order *tree.Order, inScope, projectionsScope, orderByScope *scope,
 ) {
 	if order.OrderType == tree.OrderByIndex {
-		b.analyzeOrderByIndex(order, inScope, projectionsScope, orderByScope)
+		b.analyzeOrderByIndex(order, inScope, orderByScope)
 		return
+	}
+
+	// Set NULL order. The default order is nulls first for ascending order and
+	// nulls last for descending order.
+	nullsDefaultOrder := true
+	if order.NullsOrder != tree.DefaultNullsOrder &&
+		((order.NullsOrder == tree.NullsFirst && order.Direction == tree.Descending) ||
+			(order.NullsOrder == tree.NullsLast && order.Direction != tree.Descending)) {
+		nullsDefaultOrder = false
 	}
 
 	// Analyze the ORDER BY column(s).
 	start := len(orderByScope.cols)
-	b.analyzeExtraArgument(order.Expr, inScope, projectionsScope, orderByScope)
+	b.analyzeExtraArgument(order.Expr, inScope, projectionsScope, orderByScope, nullsDefaultOrder)
 	for i := start; i < len(orderByScope.cols); i++ {
 		col := &orderByScope.cols[i]
 		col.descending = order.Direction == tree.Descending
@@ -184,9 +193,12 @@ func (b *Builder) buildOrderByArg(
 
 // analyzeExtraArgument analyzes a single ORDER BY or DISTINCT ON argument.
 // Typically this is a single column, with the exception of qualified star
-// (table.*). The resulting typed expression(s) are added to extraColsScope.
+// (table.*). The resulting typed expression(s) are added to extraColsScope. The
+// nullsDefaultOrder bool determines whether an extra ordering column is
+// required to explicitly place nulls first or nulls last (when
+// nullsDefaultOrder is false).
 func (b *Builder) analyzeExtraArgument(
-	expr tree.Expr, inScope, projectionsScope, extraColsScope *scope,
+	expr tree.Expr, inScope, projectionsScope, extraColsScope *scope, nullsDefaultOrder bool,
 ) {
 	// Unwrap parenthesized expressions like "((a))" to "a".
 	expr = tree.StripParens(expr)
@@ -248,6 +260,13 @@ func (b *Builder) analyzeExtraArgument(
 	for _, e := range exprs {
 		// Ensure we can order on the given column(s).
 		ensureColumnOrderable(e)
+		if !nullsDefaultOrder {
+			metadataName := fmt.Sprintf("nulls_ordering_%s", e.String())
+			extraColsScope.addColumn(
+				scopeColName("").WithMetadataName(metadataName),
+				tree.NewTypedIsNullExpr(e),
+			)
+		}
 		extraColsScope.addColumn(scopeColName(""), e)
 	}
 }

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -1037,6 +1037,7 @@ CREATE TABLE abcd (
 )
 ----
 
+# Next two plans should be the same.
 build
 SELECT a, b FROM abcd ORDER BY b, c
 ----
@@ -1047,6 +1048,46 @@ sort
       ├── columns: a:1!null b:2 c:3
       └── scan abcd
            └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
+build
+SELECT a, b FROM abcd ORDER BY b, c NULLS FIRST
+----
+sort
+ ├── columns: a:1!null b:2  [hidden: c:3]
+ ├── ordering: +2,+3
+ └── project
+      ├── columns: a:1!null b:2 c:3
+      └── scan abcd
+           └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
+# Should be different from the plan above (1 null re-ordering).
+build
+SELECT a, b FROM abcd ORDER BY b NULLS LAST, c
+----
+sort
+ ├── columns: a:1!null b:2  [hidden: c:3 nulls_ordering_b:7!null]
+ ├── ordering: +7,+2,+3
+ └── project
+      ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3
+      ├── scan abcd
+      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── projections
+           └── b:2 IS NULL [as=nulls_ordering_b:7]
+
+# Should be different from the two plans above (2 null re-orderings).
+build
+SELECT a, b FROM abcd ORDER BY b NULLS LAST, c DESC NULLS FIRST
+----
+sort
+ ├── columns: a:1!null b:2  [hidden: c:3 nulls_ordering_b:7!null nulls_ordering_c:8!null]
+ ├── ordering: +7,+2,-8,-3
+ └── project
+      ├── columns: nulls_ordering_b:7!null nulls_ordering_c:8!null a:1!null b:2 c:3
+      ├── scan abcd
+      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── projections
+           ├── b:2 IS NULL [as=nulls_ordering_b:7]
+           └── c:3 IS NULL [as=nulls_ordering_c:8]
 
 build
 SELECT a FROM abcd ORDER BY b, c
@@ -1081,3 +1122,40 @@ sort
       │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
       └── projections
            └── ARRAY[a:1] [as=array:7]
+
+# Next two plans should be the same.
+build
+SELECT * FROM abcd ORDER BY b DESC
+----
+sort
+ ├── columns: a:1!null b:2 c:3 d:4
+ ├── ordering: -2
+ └── project
+      ├── columns: a:1!null b:2 c:3 d:4
+      └── scan abcd
+           └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
+build
+SELECT * FROM abcd ORDER BY b DESC NULLS LAST
+----
+sort
+ ├── columns: a:1!null b:2 c:3 d:4
+ ├── ordering: -2
+ └── project
+      ├── columns: a:1!null b:2 c:3 d:4
+      └── scan abcd
+           └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
+# Should be different from the plan above (1 null re-ordering).
+build
+SELECT * FROM abcd ORDER BY b DESC NULLS FIRST
+----
+sort
+ ├── columns: a:1!null b:2 c:3 d:4  [hidden: nulls_ordering_b:7!null]
+ ├── ordering: -7,-2
+ └── project
+      ├── columns: nulls_ordering_b:7!null a:1!null b:2 c:3 d:4
+      ├── scan abcd
+      │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── projections
+           └── b:2 IS NULL [as=nulls_ordering_b:7]

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -531,10 +531,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`SELECT 1 FROM t GROUP BY CUBE (b)`, 46280, `cube`, ``},
 		{`SELECT 1 FROM t GROUP BY GROUPING SETS (b)`, 46280, `grouping sets`, ``},
 
-		{`SELECT a FROM t ORDER BY a NULLS LAST`, 6224, ``, ``},
-		{`SELECT a FROM t ORDER BY a ASC NULLS LAST`, 6224, ``, ``},
-		{`SELECT a FROM t ORDER BY a DESC NULLS FIRST`, 6224, ``, ``},
-
 		{`CREATE TABLE a(b BOX)`, 21286, `box`, ``},
 		{`CREATE TABLE a(b CIDR)`, 18846, `cidr`, ``},
 		{`CREATE TABLE a(b CIRCLE)`, 21286, `circle`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -9503,15 +9503,6 @@ sortby:
     /* FORCE DOC */
     dir := $2.dir()
     nullsOrder := $3.nullsOrder()
-    // We currently only support the opposite of Postgres defaults.
-    if nullsOrder != tree.DefaultNullsOrder {
-      if dir == tree.Descending && nullsOrder == tree.NullsFirst {
-        return unimplementedWithIssue(sqllex, 6224)
-      }
-      if dir != tree.Descending && nullsOrder == tree.NullsLast {
-        return unimplementedWithIssue(sqllex, 6224)
-      }
-    }
     $$.val = &tree.Order{
       OrderType:  tree.OrderByColumn,
       Expr:       $1.expr(),


### PR DESCRIPTION
Previously, we only supported the default ordering for
ORDER BY. That is, NULLS come first for ascending order and NULLS
come last for descending order. Postgres also supports the keywords
"NULLS FIRST" and "NULLS LAST", which explicitly places all the NULLS
first or last, respectively. This PR adds support for this non-default
ordering. Note that our default is the opposite of Postgres.

Informs #6224.

Release note (sql change): NULLS FIRST and NULLS LAST specifiers now
supported for ORDER BY. 