### PR TITLE
backupccl: unblock table restore of regional by row tables

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -658,13 +658,11 @@ func allocateDescriptorRewrites(
 					return err
 				}
 
-				if parentDB.IsMultiRegion() && table.GetLocalityConfig() != nil {
-					// We're restoring a table and not its parent database. We may block
-					// restoring multi-region tables to multi-region databases since
-					// regions may mismatch.
-					if err := checkMultiRegionCompatible(ctx, txn, p.ExecCfg().Codec, table, parentDB); err != nil {
-						return pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
-					}
+				// We're restoring a table and not its parent database. We may block
+				// restoring multi-region tables to multi-region databases since
+				// regions may mismatch.
+				if err := checkMultiRegionCompatible(ctx, txn, p.ExecCfg().Codec, table, parentDB); err != nil {
+					return pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
 				}
 
 				// Create the table rewrite with the new parent ID. We've done all the

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -604,9 +603,26 @@ func checkMultiRegionCompatible(
 	table *tabledesc.Mutable,
 	database catalog.DatabaseDescriptor,
 ) error {
-	// If either the database or table are non-MR then allow it.
-	if !database.IsMultiRegion() || table.GetLocalityConfig() == nil {
+	// If we are not dealing with an MR database and table there are no
+	// compatibility checks that need to be performed.
+	if !database.IsMultiRegion() && table.GetLocalityConfig() == nil {
 		return nil
+	}
+
+	// If we are restoring a non-MR table into a MR database, allow it. We will
+	// set the table to a REGIONAL BY TABLE IN PRIMARY REGION before writing the
+	// table descriptor to disk.
+	if database.IsMultiRegion() && table.GetLocalityConfig() == nil {
+		return nil
+	}
+
+	// If we are restoring a MR table into a non-MR database, disallow it.
+	if !database.IsMultiRegion() && table.GetLocalityConfig() != nil {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot restore descriptor for multi-region table %s into non-multi-region database %s",
+			table.GetName(),
+			database.GetName(),
+		)
 	}
 
 	if table.IsLocalityGlobal() {
@@ -650,10 +666,13 @@ func checkMultiRegionCompatible(
 	}
 
 	if table.IsLocalityRegionalByRow() {
-		return unimplemented.NewWithIssuef(67269,
-			"cannot restore REGIONAL BY ROW table %s (ID: %d) individually into a multi-region database %s",
-			table.GetName(), table.GetID(), database.GetName(),
-		)
+		// Unlike the check for RegionalByTable above, we do not want to run a
+		// verification on every row in a RegionalByRow table. If the table has a
+		// row with a `crdb_region` that is not in the parent databases' regions,
+		// this will be caught later in the restore when we attempt to remap the
+		// backed up MR enum to point to the existing MR enum in the restoring
+		// cluster.
+		return nil
 	}
 
 	return errors.AssertionFailedf(

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1296,8 +1296,7 @@ func prepareNewTableDescsForIngestion(
 	// imported data.
 	if err := backupccl.WriteDescriptors(ctx, p.ExecCfg().Codec, txn, p.User(), descsCol,
 		nil /* databases */, nil, /* schemas */
-		tableDescs, nil, tree.RequestedDescriptors,
-		p.ExecCfg().Settings, seqValKVs); err != nil {
+		tableDescs, nil, tree.RequestedDescriptors, seqValKVs); err != nil {
 		return nil, errors.Wrapf(err, "creating importTables")
 	}
 

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -6560,7 +6560,7 @@ DROP VIEW IF EXISTS v`,
 				table:     "simple",
 				sql:       "IMPORT TABLE simple CREATE USING $1 AVRO DATA ($2)",
 				args:      []interface{}{tableSchemaMR, simpleOcf},
-				errString: "cannot write descriptor for multi-region table",
+				errString: "cannot restore or create multi-region table simple into non-multi-region database foo",
 			},
 			{
 				name:  "import-create-using-multi-region-regional-by-table-to-multi-region-database",

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1070,6 +1070,10 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
 statement ok
 RESTORE TABLE non_mr_table FROM 'nodelocal://1/non_mr_table/' WITH into_db = 'mr-backup-1'
 
+# Verify that an MR table cannot be restored in a non-MR database.
+statement error cannot restore descriptor for multi-region table regional_by_row_table into non-multi-region database non_mr_backup
+RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://1/mr-backup-2/' WITH into_db = 'non_mr_backup'
+
 statement ok
 USE 'mr-backup-1'
 
@@ -1110,8 +1114,25 @@ DROP TABLE global_table;
 # Restore individual tables into a database with the same regions.
 subtest restore_tables_into_database_with_same_regions
 
-statement error cannot restore REGIONAL BY ROW table regional_by_row_table .* individually into a multi-region database
+statement ok
 RESTORE TABLE regional_by_row_table FROM 'nodelocal://1/mr-backup-2/'
+
+query TT
+SHOW CREATE TABLE regional_by_row_table
+----
+regional_by_row_table     CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+                          ) LOCALITY REGIONAL BY ROW
 
 statement ok
 RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://1/mr-backup-2/'
@@ -1224,5 +1245,5 @@ RESTORE TABLE "mr-backup-2".regional_by_table_in_ap_southeast_2 FROM 'nodelocal:
 statement error cannot restore REGIONAL BY TABLE regional_by_table_in_ca_central_1 IN REGION "ca-central-1" \(table ID: [0-9]+\) into database "mr-restore-1"; region "ca-central-1" not found in database regions "ap-southeast-2", "us-east-1"
 RESTORE TABLE "mr-backup-2".regional_by_table_in_ca_central_1 FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'
 
-statement error cannot restore REGIONAL BY ROW table regional_by_row_table
+statement error "crdb_internal_region" is not compatible with type "crdb_internal_region" existing in cluster: could not find enum value "ca-central-1" in "crdb_internal_region"
 RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'


### PR DESCRIPTION
Previously, we disallowed table restore of RBR tables.

An RBR table has a hidden `crdb_region` column that contais a
value equal to one of the members of the multiregion enum of the parent
database. When we backup a database containing an RBR table, we will
also backup this MR enum. On restore, when we realize that the RBR
table is dependent on a UDT, we will fetch the MR enum from the backup
and check if it is compatible with the MR enum in the restoring database.
Concretely, we will check that the MR enum in the backup has the same
logical and physical representation of a subset of the enum members on
the restoring clusters' MR enum. This check should be sufficient to
catch rows in an RBR table that might have a region that is not present
in the restoring cluster.

Fixes: #67269

Epic CRDB-10552

Release note (sql change): RESTORE TABLE for a regional by row table into
a multiregion database with the same regions as the backed up database, is
now allowed. It is important to note that by "same" regions we mean the
multi-region enum in the backing up cluster should have the same "logical"
and "physical" representation as the enum in the restoring cluster. From a
users perspective, this means that the regions (enum members) must have been
added in the same relative order on both clusters.