### PR TITLE
metamorphic: Increase test surface area, run many more operations

### DIFF
--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
+        "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/uint128",
         "//pkg/util/uuid",

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "generator.go",
         "operands.go",
         "operations.go",
+        "options.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/storage/metamorphic",
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ go_library(
         "//pkg/util/uint128",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//vfs",
     ],
 )
 
@@ -38,6 +40,8 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//vfs",
     ],
 )

--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -38,58 +38,13 @@ func makeStorageConfig(path string) base.StorageConfig {
 	}
 }
 
-
 func rngIntRange(rng *rand.Rand, min int64, max int64) int64 {
 	return min + rng.Int63n(max-min)
 }
 
-func createTestPebbleVarOpts(path string, seed int64, fs vfs.FS) (storage.Engine, error) {
-	opts := storage.DefaultPebbleOptions()
-
-	if fs != nil {
-		opts.FS = fs
-	}
-	rng := rand.New(rand.NewSource(seed))
-	opts.BytesPerSync = 1 << rngIntRange(rng, 8, 30)
-	opts.FlushSplitBytes = 1 << rng.Intn(20)
-	opts.LBaseMaxBytes = 1 << rngIntRange(rng, 8, 30)
-	opts.L0CompactionThreshold = int(rngIntRange(rng, 1, 10))
-	opts.L0StopWritesThreshold = int(rngIntRange(rng, 1, 32))
-	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
-		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
-	}
-	for i := range opts.Levels {
-		if i == 0 {
-			opts.Levels[i].BlockRestartInterval = int(rngIntRange(rng, 1, 64))
-			opts.Levels[i].BlockSize = 1 << rngIntRange(rng, 1, 20)
-			opts.Levels[i].BlockSizeThreshold = int(rngIntRange(rng, 50, 100))
-			opts.Levels[i].IndexBlockSize = opts.Levels[i].BlockSize
-			opts.Levels[i].TargetFileSize = 1 << rngIntRange(rng, 1, 20)
-		} else {
-			opts.Levels[i] = opts.Levels[i-1]
-			opts.Levels[i].TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
-		}
-	}
-	opts.MaxManifestFileSize = 1 << rngIntRange(rng, 1, 28)
-	opts.MaxOpenFiles = int(rngIntRange(rng, 20, 2000))
-	opts.MemTableSize = 1 << rngIntRange(rng, 10, 28)
-	opts.MemTableStopWritesThreshold = int(rngIntRange(rng, 2, 7))
-	opts.MaxConcurrentCompactions = int(rngIntRange(rng, 1, 4))
-
-	opts.Cache = pebble.NewCache(1 << rngIntRange(rng, 1, 30))
-	defer opts.Cache.Unref()
-
-	pebbleConfig := storage.PebbleConfig{
-		StorageConfig: makeStorageConfig(path),
-		Opts:          opts,
-	}
-
-	return storage.NewPebble(context.Background(), pebbleConfig)
-}
-
 type engineConfig struct {
-	name   string
-	opts   *pebble.Options
+	name string
+	opts *pebble.Options
 }
 
 func (e *engineConfig) create(path string, fs vfs.FS) (storage.Engine, error) {
@@ -143,6 +98,7 @@ type metaTestRunner struct {
 	rwGenerator     *readWriterGenerator
 	iterGenerator   *iteratorGenerator
 	keyGenerator    *keyGenerator
+	txnKeyGenerator *txnKeyGenerator
 	valueGenerator  *valueGenerator
 	pastTSGenerator *pastTSGenerator
 	nextTSGenerator *nextTSGenerator
@@ -163,6 +119,7 @@ func (m *metaTestRunner) init() {
 	m.rng = rand.New(rand.NewSource(m.seed))
 	m.tsGenerator.init(m.rng)
 	m.curEngine = 0
+	m.printComment(fmt.Sprintf("seed: %d", m.seed))
 
 	var err error
 	m.engine, err = m.engineSeq.configs[0].create(m.path, m.engineFS)
@@ -179,6 +136,7 @@ func (m *metaTestRunner) init() {
 		tsGenerator:    &m.tsGenerator,
 		txnIDMap:       make(map[txnID]*roachpb.Transaction),
 		openBatches:    make(map[txnID]map[readWriterID]struct{}),
+		inUseKeys:      make(map[txnID][]writtenKeySpan),
 		openSavepoints: make(map[txnID]int),
 		testRunner:     m,
 	}
@@ -200,6 +158,10 @@ func (m *metaTestRunner) init() {
 		rng:         m.rng,
 		tsGenerator: &m.tsGenerator,
 	}
+	m.txnKeyGenerator = &txnKeyGenerator{
+		txns: m.txnGenerator,
+		keys: m.keyGenerator,
+	}
 	m.valueGenerator = &valueGenerator{m.rng}
 	m.pastTSGenerator = &pastTSGenerator{
 		rng:         m.rng,
@@ -215,22 +177,27 @@ func (m *metaTestRunner) init() {
 	m.boolGenerator = &boolGenerator{rng: m.rng}
 
 	m.opGenerators = map[operandType]operandGenerator{
-		operandTransaction: m.txnGenerator,
-		operandReadWriter:  m.rwGenerator,
-		operandMVCCKey:     m.keyGenerator,
-		operandPastTS:      m.pastTSGenerator,
-		operandNextTS:      m.nextTSGenerator,
-		operandValue:       m.valueGenerator,
-		operandIterator:    m.iterGenerator,
-		operandFloat:       m.floatGenerator,
-		operandBool:        m.boolGenerator,
-		operandSavepoint:   m.spGenerator,
+		operandTransaction:   m.txnGenerator,
+		operandReadWriter:    m.rwGenerator,
+		operandMVCCKey:       m.keyGenerator,
+		operandUnusedMVCCKey: m.txnKeyGenerator,
+		operandPastTS:        m.pastTSGenerator,
+		operandNextTS:        m.nextTSGenerator,
+		operandValue:         m.valueGenerator,
+		operandIterator:      m.iterGenerator,
+		operandFloat:         m.floatGenerator,
+		operandBool:          m.boolGenerator,
+		operandSavepoint:     m.spGenerator,
 	}
 
 	m.nameToGenerator = make(map[string]*opGenerator)
 	m.weights = make([]int, len(opGenerators))
 	for i := range opGenerators {
 		m.weights[i] = opGenerators[i].weight
+		if !m.restarts && opGenerators[i].name == "restart" {
+			// Don't generate restarts.
+			m.weights[i] = 0
+		}
 		m.nameToGenerator[opGenerators[i].name] = &opGenerators[i]
 	}
 	m.ops = nil
@@ -445,7 +412,7 @@ func (m *metaTestRunner) parseFileAndRun(f io.Reader) {
 			if strings.Contains(op.expectedOutput, "error") && strings.Contains(actualOutput, "error") {
 				continue
 			}
-			m.t.Fatalf("mismatching output at line %d: expected %s, got %s", op.lineNum, op.expectedOutput, actualOutput)
+			m.t.Fatalf("mismatching output at line %d, operation index %d: expected %s, got %s", op.lineNum, i, op.expectedOutput, actualOutput)
 		}
 	}
 }

--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -38,41 +38,6 @@ func makeStorageConfig(path string) base.StorageConfig {
 	}
 }
 
-func createTestPebbleEngine(path string, seed int64, fs vfs.FS) (storage.Engine, error) {
-	pebbleConfig := storage.PebbleConfig{
-		StorageConfig: makeStorageConfig(path),
-		Opts:          storage.DefaultPebbleOptions(),
-	}
-	if fs != nil {
-		pebbleConfig.Opts.FS = fs
-	}
-	pebbleConfig.Opts.Cache = pebble.NewCache(1 << 20)
-	defer pebbleConfig.Opts.Cache.Unref()
-
-	return storage.NewPebble(context.Background(), pebbleConfig)
-}
-
-func createTestPebbleManySSTs(path string, seed int64, fs vfs.FS) (storage.Engine, error) {
-	pebbleConfig := storage.PebbleConfig{
-		StorageConfig: makeStorageConfig(path),
-		Opts:          storage.DefaultPebbleOptions(),
-	}
-	if fs != nil {
-		pebbleConfig.Opts.FS = fs
-	}
-	levels := pebbleConfig.Opts.Levels
-	for i := range levels {
-		if i == 0 {
-			levels[i].TargetFileSize = 1 << 8 // 256 bytes
-		} else {
-			levels[i].TargetFileSize = levels[i-1].TargetFileSize * 2
-		}
-	}
-	pebbleConfig.Opts.Cache = pebble.NewCache(1 << 20)
-	defer pebbleConfig.Opts.Cache.Unref()
-
-	return storage.NewPebble(context.Background(), pebbleConfig)
-}
 
 func rngIntRange(rng *rand.Rand, min int64, max int64) int64 {
 	return min + rng.Int63n(max-min)
@@ -122,20 +87,40 @@ func createTestPebbleVarOpts(path string, seed int64, fs vfs.FS) (storage.Engine
 	return storage.NewPebble(context.Background(), pebbleConfig)
 }
 
-type engineImpl struct {
+type engineConfig struct {
 	name   string
-	create func(path string, seed int64, fs vfs.FS) (storage.Engine, error)
+	opts   *pebble.Options
 }
 
-var _ fmt.Stringer = &engineImpl{}
+func (e *engineConfig) create(path string, fs vfs.FS) (storage.Engine, error) {
+	pebbleConfig := storage.PebbleConfig{
+		StorageConfig: makeStorageConfig(path),
+		Opts:          e.opts,
+	}
+	if pebbleConfig.Opts == nil {
+		pebbleConfig.Opts = storage.DefaultPebbleOptions()
+	}
+	if fs != nil {
+		pebbleConfig.Opts.FS = fs
+	}
+	pebbleConfig.Opts.Cache = pebble.NewCache(1 << 20)
+	defer pebbleConfig.Opts.Cache.Unref()
 
-func (e *engineImpl) String() string {
+	return storage.NewPebble(context.Background(), pebbleConfig)
+}
+
+var _ fmt.Stringer = &engineConfig{}
+
+func (e *engineConfig) String() string {
 	return e.name
 }
 
-var engineImplPebble = engineImpl{"pebble", createTestPebbleEngine}
-var engineImplPebbleManySSTs = engineImpl{"pebble_many_ssts", createTestPebbleManySSTs}
-var engineImplPebbleVarOpts = engineImpl{"pebble_var_opts", createTestPebbleVarOpts}
+var engineConfigStandard = engineConfig{"standard=0", storage.DefaultPebbleOptions()}
+
+type engineSequence struct {
+	name    string
+	configs []engineConfig
+}
 
 // Object to store info corresponding to one metamorphic test run. Responsible
 // for generating and executing operations.
@@ -147,7 +132,7 @@ type metaTestRunner struct {
 	seed            int64
 	path            string
 	engineFS        vfs.FS
-	engineImpls     []engineImpl
+	engineSeq       engineSequence
 	curEngine       int
 	restarts        bool
 	engine          storage.Engine
@@ -180,7 +165,8 @@ func (m *metaTestRunner) init() {
 	m.curEngine = 0
 
 	var err error
-	m.engine, err = m.engineImpls[0].create(m.path, m.seed, m.engineFS)
+	m.engine, err = m.engineSeq.configs[0].create(m.path, m.engineFS)
+	m.printComment(fmt.Sprintf("engine options: %s", m.engineSeq.configs[0].opts.String()))
 	if err != nil {
 		m.engine = nil
 		m.t.Fatal(err)
@@ -353,25 +339,25 @@ func (m *metaTestRunner) generateAndRun(n int) {
 }
 
 // Closes the current engine and starts another one up, with the same path.
-// Returns the engine transition that
-func (m *metaTestRunner) restart() (string, string) {
+// Returns the old and new engine configs.
+func (m *metaTestRunner) restart() (engineConfig, engineConfig) {
 	m.closeAll()
-	oldEngineName := m.engineImpls[m.curEngine].name
+	oldEngine := m.engineSeq.configs[m.curEngine]
 	// TODO(itsbilal): Select engines at random instead of cycling through them.
 	m.curEngine++
-	if m.curEngine >= len(m.engineImpls) {
+	if m.curEngine >= len(m.engineSeq.configs) {
 		// If we're restarting more times than the number of engine implementations
 		// specified, loop back around to the first engine type specified.
 		m.curEngine = 0
 	}
 
 	var err error
-	m.engine, err = m.engineImpls[m.curEngine].create(m.path, m.seed, m.engineFS)
+	m.engine, err = m.engineSeq.configs[m.curEngine].create(m.path, m.engineFS)
 	if err != nil {
 		m.engine = nil
 		m.t.Fatal(err)
 	}
-	return oldEngineName, m.engineImpls[m.curEngine].name
+	return oldEngine, m.engineSeq.configs[m.curEngine]
 }
 
 func (m *metaTestRunner) parseFileAndRun(f io.Reader) {
@@ -541,6 +527,7 @@ func (m *metaTestRunner) printOp(opName string, argStrings []string, output stri
 // printComment prints a comment line into the output file. Supports single-line
 // comments only.
 func (m *metaTestRunner) printComment(comment string) {
+	comment = strings.ReplaceAll(comment, "\n", "\n# ")
 	fmt.Fprintf(m.w, "# %s\n", comment)
 }
 

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	keep    = flag.Bool("keep", false, "keep temp directories after test")
 	check   = flag.String("check", "", "run operations in specified file and check output for equality")
-	seed    = flag.Int64("seed", randutil.NewPseudoSeed(), "specify seed to use for random number generator")
 	opCount = flag.Int("operations", 100000, "number of MVCC operations to generate and run")
 )
 
@@ -168,6 +167,7 @@ func TestPebbleEquivalence(t *testing.T) {
 	ctx := context.Background()
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)
+	_, seed := randutil.NewTestRand()
 
 	engineSeqs := make([]engineSequence, 0, numStandardOptions+numRandomOptions)
 
@@ -186,7 +186,7 @@ func TestPebbleEquivalence(t *testing.T) {
 		engineSeq := engineSequence{
 			configs: []engineConfig{{
 				name: fmt.Sprintf("random=%d", i),
-				opts: randomOptions(i, *seed),
+				opts: randomOptions(),
 			}},
 		}
 		engineSeq.name = engineSeq.configs[0].name
@@ -196,7 +196,7 @@ func TestPebbleEquivalence(t *testing.T) {
 	run := testRun{
 		ctx:             ctx,
 		t:               t,
-		seed:            *seed,
+		seed:            seed,
 		restarts:        false,
 		inMem:           true,
 		engineSequences: engineSeqs,
@@ -212,6 +212,7 @@ func TestPebbleRestarts(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)
+	_, seed := randutil.NewTestRand()
 
 	engineConfigs := make([]engineConfig, 0, numStandardOptions+numRandomOptions-1)
 	// Create one config sequence that contains all options.
@@ -229,7 +230,7 @@ func TestPebbleRestarts(t *testing.T) {
 	for i := 0; i < numRandomOptions; i++ {
 		engineConfigs = append(engineConfigs, engineConfig{
 			name: fmt.Sprintf("random=%d", i),
-			opts: randomOptions(i, *seed),
+			opts: randomOptions(),
 		})
 	}
 
@@ -237,7 +238,7 @@ func TestPebbleRestarts(t *testing.T) {
 	run := testRun{
 		ctx:      ctx,
 		t:        t,
-		seed:     *seed,
+		seed:     seed,
 		inMem:    true,
 		restarts: true,
 		engineSequences: []engineSequence{
@@ -281,7 +282,7 @@ func TestPebbleCheck(t *testing.T) {
 			engineSeq := engineSequence{
 				configs: []engineConfig{{
 					name: fmt.Sprintf("random=%d", i),
-					opts: randomOptions(i, *seed),
+					opts: randomOptions(),
 				}},
 			}
 			engineSeq.name = engineSeq.configs[0].name

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -66,6 +66,8 @@ func runMetaTestForEngines(run testRunForEngines) {
 	var fs vfs.FS
 	if run.inMem && !*keep {
 		fs = vfs.NewMem()
+	} else {
+		fs = vfs.Default
 	}
 
 	testRunner := metaTestRunner{
@@ -167,13 +169,13 @@ func TestPebbleEquivalence(t *testing.T) {
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)
 
-	engineSeqs := make([]engineSequence, 0, numStandardOptions + numRandomOptions)
+	engineSeqs := make([]engineSequence, 0, numStandardOptions+numRandomOptions)
 
 	for i := 0; i < numStandardOptions; i++ {
 		engineSeq := engineSequence{
 			configs: []engineConfig{{
-				name:   fmt.Sprintf("standard=%d", i),
-				opts:   standardOptions(i),
+				name: fmt.Sprintf("standard=%d", i),
+				opts: standardOptions(i),
 			}},
 		}
 		engineSeq.name = engineSeq.configs[0].name
@@ -183,8 +185,8 @@ func TestPebbleEquivalence(t *testing.T) {
 	for i := 0; i < numRandomOptions; i++ {
 		engineSeq := engineSequence{
 			configs: []engineConfig{{
-				name:   fmt.Sprintf("random=%d", i),
-				opts:   randomOptions(i, *seed),
+				name: fmt.Sprintf("random=%d", i),
+				opts: randomOptions(i, *seed),
 			}},
 		}
 		engineSeq.name = engineSeq.configs[0].name
@@ -211,19 +213,23 @@ func TestPebbleRestarts(t *testing.T) {
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)
 
-	engineConfigs := make([]engineConfig, 0, numStandardOptions + numRandomOptions)
+	engineConfigs := make([]engineConfig, 0, numStandardOptions+numRandomOptions-1)
 	// Create one config sequence that contains all options.
 	for i := 0; i < numStandardOptions; i++ {
+		// Skip standard config at index 9 as it's incompatible with restarts.
+		if i == 9 {
+			continue
+		}
 		engineConfigs = append(engineConfigs, engineConfig{
-			name:   fmt.Sprintf("standard=%d", i),
-			opts:   standardOptions(i),
+			name: fmt.Sprintf("standard=%d", i),
+			opts: standardOptions(i),
 		})
 	}
 
 	for i := 0; i < numRandomOptions; i++ {
 		engineConfigs = append(engineConfigs, engineConfig{
-			name:   fmt.Sprintf("random=%d", i),
-			opts:   randomOptions(i, *seed),
+			name: fmt.Sprintf("random=%d", i),
+			opts: randomOptions(i, *seed),
 		})
 	}
 
@@ -237,7 +243,7 @@ func TestPebbleRestarts(t *testing.T) {
 		engineSequences: []engineSequence{
 			{name: "standard", configs: []engineConfig{engineConfigStandard}},
 			{
-				name: fmt.Sprintf("standards=%d,randoms=%d", numStandardOptions, numRandomOptions),
+				name:    fmt.Sprintf("standards=%d,randoms=%d", numStandardOptions-1, numRandomOptions),
 				configs: engineConfigs,
 			},
 		},
@@ -258,15 +264,37 @@ func TestPebbleCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		engineSeqs := make([]engineSequence, 0, numStandardOptions+numRandomOptions)
+
+		for i := 0; i < numStandardOptions; i++ {
+			engineSeq := engineSequence{
+				configs: []engineConfig{{
+					name: fmt.Sprintf("standard=%d", i),
+					opts: standardOptions(i),
+				}},
+			}
+			engineSeq.name = engineSeq.configs[0].name
+			engineSeqs = append(engineSeqs, engineSeq)
+		}
+
+		for i := 0; i < numRandomOptions; i++ {
+			engineSeq := engineSequence{
+				configs: []engineConfig{{
+					name: fmt.Sprintf("random=%d", i),
+					opts: randomOptions(i, *seed),
+				}},
+			}
+			engineSeq.name = engineSeq.configs[0].name
+			engineSeqs = append(engineSeqs, engineSeq)
+		}
+
 		run := testRun{
-			ctx:       ctx,
-			t:         t,
-			checkFile: *check,
-			restarts:  true,
-			inMem:     true,
-			engineSequences: []engineSequence{
-				{name: "standard", configs: []engineConfig{engineConfigStandard}},
-			},
+			ctx:             ctx,
+			t:               t,
+			checkFile:       *check,
+			restarts:        true,
+			inMem:           false,
+			engineSequences: engineSeqs,
 		}
 		runMetaTest(run)
 	}

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -57,7 +57,7 @@ type testRunForEngines struct {
 func runMetaTestForEngines(run testRunForEngines) {
 	tempDir, cleanup := testutils.TempDir(run.t)
 	defer func() {
-		if !*keep {
+		if !*keep && !run.t.Failed() {
 			cleanup()
 		}
 	}()
@@ -86,7 +86,7 @@ func runMetaTest(run testRun) {
 	t := run.t
 	outerTempDir, cleanup := testutils.TempDir(run.t)
 	defer func() {
-		if !*keep {
+		if !*keep && !t.Failed() {
 			cleanup()
 		}
 	}()
@@ -106,7 +106,7 @@ func runMetaTest(run testRun) {
 		t.Run(strings.Join(engineNames, ","), func(t *testing.T) {
 			innerTempDir, cleanup := testutils.TempDir(t)
 			defer func() {
-				if !*keep {
+				if !*keep && !t.Failed() {
 					cleanup()
 				}
 			}()

--- a/pkg/storage/metamorphic/operands.go
+++ b/pkg/storage/metamorphic/operands.go
@@ -32,6 +32,7 @@ const (
 	operandIterator
 	operandFloat
 	operandBool
+	operandSavepoint
 )
 
 const (
@@ -52,19 +53,23 @@ type operandGenerator interface {
 	// keys), it could also generate and return a new type of an instance. An
 	// operand is represented as a serializable string, that can be converted into
 	// a concrete instance type during execution by calling a get<concrete type>()
-	// or parse() method on the concrete operand generator.
-	get() string
+	// or parse() method on the concrete operand generator. Operands generated
+	// so far are passed in, in case this generator relies on them to generate
+	// new ones.
+	get(args []string) string
 	// getNew retrieves a new instance of this type of operand. Called when an
 	// opener operation (with isOpener = true) needs an ID to store its output.
-	getNew() string
+	getNew(args []string) string
 	// opener returns the name of an operation generator (defined in
 	// operations.go) that always creates a new instance of this object. Called by
 	// the test runner when an operation requires one instance of this
 	// operand to exist, and count() == 0.
 	opener() string
 	// count returns the number of live objects being managed by this generator.
-	// If 0, the opener() operation can be called when necessary.
-	count() int
+	// If this generator depends on some other previously-generated args, those
+	// can be obtained from the args list. If 0, the opener() operation can be
+	// called when necessary.
+	count(args []string) int
 	// closeAll closes all managed operands. Used when the test exits, or when a
 	// restart operation executes.
 	closeAll()
@@ -93,7 +98,7 @@ func (k *keyGenerator) opener() string {
 	return ""
 }
 
-func (k *keyGenerator) count() int {
+func (k *keyGenerator) count(args []string) int {
 	// Always return a nonzero value so opener() is never called directly.
 	return len(k.liveKeys) + 1
 }
@@ -111,7 +116,7 @@ func (k *keyGenerator) toString(key storage.MVCCKey) string {
 	return fmt.Sprintf("%s/%d", key.Key, key.Timestamp.WallTime)
 }
 
-func (k *keyGenerator) get() string {
+func (k *keyGenerator) get(args []string) string {
 	// 15% chance of returning a new key even if some exist.
 	if len(k.liveKeys) == 0 || k.rng.Float64() < 0.30 {
 		return k.toString(k.open())
@@ -120,8 +125,8 @@ func (k *keyGenerator) get() string {
 	return k.toString(k.liveKeys[k.rng.Intn(len(k.liveKeys))])
 }
 
-func (k *keyGenerator) getNew() string {
-	return k.get()
+func (k *keyGenerator) getNew(args []string) string {
+	return k.get(args)
 }
 
 func (k *keyGenerator) closeAll() {
@@ -148,16 +153,16 @@ func (v *valueGenerator) opener() string {
 	return ""
 }
 
-func (v *valueGenerator) count() int {
+func (v *valueGenerator) count(args []string) int {
 	return 1
 }
 
-func (v *valueGenerator) get() string {
+func (v *valueGenerator) get(args []string) string {
 	return v.toString(generateBytes(v.rng, 4, maxValueSize))
 }
 
-func (v *valueGenerator) getNew() string {
-	return v.get()
+func (v *valueGenerator) getNew(args []string) string {
+	return v.get(args)
 }
 
 func (v *valueGenerator) closeAll() {
@@ -175,12 +180,13 @@ func (v *valueGenerator) parse(input string) []byte {
 type txnID string
 
 type txnGenerator struct {
-	rng         *rand.Rand
-	testRunner  *metaTestRunner
-	tsGenerator *tsGenerator
-	liveTxns    []txnID
-	txnIDMap    map[txnID]*roachpb.Transaction
-	openBatches map[txnID]map[readWriterID]struct{}
+	rng            *rand.Rand
+	testRunner     *metaTestRunner
+	tsGenerator    *tsGenerator
+	liveTxns       []txnID
+	txnIDMap       map[txnID]*roachpb.Transaction
+	openBatches    map[txnID]map[readWriterID]struct{}
+	openSavepoints map[txnID]int
 	// Counts "generated" transactions - i.e. how many txn_open()s have been
 	// inserted so far. Could stay 0 in check mode.
 	txnGenCounter uint64
@@ -192,11 +198,11 @@ func (t *txnGenerator) opener() string {
 	return "txn_open"
 }
 
-func (t *txnGenerator) count() int {
+func (t *txnGenerator) count(args []string) int {
 	return len(t.txnIDMap)
 }
 
-func (t *txnGenerator) get() string {
+func (t *txnGenerator) get(args []string) string {
 	if len(t.liveTxns) == 0 {
 		panic("no open txns")
 	}
@@ -206,7 +212,7 @@ func (t *txnGenerator) get() string {
 // getNew returns a transaction ID, and saves this transaction as a "live"
 // transaction for generation purposes. Called only during generation, and
 // must be matched with a generateClose call.
-func (t *txnGenerator) getNew() string {
+func (t *txnGenerator) getNew(args []string) string {
 	t.txnGenCounter++
 	id := txnID(fmt.Sprintf("t%d", t.txnGenCounter))
 	// Increment the timestamp.
@@ -221,6 +227,7 @@ func (t *txnGenerator) getNew() string {
 func (t *txnGenerator) generateClose(id txnID) {
 	delete(t.openBatches, id)
 	delete(t.txnIDMap, id)
+	delete(t.openSavepoints, id)
 
 	for i := range t.liveTxns {
 		if t.liveTxns[i] == id {
@@ -253,6 +260,39 @@ func (t *txnGenerator) closeAll() {
 	t.liveTxns = nil
 	t.txnIDMap = make(map[txnID]*roachpb.Transaction)
 	t.openBatches = make(map[txnID]map[readWriterID]struct{})
+	t.openSavepoints = make(map[txnID]int)
+}
+
+type savepointGenerator struct {
+	rng            *rand.Rand
+	txnGenerator   *txnGenerator
+}
+
+var _ operandGenerator = &savepointGenerator{}
+
+func (s *savepointGenerator) get(args []string) string {
+	id := txnID(args[len(args)-1])
+	n := s.rng.Intn(s.txnGenerator.openSavepoints[id])
+	return strconv.Itoa(n)
+}
+
+func (s *savepointGenerator) getNew(args []string) string {
+	id := txnID(args[len(args)-1])
+	s.txnGenerator.openSavepoints[id]++
+	return strconv.Itoa(s.txnGenerator.openSavepoints[id] - 1)
+}
+
+func (s *savepointGenerator) opener() string {
+	return "txn_create_savepoint"
+}
+
+func (s *savepointGenerator) count(args []string) int {
+	id := txnID(args[len(args)-1])
+	return s.txnGenerator.openSavepoints[id]
+}
+
+func (s *savepointGenerator) closeAll() {
+	// No-op.
 }
 
 type pastTSGenerator struct {
@@ -266,7 +306,7 @@ func (t *pastTSGenerator) opener() string {
 	return ""
 }
 
-func (t *pastTSGenerator) count() int {
+func (t *pastTSGenerator) count(args []string) int {
 	// Always return a non-zero count so opener() is never called.
 	return int(t.tsGenerator.lastTS.WallTime) + 1
 }
@@ -289,12 +329,12 @@ func (t *pastTSGenerator) parse(input string) hlc.Timestamp {
 	return ts
 }
 
-func (t *pastTSGenerator) get() string {
+func (t *pastTSGenerator) get(args []string) string {
 	return t.toString(t.tsGenerator.randomPastTimestamp(t.rng))
 }
 
-func (t *pastTSGenerator) getNew() string {
-	return t.get()
+func (t *pastTSGenerator) getNew(args []string) string {
+	return t.get(args)
 }
 
 // Similar to pastTSGenerator, except it always increments the "current" timestamp
@@ -303,12 +343,12 @@ type nextTSGenerator struct {
 	pastTSGenerator
 }
 
-func (t *nextTSGenerator) get() string {
+func (t *nextTSGenerator) get(args []string) string {
 	return t.toString(t.tsGenerator.generate())
 }
 
-func (t *nextTSGenerator) getNew() string {
-	return t.get()
+func (t *nextTSGenerator) getNew(args []string) string {
+	return t.get(args)
 }
 
 type readWriterID string
@@ -323,7 +363,7 @@ type readWriterGenerator struct {
 
 var _ operandGenerator = &readWriterGenerator{}
 
-func (w *readWriterGenerator) get() string {
+func (w *readWriterGenerator) get(args []string) string {
 	// 25% chance of returning the engine, even if there are live batches.
 	if len(w.liveBatches) == 0 || w.rng.Float64() < 0.25 {
 		return "engine"
@@ -333,7 +373,7 @@ func (w *readWriterGenerator) get() string {
 }
 
 // getNew is called during generation to generate a batch ID.
-func (w *readWriterGenerator) getNew() string {
+func (w *readWriterGenerator) getNew(args []string) string {
 	w.batchGenCounter++
 	id := readWriterID(fmt.Sprintf("batch%d", w.batchGenCounter))
 	w.batchIDMap[id] = nil
@@ -363,7 +403,7 @@ func (w *readWriterGenerator) generateClose(id readWriterID) {
 	w.m.txnGenerator.clearBatch(id)
 }
 
-func (w *readWriterGenerator) count() int {
+func (w *readWriterGenerator) count(args []string) int {
 	return len(w.batchIDMap) + 1
 }
 
@@ -395,7 +435,7 @@ type iteratorGenerator struct {
 
 var _ operandGenerator = &iteratorGenerator{}
 
-func (i *iteratorGenerator) get() string {
+func (i *iteratorGenerator) get(args []string) string {
 	if len(i.liveIters) == 0 {
 		panic("no open iterators")
 	}
@@ -403,7 +443,7 @@ func (i *iteratorGenerator) get() string {
 	return string(i.liveIters[i.rng.Intn(len(i.liveIters))])
 }
 
-func (i *iteratorGenerator) getNew() string {
+func (i *iteratorGenerator) getNew(args []string) string {
 	i.iterGenCounter++
 	id := fmt.Sprintf("iter%d", i.iterGenCounter)
 	return id
@@ -451,7 +491,7 @@ func (i *iteratorGenerator) opener() string {
 	return "iterator_open"
 }
 
-func (i *iteratorGenerator) count() int {
+func (i *iteratorGenerator) count(args []string) int {
 	return len(i.iterInfo)
 }
 
@@ -465,12 +505,12 @@ type floatGenerator struct {
 	rng *rand.Rand
 }
 
-func (f *floatGenerator) get() string {
+func (f *floatGenerator) get(args []string) string {
 	return fmt.Sprintf("%.4f", f.rng.Float32())
 }
 
-func (f *floatGenerator) getNew() string {
-	return f.get()
+func (f *floatGenerator) getNew(args []string) string {
+	return f.get(args)
 }
 
 func (f *floatGenerator) parse(input string) float32 {
@@ -486,7 +526,7 @@ func (f *floatGenerator) opener() string {
 	return ""
 }
 
-func (f *floatGenerator) count() int {
+func (f *floatGenerator) count(args []string) int {
 	return 1
 }
 

--- a/pkg/storage/metamorphic/operands.go
+++ b/pkg/storage/metamorphic/operands.go
@@ -419,10 +419,11 @@ func (w *readWriterGenerator) closeAll() {
 
 type iteratorID string
 type iteratorInfo struct {
-	id          iteratorID
-	iter        storage.MVCCIterator
-	lowerBound  roachpb.Key
-	isBatchIter bool
+	id           iteratorID
+	iter         storage.MVCCIterator
+	lowerBound   roachpb.Key
+	isBatchIter  bool
+	isEngineIter bool
 }
 
 type iteratorGenerator struct {

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -14,10 +14,10 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -153,6 +153,16 @@ func printIterState(iter storage.MVCCIterator) string {
 	return fmt.Sprintf("key = %s", iter.UnsafeKey().String())
 }
 
+func addKeyToLockSpans(txn *roachpb.Transaction, key roachpb.Key) {
+	// Update the txn's lock spans to account for this intent being written.
+	newLockSpans := make([]roachpb.Span, 0, len(txn.LockSpans)+1)
+	newLockSpans = append(newLockSpans, txn.LockSpans...)
+	newLockSpans = append(newLockSpans, roachpb.Span{
+		Key: key,
+	})
+	txn.LockSpans, _ = roachpb.MergeSpans(&newLockSpans)
+}
+
 type mvccGetOp struct {
 	m            *metaTestRunner
 	reader       readWriterID
@@ -201,10 +211,7 @@ func (m mvccPutOp) run(ctx context.Context) string {
 		return fmt.Sprintf("error: %s", err)
 	}
 
-	// Update the txn's lock spans to account for this intent being written.
-	txn.LockSpans = append(txn.LockSpans, roachpb.Span{
-		Key: m.key,
-	})
+	addKeyToLockSpans(txn, m.key)
 	return "ok"
 }
 
@@ -227,10 +234,7 @@ func (m mvccCPutOp) run(ctx context.Context) string {
 		return fmt.Sprintf("error: %s", err)
 	}
 
-	// Update the txn's lock spans to account for this intent being written.
-	txn.LockSpans = append(txn.LockSpans, roachpb.Span{
-		Key: m.key,
-	})
+	addKeyToLockSpans(txn, m.key)
 	return "ok"
 }
 
@@ -252,10 +256,7 @@ func (m mvccInitPutOp) run(ctx context.Context) string {
 		return fmt.Sprintf("error: %s", err)
 	}
 
-	// Update the txn's lock spans to account for this intent being written.
-	txn.LockSpans = append(txn.LockSpans, roachpb.Span{
-		Key: m.key,
-	})
+	addKeyToLockSpans(txn, m.key)
 	return "ok"
 }
 
@@ -279,11 +280,17 @@ func (m mvccDeleteRangeOp) run(ctx context.Context) string {
 
 	// Update the txn's lock spans to account for this intent being written.
 	for _, key := range keys {
-		txn.LockSpans = append(txn.LockSpans, roachpb.Span{
-			Key: key,
-		})
+		addKeyToLockSpans(txn, key)
 	}
-	return "ok"
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "truncated range to delete = %s - %s, deleted keys = ", m.key, m.endKey)
+	for i, key := range keys {
+		fmt.Fprintf(&builder, "%s", key)
+		if i < len(keys)-1 {
+			fmt.Fprintf(&builder, ", ")
+		}
+	}
+	return builder.String()
 }
 
 type mvccClearTimeRangeOp struct {
@@ -324,9 +331,7 @@ func (m mvccDeleteOp) run(ctx context.Context) string {
 	}
 
 	// Update the txn's lock spans to account for this intent being written.
-	txn.LockSpans = append(txn.LockSpans, roachpb.Span{
-		Key: m.key,
-	})
+	addKeyToLockSpans(txn, m.key)
 	return "ok"
 }
 
@@ -462,8 +467,11 @@ func (t txnAbortOp) run(ctx context.Context) string {
 }
 
 type txnCreateSavepointOp struct {
-	m         *metaTestRunner
-	id        txnID
+	m  *metaTestRunner
+	id txnID
+	// The index of the savepoint (in m.openSavepoints[id]) being created.
+	// As savepoints are only appended to the end, this must equal
+	// len(m.openSavepoints[t.id]) at time of running.
 	savepoint int
 }
 
@@ -482,8 +490,10 @@ func (t txnCreateSavepointOp) run(ctx context.Context) string {
 }
 
 type txnRollbackSavepointOp struct {
-	m         *metaTestRunner
-	id        txnID
+	m  *metaTestRunner
+	id txnID
+	// The index of the savepoint (in m.openSavepoints[id]) being rolled back to.
+	// Txn sequences are generated and stored at runtime in that slice.
 	savepoint int
 }
 
@@ -696,11 +706,10 @@ type ingestOp struct {
 
 func (i ingestOp) run(ctx context.Context) string {
 	sstPath := filepath.Join(i.m.path, "ingest.sst")
-	f, err := os.Create(sstPath)
+	f, err := i.m.engineFS.Create(sstPath)
 	if err != nil {
 		return fmt.Sprintf("error = %s", err.Error())
 	}
-	defer f.Close()
 
 	sstWriter := storage.MakeIngestionSSTWriter(f)
 	for _, key := range i.keys {
@@ -740,7 +749,6 @@ func (r restartOp) run(ctx context.Context) string {
 //  - MVCCBlindPut
 //  - MVCCMerge
 //  - MVCCIncrement
-//  - MVCCResolveWriteIntent in the aborted case
 //  - and any others that would be important to test.
 var opGenerators = []opGenerator{
 	{
@@ -788,13 +796,13 @@ var opGenerators = []opGenerator{
 		name: "mvcc_put",
 		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
 			writer := readWriterID(args[0])
-			key := m.keyGenerator.parse(args[1])
-			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[2]))
-			txn := txnID(args[3])
+			txn := txnID(args[1])
+			key := m.txnKeyGenerator.parse(args[2])
+			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[3]))
 
 			// Track this write in the txn generator. This ensures the batch will be
 			// committed before the transaction is committed
-			m.txnGenerator.trackWriteOnBatch(writer, txn)
+			m.txnGenerator.trackTransactionalWrite(writer, txn, key.Key, nil)
 			return &mvccPutOp{
 				m:      m,
 				writer: writer,
@@ -805,9 +813,9 @@ var opGenerators = []opGenerator{
 		},
 		operands: []operandType{
 			operandReadWriter,
-			operandMVCCKey,
-			operandValue,
 			operandTransaction,
+			operandUnusedMVCCKey,
+			operandValue,
 		},
 		weight: 500,
 	},
@@ -815,14 +823,14 @@ var opGenerators = []opGenerator{
 		name: "mvcc_conditional_put",
 		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
 			writer := readWriterID(args[0])
-			key := m.keyGenerator.parse(args[1])
-			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[2]))
-			expVal := m.valueGenerator.parse(args[3])
-			txn := txnID(args[4])
+			txn := txnID(args[1])
+			key := m.txnKeyGenerator.parse(args[2])
+			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[3]))
+			expVal := m.valueGenerator.parse(args[4])
 
 			// Track this write in the txn generator. This ensures the batch will be
 			// committed before the transaction is committed
-			m.txnGenerator.trackWriteOnBatch(writer, txn)
+			m.txnGenerator.trackTransactionalWrite(writer, txn, key.Key, nil)
 			return &mvccCPutOp{
 				m:      m,
 				writer: writer,
@@ -834,10 +842,10 @@ var opGenerators = []opGenerator{
 		},
 		operands: []operandType{
 			operandReadWriter,
-			operandMVCCKey,
-			operandValue,
-			operandValue,
 			operandTransaction,
+			operandUnusedMVCCKey,
+			operandValue,
+			operandValue,
 		},
 		weight: 50,
 	},
@@ -845,13 +853,13 @@ var opGenerators = []opGenerator{
 		name: "mvcc_init_put",
 		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
 			writer := readWriterID(args[0])
-			key := m.keyGenerator.parse(args[1])
-			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[2]))
-			txn := txnID(args[3])
+			txn := txnID(args[1])
+			key := m.txnKeyGenerator.parse(args[2])
+			value := roachpb.MakeValueFromBytes(m.valueGenerator.parse(args[3]))
 
 			// Track this write in the txn generator. This ensures the batch will be
 			// committed before the transaction is committed
-			m.txnGenerator.trackWriteOnBatch(writer, txn)
+			m.txnGenerator.trackTransactionalWrite(writer, txn, key.Key, nil)
 			return &mvccInitPutOp{
 				m:      m,
 				writer: writer,
@@ -862,9 +870,9 @@ var opGenerators = []opGenerator{
 		},
 		operands: []operandType{
 			operandReadWriter,
-			operandMVCCKey,
-			operandValue,
 			operandTransaction,
+			operandUnusedMVCCKey,
+			operandValue,
 		},
 		weight: 50,
 	},
@@ -872,17 +880,22 @@ var opGenerators = []opGenerator{
 		name: "mvcc_delete_range",
 		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
 			writer := readWriterID(args[0])
-			key := m.keyGenerator.parse(args[1]).Key
-			endKey := m.keyGenerator.parse(args[2]).Key
-			txn := txnID(args[3])
+			txn := txnID(args[1])
+			key := m.keyGenerator.parse(args[2]).Key
+			endKey := m.keyGenerator.parse(args[3]).Key
 
 			if endKey.Compare(key) < 0 {
 				key, endKey = endKey, key
 			}
+			// forEachConflict is guaranteed to iterate
+			m.txnGenerator.forEachConflict(writer, txn, key, endKey, func(conflict roachpb.Span) bool {
+				endKey = conflict.Key
+				return false
+			})
 
 			// Track this write in the txn generator. This ensures the batch will be
 			// committed before the transaction is committed
-			m.txnGenerator.trackWriteOnBatch(writer, txn)
+			m.txnGenerator.trackTransactionalWrite(writer, txn, key, endKey)
 			return &mvccDeleteRangeOp{
 				m:      m,
 				writer: writer,
@@ -896,9 +909,9 @@ var opGenerators = []opGenerator{
 		},
 		operands: []operandType{
 			operandReadWriter,
-			operandMVCCKey,
-			operandMVCCKey,
 			operandTransaction,
+			operandUnusedMVCCKey,
+			operandUnusedMVCCKey,
 		},
 		weight: 20,
 	},
@@ -942,12 +955,12 @@ var opGenerators = []opGenerator{
 		name: "mvcc_delete",
 		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
 			writer := readWriterID(args[0])
-			key := m.keyGenerator.parse(args[1])
-			txn := txnID(args[2])
+			txn := txnID(args[1])
+			key := m.txnKeyGenerator.parse(args[2])
 
 			// Track this write in the txn generator. This ensures the batch will be
 			// committed before the transaction is committed
-			m.txnGenerator.trackWriteOnBatch(writer, txn)
+			m.txnGenerator.trackTransactionalWrite(writer, txn, key.Key, nil)
 			return &mvccDeleteOp{
 				m:      m,
 				writer: writer,
@@ -957,8 +970,8 @@ var opGenerators = []opGenerator{
 		},
 		operands: []operandType{
 			operandReadWriter,
-			operandMVCCKey,
 			operandTransaction,
+			operandUnusedMVCCKey,
 		},
 		weight: 100,
 	},
@@ -1118,7 +1131,7 @@ var opGenerators = []opGenerator{
 			operandSavepoint,
 		},
 		isOpener: true,
-		weight: 10,
+		weight:   10,
 	},
 	{
 		name: "txn_rollback_savepoint",

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -420,6 +421,7 @@ type txnCommitOp struct {
 func (t txnCommitOp) run(ctx context.Context) string {
 	txn := t.m.getTxn(t.id)
 	txn.Status = roachpb.COMMITTED
+	txn.Sequence++
 
 	for _, span := range txn.LockSpans {
 		intent := roachpb.MakeLockUpdate(txn, span)
@@ -430,7 +432,74 @@ func (t txnCommitOp) run(ctx context.Context) string {
 		}
 	}
 	delete(t.m.openTxns, t.id)
+	delete(t.m.openSavepoints, t.id)
 
+	return "ok"
+}
+
+type txnAbortOp struct {
+	m  *metaTestRunner
+	id txnID
+}
+
+func (t txnAbortOp) run(ctx context.Context) string {
+	txn := t.m.getTxn(t.id)
+	txn.Status = roachpb.ABORTED
+
+	for _, span := range txn.LockSpans {
+		intent := roachpb.MakeLockUpdate(txn, span)
+		intent.Status = roachpb.ABORTED
+		_, err := storage.MVCCResolveWriteIntent(context.TODO(), t.m.engine, nil, intent)
+		if err != nil {
+			panic(err)
+		}
+	}
+	delete(t.m.openTxns, t.id)
+	delete(t.m.openSavepoints, t.id)
+
+	return "ok"
+}
+
+type txnCreateSavepointOp struct {
+	m         *metaTestRunner
+	id        txnID
+	savepoint int
+}
+
+func (t txnCreateSavepointOp) run(ctx context.Context) string {
+	txn := t.m.getTxn(t.id)
+	txn.Sequence++
+
+	// Append txn.Sequence.
+	if len(t.m.openSavepoints[t.id]) == t.savepoint {
+		t.m.openSavepoints[t.id] = append(t.m.openSavepoints[t.id], txn.Sequence)
+	} else {
+		panic(fmt.Sprintf("mismatching savepoint index: %d != %d", len(t.m.openSavepoints[t.id]), t.savepoint))
+	}
+
+	return fmt.Sprintf("savepoint %d", t.savepoint)
+}
+
+type txnRollbackSavepointOp struct {
+	m         *metaTestRunner
+	id        txnID
+	savepoint int
+}
+
+func (t txnRollbackSavepointOp) run(ctx context.Context) string {
+	txn := t.m.getTxn(t.id)
+	txn.Sequence++
+
+	savepoints := t.m.openSavepoints[t.id]
+	if len(savepoints) == 0 || t.savepoint > len(savepoints) {
+		panic(fmt.Sprintf("got a higher savepoint idx %d than allowed for txn %s", t.savepoint, t.id))
+	}
+
+	ignoredSeqNumRange := enginepb.IgnoredSeqNumRange{
+		Start: savepoints[t.savepoint],
+		End:   txn.Sequence,
+	}
+	txn.AddIgnoredSeqNumRange(ignoredSeqNumRange)
 	return "ok"
 }
 
@@ -523,7 +592,7 @@ func (i iterSeekOp) run(ctx context.Context) string {
 		if i.seekLT {
 			return "noop due to missing seekLT support in rocksdb batch iterators"
 		}
-		// RocksDB batch iterators do not account for lower bounds consistently:
+		// RocksDB batch iterators do not account åfor lower bounds consistently:
 		// https://github.com/cockroachdb/cockroach/issues/44512
 		// In the meantime, ensure the SeekGE key >= lower bound.
 		lowerBound := iterInfo.lowerBound
@@ -820,9 +889,6 @@ var opGenerators = []opGenerator{
 				txn:    txn,
 			}
 		},
-		dependentOps: func(m *metaTestRunner, args ...string) (results []opReference) {
-			return closeItersOnBatch(m, readWriterID(args[0]))
-		},
 		operands: []operandType{
 			operandReadWriter,
 			operandMVCCKey,
@@ -854,9 +920,6 @@ var opGenerators = []opGenerator{
 				startTime: startTime,
 				endTime:   endTime,
 			}
-		},
-		dependentOps: func(m *metaTestRunner, args ...string) (results []opReference) {
-			return closeItersOnBatch(m, readWriterID(args[0]))
 		},
 		operands: []operandType{
 			operandReadWriter,
@@ -1000,7 +1063,73 @@ var opGenerators = []opGenerator{
 		operands: []operandType{
 			operandTransaction,
 		},
-		weight: 100,
+		weight: 50,
+	},
+	{
+		name: "txn_abort",
+		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
+			m.txnGenerator.generateClose(txnID(args[0]))
+			return &txnAbortOp{
+				m:  m,
+				id: txnID(args[0]),
+			}
+		},
+		dependentOps: func(m *metaTestRunner, args ...string) (result []opReference) {
+			txn := txnID(args[0])
+
+			// A transaction could have in-flight writes in some batches. Get a list
+			// of all those batches, and dispatch batch_commit operations for them.
+			for batch := range m.txnGenerator.openBatches[txn] {
+				result = append(result, opReference{
+					generator: m.nameToGenerator["batch_commit"],
+					args:      []string{string(batch)},
+				})
+			}
+			return
+		},
+		operands: []operandType{
+			operandTransaction,
+		},
+		weight: 50,
+	},
+	{
+		name: "txn_create_savepoint",
+		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
+			savepoint, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil {
+				panic(err.Error())
+			}
+			return &txnCreateSavepointOp{
+				m:         m,
+				id:        txnID(args[0]),
+				savepoint: int(savepoint),
+			}
+		},
+		operands: []operandType{
+			operandTransaction,
+			operandSavepoint,
+		},
+		isOpener: true,
+		weight: 10,
+	},
+	{
+		name: "txn_rollback_savepoint",
+		generate: func(ctx context.Context, m *metaTestRunner, args ...string) mvccOp {
+			savepoint, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil {
+				panic(err.Error())
+			}
+			return &txnRollbackSavepointOp{
+				m:         m,
+				id:        txnID(args[0]),
+				savepoint: int(savepoint),
+			}
+		},
+		operands: []operandType{
+			operandTransaction,
+			operandSavepoint,
+		},
+		weight: 10,
 	},
 	{
 		name: "batch_open",

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -728,8 +728,9 @@ func (r restartOp) run(ctx context.Context) string {
 		return "ok"
 	}
 
-	oldEngineName, newEngineName := r.m.restart()
-	r.m.printComment(fmt.Sprintf("restarting: %s -> %s", oldEngineName, newEngineName))
+	oldEngine, newEngine := r.m.restart()
+	r.m.printComment(fmt.Sprintf("restarting: %s -> %s", oldEngine.name, newEngine.name))
+	r.m.printComment(fmt.Sprintf("new options: %s", newEngine.opts.String()))
 	return "ok"
 }
 

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -297,8 +297,9 @@ type mvccClearTimeRangeOp struct {
 
 func (m mvccClearTimeRangeOp) run(ctx context.Context) string {
 	writer := m.m.getReadWriter(m.writer)
+	useTBI := m.writer == "engine"
 	span, err := storage.MVCCClearTimeRange(ctx, writer, &enginepb.MVCCStats{}, m.key, m.endKey,
-		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64, true /* useTBI */)
+		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64, useTBI)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
@@ -542,7 +543,7 @@ type iterOpenOp struct {
 
 func (i iterOpenOp) run(ctx context.Context) string {
 	rw := i.m.getReadWriter(i.rw)
-	iter := rw.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	iter := rw.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		Prefix:     false,
 		LowerBound: i.key,
 		UpperBound: i.endKey.Next(),
@@ -889,6 +890,9 @@ var opGenerators = []opGenerator{
 				txn:    txn,
 			}
 		},
+		dependentOps: func(m *metaTestRunner, args ...string) []opReference {
+			return closeItersOnBatch(m, readWriterID(args[0]))
+		},
 		operands: []operandType{
 			operandReadWriter,
 			operandMVCCKey,
@@ -920,6 +924,9 @@ var opGenerators = []opGenerator{
 				startTime: startTime,
 				endTime:   endTime,
 			}
+		},
+		dependentOps: func(m *metaTestRunner, args ...string) []opReference {
+			return closeItersOnBatch(m, readWriterID(args[0]))
 		},
 		operands: []operandType{
 			operandReadWriter,

--- a/pkg/storage/metamorphic/options.go
+++ b/pkg/storage/metamorphic/options.go
@@ -11,9 +11,8 @@
 package metamorphic
 
 import (
-	"math/rand"
-
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/pebble"
 )
 
@@ -104,10 +103,10 @@ func standardOptions(i int) *pebble.Options {
 	return opts
 }
 
-func randomOptions(offset int, seed int64) *pebble.Options {
+func randomOptions() *pebble.Options {
 	opts := storage.DefaultPebbleOptions()
 
-	rng := rand.New(rand.NewSource(seed + int64(offset)))
+	rng, _ := randutil.NewTestRand()
 	opts.BytesPerSync = 1 << rngIntRange(rng, 8, 30)
 	opts.FlushSplitBytes = 1 << rng.Intn(20)
 	opts.LBaseMaxBytes = 1 << rngIntRange(rng, 8, 30)

--- a/pkg/storage/metamorphic/options.go
+++ b/pkg/storage/metamorphic/options.go
@@ -1,0 +1,141 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metamorphic
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/pebble"
+)
+
+const numStandardOptions = 18
+const numRandomOptions = 10
+
+func standardOptions(i int) *pebble.Options {
+	stdOpts := []string{
+		0: "", // default options
+		1: `
+[Options]
+  cache_size=1
+`,
+		2: `
+[Options]
+  l0_compaction_threshold=1
+`,
+		3: `
+[Options]
+  l0_compaction_threshold=1
+  l0_stop_writes_threshold=1
+`,
+		4: `
+[Options]
+  lbase_max_bytes=1
+`,
+		5: `
+[Options]
+  max_manifest_file_size=1
+`,
+		6: `
+[Options]
+  max_open_files=1
+`,
+		7: `
+[Options]
+  mem_table_size=1000
+`,
+		8: `
+[Options]
+  mem_table_stop_writes_threshold=2
+`,
+		9: `
+[Options]
+  wal_dir=wal
+`,
+		10: `
+[Level "0"]
+  block_restart_interval=1
+`,
+		11: `
+[Level "0"]
+  block_size=1
+`,
+		12: `
+[Level "0"]
+  compression=NoCompression
+`,
+		13: `
+[Level "0"]
+  index_block_size=1
+`,
+		14: `
+[Level "0"]
+  target_file_size=1
+`,
+		15: `
+[Level "0"]
+  filter_policy=none
+`,
+		// 1GB
+		16: `
+[Options]
+  bytes_per_sync=1073741824
+`,
+		17: `
+[Options]
+  max_concurrent_compactions=2
+`,
+	}
+	if i < 0 || i > len(stdOpts) {
+		panic("invalid index for standard option")
+	}
+	opts := storage.DefaultPebbleOptions()
+	if err := opts.Parse(stdOpts[i], nil); err != nil {
+		panic(err)
+	}
+	return opts
+}
+
+func randomOptions(offset int, seed int64) *pebble.Options {
+	opts := storage.DefaultPebbleOptions()
+
+	rng := rand.New(rand.NewSource(seed + int64(offset)))
+	opts.BytesPerSync = 1 << rngIntRange(rng, 8, 30)
+	opts.FlushSplitBytes = 1 << rng.Intn(20)
+	opts.LBaseMaxBytes = 1 << rngIntRange(rng, 8, 30)
+	opts.L0CompactionThreshold = int(rngIntRange(rng, 1, 10))
+	opts.L0StopWritesThreshold = int(rngIntRange(rng, 1, 32))
+	if opts.L0StopWritesThreshold < opts.L0CompactionThreshold {
+		opts.L0StopWritesThreshold = opts.L0CompactionThreshold
+	}
+	for i := range opts.Levels {
+		if i == 0 {
+			opts.Levels[i].BlockRestartInterval = int(rngIntRange(rng, 1, 64))
+			opts.Levels[i].BlockSize = 1 << rngIntRange(rng, 1, 20)
+			opts.Levels[i].BlockSizeThreshold = int(rngIntRange(rng, 50, 100))
+			opts.Levels[i].IndexBlockSize = opts.Levels[i].BlockSize
+			opts.Levels[i].TargetFileSize = 1 << rngIntRange(rng, 1, 20)
+		} else {
+			opts.Levels[i] = opts.Levels[i-1]
+			opts.Levels[i].TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
+		}
+	}
+	opts.MaxManifestFileSize = 1 << rngIntRange(rng, 1, 28)
+	opts.MaxOpenFiles = int(rngIntRange(rng, 20, 2000))
+	opts.MemTableSize = 1 << rngIntRange(rng, 10, 28)
+	opts.MemTableStopWritesThreshold = int(rngIntRange(rng, 2, 7))
+	opts.MaxConcurrentCompactions = int(rngIntRange(rng, 1, 4))
+
+	opts.Cache = pebble.NewCache(1 << rngIntRange(rng, 1, 30))
+	defer opts.Cache.Unref()
+
+	return opts
+}


### PR DESCRIPTION
This PR contains the following major changes (all in separate commits):

1) A move from on-disk to memFS and a move from 1,000 operations per run to 100,000 to take advantage of the faster performance of memFS
2) Addition of savepoints and txn aborts
3) A move from 2 standard 1 random configs to 18 standard and 10 random configs

Implements a large part of #70935, but not all of it. Remaining changes will be
in a future PR.

Fallout of discussion in #69891.

Release notes: None.