### PR TITLE
sql: fix FK check bug in ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -203,9 +203,18 @@ func alterColumnTypeGeneral(
 	// Disallow ALTER COLUMN TYPE general for columns that have a foreign key
 	// constraint.
 	for _, fk := range tableDesc.AllActiveAndInactiveForeignKeys() {
-		for _, id := range append(fk.OriginColumnIDs, fk.ReferencedColumnIDs...) {
-			if col.GetID() == id {
-				return colWithConstraintNotSupportedErr
+		if fk.OriginTableID == tableDesc.GetID() {
+			for _, id := range fk.OriginColumnIDs {
+				if col.GetID() == id {
+					return colWithConstraintNotSupportedErr
+				}
+			}
+		}
+		if fk.ReferencedTableID == tableDesc.GetID() {
+			for _, id := range fk.ReferencedColumnIDs {
+				if col.GetID() == id {
+					return colWithConstraintNotSupportedErr
+				}
 			}
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -523,6 +523,15 @@ SELECT x FROM t29 ORDER BY x
 2
 3
 
+# Regression 71089, check that foreign key references are checked properly.
+
+statement ok
+CREATE TABLE parent_71089 (id INT PRIMARY KEY);
+CREATE TABLE child_71089 (a INT, b INT REFERENCES parent_71089 (id) NOT NULL)
+
+statement ok
+ALTER TABLE child_71089 ALTER COLUMN a TYPE FLOAT;
+
 # ColumnConversionValidate should error out if the conversion is not valid.
 # STRING -> BYTES is a ColumnConversionValidate type conversion, it should
 # try the conversion and error out if the cast cannot be applied.


### PR DESCRIPTION
This commit fixes an implementation bug when checking that the table's
foreign keys didn't hold a reference to the altered column.

Fixes #71089.

Release note (bug fix): fixes a bug which caused ALTER COLUMN TYPE
statements to fail when they shouldn't have.