### PR TITLE
workload: don't log from pgx if ctx is canceled

### DIFF
--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -59,6 +59,11 @@ var _ pgx.Logger = pgxLogger{}
 func (p pgxLogger) Log(
 	ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{},
 ) {
+	if ctx.Err() != nil {
+		// Don't log anything from pgx if the context was canceled by the workload
+		// runner. It would result in spam at the end of every workload.
+		return
+	}
 	if strings.Contains(msg, "restart transaction") {
 		// Our workloads have a lot of contention, so "restart transaction" messages
 		// are expected and noisy.


### PR DESCRIPTION
Canceling the context is how all the workloads complete themselves. It
results in queries failing, which pgx logs as errors, but they are
expected. So we shouldn't log these errors.

Release note: None