### PR TITLE
backupccl: fix bug where cluster backups were exporting opt-out system tables

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -989,7 +989,7 @@ func backupPlanHook(
 		var revs []BackupManifest_DescriptorRevision
 		if mvccFilter == MVCCFilter_All {
 			priorIDs = make(map[descpb.ID]descpb.ID)
-			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.Coverage())
+			revs, err = getRelevantDescChanges(ctx, p.ExecCfg(), startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.Coverage())
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8624,7 +8624,7 @@ func TestBackupWorkerFailure(t *testing.T) {
 // Regression test for #66797 ensuring that the span merging optimization
 // doesn't produce an error when there are span-merging opportunities on
 // descriptor revisions from before the GC threshold of the table.
-func TestSpanMergeingBeforeGCThreshold(t *testing.T) {
+func TestSpanMergingBeforeGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -997,3 +997,31 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 		destDB.ExpectErr(t, `relation "restoredb.bank" does not exist`, `SELECT count(*) FROM restoredb.bank`)
 	})
 }
+
+// TestClusterRevisionDoesNotBackupOptOutSystemTables is a regression test for a
+// bug that was introduced where we would include revisions for descriptors that
+// are not supposed to be backed up egs: system tables that are opted out.
+//
+// The test would previously fail with an error that the descriptors table (an
+// opt out system table) did not have a span covering the time between the
+// `EndTime` of the first backup and second backup, since there are no revisions
+// to it between those backups.
+func TestClusterRevisionDoesNotBackupOptOutSystemTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, tc, _, _, cleanup := BackupRestoreTestSetup(t, singleNode, 10, InitManualReplication)
+	conn := tc.Conns[0]
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+	defer cleanup()
+
+	sqlDB.Exec(t, `
+CREATE DATABASE test;
+USE test;
+CREATE TABLE foo (id INT);
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+CREATE TABLE bar (id INT);
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+`)
+}


### PR DESCRIPTION
This change fixes a bug that was introduced where we would include
revisions for descriptors that are not supposed to be backed up
egs: system tables that are opted out. This was introduced in
https://github.com/cockroachdb/cockroach/pull/68983 when we fixed
cluster backup to include dropped database descriptors.

The test would previously fail with an error that the descriptors table (an
opt out system table) did not have a span covering the time between the
`EndTime` of the first backup and second backup, since there are no revisions
to it between those backups.

Fixes: #71277

Release note (bug fix): Fix a bug where cluster backups were
backing up opt-out system tables unexpectedly.