### PR TITLE
dev: update how we test for presence of `--dev` config in `doctor`

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,14 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(":lint.bzl", "lint_binary")
 
-# Built by `dev doctor`. This target will fail to build iff the dev config
-# isn't being used.
-filegroup(
-    name = "dev_toolchain_being_used",
-    srcs = select({
-        "//build/toolchains:dev": [],
-        "//conditions:default": ["NONEXISTENT_FILE"],
-    }),
+genrule(
+    name = "test_stamping",
+    outs = ["test_stamping.txt"],
+    cmd = """cat bazel-out/stable-status.txt | grep STABLE_BUILD > $@""",
+    stamp = True,
 )
 
 lint_binary(


### PR DESCRIPTION
Some people are running Linux and can therefore use the `crosslinux`
config on a day-to-day basis. This is OK and `dev doctor` should allow
this. Instead of failing the `doctor` check if `--config dev` isn't set,
we instead test whether the user has stamping enabled on a `bazel
build`. The built `cockroach` binary won't start if stamping is disabled
and both the `dev` and `crosslinux` configs enable stamping.

Release note: None