### PR TITLE
sql: UserHasAdminRole should return true for the admin role itself

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -266,10 +266,10 @@ func (p *planner) UserHasAdminRole(ctx context.Context, user security.SQLUsernam
 		return false, errors.AssertionFailedf("cannot use HasAdminRole without a txn")
 	}
 
-	// Check if user is 'root' or 'node'.
+	// Check if user is either 'admin', 'root' or 'node'.
 	// TODO(knz): planner HasAdminRole has no business authorizing
 	// the "node" principal - node should not be issuing SQL queries.
-	if user.IsRootUser() || user.IsNodeUser() {
+	if user.IsAdminRole() || user.IsRootUser() || user.IsNodeUser() {
 		return true, nil
 	}
 


### PR DESCRIPTION
This PR makes `planner.UserHasAdminRole` returns true on the `admin` role for improving introspection.

This PR had checked by running `make testbaselogic` .

Fixes #70779 

Release note: None