### PR TITLE
dev: add `rewrite` flag

### DIFF
--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -167,3 +167,14 @@ bazel test //pkg/roachpb:roachpb_test //pkg/roachpb:string_test --test_output er
 
 bazel test pkg/roachpb:string_test --test_output errors
 ----
+
+bazel query 'kind(go_test, //pkg/testutils:all)'
+----
+//pkg/testutils:testutils_test
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+bazel test //pkg/testutils:testutils_test --run_under 'cd go/src/github.com/cockroachdb/cockroach/pkg/testutils && ' --test_env=YOU_ARE_IN_THE_WORKSPACE=1 --test_arg -rewrite --test_output errors
+----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -56,3 +56,9 @@ bazel test //pkg/roachpb:roachpb_test //pkg/roachpb:string_test --test_output er
 dev test pkg/roachpb:string_test
 ----
 bazel test pkg/roachpb:string_test --test_output errors
+
+dev test //pkg/testutils --rewrite
+----
+bazel query 'kind(go_test, //pkg/testutils:all)'
+bazel info workspace --color=no
+bazel test //pkg/testutils:testutils_test --run_under 'cd go/src/github.com/cockroachdb/cockroach/pkg/testutils && ' --test_env=YOU_ARE_IN_THE_WORKSPACE=1 --test_arg -rewrite --test_output errors

--- a/pkg/testutils/data_path.go
+++ b/pkg/testutils/data_path.go
@@ -11,6 +11,7 @@
 package testutils
 
 import (
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -26,14 +27,15 @@ import (
 // file using TestDataPath(t, "a.txt").
 func TestDataPath(t testing.TB, relative ...string) string {
 	relative = append([]string{"testdata"}, relative...)
-	if bazel.BuiltWithBazel() {
+	// dev notifies the library that the test is running in a subdirectory of the
+	// workspace with the environment variable below.
+	if bazel.BuiltWithBazel() && os.Getenv("YOU_ARE_IN_THE_WORKSPACE") != "" {
 		runfiles, err := bazel.RunfilesPath()
 		require.NoError(t, err)
 		return path.Join(runfiles, bazel.RelativeTestTargetPath(), path.Join(relative...))
 	}
 
-	// If we're not running in Bazel, we're in the package directory and can
-	// just return a relative path.
+	// Otherwise we're in the package directory and can just return a relative path.
 	ret := path.Join(relative...)
 	ret, err := filepath.Abs(ret)
 	require.NoError(t, err)


### PR DESCRIPTION
Some of our tests support a `-rewrite` flag which updates the `testdata`
on-disk. At a glance this behavior is broken in Bazel, since tests don't
have write access to the `testdata` in the sandbox.

To address this we add a `--rewrite` flag to `dev`. When set,
this flag causes `dev` to `cd` to the subpackage under test in the
workspace before running the test. We also set the environment variable
`YOU_ARE_IN_THE_WORKSPACE` to denote that this happened. We also pass
`-rewrite` to the test.

On the Go side, we check if `YOU_ARE_IN_THE_WORKSPACE` is set and
find `testdata` relative to `PWD` accordingly.

Closes #69570.

Release note: None