### PR TITLE
release-21.1: rowexec: fix zigzag joiner with ON expression in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -208,3 +208,11 @@ query I
 SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
 ----
 1
+
+# Regression test for mistakenly attempting to fetch columns not needed by ON
+# expr that are not in the index (#71271).
+statement ok
+CREATE TABLE t71271(a INT, b INT, c INT, d INT, INDEX (c), INDEX (d))
+
+statement ok
+SELECT d FROM t71271 WHERE c = 3 AND d = 4

--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -184,3 +184,27 @@ query IT
 SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
+
+# Regression tests for not fetching columns that are only needed by the ON
+# expression (#71093).
+statement ok
+CREATE TABLE t71093 (a INT, b INT, c INT, d INT, INDEX a_idx(a) STORING (b), INDEX c_idx(c) STORING (d));
+INSERT INTO t71093 VALUES (0, 1, 2, 3)
+
+# ON expr needs the stored column from the left side.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2
+----
+1
+
+# ON expr needs the stored column from the right side.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
+----
+1
+
+# ON expr needs the stored columns from both sides.
+query I
+SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
+----
+1

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -1,0 +1,57 @@
+# LogicTest: local
+
+# Make sure that the zigzag join is used in the regression tests for #71093.
+statement ok
+CREATE TABLE t71093 (a INT, b INT, c INT, d INT, INDEX a_idx(a) STORING (b), INDEX c_idx(c) STORING (d));
+INSERT INTO t71093 VALUES (0, 1, 2, 3)
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: ((a = 0) AND (b = 1)) AND (c = 2)
+      left table: t71093@a_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c)
+      right fixed values: 1 column
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: ((a = 0) AND (c = 2)) AND (d = 3)
+      left table: t71093@a_idx
+      left columns: (a)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c, d)
+      right fixed values: 1 column
+
+query T
+EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│
+└── • zigzag join
+      pred: (((a = 0) AND (b = 1)) AND (c = 2)) AND (d = 3)
+      left table: t71093@a_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      right table: t71093@c_idx
+      right columns: (c, d)
+      right fixed values: 1 column

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -55,3 +55,22 @@ vectorized: true
       right table: t71093@c_idx
       right columns: (c, d)
       right fixed values: 1 column
+
+# Make sure that the zigzag join is used in the regression test for #71271.
+statement ok
+CREATE TABLE t71271(a INT, b INT, c INT, d INT, INDEX (c), INDEX (d))
+
+query T
+EXPLAIN SELECT d FROM t71271 WHERE c = 3 AND d = 4
+----
+distribution: local
+vectorized: true
+·
+• zigzag join
+  pred: (c = 3) AND (d = 4)
+  left table: t71271@t71271_c_idx
+  left columns: (c)
+  left fixed values: 1 column
+  right table: t71271@t71271_d_idx
+  right columns: (d)
+  right fixed values: 1 column

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -107,6 +107,7 @@ go_test(
         "inverted_expr_evaluator_test.go",
         "inverted_filterer_test.go",
         "inverted_joiner_test.go",
+        "joinerbase_test.go",
         "joinreader_test.go",
         "main_test.go",
         "mergejoiner_test.go",

--- a/pkg/sql/rowexec/joinerbase_test.go
+++ b/pkg/sql/rowexec/joinerbase_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rowexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddColumnsNeededByOnExpr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	checkOneSide := func(jb *joinerBase, startIdx, endIdx int, needed []int) {
+		var neededCols util.FastIntSet
+		var expected util.FastIntSet
+		jb.addColumnsNeededByOnExpr(&neededCols, startIdx, endIdx)
+		for _, col := range needed {
+			expected.Add(col)
+		}
+		require.Equal(t, expected, neededCols)
+	}
+
+	leftTypes := rowenc.ThreeIntCols
+	rightTypes := rowenc.FourIntCols
+	for _, tc := range []struct {
+		onExpr         execinfrapb.Expression
+		neededFromLeft []int
+		// Note that onExpr refers to columns from right with len(leftTypes)
+		// offset, but neededFromRight without it.
+		neededFromRight []int
+	}{
+		{
+			onExpr:          execinfrapb.Expression{Expr: "@1 > 1 AND @6 > 1"},
+			neededFromLeft:  []int{0},
+			neededFromRight: []int{2},
+		},
+		{
+			onExpr:         execinfrapb.Expression{Expr: "@2 > 1 AND @3 > 1"},
+			neededFromLeft: []int{1, 2},
+		},
+		{
+			onExpr:          execinfrapb.Expression{Expr: "@5 > 1 AND @7 > 1 OR @4 < 1"},
+			neededFromRight: []int{0, 1, 3},
+		},
+	} {
+		var jb joinerBase
+		require.NoError(t, jb.init(
+			nil, /* self */
+			flowCtx,
+			0, /* processorID */
+			leftTypes,
+			rightTypes,
+			descpb.InnerJoin,
+			tc.onExpr,
+			nil,   /* leftEqColumns */
+			nil,   /* rightEqColumns */
+			false, /* outputContinuationColumn */
+			&execinfrapb.PostProcessSpec{},
+			&distsqlutils.RowBuffer{},
+			execinfra.ProcStateOpts{},
+		))
+		checkOneSide(&jb, 0 /* startIdx */, len(leftTypes), tc.neededFromLeft)
+		checkOneSide(&jb, len(leftTypes), len(leftTypes)+len(rightTypes), tc.neededFromRight)
+	}
+}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -292,7 +292,7 @@ func newJoinReader(
 		return nil, err
 	}
 
