### PR TITLE
sql: show create all types command

### DIFF
--- a/docs/generated/sql/bnf/show_create_stmt.bnf
+++ b/docs/generated/sql/bnf/show_create_stmt.bnf
@@ -1,4 +1,5 @@
 show_create_stmt ::=
 	'SHOW' 'CREATE' object_name
-	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
 	| 'SHOW' 'CREATE' 'ALL' 'SCHEMAS'
+	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
+	| 'SHOW' 'CREATE' 'ALL' 'TYPES'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -642,8 +642,9 @@ show_constraints_stmt ::=
 
 show_create_stmt ::=
 	'SHOW' 'CREATE' table_name
-	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
 	| 'SHOW' 'CREATE' 'ALL' 'SCHEMAS'
+	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
+	| 'SHOW' 'CREATE' 'ALL' 'TYPES'
 
 show_create_schedules_stmt ::=
 	'SHOW' 'CREATE' 'ALL' 'SCHEDULES'

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2546,6 +2546,9 @@ It is not recommended to perform this operation on a database with many
 tables.
 The output can be used to recreate a database.’</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.show_create_all_types"></a><code>crdb_internal.show_create_all_types(database_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of CREATE type statements.
+The output can be used to recreate a database.’</p>
+</span></td></tr>
 <tr><td><a name="decode"></a><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td></tr>
 <tr><td><a name="decompress"></a><code>decompress(data: <a href="bytes.html">bytes</a>, codec: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decompress <code>data</code> with the specified <code>codec</code> (<code>gzip</code>).</p>

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2231,8 +2231,7 @@ CREATE TABLE crdb_internal.create_type_statements (
   descriptor_id      INT,
   descriptor_name    STRING,
   create_statement   STRING,
-  enum_members       STRING[], -- populated only for ENUM types
-	INDEX (descriptor_id)
+  enum_members       STRING[] -- populated only for ENUM types
 )
 `,
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -52,11 +52,14 @@ func TryDelegate(
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)
 
+	case *tree.ShowCreateAllSchemas:
+		return d.delegateShowCreateAllSchemas()
+
 	case *tree.ShowCreateAllTables:
 		return d.delegateShowCreateAllTables()
 
-	case *tree.ShowCreateAllSchemas:
-		return d.delegateShowCreateAllSchemas()
+	case *tree.ShowCreateAllTypes:
+		return d.delegateShowCreateAllTypes()
 
 	case *tree.ShowDatabaseIndexes:
 		return d.delegateShowDatabaseIndexes(t)

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -287,8 +287,7 @@ CREATE TABLE crdb_internal.create_type_statements (
    descriptor_id INT8 NULL,
    descriptor_name STRING NULL,
    create_statement STRING NULL,
-   enum_members STRING[] NULL,
-   INDEX create_type_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_name, create_statement, enum_members)
+   enum_members STRING[] NULL
 )  CREATE TABLE crdb_internal.create_type_statements (
    database_id INT8 NULL,
    database_name STRING NULL,
@@ -296,8 +295,7 @@ CREATE TABLE crdb_internal.create_type_statements (
    descriptor_id INT8 NULL,
    descriptor_name STRING NULL,
    create_statement STRING NULL,
-   enum_members STRING[] NULL,
-   INDEX create_type_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_name, create_statement, enum_members)
+   enum_members STRING[] NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cross_db_references (
    object_database STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_types
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_types
@@ -1,0 +1,53 @@
+statement ok
+CREATE DATABASE d
+
+statement ok
+USE d
+
+query T colnames
+SHOW CREATE ALL TYPES
+----
+create_statement
+
+statement ok
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+
+query T colnames
+SHOW CREATE ALL TYPES
+----
+create_statement
+CREATE TYPE public.status AS ENUM ('open', 'closed', 'inactive');
+
+statement ok
+CREATE TYPE tableObj AS ENUM('row', 'col');
+
+query T colnames
+SHOW CREATE ALL TYPES
+----
+create_statement
+CREATE TYPE public.status AS ENUM ('open', 'closed', 'inactive');
+CREATE TYPE public.tableobj AS ENUM ('row', 'col');
+
+statement ok
+DROP TYPE status
+
+query T colnames
+SHOW CREATE ALL TYPES
+----
+create_statement
+CREATE TYPE public.tableobj AS ENUM ('row', 'col');
+
+# type in user-defined schema
+statement ok
+CREATE SCHEMA s
+
+statement ok
+CREATE TYPE s.status AS ENUM ('a', 'b', 'c');
+
+query T colnames
+SHOW CREATE ALL TYPES
+----
+create_statement
+CREATE TYPE public.tableobj AS ENUM ('row', 'col');
+CREATE TYPE s.status AS ENUM ('a', 'b', 'c');
+

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5630,8 +5630,9 @@ show_transaction_stmt:
 // %Category: DDL
 // %Text:
 // SHOW CREATE [ TABLE | SEQUENCE | VIEW | DATABASE ] <object_name>
-// SHOW CREATE ALL TABLES
 // SHOW CREATE ALL SCHEMAS
+// SHOW CREATE ALL TABLES
+// SHOW CREATE ALL TYPES
 // %SeeAlso: WEBDOCS/show-create.html
 show_create_stmt:
   SHOW CREATE table_name
@@ -5658,13 +5659,17 @@ show_create_stmt:
     /* SKIP DOC */
     $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeDatabase, Name: $4.unresolvedObjectName()}
 	}
+| SHOW CREATE ALL SCHEMAS
+  {
+    $$.val = &tree.ShowCreateAllSchemas{}
+  }
 | SHOW CREATE ALL TABLES
   {
     $$.val = &tree.ShowCreateAllTables{}
   }
-| SHOW CREATE ALL SCHEMAS
+| SHOW CREATE ALL TYPES
   {
-    $$.val = &tree.ShowCreateAllSchemas{}
+    $$.val = &tree.ShowCreateAllTypes{}
   }
 | SHOW CREATE error // SHOW HELP: SHOW CREATE
 

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "pg_builtins.go",
         "show_create_all_schemas_builtin.go",
         "show_create_all_tables_builtin.go",
+        "show_create_all_types_builtin.go",
         "window_builtins.go",
         "window_frame_builtins.go",
     ],

--- a/pkg/sql/sem/builtins/show_create_all_types_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_types_builtin.go
@@ -1,0 +1,93 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package builtins
+
+import (
+	"context"
+	"fmt"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// getTypeIDs returns the set of type ids from
+// crdb_internal.show_create_all_types for a specified database.
+func getTypeIDs(
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	dbName string,
+	acc *mon.BoundAccount,
+) ([]int64, error) {
+	query := fmt.Sprintf(`
+		SELECT descriptor_id
+		FROM %s.crdb_internal.create_type_statements
+		WHERE database_name = $1
+		`, dbName)
+	it, err := ie.QueryIteratorEx(
+		ctx,
+		"crdb_internal.show_create_all_types",
+		txn,
+		sessiondata.NoSessionDataOverride,
+		query,
+		dbName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var typeIDs []int64
+
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		tid := tree.MustBeDInt(it.Cur()[0])
+
+		typeIDs = append(typeIDs, int64(tid))
+		if err = acc.Grow(ctx, int64(unsafe.Sizeof(tid))); err != nil {
+			return nil, err
+		}
+	}
+	if err != nil {
+		return typeIDs, err
+	}
+
+	return typeIDs, nil
+}
+
+// getTypeCreateStatement gets the create statement to recreate a type (ignoring fks)
+// for a given type id in a database.
+func getTypeCreateStatement(
+	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, id int64, dbName string,
+) (tree.Datum, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			create_statement
+		FROM %s.crdb_internal.create_type_statements
+		WHERE descriptor_id = $1
+	`, dbName)
+	row, err := ie.QueryRowEx(
+		ctx,
+		"crdb_internal.show_create_all_types",
+		txn,
+		sessiondata.NoSessionDataOverride,
+		query,
+		id,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return row[0], nil
+}

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -542,6 +542,14 @@ func (node *ShowCreateAllTables) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ALL TABLES")
 }
 
