### PR TITLE
colexec: take advantage of partial ordering in the hash aggregator

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/apd/v2"
@@ -52,6 +51,7 @@ type aggregatorTestCase struct {
 	aggDistinct    []bool
 	aggFilter      []int
 	unorderedInput bool
+	orderedCols    []uint32
 
 	// convToDecimal will convert any float64s to apd.Decimals. If a string is
 	// encountered, a best effort is made to convert that string to an
@@ -59,27 +59,49 @@ type aggregatorTestCase struct {
 	convToDecimal bool
 }
 
+type ordering int64
+
+const (
+	ordered ordering = iota
+	partial
+	unordered
+)
+
 // aggType is a helper struct that allows tests to test both the ordered and
 // hash aggregators at the same time.
 type aggType struct {
-	new  func(*colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error)
-	name string
+	new   func(*colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error)
+	name  string
+	order ordering
 }
 
-var aggTypes = []aggType{
+var aggTypesWithPartial = []aggType{
 	{
 		// This is a wrapper around NewHashAggregator so its signature is
 		// compatible with NewOrderedAggregator.
 		new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
 			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
 		},
-		name: "hash",
+		name:  "hash",
+		order: unordered,
 	},
 	{
-		new:  NewOrderedAggregator,
-		name: "ordered",
+		new:   NewOrderedAggregator,
+		name:  "ordered",
+		order: ordered,
+	},
+	{
+		// This is a wrapper around NewHashAggregator so its signature is
+		// compatible with NewOrderedAggregator.
+		new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
+			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+		},
+		name:  "hash-partial-order",
+		order: partial,
 	},
 }
