### PR TITLE
opt: pass ordering through With

### DIFF
--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "sort.go",
         "statement.go",
         "topk.go",
+        "with.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/ordering",
     visibility = ["//visibility:public"],

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -276,6 +276,11 @@ func init() {
 		buildChildReqOrdering: exportBuildChildReqOrdering,
 		buildProvidedOrdering: noProvidedOrdering,
 	}
+	funcMap[opt.WithOp] = funcs{
+		canProvideOrdering:    withCanProvideOrdering,
+		buildChildReqOrdering: withBuildChildReqOrdering,
+		buildProvidedOrdering: withBuildProvided,
+	}
 }
 
 func canNeverProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {

--- a/pkg/sql/opt/ordering/with.go
+++ b/pkg/sql/opt/ordering/with.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+)
+
+func withCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+	// With operator can always pass through ordering to its main input.
+	return true
+}
+
+func withBuildChildReqOrdering(
+	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+) props.OrderingChoice {
+	switch childIdx {
+	case 0:
+		// No ordering required of the binding.
+
+	case 1:
+		// We can pass through any required ordering to the main query.
+		return *required
+	}
+	return props.OrderingChoice{}
+}
+
+func withBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+	w := expr.(*memo.WithExpr)
+	return w.Main.ProvidedPhysical().Ordering
+}

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2267,6 +2267,63 @@ sort
            └── filters
                 └── b:16 = c:17 [outer=(16,17), fd=(16)==(17), (17)==(16)]
 
+# --------------------------------------------------
+# With operator.
+# --------------------------------------------------
+
+# Verify that we can pass through the ordering requirement through the With
+# operator.
+opt
+WITH cte AS MATERIALIZED (SELECT x FROM xyz)
+SELECT * FROM abc ORDER BY a,b,c
+----
+with &1 (cte)
+ ├── columns: a:6!null b:7!null c:8!null
+ ├── materialized
+ ├── key: (6-8)
+ ├── ordering: +6,+7,+8
+ ├── scan xyz
+ │    └── columns: x:1!null
+ └── scan abc
+      ├── columns: a:6!null b:7!null c:8!null
+      ├── key: (6-8)
+      └── ordering: +6,+7,+8
+
+opt
+WITH cte AS MATERIALIZED (SELECT x FROM xyz)
+SELECT * FROM abc INNER MERGE JOIN cte ON a = x ORDER BY a
+----
+with &1 (cte)
+ ├── columns: a:6!null b:7!null c:8!null x:11!null
+ ├── materialized
+ ├── fd: (6)==(11), (11)==(6)
+ ├── ordering: +(6|11) [actual: +6]
+ ├── scan xyz
+ │    └── columns: xyz.x:1!null
+ └── inner-join (merge)
+      ├── columns: a:6!null b:7!null c:8!null x:11!null
+      ├── flags: force merge join
+      ├── left ordering: +6
+      ├── right ordering: +11
+      ├── fd: (6)==(11), (11)==(6)
+      ├── ordering: +(6|11) [actual: +6]
+      ├── scan abc
+      │    ├── columns: a:6!null b:7!null c:8!null
+      │    ├── key: (6-8)
+      │    └── ordering: +6
+      ├── sort
+      │    ├── columns: x:11!null
+      │    ├── ordering: +11
+      │    └── with-scan &1 (cte)
+      │         ├── columns: x:11!null
+      │         └── mapping:
+      │              └──  xyz.x:1 => x:11
+      └── filters (true)
+
+
+# --------------------------------------------------
+# Misc tests.
+# --------------------------------------------------
 
 # Regression test for #36219: lookup join with ON condition that imposes an
 # equality on two input columns (which isn't pushed down).


### PR DESCRIPTION
This change fixes an omission related to orderings: the With
expression can always pass any ordering through to the main
expression.

In practice, the omission wasn't important because in most cases we
inline CTEs and the With operator goes away.

Release note: None