### PR TITLE
kvserver: add logging for raft proposals after request evaluation

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -839,6 +839,8 @@ func (r *Replica) evaluateProposal(
 		ba.RequiresConsensus()
 
 	if needConsensus {
+		log.VEventf(ctx, 2, "need consensus on write batch with op count=%d", batch.Count())
+
 		// Set the proposal's WriteBatch, which is the serialized representation of
 		// the proposals effect on RocksDB.
 		res.WriteBatch = &kvserverpb.WriteBatch{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -127,6 +127,15 @@ func (r *Replica) evalAndPropose(
 		return proposalCh, func() {}, "", nil
 	}
 
+	log.VEventf(proposal.ctx, 2,
+		"proposing command to write %d new keys, %d new values, %d new intents, "+
+			"write batch size=%d bytes",
+		proposal.command.ReplicatedEvalResult.Delta.KeyCount,
+		proposal.command.ReplicatedEvalResult.Delta.ValCount,
+		proposal.command.ReplicatedEvalResult.Delta.IntentCount,
+		proposal.command.WriteBatch.Size(),
+	)
+
 	// If the request requested that Raft consensus be performed asynchronously,
 	// return a proposal result immediately on the proposal's done channel.
 	// The channel's capacity will be large enough to accommodate this.

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -721,6 +721,10 @@ func (s spanSetBatch) Empty() bool {
 	return s.b.Empty()
 }
 
+func (s spanSetBatch) Count() uint32 {
+	return s.b.Count()
+}
+
 func (s spanSetBatch) Len() int {
 	return s.b.Len()
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -854,6 +854,8 @@ type Batch interface {
 	Commit(sync bool) error
 	// Empty returns whether the batch has been written to or not.
 	Empty() bool
+	// Count returns the number of memtable-modifying operations in the batch.
+	Count() uint32
 	// Len returns the size of the underlying representation of the batch.
 	// Because of the batch header, the size of the batch is never 0 and should
 	// not be used interchangeably with Empty. The method avoids the memory copy

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -519,6 +519,11 @@ func (p *pebbleBatch) Empty() bool {
 	return p.batch.Count() == 0
 }
 
+// Count implements the Batch interface.
+func (p *pebbleBatch) Count() uint32 {
+	return p.batch.Count()
+}
+
 // Len implements the Batch interface.
 func (p *pebbleBatch) Len() int {
 	return len(p.batch.Repr())


### PR DESCRIPTION
Previously there was no logging of operations resulting from a batch request
after evaluation to a `WriteBatch` to be proposed via Raft.  This change adds
logging to indicate the number of keys, values, and intents actually
being proposed, as well as on the number of operations in the `WriteBatch`
itself prior to serialization.

Release note: None