### PR TITLE
sql: display limit hint for EXPLAIN when limit hint is nonzero

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1243,7 +1243,7 @@ LIMIT 1] OFFSET 2
                 │   │   └── • scan
                 │   │         columns: (a, b)
                 │   │         ordering: +a,+b
-                │   │         estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
+                │   │         estimated row count: 4 - 333,334 (33% of the table; stats collected <hidden> ago)
                 │   │         table: t56201@key_a_b
                 │   │         spans: /"@"/!NULL-/"@"/PrefixEnd
                 │   │
@@ -1256,7 +1256,7 @@ LIMIT 1] OFFSET 2
                 │       └── • scan
                 │             columns: (a, b)
                 │             ordering: +a,+b
-                │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
+                │             estimated row count: 4 - 333,334 (33% of the table; stats collected <hidden> ago)
                 │             table: t56201@key_a_b
                 │             spans: /"\x80"/!NULL-/"\x80"/PrefixEnd
                 │
@@ -1269,7 +1269,7 @@ LIMIT 1] OFFSET 2
                     └── • scan
                           columns: (a, b)
                           ordering: +a,+b
-                          estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
+                          estimated row count: 4 - 333,334 (33% of the table; stats collected <hidden> ago)
                           table: t56201@key_a_b
                           spans: /"\xc0"/!NULL-/"\xc0"/PrefixEnd
 
@@ -1323,21 +1323,21 @@ LIMIT 1] OFFSET 2
                     │   ├── • scan
                     │   │     columns: (b, crdb_region, rowid)
                     │   │     ordering: +b
-                    │   │     estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                    │   │     estimated row count: 3 - 111,112 (11% of the table; stats collected <hidden> ago)
                     │   │     table: t56201@key_b_partial (partial index)
                     │   │     spans: /"@"/!NULL-/"@"/PrefixEnd
                     │   │
                     │   └── • scan
                     │         columns: (b, crdb_region, rowid)
                     │         ordering: +b
-                    │         estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                    │         estimated row count: 3 - 111,112 (11% of the table; stats collected <hidden> ago)
                     │         table: t56201@key_b_partial (partial index)
                     │         spans: /"\x80"/!NULL-/"\x80"/PrefixEnd
                     │
                     └── • scan
                           columns: (b, crdb_region, rowid)
                           ordering: +b
-                          estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                          estimated row count: 3 - 111,112 (11% of the table; stats collected <hidden> ago)
                           table: t56201@key_b_partial (partial index)
                           spans: /"\xc0"/!NULL-/"\xc0"/PrefixEnd
 
@@ -1387,21 +1387,21 @@ LIMIT 1] OFFSET 2
                 │   ├── • scan
                 │   │     columns: (c)
                 │   │     ordering: +c
-                │   │     estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                │   │     estimated row count: 4 - 111,112 (11% of the table; stats collected <hidden> ago)
                 │   │     table: t56201@key_c_partial (partial index)
                 │   │     spans: /"@"-/"@"/PrefixEnd
                 │   │
                 │   └── • scan
                 │         columns: (c)
                 │         ordering: +c
-                │         estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                │         estimated row count: 4 - 111,112 (11% of the table; stats collected <hidden> ago)
                 │         table: t56201@key_c_partial (partial index)
                 │         spans: /"\x80"-/"\x80"/PrefixEnd
                 │
                 └── • scan
                       columns: (c)
                       ordering: +c
-                      estimated row count: 111,111 (11% of the table; stats collected <hidden> ago)
+                      estimated row count: 4 - 111,112 (11% of the table; stats collected <hidden> ago)
                       table: t56201@key_c_partial (partial index)
                       spans: /"\xc0"-/"\xc0"/PrefixEnd
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -382,6 +382,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 					val.TableStatsRowCount = 1
 				}
 				val.TableStatsCreatedAt = stat.CreatedAt()
+				val.LimitHint = scan.RequiredPhysical().LimitHint
 			}
 		}
 		ef.AnnotateNode(ep.root, exec.EstimatedStatsID, &val)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -490,3 +490,70 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: t@primary
       spans: FULL SCAN
+
+
+
+statement ok
+CREATE TABLE a AS (SELECT i, i AS j FROM generate_series(0, 1000) AS gen(i));
+
+statement ok
+CREATE INDEX ON a (i, j);
+
+statement ok
+CREATE TABLE b AS SELECT k, k::STRING AS s FROM generate_series(0, 99) AS gen(k);
+
+statement ok
+CREATE INDEX ON b (k, s);
+
+statement ok
+ANALYZE a;
+
+statement ok
+ANALYZE b;
+
+query T
+EXPLAIN ANALYZE SELECT * FROM a INNER LOOKUP JOIN b ON k = j ORDER BY i LIMIT 5;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 176 (1.4 KiB)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+·
+• limit
+│ nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 5
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows read: 76
+│ KV bytes read: 608 B
+│ estimated row count: 5
+│ count: 5
+│
+└── • lookup join
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 5
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows read: 76
+    │ KV bytes read: 608 B
+    │ estimated row count: 100
+    │ table: b@b_k_s_idx
+    │ equality: (j) = (k)
+    │
+    └── • scan
+          nodes: <hidden>
+          regions: <hidden>
+          actual row count: 100
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows read: 100
+          KV bytes read: 800 B
+          estimated row count: 100 - 1,001 (100% of the table; stats collected <hidden> ago)
+          table: a@a_i_j_idx
+          spans: FULL SCAN

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -304,6 +304,9 @@ type EstimatedStats struct {
 	// Cost is the estimated cost of the operator. This cost includes the costs of
 	// the child operators.
 	Cost float64
+	// LimitHint is the "soft limit" of the number of result rows that may be
+	// required. See physical.Required for details.
+	LimitHint float64
 }
 
 // ExecutionStats contain statistics about a given operator gathered from the


### PR DESCRIPTION
Previously, the EXPLAIN output only included the estimated
row count but not the limit hint. This could lead to confusions
when the actual output row count is significantly less than the
estimated row count due to the limit hint.
This commit displays the limit hint for EXPLAIN output as
part of the 'estimated row count' field when the limit hint
is greater than zero.

Example output:

```
estimated row count: 100 - 1,001 (100% of the table; sta....
```

Resolves #69564

Release note (sql change): EXPLAIN output now displays limit hint
when limit hint is nonzero as part of the 'estimated row count' field.