### PR TITLE
roachtest: skip the follower-reads suite

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -50,6 +50,7 @@ func registerFollowerReads(r registry.Registry) {
 			name = name + "/insufficient-quorum"
 		}
 		r.Add(registry.TestSpec{
+			Skip:  "https://github.com/cockroachdb/cockroach/issues/69817",
 			Name:  name,
 			Owner: registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(
@@ -89,6 +90,7 @@ func registerFollowerReads(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
+		Skip:  "https://github.com/cockroachdb/cockroach/issues/69817",
 		Name:  "follower-reads/mixed-version/single-region",
 		Owner: registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(


### PR DESCRIPTION
This commit skips the follower-reads suite of roachtests until
https://github.com/cockroachdb/cockroach/issues/69817 is fixed.

Release note: None