### PR TITLE
sql: remove InternalExecutor from EvalCtx

### DIFF
--- a/pkg/ccl/streamingccl/streamingutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingutils/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/kv",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -785,6 +785,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		ie.SetSessionData(sessionData)
 		return &ie
 	}
+
 	distSQLServer.ServerConfig.SessionBoundInternalExecutorFactory = ieFactory
 	jobRegistry.SetSessionBoundInternalExecutorFactory(ieFactory)
 	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg, ieFactory)
@@ -795,6 +796,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		sql.ValidateForwardIndexes,
 		sql.ValidateInvertedIndexes,
 		sql.NewFakeSessionData)
+	execCfg.InternalExecutorFactory = ieFactory
 
 	distSQLServer.ServerConfig.ProtectedTimestampProvider = execCfg.ProtectedTimestampProvider
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -809,7 +809,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateCheckInTxn(
-					params.ctx, &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
+					params.ctx, &params.p.semaCtx, params.ExecCfg().InternalExecutor, params.SessionData(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
 				); err != nil {
 					return err
 				}
@@ -831,7 +831,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateFkInTxn(
-					params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+					params.ctx, params.p.LeaseMgr(), params.ExecCfg().InternalExecutor,
+					n.tableDesc, params.EvalContext().Txn, name, params.EvalContext().Codec,
 				); err != nil {
 					return err
 				}
@@ -854,7 +855,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 							"constraint %q in the middle of being added, try again later", t.Constraint)
 					}
 					if err := validateUniqueWithoutIndexConstraintInTxn(
-						params.ctx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+						params.ctx, params.ExecCfg().InternalExecutor, n.tableDesc, params.EvalContext().Txn, name,
 					); err != nil {
 						return err
 					}

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -270,7 +270,8 @@ func validateForeignKey(
 			query,
 		)
 
-		values, err := ie.QueryRow(ctx, "validate foreign key constraint", txn, query)
+		values, err := ie.QueryRowEx(ctx, "validate foreign key constraint",
+			txn, sessiondata.NodeUserSessionDataOverride, query)
 		if err != nil {
 			return err
 		}
@@ -295,7 +296,8 @@ func validateForeignKey(
 		query,
 	)
 
-	values, err := ie.QueryRow(ctx, "validate fk constraint", txn, query)
+	values, err := ie.QueryRowEx(ctx, "validate fk constraint", txn,
+		sessiondata.NodeUserSessionDataOverride, query)
 	if err != nil {
 		return err
 	}
@@ -390,7 +392,8 @@ func validateUniqueConstraint(
 		query,
 	)
 
