### PR TITLE
cli: cleanup TestDebugJobTrace temp directory

### DIFF
--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,7 @@ func (r *traceSpanResumer) OnFailOrCancel(ctx context.Context, execCtx interface
 
 func TestDebugJobTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	argsFn := func(args *base.TestServerArgs) {
@@ -115,8 +117,9 @@ func TestDebugJobTrace(t *testing.T) {
 	<-recordedSpanCh
 
 	args := []string{strconv.Itoa(int(id))}
-	pgURL, _ := sqlutils.PGUrl(t, c.TestServer.ServingSQLAddr(),
+	pgURL, cleanup := sqlutils.PGUrl(t, c.TestServer.ServingSQLAddr(),
 		"TestDebugJobTrace", url.User(security.RootUser))
+	defer cleanup()
 
 	_, err := c.RunWithCaptureArgs([]string{`debug`, `job-trace`, args[0], fmt.Sprintf(`--url=%s`, pgURL.String()), `--format=csv`})
 	require.NoError(t, err)


### PR DESCRIPTION
This change cleans up the directory where we dump the job
trace in TestDebugJobTrace.

Release note: None