### PR TITLE
bazel: set `rpath`, etc properly in `libgeos` when cross-compiling

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,19 +26,20 @@ test:ci --test_tmpdir=/artifacts/tmp
 build:crosslinux --platforms=//build/toolchains:cross_linux
 build:crosslinux --crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
 build:crosslinux '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-pc-linux-gnu'
-build:crosslinux --config=ci
+build:crosslinux --config=ci --config=cross
 build:crosswindows --platforms=//build/toolchains:cross_windows
 build:crosswindows --crosstool_top=@toolchain_cross_x86_64-w64-mingw32//:suite
 build:crosswindows '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-w64-mingw32'
-build:crosswindows --config=ci
+build:crosswindows --config=ci --config=cross
 build:crossmacos --platforms=//build/toolchains:cross_macos
 build:crossmacos --crosstool_top=@toolchain_cross_x86_64-apple-darwin19//:suite
 build:crossmacos '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-apple-darwin19'
-build:crossmacos --config=ci
+build:crossmacos --config=ci --config=cross
 build:crosslinuxarm --platforms=//build/toolchains:cross_linux_arm
 build:crosslinuxarm --crosstool_top=@toolchain_cross_aarch64-unknown-linux-gnu//:suite
 build:crosslinuxarm '--workspace_status_command=./build/bazelutil/stamp.sh aarch64-unknown-linux-gnu'
-build:crosslinuxarm --config=ci
+build:crosslinuxarm --config=ci --config=cross
+build:cross --define cockroach_cross=y
 
 # developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
 build:devdarwinx86_64 --crosstool_top=@toolchain_dev_darwin_x86-64//:suite

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     make \
     netbase \
     openjdk-8-jre \
+    patchelf \
     unzip \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20211006-125507
+BAZEL_IMAGE=cockroachdb/bazel:20211008-130456
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -92,3 +92,23 @@ config_setting(
         "cockroach_bazel_dev": "y",
     },
 )
+
+config_setting(
+    name = "is_cross_macos",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:darwin",
+    ],
+    define_values = {
+        "cockroach_cross": "y",
+    },
+)
+
+config_setting(
+    name = "is_cross_linux",
+    constraint_values = [
+        "@io_bazel_rules_go//go/toolchain:linux",
+    ],
+    define_values = {
+        "cockroach_cross": "y",
+    },
+)

--- a/build/toolchains/darwin-x86_64/BUILD.tmpl
+++ b/build/toolchains/darwin-x86_64/BUILD.tmpl
@@ -2,6 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
+exports_files([
+    "bin/x86_64-apple-darwin19-install_name_tool",
+    "bin/x86_64-apple-darwin19-otool",
+])
+
 cc_toolchain_suite(
     name = "suite",
     toolchains = {

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -89,25 +89,52 @@ cmake(
         },
     }),
     cmake_options = ["-GUnix Makefiles"],
+    data = select({
+        "//build/toolchains:is_cross_macos": [
+            "@toolchain_cross_x86_64-apple-darwin19//:bin/x86_64-apple-darwin19-install_name_tool",
+            "@toolchain_cross_x86_64-apple-darwin19//:bin/x86_64-apple-darwin19-otool",
+        ],
+        "//conditions:default": [],
+    }),
+    env = select({
+        "//build/toolchains:is_cross_macos": {
+            "CMAKE_INSTALL_NAME_TOOL": "$(execpath @toolchain_cross_x86_64-apple-darwin19//:bin/x86_64-apple-darwin19-install_name_tool)",
+            "OTOOL": "$(execpath @toolchain_cross_x86_64-apple-darwin19//:bin/x86_64-apple-darwin19-otool)",
+        },
+        "//conditions:default": {},
+    }),
     lib_source = "@geos//:all",
     make_commands = [
         "mkdir -p libgeos/lib",
         "make --no-print-directory geos_c",
     ] + select({
+        "//build/toolchains:is_cross_macos": [
+            "cp -L lib/libgeos.dylib libgeos/lib",
+            "cp -L lib/libgeos_c.dylib libgeos/lib",
+            "PREFIX=$($OTOOL -D lib/libgeos_c.dylib | tail -n1 | rev | cut -d/ -f2- | rev)",
+            "$CMAKE_INSTALL_NAME_TOOL -id @rpath/libgeos.3.8.1.dylib libgeos/lib/libgeos.dylib",
+            "$CMAKE_INSTALL_NAME_TOOL -id @rpath/libgeos_c.1.dylib libgeos/lib/libgeos_c.dylib",
+            "$CMAKE_INSTALL_NAME_TOOL -change $PREFIX/libgeos.3.8.1.dylib @rpath/libgeos.3.8.1.dylib libgeos/lib/libgeos_c.dylib",
+        ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "cp -L lib/libgeos.dylib libgeos/lib",
             "cp -L lib/libgeos_c.dylib libgeos/lib",
-            # TODO(#bazel): install_name_tool is also required here for release.
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             # NOTE: Windows ends up in bin/ on the BUILD_TMPDIR.
             "cp -L bin/libgeos.dll libgeos/lib",
             "cp -L bin/libgeos_c.dll libgeos/lib",
         ],
+        "//build/toolchains:is_cross_linux": [
+            "cp -L lib/libgeos.so libgeos/lib",
+            "cp -L lib/libgeos_c.so libgeos/lib",
+            "patchelf --set-rpath /usr/local/lib/cockroach/ libgeos/lib/libgeos_c.so",
+            "patchelf --set-soname libgeos.so libgeos/lib/libgeos.so",
+            "patchelf --replace-needed libgeos.so.3.8.1 libgeos.so libgeos/lib/libgeos_c.so",
+        ],
         "//conditions:default": [
             "cp -L lib/libgeos.so libgeos/lib",
             "cp -L lib/libgeos_c.so libgeos/lib",
-            # TODO(#bazel): patchelf is also required here for release.
         ],
     }),
     out_shared_libs = select({


### PR DESCRIPTION
This logic is ported directly from the `Makefile`.

Closes #68350.

Release note: None