### PR TITLE
security: remove the node TLS client cert exemption

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -39,7 +39,7 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
-		1024, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
+		2048, 48*time.Hour, false, security.RootUserName(), true /* generate pk8 key */))
 
 	// Test user.
 	maybePanic(security.CreateClientPair(

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -20,13 +20,10 @@ services:
     build: ./python
     depends_on:
       - cockroach
-    command: /start.sh
     environment:
       - PGHOST=cockroach
       - PGPORT=26257
       - PGSSLMODE=require
-      - PGSSLCERT=/certs/node.crt
-      - PGSSLKEY=/certs/node.key
     volumes:
       - ./kdc/krb5.conf:/etc/krb5.conf
       - ./python/start.sh:/start.sh

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -23,8 +23,6 @@ services:
     environment:
       - PGHOST=cockroach
       - PGPORT=26257
-      - PGSSLCERT=/certs/node.crt
-      - PGSSLKEY=/certs/node.key
     volumes:
       - ./kdc/krb5.conf:/etc/krb5.conf
       - ./psql/gss_test.go:/test/gss_test.go

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func TestGSS(t *testing.T) {
-	connector, err := pq.NewConnector("user=root sslmode=require")
+	connector, err := pq.NewConnector("user=root password=rootpw sslmode=require")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+echo "Available certs:"
+ls -l /certs
+
+echo "Environment:"
+env
+
+echo "Creating a k5s token..."
 echo psql | kinit tester@MY.EX
 
+echo "Preparing SQL user ahead of test"
+env \
+    PGSSLKEY=/certs/client.root.key \
+    PGSSLCERT=/certs/client.root.crt \
+    psql -c "ALTER USER root WITH PASSWORD rootpw"
+
+echo "Running test"
 ./gss.test

--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -11,3 +11,5 @@ WORKDIR /code
 COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
+
+ENTRYPOINT ["/start.sh"]

--- a/pkg/acceptance/compose/gss/python/start.sh
+++ b/pkg/acceptance/compose/gss/python/start.sh
@@ -2,10 +2,29 @@
 
 set -e
 
-psql -c "SET CLUSTER SETTING server.host_based_authentication.configuration = 'host all all all gss include_realm=0'"
-psql -c "CREATE USER tester"
+echo "Available certs:"
+ls -l /certs
 
+echo "Environment:"
+env
+
+echo "Creating a k5s token..."
 echo psql | kinit tester@MY.EX
+
+export PGSSLKEY=/certs/client.root.key
+export PGSSLCERT=/certs/client.root.crt
+export PGUSER=root
+
+echo "Creating test user"
+psql -c "CREATE USER tester"
+echo "Configuring the HBA rule prior to running the test..."
+psql -c "SET CLUSTER SETTING server.host_based_authentication.configuration = 'host all all all gss include_realm=0'"
+
+echo "Testing the django connection..."
+
+unset PGSSLKEY
+unset PGSSLCERT
+export PGUSER=tester
 
 # Exit with error unless we find the expected error message.
 python manage.py inspectdb 2>&1 | grep 'use of GSS authentication requires an enterprise license'

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -134,10 +134,8 @@ func UserAuthCertHook(insecureMode bool, tlsState *tls.ConnectionState) (UserAut
 				errors.Errorf("using tenant client certificate as user certificate is not allowed")
 		}
 
-		// The client certificate user must match the requested user,
-		// except if the certificate user is NodeUser, which is allowed to
-		// act on behalf of all other users.
-		if !Contains(certUsers, requestedUser.Normalized()) && !Contains(certUsers, NodeUser) {
+		// The client certificate user must match the requested user.
+		if !Contains(certUsers, requestedUser.Normalized()) {
 			return nil, errors.Errorf("requested user is %s, but certificate is for %s", requestedUser, certUsers)
 		}
 

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -195,6 +195,8 @@ func TestAuthenticationHook(t *testing.T) {
 		{false, "foo", security.NodeUserName(), "", true, false, false},
 		// Secure mode, node user.
 		{false, security.NodeUser, security.NodeUserName(), "", true, true, true},
+		// Secure mode, node cert and unrelated user.
+		{false, security.NodeUser, fooUser, "", true, false, false},
 		// Secure mode, root user.
 		{false, security.RootUser, security.NodeUserName(), "", true, false, false},
 		// Secure mode, tenant cert, foo user.


### PR DESCRIPTION
Fixes #71102.

Release note (security update): It is not possible any more to use a
node TLS certificate to establish a SQL connection with another
username than `node`. This facility had existed as an "escape hatch"
so that an operator could use the node cert to perform operations on
behalf of another SQL user. However, this facility is not necessary:
an operator with access to a node cert can log in as `node` directly
and create new credentials for another user anyway. By removing
this facility, we tighten the guarantee that the principal in the TLS
client cert always matches the SQL identity.