### PR TITLE
*: add go 1.17 build constraints / build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,6 +566,7 @@ $(BASE_CGO_FLAGS_FILES): Makefile build/defs.mk.sig | bin/.submodules-initialize
 	@echo "regenerating $@"
 	@echo '// GENERATED FILE DO NOT EDIT' > $@
 	@echo >> $@
+	@echo '//go:build $(if $(findstring $(native-tag),$@),$(native-tag),!make)' >> $@
 	@echo '// +build $(if $(findstring $(native-tag),$@),$(native-tag),!make)' >> $@
 	@echo >> $@
 	@echo 'package $(if $($(@D)-package),$($(@D)-package),$(notdir $(@D)))' >> $@

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -12,6 +12,7 @@
 // within docker compose. We also can't use just "gss" here because that
 // tag is reserved for the toplevel Makefile's linux-gnu build.
 
+//go:build gss_compose
 // +build gss_compose
 
 package gss

--- a/pkg/acceptance/test_acceptance.go
+++ b/pkg/acceptance/test_acceptance.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build acceptance
 // +build acceptance
 
 // Acceptance tests are comparatively slow to run, so we use the above build

--- a/pkg/acceptance/test_main.go
+++ b/pkg/acceptance/test_main.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !acceptance
 // +build !acceptance
 
 // Our Docker-based acceptance tests are comparatively slow to run, so we use

--- a/pkg/build/bazel/bazel.go
+++ b/pkg/build/bazel/bazel.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build bazel
 // +build bazel
 
 package bazel

--- a/pkg/build/bazel/non_bazel.go
+++ b/pkg/build/bazel/non_bazel.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !bazel
 // +build !bazel
 
 package bazel

--- a/pkg/build/cgo_compiler_nocgo.go
+++ b/pkg/build/cgo_compiler_nocgo.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !cgo
 // +build !cgo
 
 package build

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -10,6 +10,7 @@
 // linux-gnu targets (i.e., not musl). Since go doesn't have a builtin way
 // to do that, we have to set this in the top-level Makefile.
 
+//go:build gss
 // +build gss
 
 package gssapiccl

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !race
 // +build !race
 
 package cli

--- a/pkg/cli/democluster/socket_unix.go
+++ b/pkg/cli/democluster/socket_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package democluster

--- a/pkg/cli/democluster/socket_windows.go
+++ b/pkg/cli/democluster/socket_windows.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build windows
 // +build windows
 
 package democluster

--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !stdmalloc
 // +build !stdmalloc
 
 package cli

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package cli

--- a/pkg/cmd/import-tools/main.go
+++ b/pkg/cmd/import-tools/main.go
@@ -11,6 +11,7 @@
 // import-tools adds a blank import to tools we use such that `go mod tidy`
 // doesn't clean up needed dependencies when running `go install`.
 
+//go:build tools
 // +build tools
 
 package main

--- a/pkg/cmd/prereqs/testdata/src/example.com/a/ignore.go
+++ b/pkg/cmd/prereqs/testdata/src/example.com/a/ignore.go
@@ -10,4 +10,5 @@
 
 package a
 
+//go:build notme
 // +build notme

--- a/pkg/cmd/publish-artifacts/slow_test.go
+++ b/pkg/cmd/publish-artifacts/slow_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build slow
 // +build slow
 
 package main

--- a/pkg/col/coldata/vec_tmpl.go
+++ b/pkg/col/coldata/vec_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for vec.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -11,6 +11,7 @@
 // "make test" would normally test this file, but it should only be tested
 // within docker compose.
 
+//go:build compose
 // +build compose
 
 package compare

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -11,6 +11,7 @@
 // "make test" would normally test this file, but it should only be tested
 // during nightlies or when invoked by "make compose".
 
+//go:build compose
 // +build compose
 
 // Package compose contains nightly tests that need docker-compose.

--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build race
 // +build race
 
 package kvcoord

--- a/pkg/kv/kvclient/kvcoord/transport_regular.go
+++ b/pkg/kv/kvclient/kvcoord/transport_regular.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !race
 // +build !race
 
 package kvcoord

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package security_test

