### PR TITLE
ui: new sql activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/common/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/common/index.tsx
@@ -1,0 +1,14 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import classNames from "classnames/bind";
+import styles from "./styles.module.scss";
+
+export const commonStyles = classNames.bind(styles);

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -1,0 +1,60 @@
+@import "src/core/index.module";
+
+.cockroach--tabs {
+  overflow: visible !important;
+  :global(.ant-tabs-bar) {
+    border-bottom: 1px solid $grey2;
+  }
+
+  :global(.ant-tabs-tab) {
+    font-family: $font-family--base;
+    font-size: 16px;
+    line-height: 1.5;
+    letter-spacing: normal;
+    color: $colors--neutral-7;
+  }
+
+  :global(.ant-tabs-nav .ant-tabs-tab-active) {
+    color: $colors--link;
+  }
+
+  :global(.ant-tabs-nav .ant-tabs-tab:hover) {
+    color: $colors--link;
+  }
+
+  :global(.ant-tabs-ink-bar) {
+    height: 3px;
+    border-radius: 40px;
+    background-color: $blue;
+  }
+}
+
+h1.base-heading {
+  font-size: 24px;
+  font-family: $font-family--base;
+}
+
+h2.base-heading {
+  padding: 12px 0;
+  font-size: 24px;
+  font-family: $font-family--base
+}
+
+h3.base-heading {
+  color: $colors--neutral-7;
+  font-family: $font-family--sans-serif;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  font-size: 20px;
+  padding-bottom: 12px;
+}
+
+.no-margin-bottom {
+  margin-bottom: 0px;
+}
+
+.separator {
+  border-left: 1px solid #C0C6D9;
+  padding-left: 25px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -18,32 +18,6 @@
   }
 }
 
