### PR TITLE
colfetcher: minor cleanup and improvement

### DIFF
--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -413,58 +413,55 @@ func NewColIndexJoin(
 	// just setting the ID and Version in the spec or something like that and
 	// retrieving the hydrated immutable from cache.
 	table := spec.BuildTableDescriptor()
-
-	typs, columnIdxMap, err := retrieveTypsAndColOrds(
-		ctx, flowCtx, evalCtx, table, nil, /* invertedCol */
-		spec.Visibility, spec.HasSystemColumns,
+	index := table.ActiveIndexes()[spec.IndexIdx]
+	tableArgs, err := populateTableArgs(
+		ctx, flowCtx, evalCtx, table, index,
+		nil /* invertedCol */, spec.Visibility, spec.HasSystemColumns,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	indexIdx := int(spec.IndexIdx)
-	if indexIdx >= len(table.ActiveIndexes()) {
-		return nil, errors.Errorf("invalid indexIdx %d", indexIdx)
-	}
-	index := table.ActiveIndexes()[indexIdx]
-
 	// Retrieve the set of columns that the index join needs to fetch.
-	var neededColumns util.FastIntSet
 	if post.OutputColumns != nil {
 		for _, neededColumn := range post.OutputColumns {
-			neededColumns.Add(int(neededColumn))
+			tableArgs.ValNeededForCol.Add(int(neededColumn))
 		}
 	} else {
 		proc := &execinfra.ProcOutputHelper{}
-		if err = proc.Init(post, typs, semaCtx, evalCtx); err != nil {
+		if err = proc.Init(post, tableArgs.typs, semaCtx, evalCtx); err != nil {
 			return nil, err
 		}
-		neededColumns = proc.NeededColumns()
+		tableArgs.ValNeededForCol = proc.NeededColumns()
 	}
 
-	fetcher, err := initCFetcher(
-		flowCtx, fetcherAllocator, kvFetcherMemAcc, table, index, neededColumns, columnIdxMap, nil, /* invertedColumn */
-		cFetcherArgs{
-			visibility:        spec.Visibility,
-			lockingStrength:   spec.LockingStrength,
-			lockingWaitPolicy: spec.LockingWaitPolicy,
-			hasSystemColumns:  spec.HasSystemColumns,
-			memoryLimit:       execinfra.GetWorkMemLimit(flowCtx),
-		},
-	)
-	if err != nil {
+	fetcher := cFetcherPool.Get().(*cFetcher)
+	fetcher.cFetcherArgs = cFetcherArgs{
+		spec.LockingStrength,
+		spec.LockingWaitPolicy,
+		flowCtx.EvalCtx.SessionData().LockTimeout,
+		execinfra.GetWorkMemLimit(flowCtx),
+		// Note that the correct estimated row count will be set by the index
+		// joiner for each set of spans to read.
+		0,     /* estimatedRowCount */
+		false, /* reverse */
+		flowCtx.TraceKV,
+	}
+	if err = fetcher.Init(flowCtx.Codec(), fetcherAllocator, kvFetcherMemAcc, tableArgs); err != nil {
+		fetcher.Release()
 		return nil, err
 	}
 
 	spanAssembler := colexecspan.NewColSpanAssembler(
-		flowCtx.Codec(), allocator, table, index, inputTypes, neededColumns)
+		flowCtx.Codec(), allocator, table, index, inputTypes, tableArgs.ValNeededForCol,
+	)
 
 	op := &ColIndexJoin{
 		OneInputNode:     colexecop.NewOneInputNode(input),
 		flowCtx:          flowCtx,
 		rf:               fetcher,
 		spanAssembler:    spanAssembler,
-		ResultTypes:      typs,
+		ResultTypes:      tableArgs.typs,
 		maintainOrdering: spec.MaintainOrdering,
 	}
 	op.prepareMemLimit(inputTypes)


### PR DESCRIPTION
**colfetcher: fix slices' reuse and fix comments**

This commit fixes the reuse of some slices that we kept the references
to but forgot to set properly when overwriting the table information.
Additionally, in order to make it easier to see whether all slices are
correctly set, this commit reorders the assignment order to match the
order in which the fields are defined.

This commit additionally clarifies things in several places that `cols`
refers to all columns of the table (that's what `colDescriptors`
argument to the cFetcher describes). It also removes some of the
duplicated code when creating a vectorized index join (a method was
refactored to be reused but was never used in the second place).

Release note: None

**colfetcher: simplify the population of the table args**

Previously, when initializing the cFetcher we were doing some work
twice: we would populate a set of columns in the table first to get the
types and the column index map only to discard it right away and
populate similar info again by calling `row.FetcherTableArgs.InitCols`.
This commit removes this inefficiency.

It also removes the duplicated slices of types and column descriptors
and refactors some fields of the cFetcher into a separate struct that
is pooled. Note that I extracted the table args struct that was
previously shared between the row fetcher and the cfetcher into
a separate struct because the follow-up work will be changing the
meaning of the fields in that struct.

Release note: None