### PR TITLE
sql: NFC-normalization on double-quoted identifiers

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
+++ b/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
@@ -17,6 +17,6 @@ p  CREATE TABLE public.p (
 ) PARTITION BY LIST (a) (
   PARTITION p1 VALUES IN ((1)),
   PARTITION "P1" VALUES IN ((2)),
-  PARTITION "Amélie" VALUES IN ((3))
+  PARTITION "Amélie" VALUES IN ((3))
 )
 -- Warning: Partitioned table with no zone configurations.

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -477,6 +477,7 @@ go_test(
         "metric_test.go",
         "metric_util_test.go",
         "mutation_test.go",
+        "normalization_test.go",
         "partition_test.go",
         "pg_metadata_test.go",
         "pg_oid_test.go",

--- a/pkg/sql/lexbase/normalize.go
+++ b/pkg/sql/lexbase/normalize.go
@@ -53,3 +53,12 @@ func NormalizeName(n string) string {
 	}
 	return norm.NFC.String(lower)
 }
+
+// NormalizeString normalizes to Unicode Normalization Form C (NFC).
+// This function is specifically for double quoted identifiers.
+func NormalizeString(s string) string {
+	if isASCII(s) {
+		return s
+	}
+	return norm.NFC.String(s)
+}

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -251,27 +251,9 @@ DROP INDEX a@I
 
 # Unicode sequences are preserved.
 
-statement ok
+# Check that normalization occurs
+statement error duplicate column name: "Amélie"
 CREATE TABLE Amelie("Amélie" INT, "Amélie" INT); INSERT INTO Amelie VALUES (1, 2)
-
-# Check that the column names were encoded properly
-query I
-SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'amelie' AND column_name::BYTES = b'Ame\xcc\x81lie'
-----
-1
-
-query I
-SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'amelie' AND column_name::BYTES = b'Am\xc3\xa9lie'
-----
-2
-
-# Check that the non-normalized names propagate throughout until results.
-
-query II colnames
-SELECT "Amélie", "Amélie" FROM Amelie
-----
-Amélie Amélie
-2      1
 
 # Check that function names are also recognized case-insensitively.
 query I

--- a/pkg/sql/normalization_test.go
+++ b/pkg/sql/normalization_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNFCNormalization(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	defer s.Stopper().Stop(context.Background())
+	defer db.Close()
+
+	_, err := db.Exec("CREATE TABLE café (a INT)")
+	require.NoError(t, err)
+
+	_, err = db.Exec("CREATE TABLE Cafe\u0301 (a INT)")
+	require.Errorf(t, err, "The tables should be considered duplicates when normalized")
+	require.True(t, strings.Contains(err.Error(), "already exists"))
+
+	_, err = db.Exec("CREATE TABLE cafe\u0301 (a INT)")
+	require.Errorf(t, err, "The tables should be considered duplicates when normalized")
+	require.True(t, strings.Contains(err.Error(), "already exists"))
+
+	_, err = db.Exec("CREATE TABLE caf\u00E9 (a INT)")
+	require.Errorf(t, err, "The tables should be considered duplicates when normalized")
+	require.True(t, strings.Contains(err.Error(), "already exists"))
+
+	_, err = db.Exec("CREATE TABLE \"caf\u00E9\" (a INT)")
+	require.Errorf(t, err, "The tables should be considered duplicates when normalized")
+	require.True(t, strings.Contains(err.Error(), "already exists"))
+
+	_, err = db.Exec("CREATE TABLE \"cafe\u0301\" (a INT)")
+	require.Errorf(t, err, "The tables should be considered duplicates when normalized")
+	require.True(t, strings.Contains(err.Error(), "already exists"))
+
+	_, err = db.Exec(`CREATE TABLE "Café" (a INT)`)
+	require.NoError(t, err)
+	//Ensure normal strings are not normalized like double quoted strings
+	var b bool
+	err = db.QueryRow("SELECT 'caf\u00E9' = 'cafe\u0301'").Scan(&b)
+	require.NoError(t, err)
+	require.False(t, b)
+
+}

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -563,7 +563,7 @@ func (s *Scanner) scanIdent(lval ScanSymType) {
 	}
 	//fmt.Println("parsed: ", s.in[start:s.pos], isASCII, isLower)
 
-	if isLower {
+	if isLower && isASCII {
 		// Already lowercased - nothing to do.
 		lval.SetStr(s.in[start:s.pos])
 	} else if isASCII {
@@ -830,7 +830,6 @@ func (s *Scanner) scanString(lval ScanSymType, ch int, allowEscapes, requireUTF8
 	buf := s.buffer()
 	var runeTmp [utf8.UTFMax]byte
 	start := s.pos
-
 outer:
 	for {
 		switch s.next() {
@@ -918,7 +917,11 @@ outer:
 		return false
 	}
 
-	lval.SetStr(s.finishString(buf))
+	if ch == identQuote {
+		lval.SetStr(lexbase.NormalizeString(s.finishString(buf)))
+	} else {
+		lval.SetStr(s.finishString(buf))
+	}
 	return true
 }
 


### PR DESCRIPTION
Resolves: #55396

There was a lack of NFC-normalization on double-quoted
identifiers. This allowed for ambiguous table/db/column names.
This change adds normalization and prevents this case.

Release note: None