+
+var aggTypes = aggTypesWithPartial[:1]
 
 func (tc *aggregatorTestCase) init() error {
 	if tc.convToDecimal {
@@ -128,10 +150,17 @@ func (tc *aggregatorTestCase) init() error {
 		Aggregations: aggregations,
 	}
 	if !tc.unorderedInput {
-		// If we have ordered on grouping columns input, then we'll require the
+		var outputOrderCols []uint32
+		if len(tc.orderedCols) == 0 {
+			outputOrderCols = tc.spec.GroupCols
+		} else {
+			outputOrderCols = tc.orderedCols
+			tc.spec.OrderedGroupCols = tc.orderedCols
+		}
+		// If input grouping columns have an ordering, then we'll require the
 		// output to also have the same ordering.
-		outputOrdering := execinfrapb.Ordering{Columns: make([]execinfrapb.Ordering_Column, len(tc.groupCols))}
-		for i, col := range tc.groupCols {
+		outputOrdering := execinfrapb.Ordering{Columns: make([]execinfrapb.Ordering_Column, len(outputOrderCols))}
+		for i, col := range outputOrderCols {
 			outputOrdering.Columns[i].ColIdx = col
 		}
 		tc.spec.OutputOrdering = outputOrdering
@@ -760,12 +789,12 @@ func TestAggregators(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, agg := range aggTypes {
-			if tc.unorderedInput && agg.name == "ordered" {
+			if tc.unorderedInput && agg.order == ordered {
 				// This test case has unordered input, so we skip ordered
 				// aggregator.
 				continue
 			}
-			if agg.name != "hash" && tc.aggFilter != nil {
+			if agg.order == ordered && tc.aggFilter != nil {
 				// Filtering aggregation is only supported with hash aggregator.
 				continue
 			}
@@ -809,13 +838,17 @@ func TestAggregatorRandom(t *testing.T) {
 		}
 		for _, numInputBatches := range []int{1, 2, 64} {
 			for _, hasNulls := range []bool{true, false} {
-				for _, agg := range aggTypes {
+				for _, agg := range aggTypesWithPartial {
 					log.Infof(context.Background(), "%s/groupSize=%d/numInputBatches=%d/hasNulls=%t", agg.name, groupSize, numInputBatches, hasNulls)
 					nTuples := coldata.BatchSize() * numInputBatches
 					typs := []*types.T{types.Int, types.Float}
 					cols := []coldata.Vec{
 						testAllocator.NewMemColumn(typs[0], nTuples),
 						testAllocator.NewMemColumn(typs[1], nTuples),
+					}
+					if agg.order == partial {
+						typs = append(typs, types.Int)
+						cols = append(cols, testAllocator.NewMemColumn(typs[2], nTuples))
 					}
 					groups, aggCol, aggColNulls := cols[0].Int64(), cols[1].Float64(), cols[1].Nulls()
 					expectedTuples := colexectestutils.Tuples{}
@@ -890,6 +923,10 @@ func TestAggregatorRandom(t *testing.T) {
 							execinfrapb.Avg,
 						},
 					}
+					if agg.order == partial {
+						tc.groupCols = []uint32{0, 2}
+						tc.orderedCols = []uint32{0}
+					}
 					require.NoError(t, tc.init())
 					constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
 						&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
@@ -912,10 +949,13 @@ func TestAggregatorRandom(t *testing.T) {
 					a.Init(context.Background())
 
 					testOutput := colexectestutils.NewOpTestOutput(a, expectedTuples)
-					if strings.Contains(agg.name, "hash") {
-						err = testOutput.VerifyAnyOrder()
-					} else {
+
+					if agg.order == ordered {
 						err = testOutput.Verify()
+					} else if agg.order == partial {
+						err = testOutput.VerifyPartialOrder()
+					} else {
+						err = testOutput.VerifyAnyOrder()
 					}
 
 					if err != nil {
@@ -927,14 +967,23 @@ func TestAggregatorRandom(t *testing.T) {
 	}
 }
 
+// benchmarkAggregateFunction runs aggregator microbenchmarks. numGroupCol is
+// the number of grouping columns. groupSize is the number of tuples to target
+// in each distinct aggregation group. chunkSize is the number of tuples to
+// target in each distinct partially ordered group column, and is intended for
+// use with partial order. Limit is the number of rows to retrieve from the
+// aggregation function before ending the microbenchmark.
 func benchmarkAggregateFunction(
 	b *testing.B,
 	agg aggType,
 	aggFn execinfrapb.AggregatorSpec_Func,
 	aggInputTypes []*types.T,
+	numGroupCol int,
 	groupSize int,
 	distinctProb float64,
 	numInputRows int,
+	chunkSize int,
+	limit int,
 ) {
 	defer log.Scope(b).Close(b)
 	if groupSize > numInputRows {
@@ -942,6 +991,15 @@ func benchmarkAggregateFunction(
 		// likely already benchmarked such scenario with this value of
 		// numInputRows, so we short-circuit.
 		return
+	}
+	if numGroupCol < 1 {
+		// We should always have at least one group column.
+		return
+	}
+	if agg.order == partial {
+		if chunkSize > numInputRows || groupSize > chunkSize {
+			return
+		}
 	}
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
@@ -951,27 +1009,46 @@ func benchmarkAggregateFunction(
 	defer aggMemAcc.Close(ctx)
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	const bytesFixedLength = 8
-	typs := append([]*types.T{types.Int}, aggInputTypes...)
+	typs := []*types.T{types.Int}
+	groupCols := []uint32{0}
+	for g := 1; g < numGroupCol; g++ {
+		typs = append(typs, types.Int)
+		groupCols = append(groupCols, uint32(g))
+	}
+	typs = append(typs, aggInputTypes...)
 	cols := make([]coldata.Vec, len(typs))
 	for i := range typs {
 		cols[i] = testAllocator.NewMemColumn(typs[i], numInputRows)
 	}
 	groups := cols[0].Int64()
-	if agg.name == "hash" {
+	if agg.order == ordered {
+		curGroup := -1
+		for i := 0; i < numInputRows; i++ {
+			if i%groupSize == 0 {
+				curGroup++
+			}
+			groups[i] = int64(curGroup)
+		}
+	} else if agg.order == unordered {
 		numGroups := numInputRows / groupSize
 		for i := 0; i < numInputRows; i++ {
 			groups[i] = int64(rng.Intn(numGroups))
 		}
 	} else {
-		curGroup := -1
+		// partial order.
+		chunks := cols[0].Int64()
+		groups = cols[1].Int64()
+		curChunk := -1
+		numGroups := chunkSize / groupSize
 		for i := 0; i < numInputRows; i++ {
-			if groupSize == 1 || i%groupSize == 0 {
-				curGroup++
+			if i%chunkSize == 0 {
+				curChunk++
 			}
-			groups[i] = int64(curGroup)
+			chunks[i] = int64(curChunk)
+			groups[i] = int64(rng.Intn(numGroups))
 		}
 	}
-	for _, col := range cols[1:] {
+	for _, col := range cols[numGroupCol:] {
 		coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
 			Rand:             rng,
 			Vec:              col,
@@ -984,7 +1061,7 @@ func benchmarkAggregateFunction(
 		// Integer summation of random Int64 values can lead
 		// to overflow, and we will panic. To go around it, we
 		// restrict the range of values.
-		vals := cols[1].Int64()
+		vals := cols[numGroupCol].Int64()
 		for i := range vals {
 			vals[i] = vals[i] % 1024
 		}
@@ -993,11 +1070,11 @@ func benchmarkAggregateFunction(
 
 	aggCols := make([]uint32, len(aggInputTypes))
 	for i := range aggCols {
-		aggCols[i] = uint32(i + 1)
+		aggCols[i] = uint32(numGroupCol + i)
 	}
 	tc := aggregatorTestCase{
 		typs:      typs,
-		groupCols: []uint32{0},
+		groupCols: groupCols,
 		aggCols:   [][]uint32{aggCols},
 		aggFns:    []execinfrapb.AggregatorSpec_Func{aggFn},
 	}
@@ -1012,12 +1089,15 @@ func benchmarkAggregateFunction(
 			vals[i] = vals[i] % distinctModulo
 		}
 	}
+	if agg.order == partial {
+		tc.unorderedInput = false
+		tc.orderedCols = []uint32{0}
+	}
 	require.NoError(b, tc.init())
 	constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
 		&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 	)
 	require.NoError(b, err)
-
 	fName := execinfrapb.AggregatorSpec_Func_name[int32(aggFn)]
 	// Only count the aggregation columns.
 	var argumentsSize int
@@ -1069,8 +1149,14 @@ func benchmarkAggregateFunction(
 					b.Fatal(err)
 				}
 				a.Init(ctx)
-				// Exhaust aggregator until all batches have been read.
+				// Exhaust aggregator until all batches have been read or limit, if
+				// non-zero, is reached.
+				tupleCount := 0
 				for b := a.Next(); b.Length() != 0; b = a.Next() {
+					tupleCount += b.Length()
+					if limit > 0 && tupleCount >= limit {
+						break
+					}
 				}
 				if err = a.(colexecop.Closer).Close(); err != nil {
 					b.Fatal(err)
@@ -1097,9 +1183,9 @@ func BenchmarkAggregator(b *testing.B) {
 		for _, numInputRows := range numRows {
 			for _, groupSize := range groupSizes {
 				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.Int}, groupSize,
-					0 /* distinctProb */, numInputRows,
-				)
+					b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
+					groupSize, 0 /* distinctProb */, numInputRows,
+					0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}
@@ -1133,10 +1219,10 @@ func BenchmarkAllOptimizedAggregateFunctions(b *testing.B) {
 				aggInputTypes = []*types.T{types.Int}
 			}
 			for _, groupSize := range []int{1, coldata.BatchSize()} {
-				benchmarkAggregateFunction(
-					b, agg, aggFn, aggInputTypes, groupSize,
+				benchmarkAggregateFunction(b, agg, aggFn, aggInputTypes,
+					1 /* numGroupCol */, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}
@@ -1157,9 +1243,10 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 						// skip such configuration.
 						continue
 					}
-					benchmarkAggregateFunction(
-						b, agg, aggFn, []*types.T{types.Int}, groupSize, distinctProb, numInputRows,
-					)
+					benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int},
+						1 /* numGroupCol */, groupSize,
+						0 /* distinctProb */, numInputRows,
+						0 /* chunkSize */, 0 /* limit */)
 				}
 			}
 		}

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -91,17 +91,15 @@ func TestRandomizedCast(t *testing.T) {
 			input = append(input, colexectestutils.Tuple{fromConverter(fromDatum)})
 			output = append(output, colexectestutils.Tuple{fromConverter(fromDatum), toPhys})
 		}
-		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(
-			t, testAllocator, []colexectestutils.Tuples{input}, [][]*types.T{{from}}, output, colexectestutils.OrderedVerifier,
+		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(t, testAllocator,
+			[]colexectestutils.Tuples{input}, [][]*types.T{{from}}, output, colexectestutils.OrderedVerifier,
 			func(input []colexecop.Operator) (colexecop.Operator, error) {
 				return colexecbase.GetCastOperator(testAllocator, input[0], 0, 1, from, to, &evalCtx)
-			},
-			func(err error) {
+			}, func(err error) {
 				if !errorExpected {
 					t.Fatal(err)
 				}
-			},
-		)
+			}, nil /* orderedCols */)
 	}
 }
 

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -146,20 +146,19 @@ func TestDefaultAggregateFunc(t *testing.T) {
 					&evalCtx, &semaCtx, tc.spec.Aggregations, tc.typs,
 				)
 				require.NoError(t, err)
-				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.UnorderedVerifier,
-					func(input []colexecop.Operator) (colexecop.Operator, error) {
-						return agg.new(&colexecagg.NewAggregatorArgs{
-							Allocator:      testAllocator,
-							MemAccount:     testMemAcc,
-							Input:          input[0],
-							InputTypes:     tc.typs,
-							Spec:           tc.spec,
-							EvalCtx:        &evalCtx,
-							Constructors:   constructors,
-							ConstArguments: constArguments,
-							OutputTypes:    outputTypes,
-						})
+				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.UnorderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
+					return agg.new(&colexecagg.NewAggregatorArgs{
+						Allocator:      testAllocator,
+						MemAccount:     testMemAcc,
+						Input:          input[0],
+						InputTypes:     tc.typs,
+						Spec:           tc.spec,
+						EvalCtx:        &evalCtx,
+						Constructors:   constructors,
+						ConstArguments: constArguments,
+						OutputTypes:    outputTypes,
 					})
+				})
 			})
 		}
 	}
@@ -171,9 +170,10 @@ func BenchmarkDefaultAggregateFunction(b *testing.B) {
 		for _, numInputRows := range []int{32, 32 * coldata.BatchSize()} {
 			for _, groupSize := range []int{1, 2, 32, 128, coldata.BatchSize()} {
 				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.String, types.String}, groupSize,
+					b, agg, aggFn, []*types.T{types.String, types.String},
+					1 /* numGroupCol */, groupSize,
 					0 /* distinctProb */, numInputRows,
-				)
+					0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -338,7 +338,7 @@ func (tc *distinctTestCase) runTests(
 		}
 		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(
 			t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs},
-			tc.expected, verifier, instrumentedConstructor, errorHandler,
+			tc.expected, verifier, instrumentedConstructor, errorHandler, nil, /* orderedCols */
 		)
 		if tc.noError {
 			require.Zero(t, numErrorRuns)

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -9,7 +9,12 @@
 
 package colexec
 
-import "github.com/cockroachdb/cockroach/pkg/col/coldata"
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/errors"
+)
 
 // populateEqChains populates op.scratch.eqChains with indices of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
@@ -45,6 +50,48 @@ func (op *hashAggregator) populateEqChains(
 		eqChainsCount = populateEqChains_false(op, batchLength, sel, HeadIDToEqChainsID)
 	}
 	return eqChainsCount, sel
+}
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+// useSel is true if the selection vector sel should be used.
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:inline
+const _ = "template_findSplit"
+
+// getNext provides the next batch of aggregated tuples. It is a finite state
+// machine that buffers incoming batches of tuples, aggregates them according to
+// the grouping column(s), and emits the aggregated tuples. The buffer may be
+// larger than the batch size in order to amortize the aggregation cost.
+// If partialOrder is true, one or more grouping columns are ordered, so the
+// input is chunked into distinct groups. When enough distinct groups are found
+// to fill the input buffer, getNext aggregates them. If the last group is
+// complete, then the aggregated groups are emitted and getNext goes back to
+// buffering more incoming tuples.
+// If partialOrder is false, there are no guarantees on input ordering and all
+// input tuples are processed before emitting any data.
+const _ = "template_getNext"
+
+// defaultSelectionVector contains all integers in [0, coldata.MaxBatchSize)
+// range.
+var defaultSelectionVector []int
+
+func init() {
+	defaultSelectionVector = make([]int, coldata.MaxBatchSize)
+	for i := range defaultSelectionVector {
+		defaultSelectionVector[i] = i
+	}
+}
+
+func (op *hashAggregator) Next() coldata.Batch {
+	if len(op.spec.OrderedGroupCols) > 0 {
+		return getNext_true(op)
+	} else {
+		return getNext_false(op)
+	}
 }
 
 // populateEqChains populates op.scratch.eqChains with indices of tuples from b
@@ -145,3 +192,496 @@ func populateEqChains_false(
 	}
 	return eqChainsCount
 }
+
+// getNext provides the next batch of aggregated tuples. It is a finite state
+// machine that buffers incoming batches of tuples, aggregates them according to
+// the grouping column(s), and emits the aggregated tuples. The buffer may be
+// larger than the batch size in order to amortize the aggregation cost.
+// If partialOrder is true, one or more grouping columns are ordered, so the
+// input is chunked into distinct groups. When enough distinct groups are found
+// to fill the input buffer, getNext aggregates them. If the last group is
+// complete, then the aggregated groups are emitted and getNext goes back to
+// buffering more incoming tuples.
+// If partialOrder is false, there are no guarantees on input ordering and all
+// input tuples are processed before emitting any data.
+func getNext_true(op *hashAggregator) coldata.Batch {
+	for {
+		switch op.state {
+		case hashAggregatorBuffering:
+			if op.bufferingState.pendingBatch != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+				if op.bufferingState.splitGroup {
+					// Check if the group split in the last buffered batch is completed
+					// in the pendingBatch.
+					var hasDistinct bool
+					var idx int
+					sel := op.bufferingState.pendingBatch.Selection()
+					if sel != nil {
+						{
+							var (
+								__retval_0 bool
+								__retval_1 int
+							)
+							{
+								var (
+									start int = op.bufferingState.unprocessedIdx
+									end   int = op.bufferingState.pendingBatch.Length() - 1
+								)
+								_ = sel[start]
+								_ = sel[end]
+								for i := start; i <= end; i++ {
+									//gcassert:bce
+									idx := sel[i]
+									if op.distinctOutput[idx] {
+										{
+											__retval_0 = true
+											__retval_1 = i
+										}
+										goto findSplit_true_true_return_0
+									}
+								}
+								{
+									__retval_0 = false
+									__retval_1 = 0
+								}
+							findSplit_true_true_return_0:
+							}
+							hasDistinct, idx = __retval_0, __retval_1
+						}
+					} else {
+						{
+							var (
+								__retval_0 bool
+								__retval_1 int
+							)
+							{
+								var (
+									start int = op.bufferingState.unprocessedIdx
+									end   int = op.bufferingState.pendingBatch.Length() - 1
+								)
+								_ = op.distinctOutput[start]
+								_ = op.distinctOutput[end]
+								for i := start; i <= end; i++ {
+									//gcassert:bce
+									if op.distinctOutput[i] {
+										{
+											__retval_0 = true
+											__retval_1 = i
+										}
+										goto findSplit_false_true_return_1
+									}
+								}
+								{
+									__retval_0 = false
+									__retval_1 = 0
+								}
+							findSplit_false_true_return_1:
+							}
+							hasDistinct, idx = __retval_0, __retval_1
+						}
+					}
+					if hasDistinct {
+						op.bufferingState.splitGroup = false
+						if op.bufferingState.unprocessedIdx < idx {
+							op.bufferingState.tuples.AppendTuples(
+								op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, idx,
+							)
+							op.bufferingState.unprocessedIdx = idx
+							op.state = hashAggregatorAggregating
+						} else {
+							// The first tuple in the pendingBatch is a new group, so we
+							// can emit the already aggregated tuples.
+							op.state = hashAggregatorOutputting
+						}
+						continue
+					}
+				}
+				op.bufferingState.tuples.AppendTuples(
+					op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, op.bufferingState.pendingBatch.Length(),
+				)
+			}
+
+			op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx = op.Input.Next(), 0
+			op.bufferingState.unprocessedIdx = 0
+			op.distincterInput.SetBatch(op.bufferingState.pendingBatch)
+			op.distincter.Next()
+			n := op.bufferingState.pendingBatch.Length()
+			if op.inputTrackingState.tuples != nil {
+				op.inputTrackingState.tuples.Enqueue(op.Ctx, op.bufferingState.pendingBatch)
+				op.inputTrackingState.zeroBatchEnqueued = n == 0
+			}
+			if n == 0 {
+				// This is the last input batch.
+				if op.bufferingState.tuples.Length() == 0 {
+					// There are currently no buffered tuples to perform the
+					// aggregation on.
+					if len(op.buckets) == 0 {
+						// We don't have any buckets which means that there were
+						// no input tuples whatsoever, so we can transition to
+						// finished state right away.
+						op.state = hashAggregatorDone
+					} else {
+						// There are some buckets, so we proceed to the
+						// outputting state.
+						op.state = hashAggregatorOutputting
+					}
+				} else {
+					// There are some buffered tuples on which we need to run
+					// the aggregation.
+					op.state = hashAggregatorAggregating
+				}
+				continue
+			}
+
+			toBuffer := n
+			if op.bufferingState.tuples.Length()+toBuffer > hashAggregatorMaxBuffered {
+				toBuffer = hashAggregatorMaxBuffered - op.bufferingState.tuples.Length()
+			}
+			hasDistinct := false
+			// Search for last distinct group in each batch. We need to process the
+			// batches in order.
+			if toBuffer > 0 && (op.bufferingState.splitGroup || op.bufferingState.tuples.Length()+toBuffer >= hashAggregatorMaxBuffered) {
+				// See if there is a complete group in the last batch.
+				// Make sure there is at least one tuple either buffered or already
+				// aggregated.
+				lowerBound := 0
+				if op.bufferingState.tuples.Length() == 0 && len(op.buckets) == 0 {
+					lowerBound = 1
+				}
+				var idx int
+				sel := op.bufferingState.pendingBatch.Selection()
+				if sel != nil {
+					{
+						var (
+							__retval_0 bool
+							__retval_1 int
+						)
+						{
+							var (
+								start int = toBuffer - 1
+								end   int = lowerBound
+							)
+							_ = sel[start]
+							_ = sel[end]
+							for i := start; i >= end; i-- {
+								//gcassert:bce
+								idx := sel[i]
+								if op.distinctOutput[idx] {
+									{
+										__retval_0 = true
+										__retval_1 = i
+									}
+									goto findSplit_true_false_return_2
+								}
+							}
+							{
+								__retval_0 = false
+								__retval_1 = 0
+							}
+						findSplit_true_false_return_2:
+						}
+						hasDistinct, idx = __retval_0, __retval_1
+					}
+				} else {
+					{
+						var (
+							__retval_0 bool
+							__retval_1 int
+						)
+						{
+							var (
+								start int = toBuffer - 1
+								end   int = lowerBound
+							)
+							_ = op.distinctOutput[start]
+							_ = op.distinctOutput[end]
+							for i := start; i >= end; i-- {
+								//gcassert:bce
+								if op.distinctOutput[i] {
+									{
+										__retval_0 = true
+										__retval_1 = i
+									}
+									goto findSplit_false_false_return_3
+								}
+							}
+							{
+								__retval_0 = false
+								__retval_1 = 0
+							}
+						findSplit_false_false_return_3:
+						}
+						hasDistinct, idx = __retval_0, __retval_1
+					}
+				}
+				if hasDistinct {
+					op.bufferingState.splitGroup = false
+					toBuffer = idx
+					if op.bufferingState.tuples.Length() == 0 && toBuffer == 0 {
+						// The last batch was split, but this is a distinct group, so we
+						// can emit the last aggregated batch.
+						op.state = hashAggregatorOutputting
+						continue
+					}
+				} else {
+					op.bufferingState.splitGroup = true
+				}
+			} else if toBuffer == 0 {
+				op.bufferingState.splitGroup = true
+			}
+			if toBuffer > 0 {
+				op.bufferingState.tuples.AppendTuples(op.bufferingState.pendingBatch, 0 /* startIdx */, toBuffer)
+				op.bufferingState.unprocessedIdx = toBuffer
+			}
+			if op.bufferingState.tuples.Length() == hashAggregatorMaxBuffered {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+			if hasDistinct {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+
+		case hashAggregatorAggregating:
+			op.inputArgsConverter.ConvertBatch(op.bufferingState.tuples)
+			op.onlineAgg(op.bufferingState.tuples)
+			if op.bufferingState.pendingBatch.Length() == 0 {
+				if len(op.buckets) == 0 {
+					op.state = hashAggregatorDone
+				} else {
+					op.state = hashAggregatorOutputting
+				}
+				continue
+			}
+			if !op.bufferingState.splitGroup {
+				// The aggregated groups are complete, so we can emit them before
+				// buffering more tuples.
+				op.bufferingState.tuples.ResetInternalBatch()
+				op.state = hashAggregatorOutputting
+				continue
+			}
+			op.bufferingState.tuples.ResetInternalBatch()
+			op.state = hashAggregatorBuffering
+
+		case hashAggregatorOutputting:
+			// Note that ResetMaybeReallocate truncates the requested capacity
+			// at coldata.BatchSize(), so we can just try asking for
+			// len(op.buckets) capacity.
+			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
+				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+			)
+			curOutputIdx := 0
+			for curOutputIdx < op.output.Capacity() &&
+				op.curOutputBucketIdx < len(op.buckets) &&
+				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+				bucket := op.buckets[op.curOutputBucketIdx]
+				for fnIdx, fn := range bucket.fns {
+					fn.SetOutput(op.output.ColVec(fnIdx))
+					fn.Flush(curOutputIdx)
+				}
+				op.accountingHelper.AccountForSet(curOutputIdx)
+				curOutputIdx++
+				op.curOutputBucketIdx++
+				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
+					op.maxCapacity = curOutputIdx
+				}
+			}
+			if op.curOutputBucketIdx >= len(op.buckets) {
+				if op.bufferingState.pendingBatch.Length() > 0 {
+					// Clear the buckets.
+					op.state = hashAggregatorBuffering
+					op.resetBucketsAndTrackingState(op.Ctx)
+					// Add back unprocessed tuples from the pending batch to the input
+					// tracking state that were not emitted. We do this by modifying or
+					// adding a selection vector to pending batch that only contains the
+					// remaining pending tuples. We can use this modified pending batch
+					// in the buffering state, since it only contains tuples that still
+					// need to be aggregated, so we do not need to reset to the original
+					// batch state.
+					if op.inputTrackingState.tuples != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+						sel := op.bufferingState.pendingBatch.Selection()
+						if sel != nil {
+							copy(sel, sel[op.bufferingState.unprocessedIdx:op.bufferingState.pendingBatch.Length()])
+							op.bufferingState.pendingBatch.SetLength(op.bufferingState.pendingBatch.Length() - op.bufferingState.unprocessedIdx)
+						} else {
+							colexecutils.UpdateBatchState(op.bufferingState.pendingBatch, op.bufferingState.pendingBatch.Length()-op.bufferingState.unprocessedIdx, true, defaultSelectionVector[op.bufferingState.unprocessedIdx:op.bufferingState.pendingBatch.Length()])
+						}
+						op.inputTrackingState.tuples.Enqueue(op.Ctx, op.bufferingState.pendingBatch)
+						// We modified pendingBatch to only contain unprocessed
+						// tuples, so we need to reset the unprocessedIdx to 0.
+						op.bufferingState.unprocessedIdx = 0
+					}
+				} else {
+					op.state = hashAggregatorDone
+				}
+			}
+			op.output.SetLength(curOutputIdx)
+			return op.output
+
+		case hashAggregatorDone:
+			return coldata.ZeroBatch
+
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("hash aggregator in unhandled state"))
+			// This code is unreachable, but the compiler cannot infer that.
+			return nil
+		}
+	}
+}
+
+// getNext provides the next batch of aggregated tuples. It is a finite state
+// machine that buffers incoming batches of tuples, aggregates them according to
+// the grouping column(s), and emits the aggregated tuples. The buffer may be
+// larger than the batch size in order to amortize the aggregation cost.
+// If partialOrder is true, one or more grouping columns are ordered, so the
+// input is chunked into distinct groups. When enough distinct groups are found
+// to fill the input buffer, getNext aggregates them. If the last group is
+// complete, then the aggregated groups are emitted and getNext goes back to
+// buffering more incoming tuples.
+// If partialOrder is false, there are no guarantees on input ordering and all
+// input tuples are processed before emitting any data.
+func getNext_false(op *hashAggregator) coldata.Batch {
+	for {
+		switch op.state {
+		case hashAggregatorBuffering:
+			if op.bufferingState.pendingBatch != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+				op.bufferingState.tuples.AppendTuples(
+					op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, op.bufferingState.pendingBatch.Length(),
+				)
+			}
+
+			op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx = op.Input.Next(), 0
+			op.bufferingState.unprocessedIdx = 0
+			n := op.bufferingState.pendingBatch.Length()
+			if op.inputTrackingState.tuples != nil {
+				op.inputTrackingState.tuples.Enqueue(op.Ctx, op.bufferingState.pendingBatch)
+				op.inputTrackingState.zeroBatchEnqueued = n == 0
+			}
+			if n == 0 {
+				// This is the last input batch.
+				if op.bufferingState.tuples.Length() == 0 {
+					// There are currently no buffered tuples to perform the
+					// aggregation on.
+					if len(op.buckets) == 0 {
+						// We don't have any buckets which means that there were
+						// no input tuples whatsoever, so we can transition to
+						// finished state right away.
+						op.state = hashAggregatorDone
+					} else {
+						// There are some buckets, so we proceed to the
+						// outputting state.
+						op.state = hashAggregatorOutputting
+					}
+				} else {
+					// There are some buffered tuples on which we need to run
+					// the aggregation.
+					op.state = hashAggregatorAggregating
+				}
+				continue
+			}
+
+			toBuffer := n
+			if op.bufferingState.tuples.Length()+toBuffer > hashAggregatorMaxBuffered {
+				toBuffer = hashAggregatorMaxBuffered - op.bufferingState.tuples.Length()
+			}
+			if toBuffer > 0 {
+				op.bufferingState.tuples.AppendTuples(op.bufferingState.pendingBatch, 0 /* startIdx */, toBuffer)
+				op.bufferingState.unprocessedIdx = toBuffer
+			}
+			if op.bufferingState.tuples.Length() == hashAggregatorMaxBuffered {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+
+		case hashAggregatorAggregating:
+			op.inputArgsConverter.ConvertBatch(op.bufferingState.tuples)
+			op.onlineAgg(op.bufferingState.tuples)
+			if op.bufferingState.pendingBatch.Length() == 0 {
+				if len(op.buckets) == 0 {
+					op.state = hashAggregatorDone
+				} else {
+					op.state = hashAggregatorOutputting
+				}
+				continue
+			}
+			op.bufferingState.tuples.ResetInternalBatch()
+			op.state = hashAggregatorBuffering
+
+		case hashAggregatorOutputting:
+			// Note that ResetMaybeReallocate truncates the requested capacity
+			// at coldata.BatchSize(), so we can just try asking for
+			// len(op.buckets) capacity.
+			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
+				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+			)
+			curOutputIdx := 0
+			for curOutputIdx < op.output.Capacity() &&
+				op.curOutputBucketIdx < len(op.buckets) &&
+				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+				bucket := op.buckets[op.curOutputBucketIdx]
+				for fnIdx, fn := range bucket.fns {
+					fn.SetOutput(op.output.ColVec(fnIdx))
+					fn.Flush(curOutputIdx)
+				}
+				op.accountingHelper.AccountForSet(curOutputIdx)
+				curOutputIdx++
+				op.curOutputBucketIdx++
+				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
+					op.maxCapacity = curOutputIdx
+				}
+			}
+			if op.curOutputBucketIdx >= len(op.buckets) {
+				op.state = hashAggregatorDone
+			}
+			op.output.SetLength(curOutputIdx)
+			return op.output
+
+		case hashAggregatorDone:
+			return coldata.ZeroBatch
+
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("hash aggregator in unhandled state"))
+			// This code is unreachable, but the compiler cannot infer that.
+			return nil
+		}
+	}
+}
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+// useSel is true if the selection vector sel should be used.
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:inline
+const _ = "inlined_findSplit_true_true"
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+// useSel is true if the selection vector sel should be used.
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:inline
+const _ = "inlined_findSplit_false_true"
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+// useSel is true if the selection vector sel should be used.
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:inline
+const _ = "inlined_findSplit_true_false"
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+// useSel is true if the selection vector sel should be used.
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:inline
+const _ = "inlined_findSplit_false_false"

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -105,6 +106,299 @@ var hashAggregatorTestCases = []aggregatorTestCase{
 		},
 		convToDecimal: true,
 	},
