### PR TITLE
rowexec: fix zigzag joiner with ON expression in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -250,3 +250,27 @@ SELECT * FROM a@{FORCE_ZIGZAG=[6],FORCE_ZIGZAG=a_idx} WHERE a = 3 AND b = 7
 
 statement error FORCE_ZIGZAG cannot be specified in conjunction with NO_ZIGZAG_JOIN
 SELECT * FROM a@{FORCE_ZIGZAG,NO_ZIGZAG_JOIN} WHERE a = 3 AND b = 7
+
+# Regression tests for not fetching columns that are only needed by the ON
+# expression (#71093).
+statement ok
+CREATE TABLE t71093 (a INT, b INT, c INT, d INT, INDEX a_idx(a) STORING (b), INDEX c_idx(c) STORING (d));
+INSERT INTO t71093 VALUES (0, 1, 2, 3)
+
+# ON expr needs the stored column from the left side.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2
+----
+1
+
+# ON expr needs the stored column from the right side.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
+----
+1
+
+# ON expr needs the stored columns from both sides.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
+----
+1

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -1,0 +1,57 @@
+# LogicTest: local
+
+# Make sure that the zigzag join is used in the regression tests for #71093.
+statement ok
+CREATE TABLE t71093 (a INT, b INT, c INT, d INT, INDEX a_idx(a) STORING (b), INDEX c_idx(c) STORING (d));
+INSERT INTO t71093 VALUES (0, 1, 2, 3)
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: ((a = 0) AND (b = 1)) AND (c = 2)
+      left table: t71093@a_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c)
+      right fixed values: 1 column
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: ((a = 0) AND (c = 2)) AND (d = 3)
+      left table: t71093@a_idx
+      left columns: (a)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c, d)
+      right fixed values: 1 column
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: (((a = 0) AND (b = 1)) AND (c = 2)) AND (d = 3)
+      left table: t71093@a_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c, d)
+      right fixed values: 1 column

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -466,6 +466,15 @@ func (z *zigzagJoiner) setupInfo(
 		neededCols.Add(int(col))
 	}
 
+	// Add columns needed by OnExpr.
+	for _, v := range z.onCond.Vars.GetIndexedVars() {
+		// We only include the columns that come from this side (all such
+		// columns have the ordinals in [colOffset, maxCol) range).
+		if v.Idx >= colOffset && v.Idx < maxCol {
+			neededCols.Add(v.Idx - colOffset)
+		}
+	}
+
 	// Setup the RowContainers.
 	info.container.Reset()
 


### PR DESCRIPTION
Zigzag joiner needs to tell the row fetcher which columns are needed.
Previously, we forgot to include the columns that are needed by the ON
expression but are not needed in the output, so when evaluating such an
ON expression, we would hit an internal error. This commit fixes the
problem by including all columns referenced by the ON expression into
the set of columns to be fetched.

Fixes: #71093

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when executing a zigzag join in some cases (when there
are multiple filters present and at least one filter refers to the
column that is part of STORING clause of the secondary index that is
used by the zigzag join), and this has been fixed.