### PR TITLE
cfetcher: operate on the typed columns rather than untyped Vecs

### DIFF
--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
 )
 
 // Workaround for bazel auto-generated code. goimports does not automatically
@@ -27,7 +29,145 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
+	_ = colexecerror.InternalError
+	_ = errors.AssertionFailedf
 )
+
+// TypedVecs represents a slice of Vecs that have been converted into the typed
+// columns. The idea is that every Vec is stored both in Vecs slice as well as
+// in the typed slice, in order. Components that know the type of the vector
+// they are working with can then access the typed column directly, avoiding
+// expensive type casts.
+type TypedVecs struct {
+	Vecs  []Vec
+	Nulls []*Nulls
+
+	// Fields below need to be accessed by an index mapped via ColsMap.
+	BoolCols      []Bools
+	BytesCols     []*Bytes
+	DecimalCols   []Decimals
+	Int16Cols     []Int16s
+	Int32Cols     []Int32s
+	Int64Cols     []Int64s
+	Float64Cols   []Float64s
+	TimestampCols []Times
+	IntervalCols  []Durations
+	JSONCols      []*JSONs
+	DatumCols     []DatumVec
+	// ColsMap contains the positions of the corresponding vectors in the slice
+	// for the same types. For example, if we have a batch with
+	//   types = [Int64, Int64, Bool, Bytes, Bool, Int64],
+	// then ColsMap will be
+	//                      [0, 1, 0, 0, 1, 2]
+	//                       ^  ^  ^  ^  ^  ^
+	//                       |  |  |  |  |  |
+	//                       |  |  |  |  |  3rd among all Int64's
+	//                       |  |  |  |  2nd among all Bool's
+	//                       |  |  |  1st among all Bytes's
+	//                       |  |  1st among all Bool's
+	//                       |  2nd among all Int64's
+	//                       1st among all Int64's
+	ColsMap []int
+}
+
+// SetBatch updates TypedVecs to represent all vectors from batch.
+func (v *TypedVecs) SetBatch(batch Batch) {
+	v.Vecs = batch.ColVecs()
+	if cap(v.Nulls) < len(v.Vecs) {
+		v.Nulls = make([]*Nulls, len(v.Vecs))
+		v.ColsMap = make([]int, len(v.Vecs))
+	} else {
+		v.Nulls = v.Nulls[:len(v.Vecs)]
+		v.ColsMap = v.ColsMap[:len(v.Vecs)]
+	}
+	v.BoolCols = v.BoolCols[:0]
+	v.BytesCols = v.BytesCols[:0]
+	v.DecimalCols = v.DecimalCols[:0]
+	v.Int16Cols = v.Int16Cols[:0]
+	v.Int32Cols = v.Int32Cols[:0]
+	v.Int64Cols = v.Int64Cols[:0]
+	v.Float64Cols = v.Float64Cols[:0]
+	v.TimestampCols = v.TimestampCols[:0]
+	v.IntervalCols = v.IntervalCols[:0]
+	v.JSONCols = v.JSONCols[:0]
+	v.DatumCols = v.DatumCols[:0]
+	for i, vec := range v.Vecs {
+		v.Nulls[i] = vec.Nulls()
+		switch vec.CanonicalTypeFamily() {
+		case types.BoolFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.BoolCols)
+				v.BoolCols = append(v.BoolCols, vec.Bool())
+			}
+		case types.BytesFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.BytesCols)
+				v.BytesCols = append(v.BytesCols, vec.Bytes())
+			}
+		case types.DecimalFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.DecimalCols)
+				v.DecimalCols = append(v.DecimalCols, vec.Decimal())
+			}
+		case types.IntFamily:
+			switch vec.Type().Width() {
+			case 16:
+				v.ColsMap[i] = len(v.Int16Cols)
+				v.Int16Cols = append(v.Int16Cols, vec.Int16())
+			case 32:
+				v.ColsMap[i] = len(v.Int32Cols)
+				v.Int32Cols = append(v.Int32Cols, vec.Int32())
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.Int64Cols)
+				v.Int64Cols = append(v.Int64Cols, vec.Int64())
+			}
+		case types.FloatFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.Float64Cols)
+				v.Float64Cols = append(v.Float64Cols, vec.Float64())
+			}
+		case types.TimestampTZFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.TimestampCols)
+				v.TimestampCols = append(v.TimestampCols, vec.Timestamp())
+			}
+		case types.IntervalFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.IntervalCols)
+				v.IntervalCols = append(v.IntervalCols, vec.Interval())
+			}
+		case types.JsonFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.JSONCols)
+				v.JSONCols = append(v.JSONCols, vec.JSON())
+			}
+		case typeconv.DatumVecCanonicalTypeFamily:
+			switch vec.Type().Width() {
+			case -1:
+			default:
+				v.ColsMap[i] = len(v.DatumCols)
+				v.DatumCols = append(v.DatumCols, vec.Datum())
+			}
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", vec.Type()))
+		}
+	}
+}
 
 func (m *memColumn) Append(args SliceArgs) {
 	switch m.CanonicalTypeFamily() {

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -169,6 +169,47 @@ func (v *TypedVecs) SetBatch(batch Batch) {
 	}
 }
 
+// Reset performs a deep reset of v while keeping the references to the slices.
+func (v *TypedVecs) Reset() {
+	v.Vecs = nil
+	for i := range v.Nulls {
+		v.Nulls[i] = nil
+	}
+	for i := range v.BoolCols {
+		v.BoolCols[i] = nil
+	}
+	for i := range v.BytesCols {
+		v.BytesCols[i] = nil
+	}
+	for i := range v.DecimalCols {
+		v.DecimalCols[i] = nil
+	}
+	for i := range v.Int16Cols {
+		v.Int16Cols[i] = nil
+	}
+	for i := range v.Int32Cols {
+		v.Int32Cols[i] = nil
+	}
+	for i := range v.Int64Cols {
+		v.Int64Cols[i] = nil
+	}
+	for i := range v.Float64Cols {
+		v.Float64Cols[i] = nil
+	}
+	for i := range v.TimestampCols {
+		v.TimestampCols[i] = nil
+	}
+	for i := range v.IntervalCols {
+		v.IntervalCols[i] = nil
+	}
+	for i := range v.JSONCols {
+		v.JSONCols[i] = nil
+	}
+	for i := range v.DatumCols {
+		v.DatumCols[i] = nil
+	}
+}
+
 func (m *memColumn) Append(args SliceArgs) {
 	switch m.CanonicalTypeFamily() {
 	case types.BoolFamily:

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -123,6 +123,21 @@ func (v *TypedVecs) SetBatch(batch Batch) {
 	}
 }
 
+// Reset performs a deep reset of v while keeping the references to the slices.
+func (v *TypedVecs) Reset() {
+	v.Vecs = nil
+	for i := range v.Nulls {
+		v.Nulls[i] = nil
+	}
+	// {{range .}}
+	// {{range .WidthOverloads}}
+	for i := range v._TYPECols {
+		v._TYPECols[i] = nil
+	}
+	// {{end}}
+	// {{end}}
+}
+
 func (m *memColumn) Append(args SliceArgs) {
 	switch m.CanonicalTypeFamily() {
 	// {{range .}}

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -27,9 +27,11 @@ import (
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
 )
 
 // Workaround for bazel auto-generated code. goimports does not automatically
@@ -39,6 +41,8 @@ var (
 	_ apd.Context
 	_ duration.Duration
 	_ json.JSON
+	_ = colexecerror.InternalError
+	_ = errors.AssertionFailedf
 )
 
 // {{/*
@@ -53,6 +57,71 @@ const _CANONICAL_TYPE_FAMILY = types.UnknownFamily
 const _TYPE_WIDTH = 0
 
 // */}}
+
+// TypedVecs represents a slice of Vecs that have been converted into the typed
+// columns. The idea is that every Vec is stored both in Vecs slice as well as
+// in the typed slice, in order. Components that know the type of the vector
+// they are working with can then access the typed column directly, avoiding
+// expensive type casts.
+type TypedVecs struct {
+	Vecs  []Vec
+	Nulls []*Nulls
+
+	// Fields below need to be accessed by an index mapped via ColsMap.
+	// {{range .}}
+	// {{range .WidthOverloads}}
+	_TYPECols []_GOTYPESLICE
+	// {{end}}
+	// {{end}}
+	// ColsMap contains the positions of the corresponding vectors in the slice
+	// for the same types. For example, if we have a batch with
+	//   types = [Int64, Int64, Bool, Bytes, Bool, Int64],
+	// then ColsMap will be
+	//                      [0, 1, 0, 0, 1, 2]
+	//                       ^  ^  ^  ^  ^  ^
+	//                       |  |  |  |  |  |
+	//                       |  |  |  |  |  3rd among all Int64's
+	//                       |  |  |  |  2nd among all Bool's
+	//                       |  |  |  1st among all Bytes's
+	//                       |  |  1st among all Bool's
+	//                       |  2nd among all Int64's
+	//                       1st among all Int64's
+	ColsMap []int
+}
+
+// SetBatch updates TypedVecs to represent all vectors from batch.
+func (v *TypedVecs) SetBatch(batch Batch) {
+	v.Vecs = batch.ColVecs()
+	if cap(v.Nulls) < len(v.Vecs) {
+		v.Nulls = make([]*Nulls, len(v.Vecs))
+		v.ColsMap = make([]int, len(v.Vecs))
+	} else {
+		v.Nulls = v.Nulls[:len(v.Vecs)]
+		v.ColsMap = v.ColsMap[:len(v.Vecs)]
+	}
+	// {{range .}}
+	// {{range .WidthOverloads}}
+	v._TYPECols = v._TYPECols[:0]
+	// {{end}}
+	// {{end}}
+	for i, vec := range v.Vecs {
+		v.Nulls[i] = vec.Nulls()
+		switch vec.CanonicalTypeFamily() {
+		// {{range .}}
+		case _CANONICAL_TYPE_FAMILY:
+			switch vec.Type().Width() {
+			// {{range .WidthOverloads}}
+			case _TYPE_WIDTH:
+				v.ColsMap[i] = len(v._TYPECols)
+				v._TYPECols = append(v._TYPECols, vec.TemplateType())
+				// {{end}}
+			}
+		// {{end}}
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", vec.Type()))
+		}
+	}
+}
 
 func (m *memColumn) Append(args SliceArgs) {
 	switch m.CanonicalTypeFamily() {

--- a/pkg/col/coldatatestutils/BUILD.bazel
+++ b/pkg/col/coldatatestutils/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/json",
         "//pkg/util/timeutil",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -91,10 +92,14 @@ func RandomVec(args RandomVecArgs) {
 		}
 	case types.BytesFamily:
 		bytes := args.Vec.Bytes()
+		isUUID := args.Vec.Type().Family() == types.UuidFamily
 		for i := 0; i < args.N; i++ {
 			bytesLen := args.BytesFixedLength
 			if bytesLen <= 0 {
 				bytesLen = args.Rand.Intn(maxVarLen)
+			}
+			if isUUID {
+				bytesLen = uuid.Size
 			}
 			randBytes := make([]byte, bytesLen)
 			// Read always returns len(bytes[i]) and nil.

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -28,7 +28,7 @@ import (
 )
 
 // DecodeKeyValsToCols decodes the values that are part of the key, writing the
-// result to the idx'th slot of the input slice of coldata.Vecs.
+// result to the rowIdx'th row in coldata.TypedVecs.
 //
 // If the unseen int set is non-nil, upon decoding the column with ordinal i,
 // i will be removed from the set to facilitate tracking whether or not columns
@@ -44,8 +44,8 @@ import (
 // should be decoded.
 func DecodeKeyValsToCols(
 	da *rowenc.DatumAlloc,
-	vecs []coldata.Vec,
-	idx int,
+	vecs *coldata.TypedVecs,
+	rowIdx int,
 	indexColIdx []int,
 	checkAllColsForNull bool,
 	types []*types.T,
@@ -57,8 +57,8 @@ func DecodeKeyValsToCols(
 ) (remainingKey []byte, foundNull bool, retScratch []byte, _ error) {
 	for j := range types {
 		var err error
-		i := indexColIdx[j]
-		if i == -1 {
+		vecIdx := indexColIdx[j]
+		if vecIdx == -1 {
 			if checkAllColsForNull {
 				isNull := encoding.PeekType(key) == encoding.Null
 				foundNull = foundNull || isNull
@@ -67,11 +67,11 @@ func DecodeKeyValsToCols(
 			key, err = rowenc.SkipTableKey(key)
 		} else {
 			if unseen != nil {
-				unseen.Remove(i)
+				unseen.Remove(vecIdx)
 			}
 			var isNull bool
-			isInverted := invertedColIdx == i
-			key, isNull, scratch, err = decodeTableKeyToCol(da, vecs[i], idx, types[j], key, directions[j], isInverted, scratch)
+			isInverted := invertedColIdx == vecIdx
+			key, isNull, scratch, err = decodeTableKeyToCol(da, vecs, vecIdx, rowIdx, types[j], key, directions[j], isInverted, scratch)
 			foundNull = isNull || foundNull
 		}
 		if err != nil {
@@ -81,14 +81,15 @@ func DecodeKeyValsToCols(
 	return key, foundNull, scratch, nil
 }
 
-// decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the result
-// to the idx'th slot of the input colexec.Vec.
-// See the analog, DecodeTableKey, in sqlbase/column_type_encoding.go.
+// decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the
+// result to the rowIdx'th slot of the vecIdx'th vector in coldata.TypedVecs.
+// See the analog, rowenc.DecodeTableKey, in rowenc/column_type_encoding.go.
 // decodeTableKeyToCol also returns whether or not the decoded value was NULL.
 func decodeTableKeyToCol(
 	da *rowenc.DatumAlloc,
-	vec coldata.Vec,
-	idx int,
+	vecs *coldata.TypedVecs,
+	vecIdx int,
+	rowIdx int,
 	valType *types.T,
 	key []byte,
 	dir descpb.IndexDescriptor_Direction,
@@ -100,9 +101,13 @@ func decodeTableKeyToCol(
 	}
 	var isNull bool
 	if key, isNull = encoding.DecodeIfNull(key); isNull {
-		vec.Nulls().SetNull(idx)
+		vecs.Nulls[vecIdx].SetNull(rowIdx)
 		return key, true, scratch, nil
 	}
+
+	// Find the position of the target vector among the typed columns of its
+	// type.
+	colIdx := vecs.ColsMap[vecIdx]
 
 	// Inverted columns should not be decoded, but should instead be
 	// passed on as a DBytes datum.
@@ -111,7 +116,7 @@ func decodeTableKeyToCol(
 		if err != nil {
 			return nil, false, scratch, err
 		}
-		vec.Bytes().Set(idx, key[:keyLen])
+		vecs.BytesCols[colIdx].Set(rowIdx, key[:keyLen])
 		return key[keyLen:], false, scratch, nil
 	}
 
@@ -125,7 +130,7 @@ func decodeTableKeyToCol(
 		} else {
 			rkey, i, err = encoding.DecodeVarintDescending(key)
 		}
-		vec.Bool()[idx] = i != 0
+		vecs.BoolCols[colIdx][rowIdx] = i != 0
 	case types.IntFamily, types.DateFamily:
 		var i int64
 		if dir == descpb.IndexDescriptor_ASC {
@@ -135,11 +140,11 @@ func decodeTableKeyToCol(
 		}
 		switch valType.Width() {
 		case 16:
-			vec.Int16()[idx] = int16(i)
+			vecs.Int16Cols[colIdx][rowIdx] = int16(i)
 		case 32:
-			vec.Int32()[idx] = int32(i)
+			vecs.Int32Cols[colIdx][rowIdx] = int32(i)
 		case 0, 64:
-			vec.Int64()[idx] = i
+			vecs.Int64Cols[colIdx][rowIdx] = i
 		}
 	case types.FloatFamily:
 		var f float64
@@ -148,7 +153,7 @@ func decodeTableKeyToCol(
 		} else {
 			rkey, f, err = encoding.DecodeFloatDescending(key)
 		}
-		vec.Float64()[idx] = f
+		vecs.Float64Cols[colIdx][rowIdx] = f
 	case types.DecimalFamily:
 		var d apd.Decimal
 		if dir == descpb.IndexDescriptor_ASC {
@@ -156,7 +161,7 @@ func decodeTableKeyToCol(
 		} else {
 			rkey, d, err = encoding.DecodeDecimalDescending(key, scratch[:0])
 		}
-		vec.Decimal()[idx] = d
+		vecs.DecimalCols[colIdx][rowIdx] = d
 	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		if dir == descpb.IndexDescriptor_ASC {
 			// We ask for the deep copy to be made so that scratch doesn't
@@ -171,7 +176,7 @@ func decodeTableKeyToCol(
 		// Set() performs a deep copy, so it is safe to return the scratch slice
 		// to the caller. Any modifications to the scratch slice made by the
 		// caller will not affect the value in the vector.
-		vec.Bytes().Set(idx, scratch)
+		vecs.BytesCols[colIdx].Set(rowIdx, scratch)
 	case types.TimestampFamily, types.TimestampTZFamily:
 		var t time.Time
 		if dir == descpb.IndexDescriptor_ASC {
@@ -179,7 +184,7 @@ func decodeTableKeyToCol(
 		} else {
 			rkey, t, err = encoding.DecodeTimeDescending(key)
 		}
-		vec.Timestamp()[idx] = t
+		vecs.TimestampCols[colIdx][rowIdx] = t
 	case types.IntervalFamily:
 		var d duration.Duration
 		if dir == descpb.IndexDescriptor_ASC {
@@ -187,13 +192,13 @@ func decodeTableKeyToCol(
 		} else {
 			rkey, d, err = encoding.DecodeDurationDescending(key)
 		}
-		vec.Interval()[idx] = d
+		vecs.IntervalCols[colIdx][rowIdx] = d
 	case types.JsonFamily:
 		// Don't attempt to decode the JSON value. Instead, just return the
 		// remaining bytes of the key.
 		var jsonLen int
 		jsonLen, err = encoding.PeekLength(key)
-		vec.JSON().Bytes.Set(idx, key[:jsonLen])
+		vecs.JSONCols[colIdx].Bytes.Set(rowIdx, key[:jsonLen])
 		rkey = key[jsonLen:]
 	default:
 		var d tree.Datum
@@ -202,68 +207,77 @@ func decodeTableKeyToCol(
 			encDir = encoding.Descending
 		}
 		d, rkey, err = rowenc.DecodeTableKey(da, valType, key, encDir)
-		vec.Datum().Set(idx, d)
+		vecs.DatumCols[colIdx].Set(rowIdx, d)
 	}
 	return rkey, false, scratch, err
 }
 
 // UnmarshalColumnValueToCol decodes the value from a roachpb.Value using the
-// type expected by the column, writing into the input Vec at the given row
-// idx. An error is returned if the value's type does not match the column's
-// type.
-// See the analog, UnmarshalColumnValue, in sqlbase/column_type_encoding.go
+// type expected by the column, writing into the vecIdx'th vector of
+// coldata.TypedVecs at the given rowIdx. An error is returned if the value's
+// type does not match the column's type.
+// See the analog, rowenc.UnmarshalColumnValue, in
+// rowenc/column_type_encoding.go.
 func UnmarshalColumnValueToCol(
-	da *rowenc.DatumAlloc, vec coldata.Vec, idx int, typ *types.T, value roachpb.Value,
+	da *rowenc.DatumAlloc,
+	vecs *coldata.TypedVecs,
+	vecIdx, rowIdx int,
+	typ *types.T,
+	value roachpb.Value,
 ) error {
 	if value.RawBytes == nil {
-		vec.Nulls().SetNull(idx)
+		vecs.Nulls[vecIdx].SetNull(rowIdx)
 	}
+
+	// Find the position of the target vector among the typed columns of its
+	// type.
+	colIdx := vecs.ColsMap[vecIdx]
 
 	var err error
 	switch typ.Family() {
 	case types.BoolFamily:
 		var v bool
 		v, err = value.GetBool()
-		vec.Bool()[idx] = v
+		vecs.BoolCols[colIdx][rowIdx] = v
 	case types.IntFamily:
 		var v int64
 		v, err = value.GetInt()
 		switch typ.Width() {
 		case 16:
-			vec.Int16()[idx] = int16(v)
+			vecs.Int16Cols[colIdx][rowIdx] = int16(v)
 		case 32:
-			vec.Int32()[idx] = int32(v)
+			vecs.Int32Cols[colIdx][rowIdx] = int32(v)
 		default:
 			// Pre-2.1 BIT was using INT encoding with arbitrary sizes.
 			// We map these to 64-bit INT now. See #34161.
-			vec.Int64()[idx] = v
+			vecs.Int64Cols[colIdx][rowIdx] = v
 		}
 	case types.FloatFamily:
 		var v float64
 		v, err = value.GetFloat()
-		vec.Float64()[idx] = v
+		vecs.Float64Cols[colIdx][rowIdx] = v
 	case types.DecimalFamily:
-		err = value.GetDecimalInto(&vec.Decimal()[idx])
+		err = value.GetDecimalInto(&vecs.DecimalCols[colIdx][rowIdx])
 	case types.BytesFamily, types.StringFamily, types.UuidFamily:
 		var v []byte
 		v, err = value.GetBytes()
-		vec.Bytes().Set(idx, v)
+		vecs.BytesCols[colIdx].Set(rowIdx, v)
 	case types.DateFamily:
 		var v int64
 		v, err = value.GetInt()
-		vec.Int64()[idx] = v
+		vecs.Int64Cols[colIdx][rowIdx] = v
 	case types.TimestampFamily, types.TimestampTZFamily:
 		var v time.Time
 		v, err = value.GetTime()
-		vec.Timestamp()[idx] = v
+		vecs.TimestampCols[colIdx][rowIdx] = v
 	case types.IntervalFamily:
 		var v duration.Duration
 		v, err = value.GetDuration()
-		vec.Interval()[idx] = v
+		vecs.IntervalCols[colIdx][rowIdx] = v
 	case types.JsonFamily:
 		var v []byte
 		v, err = value.GetBytes()
-		vec.JSON().Bytes.Set(idx, v)
+		vecs.JSONCols[colIdx].Bytes.Set(rowIdx, v)
 	// Types backed by tree.Datums.
 	default:
 		var d tree.Datum
@@ -271,7 +285,7 @@ func UnmarshalColumnValueToCol(
 		if err != nil {
 			return err
 		}
-		vec.Datum().Set(idx, d)
+		vecs.DatumCols[colIdx].Set(rowIdx, d)
 	}
 	return err
 }

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -45,13 +45,17 @@ func TestDecodeTableValueToCol(t *testing.T) {
 		}
 	}
 	batch := coldata.NewMemBatchWithCapacity(typs, 1 /* capacity */, coldataext.NewExtendedColumnFactory(nil /*evalCtx */))
+	var vecs coldata.TypedVecs
+	vecs.SetBatch(batch)
 	for i := 0; i < nCols; i++ {
 		typeOffset, dataOffset, _, typ, err := encoding.DecodeValueTag(buf)
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf, err = DecodeTableValueToCol(&da, batch.ColVec(i), 0 /* rowIdx */, typ,
-			dataOffset, typs[i], buf[typeOffset:])
+		buf, err = DecodeTableValueToCol(
+			&da, &vecs, i /* vecIdx */, 0 /* rowIdx */, typ,
+			dataOffset, typs[i], buf[typeOffset:],
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/colexec/execgen/cmd/execgen/ordered_synchronizer_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/ordered_synchronizer_gen.go
@@ -22,10 +22,8 @@ const ordSyncTmpl = "pkg/sql/colexec/ordered_synchronizer_tmpl.go"
 
 func genOrderedSynchronizer(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
-
 		"_CANONICAL_TYPE_FAMILY", "{{.CanonicalTypeFamilyStr}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
-		"_GOTYPESLICE", "{{.GoTypeSliceName}}",
 		"_TYPE", "{{.VecMethod}}",
 	)
 	s := r.Replace(inputFileContents)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -449,6 +449,13 @@ func (b *argWidthOverloadBase) GoTypeSliceName() string {
 	return goTypeSliceName(b.CanonicalTypeFamily, b.Width)
 }
 
+// GoTypeSliceNameInColdata is the same as GoTypeSliceName, but it removes the
+// "coldata." substring (and, thus, can be used by a template in coldata
+// package).
+func (b *argWidthOverloadBase) GoTypeSliceNameInColdata() string {
+	return strings.Replace(b.GoTypeSliceName(), "coldata.", "", -1)
+}
+
 func copyVal(canonicalTypeFamily types.Family, dest, src string) string {
 	switch canonicalTypeFamily {
 	case types.BytesFamily:
@@ -595,6 +602,7 @@ var (
 
 	awob = &argWidthOverloadBase{}
 	_    = awob.GoTypeSliceName
+	_    = awob.GoTypeSliceNameInColdata
 	_    = awob.CopyVal
 	_    = awob.Sliceable
 	_    = awob.AppendSlice

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_gen.go
@@ -23,7 +23,9 @@ const vecTmpl = "pkg/col/coldata/vec_tmpl.go"
 func genVec(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer("_CANONICAL_TYPE_FAMILY", "{{.CanonicalTypeFamilyStr}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
+		"_GOTYPESLICE", "{{.GoTypeSliceNameInColdata}}",
 		"_GOTYPE", "{{.GoType}}",
+		"_TYPE", "{{.VecMethod}}",
 		"TemplateType", "{{.VecMethod}}",
 	)
 	s := r.Replace(inputFileContents)

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
+        "//pkg/col/coldatatestutils",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -29,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -295,16 +299,81 @@ func benchmarkWriteType(b *testing.B, d tree.Datum, format pgwirebase.FormatCode
 	}
 }
 
+func benchmarkWriteColumnar(b *testing.B, batch coldata.Batch, format pgwirebase.FormatCode) {
+	ctx := context.Background()
+
+	buf := newWriteBuffer(nil /* bytecount */)
+	buf.bytecount = metric.NewCounter(metric.Metadata{Name: ""})
+
+	writeMethod := func(ctx context.Context, batch coldata.Batch, loc *time.Location) {
+		defaultConv, _ := makeTestingConvCfg()
+		for rowIdx := 0; rowIdx < batch.Length(); rowIdx++ {
+			buf.writeTextColumnarElement(ctx, batch.ColVec(0), rowIdx, defaultConv, loc)
+		}
+	}
+	if format == pgwirebase.FormatBinary {
+		writeMethod = func(ctx context.Context, batch coldata.Batch, loc *time.Location) {
+			for rowIdx := 0; rowIdx < batch.Length(); rowIdx++ {
+				buf.writeBinaryColumnarElement(ctx, batch.ColVec(0), rowIdx, loc)
+			}
+		}
+	}
+
+	// Warm up the buffer.
+	writeMethod(ctx, batch, nil)
+	buf.wrapped.Reset()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Starting and stopping the timer in each loop iteration causes this
+		// to take much longer. See http://stackoverflow.com/a/37624250/3435257.
+		// buf.wrapped.Reset() should be fast enough to be negligible.
+		writeMethod(ctx, batch, nil)
+		if buf.err != nil {
+			b.Fatal(buf.err)
+		}
+		buf.wrapped.Reset()
+	}
+}
+
+// getBatch returns a batch with a single vector of the provided type,
+// coldata.BatchSize() in length.
+func getBatch(t *types.T) coldata.Batch {
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	batch := coldata.NewMemBatch([]*types.T{t}, coldataext.NewExtendedColumnFactory(&evalCtx))
+	rng, _ := randutil.NewTestRand()
+	coldatatestutils.RandomVec(coldatatestutils.RandomVecArgs{
+		Rand:             rng,
+		Vec:              batch.ColVec(0),
+		N:                coldata.BatchSize(),
+		BytesFixedLength: 8,
+	})
+	batch.SetLength(coldata.BatchSize())
+	return batch
+}
+
 func benchmarkWriteBool(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.DBoolTrue, format)
+}
+
+func benchmarkWriteColumnarBool(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Bool), format)
 }
 
 func benchmarkWriteInt(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDInt(1234), format)
 }
 
+func benchmarkWriteColumnarInt(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Int), format)
+}
+
 func benchmarkWriteFloat(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDFloat(12.34), format)
+}
+
+func benchmarkWriteColumnarFloat(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Float), format)
 }
 
 func benchmarkWriteDecimal(b *testing.B, format pgwirebase.FormatCode) {
@@ -316,8 +385,16 @@ func benchmarkWriteDecimal(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, dec, pgwirebase.FormatText)
 }
 
+func benchmarkWriteColumnarDecimal(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Decimal), format)
+}
+
 func benchmarkWriteBytes(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDBytes("testing"), format)
+}
+
+func benchmarkWriteColumnarBytes(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Bytes), format)
 }
 
 func benchmarkWriteUUID(b *testing.B, format pgwirebase.FormatCode) {
@@ -325,8 +402,16 @@ func benchmarkWriteUUID(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDUuid(tree.DUuid{UUID: u}), format)
 }
 
+func benchmarkWriteColumnarUUID(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Uuid), format)
+}
+
 func benchmarkWriteString(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tree.NewDString("testing"), format)
+}
+
+func benchmarkWriteColumnarString(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.String), format)
 }
 
 func benchmarkWriteDate(b *testing.B, format pgwirebase.FormatCode) {
@@ -337,12 +422,20 @@ func benchmarkWriteDate(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, d, format)
 }
 
+func benchmarkWriteColumnarDate(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Date), format)
+}
+
 func benchmarkWriteTimestamp(b *testing.B, format pgwirebase.FormatCode) {
 	ts, _, err := tree.ParseDTimestamp(nil, "2010-09-28 12:00:00.1", time.Microsecond)
 	if err != nil {
 		b.Fatal(err)
 	}
 	benchmarkWriteType(b, ts, format)
+}
+
+func benchmarkWriteColumnarTimestamp(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Timestamp), format)
 }
 
 func benchmarkWriteTimestampTZ(b *testing.B, format pgwirebase.FormatCode) {
@@ -353,12 +446,20 @@ func benchmarkWriteTimestampTZ(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, tstz, format)
 }
 
+func benchmarkWriteColumnarTimestampTZ(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.TimestampTZ), format)
+}
+
 func benchmarkWriteInterval(b *testing.B, format pgwirebase.FormatCode) {
 	i, err := tree.ParseDInterval(duration.IntervalStyle_POSTGRES, "PT12H2M")
 	if err != nil {
 		b.Fatal(err)
 	}
 	benchmarkWriteType(b, i, format)
+}
+
+func benchmarkWriteColumnarInterval(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.Interval), format)
 }
 
 func benchmarkWriteTuple(b *testing.B, format pgwirebase.FormatCode) {
@@ -368,6 +469,11 @@ func benchmarkWriteTuple(b *testing.B, format pgwirebase.FormatCode) {
 	typ := types.MakeTuple([]*types.T{types.Int, types.Float, types.String})
 	t := tree.NewDTuple(typ, i, f, s)
 	benchmarkWriteType(b, t, format)
+}
+
+func benchmarkWriteColumnarTuple(b *testing.B, format pgwirebase.FormatCode) {
+	typ := types.MakeTuple([]*types.T{types.Int, types.Float, types.String})
+	benchmarkWriteColumnar(b, getBatch(typ), format)
 }
 
 func benchmarkWriteArray(b *testing.B, format pgwirebase.FormatCode) {
@@ -380,11 +486,21 @@ func benchmarkWriteArray(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteType(b, a, format)
 }
 
+func benchmarkWriteColumnarArray(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.MakeArray(types.Int)), format)
+}
+
 func BenchmarkWriteTextBool(b *testing.B) {
 	benchmarkWriteBool(b, pgwirebase.FormatText)
 }
 func BenchmarkWriteBinaryBool(b *testing.B) {
 	benchmarkWriteBool(b, pgwirebase.FormatBinary)
+}
+func BenchmarkWriteTextColumnarBool(b *testing.B) {
+	benchmarkWriteColumnarBool(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarBool(b *testing.B) {
+	benchmarkWriteColumnarBool(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextInt(b *testing.B) {
@@ -393,12 +509,24 @@ func BenchmarkWriteTextInt(b *testing.B) {
 func BenchmarkWriteBinaryInt(b *testing.B) {
 	benchmarkWriteInt(b, pgwirebase.FormatBinary)
 }
+func BenchmarkWriteTextColumnarInt(b *testing.B) {
+	benchmarkWriteColumnarInt(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarInt(b *testing.B) {
+	benchmarkWriteColumnarInt(b, pgwirebase.FormatBinary)
+}
 
 func BenchmarkWriteTextFloat(b *testing.B) {
 	benchmarkWriteFloat(b, pgwirebase.FormatText)
 }
 func BenchmarkWriteBinaryFloat(b *testing.B) {
 	benchmarkWriteFloat(b, pgwirebase.FormatBinary)
+}
+func BenchmarkWriteTextColumnarFloat(b *testing.B) {
+	benchmarkWriteColumnarFloat(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarFloat(b *testing.B) {
+	benchmarkWriteColumnarFloat(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextDecimal(b *testing.B) {
@@ -407,12 +535,24 @@ func BenchmarkWriteTextDecimal(b *testing.B) {
 func BenchmarkWriteBinaryDecimal(b *testing.B) {
 	benchmarkWriteDecimal(b, pgwirebase.FormatBinary)
 }
+func BenchmarkWriteTextColumnarDecimal(b *testing.B) {
+	benchmarkWriteColumnarDecimal(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarDecimal(b *testing.B) {
+	benchmarkWriteColumnarDecimal(b, pgwirebase.FormatBinary)
+}
 
 func BenchmarkWriteTextBytes(b *testing.B) {
 	benchmarkWriteBytes(b, pgwirebase.FormatText)
 }
 func BenchmarkWriteBinaryBytes(b *testing.B) {
 	benchmarkWriteBytes(b, pgwirebase.FormatBinary)
+}
+func BenchmarkWriteTextColumnarBytes(b *testing.B) {
+	benchmarkWriteColumnarBytes(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarBytes(b *testing.B) {
+	benchmarkWriteColumnarBytes(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextUUID(b *testing.B) {
@@ -421,12 +561,24 @@ func BenchmarkWriteTextUUID(b *testing.B) {
 func BenchmarkWriteBinaryUUID(b *testing.B) {
 	benchmarkWriteUUID(b, pgwirebase.FormatBinary)
 }
+func BenchmarkWriteTextColumnarUUID(b *testing.B) {
+	benchmarkWriteColumnarUUID(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarUUID(b *testing.B) {
+	benchmarkWriteColumnarUUID(b, pgwirebase.FormatBinary)
+}
 
 func BenchmarkWriteTextString(b *testing.B) {
 	benchmarkWriteString(b, pgwirebase.FormatText)
 }
 func BenchmarkWriteBinaryString(b *testing.B) {
 	benchmarkWriteString(b, pgwirebase.FormatBinary)
+}
+func BenchmarkWriteTextColumnarString(b *testing.B) {
+	benchmarkWriteColumnarString(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarString(b *testing.B) {
+	benchmarkWriteColumnarString(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextDate(b *testing.B) {
@@ -435,12 +587,24 @@ func BenchmarkWriteTextDate(b *testing.B) {
 func BenchmarkWriteBinaryDate(b *testing.B) {
 	benchmarkWriteDate(b, pgwirebase.FormatBinary)
 }
+func BenchmarkWriteTextColumnarDate(b *testing.B) {
+	benchmarkWriteColumnarDate(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarDate(b *testing.B) {
+	benchmarkWriteColumnarDate(b, pgwirebase.FormatBinary)
+}
 
 func BenchmarkWriteTextTimestamp(b *testing.B) {
 	benchmarkWriteTimestamp(b, pgwirebase.FormatText)
 }
 func BenchmarkWriteBinaryTimestamp(b *testing.B) {
 	benchmarkWriteTimestamp(b, pgwirebase.FormatBinary)
+}
+func BenchmarkWriteTextColumnarTimestamp(b *testing.B) {
+	benchmarkWriteColumnarTimestamp(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarTimestamp(b *testing.B) {
+	benchmarkWriteColumnarTimestamp(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextTimestampTZ(b *testing.B) {
@@ -449,17 +613,32 @@ func BenchmarkWriteTextTimestampTZ(b *testing.B) {
 func BenchmarkWriteBinaryTimestampTZ(b *testing.B) {
 	benchmarkWriteTimestampTZ(b, pgwirebase.FormatBinary)
 }
+func BenchmarkWriteTextColumnarTimestampTZ(b *testing.B) {
+	benchmarkWriteColumnarTimestampTZ(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarTimestampTZ(b *testing.B) {
+	benchmarkWriteColumnarTimestampTZ(b, pgwirebase.FormatBinary)
+}
 
 func BenchmarkWriteTextInterval(b *testing.B) {
 	benchmarkWriteInterval(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteTextColumnarInterval(b *testing.B) {
+	benchmarkWriteColumnarInterval(b, pgwirebase.FormatText)
 }
 
 func BenchmarkWriteTextTuple(b *testing.B) {
 	benchmarkWriteTuple(b, pgwirebase.FormatText)
 }
+func BenchmarkWriteTextColumnarTuple(b *testing.B) {
+	benchmarkWriteColumnarTuple(b, pgwirebase.FormatText)
+}
 
 func BenchmarkWriteTextArray(b *testing.B) {
 	benchmarkWriteArray(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteTextColumnarArray(b *testing.B) {
+	benchmarkWriteColumnarArray(b, pgwirebase.FormatText)
 }
 
 func BenchmarkDecodeBinaryDecimal(b *testing.B) {


### PR DESCRIPTION
**coldata: introduce TypedVecs helper**

This commit extracts the helper struct out of the ordered synchronizer
that stores the well-typed columns alongside the untyped Vecs. The idea
is that every Vec is stored both in Vecs slice as well as in the typed
slice, in order. Components that know the type of the vector they are
working with can then access the typed column directly, avoiding
expensive type casts.

The newly introduced struct is used by the ordered synchronizer and the
follow-up commits will introduce it elsewhere (for example, in the
cFetcher).

Release note: None

**cfetcher: operate on the typed columns rather than untyped Vecs**

This commit uses the `coldata.TypedVecs` helper (introduced in the
previous commit) in the context of the cFetcher. In all decoding methods
we are already performing a large type switch for each value for each
row, so we always know exactly the type of the column we're writing
into.

Additionally, this commit inlines a single function call and removes an
`if` conditional in the value decoding path.

Release note: None

**pgwire: add benchmarks for writing from columnar representation**

Release note: None

**pgwire: operate on the well-typed columns**

This commit applies the same optimization as in the previous commit but
to the pgwire-writing logic.

Release note: None