### PR TITLE
*: revive the test deadlock detector

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3709,8 +3709,8 @@ def go_deps():
         name = "com_github_sasha_s_go_deadlock",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sasha-s/go-deadlock",
-        sum = "h1:lMqc+fUb7RrFS3gQLtoQsJ7/6TV/pAIFvBsqX73DK8Y=",
-        version = "v0.2.0",
+        sum = "h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=",
+        version = "v0.3.1",
     )
     go_repository(
         name = "com_github_satori_go_uuid",

--- a/Makefile
+++ b/Makefile
@@ -911,7 +911,7 @@ ifneq ($(removed-files-to-remove),)
 endif
 
 test-targets := \
-	check test testshort testslow testrace testraceslow testbuild \
+	check test testshort testslow testrace testraceslow testdeadlock testbuild \
 	stress stressrace \
 	roachprod-stress roachprod-stressrace \
 	testlogic testbaselogic testccllogic testoptlogic
@@ -921,7 +921,7 @@ go-targets-ccl := \
 	bin/workload \
 	go-install \
 	bench benchshort \
-	check test testshort testslow testrace testraceslow testbuild \
+	check test testshort testslow testrace testraceslow testdeadlock testbuild \
 	stress stressrace \
 	roachprod-stress roachprod-stressrace \
 	generate \
@@ -1044,6 +1044,8 @@ testbuild:
 
 testshort: override TESTFLAGS += -short
 
+testdeadlock: TAGS += deadlock
+
 testrace: ## Run tests with the Go race detector enabled.
 testrace stressrace roachprod-stressrace: override GOFLAGS += -race
 testrace stressrace roachprod-stressrace: export GORACE := halt_on_error=1
@@ -1063,9 +1065,9 @@ bench benchshort: TESTTIMEOUT := $(BENCHTIMEOUT)
 # that longer running benchmarks can skip themselves.
 benchshort: override TESTFLAGS += -benchtime=1ns -short
 
-.PHONY: check test testshort testrace testlogic testbaselogic testccllogic testoptlogic bench benchshort
+.PHONY: check test testshort testrace testdeadlock testlogic testbaselogic testccllogic testoptlogic bench benchshort
 test: ## Run tests.
-check test testshort testrace bench benchshort:
+check test testshort testrace testdeadlock bench benchshort:
 	$(xgo) test $(GOTESTFLAGS) $(GOFLAGS) $(GOMODVENDORFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" $(if $(BENCHES),-bench "$(BENCHES)") -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 
 .PHONY: stress stressrace

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/pseudomuto/protoc-gen-doc v1.3.2
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/russross/blackfriday v1.6.0 // indirect
-	github.com/sasha-s/go-deadlock v0.2.0
+	github.com/sasha-s/go-deadlock v0.3.1
 	github.com/shirou/gopsutil v2.20.9+incompatible
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1311,8 +1311,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sasha-s/go-deadlock v0.2.0 h1:lMqc+fUb7RrFS3gQLtoQsJ7/6TV/pAIFvBsqX73DK8Y=
-github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
+github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
+github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1316,6 +1316,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 func TestChangefeedColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlock(t, "sometimes hangs")
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
@@ -2059,6 +2060,7 @@ func TestChangefeedUpdatePrimaryKey(t *testing.T) {
 func TestChangefeedTruncateOrDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlock(t, "sometimes hangs")
 
 	assertFailuresCounter := func(t *testing.T, m *Metrics, exp int64) {
 		t.Helper()
@@ -4758,6 +4760,7 @@ func (s *memoryHoggingSink) Close() error {
 func TestChangefeedFlushesSinkToReleaseMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71364)
 
 	s, db, stopServer := startTestServer(t, newTestOptions())
 	defer stopServer()

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
         "//pkg/sql/types",
+        "//pkg/testutils/skip",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -64,6 +65,7 @@ func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup 
 func TestBlockingBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71364)
 
 	metrics := kvevent.MakeMetrics(time.Minute)
 	ba, release := getBoundAccountWithBudget(4096)
@@ -115,6 +117,7 @@ func TestBlockingBuffer(t *testing.T) {
 func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71364)
 
 	metrics := kvevent.MakeMetrics(time.Minute)
 	ba, release := getBoundAccountWithBudget(4096)

--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql/logictest",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -22,6 +23,7 @@ const logictestGlob = "logic_test/[^.]*"
 
 func TestCCLLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlockWithIssue(t, 71366)
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, filepath.Join("testdata/", logictestGlob))
 }
 
@@ -31,6 +33,7 @@ func TestCCLLogic(t *testing.T) {
 // configuration (i.e. "# LogicTest: !3node-tenant") are not run.
 func TestTenantLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlockWithIssue(t, 71366)
 
 	testdataDir := "../../sql/logictest/testdata/"
 	if bazel.BuiltWithBazel() {

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//pkg/sql/pgwire",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -586,6 +587,7 @@ func TestDenylistUpdate(t *testing.T) {
 
 func TestDirectoryConnect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlockWithIssue(t, 71365)
 
 	ctx := context.Background()
 	te := newTester()

--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/ccl/sqlproxyccl/tenant/directory_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -67,6 +68,7 @@ func TestDirectoryErrors(t *testing.T) {
 func TestWatchPods(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71365)
 
 	// Make pod watcher channel.
 	podWatcher := make(chan *tenant.Pod, 1)
@@ -220,6 +222,7 @@ func TestCancelLookups(t *testing.T) {
 func TestResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71365)
 
 	tenantID := roachpb.MakeTenantID(40)
 	const lookupCount = 5
@@ -319,6 +322,7 @@ func TestDeleteTenant(t *testing.T) {
 func TestRefreshThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
+	skip.UnderDeadlockWithIssue(t, 71365)
 
 	// Create the directory, but with extreme rate limiting so that directory
 	// will never refresh.

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -975,6 +975,7 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	skip.UnderStress(t, 38565)
 	skip.UnderRaceWithIssue(t, 38565)
 	skip.UnderShort(t, 38565)
+	skip.UnderDeadlockWithIssue(t, 38565)
 	ctx := context.Background()
 
 	// Create a cluster with really small ranges.

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -13,6 +13,7 @@ package logictest
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -26,6 +27,7 @@ import (
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlockWithIssue(t, 71366)
 	RunLogicTest(t, TestServerArgs{}, "testdata/logic_test/[^.]*")
 }
 
@@ -33,6 +35,7 @@ func TestLogic(t *testing.T) {
 // for runSQLLiteLogicTest for more detail on these tests.
 func TestSqlLiteLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlockWithIssue(t, 71366)
 	RunSQLLiteLogicTest(t, "" /* configOverride */)
 }
 

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/sql/opt",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -27,5 +28,6 @@ import (
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	skip.UnderDeadlockWithIssue(t, 71366)
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/[^.]*")
 }

--- a/pkg/testutils/skip/BUILD.bazel
+++ b/pkg/testutils/skip/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "//pkg/build/bazel",
         "//pkg/util",
         "//pkg/util/envutil",
+        "//pkg/util/syncutil",
     ],
 )

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // SkippableTest is a testing.TB with Skip methods.
@@ -46,6 +47,26 @@ func IgnoreLint(t SkippableTest, args ...interface{}) {
 func IgnoreLintf(t SkippableTest, format string, args ...interface{}) {
 	t.Helper()
 	t.Skipf(format, args...)
+}
+
+// UnderDeadlock skips this test if the deadlock detector is enabled.
+func UnderDeadlock(t SkippableTest, args ...interface{}) {
+	t.Helper()
+	if syncutil.DeadlockEnabled {
+		t.Skip(append([]interface{}{"disabled under deadlock detector"}, args...))
+	}
+}
+
+// UnderDeadlockWithIssue skips this test if the deadlock detector is enabled,
+// logging the given issue ID as the reason.
+func UnderDeadlockWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Helper()
+	if syncutil.DeadlockEnabled {
+		t.Skip(append([]interface{}{fmt.Sprintf(
+			"disabled under deadlock detector. issue: https://github.com/cockroachdb/cockroach/issue/%d",
+			githubIssueID,
+		)}, args...))
+	}
 }
 
 // UnderRace skips this test if the race detector is enabled.

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -18,6 +18,9 @@ import (
 	deadlock "github.com/sasha-s/go-deadlock"
 )
 
+// DeadlockEnabled is true if the deadlock detector is enabled.
+const DeadlockEnabled = true
+
 func init() {
 	deadlock.Opts.DeadlockTimeout = 5 * time.Minute
 }

--- a/pkg/util/syncutil/mutex_sync.go
+++ b/pkg/util/syncutil/mutex_sync.go
@@ -15,6 +15,9 @@ package syncutil
 
 import "sync"
 
+// DeadlockEnabled is true if the deadlock detector is enabled.
+const DeadlockEnabled = false
+
 // A Mutex is a mutual exclusion lock.
 type Mutex struct {
 	sync.Mutex

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -18,6 +18,9 @@ import (
 	"sync/atomic"
 )
 
+// DeadlockEnabled is true if the deadlock detector is enabled.
+const DeadlockEnabled = false
+
 // A Mutex is a mutual exclusion lock.
 type Mutex struct {
 	mu      sync.Mutex


### PR DESCRIPTION
**go.mod: upgrade go-deadlock**

Release note: None

**skip: add `UnderDeadlock`**

Release note: None

**Makefile: add `testdeadlock` target**

This adds a `testdeadlock` target which runs tests under the deadlock
detector.

Touches #66764.

Release note: None

***: skip tests that fail the deadlock detector**

These tests fail with deadlock detection enabled via `-tags deadlock`.
They are skipped for now, and will be investigated separately.

Release note: None