### PR TITLE
cmd/roachtest: add testLifecycle to hibernateIgnoreList

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -219,4 +219,6 @@ var hibernateIgnoreList22_1 = hibernateIgnoreList21_2
 
 var hibernateIgnoreList21_2 = hibernateIgnoreList21_1
 
-var hibernateIgnoreList21_1 = blocklist{}
+var hibernateIgnoreList21_1 = blocklist{
+	"org.hibernate.userguide.pc.WhereTest.testLifecycle": "unknown",
+}


### PR DESCRIPTION
Resolves #70482

Add `org.hibernate.userguide.pc.WhereTest.testLifecycle`
to `hibernateIgnoreList21_1`, `hibernateIgnoreList21_2`,
 and `hibernateIgnoreList22_1`.

Release note: None
Release justification: None