--- a/pkg/security/permission_check_test.go
+++ b/pkg/security/permission_check_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows && !plan9
 // +build !windows,!plan9
 
 package security

--- a/pkg/server/config_unix.go
+++ b/pkg/server/config_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package server

--- a/pkg/server/rlimit_bsd.go
+++ b/pkg/server/rlimit_bsd.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build freebsd || dragonfly
 // +build freebsd dragonfly
 
 package server

--- a/pkg/server/rlimit_darwin.go
+++ b/pkg/server/rlimit_darwin.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows && !freebsd && !dragonfly
 // +build !windows,!freebsd,!dragonfly
 
 package server

--- a/pkg/server/rlimit_unix.go
+++ b/pkg/server/rlimit_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows && !freebsd && !dragonfly && !darwin
 // +build !windows,!freebsd,!dragonfly,!darwin
 
 package server

--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !darwin
 // +build !darwin
 
 package status

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build darwin
 // +build darwin
 
 package status

--- a/pkg/server/status/jemalloc_test.go
+++ b/pkg/server/status/jemalloc_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !stdmalloc
 // +build !stdmalloc
 
 package status

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !stdmalloc
 // +build !stdmalloc
 
 package status

--- a/pkg/server/status/runtime_jemalloc_darwin.go
+++ b/pkg/server/status/runtime_jemalloc_darwin.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !stdmalloc && darwin
 // +build !stdmalloc,darwin
 
 package status

--- a/pkg/sql/colconv/datum_to_vec_tmpl.go
+++ b/pkg/sql/colconv/datum_to_vec_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for datum_to_vec.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for vec_to_datum.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for and_or_projection.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for any_not_null_agg.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for avg_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for bool_and_or_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/concat_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for concat_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for count_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for default_agg.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for min_max_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for sum_agg.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for cast.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for const.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for distinct.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for default_cmp_expr.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for hash_utils.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for hashtable.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for crossjoiner.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build execgen_template
 // +build execgen_template
 
 package colexecjoin

--- a/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoinbase_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for mergejoinbase.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for mergejoiner.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for default_cmp_proj_ops.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for proj_const_{left,right}_ops.eg.go.
 // It's formatted in a special way, so it's both valid Go and a valid

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for proj_non_const_ops.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for default_cmp_sel_ops.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for selection_ops.eg.go. It's formatted in
 // a special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for span_assembler.eg.go. It's formatted in
 // a special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for span_encoder.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for first_value.eg.go, last_value.eg.go,
 // and nth_value.eg.go. It's formatted in a special way, so it's both valid Go

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for lag.eg.go and lead.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for min_max_removable_agg.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for ntile.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for range_offset_handler.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/colexecwindow/rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/rank_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for rank.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for relative_rank.eg.go. It's formatted in
 // a special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for row_number.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for window_aggregator.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for window_framer.eg.go. It's formatted in
 // a special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for window_peer_grouper.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/execgen/cmd/execgen/main.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/main.go