-	values, err := ie.QueryRow(ctx, "validate unique constraint", txn, query)
+	values, err := ie.QueryRowEx(ctx, "validate unique constraint", txn,
+		sessiondata.NodeUserSessionDataOverride, query)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -844,6 +844,7 @@ func (s *Server) newConnExecutor(
 	}
 
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionInit, timeutil.Now())
+
 	ex.extraTxnState.prepStmtsNamespace = prepStmtNamespace{
 		prepStmts: make(map[string]*PreparedStatement),
 		portals:   make(map[string]PreparedPortal),
@@ -2458,14 +2459,6 @@ func (ex *connExecutor) asOfClauseWithSessionDefault(expr tree.AsOfClause) tree.
 // same across multiple statements. resetEvalCtx must also be called before each
 // statement, to reinitialize other fields.
 func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalContext, p *planner) {
-	ie := MakeInternalExecutor(
-		ctx,
-		ex.server,
-		ex.memMetrics,
-		ex.server.cfg.Settings,
-	)
-	ie.SetSessionDataStack(ex.sessionDataStack)
-
 	*evalCtx = extendedEvalContext{
 		EvalContext: tree.EvalContext{
 			Planner:                   p,
@@ -2488,7 +2481,6 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			Locality:                  ex.server.cfg.Locality,
 			Tracer:                    ex.server.cfg.AmbientCtx.Tracer,
 			ReCache:                   ex.server.reCache,
-			InternalExecutor:          &ie,
 			DB:                        ex.server.cfg.DB,
 			SQLLivenessReader:         ex.server.cfg.SQLLiveness,
 			SQLStatsController:        ex.server.sqlStatsController,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -326,11 +326,6 @@ func (ds *ServerImpl) setupFlow(
 		if err != nil {
 			return ctx, nil, nil, err
 		}
-		ie := &lazyInternalExecutor{
-			newInternalExecutor: func() sqlutil.InternalExecutor {
-				return ds.SessionBoundInternalExecutorFactory(ctx, sd)
-			},
-		}
 
 		// It's important to populate evalCtx.Txn early. We'll write it again in the
 		// f.SetTxn() call below, but by then it will already have been captured by
@@ -360,7 +355,6 @@ func (ds *ServerImpl) setupFlow(
 			Sequence:                  &faketreeeval.DummySequenceOperators{},
 			Tenant:                    &faketreeeval.DummyTenantOperator{},
 			Regions:                   &faketreeeval.DummyRegionOperator{},
-			InternalExecutor:          ie,
 			Txn:                       leafTxn,
 			SQLLivenessReader:         ds.ServerConfig.SQLLivenessReader,
 			SQLStatsController:        ds.ServerConfig.SQLStatsController,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -80,6 +80,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -1155,6 +1156,11 @@ type ExecutorConfig struct {
 	// SpanConfigReconciliationJobDeps are used to drive the span config
 	// reconciliation job.
 	SpanConfigReconciliationJobDeps spanconfig.ReconciliationDependencies
+
+	// InternalExecutorFactory is used to create an InternalExecutor binded with
+	// SessionData and other ExtraTxnState.
+	// This is currently only for builtin functions where we need to execute sql.
+	InternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
 }
 
 // UpdateVersionSystemSettingHook provides a callback that allows us

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -434,7 +434,6 @@ func makeStmtEnvCollector(ctx context.Context, ie *InternalExecutor) stmtEnvColl
 // environmentQuery is a helper to run a query that returns a single string
 // value.
 func (c *stmtEnvCollector) query(query string) (string, error) {
-	var row tree.Datums
 	row, err := c.ie.QueryRowEx(
 		c.ctx,
 		"stmtEnvCollector",

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/faketreeeval",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/security",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -330,6 +331,30 @@ func (ep *DummyEvalPlanner) ResolveTypeByOID(_ context.Context, _ oid.Oid) (*typ
 func (ep *DummyEvalPlanner) ResolveType(
 	_ context.Context, _ *tree.UnresolvedObjectName,
 ) (*types.T, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// QueryRowEx is part of the tree.EvalPlanner interface.
+func (ep *DummyEvalPlanner) QueryRowEx(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sessiondata.InternalExecutorOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// QueryIteratorEx is part of the tree.EvalPlanner interface.
+func (ep *DummyEvalPlanner) QueryIteratorEx(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sessiondata.InternalExecutorOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.InternalRows, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -312,7 +312,7 @@ func (ih *instrumentationHelper) Finish(
 
 	var bundle diagnosticsBundle
 	if ih.collectBundle {
-		ie := p.extendedEvalCtx.InternalExecutor.(*InternalExecutor)
+		ie := p.extendedEvalCtx.ExecCfg.InternalExecutor
 		phaseTimes := statsCollector.PhaseTimes()
 		if ih.stmtDiagnosticsRecorder.IsExecLatencyConditionMet(
 			ih.diagRequestID, ih.diagRequest, phaseTimes.GetServiceLatencyNoOverhead(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -125,11 +125,6 @@ func (ie *InternalExecutor) SetSessionData(sessionData *sessiondata.SessionData)
 	ie.sessionDataStack = sessiondata.NewStack(sessionData)
 }
 
-// SetSessionDataStack binds the session variable stack to the internal executor.
-func (ie *InternalExecutor) SetSessionDataStack(sessionDataStack *sessiondata.Stack) {
-	ie.sessionDataStack = sessionDataStack
-}
-
 // initConnEx creates a connExecutor and runs it on a separate goroutine. It
 // takes in a StmtBuf into which commands can be pushed and a WaitGroup that
 // will be signaled when connEx.run() returns.
@@ -263,6 +258,7 @@ type rowsIterator struct {
 }
 
 var _ sqlutil.InternalRows = &rowsIterator{}
+var _ tree.InternalRows = &rowsIterator{}
 
 func (r *rowsIterator) Next(ctx context.Context) (_ bool, retErr error) {
 	// Due to recursive calls to Next() below, this deferred function might get

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1157,10 +1157,11 @@ func (e *urlOutputter) finish() (url.URL, error) {
 func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.Node, error) {
 	var out urlOutputter
 
-	c := makeStmtEnvCollector(
+	ie := ef.planner.extendedEvalCtx.ExecCfg.InternalExecutorFactory(
 		ef.planner.EvalContext().Context,
-		ef.planner.extendedEvalCtx.InternalExecutor.(*InternalExecutor),
+		ef.planner.SessionData(),
 	)
+	c := makeStmtEnvCollector(ef.planner.EvalContext().Context, ie.(*InternalExecutor))
 
 	// Show the version of Cockroach running.
 	if err := c.PrintVersion(&out.buf); err != nil {

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -99,7 +99,6 @@ go_test(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowinfra",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sqlutil",
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -82,10 +81,9 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	evalCtx := &tree.EvalContext{
-		Context:          ctx,
-		DB:               db,
-		Codec:            keys.TODOSQLCodec,
-		InternalExecutor: s.InternalExecutor().(sqlutil.InternalExecutor),
+		Context: ctx,
+		DB:      db,
+		Codec:   keys.TODOSQLCodec,
 	}
 
 	registry := s.JobRegistry().(*jobs.Registry)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1949,17 +1949,18 @@ func createSchemaChangeEvalCtx(
 ) extendedEvalContext {
 
 	sd := NewFakeSessionData(execCfg.SV())
+	ie := ieFactory(ctx, sd)
 
 	evalCtx := extendedEvalContext{
 		// Make a session tracing object on-the-fly. This is OK
 		// because it sets "enabled: false" and thus none of the
 		// other fields are used.
-		Tracing: &SessionTracing{},
-		ExecCfg: execCfg,
-		Descs:   descriptors,
+		Tracing:                      &SessionTracing{},
+		ExecCfg:                      execCfg,
+		Descs:                        descriptors,
+		SchemaChangeInternalExecutor: ie.(*InternalExecutor),
 		EvalContext: tree.EvalContext{
 			SessionDataStack: sessiondata.NewStack(sd),
-			InternalExecutor: ieFactory(ctx, sd),
 			// TODO(andrei): This is wrong (just like on the main code path on
 			// setupFlow). Each processor should override Ctx with its own context.
 			Context:            ctx,

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -64,7 +64,6 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqltelemetry",
-        "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/streaming",
         "//pkg/util",

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -106,8 +106,9 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if n.index.GetID() != n.tableDesc.GetPrimaryIndexID() {
 		indexName = n.index.GetName()
 	}
-	it, err := params.p.ExtendedEvalContext().InternalExecutor.(*InternalExecutor).QueryIteratorEx(
-		params.ctx, "split points query", params.p.txn, sessiondata.InternalExecutorOverride{},
+	ie := params.p.ExecCfg().InternalExecutorFactory(params.ctx, params.SessionData())
+	it, err := ie.QueryIteratorEx(
+		params.ctx, "split points query", params.p.txn, sessiondata.NoSessionDataOverride,
 		statement,
 		dbDesc.GetName(),
 		n.tableDesc.GetName(),


### PR DESCRIPTION
Minor refactor to remove duplicate InternalExecutor definition
on EvalCtx and in the tree package.

We already have 2 interface declarations for InternalExecutor
in sql and sqlutil, this refactor hopefully makes the dependencies
a little more clear.

Resolves https://github.com/cockroachdb/cockroach/issues/60507