### PR TITLE
bazel: avoid `read-only file system` error when calling into `autom4te`

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -64,8 +64,6 @@ RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
-COPY autom4te /usr/local/sbin
-
 RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
   && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
   && tar xzf autouseradd.tar.gz --strip-components 1 \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20210914-174235
+BAZEL_IMAGE=cockroachdb/bazel:20211006-125507
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -132,15 +132,16 @@ configure_make(
     name = "libkrb5",
     autoreconf = True,
     autoreconf_directory = "src",
-    autoreconf_env_vars = {
-        "AUTOM4TE": "autom4te",
-    },
     configure_command = "src/configure",
     configure_in_place = True,
     configure_options = [
         "--enable-static",
         "--disable-shared",
     ],
+    data = [":autom4te"],
+    env = {
+        "AUTOM4TE": "$(execpath :autom4te)",
+    },
     lib_source = "@krb5//:all",
     make_commands = [
         "make",

--- a/c-deps/autom4te
+++ b/c-deps/autom4te
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Autom4te's default caching behavior breaks the Bazel sandbox sometimes. This
 # shim script just invokes the actual `autom4te` script disabling caching.
-/usr/bin/autom4te --no-cache "$@"
+autom4te --no-cache "$@"


### PR DESCRIPTION
See 3f50217d036400aa6b01242b3f03101fb1c1b950 for more context. Many
people are encountering the error described in that commit and it's not
feasible to ask everyone to install an `autom4te` shim. Instead we
include the shim in the build definition. We also remove it from the
builder image to demonstrate that the fix works.

Closes #70986.

Release note: None