@@ -146,6 +146,7 @@ func (g *execgenTool) generate(path string, entry entry) error {
 	b = emptyCommentRegex.ReplaceAll(b, []byte{})
 	b = emptyBlockCommentRegex.ReplaceAll(b, []byte{})
 	// Delete execgen_template build tag.
+	b = bytes.ReplaceAll(b, []byte("//go:build execgen_template"), []byte{})
 	b = bytes.ReplaceAll(b, []byte("// +build execgen_template"), []byte{})
 
 	if g.fmtSources {

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build execgen_template
 // +build execgen_template
 
 package colexec

--- a/pkg/sql/colexec/is_null_ops_tmpl.go
+++ b/pkg/sql/colexec/is_null_ops_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for is_null_ops.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for ordered_synchronizer.eg.go. It's
 // formatted in a special way, so it's both valid Go and a valid text/template

--- a/pkg/sql/colexec/quicksort_tmpl.go
+++ b/pkg/sql/colexec/quicksort_tmpl.go
@@ -13,7 +13,9 @@
 // license that can be found in the LICENSE file.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 // */}}
 
 package colexec

--- a/pkg/sql/colexec/rowstovec_tmpl.go
+++ b/pkg/sql/colexec/rowstovec_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for rowstovec.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for select_in.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for sort.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/sorttopk_tmpl.go
+++ b/pkg/sql/colexec/sorttopk_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for sorttopk.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for substring.eg.go. It's formatted in a
 // special way, so it's both valid Go and a valid text/template input. This

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for values_differ.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -9,7 +9,9 @@
 // licenses/APL.txt.
 
 // {{/*
+//go:build execgen_template
 // +build execgen_template
+
 //
 // This file is the execgen template for vec_comparators.eg.go. It's formatted
 // in a special way, so it's both valid Go and a valid text/template input.

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build crdb_test
 // +build crdb_test
 
 package memo

--- a/pkg/sql/opt/memo/check_expr_skip.go
+++ b/pkg/sql/opt/memo/check_expr_skip.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !crdb_test
 // +build !crdb_test
 
 package memo

--- a/pkg/sql/opt/memo/filters_expr_mutate_checker.go
+++ b/pkg/sql/opt/memo/filters_expr_mutate_checker.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build crdb_test
 // +build crdb_test
 
 package memo

--- a/pkg/sql/opt/memo/filters_expr_mutate_checker_skip.go
+++ b/pkg/sql/opt/memo/filters_expr_mutate_checker_skip.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !crdb_test
 // +build !crdb_test
 
 package memo

--- a/pkg/sql/opt/props/verify.go
+++ b/pkg/sql/opt/props/verify.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build crdb_test
 // +build crdb_test
 
 package props

--- a/pkg/sql/parser/fuzz/fuzz.go
+++ b/pkg/sql/parser/fuzz/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 // The parser fuzzer needs to live in its own package because it must import

--- a/pkg/sql/pgwire/fuzz.go
+++ b/pkg/sql/pgwire/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 package pgwire

--- a/pkg/sql/pgwire/hba/fuzz.go
+++ b/pkg/sql/pgwire/hba/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 package hba

--- a/pkg/sql/pgwire/pgwirebase/fuzz.go
+++ b/pkg/sql/pgwire/pgwirebase/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 package pgwirebase

--- a/pkg/sql/schemachanger/scop/generate_visitor.go
+++ b/pkg/sql/schemachanger/scop/generate_visitor.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build generator
 // +build generator
 
 package main

--- a/pkg/sql/sem/tree/fuzz.go
+++ b/pkg/sql/sem/tree/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 package tree

--- a/pkg/sql/sem/tree/nightly_pretty_test.go
+++ b/pkg/sql/sem/tree/nightly_pretty_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build nightly
 // +build nightly
 
 package tree_test

--- a/pkg/storage/array_32bit.go
+++ b/pkg/storage/array_32bit.go
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build 386 amd64p32 arm armbe  mips mipsle mips64p32 mips64p32le ppc sparc
+//go:build 386 || amd64p32 || arm || armbe || mips || mipsle || mips64p32 || mips64p32le || ppc || sparc
+// +build 386 amd64p32 arm armbe mips mipsle mips64p32 mips64p32le ppc sparc
 
 package storage
 

--- a/pkg/storage/array_64bit.go
+++ b/pkg/storage/array_64bit.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64
 // +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
 
 package storage

--- a/pkg/storage/slice_gccgo.go
+++ b/pkg/storage/slice_gccgo.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gccgo
 // +build gccgo
 
 package storage

--- a/pkg/storage/slice_go1.9.go
+++ b/pkg/storage/slice_go1.9.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gc && go1.9
 // +build gc,go1.9
 
 package storage

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build lint
 // +build lint
 
 package lint

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build lint && nightly
 // +build lint,nightly
 
 package lint

--- a/pkg/util/crdb_test_off.go
+++ b/pkg/util/crdb_test_off.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !crdb_test || crdb_test_off
 // +build !crdb_test crdb_test_off
 
 package util

--- a/pkg/util/crdb_test_on.go
+++ b/pkg/util/crdb_test_on.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build crdb_test && !crdb_test_off
 // +build crdb_test,!crdb_test_off
 
 package util

--- a/pkg/util/encoding/complement_fast.go
+++ b/pkg/util/encoding/complement_fast.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build 386 || amd64
 // +build 386 amd64
 
 package encoding

--- a/pkg/util/encoding/complement_safe.go
+++ b/pkg/util/encoding/complement_safe.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !386 && !amd64
 // +build !386,!amd64
 
 package encoding

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !fast_int_set_small && !fast_int_set_large
 // +build !fast_int_set_small,!fast_int_set_large
 
 package util

--- a/pkg/util/fast_int_set_large.go
+++ b/pkg/util/fast_int_set_large.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build fast_int_set_large
 // +build fast_int_set_large
 
 package util

--- a/pkg/util/fast_int_set_small.go
+++ b/pkg/util/fast_int_set_small.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build fast_int_set_small
 // +build fast_int_set_small
 
 package util

--- a/pkg/util/fast_int_set_testonly.go
+++ b/pkg/util/fast_int_set_testonly.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build fast_int_set_small || fast_int_set_large
 // +build fast_int_set_small fast_int_set_large
 
 // This file implements two variants of FastIntSet used for testing which always

--- a/pkg/util/goschedstats/runtime_go1.16.go
+++ b/pkg/util/goschedstats/runtime_go1.16.go
@@ -12,6 +12,7 @@
 // go1.16, and go1.17beta1 (needs revalidation). Before allowing newer
 // versions, please check that the structures still match with those in
 // go/src/runtime.
+//go:build gc && go1.16 && !go1.18
 // +build gc,go1.16,!go1.18
 
 package goschedstats

--- a/pkg/util/hlc/hlc_clock_device_linux.go
+++ b/pkg/util/hlc/hlc_clock_device_linux.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build linux
 // +build linux
 
 package hlc

--- a/pkg/util/hlc/hlc_clock_device_stub.go
+++ b/pkg/util/hlc/hlc_clock_device_stub.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !linux
 // +build !linux
 
 package hlc

--- a/pkg/util/interval/bu23.go
+++ b/pkg/util/interval/bu23.go
@@ -14,6 +14,7 @@
 
 // This code originated in the github.com/biogo/store/interval package.
 
+//go:build !td234
 // +build !td234
 
 package interval

--- a/pkg/util/interval/generic/gen.sh
+++ b/pkg/util/interval/generic/gen.sh
@@ -36,7 +36,7 @@ for template in "${templates[@]}" ; do
     dst=${dst_prefix}_${template//_tmpl/}
     echo -e ${gen_header_comment} \
     | cat - ${internal_pkg}/${template} <(echo "$STRIPPED") \
-    | grep -v '// +build ignore' \
+    | grep -v '//go:build ignore\|// +build ignore' \
     | go_generics -i /dev/stdin -t T=${type} -p ${pkg} -o ${dst}
     crlfmt -w -diff=false ${dst}
 done

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build ignore
 // +build ignore
 
 package internal

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build ignore
 // +build ignore
 
 package internal

--- a/pkg/util/interval/td234.go
+++ b/pkg/util/interval/td234.go
@@ -14,6 +14,7 @@
 
 // This code originated in the github.com/biogo/store/interval package.
 
+//go:build td234
 // +build td234
 
 package interval

--- a/pkg/util/json/fuzz.go
+++ b/pkg/util/json/fuzz.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build gofuzz
 // +build gofuzz
 
 package json

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build bazel
 // +build bazel
 
 package main

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build bazel
 // +build bazel
 
 package main

--- a/pkg/util/log/logcrash/crash_reporting_unix_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_unix_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package logcrash

--- a/pkg/util/log/stderr_redirect_unix.go
+++ b/pkg/util/log/stderr_redirect_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package log

--- a/pkg/util/race_off.go
+++ b/pkg/util/race_off.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !race
 // +build !race
 
 package util

--- a/pkg/util/race_on.go
+++ b/pkg/util/race_on.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build race
 // +build race
 
 package util

--- a/pkg/util/sdnotify/sdnotify_unix.go
+++ b/pkg/util/sdnotify/sdnotify_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package sdnotify

--- a/pkg/util/sdnotify/sdnotify_unix_test.go
+++ b/pkg/util/sdnotify/sdnotify_unix_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package sdnotify

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build deadlock
 // +build deadlock
 
 package syncutil

--- a/pkg/util/syncutil/mutex_sync.go
+++ b/pkg/util/syncutil/mutex_sync.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !deadlock
-// +build !race
+//go:build !deadlock && !race
+// +build !deadlock,!race
 
 package syncutil
 

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !deadlock
-// +build race
+//go:build !deadlock && race
+// +build !deadlock,race
 
 package syncutil
 

--- a/pkg/util/syncutil/mutex_sync_race_test.go
+++ b/pkg/util/syncutil/mutex_sync_race_test.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !deadlock
-// +build race
+//go:build !deadlock && race
+// +build !deadlock,race
 
 package syncutil
 

--- a/pkg/util/sysutil/acl_unix.go
+++ b/pkg/util/sysutil/acl_unix.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !windows
-// +build !plan9
+//go:build !windows && !plan9
+// +build !windows,!plan9
 
 package sysutil
 

--- a/pkg/util/sysutil/acl_unix_test.go
+++ b/pkg/util/sysutil/acl_unix_test.go
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// +build !windows
-// +build !plan9
+//go:build !windows && !plan9
+// +build !windows,!plan9
 
 package sysutil
 

--- a/pkg/util/sysutil/large_file_linux.go
+++ b/pkg/util/sysutil/large_file_linux.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build linux
 // +build linux
 
 package sysutil

--- a/pkg/util/sysutil/large_file_nonlinux.go
+++ b/pkg/util/sysutil/large_file_nonlinux.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !linux
 // +build !linux
 
 package sysutil

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 //lint:file-ignore Unconvert (redundant conversions are necessary for cross-platform compatibility)

--- a/pkg/util/sysutil/sysutil_unix_test.go
+++ b/pkg/util/sysutil/sysutil_unix_test.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package sysutil

--- a/pkg/util/sysutil/sysutil_windows.go
+++ b/pkg/util/sysutil/sysutil_windows.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build windows
 // +build windows
 
 package sysutil

--- a/pkg/util/testaddr_default.go
+++ b/pkg/util/testaddr_default.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !linux
 // +build !linux
 
 package util

--- a/pkg/util/testaddr_random.go
+++ b/pkg/util/testaddr_random.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build linux
 // +build linux
 
 package util

--- a/pkg/util/timeutil/now_unix.go
+++ b/pkg/util/timeutil/now_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package timeutil

--- a/pkg/util/uuid/fuzz.go
+++ b/pkg/util/uuid/fuzz.go
@@ -14,6 +14,7 @@
 
 // This code originated in github.com/gofrs/uuid.
 
+//go:build gofuzz
 // +build gofuzz
 
 package uuid

--- a/pkg/workload/cli/run_unix.go
+++ b/pkg/workload/cli/run_unix.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build !windows
 // +build !windows
 
 package cli

--- a/pkg/workload/cli/run_windows.go
+++ b/pkg/workload/cli/run_windows.go
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+//go:build windows
 // +build windows
 
 package cli


### PR DESCRIPTION
In go 1.17 the format of build constraints / build tags changed. From
the documentation for gofmt:

> Go versions 1.16 and earlier used a different syntax for build
constraints, with a "// +build" prefix. The gofmt command will add an
equivalent //go:build constraint when encountering the older syntax.

This commit was generated with:

```sh
git grep -l '+build' | xargs -n1 crlfmt -w
```

And then these files were edited by hand (and need a closer look):
- `Makefile`
- `pkg/cmd/prereqs/testdata/src/example.com/a/ignore.go`
- `pkg/sql/colexec/execgen/cmd/execgen/main.go`
- `pkg/util/interval/generic/gen.sh`

Note that this change does not remove go 1.16 build tags, so it should
still be possible to build with go 1.16.

Release note: None