### PR TITLE
sql: clear (rather than emptying) bound account

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -636,7 +636,7 @@ func (s *Container) freeLocked(ctx context.Context) {
 	atomic.AddInt64(s.atomic.uniqueStmtFingerprintCount, int64(-len(s.mu.stmts)))
 	atomic.AddInt64(s.atomic.uniqueTxnFingerprintCount, int64(-len(s.mu.txns)))
 
-	s.mu.acc.Empty(ctx)
+	s.mu.acc.Clear(ctx)
 }
 
 // MergeApplicationStatementStats implements the sqlstats.ApplicationStats interface.


### PR DESCRIPTION
Empty() leaves some number of bytes in the bound account as
reserved. When we abandon a Container, those "reserved" bytes were
never released back to the parent. I believe we currently abandon one
Container at the end of each explicit transaction.

Fixes #71262
Fixes #71263
Fixes #71264
Fixes #65279

We may want to provide two different methods. One that calls Empty() and one that
calls Clear() in case there are users of this who really need to keep their reserved bytes.

Release note: None