### PR TITLE
util/timeutil: speedup Since 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,10 @@ build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,c
 test --config=test
 build:with_ui --define cockroach_with_ui=y
 build:test --define gotags=bazel,crdb_test,gss
+# Certain time based fail if UTC isn't the default timezone (see #25064).
+# CRDB sets time.Local=time.UTC, which should also satisfy these tests (plus I
+# couldn't reproduce the failure years later), but let's not rely on that - so
+# we set the TZ to UTC explicitly.
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
 test:test --test_env=TZ=
 query --ui_event_filters=-DEBUG

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,10 @@ LDFLAGS ?=
 CGO_CFLAGS = $(filter-out -g%,$(CFLAGS))
 CGO_CXXFLAGS = $(CXXFLAGS)
 CGO_LDFLAGS = $(filter-out -static,$(LDFLAGS))
-# certain time based fail if UTC isn't the default timezone
+# Certain time based fail if UTC isn't the default timezone (see #25064).
+# CRDB sets time.Local=time.UTC, which should also satisfy these tests (plus I
+# couldn't reproduce the failure years later), but let's not rely on that - so
+# we set the TZ to UTC explicitly.
 TZ=""
 
 export CFLAGS CXXFLAGS LDFLAGS CGO_CFLAGS CGO_CXXFLAGS CGO_LDFLAGS TZ

--- a/pkg/ccl/sqlproxyccl/denylist/file_test.go
+++ b/pkg/ccl/sqlproxyccl/denylist/file_test.go
@@ -121,12 +121,12 @@ denylist:
 			Denylist: []*DenyEntry{
 				{
 					DenyEntity{"63", ClusterType},
-					timeutil.Now(),
+					timeutil.StripMonotonic(timeutil.Now()),
 					"over usage",
 				},
 				{
 					DenyEntity{"8.8.8.8", IPAddrType},
-					timeutil.Now().Add(1 * time.Hour),
+					timeutil.StripMonotonic(timeutil.Now().Add(1 * time.Hour)),
 					"malicious IP",
 				},
 			},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1244,6 +1244,13 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) PreStart(ctx context.Context) error {
 	ctx = s.AnnotateCtx(ctx)
 
+	if time.Local != nil {
+		// Sanity check that no 3rd-party library messes the global that our
+		// timeutil library messes with.
+		return errors.AssertionFailedf("expected time.Local to be set to UTC. " +
+			"Did you include a 3rd party package that overwrites that global?")
+	}
+
 	// Start the time sanity checker.
 	s.startTime = timeutil.Now()
 	if err := s.startMonitoringForwardClockJumps(ctx); err != nil {

--- a/pkg/sql/protoreflect/utils_test.go
+++ b/pkg/sql/protoreflect/utils_test.go
@@ -88,7 +88,7 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 				TraceID: 123,
 				Tags:    map[string]string{"one": "1", "two": "2", "three": "3"},
 				StructuredRecords: []tracingpb.StructuredRecord{{
-					Time:    timeutil.Now(),
+					Time:    timeutil.StripMonotonic(timeutil.Now()),
 					Payload: makeAny(t, &descpb.ColumnDescriptor{Name: "bogus stats"})}},
 			},
 		},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
@@ -67,7 +67,7 @@ func genRandomData() randomData {
 		r.IntArray[i] = rand.Int63()
 	}
 
