### PR TITLE
testutils: adding error wrapping linter

### DIFF
--- a/pkg/testutils/lint/passes/errwrap/errwrap.go
+++ b/pkg/testutils/lint/passes/errwrap/errwrap.go
@@ -1,0 +1,91 @@
+package errwrap
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const Doc = `check for unwrapped errors`
+
+var errorType = types.Universe.Lookup("error").Type().String()
+
+// Analyzer checks for usage of errors.Is instead of direct ==/!=
+// comparisons.
+var Analyzer = &analysis.Analyzer{
+	Name:     "errwrap",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.ReturnStmt)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		// Catch-all for possible bugs in the linter code.
+		defer func() {
+			if r := recover(); r != nil {
+				if err, ok := r.(error); ok {
+					pass.Reportf(n.Pos(), "internal linter error: %v", err)
+					return
+				}
+				panic(r)
+			}
+		}()
+
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return
+		}
+
+		for _, expr := range ret.Results {
+			retFn, ok := expr.(*ast.CallExpr)
+			if ok {
+				if len(retFn.Args) > 1 {
+					for i := 0; i < len(retFn.Args); i++ {
+						val := retFn.Args[i]
+						if val == nil {
+							return
+						}
+						if pass.TypesInfo.TypeOf(val).String() == errorType {
+							reportUnwrappedErr(pass, retFn)
+							return
+						}
+					}
+				}
+
+				if pass.TypesInfo.TypeOf(retFn.Args[0]).String() == errorType {
+					reportUnwrappedErr(pass, retFn)
+					return
+				}
+				return
+			}
+
+			if pass.TypesInfo.TypeOf(expr).String() == errorType {
+				reportUnwrappedErr(pass, expr)
+				return
+			}
+
+		}
+		return
+	})
+
+	return nil, nil
+}
+
+func reportUnwrappedErr(pass *analysis.Pass, expr ast.Expr) {
+	//Not sure if we can ignore signatures
+	pass.Reportf(expr.Pos(), escNl(`unwrapped err insert advice`))
+}
+
+func escNl(msg string) string {
+	return strings.ReplaceAll(msg, "\n", "\\n++")
+}

--- a/pkg/testutils/lint/passes/errwrap/errwrap_test.go
+++ b/pkg/testutils/lint/passes/errwrap/errwrap_test.go
@@ -1,0 +1,24 @@
+package errwrap_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/errwrap"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func init() {
+	if bazel.BuiltWithBazel() {
+		bazel.SetGoEnv()
+	}
+}
+
+func Test(t *testing.T) {
+	skip.UnderStress(t, "Go cache files don't work under stress")
+	testdata := testutils.TestDataPath(t)
+	analysistest.TestData = func() string { return testdata }
+	analysistest.Run(t, testdata, errwrap.Analyzer, "err")
+}

--- a/pkg/testutils/lint/passes/errwrap/testdata/src/err/err.go
+++ b/pkg/testutils/lint/passes/errwrap/testdata/src/err/err.go
@@ -1,0 +1,29 @@
+package err
+
+import "errors"
+
+func singleReturn(err error) error {
+	if err == nil {
+		err = errors.New("foo")
+	}
+	return err
+}
+
+func multiReturn(str string, err error, int int) (string, error, int) {
+	if err == nil {
+		str = "a"
+		err = errors.New("bar")
+		int = 10
+	}
+	return str, err, int
+}
+
+func multiCallReturn() (string, error, int) {
+	err := errors.New("baz")
+	return multiReturn("abc", err, 20)
+}
+
+func singleCallReturn() error {
+	err := errors.New("bat")
+	return singleReturn(err)
+}

--- a/pkg/testutils/lint/testdata/errwrap_excludes.txt
+++ b/pkg/testutils/lint/testdata/errwrap_excludes.txt
@@ -1,0 +1,8 @@
+errors.Errorf
+errors.New
+errors.Unwrap
+errors.Wrap
+errors.Wrapf
+errors.WithMessage
+errors.WithMessagef(
+errors.WithStack


### PR DESCRIPTION
resolves https://github.com/cockroachdb/cockroach/issues/42510

Issue: When I run the test. get this error:
```
exec: "returncheck": executable file not found in $PATH
```
I get the same error when I try to run TestErrCheck, the test I based mine off of.


There is an issue where error objects are being flattened
stripping them of all their details(stack traces, user hints).
This introduces a linter that will find remaining cases of
unwrapped errors and prevent more cases from occurring.

Release note: None