### PR TITLE
logictest: retry job table query in auto_span_config_reconciliation_job

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
+++ b/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
@@ -5,7 +5,7 @@ SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.enabled = true;
 
 # Ensure there's a single auto span config reconciliation job in the system,
 # and that it's running.
-query ITT colnames
+query ITT colnames,retry
 SELECT count(*), job_type, status FROM [SHOW AUTOMATIC JOBS] WHERE job_type = 'AUTO SPAN CONFIG RECONCILIATION' GROUP BY (job_type, status)
 ----
 count  job_type                         status


### PR DESCRIPTION
This test was somewhat reliably failing under stress. I assume this is
caused by the fact that while the job creation is triggered based on
the setting change, the job itself may not be started for a few more
moments.

Fixes #70910.

Release note: None