### PR TITLE
storage: remove RocksDBBatchBuilder

### DIFF
--- a/pkg/kv/kvserver/debug_print_test.go
+++ b/pkg/kv/kvserver/debug_print_test.go
@@ -35,19 +35,19 @@ func TestStringifyWriteBatch(t *testing.T) {
 		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
 	}
 
-	builder := storage.RocksDBBatchBuilder{}
-	builder.Put(storage.MVCCKey{
+	batch := pebble.Batch{}
+	require.NoError(t, batch.Set(storage.EncodeKey(storage.MVCCKey{
 		Key:       roachpb.Key("/db1"),
 		Timestamp: hlc.Timestamp{WallTime: math.MaxInt64},
-	}, []byte("test value"))
-	wb.Data = builder.Finish()
+	}), []byte("test value"), nil /* WriteOptions */))
+	wb.Data = batch.Repr()
 	swb = stringifyWriteBatch(wb)
 	if str, expStr := swb.String(), "Put: 9223372036.854775807,0 \"/db1\" (0x2f646231007fffffffffffffff09): \"test value\"\n"; str != expStr {
 		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
 	}
 
 	var err error
-	batch := pebble.Batch{}
+	batch = pebble.Batch{}
 	encodedKey, err := hex.DecodeString("017a6b12c089f704918df70bee8800010003623a9318c0384d07a6f22b858594df6012")
 	require.NoError(t, err)
 	err = batch.SingleDelete(encodedKey, nil)


### PR DESCRIPTION
The RocksDBBatchBuilder was a relic and just a lightweight wrapper
around a Pebble batch, used in a couple of tests.

Release note: None