### PR TITLE
tenantrate, tenantcostclient: better -rewrite behavior for tests

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -697,8 +697,8 @@ def go_deps():
         name = "com_github_cockroachdb_datadriven",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/datadriven",
-        sum = "h1:BHgxdYByzfRUAykFACqyzt014mS8RzwbfuW36NmkG/E=",
-        version = "v1.0.1-0.20201212195501-e89bf9ee1861",
+        sum = "h1:a197bPNBWPgSksS9OFr1vOLmp0KnLkDRYMchdA8g+Fk=",
+        version = "v1.0.1-0.20211007161720-b558070c3be0",
     )
     go_repository(
         name = "com_github_cockroachdb_errors",

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292
 	github.com/cockroachdb/cockroach-go/v2 v2.1.1
 	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
-	github.com/cockroachdb/datadriven v1.0.1-0.20201212195501-e89bf9ee1861
+	github.com/cockroachdb/datadriven v1.0.1-0.20211007161720-b558070c3be0
 	github.com/cockroachdb/errors v1.8.5
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79/go.mod h1:EOI6r
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
-github.com/cockroachdb/datadriven v1.0.1-0.20201212195501-e89bf9ee1861 h1:BHgxdYByzfRUAykFACqyzt014mS8RzwbfuW36NmkG/E=
-github.com/cockroachdb/datadriven v1.0.1-0.20201212195501-e89bf9ee1861/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
+github.com/cockroachdb/datadriven v1.0.1-0.20211007161720-b558070c3be0 h1:a197bPNBWPgSksS9OFr1vOLmp0KnLkDRYMchdA8g+Fk=
+github.com/cockroachdb/datadriven v1.0.1-0.20211007161720-b558070c3be0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -375,12 +375,18 @@ func (ts *testState) waitForEvent(t *testing.T, d *datadriven.TestData, args cmd
 //  00:00:02.000
 //
 func (ts *testState) timers(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+	// If we are rewriting the test, just sleep a bit before returning the
+	// timers.
+	if d.Rewrite {
+		time.Sleep(time.Second)
+		return timesToString(ts.timeSrc.Timers())
+	}
+
 	exp := strings.TrimSpace(d.Expected)
 	if err := testutils.SucceedsSoonError(func() error {
-		got := timesToStrings(ts.timeSrc.Timers())
-		gotStr := strings.Join(got, "\n")
-		if gotStr != exp {
-			return errors.Errorf("got: %q, exp: %q", gotStr, exp)
+		got := timesToString(ts.timeSrc.Timers())
+		if got != exp {
+			return errors.Errorf("got: %q, exp: %q", got, exp)
 		}
 		return nil
 	}); err != nil {
@@ -389,12 +395,12 @@ func (ts *testState) timers(t *testing.T, d *datadriven.TestData, args cmdArgs) 
 	return d.Expected
 }
 
-func timesToStrings(times []time.Time) []string {
+func timesToString(times []time.Time) string {
 	strs := make([]string, len(times))
 	for i, t := range times {
 		strs[i] = t.Format(timeFormat)
 	}
-	return strs
+	return strings.Join(strs, "\n")
 }
 
 // configure the test provider.

--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -372,6 +372,17 @@ func (ts *testState) metrics(t *testing.T, d *datadriven.TestData) string {
 		d.Fatalf(t, "failed to compile pattern: %v", err)
 	}
 
+	// If we are rewriting the test, just sleep a bit before returning the
+	// metrics.
+	if d.Rewrite {
+		time.Sleep(time.Second)
+		result, err := metrictestutils.GetMetricsText(ts.m, re)
+		if err != nil {
+			d.Fatalf(t, "failed to scrape metrics: %v", err)
+		}
+		return result
+	}
+
 	exp := strings.TrimSpace(d.Expected)
 	if err := testutils.SucceedsSoonError(func() error {
 		got, err := metrictestutils.GetMetricsText(ts.m, re)
@@ -402,12 +413,18 @@ func (ts *testState) metrics(t *testing.T, d *datadriven.TestData) string {
 //  00:00:02.000
 //
 func (ts *testState) timers(t *testing.T, d *datadriven.TestData) string {
+	// If we are rewriting the test, just sleep a bit before returning the
+	// timers.
+	if d.Rewrite {
+		time.Sleep(time.Second)
+		return timesToString(ts.clock.Timers())
+	}
+
 	exp := strings.TrimSpace(d.Expected)
 	if err := testutils.SucceedsSoonError(func() error {
-		got := timesToStrings(ts.clock.Timers())
-		gotStr := strings.Join(got, "\n")
-		if gotStr != exp {
-			return errors.Errorf("got: %q, exp: %q", gotStr, exp)
+		got := timesToString(ts.clock.Timers())
+		if got != exp {
+			return errors.Errorf("got: %q, exp: %q", got, exp)
 		}
 		return nil
 	}); err != nil {
@@ -416,12 +433,12 @@ func (ts *testState) timers(t *testing.T, d *datadriven.TestData) string {
 	return d.Expected
 }
 
-func timesToStrings(times []time.Time) []string {
+func timesToString(times []time.Time) string {
 	strs := make([]string, len(times))
 	for i, t := range times {
 		strs[i] = t.Format(timeFormat)
 	}
-	return strs
+	return strings.Join(strs, "\n")
 }
 
 // getTenants acquires references to tenants. It is a prerequisite to launching


### PR DESCRIPTION
#### vendor: update datadriven

This commit updates `datadriven` and its dependencies.

Release note: None

#### tenantrate, tenantcostclient: better -rewrite behavior for tests

These packages use certain directives where the output requires some
background task to complete; they retry until the output matches the
expected one (or time out at 45s). This behavior is very bad when
writing new tests or modifying existing tests using `-rewrite`.
Typically you have to wait for the timeout and then manually copy the
correct output.

This change improves this by using the newly added
`datadriven.TestData.Rewrite` flag. If we are rewriting the test, we
just sleep for a second and return the output, without trying to match
the `Expected` output.

Release note: None
