### PR TITLE
Use include_cached to speed up build time, adding comment tags.

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -848,7 +848,7 @@ if options.prod_release:
 if not hidedownloads:
     print("""Get future release notes emailed to you:
 
-{% include marketo.html %}
+{% include_cached marketo.html %}
 """)
     print()
 
@@ -862,13 +862,13 @@ if not hidedownloads:
 </div>
 
 <section class="filter-content" data-scope="windows">
-{% include windows_warning.md %}
+{% include_cached windows_warning.md %}
 </section>
 """)
 
     print("""### Docker image
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~shell
 $ docker pull cockroachdb/cockroach""" + (":" if options.prod_release else "-unstable:") + current_version + """
 ~~~
@@ -933,7 +933,7 @@ if len(missing_release_notes) > 0:
 # Print the Doc Updates section.
 print("### Doc updates")
 print()
-print("Docs team: Please add these manually.")
+print("{% comment %}Docs team: Please add these manually.{% endcomment %}")
 print()
 
 # Print the Contributors section.


### PR DESCRIPTION
This PR has minor changes to the Markdown output of the release notes script. The docs team now uses the `include_cached` plugin for Jekyll for common included files to speed up build times. And I wrapped the comment for the docs team in Liquid comment tags. 

release notes: none