### PR TITLE
bazel: put tools at head of `PATH` in `util/interval/generic/gen.bzl`

### DIFF
--- a/pkg/util/interval/generic/gen.bzl
+++ b/pkg/util/interval/generic/gen.bzl
@@ -11,7 +11,7 @@ def gen_interval_btree(name, type, package):
             "@com_github_mmatczuk_go_generics//cmd/go_generics",
         ],
         cmd = """
-        export PATH=$$PATH:$$(dirname $(location @com_github_cockroachdb_crlfmt//:crlfmt)):$$(dirname $(location @com_github_mmatczuk_go_generics//cmd/go_generics))
+        export PATH=$$(dirname $(location @com_github_cockroachdb_crlfmt//:crlfmt)):$$(dirname $(location @com_github_mmatczuk_go_generics//cmd/go_generics)):$$PATH
         SCRIPT_LOC=$$(echo $(locations @cockroach//pkg/util/interval/generic:gen_srcs) | grep -o '[^ ]*\\.sh')
         $$SCRIPT_LOC {type} {package}
         mv {src_out} $(location {src_out})


### PR DESCRIPTION
If you happened to have `crlfmt` in your `PATH` this could break the
build.

Closes #71177.

Release note: None