### PR TITLE
opt: remove UnsupportedExpr

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -37,24 +37,23 @@ func init() {
 	// the functions depend on scalarBuildFuncMap which in turn depends on the
 	// functions).
 	scalarBuildFuncMap = [opt.NumOperators]buildFunc{
-		opt.VariableOp:        (*Builder).buildVariable,
-		opt.ConstOp:           (*Builder).buildTypedExpr,
-		opt.NullOp:            (*Builder).buildNull,
-		opt.PlaceholderOp:     (*Builder).buildTypedExpr,
-		opt.TupleOp:           (*Builder).buildTuple,
-		opt.FunctionOp:        (*Builder).buildFunction,
-		opt.CaseOp:            (*Builder).buildCase,
-		opt.CastOp:            (*Builder).buildCast,
-		opt.CoalesceOp:        (*Builder).buildCoalesce,
-		opt.ColumnAccessOp:    (*Builder).buildColumnAccess,
-		opt.ArrayOp:           (*Builder).buildArray,
-		opt.AnyOp:             (*Builder).buildAny,
-		opt.AnyScalarOp:       (*Builder).buildAnyScalar,
-		opt.IndirectionOp:     (*Builder).buildIndirection,
-		opt.CollateOp:         (*Builder).buildCollate,
-		opt.ArrayFlattenOp:    (*Builder).buildArrayFlatten,
-		opt.IfErrOp:           (*Builder).buildIfErr,
-		opt.UnsupportedExprOp: (*Builder).buildUnsupportedExpr,
+		opt.VariableOp:     (*Builder).buildVariable,
+		opt.ConstOp:        (*Builder).buildTypedExpr,
+		opt.NullOp:         (*Builder).buildNull,
+		opt.PlaceholderOp:  (*Builder).buildTypedExpr,
+		opt.TupleOp:        (*Builder).buildTuple,
+		opt.FunctionOp:     (*Builder).buildFunction,
+		opt.CaseOp:         (*Builder).buildCase,
+		opt.CastOp:         (*Builder).buildCast,
+		opt.CoalesceOp:     (*Builder).buildCoalesce,
+		opt.ColumnAccessOp: (*Builder).buildColumnAccess,
+		opt.ArrayOp:        (*Builder).buildArray,
+		opt.AnyOp:          (*Builder).buildAny,
+		opt.AnyScalarOp:    (*Builder).buildAnyScalar,
+		opt.IndirectionOp:  (*Builder).buildIndirection,
+		opt.CollateOp:      (*Builder).buildCollate,
+		opt.ArrayFlattenOp: (*Builder).buildArrayFlatten,
+		opt.IfErrOp:        (*Builder).buildIfErr,
 
 		// Item operators.
 		opt.ProjectionsItemOp:  (*Builder).buildItem,
@@ -489,12 +488,6 @@ func (b *Builder) buildIfErr(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.T
 	}
 
 	return tree.NewTypedIfErrExpr(cond, orElse, errCode), nil
-}
-
-func (b *Builder) buildUnsupportedExpr(
-	ctx *buildScalarCtx, scalar opt.ScalarExpr,
-) (tree.TypedExpr, error) {
-	return scalar.(*memo.UnsupportedExprExpr).Value, nil
 }
 
 func (b *Builder) buildItem(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -169,7 +169,6 @@ var typingFuncMap map[opt.Operator]typingFunc
 func init() {
 	typingFuncMap = make(map[opt.Operator]typingFunc)
 	typingFuncMap[opt.PlaceholderOp] = typeAsTypedExpr
-	typingFuncMap[opt.UnsupportedExprOp] = typeAsTypedExpr
 	typingFuncMap[opt.CoalesceOp] = typeCoalesce
 	typingFuncMap[opt.CaseOp] = typeCase
 	typingFuncMap[opt.WhenOp] = typeWhen

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -773,13 +773,6 @@ define ColumnAccess {
     Idx TupleOrdinal
 }
 
-# UnsupportedExpr is used for interfacing with the old planner code. It can
-# encapsulate a TypedExpr that is otherwise not supported by the optimizer.
-[Scalar]
-define UnsupportedExpr {
-    Value TypedExpr
-}
-
 [Scalar, Aggregate]
 define ArrayAgg {
     Input ScalarExpr

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
@@ -183,7 +183,6 @@
                         FunctionPrivate |
                         Coalesce |
                         ColumnAccess |
-                        UnsupportedExpr |
                         Avg |
                         BoolAnd |
                         BoolOr |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -15,7 +15,7 @@ syn match Comment display '#.*$' contains=Todo
 syn keyword Todo TODO XXX
 
 syn region ruletags start='^\[' end='\]$' contains=ruletag
-syn match ruletag contained display '[A-Za-z0-9_]*' 
+syn match ruletag contained display '[A-Za-z0-9_]*'
 
 syn region list start='(' end=')' contains=list,func,var,operator
 syn match func contained display '\((\)\@<=[A-Za-z0-9_]\+\( | [A-Za-z0-9_]\+\)*'
@@ -42,7 +42,7 @@ syn keyword operator RegIMatch NotRegIMatch Is IsNot Contains JsonExists JsonAll
 syn keyword operator JsonSomeExists AnyScalar Bitand Bitor Bitxor Plus Minus Mult Div FloorDiv
 syn keyword operator Mod Pow Concat LShift RShift FetchVal FetchText FetchValPath FetchTextPath
 syn keyword operator UnaryMinus UnaryComplement Cast Case When Array Indirection
-syn keyword operator Function FunctionPrivate Coalesce ColumnAccess UnsupportedExpr
+syn keyword operator Function FunctionPrivate Coalesce ColumnAccess
 syn keyword operator Avg BoolAnd BoolOr ConcatAgg Count CountRows Max Min SumInt Sum SqrDiff
 syn keyword operator Variance StdDev XorAgg JsonAgg JsonbAgg ConstAgg ConstNotNullAgg
 syn keyword operator AnyNotNullAgg FirstAgg AggDistinct ScalarList

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -183,7 +183,6 @@
                         FunctionPrivate |
                         Coalesce |
                         ColumnAccess |
-                        UnsupportedExpr |
                         Avg |
                         BoolAnd |
                         BoolOr |


### PR DESCRIPTION
This commit removes UnsupportedExpr because it is no longer used.

Release note: None