### PR TITLE
storage: always close iterators, batches in unit tests

### DIFF
--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -388,74 +388,75 @@ func TestIntentInterleavingIterBoundaries(t *testing.T) {
 	func() {
 		opts := IterOptions{LowerBound: keys.MinKey}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalMax})
-		iter.Close()
 	}()
 	func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
 		require.Equal(t, constrainedToLocal, iter.constraint)
-		iter.Close()
 	}()
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		iter.SeekLT(MVCCKey{Key: keys.MaxKey})
 	})
 	// Boundary cases for constrainedToGlobal
 	func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
-		iter.Close()
 	}()
 	require.Panics(t, func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
 		iter.SetUpperBound(keys.LocalMax)
-		iter.Close()
 	})
 	require.Panics(t, func() {
 		opts := IterOptions{LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalMax})
-		iter.Close()
 	})
 	// Panics for using a local key that is above the lock table.
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekLT(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()})
-		iter.Close()
 	})
 	require.Panics(t, func() {
 		opts := IterOptions{UpperBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToLocal, iter.constraint)
 		iter.SeekGE(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()})
-		iter.Close()
 	})
 	// Prefix iteration does not affect the constraint if bounds are
 	// specified.
 	func() {
 		opts := IterOptions{Prefix: true, LowerBound: keys.LocalMax}
 		iter := newIntentInterleavingIterator(eng, opts).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, constrainedToGlobal, iter.constraint)
-		iter.Close()
 	}()
 	// Prefix iteration with no bounds.
 	func() {
 		iter := newIntentInterleavingIterator(eng, IterOptions{Prefix: true}).(*intentInterleavingIter)
+		defer iter.Close()
 		require.Equal(t, notConstrained, iter.constraint)
-		iter.Close()
 	}()
 }
 
@@ -643,6 +644,13 @@ func generateIterOps(rng *rand.Rand, mvcckv []MVCCKeyValue, isLocal bool) []stri
 
 func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings.Builder) {
 	var iter MVCCIterator
+	closeIter := func() {
+		if iter != nil {
+			iter.Close()
+			iter = nil
+		}
+	}
+	defer closeIter()
 	var d datadriven.TestData
 	var err error
 	for _, op := range ops {
@@ -650,6 +658,7 @@ func doOps(t *testing.T, ops []string, eng Engine, interleave bool, out *strings
 		require.NoError(t, err)
 		switch d.Cmd {
 		case "iter":
+			closeIter()
 			var opts IterOptions
 			if d.HasArg("lower") {
 				opts.LowerBound = scanRoachKey(t, &d, "lower")

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -595,6 +595,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 					EndTime:      tsMax,
 					InlinePolicy: MVCCIncrementalIterInlinePolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				_, err := iter.Valid()
 				assert.EqualError(t, err, "unexpected inline value found: \"/db1\"")
@@ -606,6 +607,7 @@ func TestMVCCIncrementalIteratorInlinePolicy(t *testing.T) {
 					EndTime:      tsMax,
 					InlinePolicy: MVCCIncrementalIterInlinePolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectInlineKeyValue(t, iter, inline1_1_1)
 				iter.Next()
@@ -686,6 +688,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				for ; ; iter.Next() {
 					if ok, _ := iter.Valid(); !ok || iter.UnsafeKey().Key.Compare(keyMax) >= 0 {
@@ -702,6 +705,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyError,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectKeyValue(t, iter, kv1_3_3)
 				iter.Next()
@@ -716,6 +720,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				for _, kv := range []MVCCKeyValue{kv1_3_3, kv1_2_2, kv1_1_1} {
 					expectKeyValue(t, iter, kv)
@@ -735,6 +740,7 @@ func TestMVCCIncrementalIteratorIntentPolicy(t *testing.T) {
 					EndTime:      tsMax,
 					IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
 				})
+				defer iter.Close()
 				iter.SeekGE(MakeMVCCMetadataKey(testKey1))
 				expectKeyValue(t, iter, kv1_3_3)
 				iter.Next()
@@ -1039,6 +1045,7 @@ func TestMVCCIncrementalIteratorIntentRewrittenConcurrently(t *testing.T) {
 				// goroutine. A non-atomic Put can cause the strict invariant checking
 				// in intentInterleavingIter to be violated.
 				b := e.NewBatch()
+				defer b.Close()
 				if err := MVCCPut(ctx, b, nil, kA, ts1, vA2, txn); err != nil {
 					return err
 				}
@@ -1404,6 +1411,7 @@ func runIncrementalBenchmark(
 			StartTime:                           ts,
 			EndTime:                             hlc.MaxTimestamp,
 		})
+		defer it.Close()
 		it.SeekGE(MVCCKey{Key: startKey})
 		for {
 			if ok, err := it.Valid(); err != nil {


### PR DESCRIPTION
This fixes a handful of instances where iterators and batches either
weren't closed, or weren't closed if the test failed because the Close
wasn't deferred.

There are more in the codebase, but I wanted to break this up a bit
since some of them are trickier to track down.

Release note: None