### PR TITLE
testcluster: reword a comment

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -121,12 +121,12 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 		tc.stopServerLocked(i)
 	}
 
-	// TODO(irfansharif): Instead of checking for empty tracing registries after
-	// shutting down each node, we're doing it after shutting down all nodes.
-	// This is because TestCluster share the same Tracer object. Perhaps a saner
-	// thing to do is to separate out individual TestServers entirely. The
-	// component sharing within TestCluster has bitten in the past as well, and
-	// it's not clear why it has to be this way.
+	// TODO(andrei): Instead of checking for empty tracing registries after
+	// shutting down each node, we're doing it after shutting down all nodes. This
+	// is because all the nodes might share the same cluster (in case the Tracer
+	// was passed in at cluster creation time). We should not allow the Tracer to
+	// be passed in like this, and we should then also added this registry
+	// draining check to individual TestServers.
 	for i := 0; i < tc.NumServers(); i++ {
 		// Wait until a server's span registry is emptied out. This helps us check
 		// to see that there are no un-Finish()ed spans. We need to wrap this in a


### PR DESCRIPTION
This comment spoke about how servers in a TestCluster share the Tracer.
That's become much rarer in #71108, once we've severed the link between
the Settings and the Tracer. This patch changes the color of the
comment.

Release note: None