### PR TITLE
rsg_test: skip crdb_internal.check_consistency

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -298,7 +298,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					// Calculating the Frechet distance is slow and testing it here
 					// is not worth it.
 					continue
-				case "crdb_internal.reset_sql_stats":
+				case "crdb_internal.reset_sql_stats", "crdb_internal.check_consistency":
 					// Skipped due to long execution time.
 					continue
 				}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70908

This is a slow function and can easily timeout.

Release note: None