+// ShowCreateAllTypes represents a SHOW CREATE ALL TYPES statement.
+type ShowCreateAllTypes struct{}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowCreateAllTypes) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CREATE ALL TYPES")
+}
+
 // ShowCreateSchedules represents a SHOW CREATE SCHEDULE statement.
 type ShowCreateSchedules struct {
 	ScheduleID Expr

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1219,6 +1219,15 @@ func (*ShowCreateAllTables) StatementType() StatementType { return TypeDML }
 func (*ShowCreateAllTables) StatementTag() string { return "SHOW CREATE ALL TABLES" }
 
 // StatementReturnType implements the Statement interface.
+func (*ShowCreateAllTypes) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*ShowCreateAllTypes) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowCreateAllTypes) StatementTag() string { return "SHOW CREATE ALL TYPES" }
+
+// StatementReturnType implements the Statement interface.
 func (*ShowCreateSchedules) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
@@ -1742,6 +1751,7 @@ func (n *ShowConstraints) String() string                { return AsString(n) }
 func (n *ShowCreate) String() string                     { return AsString(n) }
 func (node *ShowCreateAllSchemas) String() string        { return AsString(node) }
 func (node *ShowCreateAllTables) String() string         { return AsString(node) }
+func (node *ShowCreateAllTypes) String() string          { return AsString(node) }
 func (n *ShowCreateSchedules) String() string            { return AsString(n) }
 func (n *ShowDatabases) String() string                  { return AsString(n) }
 func (n *ShowDatabaseIndexes) String() string            { return AsString(n) }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/67685

Release note (sql change): SHOW CREATE ALL TYPES is a command that allows the user to get the statements to recreate
user-defined types of the current database. The command returns a flat log of the create statements for types.

Example output:
```
SHOW CREATE ALL TYPES
----
CREATE TYPE public.tableobj AS ENUM ('row', 'col');

```