### PR TITLE
release-20.2: sql: fix FK check bug in ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -205,9 +205,18 @@ func alterColumnTypeGeneralOld(
 	}
 
 	for _, fk := range tableDesc.AllActiveAndInactiveForeignKeys() {
-		for _, id := range append(fk.OriginColumnIDs, fk.ReferencedColumnIDs...) {
-			if col.ID == id {
-				return colWithConstraintNotSupportedErr
+		if fk.OriginTableID == tableDesc.GetID() {
+			for _, id := range fk.OriginColumnIDs {
+				if col.ID == id {
+					return colWithConstraintNotSupportedErr
+				}
+			}
+		}
+		if fk.ReferencedTableID == tableDesc.GetID() {
+			for _, id := range fk.ReferencedColumnIDs {
+				if col.ID == id {
+					return colWithConstraintNotSupportedErr
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #71097.

/cc @cockroachdb/release

---

This commit fixes an implementation bug when checking that the table's
foreign keys didn't hold a reference to the altered column.

Fixes #71089.

Release justification: simple fix for blatant correctness bug

Release note (bug fix): fixes a bug which caused ALTER COLUMN TYPE
statements to fail when they shouldn't have.
