### PR TITLE
release-21.2: doctor: examine zipdir now checks for .err.txt files

### DIFF
--- a/pkg/cli/testdata/doctor/debugzip/system.jobs.txt.err.txt
+++ b/pkg/cli/testdata/doctor/debugzip/system.jobs.txt.err.txt
@@ -1,0 +1,1 @@
+something might have happened

--- a/pkg/cli/testdata/doctor/test_examine_zipdir
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir
@@ -1,6 +1,7 @@
 debug doctor examine zipdir testdata/doctor/debugzip
 ----
 debug doctor examine zipdir testdata/doctor/debugzip
+WARNING: errors occurred during the production of system.jobs.txt, contents may be missing or incomplete.
 Examining 37 descriptors and 42 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: descriptor not found
   ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: descriptor not found

--- a/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
@@ -3,6 +3,7 @@ debug doctor zipdir --verbose
 debug doctor zipdir testdata/doctor/debugzip --verbose
 reading testdata/doctor/debugzip/system.descriptor.txt
 reading testdata/doctor/debugzip/system.namespace.txt
+WARNING: errors occurred during the production of system.jobs.txt, contents may be missing or incomplete.
 reading testdata/doctor/debugzip/system.jobs.txt
 Examining 37 descriptors and 42 namespace entries...
   ParentID   0, ParentSchemaID  0: database "system" (1): processed

--- a/pkg/cli/testdata/doctor/test_recreate_zipdir
+++ b/pkg/cli/testdata/doctor/test_recreate_zipdir
@@ -1,6 +1,7 @@
 debug doctor recreate zipdir testdata/doctor/debugzip
 ----
 debug doctor recreate zipdir testdata/doctor/debugzip
+WARNING: errors occurred during the production of system.jobs.txt, contents may be missing or incomplete.
 BEGIN;
 SELECT 1/(1-sign(count(*))) FROM system.descriptor WHERE id >= 52;
 SELECT crdb_internal.unsafe_delete_descriptor(id, true) FROM system.descriptor WHERE id >= 50;


### PR DESCRIPTION
Backport 1/1 commits from #70638.

/cc @cockroachdb/release

---

Previously, the debug doctor tool would ignore these files which could
lead to confusion when interpreting the results. These files are a good
sign that the debug zip is incomplete which can be the source of many
spurious validation errors.

This commit adds a warning message to alert the user to the fact that
the subsequent output may be questionable.

Fixes #64960.

Release justification: low risk bug fix in debug tooling.

Release note: None