+	{
+		name: "oneOrderedCol",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{0, 1, 1},
+			{1, 0, 1},
+			{2, 1, 1},
+			{2, 1, 1},
+			{2, 0, 1},
+			{3, 1, 1},
+			{3, 0, 1},
+			{3, 0, 1},
+			{3, 1, 1},
+			{4, 0, 1},
+			{4, 0, 1},
+			{5, 1, 1},
+			{5, 0, 1},
+			{5, 1, 1},
+		},
+		groupCols: []uint32{0, 1},
+		aggCols:   [][]uint32{{0}, {1}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{0, 1, 1},
+			{1, 0, 1},
+			{2, 1, 2},
+			{2, 0, 1},
+			{3, 1, 2},
+			{3, 0, 2},
+			{4, 0, 2},
+			{5, 1, 2},
+			{5, 0, 1},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0},
+	},
+	{
+		name: "twoOrderedCol",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{0, 1, 1},
+			{1, 0, 1},
+			{2, 0, 1},
+			{2, 1, 1},
+			{2, 1, 1},
+			{3, 0, 1},
+			{3, 0, 1},
+			{3, 1, 1},
+			{3, 1, 1},
+			{4, 0, 1},
+			{4, 0, 1},
+			{5, 0, 1},
+			{5, 1, 1},
+			{5, 1, 1},
+		},
+		groupCols: []uint32{0, 1, 2},
+		aggCols:   [][]uint32{{0}, {1}, {2}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{0, 1, 1, 1},
+			{1, 0, 1, 1},
+			{2, 0, 1, 1},
+			{2, 1, 1, 2},
+			{3, 0, 1, 2},
+			{3, 1, 1, 2},
+			{4, 0, 1, 2},
+			{5, 0, 1, 1},
+			{5, 1, 1, 2},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0, 1},
+	},
+	{
+		name: "PartialOrderWithNulls",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{nil, 1, 1},
+			{nil, 1, 1},
+			{nil, 1, 1},
+			{nil, 1, 1},
+			{nil, 0, 1},
+			{2, 1, 1},
+			{2, 0, 1},
+			{3, 1, 1},
+			{3, 0, 1},
+			{3, 0, 1},
+		},
+		groupCols: []uint32{0, 1},
+		aggCols:   [][]uint32{{0}, {1}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{nil, 1, 4},
+			{nil, 0, 1},
+			{2, 1, 1},
+			{2, 0, 1},
+			{3, 1, 1},
+			{3, 0, 2},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0},
+	},
+	{
+		name: "orderedColSpansMultMaxBufferBoundary",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{0, 1, 1},
+			{0, 1, 1},
+			{0, 3, 1},
+			{0, 2, 1},
+			{0, 3, 1},
+			{0, 3, 1},
+			{0, 3, 1},
+			{0, 2, 1},
+			{0, 1, 1},
+			{0, 3, 1},
+			{0, 1, 1},
+			{0, 1, 1},
+			{0, 3, 1},
+			{0, 1, 1},
+			{0, 3, 1},
+			{0, 1, 1},
+			{0, 1, 1},
+			{0, 2, 1},
+			{0, 2, 1},
+			{0, 2, 1},
+			{0, 3, 1},
+			{0, 1, 1},
+			{0, 1, 1},
+			{0, 1, 1},
+			{0, 2, 1},
+			{1, 1, 1},
+		},
+		groupCols: []uint32{0, 1},
+		aggCols:   [][]uint32{{0}, {1}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{0, 1, 11},
+			{0, 3, 8},
+			{0, 2, 6},
+			{1, 1, 1},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0},
+	},
+	{
+		name: "orderedColUnique",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{0, 1, 2},
+			{1, 1, 3},
+			{2, 3, 1},
+			{3, 2, 1},
+			{4, 3, 0},
+			{5, 3, 5},
+			{6, 3, 1},
+			{7, 3, 1},
+			{8, 1, 1},
+			{9, 4, 8},
+			{10, 3, 2},
+			{11, 3, 1},
+			{12, 2, 3},
+			{13, 1, 3},
+			{14, 1, 2},
+		},
+		groupCols: []uint32{0, 1},
+		aggCols:   [][]uint32{{0}, {1}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{0, 1, 2},
+			{1, 1, 3},
+			{2, 3, 1},
+			{3, 2, 1},
+			{4, 3, 0},
+			{5, 3, 5},
+			{6, 3, 1},
+			{7, 3, 1},
+			{8, 1, 1},
+			{9, 4, 8},
+			{10, 3, 2},
+			{11, 3, 1},
+			{12, 2, 3},
+			{13, 1, 3},
+			{14, 1, 2},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0},
+	},
+	{
+		name: "spilloverAfterEmit",
+		typs: []*types.T{types.Int, types.Int, types.Int},
+		input: colexectestutils.Tuples{
+			{1, 0, 1},
+			{1, 0, 1},
+			{1, 0, 1},
+			{1, 0, 1},
+			{1, 0, 1},
+			{3, 0, 1},
+			{3, 1, 1},
+			{3, 2, 1},
+			{3, 3, 1},
+			{3, 4, 1},
+			{3, 5, 1},
+			{3, 6, 1},
+			{3, 7, 1},
+			{3, 8, 1},
+			{3, 9, 1},
+			{3, 10, 1},
+			{3, 11, 1},
+			{3, 12, 1},
+			{3, 13, 1},
+			{3, 14, 1},
+			{3, 15, 1},
+			{3, 16, 1},
+			{3, 17, 1},
+			{3, 18, 1},
+			{3, 19, 1},
+			{3, 20, 1},
+			{3, 21, 1},
+			{3, 22, 1},
+			{3, 23, 1},
+			{3, 24, 1},
+			{3, 25, 1},
+			{3, 26, 1},
+			{3, 27, 1},
+			{3, 28, 1},
+			{3, 29, 1},
+			{4, 0, 1},
+		},
+		groupCols: []uint32{0, 1},
+		aggCols:   [][]uint32{{0}, {1}, {2}},
+		aggFns: []execinfrapb.AggregatorSpec_Func{
+			execinfrapb.AnyNotNull,
+			execinfrapb.AnyNotNull,
+			execinfrapb.SumInt,
+		},
+		expected: colexectestutils.Tuples{
+			{1, 0, 5},
+			{3, 0, 1},
+			{3, 1, 1},
+			{3, 2, 1},
+			{3, 3, 1},
+			{3, 4, 1},
+			{3, 5, 1},
+			{3, 6, 1},
+			{3, 7, 1},
+			{3, 8, 1},
+			{3, 9, 1},
+			{3, 10, 1},
+			{3, 11, 1},
+			{3, 12, 1},
+			{3, 13, 1},
+			{3, 14, 1},
+			{3, 15, 1},
+			{3, 16, 1},
+			{3, 17, 1},
+			{3, 18, 1},
+			{3, 19, 1},
+			{3, 20, 1},
+			{3, 21, 1},
+			{3, 22, 1},
+			{3, 23, 1},
+			{3, 24, 1},
+			{3, 25, 1},
+			{3, 26, 1},
+			{3, 27, 1},
+			{3, 28, 1},
+			{3, 29, 1},
+			{4, 0, 1},
+		},
+		unorderedInput: false,
+		orderedCols:    []uint32{0},
+	},
 }
 
 func init() {
@@ -122,31 +416,37 @@ func TestHashAggregator(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	for _, tc := range hashAggregatorTestCases {
+		log.Infof(context.Background(), "%s", tc.name)
 		constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
 			&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 		)
 		require.NoError(t, err)
+		var typs [][]*types.T
+		typs = append(typs, tc.typs)
 		verifier := colexectestutils.OrderedVerifier
 		if tc.unorderedInput {
 			verifier = colexectestutils.UnorderedVerifier
+		} else if len(tc.orderedCols) > 0 {
+			verifier = colexectestutils.PartialOrderedVerifier
 		}
-		colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tc.input}, tc.expected, verifier, func(sources []colexecop.Operator) (colexecop.Operator, error) {
-			return NewHashAggregator(&colexecagg.NewAggregatorArgs{
-				Allocator:      testAllocator,
-				MemAccount:     testMemAcc,
-				Input:          sources[0],
-				InputTypes:     tc.typs,
-				Spec:           tc.spec,
-				EvalCtx:        &evalCtx,
-				Constructors:   constructors,
-				ConstArguments: constArguments,
-				OutputTypes:    outputTypes,
-			},
-				nil, /* newSpillingQueueArgs */
-				testAllocator,
-				math.MaxInt64,
-			)
-		})
+		colexectestutils.RunTestsWithOrderedCols(t, testAllocator, []colexectestutils.Tuples{tc.input}, typs, tc.expected, verifier, tc.orderedCols,
+			func(sources []colexecop.Operator) (colexecop.Operator, error) {
+				return NewHashAggregator(&colexecagg.NewAggregatorArgs{
+					Allocator:      testAllocator,
+					MemAccount:     testMemAcc,
+					Input:          sources[0],
+					InputTypes:     tc.typs,
+					Spec:           tc.spec,
+					EvalCtx:        &evalCtx,
+					Constructors:   constructors,
+					ConstArguments: constArguments,
+					OutputTypes:    outputTypes,
+				},
+					nil, /* newSpillingQueueArgs */
+					testAllocator,
+					math.MaxInt64,
+				)
+			})
 	}
 }
 
