### PR TITLE
rpc: add logging tags for rpc connect events

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1208,7 +1208,7 @@ func (rpcCtx *Context) grpcDialRaw(
 // used with the gossip client and CLI commands which can talk to any
 // node. This method implies a SystemClass.
 func (rpcCtx *Context) GRPCUnvalidatedDial(target string) *Connection {
-	return rpcCtx.grpcDialNodeInternal(target, 0, SystemClass)
+	return rpcCtx.grpcDialNodeInternal(rpcCtx.masterCtx, target, 0, SystemClass)
 }
 
 // GRPCDialNode calls grpc.Dial with options appropriate for the
@@ -1224,7 +1224,7 @@ func (rpcCtx *Context) GRPCDialNode(
 	if remoteNodeID == 0 && !rpcCtx.TestingAllowNamedRPCToAnonymousServer {
 		log.Fatalf(context.TODO(), "%v", errors.AssertionFailedf("invalid node ID 0 in GRPCDialNode()"))
 	}
-	return rpcCtx.grpcDialNodeInternal(target, remoteNodeID, class)
+	return rpcCtx.grpcDialNodeInternal(rpcCtx.masterCtx, target, remoteNodeID, class)
 }
 
 // GRPCDialPod wraps GRPCDialNode and treats the `remoteInstanceID`
@@ -1240,8 +1240,11 @@ func (rpcCtx *Context) GRPCDialPod(
 	return rpcCtx.GRPCDialNode(target, roachpb.NodeID(remoteInstanceID), class)
 }
 
+// grpcDialNodeInternal connects to the remote node and sets up the async heartbeater.
+// The ctx passed as argument must be derived from rpcCtx.masterCtx, so
+// that it respects the same cancellation policy.
 func (rpcCtx *Context) grpcDialNodeInternal(
-	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
+	ctx context.Context, target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) *Connection {
 	thisConnKeys := []connKey{{target, remoteNodeID, class}}
 	value, ok := rpcCtx.conns.Load(thisConnKeys[0])
@@ -1276,10 +1279,10 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 		// Either we kick off the heartbeat loop (and clean up when it's done),
 		// or we clean up the connKey entries immediately.
 		var redialChan <-chan struct{}
-		conn.grpcConn, redialChan, conn.dialErr = rpcCtx.grpcDialRaw(rpcCtx.masterCtx, target, remoteNodeID, class)
+		conn.grpcConn, redialChan, conn.dialErr = rpcCtx.grpcDialRaw(ctx, target, remoteNodeID, class)
 		if conn.dialErr == nil {
 			if err := rpcCtx.Stopper.RunAsyncTask(
-				rpcCtx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {
+				ctx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {
 					err := rpcCtx.runHeartbeat(conn, target, redialChan)
 					if err != nil && !grpcutil.IsClosedConnection(err) &&
 						!grpcutil.IsConnectionRejected(err) {

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1139,11 +1139,14 @@ type delayingHeader struct {
 // This method implies a DefaultClass ConnectionClass for the returned
 // ClientConn.
 func (rpcCtx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{}, error) {
-	return rpcCtx.grpcDialRaw(target, 0, DefaultClass)
+	return rpcCtx.grpcDialRaw(rpcCtx.masterCtx, target, 0, DefaultClass)
 }
 
+// grpcDialRaw connects to the remote node.
+// The ctx passed as argument must be derived from rpcCtx.masterCtx, so
+// that it respects the same cancellation policy.
 func (rpcCtx *Context) grpcDialRaw(
-	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
+	ctx context.Context, target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) (*grpc.ClientConn, <-chan struct{}, error) {
 	dialOpts, err := rpcCtx.grpcDialOptions(target, class)
 	if err != nil {
@@ -1174,7 +1177,7 @@ func (rpcCtx *Context) grpcDialRaw(
 	dialerFunc := dialer.dial
 	if rpcCtx.Knobs.ArtificialLatencyMap != nil {
 		latency := rpcCtx.Knobs.ArtificialLatencyMap[target]
-		log.VEventf(rpcCtx.masterCtx, 1, "connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
+		log.VEventf(ctx, 1, "connecting to node %s (%d) with simulated latency %dms", target, remoteNodeID,
 			latency)
 		dialer := artificialLatencyDialer{
 			dialerFunc: dialerFunc,
@@ -1189,8 +1192,8 @@ func (rpcCtx *Context) grpcDialRaw(
 	// behavior and redialChan will never be closed).
 	dialOpts = append(dialOpts, rpcCtx.testingDialOpts...)
 
-	log.Health.Infof(rpcCtx.masterCtx, "dialing n%v: %s (%v)", remoteNodeID, target, class)
-	conn, err := grpc.DialContext(rpcCtx.masterCtx, target, dialOpts...)
+	log.Health.Infof(ctx, "dialing n%v: %s (%v)", remoteNodeID, target, class)
+	conn, err := grpc.DialContext(ctx, target, dialOpts...)
 	if err != nil && rpcCtx.masterCtx.Err() != nil {
 		// If the node is draining, discard the error (which is likely gRPC's version
 		// of context.Canceled) and return errDialRejected which instructs callers not
@@ -1273,7 +1276,7 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 		// Either we kick off the heartbeat loop (and clean up when it's done),
 		// or we clean up the connKey entries immediately.
 		var redialChan <-chan struct{}
-		conn.grpcConn, redialChan, conn.dialErr = rpcCtx.grpcDialRaw(target, remoteNodeID, class)
+		conn.grpcConn, redialChan, conn.dialErr = rpcCtx.grpcDialRaw(rpcCtx.masterCtx, target, remoteNodeID, class)
 		if conn.dialErr == nil {
 			if err := rpcCtx.Stopper.RunAsyncTask(
 				rpcCtx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1893,7 +1893,9 @@ func TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat(t *testin
 	require.NoError(t, c.dialErr)
 	// It is possible that the redial chan being closed is not seen on the first
 	// pass through the loop.
-	err = rpcCtx.runHeartbeat(c, "", redialChan)
+	// NB: we use rpcCtx.masterCtx and not just ctx because we need
+	// this to be cancelled when the RPC context is closed.
+	err = rpcCtx.runHeartbeat(rpcCtx.masterCtx, c, "", redialChan)
 	require.EqualError(t, err, grpcutil.ErrCannotReuseClientConn.Error())
 	// Even when the runHeartbeat returns, we could have heartbeated successfully.
 	// If we did not, then we expect the `not yet heartbeated` error.

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1889,7 +1889,7 @@ func TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat(t *testin
 	redialChan := make(chan struct{})
 	close(redialChan)
 
-	c.grpcConn, _, c.dialErr = rpcCtx.grpcDialRaw(remoteAddr, serverNodeID, DefaultClass)
+	c.grpcConn, _, c.dialErr = rpcCtx.grpcDialRaw(rpcCtx.masterCtx, remoteAddr, serverNodeID, DefaultClass)
 	require.NoError(t, c.dialErr)
 	// It is possible that the redial chan being closed is not seen on the first
 	// pass through the loop.


### PR DESCRIPTION
Epic: CRDB-11517
First commit from #75237.

This ensures that the log messages sent to the DEV channel relating to
RPC low-level activity (e.g. conn failures, heartbeat etc) include the
remote node ID and address and connection class.

This also connects the heartbeat task to the tracing infra properly.

Example before:
```
[n6] 87  dialing n4: 127.0.0.1:41706 (default)
```

After:
```
[n6,rnode=4,raddr=127.0.0.1:41706,class=default] 87  dialing
```
