### PR TITLE
colfetcher: fix the index join

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1159,6 +1159,9 @@ func (rf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			}
 
 		case stateEmitLastBatch:
+			// Close the fetcher eagerly so that its memory could be GCed.
+			rf.fetcher.Close(ctx)
+			rf.fetcher = nil
 			rf.machine.state[0] = stateFinished
 			rf.finalizeBatch()
 			return rf.machine.batch, nil

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -210,7 +210,12 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 // result batches. TODO(drewk): once the Streamer work is finished, the fetcher
 // logic will be able to control result size without sacrificing parallelism, so
 // we can remove this limit.
-const inputBatchSizeLimit = 4 << 20 /* 4 MB */
+var inputBatchSizeLimit = int64(util.ConstantWithMetamorphicTestRange(
+	"ColIndexJoin-batch-size",
+	4<<20, /* 4 MB */
+	1,     /* min */
+	4<<20, /* max */
+))
 
 // findEndIndex returns an index endIdx into s.batch such that generating spans
 // for rows in the interval [s.startIdx, endIdx) will get as close to the memory


### PR DESCRIPTION
The vectorized index join uses the cFetcher which is started multiple
times. Previously, we forgot to close the old kv fetcher on the second
and all subsequent calls. This was mostly ok (modulo not helping the GC
with the collection of old spans) up until recently when we added the
memory accounting to the kv fetcher when used by the cFetcher. After
that change, if the index join issues at least two batches of spans to
fetch, we won't close all of the memory accounts, which would lead to
a crash in non-release build. This is now fixed by eagerly closing the
fetcher when emitting the last batch, and the relevant code path is
exercised by randomizing the index join batch size limit.

Release note: None (no stable release with this bug)