@@ -178,7 +478,8 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 					new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
 						return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
 					},
-					name: "tracking=false",
+					name:  "tracking=false",
+					order: unordered,
 				},
 				{
 					new: func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
@@ -193,17 +494,96 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 							DiskAcc:            testDiskAcc,
 						}, testAllocator, math.MaxInt64)
 					},
-					name: "tracking=true",
+					name:  "tracking=true",
+					order: unordered,
 				},
 			} {
 				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.Int}, groupSize,
-					0 /* distinctProb */, numInputRows,
-				)
+					b, agg, aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
+					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
 			}
 		}
 	}
 
+	for _, account := range memAccounts {
+		account.Close(ctx)
+	}
+}
+
+// BenchmarkHashAggregatorPartialOrder compares the performance of the in-memory
+// hash aggregator with one of two grouping columns ordered against both
+// grouping columns unordered.
+func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
+	defer cleanup()
+	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
+	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
+
+	aggFn := execinfrapb.Min
+	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
+	// chunkSizes is the number of distinct values in the ordered group column.
+	chunkSizes := []int{1, 32, coldata.BatchSize() + 1}
+	// groupSizes is the total number of groups.
+	groupSizes := []int{1, 32, 128, coldata.BatchSize() + 1}
+	limits := []int{1, 32 * coldata.BatchSize()}
+	if testing.Short() {
+		numRows = []int{32, 32 * coldata.BatchSize()}
+		chunkSizes = []int{1, coldata.BatchSize() + 1}
+		groupSizes = []int{1, coldata.BatchSize()}
+	}
+	var memAccounts []*mon.BoundAccount
+	f := func(args *colexecagg.NewAggregatorArgs) (colexecop.ResettableOperator, error) {
+		spillingQueueMemAcc := testMemMonitor.MakeBoundAccount()
+		memAccounts = append(memAccounts, &spillingQueueMemAcc)
+		return NewHashAggregator(args, &colexecutils.NewSpillingQueueArgs{
+			UnlimitedAllocator: colmem.NewAllocator(ctx, &spillingQueueMemAcc, testColumnFactory),
+			Types:              args.InputTypes,
+			MemoryLimit:        execinfra.DefaultMemoryLimit,
+			DiskQueueCfg:       queueCfg,
+			FDSemaphore:        &colexecop.TestingSemaphore{},
+			DiskAcc:            testDiskAcc,
+		}, testAllocator, math.MaxInt64)
+	}
+	for _, numInputRows := range numRows {
+		for _, limit := range limits {
+			if limit > numInputRows {
+				continue
+			}
+			for _, groupSize := range groupSizes {
+				for _, chunkSize := range chunkSizes {
+					if groupSize > chunkSize || chunkSize > numInputRows {
+						continue
+					}
+					for _, agg := range []aggType{
+						{
+							new:   f,
+							name:  fmt.Sprintf("hash-unordered/limit=%d/chunkSize=%d", limit, chunkSize),
+							order: unordered,
+						},
+						{
+							new:   f,
+							name:  fmt.Sprintf("hash-partial-order/limit=%d/chunkSize=%d", limit, chunkSize),
+							order: partial,
+						},
+					} {
+						if agg.order == unordered && chunkSize != chunkSizes[0] {
+							// Chunk size isn't a factor for the unordered hash aggregator,
+							// so we can skip all but one case.
+							continue
+						}
+						benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int}, 2, groupSize, 0, numInputRows, chunkSize, limit)
+					}
+				}
+			}
+		}
+	}
 	for _, account := range memAccounts {
 		account.Close(ctx)
 	}

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -12,7 +12,12 @@
 
 package colexec
 