-.cockroach--tabs {
-  :global(.ant-tabs-bar) {
-    border-bottom: 1px solid $grey2;
-  }
-
-  :global(.ant-tabs-tab) {
-    @include text--heading-5;
-    font-weight: $font-weight--medium;
-    color: $colors--neutral-7;
-  }
-
-  :global(.ant-tabs-tab-active) {
-    color: $colors--neutral-8;
-  }
-
-  :global(.ant-tabs-tab:hover) {
-    color: $colors--link;
-  }
-
-  :global(.ant-tabs-ink-bar) {
-    height: 3px;
-    border-radius: 40px;
-    background-color: $colors--link;
-  }
-}
-
 .summary-card {
   h4 {
     @include text--body-strong;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -23,6 +23,7 @@ import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import * as format from "src/util/format";
 
 import styles from "./databaseTablePage.module.scss";
+import { commonStyles } from "src/common";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
 const cx = classNames.bind(styles);
 
@@ -200,7 +201,7 @@ export class DatabaseTablePage extends React.Component<
         </section>
 
         <section className={baseHeadingClasses.wrapper}>
-          <Tabs className={cx("cockroach--tabs")}>
+          <Tabs className={commonStyles("cockroach--tabs")}>
             <TabPane tab="Overview" key="overview">
               <Row>
                 <Col>

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -15,6 +15,7 @@ export * from "./anchor";
 export * from "./badge";
 export * from "./barCharts";
 export * from "./button";
+export * from "./common";
 export * from "./databaseDetailsPage";
 export * from "./databaseTablePage";
 export * from "./databasesPage";

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
@@ -19,7 +19,7 @@ export interface PageConfigProps {
 
 const cx = classnames.bind(styles);
 
-export function PageConfig(props: PageConfigProps) {
+export function PageConfig(props: PageConfigProps): React.ReactElement {
   const classes = cx({
     "page-config__list": props.layout !== "spread",
     "page-config__spread": props.layout === "spread",
@@ -34,8 +34,13 @@ export function PageConfig(props: PageConfigProps) {
 
 export interface PageConfigItemProps {
   children?: React.ReactNode;
+  className?: string;
 }
 
-export function PageConfigItem(props: PageConfigItemProps) {
-  return <li className={cx("page-config__item")}>{props.children}</li>;
+export function PageConfigItem(props: PageConfigItemProps): React.ReactElement {
+  return (
+    <li className={`${cx("page-config__item")} ${props.className}`}>
+      {props.children}
+    </li>
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -236,7 +236,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
   };
 
-  isOptionSelected = (option: string, field: string) => {
+  isOptionSelected = (option: string, field: string): boolean => {
     const selection = field.split(",");
     return selection.length > 0 && selection.includes(option);
   };

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -48,6 +48,7 @@ import { UIConfigState } from "src/store";
 import statementsPageStyles from "src/statementsPage/statementsPage.module.scss";
 import styles from "./sessionDetails.module.scss";
 import classNames from "classnames/bind";
+import { commonStyles } from "src/common";
 
 const cx = classNames.bind(styles);
 const statementsPageCx = classNames.bind(statementsPageStyles);
@@ -98,7 +99,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
     isTenant: false,
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     if (!this.props.isTenant) {
       this.props.refreshNodes();
       this.props.refreshNodesLiveness();
@@ -106,7 +107,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
     this.props.refreshSessions();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(): void {
     // Normally, we would refresh the sessions here, but we don't want to
     // have the per-session page update whenever our data source updates
     // because in real workloads, sessions change what they're doing very
@@ -122,16 +123,16 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
     this.terminateQueryRef = React.createRef();
   }
 
-  backToSessionsPage = () => {
+  backToSessionsPage = (): void => {
     const { history, location, onBackButtonClick } = this.props;
     onBackButtonClick && onBackButtonClick();
     history.push({
       ...location,
-      pathname: "/sessions",
+      pathname: "/sql-activity/sessions",
     });
   };
 
-  render() {
+  render(): React.ReactElement {
     const sessionID = getMatchParamByName(this.props.match, sessionAttr);
     const {
       sessionError,
@@ -159,7 +160,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
           </Button>
           <div className={cx("heading-with-controls")}>
             <h3
-              className={`${statementsPageCx("base-heading")} ${cx(
+              className={`${commonStyles("base-heading")} ${cx(
                 "page--header__title",
               )}`}
             >
@@ -223,7 +224,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
     );
   }
 
-  renderContent = () => {
+  renderContent = (): React.ReactElement => {
     if (!this.props.session) {
       return null;
     }
@@ -273,7 +274,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
               className={cx("details-item")}
             />
           </Col>
-          <Col className="gutter-row" span={4}></Col>
+          <Col className="gutter-row" span={4} />
           <Col className="gutter-row" span={10}>
             <SummaryCardItem
               label={"Priority"}
@@ -308,7 +309,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
       const stmt = session.active_queries[0];
       curStmtInfo = (
         <React.Fragment>
-          <SqlBox value={stmt.sql}></SqlBox>
+          <SqlBox value={stmt.sql} />
           <SummaryCard className={cx("details-section")}>
             <Row>
               <Col className="gutter-row" span={10}>
@@ -331,7 +332,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                   View Statement Details
                 </Link>
               </Col>
-              <Col className="gutter-row" span={4}></Col>
+              <Col className="gutter-row" span={4} />
               <Col className="gutter-row" span={10}>
                 <SummaryCardItem
                   label={"Distributed Execution?"}
@@ -372,7 +373,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 />
               )}
             </Col>
-            <Col className="gutter-row" span={4}></Col>
+            <Col className="gutter-row" span={4} />
             <Col className="gutter-row" span={10}>
               <SummaryCardItem
                 label={"Client Address"}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -113,7 +113,7 @@ export class SessionsPage extends React.Component<
     };
   };
 
-  syncHistory = (params: Record<string, string | undefined>) => {
+  syncHistory = (params: Record<string, string | undefined>): void => {
     const { history } = this.props;
     const currentSearchParams = new URLSearchParams(history.location.search);
     forIn(params, (value, key) => {
@@ -128,7 +128,7 @@ export class SessionsPage extends React.Component<
     history.replace(history.location);
   };
 
-  changeSortSetting = (ss: SortSetting) => {
+  changeSortSetting = (ss: SortSetting): void => {
     const { onSortingChange } = this.props;
     onSortingChange && onSortingChange(ss.columnTitle);
 
@@ -142,7 +142,7 @@ export class SessionsPage extends React.Component<
     });
   };
 
-  resetPagination = () => {
+  resetPagination = (): void => {
     this.setState(prevState => {
       return {
         pagination: {
@@ -153,27 +153,27 @@ export class SessionsPage extends React.Component<
     });
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.props.refreshSessions();
   }
 
-  componentDidUpdate = (__: SessionsPageProps, _: SessionsPageState) => {
+  componentDidUpdate = (__: SessionsPageProps, _: SessionsPageState): void => {
     this.props.refreshSessions();
   };
 
-  onChangePage = (current: number) => {
+  onChangePage = (current: number): void => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
     this.props.onPageChanged(current);
   };
 
-  renderSessions = () => {
+  renderSessions = (): React.ReactElement => {
     const sessionsData = this.props.sessions;
     const { pagination } = this.state;
 
     return (
       <>
-        <section className={sortableTableCx("cl-table-container")}>
+        <section>
           <div className={statementsPageCx("cl-table-statistic")}>
             <h4 className={statementsPageCx("cl-count-title")}>
               <ResultsPerPageLabel
@@ -224,13 +224,12 @@ export class SessionsPage extends React.Component<
     );
   };
 
-  render() {
+  render(): React.ReactElement {
     const { match, cancelSession, cancelQuery } = this.props;
     const app = getMatchParamByName(match, appAttr);
     return (
       <div className={sessionsPageCx("sessions-page")}>
         <Helmet title={app ? `${app} App | Sessions` : "Sessions"} />
-        <h3 className={statementsPageCx("base-heading")}>Sessions</h3>
         <Loading
           loading={isNil(this.props.sessions)}
           error={this.props.sessionsError}

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/clearStats.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/clearStats.tsx
@@ -1,0 +1,59 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Tooltip } from "@cockroachlabs/ui-components";
+import {
+  contentModifiers,
+  StatisticType,
+} from "../statsTableUtil/statsTableUtil";
+import classNames from "classnames/bind";
+import styles from "./sqlActivity.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface clearStatsProps {
+  resetSQLStats: () => void;
+  tooltipType: StatisticType;
+}
+
+const ClearStats = (props: clearStatsProps): React.ReactElement => {
+  let statsType = "";
+  switch (props.tooltipType) {
+    case "transaction":
+      statsType = contentModifiers.transactionCapital;
+      break;
+    case "statement":
+      statsType = contentModifiers.statementCapital;
+      break;
+    case "transactionDetails":
+      statsType = contentModifiers.statementCapital;
+      break;
+    default:
+      break;
+  }
+  const toolTipText = `${statsType} statistics are aggregated once an hour by default and organized by the start time. 
+  Statistics between two hourly intervals belong to the nearest hour rounded down. 
+  For example, a ${statsType} execution ending at 1:50 would have its statistics aggregated in the 1:00 interval 
+  start time. Clicking ‘clear SQL stats’ will reset SQL stats on the Statements and Transactions pages and 
+  crdb_internal tables.`;
+  return (
+    <Tooltip content={toolTipText} style="tableTitle">
+      <a
+        className={cx("action", "tooltip-info", "separator")}
+        onClick={props.resetSQLStats}
+      >
+        clear SQL stats
+      </a>
+    </Tooltip>
+  );
+};
+
+export default ClearStats;

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
@@ -1,0 +1,15 @@
+@import "src/core/index.module";
+
+.tooltip-info {
+  border-bottom: 1px dashed $colors--neutral-5;
+}
+
+.action {
+  color: $colors--link;
+  display: flex;
+  line-height: 24px;
+  &:hover {
+  color: $colors--link;
+    text-decoration: underline;
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -38,59 +38,9 @@
   }
 }
 
-h1.base-heading {
-  font-size: 24px;
-  font-family: $font-family--base;
-}
-
-h2.base-heading {
-  padding: 12px 0;
-  font-size: 24px;
-  font-family: $font-family--base
-}
-
-h3.base-heading {
-  color: $colors--neutral-7;
-  font-family: $font-family--sans-serif;
-  font-weight: 600;
-  font-style: normal;
-  font-stretch: normal;
-  font-size: 20px;
-  padding-bottom: 12px;
-}
-
 .back-link {
   text-decoration: none;
   color: $link-color;
-}
-
-.cockroach--tabs {
-  overflow: visible !important;
-  :global(.ant-tabs-bar) {
-    border-bottom: 1px solid $grey2;
-  }
-
-  :global(.ant-tabs-tab) {
-    font-family: $font-family--base;
-    font-size: 16px;
-    line-height: 1.5;
-    letter-spacing: normal;
-    color: $colors--neutral-7;
-  }
-
-  :global(.ant-tabs-nav .ant-tabs-tab-active) {
-    color: $colors--link;
-  }
-
-  :global(.ant-tabs-nav .ant-tabs-tab:hover) {
-    color: $colors--link;
-  }
-
-  :global(.ant-tabs-ink-bar) {
-    height: 3px;
-    border-radius: 40px;
-    background-color: $blue;
-  }
 }
 
 .fit-content-width {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -60,6 +60,7 @@ import { DiagnosticsView } from "./diagnostics/diagnosticsView";
 import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import styles from "./statementDetails.module.scss";
+import { commonStyles } from "src/common";
 import { NodeSummaryStats } from "../nodes";
 import { UIConfigState } from "../store";
 import moment, { Moment } from "moment";
@@ -385,7 +386,7 @@ export class StatementDetails extends React.Component<
   };
 
   backToStatementsClick = (): void => {
-    this.props.history.push("/statements");
+    this.props.history.push("/sql-activity/statements");
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }
@@ -407,7 +408,7 @@ export class StatementDetails extends React.Component<
           >
             Statements
           </Button>
-          <h3 className={cx("base-heading", "no-margin-bottom")}>
+          <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
             Statement Details
           </h3>
         </div>
@@ -533,7 +534,7 @@ export class StatementDetails extends React.Component<
     return (
       <Tabs
         defaultActiveKey="1"
-        className={cx("cockroach--tabs")}
+        className={commonStyles("cockroach--tabs")}
         onChange={this.onTabChange}
         activeKey={currentTab}
       >
@@ -798,7 +799,7 @@ export class StatementDetails extends React.Component<
           <SummaryCard>
             <h3
               className={classNames(
-                cx("base-heading"),
+                commonStyles("base-heading"),
                 summaryCardStylesCx("summary--card__title"),
               )}
             >
@@ -841,7 +842,7 @@ export class StatementDetails extends React.Component<
           <SummaryCard>
             <h3
               className={classNames(
-                cx("base-heading"),
+                commonStyles("base-heading"),
                 summaryCardStylesCx("summary--card__title"),
               )}
             >
@@ -897,7 +898,7 @@ export class StatementDetails extends React.Component<
             <SummaryCard className={cx("fit-content-width")}>
               <h3
                 className={classNames(
-                  cx("base-heading"),
+                  commonStyles("base-heading"),
                   summaryCardStylesCx("summary--card__title"),
                 )}
               >

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -37,27 +37,6 @@
   }
 }
 
-h1.base-heading {
-  font-size: 24px;
-  font-family: $font-family--base;
-}
-
-h2.base-heading {
-  padding: 12px 0;
-  font-size: 24px;
-  font-family: $font-family--base;
-}
-
-h3.base-heading {
-  color: $colors--neutral-7;
-  font-family: $font-family--sans-serif;
-  font-weight: 600;
-  font-style: normal;
-  font-stretch: normal;
-  font-size: 20px;
-  padding-bottom: 12px;
-}
-
 .no-margin-bottom {
   margin-bottom: 0px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -32,7 +32,6 @@ import {
 
 import {
   appAttr,
-  getMatchParamByName,
   calculateTotalWorkload,
   unique,
   containAny,
@@ -64,6 +63,8 @@ import { SelectOption } from "../multiSelectCheckbox/multiSelectCheckbox";
 import { UIConfigState } from "../store";
 import { StatementsRequest } from "src/api/statementsApi";
 import Long from "long";
+import ClearStats from "../sqlActivity/clearStats";
+import { commonStyles } from "../common";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -404,12 +405,11 @@ export class StatementsPage extends React.Component<
       );
   };
 
-  renderStatements = () => {
+  renderStatements = (): React.ReactElement => {
     const { pagination, search, filters, activeFilters } = this.state;
     const {
       statements,
       databases,
-      lastReset,
       location,
       onDiagnosticsReportDownload,
       onStatementClick,
@@ -520,6 +520,9 @@ export class StatementsPage extends React.Component<
               reset time
             </button>
           </PageConfigItem>
+          <PageConfigItem className={commonStyles("separator")}>
+            <ClearStats resetSQLStats={resetSQLStats} tooltipType="statement" />
+          </PageConfigItem>
         </PageConfig>
         <section className={sortableTableCx("cl-table-container")}>
           <div>
@@ -529,14 +532,11 @@ export class StatementsPage extends React.Component<
             />
             <TableStatistics
               pagination={pagination}
-              lastReset={lastReset}
               search={search}
               totalCount={totalCount}
               arrayItemName="statements"
-              tooltipType="statement"
               activeFilters={activeFilters}
               onClearFilters={this.onClearFilters}
-              resetSQLStats={resetSQLStats}
             />
           </div>
           <StatementsSortedTable
@@ -563,7 +563,7 @@ export class StatementsPage extends React.Component<
     );
   };
 
-  render() {
+  render(): React.ReactElement {
     const {
       location,
       refreshStatementDiagnosticsRequests,
@@ -574,7 +574,6 @@ export class StatementsPage extends React.Component<
     return (
       <div className={cx("root", "table-area")}>
         <Helmet title={app ? `${app} App | Statements` : "Statements"} />
-        <h3 className={cx("base-heading")}>Statements</h3>
         <Loading
           loading={isNil(this.props.statements)}
           error={this.props.statementsError}

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -3,17 +3,3 @@
 .flex-display {
   display: flex;
 }
-
-.tooltip-hover-area {
-  padding-top: 3px;
-  padding-right: 10px;
-}
-
-.action {
-  color: $colors--link;
-  line-height: 24px;
-  &:hover {
-  color: $colors--link;
-    text-decoration: underline;
-  }
-}

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -9,46 +9,34 @@
 // licenses/APL.txt.
 
 import React from "react";
-import moment from "moment";
-import { DATE_FORMAT } from "src/util";
 import { statisticsClasses } from "../transactionsPage/transactionsPageClasses";
 import { ISortedTablePagination } from "../sortedtable";
 import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
-import { Tooltip } from "@cockroachlabs/ui-components";
-import tableStatsStyles from "./tableStatistics.module.scss";
-import classNames from "classnames/bind";
-import { Icon } from "@cockroachlabs/ui-components";
-import {
-  contentModifiers,
-  StatisticType,
-} from "../statsTableUtil/statsTableUtil";
 
-const { statistic, countTitle, lastCleared } = statisticsClasses;
-const cxStats = classNames.bind(tableStatsStyles);
+const { statistic, countTitle } = statisticsClasses;
 
 interface TableStatistics {
   pagination: ISortedTablePagination;
   totalCount: number;
-  lastReset: Date | string;
   arrayItemName: string;
-  tooltipType: StatisticType;
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
-  resetSQLStats: () => void;
 }
 
+// TableStatistics shows statistics about the results being
+// displayed on the table, including total results count,
+// how many are currently being displayed on the page and
+// if there is an active filter.
+// This component has also a clear filter option.
 export const TableStatistics: React.FC<TableStatistics> = ({
   pagination,
   totalCount,
-  lastReset,
   search,
   arrayItemName,
-  tooltipType,
   onClearFilters,
   activeFilters,
-  resetSQLStats,
 }) => {
   const resultsPerPageLabel = (
     <ResultsPerPageLabel
@@ -68,43 +56,11 @@ export const TableStatistics: React.FC<TableStatistics> = ({
     </>
   );
 
-  let statsType = "";
-  switch (tooltipType) {
-    case "transaction":
-      statsType = contentModifiers.transactionCapital;
-      break;
-    case "statement":
-      statsType = contentModifiers.statementCapital;
-      break;
-    case "transactionDetails":
-      statsType = contentModifiers.statementCapital;
-      break;
-    default:
-      break;
-  }
-  const toolTipText = `${statsType} statistics are aggregated once an hour and organized by the start time. 
-  Statistics between two hourly intervals belong to the nearest hour rounded down. 
-  For example, a ${statsType} execution ending at 1:50 would have its statistics aggregated in the 1:00 interval 
-  start time. Clicking ‘clear SQL stats’ will reset SQL stats on the Statements and Transactions pages and 
-  crdb_internal tables.`;
-
   return (
     <div className={statistic}>
       <h4 className={countTitle}>
         {activeFilters ? resultsCountAndClear : resultsPerPageLabel}
       </h4>
-      <div className={cxStats("flex-display")}>
-        <Tooltip content={toolTipText} style="tableTitle">
-          <div className={cxStats("tooltip-hover-area")}>
-            <Icon iconName={"InfoCircle"} />
-          </div>
-        </Tooltip>
-        <div className={lastCleared}>
-          <a className={cxStats("action")} onClick={resetSQLStats}>
-            clear SQL stats
-          </a>
-        </div>
-      </div>
     </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -109,7 +109,6 @@ export class TransactionDetails extends React.Component<
       transactionStats,
       handleDetails,
       error,
-      resetSQLStats,
       nodeRegions,
     } = this.props;
     return (
@@ -131,12 +130,7 @@ export class TransactionDetails extends React.Component<
           error={error}
           loading={!statements || !transactionStats}
           render={() => {
-            const {
-              statements,
-              transactionStats,
-              lastReset,
-              isTenant,
-            } = this.props;
+            const { statements, transactionStats, isTenant } = this.props;
             const { sortSetting, pagination } = this.state;
             const aggregatedStatements = aggregateStatements(statements);
             populateRegionNodeForStatements(
@@ -283,13 +277,10 @@ export class TransactionDetails extends React.Component<
                   <TableStatistics
                     pagination={pagination}
                     totalCount={statements.length}
-                    lastReset={lastReset}
                     arrayItemName={
                       "statement fingerprints for this transaction"
                     }
-                    tooltipType="transactionDetails"
                     activeFilters={0}
-                    resetSQLStats={resetSQLStats}
                   />
                   <div className={cx("table-area")}>
                     <SortedTable

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -28,10 +28,7 @@ import {
 } from "../sortedtable";
 import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
-import {
-  baseHeadingClasses,
-  statisticsClasses,
-} from "./transactionsPageClasses";
+import { statisticsClasses } from "./transactionsPageClasses";
 import {
   aggregateAcrossNodeIDs,
   generateRegionNode,
@@ -64,6 +61,8 @@ import {
   getLabel,
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
+import ClearStats from "../sqlActivity/clearStats";
+import { commonStyles } from "../common";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
@@ -153,7 +152,7 @@ export class TransactionsPage extends React.Component<
     this.refreshData();
   }
 
-  syncHistory = (params: Record<string, string | undefined>) => {
+  syncHistory = (params: Record<string, string | undefined>): void => {
     const { history } = this.props;
     const currentSearchParams = new URLSearchParams(history.location.search);
 
@@ -270,10 +269,9 @@ export class TransactionsPage extends React.Component<
     );
   };
 
-  renderTransactionsList() {
+  renderTransactionsList(): React.ReactElement {
     return (
       <div className={cx("table-area")}>
-        <h3 className={baseHeadingClasses.tableName}>Transactions</h3>
         <Loading
           loading={!this.props?.data}
           error={this.props?.error}
@@ -413,6 +411,12 @@ export class TransactionsPage extends React.Component<
                       reset time
                     </button>
                   </PageConfigItem>
+                  <PageConfigItem className={commonStyles("separator")}>
+                    <ClearStats
+                      resetSQLStats={resetSQLStats}
+                      tooltipType="transaction"
+                    />
+                  </PageConfigItem>
                 </PageConfig>
                 <section className={statisticsClasses.tableContainerClass}>
                   <ColumnsSelector
@@ -421,14 +425,11 @@ export class TransactionsPage extends React.Component<
                   />
                   <TableStatistics
                     pagination={pagination}
-                    lastReset={this.lastReset()}
                     search={search}
                     totalCount={transactionsToDisplay.length}
                     arrayItemName="transactions"
-                    tooltipType="transaction"
                     activeFilters={activeFilters}
                     onClearFilters={this.onClearFilters}
-                    resetSQLStats={resetSQLStats}
                   />
                   <TransactionsTable
                     columns={displayColumns}
@@ -457,7 +458,7 @@ export class TransactionsPage extends React.Component<
     );
   }
 
-  renderTransactionDetails() {
+  renderTransactionDetails(): React.ReactElement {
     const { statements } = this.props.data;
     const {
       aggregatedTs,
@@ -490,7 +491,7 @@ export class TransactionsPage extends React.Component<
     );
   }
 
-  render() {
+  render(): React.ReactElement {
     const { statementFingerprintIds } = this.state;
     const renderTxDetailsView = !!statementFingerprintIds;
     return renderTxDetailsView

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageClasses.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageClasses.ts
@@ -11,18 +11,18 @@
 import classNames from "classnames/bind";
 import statementsPageStyles from "src/statementsPage/statementsPage.module.scss";
 import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
+import { commonStyles } from "../common";
 
 const pageCx = classNames.bind(statementsPageStyles);
 const sortedTableCx = classNames.bind(sortedTableStyles);
 
 export const baseHeadingClasses = {
   wrapper: pageCx("section--heading"),
-  tableName: pageCx("base-heading", "no-margin-bottom"),
+  tableName: commonStyles("base-heading", "no-margin-bottom"),
 };
 
 export const statisticsClasses = {
   statistic: pageCx("cl-table-statistic"),
   countTitle: pageCx("cl-count-title"),
-  lastCleared: pageCx("last-cleared-title"),
   tableContainerClass: sortedTableCx("cl-table-container"),
 };

--- a/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
@@ -27,7 +27,11 @@ export function propsToQueryString(props: { [k: string]: any }): string {
   return params.toString();
 }
 
-export function queryToObj(location: Location, key: string, value: string) {
+export function queryToObj(
+  location: Location,
+  key: string,
+  value: string,
+): ParamsObj {
   const params = new URLSearchParams(location.search);
   const paramObj: ParamsObj = {};
 

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -339,10 +339,10 @@ describe("Routing to", () => {
   });
 
   describe("'/statement' path", () => {
-    it("redirected to '/statements'", () => {
+    it("redirected to '/sql-activity/statements'", () => {
       navigateToPath("/statement");
       const location = history.location;
-      assert.equal(location.pathname, "/statements");
+      assert.equal(location.pathname, "/sql-activity/statements");
     });
   });
 
@@ -580,6 +580,30 @@ describe("Routing to", () => {
     it("routes to <NotFound> component", () => {
       navigateToPath("/some-random-ulr");
       assert.lengthOf(appWrapper.find(NotFound), 1);
+    });
+  });
+
+  describe("'/statements' path", () => {
+    it("redirected to '/sql-activity/statements'", () => {
+      navigateToPath("/statements");
+      const location = history.location;
+      assert.equal(location.pathname, "/sql-activity/statements");
+    });
+  });
+
+  describe("'/sessions' path", () => {
+    it("redirected to '/sql-activity/sessions'", () => {
+      navigateToPath("/sessions");
+      const location = history.location;
+      assert.equal(location.pathname, "/sql-activity/sessions");
+    });
+  });
+
+  describe("'/transactions' path", () => {
+    it("redirected to '/sql-activity/transactions'", () => {
+      navigateToPath("/transactions");
+      const location = history.location;
+      assert.equal(location.pathname, "/sql-activity/transactions");
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -29,6 +29,7 @@ import {
   rangeIDAttr,
   sessionAttr,
   statementAttr,
+  tabAttr,
   tableNameAttr,
 } from "src/util/constants";
 import NotFound from "src/views/app/components/NotFound";
@@ -59,11 +60,9 @@ import Range from "src/views/reports/containers/range";
 import ReduxDebug from "src/views/reports/containers/redux";
 import Settings from "src/views/reports/containers/settings";
 import Stores from "src/views/reports/containers/stores";
+import SQLActivityPage from "src/views/sqlActivity/sqlActivityPage";
 import StatementDetails from "src/views/statements/statementDetails";
-import StatementsPage from "src/views/statements/statementsPage";
-import SessionsPage from "src/views/sessions/sessionsPage";
 import SessionDetails from "src/views/sessions/sessionDetails";
-import TransactionsPage from "src/views/transactions/transactionsPage";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetails";
 import "styl/app.styl";
@@ -177,8 +176,20 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   component={DataDistributionPage}
                 />
 
+                {/* SQL activity */}
+                <Route exact path="/sql-activity" component={SQLActivityPage} />
+                <Route
+                  exact
+                  path={`/sql-activity/:${tabAttr}`}
+                  component={SQLActivityPage}
+                />
+
                 {/* statement statistics */}
-                <Route exact path="/statements" component={StatementsPage} />
+                <Redirect
+                  exact
+                  from={`/statements`}
+                  to={`/sql-activity/statements`}
+                />
                 <Redirect
                   exact
                   from={`/statements/:${appAttr}`}
@@ -214,24 +225,29 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   path={`/statement/:${databaseAttr}/:${implicitTxnAttr}/:${statementAttr}`}
                   render={RedirectToStatementDetails}
                 />
-                <Route
+                <Redirect
                   exact
-                  path="/statement"
-                  component={() => <Redirect to="/statements" />}
+                  from={`/statement`}
+                  to={`/sql-activity/statements`}
                 />
 
                 {/* sessions */}
-                <Route exact path="/sessions" component={SessionsPage} />
+                <Redirect
+                  exact
+                  from={`/sessions`}
+                  to={`/sql-activity/sessions`}
+                />
                 <Route
                   exact
                   path={`/session/:${sessionAttr}`}
                   component={SessionDetails}
                 />
+
                 {/* transactions */}
-                <Route
+                <Redirect
                   exact
-                  path="/transactions"
-                  component={TransactionsPage}
+                  from={`/transactions`}
+                  to={`/sql-activity/transactions`}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -21,6 +21,7 @@ export const databaseAttr = "database";
 export const sessionAttr = "session";
 export const tableNameAttr = "table_name";
 export const aggregatedTsAttr = "aggregated_ts";
+export const tabAttr = "tab";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -39,13 +39,11 @@ export class Sidebar extends React.Component<SidebarProps> {
     { path: "/overview", text: "Overview", activeFor: ["/node"] },
     { path: "/metrics", text: "Metrics", activeFor: [] },
     { path: "/databases", text: "Databases", activeFor: ["/database"] },
-    { path: "/sessions", text: "Sessions", activeFor: ["/session"] },
     {
-      path: "/transactions",
-      text: "Transactions",
-      activeFor: ["/transactions"],
+      path: "/sql-activity",
+      text: "SQL Activity",
+      activeFor: ["/sql-activity", "/session", "/transaction", "/statement"],
     },
-    { path: "/statements", text: "Statements", activeFor: ["/statement"] },
     {
       path: "/reports/network",
       text: "Network Latency",

--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// All changes made on this file, should also be done on the equivalent
+// file on managed-service repo.
+
+import React from "react";
+import { Tabs } from "antd";
+import { commonStyles } from "@cockroachlabs/cluster-ui";
+import SessionsPageConnected from "src/views/sessions/sessionsPage";
+import TransactionsPageConnected from "src/views/transactions/transactionsPage";
+import StatementsPageConnected from "src/views/statements/statementsPage";
+import { getMatchParamByName } from "src/util/query";
+import { RouteComponentProps } from "react-router-dom";
+
+const { TabPane } = Tabs;
+
+const SQLActivityPage = (props: RouteComponentProps) => {
+  const defaultTab = getMatchParamByName(props.match, "tab") || "sessions";
+  const [currentTab, setCurrentTab] = React.useState(defaultTab);
+
+  const onTabChange = (tabId: string): void => {
+    setCurrentTab(tabId);
+  };
+
+  return (
+    <div>
+      <h3 className={commonStyles("base-heading")}>SQL Activity</h3>
+      <Tabs
+        defaultActiveKey={defaultTab}
+        className={commonStyles("cockroach--tabs")}
+        onChange={onTabChange}
+        activeKey={currentTab}
+      >
+        <TabPane tab="Sessions" key="sessions">
+          <SessionsPageConnected />
+        </TabPane>
+        <TabPane tab="Transactions" key="transactions">
+          <TransactionsPageConnected />
+        </TabPane>
+        <TabPane tab="Statements" key="statements">
+          <StatementsPageConnected />
+        </TabPane>
+      </Tabs>
+    </div>
+  );
+};
+
+export default SQLActivityPage;


### PR DESCRIPTION
New SQL Activity page that includes Sessions, Statement
and Transaction pages.
Clear Stats action link moved to the top of Transactions and Statements page.

Partially addresses #66052
Session Details and Statement Details replace the full page. A following PR will make Transaction Details have the same behaviour.

https://www.loom.com/share/655914eba8ed4c449dad46fc786f17eb


<img width="710" alt="Screen Shot 2021-10-14 at 4 21 41 PM" src="https://user-images.githubusercontent.com/1017486/137390536-c4f16a2a-d362-4614-8552-4fdf3b16ed8e.png">
<img width="1243" alt="Screen Shot 2021-10-14 at 4 21 49 PM" src="https://user-images.githubusercontent.com/1017486/137390548-d74e0624-fbce-4b66-b460-8bc723be6e7f.png">
<img width="1250" alt="Screen Shot 2021-10-14 at 4 21 57 PM" src="https://user-images.githubusercontent.com/1017486/137390561-bbdc0bda-29c6-4a04-bed8-8204f0eb7a5a.png">

Release note (ui change): Session, Statement and Transaction pages
are now grouped inside the new SQL Activity page.