### PR TITLE
randutil: adds NewTestRand to provide more deterministic random number generation

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3538,7 +3538,7 @@ func TestBackupRestoreIncremental(t *testing.T) {
 	_, tc, sqlDB, dir, cleanupFn := BackupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
 	defer cleanupFn()
 	args := base.TestServerArgs{ExternalIODir: dir}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var backupDirs []string
 	var checksums []uint32
@@ -3630,7 +3630,7 @@ func TestBackupRestorePartitionedIncremental(t *testing.T) {
 	_, _, sqlDB, dir, cleanupFn := BackupRestoreTestSetup(t, MultiNode, 0, InitManualReplication)
 	defer cleanupFn()
 	args := base.TestServerArgs{ExternalIODir: dir}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Each incremental backup is written to two different subdirectories in
 	// defaultDir and dc1Dir, respectively.
@@ -3713,7 +3713,7 @@ func TestBackupRestorePartitionedIncremental(t *testing.T) {
 func startBackgroundWrites(
 	stopper *stop.Stopper, sqlDB *gosql.DB, maxID int, wake chan<- struct{}, allowErrors *int32,
 ) error {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for {
 		select {
@@ -6203,7 +6203,7 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 		allowRequest = make(chan struct{})
 		runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '100ms';")
 		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds = 1;")
-		rRand, _ := randutil.NewPseudoRand()
+		rRand, _ := randutil.NewTestRand()
 		writeGarbage := func(from, to int) {
 			for i := from; i < to; i++ {
 				runner.Exec(t, "UPSERT INTO foo VALUES ($1, $2)", i, randutil.RandBytes(rRand, 1<<10))

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -192,7 +192,7 @@ func createEnum(enumLabels tree.EnumValueList, typeName tree.TypeName) *types.T 
 func TestAvroSchema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	type test struct {
 		name   string
@@ -814,7 +814,7 @@ func TestDecimalRatRoundtrip(t *testing.T) {
 		require.EqualError(t, err, "cannot convert Infinite form decimal")
 	})
 	t.Run(`rand`, func(t *testing.T) {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		precision := rng.Int31n(10) + 1
 		scale := rng.Int31n(precision + 1)
 		coeff := rng.Int63n(int64(math.Pow10(int(precision))))
@@ -852,7 +852,7 @@ func benchmarkEncodeType(b *testing.B, typ *types.T, encRow rowenc.EncDatumRow) 
 func randEncDatumRow(typ *types.T) rowenc.EncDatumRow {
 	const allowNull = true
 	const notNull = false
-	rnd, _ := randutil.NewTestPseudoRand()
+	rnd, _ := randutil.NewTestRand()
 	return rowenc.EncDatumRow{
 		rowenc.DatumToEncDatum(typ, randgen.RandDatum(rnd, typ, allowNull)),
 		rowenc.DatumToEncDatum(types.Int, randgen.RandDatum(rnd, types.Int, notNull)),
@@ -917,7 +917,7 @@ func BenchmarkEncodeString(b *testing.B) {
 	benchmarkEncodeType(b, types.String, randEncDatumRow(types.String))
 }
 
-var collatedStringType *types.T = types.MakeCollatedString(types.String, `fr`)
+var collatedStringType = types.MakeCollatedString(types.String, `fr`)
 
 func BenchmarkEncodeCollatedString(b *testing.B) {
 	benchmarkEncodeType(b, collatedStringType, randEncDatumRow(collatedStringType))

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4217,7 +4217,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderShort(t)
 
-	rnd, _ := randutil.NewPseudoRand()
+	rnd, _ := randutil.NewTestRand()
 
 	var maxCheckpointSize int64
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -91,7 +91,7 @@ func TestBlockingBuffer(t *testing.T) {
 
 	// Start adding KVs to the buffer until we block.
 	wg.GoCtx(func(ctx context.Context) error {
-		rnd, _ := randutil.NewTestPseudoRand()
+		rnd, _ := randutil.NewTestRand()
 		for {
 			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
 			if err != nil {
@@ -134,7 +134,7 @@ func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
 
 	// Start adding KVs to the buffer until we block.
 	wg.GoCtx(func(ctx context.Context) error {
-		rnd, _ := randutil.NewTestPseudoRand()
+		rnd, _ := randutil.NewTestRand()
 		for {
 			err := buf.Add(ctx, kvevent.MakeKVEvent(makeKV(t, rnd), roachpb.Value{}, hlc.Timestamp{}))
 			if err != nil {

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -663,7 +663,7 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	require.NoError(t, sink.Flush(ctx))
 
 	// Emit few messages
-	rnd, _ := randutil.NewTestPseudoRand()
+	rnd, _ := randutil.NewTestRand()
 	key := randutil.RandBytes(rnd, 1+rnd.Intn(64))
 	val := randutil.RandBytes(rnd, 1+rnd.Intn(512))
 

--- a/pkg/ccl/importccl/import_into_test.go
+++ b/pkg/ccl/importccl/import_into_test.go
@@ -67,7 +67,7 @@ func TestProtectedTimestampsDuringImportInto(t *testing.T) {
 	runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
 	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '100ms';")
 	runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds = 1;")
-	rRand, _ := randutil.NewPseudoRand()
+	rRand, _ := randutil.NewTestRand()
 	writeGarbage := func(from, to int) {
 		for i := from; i < to; i++ {
 			runner.Exec(t, "UPSERT INTO foo VALUES ($1, $2)", i, randutil.RandBytes(rRand, 1<<10))

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1211,7 +1211,7 @@ func TestInitialPartitioning(t *testing.T) {
 	skip.UnderStressRace(t)
 	skip.UnderShort(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	testCases := allPartitioningTests(rng)
 
 	ctx := context.Background()
@@ -1324,7 +1324,7 @@ func TestRepartitioning(t *testing.T) {
 	// race stress.
 	skip.UnderStressRace(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))
 	if err != nil {
 		t.Fatalf("%+v", err)

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -277,7 +277,7 @@ func TestInvalidIndexPartitionSetShowZones(t *testing.T) {
 func TestGenerateSubzoneSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	partitioningTests := allPartitioningTests(rng)
 	for _, test := range partitioningTests {

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -58,7 +58,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	})
 
 	t.Run("ReadAt", func(t *testing.T) {
-		rng, _ := randutil.NewTestPseudoRand()
+		rng, _ := randutil.NewTestRand()
 
 		encryptionChunkSizeV2 = 32
 
@@ -151,7 +151,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	})
 
 	t.Run("Random", func(t *testing.T) {
-		rng, _ := randutil.NewTestPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		t.Run("DecryptFile", func(t *testing.T) {
 			// For some number of randomly chosen chunk-sizes, generate a number
 			// of random length plaintexts of random bytes and ensure they each

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -154,7 +154,7 @@ func CheckExportStore(
 		t.Fatalf("conf does not roundtrip: started with %+v, got back %+v", conf, readConf)
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	t.Run("simple round trip", func(t *testing.T) {
 		sampleName := "somebytes"
@@ -509,7 +509,7 @@ func uploadData(
 func CheckAntagonisticRead(
 	t *testing.T, conf roachpb.ExternalStorage, testSettings *cluster.Settings,
 ) {
-	rnd, _ := randutil.NewPseudoRand()
+	rnd, _ := randutil.NewTestRand()
 
 	const basename = "test-antagonistic-read"
 	data, cleanup := uploadData(t, testSettings, rnd, conf, basename)

--- a/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
@@ -45,7 +45,7 @@ func uploadFile(
 	db *kv.DB,
 ) ([]byte, error) {
 	data := make([]byte, fileSize)
-	randGen, _ := randutil.NewPseudoRand()
+	randGen, _ := randutil.NewTestRand()
 	randutil.ReadTestdataBytes(randGen, data)
 
 	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -279,7 +279,7 @@ func TestReadWriteFile(t *testing.T) {
 		fileSize := 1024
 
 		data := make([]byte, fileSize)
-		randGen, _ := randutil.NewPseudoRand()
+		randGen, _ := randutil.NewTestRand()
 		randutil.ReadTestdataBytes(randGen, data)
 
 		writer, err := fileTableReadWriter.NewFileWriter(ctx, testFileName, chunkSize)

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -137,7 +137,7 @@ func registerAlterPK(r registry.Registry) {
 				`ALTER TABLE order_line ALTER PRIMARY KEY USING COLUMNS (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`,
 			}
 
-			rand, _ := randutil.NewPseudoRand()
+			rand, _ := randutil.NewTestRand()
 			randStmt := alterStmts[rand.Intn(len(alterStmts))]
 			t.Status("Running command: ", randStmt)
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -92,7 +92,7 @@ func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 
 const randomSettingPercent = 0.50
 
-var rng, _ = randutil.NewTestPseudoRand()
+var rng, _ = randutil.NewTestRand()
 
 func randomlyRun(t test.Test, db *sqlutils.SQLRunner, query string) {
 	if rng.Float64() < randomSettingPercent {

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -83,7 +83,7 @@ func registerSQLSmith(r registry.Registry) {
 			fmt.Fprint(smithLog, "\n\n")
 		}
 
-		rng, seed := randutil.NewPseudoRand()
+		rng, seed := randutil.NewTestRand()
 		t.L().Printf("seed: %d", seed)
 
 		c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -66,7 +66,7 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	conn := c.Conn(ctx, 1)
 
-	rnd, seed := randutil.NewPseudoRand()
+	rnd, seed := randutil.NewTestRand()
 	t.L().Printf("seed: %d", seed)
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -444,7 +444,7 @@ func (d tpchVecDiskTest) preTestRunHook(
 	// order of 800MiB) in partitions of roughly workmem/4 in size. Such
 	// behavior is determined by the fact that we allocate some RAM for caches
 	// of disk queues (limiting us to use at most 2 input partitions).
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	workmemInKiB := 650 + rng.Intn(1350)
 	workmem := fmt.Sprintf("%dKiB", workmemInKiB)
 	t.Status(fmt.Sprintf("setting workmem='%s'", workmem))

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -196,7 +196,7 @@ func prettyByteSlice(b [][]byte) string {
 func TestBytesRefImpl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	const (
 		maxNumberOfCalls = 64
@@ -454,7 +454,7 @@ func TestBytes(t *testing.T) {
 	})
 
 	t.Run("Abbreviated", func(t *testing.T) {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 
 		// Create a vector with random bytes values.
 		b := NewBytes(250)
@@ -489,7 +489,7 @@ func TestProportionalSize(t *testing.T) {
 	// Use a large value so that the bytes vector needs to expand.
 	value := make([]byte, 3*BytesInitialAllocationFactor)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	// We need a number divisible by 4.
 	fullCapacity := (1 + rng.Intn(100)) * 4
 	b := NewBytes(fullCapacity)
@@ -516,7 +516,7 @@ const letters = "abcdefghijklmnopqrstuvwxyz"
 func TestToArrowSerializationFormat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nullChance := 0.2
 	maxStringLength := 10
 	numElements := 1 + rng.Intn(BatchSize())

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -228,7 +228,7 @@ func TestSlice(t *testing.T) {
 }
 
 func TestNullsOr(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	randomNulls := NewNulls(BatchSize())
 	for i := 0; i < BatchSize(); i++ {
 		if rng.Float64() < 0.5 {

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -25,7 +25,7 @@ import (
 func TestMemColumnWindow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	c := coldata.NewMemColumn(types.Int, coldata.BatchSize(), coldata.StandardColumnFactory)
 
@@ -359,7 +359,7 @@ func TestCopyNulls(t *testing.T) {
 }
 
 func TestCopyWithReorderedSource(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	var typ = types.Int
 
 	for _, hasNulls := range []bool{false, true} {
@@ -397,7 +397,7 @@ func TestCopyWithReorderedSource(t *testing.T) {
 }
 
 func BenchmarkAppend(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	sel := rng.Perm(coldata.BatchSize())
 
 	benchCases := []struct {
@@ -444,7 +444,7 @@ func BenchmarkAppend(b *testing.B) {
 }
 
 func BenchmarkCopy(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	sel := rng.Perm(coldata.BatchSize())
 
 	benchCases := []struct {

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -29,7 +29,7 @@ import (
 
 func randomBatch(allocator *colmem.Allocator) ([]*types.T, coldata.Batch) {
 	const maxTyps = 16
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	typs := make([]*types.T, rng.Intn(maxTyps)+1)
 	for i := range typs {
@@ -87,7 +87,7 @@ func roundTripBatch(
 func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for run := 0; run < 10; run++ {
 		var typs []*types.T
 		var src coldata.Batch
@@ -137,7 +137,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 	// to in order to reduce benchmark noise.
 	const fixedLen = 64
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	typs := []*types.T{
 		types.Bool,

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -251,7 +251,7 @@ func TestRecordBatchSerializer(t *testing.T) {
 func TestRecordBatchSerializerSerializeDeserializeRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	const (
 		maxTypes   = 16
@@ -317,7 +317,7 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var err error
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	typs := []*types.T{types.Bytes}
 	src := testAllocator.NewMemBatchWithMaxCapacity(typs)
@@ -354,7 +354,7 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 }
 
 func BenchmarkRecordBatchSerializerInt64(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var (
 		typs             = []*types.T{types.Int}

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -124,7 +124,7 @@ func TestCompare(t *testing.T) {
 	for confName, config := range configs {
 		t.Run(confName, func(t *testing.T) {
 			t.Logf("starting test: %s", confName)
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			setup := config.setup(rng)
 			setup, _ = randgen.ApplyString(rng, setup, config.setupMutators...)
 

--- a/pkg/geo/geogen/geogen_test.go
+++ b/pkg/geo/geogen/geogen_test.go
@@ -24,7 +24,7 @@ import (
 const numRuns = 25
 
 func TestRandomValidLinearRingCoords(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for run := 0; run < numRuns; run++ {
 		t.Run(strconv.Itoa(run), func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestRandomValidLinearRingCoords(t *testing.T) {
 }
 
 func TestRandomGeomT(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for run := 0; run < numRuns; run++ {
 		t.Run(strconv.Itoa(run), func(t *testing.T) {
 			g := RandomGeomT(rng, MakeRandomGeomBoundsForGeography(), geopb.SRID(run), geom.NoLayout)

--- a/pkg/gossip/util_test.go
+++ b/pkg/gossip/util_test.go
@@ -78,7 +78,7 @@ func assertModified(
 
 func TestSystemConfigDeltaFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	df := MakeSystemConfigDeltaFilter(nil)
 	cfg := config.NewSystemConfig(zonepb.DefaultZoneConfigRef())
@@ -108,7 +108,7 @@ func TestSystemConfigDeltaFilter(t *testing.T) {
 
 func TestSystemConfigDeltaFilterWithKeyPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	df := MakeSystemConfigDeltaFilter(keyFromInt(12))
 	cfg := config.NewSystemConfig(zonepb.DefaultZoneConfigRef())
@@ -134,7 +134,7 @@ func TestSystemConfigDeltaFilterWithKeyPrefix(t *testing.T) {
 
 func BenchmarkSystemConfigDeltaFilter(b *testing.B) {
 	df := MakeSystemConfigDeltaFilter(keyFromInt(1))
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Create two configs.
 	cfg1, cfg2 := config.NewSystemConfig(zonepb.DefaultZoneConfigRef()), config.NewSystemConfig(zonepb.DefaultZoneConfigRef())

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -44,7 +44,7 @@ func TestSetups(t *testing.T) {
 			s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 			defer s.Stopper().Stop(ctx)
 
-			rnd, _ := randutil.NewPseudoRand()
+			rnd, _ := randutil.NewTestRand()
 
 			sql := setup(rnd)
 			if _, err := sqlDB.Exec(sql); err != nil {
@@ -84,7 +84,7 @@ func TestRandTableInserts(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	rnd, _ := randutil.NewPseudoRand()
+	rnd, _ := randutil.NewTestRand()
 
 	setup := randTablesN(rnd, 10)
 	if _, err := sqlDB.Exec(setup); err != nil {
@@ -145,7 +145,7 @@ func TestGenerateParse(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	rnd, seed := randutil.NewPseudoRand()
+	rnd, seed := randutil.NewTestRand()
 	t.Log("seed:", seed)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/kv/bulk/kv_buf_test.go
+++ b/pkg/kv/bulk/kv_buf_test.go
@@ -28,7 +28,7 @@ type kvPair struct {
 
 func makeTestData(num int) (kvs []kvPair, totalSize int) {
 	kvs = make([]kvPair, num)
-	r, _ := randutil.NewPseudoRand()
+	r, _ := randutil.NewTestRand()
 	alloc := make([]byte, num*500)
 	randutil.ReadTestdataBytes(r, alloc)
 	for i := range kvs {

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -42,7 +42,7 @@ import (
 func makeIntTableKVs(numKeys, valueSize, maxRevisions int) []storage.MVCCKeyValue {
 	prefix := keys.SystemSQLCodec.IndexPrefix(100, 1)
 	kvs := make([]storage.MVCCKeyValue, numKeys)
-	r, _ := randutil.NewPseudoRand()
+	r, _ := randutil.NewTestRand()
 
 	var k int
 	for i := 0; i < numKeys; {

--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -68,7 +68,7 @@ func TestRandStep(t *testing.T) {
 	const minEachType = 5
 	config := newAllOperationsConfig()
 	config.NumNodes, config.NumReplicas = 2, 1
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	getReplicasFn := func(_ roachpb.Key) []roachpb.ReplicationTarget {
 		return make([]roachpb.ReplicationTarget, rng.Intn(2)+1)
 	}

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -59,7 +59,7 @@ func TestKVNemesisSingleNode(t *testing.T) {
 
 	config := NewDefaultConfig()
 	config.NumNodes, config.NumReplicas = 1, 1
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	env := &Env{sqlDBs: []*gosql.DB{sqlDB}}
 	failures, err := RunNemesis(ctx, rng, env, config, numSteps, db)
 	require.NoError(t, err, `%+v`, err)
@@ -102,7 +102,7 @@ func TestKVNemesisMultiNode(t *testing.T) {
 
 	config := NewDefaultConfig()
 	config.NumNodes, config.NumReplicas = numNodes, 3
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	env := &Env{sqlDBs: sqlDBs}
 	failures, err := RunNemesis(ctx, rng, env, config, numSteps, dbs...)
 	require.NoError(t, err, `%+v`, err)

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -757,7 +757,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 	testWithTargetSize := func(t *testing.T, targetSize uint64) {
 		e, cleanup := mkEngine(t)
 		defer cleanup()
-		rnd, _ := randutil.NewPseudoRand()
+		rnd, _ := randutil.NewTestRand()
 		numKeys := getNumKeys(t, rnd, targetSize)
 		keys, timestamps := mkData(t, e, rnd, numKeys)
 		var (

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4204,7 +4204,7 @@ func TestMergeQueue(t *testing.T) {
 			t.Fatal(pErr)
 		}
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	randBytes := randutil.RandBytes(rng, int(conf.RangeMinBytes))
 
 	lhsStartKey := roachpb.RKey(tc.ScratchRange(t))

--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -72,7 +72,7 @@ func TestProtectedTimestamps(t *testing.T) {
 		"gc.ttlseconds = 1, range_max_bytes = 1<<18, range_min_bytes = 1<<10;")
 	require.NoError(t, err)
 
-	rRand, _ := randutil.NewPseudoRand()
+	rRand, _ := randutil.NewTestRand()
 	upsertUntilBackpressure := func() {
 		for {
 			_, err := conn.Exec("UPSERT INTO foo VALUES (1, $1)",

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2499,7 +2499,7 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, seed := randutil.NewTestPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	t.Logf("seed is %d", seed)
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -39,7 +39,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rRand, _ := randutil.NewPseudoRand()
+	rRand, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	// Some arbitrary data sizes we'll load into a table and then use to derive

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1999,7 +1999,7 @@ func TestClearRange(t *testing.T) {
 		}
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Write four keys with values small enough to use individual deletions
 	// (sm1-sm4) and four keys with values large enough to require a range

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -308,7 +308,7 @@ func TestGCIntentBatcher(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	rand, _ := randutil.NewTestPseudoRand()
+	rand, _ := randutil.NewTestRand()
 
 	for _, s := range []struct {
 		name    string

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -86,7 +86,7 @@ func TestGCQueueMakeGCScoreInvariantQuick(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rnd, seed := randutil.NewPseudoRand()
+	rnd, seed := randutil.NewTestRand()
 	cfg := quick.Config{
 		MaxCount: 50000,
 		Rand:     rnd,

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -415,7 +415,7 @@ func TestTransactionBumpEpoch(t *testing.T) {
 // advertised.
 func TestTransactionObservedTimestamp(t *testing.T) {
 	var txn Transaction
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	t.Logf("running with seed %d", seed)
 	ids := append([]int{109, 104, 102, 108, 1000}, rand.Perm(100)...)
 	timestamps := make(map[NodeID]hlc.ClockTimestamp, len(ids))

--- a/pkg/roachpb/merge_spans_test.go
+++ b/pkg/roachpb/merge_spans_test.go
@@ -113,7 +113,7 @@ func TestSubtractSpans(t *testing.T) {
 	t.Run("random", func(t *testing.T) {
 		const iterations = 100
 		for i := 0; i < iterations; i++ {
-			r, s := randutil.NewPseudoRand()
+			r, s := randutil.NewTestRand()
 			t.Logf("random seed: %d", s)
 			const max = 1000
 			before := makeRandomParitialCovering(r, max)

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -71,7 +71,7 @@ func TestIntentResolution(t *testing.T) {
 	for i, tc := range testCases {
 		// Use deterministic randomness to randomly put the writes in separate
 		// batches or commit them with EndTxn.
-		rnd, seed := randutil.NewPseudoRand()
+		rnd, seed := randutil.NewTestRand()
 		log.Infof(context.Background(), "%d: using intent test seed %d", i, seed)
 
 		results := map[string]struct{}{}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -39,7 +39,7 @@ func TestDiskQueue(t *testing.T) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, rewindable := range []bool{false, true} {
 		for _, bufferSizeBytes := range []int{0, 16<<10 + rng.Intn(1<<20) /* 16 KiB up to 1 MiB */} {
 			for _, maxFileSizeBytes := range []int{10 << 10 /* 10 KiB */, 1<<20 + rng.Intn(64<<20) /* 1 MiB up to 64 MiB */} {
@@ -232,7 +232,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 	queueCfg.BufferSizeBytes = int(bufSize)
 	queueCfg.MaxFileSizeBytes = int(blockSize)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int}
 	batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0, 0)
 	op := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -146,7 +146,7 @@ func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
 		ctx    = context.Background()
 		typs   = []*types.T{types.Int}
 		batch  = testAllocator.NewMemBatchWithMaxCapacity(typs)
-		rng, _ = randutil.NewPseudoRand()
+		rng, _ = randutil.NewTestRand()
 		// maxPartitions is in [1, 10]. The maximum partitions on a single level.
 		maxPartitions = 1 + rng.Intn(10)
 		// numRepartitions is in [1, 5].

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDecodeTableValueToCol(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	var (
 		da           rowenc.DatumAlloc
 		buf, scratch []byte

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -829,7 +829,7 @@ func TestAggregatorRandom(t *testing.T) {
 	defer evalCtx.Stop(context.Background())
 	// This test aggregates random inputs, keeping track of the expected results
 	// to make sure the aggregations are correct.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, groupSize := range []int{1, 2, coldata.BatchSize() / 4, coldata.BatchSize() / 2} {
 		if groupSize == 0 {
 			// We might be varying coldata.BatchSize() so that when it is divided by
@@ -1001,7 +1001,7 @@ func benchmarkAggregateFunction(
 			return
 		}
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -233,7 +233,7 @@ func benchmarkLogicalProjOp(
 			Settings: st,
 		},
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	batch := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Bool, types.Bool})
 	col1 := batch.ColVec(0).Bool()

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -115,7 +115,7 @@ func TestCaseOpRandomized(t *testing.T) {
 	}
 
 	var da rowenc.DatumAlloc
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	numWhenArms := 1 + rng.Intn(5)
 	hasElseArm := rng.Float64() < 0.5

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -40,7 +40,7 @@ func TestRandomizedCast(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	evalCtx.Planner = &faketreeeval.DummyEvalPlanner{}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	getValidSupportedCast := func() (from, to *types.T) {
 		for {
@@ -109,7 +109,7 @@ func BenchmarkCastOp(b *testing.B) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, typePair := range [][]*types.T{
 		{types.Int, types.Float},
 		{types.Int, types.Decimal},

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -60,7 +60,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	nTuples := 2*coldata.BatchSize() + 1
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int, types.Bytes, types.Decimal}
 	colsLeft := make([]coldata.Vec, len(typs))
 	colsRight := make([]coldata.Vec, len(typs))

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -182,7 +182,7 @@ func TestRandomComparisons(t *testing.T) {
 		},
 	}
 	const numTuples = 2048
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	expected := make([]bool, numTuples)
 	var da rowenc.DatumAlloc
@@ -303,7 +303,7 @@ func benchmarkProjOp(
 	hasNulls bool,
 ) {
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	batch := testAllocator.NewMemBatchWithMaxCapacity(inputTypes)
 	nullProb := 0.0
 	if hasNulls {

--- a/pkg/sql/colexec/colexecsel/like_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/like_ops_test.go
@@ -103,7 +103,7 @@ func TestLikeOperators(t *testing.T) {
 
 func BenchmarkLikeOps(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	typs := []*types.T{types.Bytes}

--- a/pkg/sql/colexec/colexecsel/selection_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_test.go
@@ -162,7 +162,7 @@ func runSelOpBenchmarks(
 	makeSelOp func(source *colexecop.RepeatableBatchSource) (colexecop.Operator, error),
 	inputTypes []*types.T,
 ) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, useSel := range []bool{true, false} {
 		for _, hasNulls := range []bool{true, false} {
 			batch := testAllocator.NewMemBatchWithMaxCapacity(inputTypes)

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -55,7 +55,7 @@ func TestSpanAssembler(t *testing.T) {
 	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
 	testAllocator := colmem.NewAllocator(ctx, testMemAcc, testColumnFactory)
 	defer testMemAcc.Close(ctx)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int, types.Bytes, types.Decimal}
 
 	for _, useColFamilies := range []bool{true, false} {

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -681,7 +681,7 @@ func RunTestsWithFn(
 					if typs != nil {
 						inputTypes = typs[i]
 					}
-					rng, _ := randutil.NewTestRandFromGlobalSeed()
+					rng, _ := randutil.NewTestRand()
 					inputSources[i] = newOpTestSelInput(allocator, rng, batchSize, tup, inputTypes)
 				}
 			} else {
@@ -965,7 +965,7 @@ func (s *opTestInput) Next() coldata.Batch {
 		}
 	}
 
-	rng, _ := randutil.NewTestRandFromGlobalSeed()
+	rng, _ := randutil.NewTestRand()
 
 	for i := range s.typs {
 		vec := s.batch.ColVec(i)
@@ -1698,7 +1698,7 @@ const MinBatchSize = 3
 func GenerateBatchSize() int {
 	randomizeBatchSize := envutil.EnvOrDefaultBool("COCKROACH_RANDOMIZE_BATCH_SIZE", true)
 	if randomizeBatchSize {
-		rng, _ := randutil.NewTestRandFromGlobalSeed()
+		rng, _ := randutil.NewTestRand()
 		// sizesToChooseFrom specifies some predetermined and one random sizes
 		// that we will choose from. Such distribution is chosen due to the
 		// fact that most of our unit tests don't have a lot of data, so in

--- a/pkg/sql/colexec/colexectestutils/utils_test.go
+++ b/pkg/sql/colexec/colexectestutils/utils_test.go
@@ -74,7 +74,7 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	typs := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	batchSize := 10
 	if batchSize > coldata.BatchSize() {
 		batchSize = coldata.BatchSize()

--- a/pkg/sql/colexec/colexecutils/deselector_test.go
+++ b/pkg/sql/colexec/colexecutils/deselector_test.go
@@ -80,7 +80,7 @@ func TestDeselector(t *testing.T) {
 
 func BenchmarkDeselector(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	nCols := 1

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -37,7 +37,7 @@ func TestSpillingBuffer(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for _, memoryLimit := range []int64{
 		10 << 10,                        /* 10 KiB */

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -38,7 +38,7 @@ func TestSpillingQueue(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, rewindable := range []bool{false, true} {
 		for _, memoryLimit := range []int64{
 			10 << 10,                        /* 10 KiB */
@@ -260,7 +260,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 	defer cleanup()
 	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeDefault
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	numBatches := int(spillingQueueInitialItemsLen)*(1+rng.Intn(4)) + rng.Intn(int(spillingQueueInitialItemsLen))
 	op := coldatatestutils.NewRandomDataOp(testAllocator, rng, coldatatestutils.RandomDataOpArgs{
 		// TODO(yuzefovich): for some types (e.g. types.MakeArray(types.Int))
@@ -336,7 +336,7 @@ func TestSpillingQueueMemoryAccounting(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int}
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
@@ -430,7 +430,7 @@ func TestSpillingQueueMovingTailWhenSpilling(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int}
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()

--- a/pkg/sql/colexec/colexecwindow/min_max_queue_test.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_queue_test.go
@@ -25,7 +25,7 @@ func TestMinMaxQueue(t *testing.T) {
 		maxValuesToAdd = 1000
 	)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var queue minMaxQueue
 	var oracle []uint32

--- a/pkg/sql/colexec/colexecwindow/window_framer_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_test.go
@@ -49,7 +49,7 @@ func TestWindowFramer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -366,7 +366,7 @@ func (tc *distinctTestCase) runTests(
 func TestDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, tc := range distinctTestCases {
 		log.Infof(context.Background(), "unordered")
 		tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
@@ -398,7 +398,7 @@ func TestDistinct(t *testing.T) {
 func TestUnorderedDistinctRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nCols := 1 + rng.Intn(3)
 	typs := make([]*types.T, nCols)
 	distinctCols := make([]uint32, nCols)
@@ -446,7 +446,7 @@ func runDistinctBenchmarks(
 	namePrefix string,
 	isExternal bool,
 ) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	const nCols = 2
 	const bytesValueLength = 8
 	distinctCols := []uint32{0, 1}

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -58,7 +58,7 @@ func TestExternalDistinct(t *testing.T) {
 		accounts []*mon.BoundAccount
 		monitors []*mon.BytesMonitor
 	)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	numForcedRepartitions := rng.Intn(5)
 	// Test the case in which the default memory is used as well as the case in
 	// which the distinct spills to disk.
@@ -139,7 +139,7 @@ func TestExternalDistinctSpilling(t *testing.T) {
 		monitors []*mon.BytesMonitor
 	)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nCols := 1 + rng.Intn(3)
 	typs := make([]*types.T, nCols)
 	distinctCols := make([]uint32, nCols)

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -57,7 +57,7 @@ func TestExternalHashAggregator(t *testing.T) {
 		accounts []*mon.BoundAccount
 		monitors []*mon.BytesMonitor
 	)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	numForcedRepartitions := rng.Intn(5)
 	for _, cfg := range []struct {
 		diskSpillingEnabled bool

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -58,7 +58,7 @@ func TestExternalHashJoiner(t *testing.T) {
 		accounts []*mon.BoundAccount
 		monitors []*mon.BytesMonitor
 	)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	numForcedRepartitions := rng.Intn(5)
 	// Test the case in which the default memory is used as well as the case in
 	// which the joiner spills to disk.

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -52,7 +52,7 @@ func TestExternalSort(t *testing.T) {
 		DiskMonitor: testDiskMonitor,
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	numForcedRepartitions := rng.Intn(5)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
@@ -142,7 +142,7 @@ func TestExternalSortRandomized(t *testing.T) {
 		},
 		DiskMonitor: testDiskMonitor,
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nTups := coldata.BatchSize()*4 + 1
 	maxCols := 2
 	// TODO(yuzefovich): randomize types as well.
@@ -261,7 +261,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 		},
 		DiskMonitor: testDiskMonitor,
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Use the Bytes type because we can control the size of values with it
 	// easily.
@@ -388,7 +388,7 @@ func BenchmarkExternalSort(b *testing.B) {
 		},
 		DiskMonitor: testDiskMonitor,
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	var (
 		memAccounts []*mon.BoundAccount
 		memMonitors []*mon.BytesMonitor

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -39,7 +39,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nCols := 1 + rng.Intn(4)
 	var typs []*types.T
 	for len(typs) < nCols {
@@ -101,7 +101,7 @@ func BenchmarkMaterializer(b *testing.B) {
 		EvalCtx: &evalCtx,
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nBatches := 10
 	nRows := nBatches * coldata.BatchSize()
 	for _, typ := range []*types.T{types.Int, types.Float, types.Bytes} {

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1924,7 +1924,7 @@ type expectedGroup struct {
 func newBatchesOfRandIntRows(
 	nTuples int, maxRunLength int64, skipValues bool, randomIncrement int64,
 ) ([]coldata.Vec, []coldata.Vec, []expectedGroup) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	lCols := []coldata.Vec{testAllocator.NewMemColumn(types.Int, nTuples)}
 	lCol := lCols[0].Int64()
 	rCols := []coldata.Vec{testAllocator.NewMemColumn(types.Int, nTuples)}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -46,7 +46,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 	)
 
 	var (
-		rng, _ = randutil.NewPseudoRand()
+		rng, _ = randutil.NewTestRand()
 		typs   = []*types.T{types.Int}
 		// We want at least two inputs (one regular and one possibly blocking).
 		numInputs     = rng.Intn(maxInputs-1) + 2

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -33,7 +33,7 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	const numInputs = 3
 	const numBatches = 4
 

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -197,7 +197,7 @@ func TestSortChunks(t *testing.T) {
 func TestSortChunksRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nTups := 8
 	maxCols := 5
 	// TODO(yuzefovich): randomize types as well.
@@ -240,7 +240,7 @@ func TestSortChunksRandomized(t *testing.T) {
 
 func BenchmarkSortChunks(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	sorterConstructors := []func(*colmem.Allocator, colexecop.Operator, []*types.T, []execinfrapb.Ordering_Column, int, int64) (colexecop.Operator, error){

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -154,7 +154,7 @@ func TestSort(t *testing.T) {
 func TestSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nTups := coldata.BatchSize()*2 + 1
 	maxCols := 3
 	// TODO(yuzefovich/mgartner): randomize types as well.
@@ -289,7 +289,7 @@ func TestAllSpooler(t *testing.T) {
 
 func BenchmarkSort(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 	k := uint64(128)
 
@@ -341,7 +341,7 @@ func BenchmarkSort(b *testing.B) {
 }
 
 func BenchmarkSortUUID(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
@@ -410,7 +410,7 @@ func BenchmarkSortUUID(b *testing.B) {
 
 func BenchmarkAllSpooler(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -125,7 +125,7 @@ func TestTopKSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	nTups := coldata.BatchSize()*2 + 1
 	maxCols := 4
 	// TODO(yuzefovich/mgartner): randomize types as well.
@@ -168,7 +168,7 @@ func TestTopKSortRandomized(t *testing.T) {
 
 func BenchmarkSortTopK(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 	k := uint64(128)
 

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -57,7 +57,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 	}
 
 	var da rowenc.DatumAlloc
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	typesToTest := 20
 
 	for i := 0; i < typesToTest; i++ {

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -59,7 +59,7 @@ func randTypes(rng *rand.Rand, numCols int) ([]*types.T, []func(tree.Datum) inte
 
 func TestValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, numRows := range []int{0, 1, 10, 13, 15} {
 		for _, numCols := range []int{1, 3} {
 			colTypes, convFns := randTypes(rng, numCols)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -154,7 +154,7 @@ func TestOutboxInbox(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate a random cancellation scenario.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	type cancellationType int
 	const (
 		// In this scenario, no cancellation happens and all the data is pushed
@@ -462,7 +462,7 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(clock, stopper, execinfra.StaticNodeID)
 	require.NoError(t, err)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
 	require.NoError(t, err)
 	defer func() {
@@ -556,7 +556,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	// numNextsBeforeDrain is used in ExplicitDrainRequest. This number is
 	// generated now to avoid racing on rng accesses between this main goroutine
 	// and the Outbox generating random batches.

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -202,7 +202,7 @@ func TestInboxShutdown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var (
-		rng, _ = randutil.NewPseudoRand()
+		rng, _ = randutil.NewTestRand()
 		// infiniteBatches will influence whether or not we're likely to test a
 		// graceful shutdown (since other shutdown mechanisms might happen before
 		// we reach the end of the data stream). If infiniteBatches is true,

--- a/pkg/sql/colflow/panic_injector.go
+++ b/pkg/sql/colflow/panic_injector.go
@@ -44,7 +44,7 @@ const (
 
 // newPanicInjector creates a new panicInjector.
 func newPanicInjector(input colexecop.Operator) colexecop.Operator {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	return &panicInjector{
 		OneInputNode: colexecop.OneInputNode{Input: input},
 		rng:          rng,

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -204,7 +204,7 @@ func TestRouterOutputAddBatch(t *testing.T) {
 	// in this test.
 	unblockEventsChan := make(chan struct{})
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
 	defer cleanup()
 	tu := newTestUtils(ctx)
@@ -316,7 +316,7 @@ func TestRouterOutputNext(t *testing.T) {
 	// never write to it in this test.
 	unblockedEventsChan := make(chan struct{})
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	queueCfg, cleanup, memoryTestCases := getDiskQueueCfgAndMemoryTestCases(t, rng)
 	defer cleanup()
 	tu := newTestUtils(ctx)
@@ -503,7 +503,7 @@ func TestRouterOutputRandom(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var (
 		maxValues        = coldata.BatchSize() * 4
@@ -876,7 +876,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	sel := coldatatestutils.RandomSel(rng, coldata.BatchSize(), rng.Float64())
 
@@ -950,7 +950,7 @@ func TestHashRouterRandom(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var (
 		maxValues        = coldata.BatchSize() * 4
@@ -1077,14 +1077,14 @@ func TestHashRouterRandom(t *testing.T) {
 					switch injectErrorScenario {
 					case hashRouterOutputErrorOnAddBatch:
 						op.testingKnobs.addBatchTestInducedErrorCb = func() error {
-							addBatchRng, _ := randutil.NewPseudoRand()
+							addBatchRng, _ := randutil.NewTestRand()
 							// Sleep between 0 and ~5 milliseconds.
 							time.Sleep(time.Microsecond * time.Duration(addBatchRng.Intn(5000)))
 							return errors.New(addBatchErrMsg)
 						}
 					case hashRouterOutputErrorOnNext:
 						op.testingKnobs.nextTestInducedErrorCb = func() error {
-							nextRng, _ := randutil.NewPseudoRand()
+							nextRng, _ := randutil.NewTestRand()
 							// Sleep between 0 and ~5 milliseconds.
 							time.Sleep(time.Microsecond * time.Duration(nextRng.Intn(5000)))
 							return errors.New(nextErrMsg)
@@ -1129,7 +1129,7 @@ func TestHashRouterRandom(t *testing.T) {
 				}{}
 				for i := range outputsAsOps {
 					go func(i int) {
-						outputRng, _ := randutil.NewPseudoRand()
+						outputRng, _ := randutil.NewTestRand()
 						outputsAsOps[i].Init(ctx)
 						for {
 							var b coldata.Batch

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -151,7 +151,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					EvalCtx: &evalCtx,
 					Cfg:     &execinfra.ServerConfig{Settings: st},
 				}
-				rng, _ := randutil.NewPseudoRand()
+				rng, _ := randutil.NewTestRand()
 				var (
 					err             error
 					wg              sync.WaitGroup

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -187,7 +187,7 @@ func TestPerformAppend(t *testing.T) {
 	const resetChance = 0.5
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	st := cluster.MakeTestingClusterSettings()
 	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
 	defer testMemMonitor.Stop(ctx)
@@ -260,7 +260,7 @@ func TestSetAccountingHelper(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	st := cluster.MakeTestingClusterSettings()
 	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
 	defer testMemMonitor.Stop(ctx)

--- a/pkg/sql/contention/registry_test.go
+++ b/pkg/sql/contention/registry_test.go
@@ -189,7 +189,7 @@ func TestRegistryConcurrentAdds(t *testing.T) {
 // - all three levels of objects satisfy the respective ordering
 //   requirements.
 func TestSerializedRegistryInvariants(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	const nonSQLKeyProbability = 0.1
 	const sizeLimit = 5
 	const keySpaceSize = sizeLimit * sizeLimit

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -91,7 +91,7 @@ func TestStatsWithLowTTL(t *testing.T) {
 			goroutineErr = err
 			return
 		}
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		for {
 			select {
 			case <-stopCh:

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -105,7 +105,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 20
 	nRows := 100
 	nAggFnsToTest := 5
@@ -345,7 +345,7 @@ func TestDistinctAgainstProcessor(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 10
 	nRows := 10
 	maxCols := 3
@@ -474,7 +474,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 5
 	nRows := 8 * coldata.BatchSize()
 	maxCols := 5
@@ -549,7 +549,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 5
 	nRows := 5 * coldata.BatchSize() / 4
 	maxCols := 3
@@ -661,7 +661,7 @@ func TestHashJoinerAgainstProcessor(t *testing.T) {
 		},
 	}
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 3
 	nRows := 10
 	maxCols := 3
@@ -860,7 +860,7 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 		},
 	}
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	nRuns := 3
 	nRows := 10
 	maxCols := 3
@@ -1079,7 +1079,7 @@ func TestWindowFunctionsAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 
 	const manyRowsProbability = 0.05
 	const fewRows = 10

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -75,7 +75,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	const floatPrecision = 0.0000001
 	rng := args.rng
 	if rng == nil {
-		rng, _ = randutil.NewPseudoRand()
+		rng, _ = randutil.NewTestRand()
 	}
 	if rng.Float64() < 0.5 {
 		randomBatchSize := 1 + rng.Intn(3)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -156,7 +156,7 @@ func TestPlanningDuringSplitsAndMerges(t *testing.T) {
 
 	// Start a worker that continuously performs splits in the background.
 	_ = tc.Stopper().RunAsyncTask(context.Background(), "splitter", func(ctx context.Context) {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		cdb := tc.Server(0).DB()
 		for {
 			select {

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -462,7 +462,7 @@ func TestCancelFlowsCoordinator(t *testing.T) {
 
 	var c cancelFlowsCoordinator
 
-	globalRng, _ := randutil.NewPseudoRand()
+	globalRng, _ := randutil.NewTestRand()
 	numNodes := globalRng.Intn(16) + 2
 	gatewayNodeID := roachpb.NodeID(1)
 
@@ -511,7 +511,7 @@ func TestCancelFlowsCoordinator(t *testing.T) {
 	for i := 0; i < numQueryRunners; i++ {
 		go func() {
 			defer wg.Done()
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			for i := 0; i < numRunsPerRunner; i++ {
 				c.addFlowsToCancel(makeFlowsToCancel(rng))
 				time.Sleep(time.Duration(rng.Int63n(int64(maxSleepTime))))
@@ -525,7 +525,7 @@ func TestCancelFlowsCoordinator(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		done := time.After(2 * time.Second)
 		for {
 			select {

--- a/pkg/sql/enum/enum_test.go
+++ b/pkg/sql/enum/enum_test.go
@@ -99,7 +99,7 @@ func TestRandomGenByteStringBetween(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const iterations = 100
 	const n = 500
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// The randomized tests work by generating a random permutation of the
 	// sequence 1..N. This sequence represents the enum values we will

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -654,7 +654,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 				b.Run(fmt.Sprintf("r%d", numRows), func(b *testing.B) {
 					// Generate some data sets, consisting of rows with three values; the
 					// first value is increasing.
-					rng, _ := randutil.NewPseudoRand()
+					rng, _ := randutil.NewTestRand()
 					lastVal := 1
 					valSpecs := make([]execinfrapb.ValuesCoreSpec, numNodes)
 					for i := range valSpecs {

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -163,7 +163,7 @@ func TestFlowScheduler(t *testing.T) {
 			atomic.AddInt32(&numCompletedFlows, 1)
 		}
 
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		maxNumActiveFlows := rng.Intn(5) + 1
 		scheduler.atomics.maxRunningFlows = int32(maxNumActiveFlows)
 		numFlows := maxNumActiveFlows*(rng.Intn(3)+1) + rng.Intn(2)

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -106,7 +106,7 @@ type rowOrMeta struct {
 func TestStreamEncodeDecode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for test := 0; test < 100; test++ {
 		rowLen := rng.Intn(20)
 		types := randgen.RandEncodableColumnTypes(rng, rowLen)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3395,7 +3395,7 @@ func RunLogicTestWithDefaultConfig(
 							t.Parallel() // SAFE FOR TESTING (this comments satisfies the linter)
 						}
 					}
-					rng, _ := randutil.NewPseudoRand()
+					rng, _ := randutil.NewTestRand()
 					lt := logicTest{
 						rootT:           t,
 						verbose:         verbose,

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -71,7 +71,7 @@ func (t *parallelTest) processTestFile(path string, nodeIdx int, db *gosql.DB, c
 	}
 
 	// Set up a dummy logicTest structure to use that code.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	l := &logicTest{
 		rootT:   t.T,
 		cluster: t.cluster,

--- a/pkg/sql/opt/constraint/spans_test.go
+++ b/pkg/sql/opt/constraint/spans_test.go
@@ -60,7 +60,7 @@ func TestSpansSortAndMerge(t *testing.T) {
 	// creating a constraint per span and calculating the union. We generate
 	// random cases and cross-check.
 	for testIdx := 0; testIdx < 100; testIdx++ {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		n := 1 + rng.Intn(10)
 		var spans Spans
 		for i := 0; i < n; i++ {

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -434,7 +434,7 @@ func TestDistAggregationTable(t *testing.T) {
 	//  - random bool value (mostly true)
 	//  - random decimals
 	//  - random decimals (with some NULLs)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	sqlutils.CreateTable(
 		t, tc.ServerConn(0), "t",
 		"k INT PRIMARY KEY, int1 INT, int2 INT, int3 INT, bool1 BOOL, bool2 BOOL, dec1 DECIMAL, dec2 DECIMAL, float1 FLOAT, float2 FLOAT, b BYTES",

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -574,7 +574,7 @@ func BenchmarkQueryCache(b *testing.B) {
 		for connIdx := 0; connIdx < numClients; connIdx++ {
 			c := h.conns[connIdx]
 			group.Go(func() error {
-				rng, _ := randutil.NewPseudoRand()
+				rng, _ := randutil.NewTestRand()
 				ctx := context.Background()
 				// We use a small or large range of values depending on the
 				// workload type.

--- a/pkg/sql/querycache/query_cache_test.go
+++ b/pkg/sql/querycache/query_cache_test.go
@@ -192,7 +192,7 @@ func TestSynchronization(t *testing.T) {
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
 		go func() {
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			var s Session
 			s.Init()
 			for j := 0; j < 5000; j++ {

--- a/pkg/sql/randgen/mutator_test.go
+++ b/pkg/sql/randgen/mutator_test.go
@@ -28,7 +28,7 @@ func TestPostgresMutator(t *testing.T) {
 		SET CLUSTER SETTING "sql.stats.automatic_collection.enabled" = false;
 	`
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	{
 		mutated, changed := ApplyString(rng, q, PostgresMutator)
 		if !changed {

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -51,7 +51,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 	numRows := 20
 	const numCols = 2
 	const smallMemoryBudget = 40
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	memoryMonitor := mon.NewMonitor(
 		"test-mem",
@@ -160,7 +160,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	defer memoryMonitor.Stop(ctx)
 
 	// Use random types and random rows.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	types := randgen.RandSortingTypes(rng, numCols)
 	ordering := colinfo.ColumnOrdering{
@@ -226,7 +226,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 func TestCompareNumberedAndIndexedRowContainers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -556,7 +556,7 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 	for i := 0; i < 10; i++ {
 		typs = append(typs, types.String)
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rows := make([]rowenc.EncDatumRow, numRows)
 	for i := 0; i < numRows; i++ {
 		rows[i] = make([]rowenc.EncDatum, len(typs))

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -78,7 +78,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.NewTestingEvalContext(st)
@@ -382,7 +382,7 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 			Direction: encoding.Descending,
 		},
 	}
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	// Use random types and random rows.
 	types := randgen.RandSortingTypes(rng, numCols)
 	numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -127,7 +127,7 @@ func TestEncDatumNull(t *testing.T) {
 	}
 
 	var alloc rowenc.DatumAlloc
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Generate random EncDatums (some of which are null), and verify that a datum
 	// created from its encoding has the same IsNull() value.
@@ -208,7 +208,7 @@ func TestEncDatumCompare(t *testing.T) {
 	a := &rowenc.DatumAlloc{}
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for _, typ := range types.OidToType {
 		switch typ.Family() {
@@ -267,7 +267,7 @@ func TestEncDatumFromBuffer(t *testing.T) {
 	var alloc rowenc.DatumAlloc
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for test := 0; test < 20; test++ {
 		var err error
 		// Generate a set of random datums.
@@ -470,7 +470,7 @@ func TestEncDatumRowAlloc(t *testing.T) {
 
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, cols := range []int{1, 2, 4, 10, 40, 100} {
 		for _, rows := range []int{1, 2, 3, 5, 10, 20} {
 			colTypes := randgen.RandColumnTypes(rng, cols)
@@ -509,7 +509,7 @@ func TestEncDatumRowAlloc(t *testing.T) {
 }
 
 func TestValueEncodeDecodeTuple(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	tests := make([]tree.Datum, 1000)
 	colTypes := make([]*types.T, 1000)
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -141,7 +141,7 @@ func decodeIndex(
 }
 
 func TestIndexKey(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	var a DatumAlloc
 
 	tests := []indexKeyTest{
@@ -503,7 +503,7 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 	}
 
 	// Run a set of randomly generated test cases.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		typ := randgen.RandArrayType(rng)
 
@@ -644,7 +644,7 @@ func TestEncodeContainedArrayInvertedIndexSpans(t *testing.T) {
 	}
 
 	// Run a set of randomly generated test cases.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		typ := randgen.RandArrayType(rng)
 

--- a/pkg/sql/rowenc/roundtrip_format_test.go
+++ b/pkg/sql/rowenc/roundtrip_format_test.go
@@ -57,7 +57,7 @@ func TestRandParseDatumStringAs(t *testing.T) {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.NewTestingEvalContext(st)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, typ := range tests {
 		const testsForTyp = 100
 		t.Run(typ.String(), func(t *testing.T) {

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -641,7 +641,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 				UseDatabase: "test",
 			},
 		}
-		rng, _ = randutil.NewPseudoRand()
+		rng, _ = randutil.NewTestRand()
 	)
 
 	filters := make([]struct {

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -110,7 +110,7 @@ func runSampleAggregator(
 		},
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rowPartitions := make([][][]int, numSamplers)
 	for _, row := range inputRows {
 		j := rng.Intn(numSamplers)

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestValuesProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for _, numRows := range []int{0, 1, 10, 13, 15} {
 		for _, numCols := range []int{0, 1, 3} {
 			t.Run(fmt.Sprintf("%d-%d", numRows, numCols), func(t *testing.T) {

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -79,7 +79,7 @@ func TestRouters(t *testing.T) {
 	const numCols = 6
 	const numRows = 200
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	alloc := &rowenc.DatumAlloc{}
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -354,7 +354,7 @@ func TestConsumerStatus(t *testing.T) {
 				d = tree.NewDInt(math.MaxInt32)
 				row1 = rowenc.EncDatumRow{rowenc.DatumToEncDatum(colTypes[0], d)}
 			default:
-				rng, _ := randutil.NewPseudoRand()
+				rng, _ := randutil.NewTestRand()
 				vals := randgen.RandEncDatumRowsOfTypes(rng, 1 /* numRows */, colTypes)
 				row0 = vals[0]
 				row1 = row0
@@ -431,7 +431,7 @@ func TestConsumerStatus(t *testing.T) {
 func preimageAttack(
 	colTypes []*types.T, hr *hashRouter, streamIdx int, numStreams int,
 ) (rowenc.EncDatumRow, error) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for {
 		vals := randgen.RandEncDatumRowOfTypes(rng, colTypes)
 		curStreamIdx, err := hr.computeDestination(vals)
@@ -686,7 +686,7 @@ func TestRouterBlocks(t *testing.T) {
 			var numRowsSent uint32
 			stop := make(chan struct{})
 			go func() {
-				rng, _ := randutil.NewPseudoRand()
+				rng, _ := randutil.NewTestRand()
 			Loop:
 				for {
 					select {

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -431,7 +431,7 @@ func makeNullTestDatum(count int) []tree.Datum {
 }
 
 func makeIntTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
@@ -441,7 +441,7 @@ func makeIntTestDatum(count int) []tree.Datum {
 }
 
 func makeBitTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	// Compute randWidth outside the loop so that all bit arrays are the same
 	// length. Generate widths in the range [0, 64].
@@ -459,7 +459,7 @@ func makeBitTestDatum(count int) []tree.Datum {
 // returned. Use this to ensure proper partial null
 // handling of aggregations.
 func makeTestWithNullDatum(count int, maker func(count int) []tree.Datum) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	values := maker(count)
 	values[rng.Int()%count] = tree.DNull
 	return values
@@ -471,7 +471,7 @@ func makeTestWithNullDatum(count int, maker func(count int) []tree.Datum) []tree
 // test the implementation of aggregates that can use an int64 to
 // optimize computations small decimal values.
 func makeSmallIntTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
@@ -485,7 +485,7 @@ func makeSmallIntTestDatum(count int) []tree.Datum {
 }
 
 func makeFloatTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
@@ -495,7 +495,7 @@ func makeFloatTestDatum(count int) []tree.Datum {
 }
 
 func makeDecimalTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
@@ -509,7 +509,7 @@ func makeDecimalTestDatum(count int) []tree.Datum {
 }
 
 func makeBoolTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
@@ -519,7 +519,7 @@ func makeBoolTestDatum(count int) []tree.Datum {
 }
 
 func makeIntervalTestDatum(count int) []tree.Datum {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {

--- a/pkg/sql/sem/tree/cast_map_test.go
+++ b/pkg/sql/sem/tree/cast_map_test.go
@@ -33,7 +33,7 @@ func TestCastMap(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	rng, _ := randutil.NewTestPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	evalCtx.Planner = &faketreeeval.DummyEvalPlanner{}
 
 	tree.ForEachCast(func(src, tgt oid.Oid) {

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -377,7 +377,7 @@ func TestHLCTimestampDecimalRoundTrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		ts := hlc.Timestamp{WallTime: rng.Int63(), Logical: rng.Int31()}
 		dec := tree.TimestampToDecimalDatum(ts)

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -76,7 +76,7 @@ func TestCastFromNull(t *testing.T) {
 func TestStringConcat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	ctx := context.Background()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -96,7 +96,7 @@ func TestSampleReservoir(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 
 	for _, n := range []int{10, 100, 1000, 10000} {
-		rng, _ := randutil.NewPseudoRand()
+		rng, _ := randutil.NewTestRand()
 		ranks := make([]int, n)
 		for i := range ranks {
 			ranks[i] = rng.Int()

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -930,7 +930,7 @@ func runMVCCGet(ctx context.Context, b *testing.B, emk engineMaker, opts benchDa
 }
 
 func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -952,7 +952,7 @@ func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize in
 }
 
 func runMVCCBlindPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -976,7 +976,7 @@ func runMVCCBlindPut(ctx context.Context, b *testing.B, emk engineMaker, valueSi
 func runMVCCConditionalPut(
 	ctx context.Context, b *testing.B, emk engineMaker, valueSize int, createFirst bool,
 ) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -1010,7 +1010,7 @@ func runMVCCConditionalPut(
 }
 
 func runMVCCBlindConditionalPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -1032,7 +1032,7 @@ func runMVCCBlindConditionalPut(ctx context.Context, b *testing.B, emk engineMak
 }
 
 func runMVCCInitPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -1054,7 +1054,7 @@ func runMVCCInitPut(ctx context.Context, b *testing.B, emk engineMaker, valueSiz
 }
 
 func runMVCCBlindInitPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -1076,7 +1076,7 @@ func runMVCCBlindInitPut(ctx context.Context, b *testing.B, emk engineMaker, val
 }
 
 func runMVCCBatchPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize, batchSize int) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
@@ -1371,7 +1371,7 @@ type benchGarbageCollectOptions struct {
 func runMVCCGarbageCollect(
 	ctx context.Context, b *testing.B, emk engineMaker, opts benchGarbageCollectOptions,
 ) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	eng := emk(b, "mvcc_gc")
 	defer eng.Close()
 
@@ -1433,7 +1433,7 @@ func runBatchApplyBatchRepr(
 	indexed, sequential bool,
 	valueSize, batchSize int,
 ) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2355,7 +2355,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	ctx := context.Background()
 

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -25,7 +25,7 @@ import (
 func makeIntTableKVs(numKeys, valueSize, maxRevisions int) []storage.MVCCKeyValue {
 	prefix := encoding.EncodeUvarintAscending(keys.SystemSQLCodec.TablePrefix(uint32(100)), uint64(1))
 	kvs := make([]storage.MVCCKeyValue, numKeys)
-	r, _ := randutil.NewPseudoRand()
+	r, _ := randutil.NewTestRand()
 
 	var k int
 	for i := 0; i < numKeys; {

--- a/pkg/util/bitarray/bitarray_test.go
+++ b/pkg/util/bitarray/bitarray_test.go
@@ -695,7 +695,7 @@ func TestConcat(t *testing.T) {
 }
 
 func TestConcatRand(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for i := 0; i < 1000; i++ {
 		w1 := uint(rng.Int31n(256))

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -86,7 +86,7 @@ func init() {
 	if CrdbTestBuild {
 		disabled := envutil.EnvOrDefaultBool(DisableMetamorphicEnvVar, false)
 		if !disabled {
-			rng, _ = randutil.NewPseudoRand()
+			rng, _ = randutil.NewTestRand()
 			metamorphicBuild = rng.Float64() < metamorphicBuildProbability
 		}
 	}

--- a/pkg/util/encoding/decimal_test.go
+++ b/pkg/util/encoding/decimal_test.go
@@ -179,7 +179,7 @@ func TestEncodeDecimal(t *testing.T) {
 		{&apd.Decimal{Form: apd.Infinite}, []byte{0x35}},
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var lastEncoded []byte
 	for _, dir := range []Direction{Ascending, Descending} {
@@ -240,7 +240,7 @@ func TestEncodeDecimal(t *testing.T) {
 }
 
 func TestEncodeDecimalRand(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	// Test both directions.
 	for _, dir := range []Direction{Ascending, Descending} {
 		var prev *apd.Decimal
@@ -349,7 +349,7 @@ func TestNonsortingEncodeDecimal(t *testing.T) {
 		{mustDecimalString("142378208485490985369999605144727062141206925976498256305323716858805588894693616552055968571135475510700810219028167653516982373238641332965927953273383572708760984694356069974208844865675206339235758647159337463780100273189720943242182911961627806424621091859596571173867825568394327041453823674373002756096"), []byte{0x34, 0xf7, 0x01, 0x35, 0xca, 0xc0, 0xd8, 0x34, 0x68, 0x5d, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for _, tmp := range [][]byte{nil, make([]byte, 0, 100)} {
 		for i, c := range testCases {
@@ -401,7 +401,7 @@ func TestNonsortingEncodeDecimal(t *testing.T) {
 }
 
 func TestNonsortingEncodeDecimalRand(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	const randomTrials = 200000
 	for i := 0; i < randomTrials; i++ {
 		var tmp, appendTo []byte
@@ -538,7 +538,7 @@ func randDecimal(rng *rand.Rand, minExp, maxExp int) *apd.Decimal {
 // makeDecimalVals creates decimal values with exponents in
 // the range [minExp, maxExp].
 func makeDecimalVals(minExp, maxExp int) []*apd.Decimal {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	vals := make([]*apd.Decimal, 10000)
 	for i := range vals {
 		vals[i] = randDecimal(rng, minExp, maxExp)
@@ -547,7 +547,7 @@ func makeDecimalVals(minExp, maxExp int) []*apd.Decimal {
 }
 
 func makeEncodedVals(minExp, maxExp int) [][]byte {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	vals := make([][]byte, 10000)
 	for i := range vals {
 		vals[i] = EncodeDecimalAscending(nil, randDecimal(rng, minExp, maxExp))
@@ -635,7 +635,7 @@ func BenchmarkNonsortingEncodeDecimal(b *testing.B) {
 }
 
 func BenchmarkNonsortingDecodeDecimal(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -753,7 +753,7 @@ func TestEncodeBitArray(t *testing.T) {
 				0, 0xc8}},
 	}
 
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	var lastEncoded []byte
 	dirNames := []string{"", "asc", "desc"}
@@ -823,7 +823,7 @@ func TestEncodeBitArray(t *testing.T) {
 }
 
 func TestKeyEncodeDecodeBitArrayRand(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]bitarray.BitArray, 1000)
 	for i := range tests {
@@ -1548,7 +1548,7 @@ func (rd randData) ipAddr() ipaddr.IPAddr {
 }
 
 func BenchmarkEncodeUint32(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]uint32, 10000)
 	for i := range vals {
@@ -1564,7 +1564,7 @@ func BenchmarkEncodeUint32(b *testing.B) {
 }
 
 func BenchmarkDecodeUint32(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1578,7 +1578,7 @@ func BenchmarkDecodeUint32(b *testing.B) {
 }
 
 func BenchmarkEncodeUint64(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]uint64, 10000)
 	for i := range vals {
@@ -1594,7 +1594,7 @@ func BenchmarkEncodeUint64(b *testing.B) {
 }
 
 func BenchmarkDecodeUint64(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1608,7 +1608,7 @@ func BenchmarkDecodeUint64(b *testing.B) {
 }
 
 func BenchmarkEncodeVarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]int64, 10000)
 	for i := range vals {
@@ -1624,7 +1624,7 @@ func BenchmarkEncodeVarint(b *testing.B) {
 }
 
 func BenchmarkDecodeVarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1638,7 +1638,7 @@ func BenchmarkDecodeVarint(b *testing.B) {
 }
 
 func BenchmarkPeekLengthVarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1652,7 +1652,7 @@ func BenchmarkPeekLengthVarint(b *testing.B) {
 }
 
 func BenchmarkEncodeUvarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]uint64, 10000)
 	for i := range vals {
@@ -1668,7 +1668,7 @@ func BenchmarkEncodeUvarint(b *testing.B) {
 }
 
 func BenchmarkDecodeUvarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1682,7 +1682,7 @@ func BenchmarkDecodeUvarint(b *testing.B) {
 }
 
 func BenchmarkPeekLengthUvarint(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1696,7 +1696,7 @@ func BenchmarkPeekLengthUvarint(b *testing.B) {
 }
 
 func BenchmarkEncodeBytes(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1712,7 +1712,7 @@ func BenchmarkEncodeBytes(b *testing.B) {
 }
 
 func BenchmarkEncodeBytesDescending(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1728,7 +1728,7 @@ func BenchmarkEncodeBytesDescending(b *testing.B) {
 }
 
 func BenchmarkDecodeBytes(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1744,7 +1744,7 @@ func BenchmarkDecodeBytes(b *testing.B) {
 }
 
 func BenchmarkPeekLengthBytes(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1758,7 +1758,7 @@ func BenchmarkPeekLengthBytes(b *testing.B) {
 }
 
 func BenchmarkDecodeBytesDescending(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1774,7 +1774,7 @@ func BenchmarkDecodeBytesDescending(b *testing.B) {
 }
 
 func BenchmarkPeekLengthBytesDescending(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1788,7 +1788,7 @@ func BenchmarkPeekLengthBytesDescending(b *testing.B) {
 }
 
 func BenchmarkEncodeString(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]string, 10000)
 	for i := range vals {
@@ -1804,7 +1804,7 @@ func BenchmarkEncodeString(b *testing.B) {
 }
 
 func BenchmarkEncodeStringDescending(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]string, 10000)
 	for i := range vals {
@@ -1820,7 +1820,7 @@ func BenchmarkEncodeStringDescending(b *testing.B) {
 }
 
 func BenchmarkDecodeUnsafeString(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1836,7 +1836,7 @@ func BenchmarkDecodeUnsafeString(b *testing.B) {
 }
 
 func BenchmarkDecodeUnsafeStringDescending(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -1852,7 +1852,7 @@ func BenchmarkDecodeUnsafeStringDescending(b *testing.B) {
 }
 
 func BenchmarkEncodeDuration(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]duration.Duration, 10000)
@@ -1871,7 +1871,7 @@ func BenchmarkEncodeDuration(b *testing.B) {
 }
 
 func BenchmarkDecodeDuration(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -1891,7 +1891,7 @@ func BenchmarkDecodeDuration(b *testing.B) {
 }
 
 func BenchmarkPeekLengthDuration(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -1925,7 +1925,7 @@ func TestValueEncodeDecodeBool(t *testing.T) {
 }
 
 func TestValueEncodeDecodeInt(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	tests := append(int64TestCases[0:], randPowDistributedInt63s(rng, 1000)...)
 	for _, test := range tests {
 		buf := EncodeIntValue(nil, NoColumnID, test)
@@ -1940,7 +1940,7 @@ func TestValueEncodeDecodeInt(t *testing.T) {
 }
 
 func TestValueEncodeDecodeFloat(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	tests := make([]float64, 1000)
 	for i := range tests {
 		tests[i] = rng.NormFloat64()
@@ -1958,7 +1958,7 @@ func TestValueEncodeDecodeFloat(t *testing.T) {
 }
 
 func TestValueEncodeDecodeBytes(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	tests := make([][]byte, 1000)
 	for i := range tests {
 		tests[i] = randutil.RandBytes(rng, 100)
@@ -1976,7 +1976,7 @@ func TestValueEncodeDecodeBytes(t *testing.T) {
 }
 
 func TestValueEncodeDecodeDecimal(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]*apd.Decimal, 1000)
 	for i := range tests {
@@ -1995,7 +1995,7 @@ func TestValueEncodeDecodeDecimal(t *testing.T) {
 }
 
 func TestValueEncodeDecodeTime(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]time.Time, 1000)
 	for i := range tests {
@@ -2014,7 +2014,7 @@ func TestValueEncodeDecodeTime(t *testing.T) {
 }
 
 func TestValueEncodeDecodeTimeTZ(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]timetz.TimeTZ, 1000)
 	for i := range tests {
@@ -2033,7 +2033,7 @@ func TestValueEncodeDecodeTimeTZ(t *testing.T) {
 }
 
 func TestValueEncodeDecodeBitArray(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]bitarray.BitArray, 1000)
 	for i := range tests {
@@ -2055,7 +2055,7 @@ func TestValueEncodeDecodeBitArray(t *testing.T) {
 }
 
 func TestValueEncodeDecodeDuration(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 	tests := make([]duration.Duration, 1000)
 	for i := range tests {
@@ -2075,7 +2075,7 @@ func TestValueEncodeDecodeDuration(t *testing.T) {
 
 func BenchmarkEncodeNonsortingVarint(b *testing.B) {
 	bytes := make([]byte, 0, b.N*MaxNonsortingVarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bytes = EncodeNonsortingStdlibVarint(bytes, rng.Int63())
@@ -2084,7 +2084,7 @@ func BenchmarkEncodeNonsortingVarint(b *testing.B) {
 
 func BenchmarkDecodeNonsortingVarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*MaxNonsortingVarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < b.N; i++ {
 		buf = EncodeNonsortingStdlibVarint(buf, rng.Int63())
 	}
@@ -2148,7 +2148,7 @@ func testNonsortingUvarint(t *testing.T, i uint64) {
 }
 
 func TestNonsortingUVarint(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	for _, test := range edgeCaseUint64s() {
 		testNonsortingUvarint(t, test)
@@ -2159,7 +2159,7 @@ func TestNonsortingUVarint(t *testing.T) {
 }
 
 func TestPeekLengthNonsortingUVarint(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 
 	var buf []byte
 	var lengths []int
@@ -2188,7 +2188,7 @@ func TestPeekLengthNonsortingUVarint(t *testing.T) {
 
 func BenchmarkEncodeNonsortingUvarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*MaxNonsortingUvarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
@@ -2197,7 +2197,7 @@ func BenchmarkEncodeNonsortingUvarint(b *testing.B) {
 
 func BenchmarkDecodeNonsortingUvarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*MaxNonsortingUvarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < b.N; i++ {
 		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
 	}
@@ -2213,7 +2213,7 @@ func BenchmarkDecodeNonsortingUvarint(b *testing.B) {
 
 func BenchmarkDecodeOneByteNonsortingUvarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*MaxNonsortingUvarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < b.N; i++ {
 		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()%(1<<7)))
 	}
@@ -2229,7 +2229,7 @@ func BenchmarkDecodeOneByteNonsortingUvarint(b *testing.B) {
 
 func BenchmarkPeekLengthNonsortingUvarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*MaxNonsortingUvarintLen)
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < b.N; i++ {
 		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
 	}
@@ -2284,7 +2284,7 @@ func randValueEncode(rd randData, buf []byte, colID uint32, typ Type) ([]byte, i
 }
 
 func TestValueEncodingPeekLength(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 
 	var buf []byte
@@ -2335,7 +2335,7 @@ func TestValueEncodingPeekLength(t *testing.T) {
 }
 
 func TestValueEncodingTags(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 
 	tests := make([]struct {
 		colID  uint32
@@ -2387,7 +2387,7 @@ func TestValueEncodingTags(t *testing.T) {
 }
 
 func TestValueEncodingRand(t *testing.T) {
-	rng, seed := randutil.NewPseudoRand()
+	rng, seed := randutil.NewTestRand()
 	rd := randData{rng}
 
 	var buf []byte
@@ -2522,7 +2522,7 @@ func TestPrettyPrintValueEncoded(t *testing.T) {
 }
 
 func BenchmarkEncodeBoolValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]bool, 10000)
@@ -2539,7 +2539,7 @@ func BenchmarkEncodeBoolValue(b *testing.B) {
 }
 
 func BenchmarkDecodeBoolValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -2556,7 +2556,7 @@ func BenchmarkDecodeBoolValue(b *testing.B) {
 }
 
 func BenchmarkEncodeIntValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]int64, 10000)
 	for i := range vals {
@@ -2572,7 +2572,7 @@ func BenchmarkEncodeIntValue(b *testing.B) {
 }
 
 func BenchmarkDecodeIntValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -2588,7 +2588,7 @@ func BenchmarkDecodeIntValue(b *testing.B) {
 }
 
 func BenchmarkEncodeFloatValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]float64, 10000)
 	for i := range vals {
@@ -2604,7 +2604,7 @@ func BenchmarkEncodeFloatValue(b *testing.B) {
 }
 
 func BenchmarkDecodeFloatValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -2620,7 +2620,7 @@ func BenchmarkDecodeFloatValue(b *testing.B) {
 }
 
 func BenchmarkEncodeBytesValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -2636,7 +2636,7 @@ func BenchmarkEncodeBytesValue(b *testing.B) {
 }
 
 func BenchmarkDecodeBytesValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
@@ -2652,7 +2652,7 @@ func BenchmarkDecodeBytesValue(b *testing.B) {
 }
 
 func BenchmarkEncodeTimeValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]time.Time, 10000)
@@ -2669,7 +2669,7 @@ func BenchmarkEncodeTimeValue(b *testing.B) {
 }
 
 func BenchmarkDecodeTimeValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -2686,7 +2686,7 @@ func BenchmarkDecodeTimeValue(b *testing.B) {
 }
 
 func BenchmarkEncodeTimeTZValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]timetz.TimeTZ, 10000)
@@ -2703,7 +2703,7 @@ func BenchmarkEncodeTimeTZValue(b *testing.B) {
 }
 
 func BenchmarkDecodeTimeTZValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -2720,7 +2720,7 @@ func BenchmarkDecodeTimeTZValue(b *testing.B) {
 }
 
 func BenchmarkEncodeIPAddrValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]ipaddr.IPAddr, 10000)
@@ -2737,7 +2737,7 @@ func BenchmarkEncodeIPAddrValue(b *testing.B) {
 }
 
 func BenchmarkDecodeIPAddrValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -2754,7 +2754,7 @@ func BenchmarkDecodeIPAddrValue(b *testing.B) {
 }
 
 func BenchmarkEncodeDecimalValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]*apd.Decimal, 10000)
@@ -2771,7 +2771,7 @@ func BenchmarkEncodeDecimalValue(b *testing.B) {
 }
 
 func BenchmarkDecodeDecimalValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)
@@ -2788,7 +2788,7 @@ func BenchmarkDecodeDecimalValue(b *testing.B) {
 }
 
 func BenchmarkEncodeDurationValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([]duration.Duration, 10000)
@@ -2805,7 +2805,7 @@ func BenchmarkEncodeDurationValue(b *testing.B) {
 }
 
 func BenchmarkDecodeDurationValue(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	rd := randData{rng}
 
 	vals := make([][]byte, 10000)

--- a/pkg/util/encoding/float_test.go
+++ b/pkg/util/encoding/float_test.go
@@ -159,7 +159,7 @@ func TestEncodeFloatValue(t *testing.T) {
 }
 
 func BenchmarkEncodeFloat(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([]float64, 10000)
 	for i := range vals {
@@ -175,7 +175,7 @@ func BenchmarkEncodeFloat(b *testing.B) {
 }
 
 func BenchmarkDecodeFloat(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 
 	vals := make([][]byte, 10000)
 	for i := range vals {

--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -30,7 +30,7 @@ func TestFastIntMap(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%d", tc.keyRange, tc.valRange), func(t *testing.T) {
 			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			var fm FastIntMap
 			m := make(map[int]int)
 			for i := 0; i < 1000; i++ {
@@ -115,7 +115,7 @@ func BenchmarkFastIntMap(b *testing.B) {
 	}
 	for _, tc := range cases {
 		b.Run(fmt.Sprintf("%dx%d-%d", tc.keyRange, tc.valRange, tc.ops), func(b *testing.B) {
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			inserts := make([][2]int, tc.ops)
 			for i := range inserts {
 				inserts[i] = [2]int{rng.Intn(tc.keyRange), rng.Intn(tc.valRange)}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -23,7 +23,7 @@ func TestFastIntSet(t *testing.T) {
 		m := mVal
 		t.Run(fmt.Sprintf("%d", m), func(t *testing.T) {
 			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			in := make([]bool, m)
 			forEachRes := make([]bool, m)
 
@@ -100,7 +100,7 @@ func TestFastIntSet(t *testing.T) {
 }
 
 func TestFastIntSetTwoSetOps(t *testing.T) {
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	// genSet creates a set of numElem values in [minVal, minVal + valRange)
 	// It also adds and then removes numRemoved elements.
 	genSet := func(numElem, numRemoved, minVal, valRange int) (FastIntSet, map[int]bool) {

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1489,7 +1489,7 @@ func TestEncodeContainingJSONInvertedIndexSpans(t *testing.T) {
 	}
 
 	// Run a set of randomly generated test cases.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		// Generate two random JSONs and evaluate the result of `left @> right`.
 		left, err := Random(20, rng)
@@ -1668,7 +1668,7 @@ func TestEncodeContainedJSONInvertedIndexSpans(t *testing.T) {
 	}
 
 	// Run a set of randomly generated test cases.
-	rng, _ := randutil.NewPseudoRand()
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		// Generate two random JSONs and evaluate the result of `left <@ right`.
 		left, err := Random(20, rng)

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -37,7 +37,7 @@ func TestMemoryAllocations(t *testing.T) {
 	poolAllocSizes := []int64{1, 2, 9, 10, 11, 100}
 	preBudgets := []int64{0, 1, 2, 9, 10, 11, 100}
 
-	rnd, seed := randutil.NewPseudoRand()
+	rnd, seed := randutil.NewTestRand()
 	t.Logf("random seed: %v", seed)
 
 	ctx := context.Background()

--- a/pkg/util/randutil/BUILD.bazel
+++ b/pkg/util/randutil/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["rand.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/randutil",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util/envutil"],
+    deps = [
+        "//pkg/util/envutil",
+        "//pkg/util/syncutil",
+    ],
 )
 
 go_test(

--- a/pkg/util/randutil/rand_test.go
+++ b/pkg/util/randutil/rand_test.go
@@ -32,15 +32,6 @@ func TestPseudoRand(t *testing.T) {
 	}
 }
 
-func TestNewTestRandFromGlobalSeed(t *testing.T) {
-	numbers := make(map[int]bool)
-	rand1, _ := randutil.NewTestRandFromGlobalSeed()
-	rand2, _ := randutil.NewTestRandFromGlobalSeed()
-	if numbers[rand1.Int()] != numbers[rand2.Int()] {
-		t.Errorf("expected numbers to be equal; got different")
-	}
-}
-
 func TestRandIntInRange(t *testing.T) {
 	rand, _ := randutil.NewPseudoRand()
 	for i := 0; i < 100; i++ {
@@ -57,6 +48,37 @@ func TestRandBytes(t *testing.T) {
 		x := randutil.RandBytes(rand, i)
 		if len(x) != i {
 			t.Errorf("got array with unexpected length: %d (expected %d)", len(x), i)
+		}
+	}
+}
+
+func TestTestRand(t *testing.T) {
+	n1 := func() map[int]bool {
+		numbers := make(map[int]bool)
+		rand1, _ := randutil.NewTestRand()
+		rand2, _ := randutil.NewTestRand()
+		numbers[rand1.Int()] = true
+		numbers[rand1.Int()] = true
+		numbers[rand2.Int()] = true
+		numbers[rand2.Int()] = true
+		return numbers
+	}()
+	n2 := func() map[int]bool {
+		numbers := make(map[int]bool)
+		rand1, _ := randutil.NewTestRand()
+		rand2, _ := randutil.NewTestRand()
+		numbers[rand1.Int()] = true
+		numbers[rand1.Int()] = true
+		numbers[rand2.Int()] = true
+		numbers[rand2.Int()] = true
+		return numbers
+	}()
+	if len(n1) != len(n2) {
+		t.Errorf("expected the same random numbers; got lengths %d and %d", len(n1), len(n2))
+	}
+	for k := range n1 {
+		if !n2[k] {
+			t.Errorf("expected the same random numbers; got unique number %d", k)
 		}
 	}
 }

--- a/pkg/util/testaddr_random.go
+++ b/pkg/util/testaddr_random.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	r, _ := randutil.NewPseudoRand()
+	r, _ := randutil.NewTestRand()
 	// 127.255.255.255 is special (broadcast), so choose values less
 	// than 255.
 	a := r.Intn(255)

--- a/pkg/util/timeutil/stopwatch_test.go
+++ b/pkg/util/timeutil/stopwatch_test.go
@@ -97,7 +97,7 @@ func TestStopWatchConcurrentUsage(t *testing.T) {
 		// concurrently.
 		go func() {
 			defer wg.Done()
-			rng, _ := randutil.NewPseudoRand()
+			rng, _ := randutil.NewTestRand()
 			var timeSpent time.Duration
 			for timeSpent < testDuration {
 				// Sleep some random time, up to maxSleepTime.


### PR DESCRIPTION
This PR adds NewTestRand, a random number generator seeded by a random number 
taken from the global rand. This provides more determinism for a test than the existing
NewPseudoRand by using a seed that is reproducible, provided the test has no other
sources of non-determinism.

As part of this PR we also migrate test use cases of NewPseudoRand and all uses of
NewTestPseudoRand to NewTestRand. 