-	r.Time = timeutil.Now()
+	r.Time = timeutil.StripMonotonic(timeutil.Now())
 	return r
 }
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -713,6 +713,8 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	// Direct use of time.Now() and friends is prohibited because we might want to
+	// mock the time source. Use timeutil.Now() instead.
 	t.Run("TestTimeutil", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(
@@ -724,11 +726,12 @@ func TestLint(t *testing.T) {
 			"--",
 			"*.go",
 			":!**/embedded.go",
+			":!testutils/lint/lint_test.go", // this file
 			":!util/timeutil/time.go",
 			":!util/timeutil/zoneinfo.go",
-			":!util/tracing/span.go",
-			":!util/tracing/crdbspan.go",
-			":!util/tracing/tracer.go",
+			// gorm_helpers.go is excluded because
+			// gormTestHelperGoFile uses Now(). gormTestHelperGoFile is not part
+			// of the cockroachdb package and does not have timeutil.
 			":!cmd/roachtest/tests/gorm_helpers.go",
 		)
 		if err != nil {

--- a/pkg/util/timeutil/BUILD.bazel
+++ b/pkg/util/timeutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "timeutil",
     srcs = [
+        "doc.go",
         "manual_time.go",
         "stopwatch.go",
         "time.go",

--- a/pkg/util/timeutil/doc.go
+++ b/pkg/util/timeutil/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+/*
+Package timeutil contains time utility functions.
+
+Note that this package contains the following initialization.
+
+	func init() {
+		time.Local = time.UTC
+	}
+
+Setting the time.Local global makes this package unfriendly to being used
+outside CRDB.
+*/
+package timeutil

--- a/pkg/util/timeutil/now_test.go
+++ b/pkg/util/timeutil/now_test.go
@@ -10,10 +10,52 @@
 
 package timeutil
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func BenchmarkNow(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		Now()
+	type test struct {
+		name    string
+		nowFunc func() time.Time
+	}
+	for _, tc := range []test{
+		{name: "stdlib-now",
+			nowFunc: time.Now,
+		},
+		{
+			name:    "timeutil-now",
+			nowFunc: Now,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Now()
+			}
+		})
+	}
+}
+
+func BenchmarkSince(b *testing.B) {
+	type test struct {
+		name    string
+		nowFunc func() time.Time
+	}
+	for _, tc := range []test{
+		{name: "stdlib-now",
+			nowFunc: time.Now,
+		},
+		{
+			name:    "timeutil-now",
+			nowFunc: Now,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			start := tc.nowFunc()
+			for i := 0; i < b.N; i++ {
+				Since(start)
+			}
+		})
 	}
 }

--- a/pkg/util/timeutil/time_test.go
+++ b/pkg/util/timeutil/time_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnixMicros(t *testing.T) {
@@ -69,4 +70,10 @@ func TestUnixMicrosRounding(t *testing.T) {
 func TestReplaceLibPQTimePrefix(t *testing.T) {
 	assert.Equal(t, "1970-02-02 11:00", ReplaceLibPQTimePrefix("1970-02-02 11:00"))
 	assert.Equal(t, "1970-01-01 11:00", ReplaceLibPQTimePrefix("0000-01-01 11:00"))
+}
+
+// Test that timestamps returned by timeutil.Now() are UTC. See the package
+// init() function for details.
+func TestNowIsUTC(t *testing.T) {
+	require.Equal(t, time.UTC, Now().Location())
 }

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -423,7 +423,7 @@ func (s *crdbSpan) recordStructured(item Structured) {
 	if clock := s.tracer.testing.Clock; clock != nil {
 		now = clock.Now()
 	} else {
-		now = time.Now()
+		now = timeutil.Now()
 	}
 	sr := &tracingpb.StructuredRecord{
 		Time:    now,
@@ -525,7 +525,7 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		// -1 indicates an unfinished Span. For a recording it's better to put some
 		// duration in it, otherwise tools get confused. For example, we export
 		// recordings to Jaeger, and spans with a zero duration don't look nice.
-		rs.Duration = time.Since(rs.StartTime)
+		rs.Duration = timeutil.Since(rs.StartTime)
 		rs.Finished = false
 	} else {
 		rs.Finished = true

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -634,7 +634,7 @@ func (t *Tracer) startSpanGeneric(
 		opts.LogTags = opts.Parent.i.crdb.logTags
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 
 	// First, create any external spans that we may need (OpenTelemetry, net/trace).
 	// We do this early so that they are available when we construct the main Span,


### PR DESCRIPTION
Our implementation of timeutil.Since(t) was doing Now().Sub(t). Now,
it's using stdlib time.Since(). This is faster because, in the happy
path, the stdlib implementation only needs one of two system clock
reading (monotonic, wall clock). On my Linux machine this halves its
cost.

Release note: None