### PR TITLE
opt: binary span merging and constraint unioning for ORed conditions

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -817,19 +817,42 @@ func (c *indexConstraintCtx) makeSpansForAnd(
 	return true
 }
 
-// makeSpansForOr calculates spans for an OrOp.
+// makeSpansForOr calculates spans for a contiguous chain of OrOps.
 func (c *indexConstraintCtx) makeSpansForOr(
 	offset int, e opt.Expr, out *constraint.Constraint,
 ) (tight bool) {
 	or := e.(*memo.OrExpr)
-	tightLeft := c.makeSpansForExpr(offset, or.Left, out)
+	disjunctions := memo.CollectContiguousOrExprs(or)
+	return c.binaryMergeSpansForOr(offset, disjunctions, out)
+}
+
+// binaryMergeSpansForOr builds and merges the spans for disjunctions with a
+// given offset using divide and conquer.
+func (c *indexConstraintCtx) binaryMergeSpansForOr(
+	offset int, disjunctions []opt.ScalarExpr, out *constraint.Constraint,
+) (tight bool) {
+	size := len(disjunctions)
+	if size == 1 {
+		tight := c.makeSpansForExpr(offset, disjunctions[0], out)
+		return tight
+	}
+	mid := size / 2
+	left := disjunctions[:mid]
+	right := disjunctions[mid:]
+	var rightConstraint constraint.Constraint
+
+	tightLeft := c.binaryMergeSpansForOr(offset, left, out)
 	if out.IsUnconstrained() {
 		// If spans can't be generated for the left child, exit early.
 		c.unconstrained(offset, out)
 		return false
 	}
-	var rightConstraint constraint.Constraint
-	tightRight := c.makeSpansForExpr(offset, or.Right, &rightConstraint)
+	tightRight := c.binaryMergeSpansForOr(offset, right, &rightConstraint)
+	if rightConstraint.IsUnconstrained() {
+		// If spans can't be generated for the right child, exit early.
+		c.unconstrained(offset, out)
+		return false
+	}
 	out.UnionWith(c.evalCtx, &rightConstraint)
 
 	// The OR is "tight" if both constraints were tight.
@@ -922,51 +945,60 @@ func (c *indexConstraintCtx) getMaxSimplifyPrefix(idxConstraint *constraint.Cons
 //    by getMaxSimplifyPrefix). So `[/1/2 - /1/2]` is contained in the
 //    expression span and we can simplify `@2 = 2` to `true`.
 //
+// nestedUnderOrExpr indicates if we are processing a ScalarExpr which is the child
+// of an OrExpr.
 func (c *indexConstraintCtx) simplifyFilter(
-	scalar opt.ScalarExpr, final *constraint.Constraint, maxSimplifyPrefix int,
+	scalar opt.ScalarExpr,
+	final *constraint.Constraint,
+	maxSimplifyPrefix int,
+	nestedUnderOrExpr bool,
 ) opt.ScalarExpr {
 	// Special handling for And, Range.
 	switch t := scalar.(type) {
 	case *memo.AndExpr:
-		left := c.simplifyFilter(t.Left, final, maxSimplifyPrefix)
-		right := c.simplifyFilter(t.Right, final, maxSimplifyPrefix)
+		left := c.simplifyFilter(t.Left, final, maxSimplifyPrefix, false /* nestedUnderOrExpr */)
+		right := c.simplifyFilter(t.Right, final, maxSimplifyPrefix, false /* nestedUnderOrExpr */)
 		return c.factory.ConstructAnd(left, right)
 
 	case *memo.RangeExpr:
-		return c.factory.ConstructRange(c.simplifyFilter(t.And, final, maxSimplifyPrefix))
+		return c.factory.ConstructRange(c.simplifyFilter(t.And, final, maxSimplifyPrefix, false /* nestedUnderOrExpr */))
 	}
 
 	// We try to create tight spans for the expression (as allowed by
 	// maxSimplifyPrefix), and check if the condition is implied by the final
 	// spans. See getMaxSimplifyPrefix for more information.
-	for offset := 0; offset <= maxSimplifyPrefix; offset++ {
-		var cExpr constraint.Constraint
-		tight := c.makeSpansForExpr(offset, scalar, &cExpr)
+	// makeSpansForExpr processes an entire contiguous chain of OrExprs, so for
+	// OrExprs, only call it on the top-most OrExpr.
+	if scalar.Op() != opt.OrOp || !nestedUnderOrExpr {
+		for offset := 0; offset <= maxSimplifyPrefix; offset++ {
+			var cExpr constraint.Constraint
+			tight := c.makeSpansForExpr(offset, scalar, &cExpr)
 
-		if !tight {
-			continue
-		}
-		for i := 0; i < final.Spans.Count(); i++ {
-			sp := *final.Spans.Get(i)
-			if offset > 0 {
-				sp.CutFront(offset)
+			if !tight {
+				continue
 			}
-			if !cExpr.ContainsSpan(c.evalCtx, &sp) {
-				// We won't get another tight constraint at another offset.
-				return scalar
+			for i := 0; i < final.Spans.Count(); i++ {
+				sp := *final.Spans.Get(i)
+				if offset > 0 {
+					sp.CutFront(offset)
+				}
+				if !cExpr.ContainsSpan(c.evalCtx, &sp) {
+					// We won't get another tight constraint at another offset.
+					return scalar
+				}
 			}
-		}
 
-		// The final spans are a subset of the spans for this expression; there
-		// is no need for a remaining filter for this condition.
-		return memo.TrueSingleton
+			// The final spans are a subset of the spans for this expression; there
+			// is no need for a remaining filter for this condition.
+			return memo.TrueSingleton
+		}
 	}
 
 	// Special handling for Or.
 	switch t := scalar.(type) {
 	case *memo.OrExpr:
-		left := c.simplifyFilter(t.Left, final, maxSimplifyPrefix)
-		right := c.simplifyFilter(t.Right, final, maxSimplifyPrefix)
+		left := c.simplifyFilter(t.Left, final, maxSimplifyPrefix, true /* nestedUnderOrExpr */)
+		right := c.simplifyFilter(t.Right, final, maxSimplifyPrefix, true /* nestedUnderOrExpr */)
 		return c.factory.ConstructOr(left, right)
 	}
 	return scalar
@@ -1091,7 +1123,7 @@ func (ic *Instance) RemainingFilters() memo.FiltersExpr {
 	var newFilters memo.FiltersExpr
 	for i := range ic.requiredFilters {
 		prefix := ic.getMaxSimplifyPrefix(&ic.constraint)
-		condition := ic.simplifyFilter(ic.requiredFilters[i].Condition, &ic.constraint, prefix)
+		condition := ic.simplifyFilter(ic.requiredFilters[i].Condition, &ic.constraint, prefix, false /* nestedUnderOrExpr */)
 		if condition.Op() != opt.TrueOp {
 			if newFilters == nil {
 				newFilters = make(memo.FiltersExpr, 0, len(ic.requiredFilters))

--- a/pkg/sql/opt/idxconstraint/testdata/many_preds
+++ b/pkg/sql/opt/idxconstraint/testdata/many_preds
@@ -1,0 +1,74 @@
+index-constraints vars=(id INT, book_id INT, book2_id INT, citation_id INT) index=(id)
+  id = 0
+  AND book2_id = 0
+  OR id = 1 AND book2_id = 1
+  OR id = 3 AND book2_id = 4
+  OR id = 3 AND book2_id = 9
+  OR id = 5 AND book2_id = 16
+  OR id = 5 AND book2_id = 25
+  OR id = 6 AND book2_id = 36
+  OR id = 7 AND book2_id = 49
+  OR id = 8 AND book2_id = 64
+  OR id = 9 AND book2_id = 81
+  OR id = 10 AND book2_id = 100
+  OR id = 11 AND book2_id = 121
+  OR id = 12 AND book2_id = 144
+  OR id = 13 AND book2_id = 169
+  OR id = 14 AND book2_id = 196
+  OR id = 15 AND book2_id = 225
+  OR id = 16 AND book2_id = 256
+  OR id = 17 AND book2_id = 289
+  OR id = 18 AND book2_id = 324
+  OR id = 19 AND book2_id = 361
+  OR id = 20 AND book2_id = 400
+----
+[/0 - /1]
+[/3 - /3]
+[/5 - /20]
+Remaining filter: (((((((((((((((((((((id = 0) AND (book2_id = 0)) OR ((id = 1) AND (book2_id = 1))) OR ((id = 3) AND (book2_id = 4))) OR ((id = 3) AND (book2_id = 9))) OR ((id = 5) AND (book2_id = 16))) OR ((id = 5) AND (book2_id = 25))) OR ((id = 6) AND (book2_id = 36))) OR ((id = 7) AND (book2_id = 49))) OR ((id = 8) AND (book2_id = 64))) OR ((id = 9) AND (book2_id = 81))) OR ((id = 10) AND (book2_id = 100))) OR ((id = 11) AND (book2_id = 121))) OR ((id = 12) AND (book2_id = 144))) OR ((id = 13) AND (book2_id = 169))) OR ((id = 14) AND (book2_id = 196))) OR ((id = 15) AND (book2_id = 225))) OR ((id = 16) AND (book2_id = 256))) OR ((id = 17) AND (book2_id = 289))) OR ((id = 18) AND (book2_id = 324))) OR ((id = 19) AND (book2_id = 361))) OR ((id = 20) AND (book2_id = 400))
+
+index-constraints vars=(id INT, book_id INT, book2_id INT, citation_id INT) index=(id,book2_id)
+  id = 0
+  AND book2_id = 0
+  OR id = 1 AND book2_id = 1
+  OR id = 3 AND book2_id = 4
+  OR id = 3 AND book2_id = 9
+  OR id = 5 AND book2_id = 16
+  OR id = 5 AND book2_id = 25
+  OR id = 6 AND book2_id = 36
+  OR id = 7 AND book2_id = 49
+  OR id = 8 AND book2_id = 64
+  OR id = 9 AND book2_id = 81
+  OR id = 10 AND book2_id = 100
+  OR id = 11 AND book2_id = 121
+  OR id = 12 AND book2_id = 144
+  OR id = 13 AND book2_id = 169
+  OR id = 14 AND book2_id = 196
+  OR id = 15 AND book2_id = 225
+  OR id = 16 AND book2_id = 256
+  OR id = 17 AND book2_id = 289
+  OR id = 18 AND book2_id = 324
+  OR id = 19 AND book2_id = 361
+  OR id = 20 AND book2_id = 400
+----
+[/0/0 - /0/0]
+[/1/1 - /1/1]
+[/3/4 - /3/4]
+[/3/9 - /3/9]
+[/5/16 - /5/16]
+[/5/25 - /5/25]
+[/6/36 - /6/36]
+[/7/49 - /7/49]
+[/8/64 - /8/64]
+[/9/81 - /9/81]
+[/10/100 - /10/100]
+[/11/121 - /11/121]
+[/12/144 - /12/144]
+[/13/169 - /13/169]
+[/14/196 - /14/196]
+[/15/225 - /15/225]
+[/16/256 - /16/256]
+[/17/289 - /17/289]
+[/18/324 - /18/324]
+[/19/361 - /19/361]
+[/20/400 - /20/400]

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -249,3 +249,65 @@ index-constraints vars=(a bool) index=(a)
 true
 ----
 [ - ]
+
+# Combinations with OR
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((a = 3 OR a = 5) AND (a = 3 OR a = 8) AND (a = 3 OR a = 11)) OR ((a = 1 OR a = 5) AND (a = 2 OR a = 5) AND (a = 4 OR a = 5))
+----
+[/3 - /3]
+[/5 - /5]
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((a = 4) OR ((a = 3 AND b = 8) OR (a = 3 AND a = 11))) OR ((a = 4) OR ((a = 3 AND b = 8) OR (a = 3 AND a = 11)))
+----
+[/3 - /4]
+Remaining filter: ((a = 4) OR ((a = 3) AND ((b = 8) OR (a = 11)))) OR ((a = 4) OR ((a = 3) AND ((b = 8) OR (a = 11))))
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((a = 5) OR ((a = 3 AND b = 8) OR (a = 3 AND a = 11))) OR ((a = 4) OR ((a = 3 AND b = 8) OR (a = 3 AND a = 11)))
+----
+[/3 - /5]
+Remaining filter: ((a = 5) OR ((a = 3) AND ((b = 8) OR (a = 11)))) OR ((a = 4) OR ((a = 3) AND ((b = 8) OR (a = 11))))
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((a = 3 AND b = 8) OR (a = 2 AND b = 8) OR (a = 3 AND b = 11)) AND ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 4))
+----
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((a = 3 AND b = 8) OR (a = 2 AND b = 8) OR (a = 3 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 4))
+----
+[/2/3 - /2/3]
+[/2/8 - /2/8]
+[/3/4 - /3/4]
+[/3/8 - /3/8]
+[/3/11 - /3/11]
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+(((a = 3 AND b = 8) OR (a = 2 AND b = 8) OR (a = 3 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 4))) AND
+(((a = 1 AND b = 8) OR (a = 1 AND b = 8) OR (a = 1 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 8)))
+----
+[/2/3 - /2/3]
+[/3/4 - /3/4]
+[/3/8 - /3/8]
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+((((a = 3 AND b = 8) OR (a = 2 AND b = 8) OR (a = 3 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 4))) AND
+(((a = 1 AND b = 8) OR (a = 1 AND b = 8) OR (a = 1 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 8)))) OR
+((((a = 3 AND b = 9) OR (a = 2 AND a > 0) OR (a = 3 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b = 3) OR (a = 3 AND b = 4))) AND
+(((a = 1 AND b = 8) OR (a = 1 AND b = 8) OR (a = 1 AND b = 11)) OR ((a = 3 AND b = 4) OR (a = 2 AND b <= 3) OR (a = 3 AND b = 8))))
+----
+(/2/NULL - /2/3]
+[/3/4 - /3/4]
+[/3/8 - /3/8]
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+a IN (1,2,3,4,5,6,7,8) OR (a=10 OR a=11 OR a=12) AND a IN (9,10,12)
+----
+[/1 - /8]
+[/10 - /10]
+[/12 - /12]
+
+index-constraints vars=(a int, b int, c int) index=(a, b)
+a = 1 AND ((a = 1 AND b = 1) OR (a = 1 AND (a = 1 AND b = 1) AND (a = 1 OR a = 2 OR (a = 1 AND b = 6))))
+----
+[/1/1 - /1/1]

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -942,6 +942,23 @@ func OutputColumnIsAlwaysNull(e RelExpr, col opt.ColumnID) bool {
 	return false
 }
 
+// CollectContiguousOrExprs finds all OrExprs in 'e' that are connected via
+// a parent-child relationship, and returns them in an array of ScalarExprs.
+func CollectContiguousOrExprs(e opt.ScalarExpr) []opt.ScalarExpr {
+	var disjunctions = make([]opt.ScalarExpr, 0, 2)
+	var collectDisjunctions func(e opt.ScalarExpr)
+	collectDisjunctions = func(e opt.ScalarExpr) {
+		if or, ok := e.(*OrExpr); ok {
+			collectDisjunctions(or.Left)
+			collectDisjunctions(or.Right)
+		} else {
+			disjunctions = append(disjunctions, e)
+		}
+	}
+	collectDisjunctions(e)
+	return disjunctions
+}
+
 // FKCascades stores metadata necessary for building cascading queries.
 type FKCascades []FKCascade
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/60602

Previously, spans for a chain of ORed predicates were merged with the
entire list of previously-built spans, one-at-a-time, which takes hours
in some cases.  This patch changes it to a divide and conquer approach
and removes redundant processing of conditions.

The old method was inadequate because app-generated SQL may contain
thousands of ORed conditions, and building the spans for such SQL needs
needs to be handled in a reasonable amount of time (seconds, not hours).
The problem revolves around the use a single linear structure that needs
to be searched for the merge point of each new span.  An ORed boolean
SQL expression gets constructed into a left-deep tree of OrExpr's,
for example, given:
```
A OR B OR C OR D OR E
```
The expression tree for these conditions is built as:
```
                OrExpr
                 /    \
              OrExpr   E
               /    \
            OrExpr   D
             /    \
          OrExpr   C
           /    \
          A      B
```
Because of the shape of the expression tree and the recursive processing
of each condition, we only maintain a single list of spans associated
with the left side of this tree.
In the worst-case scenario, to merge a given span into m
previously-added spans, we need to search all m of them to find the
merge location.  For n items, the average span list size during
construction is n/2.  So, to merge all n items could take a worst-case
n*(n/2) operations, or O(n²).

Besides the above, there were redundant calls to makeSpansForExpr which
would cause ORed conditions to be processed more than once.  Given the
example above, we would end up processing conditions as follows:
```
1. A, B, C, D, E
2. B, C, D, E
3. C, D, E
4. D, E
5. E
```
For long chains of ORed conditions, this is quite expensive.  In fact,
this appears to be the main source of the performance issue.

To address the single span list issue, we collect all directly-connected
ORed conditions into a list, and use divide and conquer to recursively
process the left and right halves.  This causes merging to be done on
multiple conditions at a time, which is more efficient.  Merging is a
single-pass operation, so the more elements we can merge in one pass,
the better.  The runtime is similar to what it would have been had the
condition tree originated as a balanced binary tree instead of a
left-deep tree.

To address the redundant calls to makeSpansForExpr, we track whether
the current expression node is the child of an OrExpr in 
indexConstraintCtx.simplifyFilter, and if so, only call makeSpansForExpr
when the first (top-most) OrExpr in an OrExpr chain is encountered.
Fixing this part alone drops runtime of a test case with 6000 terms from
2 hours to 1 minute.  With divide and conquer added as well, the test
case takes 1 second.

Release note (performance improvement): Queries with many ORed WHERE
clause predicates previously took an excessive amount of time for the optimizer
to process, especially if the predicates involved index columns, and if
there were more than 1000 predicates (which could happen with
application-generated SQL). To fix this, we optimized the processing of SQL
with many ORed predicates to make sure a query plan can be generated in
seconds instead of minutes or hours.