### PR TITLE
release-21.2: cli: add --max-sql-memory flag to `cockroach mt start-sql`

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -932,7 +932,7 @@ func init() {
 		}
 	}
 
-	// Multi-tenancy commands.
+	// Multi-tenancy start-sql command flags.
 	{
 		f := mtStartSQLCmd.Flags()
 		varFlag(f, &tenantIDWrapper{&serverCfg.SQLConfig.TenantID}, cliflags.TenantID)
@@ -953,10 +953,13 @@ func init() {
 
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 
+		// Enable/disable various external storage endpoints.
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableOutbound, cliflags.ExternalIODisabled)
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials, cliflags.ExternalIODisableImplicitCredentials)
 
+		// Engine flags.
+		varFlag(f, sqlSizeValue, cliflags.SQLMem)
 		// N.B. diskTempStorageSizeValue.ResolvePercentage() will be called after
 		// the stores flag has been parsed and the storage device that a percentage
 		// refers to becomes known.


### PR DESCRIPTION
Backport 1/1 commits from #71011.

/cc @cockroachdb/release

---

Previously the `--max-sql-memory` flag wasn't available to the multi-tenancy
start-sql command, even though the feature was already there for other
`start`-related commands.

Release note (cli change): `cockroach mt start-sql` will now support the
`--max-sql-memory` flag to configure maximum SQL memory capacity to store
temporary data.

Release justification: The upcoming Serverless MVP release plans to use a
different value for `--max-sql-memory` instead of the default value of 25%
of container memory. This commit is only a flag change that will only be used
in multi-tenant scenarios, and should have no impact on dedicated customers.
