### PR TITLE
jobs, backupccl: redact output of SHOW CREATE SCHEDULE

### DIFF
--- a/pkg/jobs/executor_impl.go
+++ b/pkg/jobs/executor_impl.go
@@ -96,7 +96,7 @@ func (e *inlineScheduledJobExecutor) GetCreateScheduleStatement(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	schedule *ScheduledJob,
+	sj *ScheduledJob,
 	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "", errors.AssertionFailedf("unimplemented method: 'GetCreateScheduleStatement'")

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -266,7 +266,7 @@ func (n *recordScheduleExecutor) GetCreateScheduleStatement(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	schedule *ScheduledJob,
+	sj *ScheduledJob,
 	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "", errors.AssertionFailedf("unimplemented method: 'GetCreateScheduleStatement'")
@@ -490,7 +490,7 @@ func (e *returnErrorExecutor) GetCreateScheduleStatement(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	schedule *ScheduledJob,
+	sj *ScheduledJob,
 	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "", errors.AssertionFailedf("unimplemented method: 'GetCreateScheduleStatement'")
@@ -673,7 +673,7 @@ func (e *txnConflictExecutor) GetCreateScheduleStatement(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	schedule *ScheduledJob,
+	sj *ScheduledJob,
 	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "", errors.AssertionFailedf("unimplemented method: 'GetCreateScheduleStatement'")

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -54,8 +54,8 @@ type ScheduledJobExecutor interface {
 	// GetCreateScheduleStatement returns a `CREATE SCHEDULE` statement that is
 	// functionally equivalent to the statement that led to the creation of
 	// the passed in `schedule`.
-	GetCreateScheduleStatement(ctx context.Context, env scheduledjobs.JobSchedulerEnv, txn *kv.Txn,
-		schedule *ScheduledJob, ex sqlutil.InternalExecutor) (string, error)
+	GetCreateScheduleStatement(ctx context.Context, env scheduledjobs.JobSchedulerEnv,
+		txn *kv.Txn, sj *ScheduledJob, ex sqlutil.InternalExecutor) (string, error)
 }
 
 // ScheduledJobController is an interface describing hooks that will execute

--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -63,7 +63,7 @@ func (s *statusTrackingExecutor) GetCreateScheduleStatement(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	schedule *ScheduledJob,
+	sj *ScheduledJob,
 	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "", errors.AssertionFailedf("unimplemented method: 'GetCreateScheduleStatement'")

--- a/pkg/sql/compact_sql_stats.go
+++ b/pkg/sql/compact_sql_stats.go
@@ -244,11 +244,11 @@ func (e *scheduledSQLStatsCompactionExecutor) Metrics() metric.Struct {
 
 // GetCreateScheduleStatement implements the jobs.ScheduledJobExecutor interface.
 func (e *scheduledSQLStatsCompactionExecutor) GetCreateScheduleStatement(
-	_ context.Context,
-	_ scheduledjobs.JobSchedulerEnv,
-	_ *kv.Txn,
-	_ *jobs.ScheduledJob,
-	_ sqlutil.InternalExecutor,
+	ctx context.Context,
+	env scheduledjobs.JobSchedulerEnv,
+	txn *kv.Txn,
+	sj *jobs.ScheduledJob,
+	ex sqlutil.InternalExecutor,
 ) (string, error) {
 	return "SELECT crdb_internal.schedule_sql_stats_compact()", nil
 }


### PR DESCRIPTION
This change redacts some of the fields that are displayed as
part of `SHOW CREATE SCHEDULE`. It uses an existing helper method
to process the underlying backup node and redact sensitive fields
from it.

Fixes: https://github.com/cockroachdb/cockroach/issues/71281

Release note (bug fix): Fixes a bug where SHOW CREATE SCHEDULES
was not redacting sensitive fields before displaying the `CREATE SCHEDULE`
query.