### PR TITLE
backport-20.2: enable always-on basic logging about RPC connections

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -12,6 +12,7 @@ pkg/roachpb/metadata.go | `RangeID`
 pkg/roachpb/metadata.go | `ReplicaID`
 pkg/roachpb/metadata.go | `RangeGeneration`
 pkg/roachpb/metadata.go | `ReplicaType`
+pkg/rpc/connection_class.go | `ConnectionClass`
 pkg/sql/catalog/descpb/structured.go | `ID`
 pkg/sql/catalog/descpb/structured.go | `FamilyID`
 pkg/sql/catalog/descpb/structured.go | `IndexID`

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1396,10 +1396,8 @@ func (g *Gossip) manage() {
 						if c := g.findClient(func(c *client) bool {
 							return c.peerID == leastUsefulID
 						}); c != nil {
-							if log.V(1) {
-								log.Infof(ctx, "closing least useful client %+v to tighten network graph", c)
-							}
-							log.Eventf(ctx, "culling %s", c.addr)
+							log.VEventf(ctx, 1, "closing least useful client %+v to tighten network graph", c)
+							log.Infof(ctx, "closing gossip client n%d %s", c.peerID, c.addr)
 							c.close()
 
 							// After releasing the lock, block until the client disconnects.
@@ -1450,9 +1448,8 @@ func (g *Gossip) tightenNetwork(ctx context.Context) {
 		if nodeAddr, err := g.getNodeIDAddressLocked(distantNodeID); err != nil {
 			log.Errorf(ctx, "unable to get address for n%d: %s", distantNodeID, err)
 		} else {
-			log.Infof(ctx, "starting client to n%d (%d > %d) to tighten network graph",
-				distantNodeID, distantHops, maxHops)
-			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
+			log.Infof(ctx, "starting client to n%d %s (%d > %d) to tighten network graph",
+				distantNodeID, nodeAddr, distantHops, maxHops)
 			g.startClientLocked(nodeAddr)
 		}
 	}
@@ -1487,9 +1484,7 @@ func (g *Gossip) maybeSignalStatusChangeLocked() {
 			log.Eventf(ctx, "now stalled")
 			if orphaned {
 				if len(g.resolvers) == 0 {
-					if log.V(1) {
-						log.Warningf(ctx, "no resolvers found; use --join to specify a connected node")
-					}
+					log.Warningf(ctx, "no gossip resolvers found; use --join to specify a connected node")
 				} else {
 					log.Warningf(ctx, "no incoming or outgoing connections")
 				}

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -263,9 +263,7 @@ func (r RemoteOffset) isHealthy(ctx context.Context, maxOffset time.Duration) bo
 		// The maximum offset is in the uncertainty window of the measured offset;
 		// health is ambiguous. For now, we err on the side of not spuriously
 		// killing nodes.
-		if log.V(1) {
-			log.Infof(ctx, "uncertain remote offset %s for maximum tolerated offset %s, treating as healthy", r, toleratedOffset)
-		}
+		log.Warningf(ctx, "uncertain remote offset %s for maximum tolerated offset %s, treating as healthy", r, toleratedOffset)
 		return true
 	}
 }

--- a/pkg/rpc/connection_class.go
+++ b/pkg/rpc/connection_class.go
@@ -41,6 +41,20 @@ const (
 	NumConnectionClasses int = iota
 )
 
+// connectionClassName maps classes to their name.
+var connectionClassName = map[ConnectionClass]string{
+	DefaultClass: "default",
+	SystemClass:  "system",
+}
+
+// String implements the fmt.Stringer interface.
+func (c ConnectionClass) String() string {
+	return connectionClassName[c]
+}
+
+// SafeValue implements the redact.SafeValue interface.
+func (ConnectionClass) SafeValue() {}
+
 var systemClassKeyPrefixes = []roachpb.RKey{
 	roachpb.RKey(keys.Meta1Prefix),
 	roachpb.RKey(keys.NodeLivenessPrefix),

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -100,7 +100,7 @@ func checkVersion(ctx context.Context, st *cluster.Settings, peerVersion roachpb
 // The requester should also estimate its offset from this server along
 // with the requester's address.
 func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingResponse, error) {
-	if log.V(2) {
+	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.Infof(ctx, "received heartbeat: %+v vs local cluster %+v node %+v", args, hs.clusterID, hs.nodeID)
 	}
 	// Check that cluster IDs match.

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -163,7 +163,7 @@ func (n *Dialer) dial(
 	defer func() {
 		// Enforce a minimum interval between warnings for failed connections.
 		if err != nil && ctx.Err() == nil && breaker != nil && breaker.ShouldLog() {
-			log.Infof(ctx, "unable to connect to n%d: %s", nodeID, err)
+			log.Warningf(ctx, "unable to connect to n%d: %s", nodeID, err)
 		}
 	}()
 	conn, err := n.rpcContext.GRPCDialNode(addr.String(), nodeID, class).Connect(ctx)


### PR DESCRIPTION
Backport 2/2 commits from #71214.

/cc @cockroachdb/release

---

This change introduces useful logging to troubleshoot network issues.
