### PR TITLE
kvclient/rangefeed: make frontier advances observable using an option

### DIFF
--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
@@ -29,6 +30,7 @@ type config struct {
 	withDiff           bool
 	onInitialScanError OnInitialScanError
 	onCheckpoint       OnCheckpoint
+	onFrontierAdvance  OnFrontierAdvance
 }
 
 type optionFunc func(*config)
@@ -90,6 +92,18 @@ type OnCheckpoint func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpo
 func WithOnCheckpoint(f OnCheckpoint) Option {
 	return optionFunc(func(c *config) {
 		c.onCheckpoint = f
+	})
+}
+
+// OnFrontierAdvance is called when the rangefeed frontier is advanced with the
+// new frontier timestamp.
+type OnFrontierAdvance func(ctx context.Context, timestamp hlc.Timestamp)
+
+// WithOnFrontierAdvance sets up a callback that's invoked whenever the
+// rangefeed frontier is advanced.
+func WithOnFrontierAdvance(f OnFrontierAdvance) Option {
+	return optionFunc(func(c *config) {
+		c.onFrontierAdvance = f
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -318,11 +318,15 @@ func (f *RangeFeed) processEvents(
 			case ev.Val != nil:
 				f.onValue(ctx, ev.Val)
 			case ev.Checkpoint != nil:
-				if _, err := frontier.Forward(ev.Checkpoint.Span, ev.Checkpoint.ResolvedTS); err != nil {
+				advanced, err := frontier.Forward(ev.Checkpoint.Span, ev.Checkpoint.ResolvedTS)
+				if err != nil {
 					return err
 				}
 				if f.onCheckpoint != nil {
 					f.onCheckpoint(ctx, ev.Checkpoint)
+				}
+				if advanced && f.onFrontierAdvance != nil {
+					f.onFrontierAdvance(ctx, frontier.Frontier())
 				}
 			case ev.Error != nil:
 				// Intentionally do nothing, we'll get an error returned from the

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,6 +113,128 @@ func TestRangeFeedIntegration(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(4), updated)
 	}
+}
+
+// TestWithOnFrontierAdvance sets up a rangefeed on a span that has more than
+// one range and ensures that the OnFrontierAdvance callback is called with the
+// correct timestamp.
+func TestWithOnFrontierAdvance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.Server(0).DB()
+	scratchKey := tc.ScratchRange(t)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	{
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		_, err := tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+		require.NoError(t, err)
+	}
+	{
+		// Lower the closed timestamp target duration to speed up the test.
+		_, err := tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
+		require.NoError(t, err)
+	}
+
+	// Split the range into two so we know the frontier has more than one span to
+	// track for certain. We later write to both these ranges.
+	_, _, err := tc.SplitRange(mkKey("b"))
+	require.NoError(t, err)
+
+	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	require.NoError(t, err)
+
+	// mu protects secondWriteTS.
+	var mu syncutil.Mutex
+	secondWriteFinished := false
+	frontierAdvancedAfterSecondWrite := false
+
+	// Track the checkpoint TS for spans belonging to both the ranges we split
+	// above. This can then be used to compute the minimum timestamp for both
+	// these spans. We use the key we write to for the ranges below as keys for
+	// this map.
+	spanCheckpointTimestamps := make(map[string]hlc.Timestamp)
+	forwardCheckpointForKey := func(key string, checkpoint *roachpb.RangeFeedCheckpoint) {
+		ts := hlc.MinTimestamp
+		if prevTS, found := spanCheckpointTimestamps[key]; found {
+			ts = prevTS
+		}
+		ts.Forward(checkpoint.ResolvedTS)
+		spanCheckpointTimestamps[key] = ts
+	}
+	rows := make(chan *roachpb.RangeFeedValue)
+	r, err := f.RangeFeed(ctx, "test", sp, db.Clock().Now(),
+		func(ctx context.Context, value *roachpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			if checkpoint.Span.ContainsKey(mkKey("a")) {
+				forwardCheckpointForKey("a", checkpoint)
+			}
+			if checkpoint.Span.ContainsKey(mkKey("c")) {
+				forwardCheckpointForKey("c", checkpoint)
+			}
+		}),
+		rangefeed.WithOnFrontierAdvance(func(ctx context.Context, frontierTS hlc.Timestamp) {
+			minTS := hlc.MaxTimestamp
+			for _, ts := range spanCheckpointTimestamps {
+				minTS.Backward(ts)
+			}
+			assert.Truef(
+				t,
+				frontierTS.Equal(minTS),
+				"expected frontier timestamp to be equal to minimum timestamp across spans %s, found %s",
+				minTS,
+				frontierTS,
+			)
+			mu.Lock()
+			defer mu.Unlock()
+			if secondWriteFinished {
+				frontierAdvancedAfterSecondWrite = true
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Write to a key on both the ranges.
+	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+
+	v := <-rows
+	require.Equal(t, mkKey("a"), v.Key)
+
+	require.NoError(t, db.Put(ctx, mkKey("c"), 1))
+	mu.Lock()
+	secondWriteFinished = true
+	mu.Unlock()
+
+	v = <-rows
+	require.Equal(t, mkKey("c"), v.Key)
+
+	testutils.SucceedsSoon(t, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		if frontierAdvancedAfterSecondWrite {
+			return nil
+		}
+		return errors.New("expected frontier to advance after second write")
+	})
 }
 
 // TestWithOnCheckpoint verifies that we correctly emit rangefeed checkpoint


### PR DESCRIPTION
This patch adds a `OnFrontierAdvance` option to the rangefeed libary.
This option allows users of this library to install a callback which
is called whenever the frontier is advanced.

The frontier is used to track the minimum resolvedTS accross all ranges
that the rangefeed span breaks down to. The intention is to allow users
of this library to be able to use this option to checkpoint the
rangefeed progress. The plan is to use it as such for #69661 and
 #69614.

Release note: None