### PR TITLE
backport-21.1: enable always-on basic logging about RPC connections

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -16,6 +16,7 @@ pkg/roachpb/metadata.go | `ReplicaID`
 pkg/roachpb/metadata.go | `RangeGeneration`
 pkg/roachpb/metadata.go | `ReplicaType`
 pkg/roachpb/method.go | `Method`
+pkg/rpc/connection_class.go | `ConnectionClass`
 pkg/sql/catalog/descpb/structured.go | `ID`
 pkg/sql/catalog/descpb/structured.go | `FamilyID`
 pkg/sql/catalog/descpb/structured.go | `IndexID`

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1393,10 +1393,8 @@ func (g *Gossip) manage() {
 						if c := g.findClient(func(c *client) bool {
 							return c.peerID == leastUsefulID
 						}); c != nil {
-							if log.V(1) {
-								log.Health.Infof(ctx, "closing least useful client %+v to tighten network graph", c)
-							}
-							log.VEventf(ctx, 1, "culling n%d %s", c.peerID, c.addr)
+							log.VEventf(ctx, 1, "closing least useful client %+v to tighten network graph", c)
+							log.Health.Infof(ctx, "closing gossip client n%d %s", c.peerID, c.addr)
 							c.close()
 
 							// After releasing the lock, block until the client disconnects.
@@ -1406,7 +1404,7 @@ func (g *Gossip) manage() {
 						} else {
 							if log.V(1) {
 								g.clientsMu.Lock()
-								log.Health.Infof(ctx, "couldn't find least useful client among %+v", g.clientsMu.clients)
+								log.Dev.Infof(ctx, "couldn't find least useful client among %+v", g.clientsMu.clients)
 								g.clientsMu.Unlock()
 							}
 						}
@@ -1447,9 +1445,8 @@ func (g *Gossip) tightenNetwork(ctx context.Context) {
 		if nodeAddr, err := g.getNodeIDAddressLocked(distantNodeID); err != nil {
 			log.Health.Errorf(ctx, "unable to get address for n%d: %s", distantNodeID, err)
 		} else {
-			log.Health.Infof(ctx, "starting client to n%d (%d > %d) to tighten network graph",
-				distantNodeID, distantHops, maxHops)
-			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
+			log.Health.Infof(ctx, "starting client to n%d %s (%d > %d) to tighten network graph",
+				distantNodeID, nodeAddr, distantHops, maxHops)
 			g.startClientLocked(nodeAddr)
 		}
 	}
@@ -1484,9 +1481,7 @@ func (g *Gossip) maybeSignalStatusChangeLocked() {
 			log.Eventf(ctx, "now stalled")
 			if orphaned {
 				if len(g.resolvers) == 0 {
-					if log.V(1) {
-						log.Ops.Warningf(ctx, "no resolvers found; use --join to specify a connected node")
-					}
+					log.Ops.Warningf(ctx, "no gossip resolvers found; use --join to specify a connected node")
 				} else {
 					log.Health.Warningf(ctx, "no incoming or outgoing connections")
 				}

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_cockroachdb_circuitbreaker//:circuitbreaker",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_facebookgo_clock//:clock",
         "@com_github_golang_snappy//:snappy",
         "@com_github_montanaflynn_stats//:stats",

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -177,7 +177,7 @@ func (r *RemoteClockMonitor) UpdateOffset(
 	}
 
 	if log.V(2) {
-		log.Health.Infof(ctx, "update offset: %s %v", addr, r.mu.offsets[addr])
+		log.Dev.Infof(ctx, "update offset: %s %v", addr, r.mu.offsets[addr])
 	}
 }
 
@@ -232,7 +232,7 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 				maxOffset, healthyOffsetCount, numClocks)
 		}
 		if log.V(1) {
-			log.Health.Infof(ctx, "%d of %d nodes are within the maximum clock offset of %s", healthyOffsetCount, numClocks, maxOffset)
+			log.Dev.Infof(ctx, "%d of %d nodes are within the maximum clock offset of %s", healthyOffsetCount, numClocks, maxOffset)
 		}
 	}
 
@@ -263,9 +263,7 @@ func (r RemoteOffset) isHealthy(ctx context.Context, maxOffset time.Duration) bo
 		// The maximum offset is in the uncertainty window of the measured offset;
 		// health is ambiguous. For now, we err on the side of not spuriously
 		// killing nodes.
-		if log.V(1) {
-			log.Health.Infof(ctx, "uncertain remote offset %s for maximum tolerated offset %s, treating as healthy", r, toleratedOffset)
-		}
+		log.Health.Warningf(ctx, "uncertain remote offset %s for maximum tolerated offset %s, treating as healthy", r, toleratedOffset)
 		return true
 	}
 }

--- a/pkg/rpc/connection_class.go
+++ b/pkg/rpc/connection_class.go
@@ -41,6 +41,20 @@ const (
 	NumConnectionClasses int = iota
 )
 
+// connectionClassName maps classes to their name.
+var connectionClassName = map[ConnectionClass]string{
+	DefaultClass: "default",
+	SystemClass:  "system",
+}
+
+// String implements the fmt.Stringer interface.
+func (c ConnectionClass) String() string {
+	return connectionClassName[c]
+}
+
+// SafeValue implements the redact.SafeValue interface.
+func (ConnectionClass) SafeValue() {}
+
 var systemClassKeyPrefixes = []roachpb.RKey{
 	roachpb.RKey(keys.Meta1Prefix),
 	roachpb.RKey(keys.NodeLivenessPrefix),

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -657,7 +657,7 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	if err := stopper.RunAsyncTask(ctx, "busyloop-closer", func(ctx context.Context) {
 		for {
 			if _, err := closeConns(); err != nil {
-				log.Health.Warningf(ctx, "%v", err)
+				log.Warningf(ctx, "%v", err)
 			}
 			select {
 			case <-done:

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -116,7 +116,7 @@ func checkVersion(ctx context.Context, st *cluster.Settings, peerVersion roachpb
 // The requester should also estimate its offset from this server along
 // with the requester's address.
 func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingResponse, error) {
-	if log.V(2) {
+	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.Dev.Infof(ctx, "received heartbeat: %+v vs local cluster %+v node %+v", args, hs.clusterID, hs.nodeID)
 	}
 	// Check that cluster IDs match.

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -117,7 +117,7 @@ func checkVersion(ctx context.Context, st *cluster.Settings, peerVersion roachpb
 // with the requester's address.
 func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingResponse, error) {
 	if log.V(2) {
-		log.Health.Infof(ctx, "received heartbeat: %+v vs local cluster %+v node %+v", args, hs.clusterID, hs.nodeID)
+		log.Dev.Infof(ctx, "received heartbeat: %+v vs local cluster %+v node %+v", args, hs.clusterID, hs.nodeID)
 	}
 	// Check that cluster IDs match.
 	clusterID := hs.clusterID.Get()

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -163,7 +163,7 @@ func (n *Dialer) dial(
 	defer func() {
 		// Enforce a minimum interval between warnings for failed connections.
 		if err != nil && ctx.Err() == nil && breaker != nil && breaker.ShouldLog() {
-			log.Health.Infof(ctx, "unable to connect to n%d: %s", nodeID, err)
+			log.Health.Warningf(ctx, "unable to connect to n%d: %s", nodeID, err)
 		}
 	}()
 	conn, err := n.rpcContext.GRPCDialNode(addr.String(), nodeID, class).Connect(ctx)


### PR DESCRIPTION
Backport 2/9 commits from #70388.

/cc @cockroachdb/release

----

This change introduces useful logging to troubleshoot network issues.