-	rightCols := jr.neededRightCols()
+	rightCols := jr.neededRightCols(len(columnTypes))
 	if isSecondary {
 		set, err := getIndexColSet(jr.index, jr.colIdxMap)
 		if err != nil {
@@ -463,7 +463,7 @@ func (jr *joinReader) Spilled() bool {
 
 // neededRightCols returns the set of column indices which need to be fetched
 // from the right side of the join (jr.desc).
-func (jr *joinReader) neededRightCols() util.FastIntSet {
+func (jr *joinReader) neededRightCols(numRightTypes int) util.FastIntSet {
 	neededCols := jr.Out.NeededColumns()
 
 	if jr.readerType == indexJoinReaderType {
@@ -488,13 +488,7 @@ func (jr *joinReader) neededRightCols() util.FastIntSet {
 		neededRightCols.Remove(lastCol)
 	}
 
-	// Add columns needed by OnExpr.
-	for _, v := range jr.onCond.Vars.GetIndexedVars() {
-		rightIdx := v.Idx - numInputTypes
-		if rightIdx >= 0 {
-			neededRightCols.Add(rightIdx)
-		}
-	}
+	jr.addColumnsNeededByOnExpr(&neededRightCols, numInputTypes, numInputTypes+numRightTypes)
 
 	return neededRightCols
 }

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -464,14 +464,7 @@ func (z *zigzagJoiner) setupInfo(
 		neededCols.Add(int(col))
 	}
 
-	// Add columns needed by OnExpr.
-	for _, v := range z.onCond.Vars.GetIndexedVars() {
-		// We only include the columns that come from this side (all such
-		// columns have the ordinals in [colOffset, maxCol) range).
-		if v.Idx >= colOffset && v.Idx < maxCol {
-			neededCols.Add(v.Idx - colOffset)
-		}
-	}
+	z.addColumnsNeededByOnExpr(&neededCols, colOffset, maxCol)
 
 	// Setup the RowContainers.
 	info.container.Reset()

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -464,6 +464,15 @@ func (z *zigzagJoiner) setupInfo(
 		neededCols.Add(int(col))
 	}
 
+	// Add columns needed by OnExpr.
+	for _, v := range z.onCond.Vars.GetIndexedVars() {
+		// We only include the columns that come from this side (all such
+		// columns have the ordinals in [colOffset, maxCol) range).
+		if v.Idx >= colOffset && v.Idx < maxCol {
+			neededCols.Add(v.Idx - colOffset)
+		}
+	}
+
 	// Setup the RowContainers.
 	info.container.Reset()
 


### PR DESCRIPTION
Backport 1/1 commits from #71226.
Backport 1/1 commits from #71289.

/cc @cockroachdb/release

---

Zigzag joiner needs to tell the row fetcher which columns are needed.
Previously, we forgot to include the columns that are needed by the ON
expression but are not needed in the output, so when evaluating such an
ON expression, we would hit an internal error. This commit fixes the
problem by including all columns referenced by the ON expression into
the set of columns to be fetched.

Fixes: #71093

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when executing a zigzag join in some cases (when there
are multiple filters present and at least one filter refers to the
column that is part of STORING clause of the secondary index that is
used by the zigzag join), and this has been fixed.
