### PR TITLE
rowexec: fix handling of needed cols by zigzag joiner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -274,3 +274,11 @@ query I
 SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
 ----
 1
+
+# Regression test for mistakenly attempting to fetch columns not needed by ON
+# expr that are not in the index (#71271).
+statement ok
+CREATE TABLE t71271(a INT, b INT, c INT, d INT, INDEX (c), INDEX (d))
+
+statement ok
+SELECT d FROM t71271 WHERE c = 3 AND d = 4

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -55,3 +55,22 @@ vectorized: true
       right table: t71093@c_idx
       right columns: (c, d)
       right fixed values: 1 column
+
+# Make sure that the zigzag join is used in the regression test for #71271.
+statement ok
+CREATE TABLE t71271(a INT, b INT, c INT, d INT, INDEX (c), INDEX (d))
+
+query T
+EXPLAIN SELECT d FROM t71271 WHERE c = 3 AND d = 4
+----
+distribution: local
+vectorized: true
+·
+• zigzag join
+  pred: (c = 3) AND (d = 4)
+  left table: t71271@t71271_c_idx
+  left columns: (c)
+  left fixed values: 1 column
+  right table: t71271@t71271_d_idx
+  right columns: (d)
+  right fixed values: 1 column

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "inverted_expr_evaluator_test.go",
         "inverted_filterer_test.go",
         "inverted_joiner_test.go",
+        "joinerbase_test.go",
         "joinreader_blackbox_test.go",
         "joinreader_test.go",
         "main_test.go",

--- a/pkg/sql/rowexec/joinerbase_test.go
+++ b/pkg/sql/rowexec/joinerbase_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rowexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddColumnsNeededByOnExpr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	checkOneSide := func(jb *joinerBase, startIdx, endIdx int, needed []int) {
+		var neededCols util.FastIntSet
+		var expected util.FastIntSet
+		jb.addColumnsNeededByOnExpr(&neededCols, startIdx, endIdx)
+		for _, col := range needed {
+			expected.Add(col)
+		}
+		require.Equal(t, expected, neededCols)
+	}
+
+	leftTypes := types.ThreeIntCols
+	rightTypes := types.FourIntCols
+	for _, tc := range []struct {
+		onExpr         execinfrapb.Expression
+		neededFromLeft []int
+		// Note that onExpr refers to columns from right with len(leftTypes)
+		// offset, but neededFromRight without it.
+		neededFromRight []int
+	}{
+		{
+			onExpr:          execinfrapb.Expression{Expr: "@1 > 1 AND @6 > 1"},
+			neededFromLeft:  []int{0},
+			neededFromRight: []int{2},
+		},
+		{
+			onExpr:         execinfrapb.Expression{Expr: "@2 > 1 AND @3 > 1"},
+			neededFromLeft: []int{1, 2},
+		},
+		{
+			onExpr:          execinfrapb.Expression{Expr: "@5 > 1 AND @7 > 1 OR @4 < 1"},
+			neededFromRight: []int{0, 1, 3},
+		},
+	} {
+		var jb joinerBase
+		require.NoError(t, jb.init(
+			nil, /* self */
+			flowCtx,
+			0, /* processorID */
+			leftTypes,
+			rightTypes,
+			descpb.InnerJoin,
+			tc.onExpr,
+			nil,   /* leftEqColumns */
+			nil,   /* rightEqColumns */
+			false, /* outputContinuationColumn */
+			&execinfrapb.PostProcessSpec{},
+			&distsqlutils.RowBuffer{},
+			execinfra.ProcStateOpts{},
+		))
+		checkOneSide(&jb, 0 /* startIdx */, len(leftTypes), tc.neededFromLeft)
+		checkOneSide(&jb, len(leftTypes), len(leftTypes)+len(rightTypes), tc.neededFromRight)
+	}
+}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -466,14 +466,7 @@ func (z *zigzagJoiner) setupInfo(
 		neededCols.Add(int(col))
 	}
 
-	// Add columns needed by OnExpr.
-	for _, v := range z.onCond.Vars.GetIndexedVars() {
-		// We only include the columns that come from this side (all such
-		// columns have the ordinals in [colOffset, maxCol) range).
-		if v.Idx >= colOffset && v.Idx < maxCol {
-			neededCols.Add(v.Idx - colOffset)
-		}
-	}
+	z.addColumnsNeededByOnExpr(&neededCols, colOffset, maxCol)
 
 	// Setup the RowContainers.
 	info.container.Reset()


### PR DESCRIPTION
We recently merged a fix so that the ON expr is handled correctly by the
zigzag joiner. However, that commit had a problem: namely, we forgot to
check that a particular IndexedVar is used, so we could include columns
that aren't actually needed (or even in the index) to be decoded. This
is now fixed.

Additionally, I originally thought that we had a similar problem in the
join reader, but everything turned out to be correct there. This commit
refactors the code there a bit to make things more clear (previously,
we were relying on the IndexedVar's ordinal to be 0 when the indexed var
is unused, so that when we shift down the ordinal by a positive number,
we get a negative ordinal, and we wouldn't include the corresponding
column into the "needed cols" set).

Fixes: #71271.

Release note: None (no release with this bug)