### PR TITLE
ui: update cluster-ui version to match npm

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "21.2.0-prerelease-5",
+  "version": "21.2.0-prerelease-7",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update cluster-ui version to match latest version
published on npm: 21.2.0-prerelease-7

Release note: None