### PR TITLE
heapprofiler: add panic handler to query dumper

### DIFF
--- a/pkg/server/heapprofiler/BUILD.bazel
+++ b/pkg/server/heapprofiler/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/cgroups",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "//pkg/util/log/logcrash",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/server/heapprofiler/activequeryprofiler_test.go
+++ b/pkg/server/heapprofiler/activequeryprofiler_test.go
@@ -195,6 +195,19 @@ func TestShouldDump(t *testing.T) {
 	}
 }
 
+func TestMaybeDumpQueries_PanicHandler(t *testing.T) {
+	ctx := context.Background()
+	memLimitFn = cgroupFnWithReturn(mbToBytes(256), "", nil)
+	s := &cluster.Settings{}
+
+	profiler, err := NewActiveQueryProfiler(ctx, heapProfilerDirName, nil)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		profiler.MaybeDumpQueries(ctx, nil, s)
+	})
+}
+
 func cgroupFnWithReturn(value int64, warnings string, err error) func() (int64, string, error) {
 	return func() (int64, string, error) {
 		return value, warnings, err


### PR DESCRIPTION
Previously, the periodic query dumper could panic and cause
irrecoverable errors. We saw this happen recently with a misconfigured
tenant server (see #70945).

This commit adds a simple panic handler to the `MaybeDumpQueries` public
method of the `ActiveQueryProfiler`.

Release note: None