### PR TITLE
release-20.2: cmd/roachtest: fix nodesource installation for sequelize/typeorm/nodejs_postgres

### DIFF
--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -74,7 +74,7 @@ func registerTypeORM(r *testRegistry) {
 			c,
 			node,
 			"add nodesource repository",
-			`curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #71039.

/cc @cockroachdb/release

---

The certificate for deb.nodesource in the installation of nodesource
seems to be expired. This commit provides a work-around per
https://github.com/nodesource/distributions/issues/1266#issuecomment-931467582.

An official fix-up should be added once
https://github.com/nodesource/distributions/issues/1266
is finished.

Release note: None
Release justification: None

Resolves #70984, #70981, #70982, #70980
