### PR TITLE
docs: fix show_grants_stmt bnf error

### DIFF
--- a/docs/generated/sql/bnf/show_grants_stmt.bnf
+++ b/docs/generated/sql/bnf/show_grants_stmt.bnf
@@ -1,5 +1,11 @@
 show_grants_stmt ::=
-	'SHOW' 'GRANTS' 'ON' ( 'ROLE' | 'ROLE' name ( ',' name ) )* | ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' ( 'ROLE' | 'ROLE' name ( ',' name ) )* | ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 
-	| 'SHOW' 'GRANTS'  'FOR' user_name ( ( ',' user_name ) )*
+	'SHOW' 'GRANTS' 'ON' 'ROLE' name ( ( ',' name ) )* 'FOR' name ( ( ',' name ) )*
+	| 'SHOW' 'GRANTS' 'ON' 'ROLE' name ( ( ',' name ) )* 
+	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' name ( ( ',' name ) )* 'FOR' name ( ( ',' name ) )*
+	| 'SHOW' 'GRANTS' 'ON' 'SCHEMA' name ( ( ',' name ) )* 
+	| 'SHOW' 'GRANTS' 'ON' 'TYPE' type_name ( ( ',' type_name ) )* 'FOR' name ( ( ',' name ) )*
+	| 'SHOW' 'GRANTS' 'ON' 'TYPE' type_name ( ( ',' type_name ) )* 
+	| 'SHOW' 'GRANTS' 'ON' ( | 'TABLE' table_name ( ( ',' table_name ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FOR' name ( ( ',' name ) )*
+	| 'SHOW' 'GRANTS' 'ON' ( | 'TABLE' table_name ( ( ',' table_name ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 
+	| 'SHOW' 'GRANTS'  'FOR' name ( ( ',' name ) )*
 	| 'SHOW' 'GRANTS'  

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1173,13 +1173,19 @@ var specs = []stmtSpec{
 		unlink:  []string{"job_id"},
 	},
 	{
-		name:   "show_grants_stmt",
-		inline: []string{"name_list", "opt_on_targets_roles", "for_grantee_clause", "name_list"},
-		replace: map[string]string{
-			"targets_roles":                "( 'ROLE' | 'ROLE' name ( ',' name ) )* | ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* )",
-			"'FOR' name ( ( ',' name ) )*": "'FOR' user_name ( ( ',' user_name ) )*",
+		name: "show_grants_stmt",
+		inline: []string{
+			"opt_on_targets_roles",
+			"for_grantee_clause",
+			"targets_roles",
+			"name_list",
+			"type_name_list",
 		},
-		unlink: []string{"role_name", "table_name", "database_name", "user_name"},
+		replace: map[string]string{
+			"targets":                 "( | 'TABLE' table_name ( ( ',' table_name ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* )",
+			"qualifiable_schema_name": "schema_name",
+		},
+		unlink: []string{"table_name", "database_name", "schema_name", "name"},
 	},
 	{
 		name: "show_indexes",


### PR DESCRIPTION
Previously the show_grants_stmt bnf that was generated
was invalid causing the railroad diagram generation to fail.
This fixes it.

Docs only change.

Release note: None

Looking to merge directly to 20.2 as this is fixed in later versions