### PR TITLE
backupccl: unblock table backups for multi-region tables

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -967,10 +967,6 @@ func backupPlanHook(
 			return err
 		}
 
-		if err := validateMultiRegionBackup(backupStmt, targetDescs, tables); err != nil {
-			return err
-		}
-
 		clusterID := p.ExecCfg().ClusterID()
 		for i := range prevBackups {
 			// IDs are how we identify tables, and those are only meaningful in the

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -228,60 +228,6 @@ func getAllDescChanges(
 	return res, nil
 }
 
-// validateMultiRegionBackup validates that for all tables included in the
-// backup, their parent database is also being backed up. For multi-region
-// tables, we require that the parent database is included to ensure that the
-// multi-region enum (which is required for multi-region tables) is also
-// present.
-func validateMultiRegionBackup(
-	backupStmt *annotatedBackupStatement,
-	descs []catalog.Descriptor,
-	tables []catalog.TableDescriptor,
-) error {
-	// We only need to block in the table backup case, so there's nothing to do
-	// if we're running a cluster backup.
-	if backupStmt.Coverage() == tree.AllDescriptors {
-		return nil
-	}
-	// We build a map of the target databases here because the supplied list of
-	// descriptors contains ALL database descriptors for the corresponding
-	// tables (regardless of whether or not the databases are included in the
-	// backup targets list). The map helps below so that we're not looping over
-	// the descriptors slice for every table.
-	databaseTargetIDs := map[descpb.ID]struct{}{}
-	databaseTargetNames := map[tree.Name]struct{}{}
-	for _, name := range backupStmt.Targets.Databases {
-		databaseTargetNames[name] = struct{}{}
-	}
-
-	for _, desc := range descs {
-		switch desc.(type) {
-		case catalog.DatabaseDescriptor:
-			// If the database descriptor found is included in the targets list, add
-			// it to the targetsID map.
-			if _, ok := databaseTargetNames[tree.Name(desc.GetName())]; ok {
-				databaseTargetIDs[desc.GetID()] = struct{}{}
-			}
-		}
-	}
-
-	// Look through the list of tables and for every multi-region table, see if
-	// its parent database is being backed up.
-	for _, table := range tables {
-		if table.GetLocalityConfig() != nil {
-			if _, ok := databaseTargetIDs[table.GetParentID()]; !ok {
-				// Found a table which is being backed up without its parent database.
-				return pgerror.Newf(pgcode.FeatureNotSupported,
-					"cannot backup individual table %d from multi-region database %d",
-					table.GetID(),
-					table.GetParentID(),
-				)
-			}
-		}
-	}
-	return nil
-}
-
 func ensureInterleavesIncluded(tables []catalog.TableDescriptor) error {
 	inBackup := make(map[descpb.ID]bool, len(tables))
 	for _, t := range tables {

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -194,6 +194,9 @@ CREATE TABLE regional_by_row_table (
 ) LOCALITY REGIONAL BY ROW
 
 statement ok
+INSERT INTO regional_by_row_table VALUES (1, 1, 1, 1, NULL), (2, 1, 1, 2, NULL)
+
+statement ok
 CREATE TABLE regional_by_table_in_primary_region (
   pk INT PRIMARY KEY,
   i INT,
@@ -1016,17 +1019,158 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                          voter_constraints = '[+region=ca-central-1]',
                                          lease_preferences = '[[+region=ca-central-1]]'
 
-statement error cannot backup individual table
+# Backup and restore individual multi-region tables.
+subtest multiregion_table_backup_and_restore
+
+statement ok
 BACKUP TABLE regional_by_row_table TO 'nodelocal://1/rbr_table/';
 
-statement error cannot backup individual table
-BACKUP TABLE regional_by_table_in_primary_region TO 'nodelocal://1/rbr_table/';
+statement ok
+BACKUP TABLE regional_by_table_in_primary_region TO 'nodelocal://1/rbt_table_in_primary_region/';
 
-statement error cannot backup individual table
-BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://1/rbr_table/';
+statement ok
+BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://1/rbt_table_in_ca_central_1/';
 
-statement error cannot backup individual table
-BACKUP TABLE global_table TO 'nodelocal://1/rbr_table/';
+statement ok
+BACKUP TABLE global_table TO 'nodelocal://1/global_table/';
+
+statement ok
+DROP TABLE regional_by_row_table;
+DROP TABLE regional_by_table_in_primary_region;
+DROP TABLE regional_by_table_in_ca_central_1;
+DROP TABLE global_table;
+
+statement ok
+RESTORE TABLE regional_by_row_table FROM 'nodelocal://1/rbr_table/';
+
+statement ok
+RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://1/rbt_table_in_primary_region/';
+
+statement ok
+RESTORE TABLE regional_by_table_in_ca_central_1 FROM 'nodelocal://1/rbt_table_in_ca_central_1/';
+
+statement ok
+RESTORE TABLE global_table FROM 'nodelocal://1/global_table/';
+
+query IIIIT
+SELECT * FROM regional_by_row_table;
+----
+1  1  1  1  NULL
+2  1  1  2  NULL
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_pkey  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_pkey  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_pkey  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW CREATE TABLE regional_by_row_table
+----
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT regional_by_row_table_pkey PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
+----
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
+----
+TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
+                                         range_min_bytes = 134217728,
+                                         range_max_bytes = 536870912,
+                                         gc.ttlseconds = 90000,
+                                         num_replicas = 5,
+                                         num_voters = 3,
+                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                         voter_constraints = '[+region=ca-central-1]',
+                                         lease_preferences = '[[+region=ca-central-1]]'
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE global_table
+----
+TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    global_reads = true,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ap-southeast-2]',
+                    lease_preferences = '[[+region=ap-southeast-2]]'
+
 
 statement ok
 CREATE DATABASE non_mr_backup;


### PR DESCRIPTION
Table backups for regional-by-row, regional-by-table and global tables
were disallowed in #60715. The motivation for that change was that table
level restores for MR tables were not supported. With #71178, a user
should be able to restore the above three kinds of MR tables with the
caveat that the regions in the backup need to be a subset of the regions
in restoring database. This change allows table backups of all
multi-region tables.

Fixes: #71180

Release note (sql change): Table backups of regional-by-row, regional-by-table,
and global table are no longer disallowed.