-import "github.com/cockroachdb/cockroach/pkg/col/coldata"
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/errors"
+)
 
 // populateEqChains populates op.scratch.eqChains with indices of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
@@ -104,4 +109,318 @@ func (op *hashAggregator) populateEqChains(
 		eqChainsCount = populateEqChains(op, batchLength, sel, HeadIDToEqChainsID, false)
 	}
 	return eqChainsCount, sel
+}
+
+// findSplit returns true if there's a distinct group in op.distinctOutput, as
+// well as the index of the first distinct group found, in the inclusive range
+// [start, end].
+//
+// useSel is true if the selection vector sel should be used.
+//
+// ascending indicates the direction in which we should look for the first
+// distinct group. If true, we look at increasing index values, if false, we
+// look at decreasing index values.
+// execgen:template<useSel, ascending>
+// execgen:inline
+func findSplit(
+	op *hashAggregator, start int, end int, sel []int, useSel bool, ascending bool,
+) (bool, int) {
+	if useSel {
+		_ = sel[start]
+		_ = sel[end]
+	} else {
+		_ = op.distinctOutput[start]
+		_ = op.distinctOutput[end]
+	}
+	if ascending {
+		for i := start; i <= end; i++ {
+			if useSel {
+				//gcassert:bce
+				idx := sel[i]
+				if op.distinctOutput[idx] {
+					return true, i
+				}
+			} else {
+				//gcassert:bce
+				if op.distinctOutput[i] {
+					return true, i
+				}
+			}
+		}
+	} else {
+		for i := start; i >= end; i-- {
+			if useSel {
+				//gcassert:bce
+				idx := sel[i]
+				if op.distinctOutput[idx] {
+					return true, i
+				}
+			} else {
+				//gcassert:bce
+				if op.distinctOutput[i] {
+					return true, i
+				}
+			}
+		}
+	}
+	return false, 0
+}
+
+// getNext provides the next batch of aggregated tuples. It is a finite state
+// machine that buffers incoming batches of tuples, aggregates them according to
+// the grouping column(s), and emits the aggregated tuples. The buffer may be
+// larger than the batch size in order to amortize the aggregation cost.
+//
+// If partialOrder is true, one or more grouping columns are ordered, so the
+// input is chunked into distinct groups. When enough distinct groups are found
+// to fill the input buffer, getNext aggregates them. If the last group is
+// complete, then the aggregated groups are emitted and getNext goes back to
+// buffering more incoming tuples.
+//
+// If partialOrder is false, there are no guarantees on input ordering and all
+// input tuples are processed before emitting any data.
+// execgen:template<partialOrder>
+func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
+	for {
+		switch op.state {
+		case hashAggregatorBuffering:
+			if op.bufferingState.pendingBatch != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+				if partialOrder {
+					if op.bufferingState.splitGroup {
+						// Check if the group split in the last buffered batch is completed
+						// in the pendingBatch.
+						var hasDistinct bool
+						var idx int
+						sel := op.bufferingState.pendingBatch.Selection()
+						if sel != nil {
+							hasDistinct, idx = findSplit(op, op.bufferingState.unprocessedIdx,
+								op.bufferingState.pendingBatch.Length()-1, sel,
+								true /* useSel */, true /* ascending */)
+						} else {
+							hasDistinct, idx = findSplit(op, op.bufferingState.unprocessedIdx,
+								op.bufferingState.pendingBatch.Length()-1, sel,
+								false /* useSel */, true /* ascending */)
+						}
+						if hasDistinct {
+							op.bufferingState.splitGroup = false
+							if op.bufferingState.unprocessedIdx < idx {
+								op.bufferingState.tuples.AppendTuples(
+									op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, idx,
+								)
+								op.bufferingState.unprocessedIdx = idx
+								op.state = hashAggregatorAggregating
+							} else {
+								// The first tuple in the pendingBatch is a new group, so we
+								// can emit the already aggregated tuples.
+								op.state = hashAggregatorOutputting
+							}
+							continue
+						}
+					}
+				}
+				op.bufferingState.tuples.AppendTuples(
+					op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx, op.bufferingState.pendingBatch.Length(),
+				)
+			}
+
+			op.bufferingState.pendingBatch, op.bufferingState.unprocessedIdx = op.Input.Next(), 0
+			op.bufferingState.unprocessedIdx = 0
+			if partialOrder {
+				op.distincterInput.SetBatch(op.bufferingState.pendingBatch)
+				op.distincter.Next()
+			}
+			n := op.bufferingState.pendingBatch.Length()
+			if op.inputTrackingState.tuples != nil {
+				op.inputTrackingState.tuples.Enqueue(op.Ctx, op.bufferingState.pendingBatch)
+				op.inputTrackingState.zeroBatchEnqueued = n == 0
+			}
+			if n == 0 {
+				// This is the last input batch.
+				if op.bufferingState.tuples.Length() == 0 {
+					// There are currently no buffered tuples to perform the
+					// aggregation on.
+					if len(op.buckets) == 0 {
+						// We don't have any buckets which means that there were
+						// no input tuples whatsoever, so we can transition to
+						// finished state right away.
+						op.state = hashAggregatorDone
+					} else {
+						// There are some buckets, so we proceed to the
+						// outputting state.
+						op.state = hashAggregatorOutputting
+					}
+				} else {
+					// There are some buffered tuples on which we need to run
+					// the aggregation.
+					op.state = hashAggregatorAggregating
+				}
+				continue
+			}
+
+			toBuffer := n
+			if op.bufferingState.tuples.Length()+toBuffer > hashAggregatorMaxBuffered {
+				toBuffer = hashAggregatorMaxBuffered - op.bufferingState.tuples.Length()
+			}
+			if partialOrder {
+				hasDistinct := false
+				// Search for last distinct group in each batch. We need to process the
+				// batches in order.
+				if toBuffer > 0 && (op.bufferingState.splitGroup || op.bufferingState.tuples.Length()+toBuffer >= hashAggregatorMaxBuffered) {
+					// See if there is a complete group in the last batch.
+					// Make sure there is at least one tuple either buffered or already
+					// aggregated.
+					lowerBound := 0
+					if op.bufferingState.tuples.Length() == 0 && len(op.buckets) == 0 {
+						lowerBound = 1
+					}
+					var idx int
+					sel := op.bufferingState.pendingBatch.Selection()
+					if sel != nil {
+						hasDistinct, idx = findSplit(op, toBuffer-1, lowerBound, sel,
+							true /* useSel */, false /* ascending */)
+					} else {
+						hasDistinct, idx = findSplit(op, toBuffer-1, lowerBound, sel,
+							false /* useSel */, false /* ascending */)
+					}
+					if hasDistinct {
+						op.bufferingState.splitGroup = false
+						toBuffer = idx
+						if op.bufferingState.tuples.Length() == 0 && toBuffer == 0 {
+							// The last batch was split, but this is a distinct group, so we
+							// can emit the last aggregated batch.
+							op.state = hashAggregatorOutputting
+							continue
+						}
+					} else {
+						op.bufferingState.splitGroup = true
+					}
+				} else if toBuffer == 0 {
+					op.bufferingState.splitGroup = true
+				}
+			}
+			if toBuffer > 0 {
+				op.bufferingState.tuples.AppendTuples(op.bufferingState.pendingBatch, 0 /* startIdx */, toBuffer)
+				op.bufferingState.unprocessedIdx = toBuffer
+			}
+			if op.bufferingState.tuples.Length() == hashAggregatorMaxBuffered {
+				op.state = hashAggregatorAggregating
+				continue
+			}
+			if partialOrder {
+				if hasDistinct {
+					op.state = hashAggregatorAggregating
+					continue
+				}
+			}
+
+		case hashAggregatorAggregating:
+			op.inputArgsConverter.ConvertBatch(op.bufferingState.tuples)
+			op.onlineAgg(op.bufferingState.tuples)
+			if op.bufferingState.pendingBatch.Length() == 0 {
+				if len(op.buckets) == 0 {
+					op.state = hashAggregatorDone
+				} else {
+					op.state = hashAggregatorOutputting
+				}
+				continue
+			}
+			if partialOrder {
+				if !op.bufferingState.splitGroup {
+					// The aggregated groups are complete, so we can emit them before
+					// buffering more tuples.
+					op.bufferingState.tuples.ResetInternalBatch()
+					op.state = hashAggregatorOutputting
+					continue
+				}
+			}
+			op.bufferingState.tuples.ResetInternalBatch()
+			op.state = hashAggregatorBuffering
+
+		case hashAggregatorOutputting:
+			// Note that ResetMaybeReallocate truncates the requested capacity
+			// at coldata.BatchSize(), so we can just try asking for
+			// len(op.buckets) capacity.
+			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
+				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+			)
+			curOutputIdx := 0
+			for curOutputIdx < op.output.Capacity() &&
+				op.curOutputBucketIdx < len(op.buckets) &&
+				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+				bucket := op.buckets[op.curOutputBucketIdx]
+				for fnIdx, fn := range bucket.fns {
+					fn.SetOutput(op.output.ColVec(fnIdx))
+					fn.Flush(curOutputIdx)
+				}
+				op.accountingHelper.AccountForSet(curOutputIdx)
+				curOutputIdx++
+				op.curOutputBucketIdx++
+				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
+					op.maxCapacity = curOutputIdx
+				}
+			}
+			if op.curOutputBucketIdx >= len(op.buckets) {
+				if partialOrder {
+					if op.bufferingState.pendingBatch.Length() > 0 {
+						// Clear the buckets.
+						op.state = hashAggregatorBuffering
+						op.resetBucketsAndTrackingState(op.Ctx)
+						// Add back unprocessed tuples from the pending batch to the input
+						// tracking state that were not emitted. We do this by modifying or
+						// adding a selection vector to pending batch that only contains the
+						// remaining pending tuples. We can use this modified pending batch
+						// in the buffering state, since it only contains tuples that still
+						// need to be aggregated, so we do not need to reset to the original
+						// batch state.
+						if op.inputTrackingState.tuples != nil && op.bufferingState.unprocessedIdx < op.bufferingState.pendingBatch.Length() {
+							sel := op.bufferingState.pendingBatch.Selection()
+							if sel != nil {
+								copy(sel, sel[op.bufferingState.unprocessedIdx:op.bufferingState.pendingBatch.Length()])
+								op.bufferingState.pendingBatch.SetLength(op.bufferingState.pendingBatch.Length() - op.bufferingState.unprocessedIdx)
+							} else {
+								colexecutils.UpdateBatchState(op.bufferingState.pendingBatch, op.bufferingState.pendingBatch.Length()-op.bufferingState.unprocessedIdx, true, defaultSelectionVector[op.bufferingState.unprocessedIdx:op.bufferingState.pendingBatch.Length()])
+							}
+							op.inputTrackingState.tuples.Enqueue(op.Ctx, op.bufferingState.pendingBatch)
+							// We modified pendingBatch to only contain unprocessed
+							// tuples, so we need to reset the unprocessedIdx to 0.
+							op.bufferingState.unprocessedIdx = 0
+						}
+					} else {
+						op.state = hashAggregatorDone
+					}
+				} else {
+					op.state = hashAggregatorDone
+				}
+			}
+			op.output.SetLength(curOutputIdx)
+			return op.output
+
+		case hashAggregatorDone:
+			return coldata.ZeroBatch
+
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("hash aggregator in unhandled state"))
+			// This code is unreachable, but the compiler cannot infer that.
+			return nil
+		}
+	}
+}
+
+// defaultSelectionVector contains all integers in [0, coldata.MaxBatchSize)
+// range.
+var defaultSelectionVector []int
+
+func init() {
+	defaultSelectionVector = make([]int, coldata.MaxBatchSize)
+	for i := range defaultSelectionVector {
+		defaultSelectionVector[i] = i
+	}
+}
+
+func (op *hashAggregator) Next() coldata.Batch {
+	if len(op.spec.OrderedGroupCols) > 0 {
+		return getNext(op, true)
+	} else {
+		return getNext(op, false)
+	}
 }

--- a/pkg/sql/colexec/inject_setup_test.go
+++ b/pkg/sql/colexec/inject_setup_test.go
@@ -13,10 +13,15 @@ package colexec_test
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 )
 
 func init() {
 	// Inject a testing helper for NewColOperator so colexec tests can
 	// use NewColOperator without an import cycle.
 	colexecargs.TestNewColOperator = colbuilder.NewColOperator
+	// Inject a testing helper for OrderedDistinctColsToOperators so colexec tests
+	// can use OrderedDistinctColsToOperators without an import cycle.
+	colexectestutils.OrderedDistinctColsToOperators = colexecbase.OrderedDistinctColsToOperators
 }


### PR DESCRIPTION
This change consists of two commits. The first adds test coverage for 
aggregation with partial ordering of group columns, including adding a new
microbenchmark. The second adds support for partial ordering in the hash 
aggregator.

Results from both the new benchmark, HashAggregatorPartialOrder, and existing
hash aggregator benchmarks show improved performance for the partial order 
case for lower limit values, and no performance degradation for the unordered 
case: 
https://gist.github.com/rharding6373/09eface5ed49a00aac540a8ea8304662

This change is fairly large, so I will follow this PR with an update to the optimizer 
cost model to take advantage of partial ordering.