### PR TITLE
kvserver,backupccl: make export, gc subject to admission control

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -99,6 +99,7 @@ go_library(
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/util",
+        "//pkg/util/admission",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/util",
+        "//pkg/util/admission",
         "//pkg/util/bufalloc",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -757,6 +758,9 @@ type StoreConfig struct {
 	// SpanConfigsEnabled determines whether we're able to use the span configs
 	// infrastructure.
 	SpanConfigsEnabled bool
+
+	// KVAdmissionController is an optional field used for admission control.
+	KVAdmissionController KVAdmissionController
 }
 
 // ConsistencyTestingKnobs is a BatchEvalTestingKnobs struct used to control the
@@ -2955,4 +2959,125 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// KVAdmissionController provides admission control for the KV layer.
+type KVAdmissionController interface {
+	// AdmitKVWork must be called before performing KV work.
+	// BatchRequest.AdmissionHeader and BatchRequest.Replica.StoreID must be
+	// populated for admission to work correctly. If err is non-nil, the
+	// returned handle can be ignored. If err is nil, AdmittedKVWorkDone must be
+	// called after the KV work is done executing.
+	AdmitKVWork(
+		ctx context.Context, tenantID roachpb.TenantID, ba *roachpb.BatchRequest,
+	) (handle interface{}, err error)
+	// AdmittedKVWorkDone is called after the admitted KV work is done
+	// executing.
+	AdmittedKVWorkDone(handle interface{})
+}
+
+// KVAdmissionControllerImpl implements KVAdmissionController interface.
+type KVAdmissionControllerImpl struct {
+	// Admission control queues and coordinators. Both should be nil or non-nil.
+	kvAdmissionQ     *admission.WorkQueue
+	storeGrantCoords *admission.StoreGrantCoordinators
+}
+
+var _ KVAdmissionController = KVAdmissionControllerImpl{}
+
+type admissionHandle struct {
+	tenantID                           roachpb.TenantID
+	callAdmittedWorkDoneOnKVAdmissionQ bool
+	storeAdmissionQ                    *admission.WorkQueue
+}
+
+func isSingleHeartbeatTxnRequest(b *roachpb.BatchRequest) bool {
+	if len(b.Requests) != 1 {
+		return false
+	}
+	_, ok := b.Requests[0].GetInner().(*roachpb.HeartbeatTxnRequest)
+	return ok
+}
+
+// MakeKVAdmissionController returns a KVAdmissionController. Both parameters
+// must together either be nil or non-nil.
+func MakeKVAdmissionController(
+	kvAdmissionQ *admission.WorkQueue, storeGrantCoords *admission.StoreGrantCoordinators,
+) KVAdmissionController {
+	return KVAdmissionControllerImpl{
+		kvAdmissionQ:     kvAdmissionQ,
+		storeGrantCoords: storeGrantCoords,
+	}
+}
+
+// AdmitKVWork implements the KVAdmissionController interface.
+func (n KVAdmissionControllerImpl) AdmitKVWork(
+	ctx context.Context, tenantID roachpb.TenantID, ba *roachpb.BatchRequest,
+) (handle interface{}, err error) {
+	ah := admissionHandle{tenantID: tenantID}
+	if n.kvAdmissionQ != nil {
+		bypassAdmission := ba.IsAdmin()
+		source := ba.AdmissionHeader.Source
+		if !roachpb.IsSystemTenantID(tenantID.ToUint64()) {
+			// Request is from a SQL node.
+			bypassAdmission = false
+			source = roachpb.AdmissionHeader_FROM_SQL
+		}
+		if source == roachpb.AdmissionHeader_OTHER {
+			bypassAdmission = true
+		}
+		createTime := ba.AdmissionHeader.CreateTime
+		if !bypassAdmission && createTime == 0 {
+			// TODO(sumeer): revisit this for multi-tenant. Specifically, the SQL use
+			// of zero CreateTime needs to be revisited. It should use high priority.
+			createTime = timeutil.Now().UnixNano()
+		}
+		admissionInfo := admission.WorkInfo{
+			TenantID:        tenantID,
+			Priority:        admission.WorkPriority(ba.AdmissionHeader.Priority),
+			CreateTime:      createTime,
+			BypassAdmission: bypassAdmission,
+		}
+		var err error
+		// Don't subject HeartbeatTxnRequest to the storeAdmissionQ. Even though
+		// it would bypass admission, it would consume a slot. When writes are
+		// throttled, we start generating more txn heartbeats, which then consume
+		// all the slots, causing no useful work to happen. We do want useful work
+		// to continue even when throttling since there are often significant
+		// number of tokens available.
+		if ba.IsWrite() && !isSingleHeartbeatTxnRequest(ba) {
+			ah.storeAdmissionQ = n.storeGrantCoords.TryGetQueueForStore(int32(ba.Replica.StoreID))
+		}
+		admissionEnabled := true
+		if ah.storeAdmissionQ != nil {
+			if admissionEnabled, err = ah.storeAdmissionQ.Admit(ctx, admissionInfo); err != nil {
+				return admissionHandle{}, err
+			}
+			if !admissionEnabled {
+				// Set storeAdmissionQ to nil so that we don't call AdmittedWorkDone
+				// on it. Additionally, the code below will not call
+				// kvAdmissionQ.Admit, and so callAdmittedWorkDoneOnKVAdmissionQ will
+				// stay false.
+				ah.storeAdmissionQ = nil
+			}
+		}
+		if admissionEnabled {
+			ah.callAdmittedWorkDoneOnKVAdmissionQ, err = n.kvAdmissionQ.Admit(ctx, admissionInfo)
+			if err != nil {
+				return admissionHandle{}, err
+			}
+		}
+	}
+	return ah, nil
+}
+
+// AdmittedKVWorkDone implement the KVAdmissionController interface.
+func (n KVAdmissionControllerImpl) AdmittedKVWorkDone(handle interface{}) {
+	ah := handle.(admissionHandle)
+	if ah.callAdmittedWorkDoneOnKVAdmissionQ {
+		n.kvAdmissionQ.AdmittedWorkDone(ah.tenantID)
+	}
+	if ah.storeAdmissionQ != nil {
+		ah.storeAdmissionQ.AdmittedWorkDone(ah.tenantID)
+	}
 }

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -429,8 +429,23 @@ func (f NonTransactionalFactoryFunc) NonTransactionalSender() Sender {
 func SendWrappedWith(
 	ctx context.Context, sender Sender, h roachpb.Header, args roachpb.Request,
 ) (roachpb.Response, *roachpb.Error) {
+	return SendWrappedWithAdmission(ctx, sender, h, roachpb.AdmissionHeader{}, args)
+}
+
+// SendWrappedWithAdmission is a convenience function which wraps the request
+// in a batch and sends it via the provided Sender and headers. It returns the
+// unwrapped response or an error. It's valid to pass a `nil` context; an
+// empty one is used in that case.
+func SendWrappedWithAdmission(
+	ctx context.Context,
+	sender Sender,
+	h roachpb.Header,
+	ah roachpb.AdmissionHeader,
+	args roachpb.Request,
+) (roachpb.Response, *roachpb.Error) {
 	ba := roachpb.BatchRequest{}
 	ba.Header = h
+	ba.AdmissionHeader = ah
 	ba.Add(args)
 
 	br, pErr := sender.Send(ctx, ba)


### PR DESCRIPTION
They are now marked with AdmissionHeader_ROOT_KV, which stops
them from bypassing admission control. The priority is set to
admission.NormalPri since there are cases where they do need
to complete in a very timely manner. There are TODOs in the
integration code to make more sophisticated priority
assignments and use LowPri when possible.

Informs #65957

Release note: None