### PR TITLE
kv: reduce lock contention in TxnWaitQueue, avoid deadlock detection collapse

### DIFF
--- a/pkg/kv/kvserver/txn_wait_queue_test.go
+++ b/pkg/kv/kvserver/txn_wait_queue_test.go
@@ -130,12 +130,6 @@ func TestTxnWaitQueueEnableDisable(t *testing.T) {
 
 	// Now disable the queue and make sure the waiter is returned.
 	q.Clear(true /* disable */)
-	if q.IsEnabled() {
-		t.Errorf("expected queue to be disabled")
-	}
-	if err := checkAllGaugesZero(tc); err != nil {
-		t.Fatal(err.Error())
-	}
 
 	respWithErr := <-retCh
 	if respWithErr.resp != nil {
@@ -145,6 +139,12 @@ func TestTxnWaitQueueEnableDisable(t *testing.T) {
 		t.Errorf("expected nil err; got %+v", respWithErr.pErr)
 	}
 
+	if q.IsEnabled() {
+		t.Errorf("expected queue to be disabled")
+	}
+	if err := checkAllGaugesZero(tc); err != nil {
+		t.Fatal(err.Error())
+	}
 	if deps := q.GetDependents(txn.ID); deps != nil {
 		t.Errorf("expected GetDependents to return nil as queue is disabled; got %+v", deps)
 	}
@@ -408,7 +408,7 @@ func TestTxnWaitQueueTxnSilentlyCompletes(t *testing.T) {
 		t.Errorf("expected committed txn response; got %+v, err=%v", respWithErr.resp, respWithErr.pErr)
 	}
 	testutils.SucceedsSoon(t, func() error {
-		if act, exp := m.PusherWaiting.Value(), int64(1); act != exp {
+		if act, exp := m.PusherWaiting.Value(), int64(0); act != exp {
 			return errors.Errorf("%d pushers, but want %d", act, exp)
 		}
 		if act, exp := m.PusheeWaiting.Value(), int64(1); act != exp {
@@ -477,8 +477,8 @@ func TestTxnWaitQueueUpdateNotPushedTxn(t *testing.T) {
 	})
 }
 
-// TestTxnWaitQueuePusheeExpires verifies that just one pusher is
-// returned when the pushee's txn may have expired.
+// TestTxnWaitQueuePusheeExpires verifies that all pushers are returned when the
+// pushee's txn may have expired.
 func TestTxnWaitQueuePusheeExpires(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -528,25 +528,10 @@ func TestTxnWaitQueuePusheeExpires(t *testing.T) {
 		resp, pErr := q.MaybeWaitForPush(context.Background(), &req1)
 		retCh <- RespWithErr{resp, pErr}
 	}()
-	testutils.SucceedsSoon(t, func() error {
-		expDeps := []uuid.UUID{pusher1.ID}
-		if deps := q.GetDependents(txn.ID); !reflect.DeepEqual(deps, expDeps) {
-			return errors.Errorf("expected GetDependents %+v; got %+v", expDeps, deps)
-		}
-		return nil
-	})
-
 	go func() {
 		resp, pErr := q.MaybeWaitForPush(context.Background(), &req2)
 		retCh <- RespWithErr{resp, pErr}
 	}()
-	testutils.SucceedsSoon(t, func() error {
-		expDeps := []uuid.UUID{pusher1.ID, pusher2.ID}
-		if deps := q.GetDependents(txn.ID); !reflect.DeepEqual(deps, expDeps) {
-			return errors.Errorf("expected GetDependents %+v; got %+v", expDeps, deps)
-		}
-		return nil
-	})
 
 	for i := 0; i < 2; i++ {
 		respWithErr := <-retCh
@@ -560,7 +545,7 @@ func TestTxnWaitQueuePusheeExpires(t *testing.T) {
 
 	m := tc.store.txnWaitMetrics
 	testutils.SucceedsSoon(t, func() error {
-		if act, exp := m.PusherWaiting.Value(), int64(2); act != exp {
+		if act, exp := m.PusherWaiting.Value(), int64(0); act != exp {
 			return errors.Errorf("%d pushers, but want %d", act, exp)
 		}
 		if act, exp := m.PusheeWaiting.Value(), int64(1); act != exp {
@@ -667,7 +652,7 @@ func TestTxnWaitQueuePusherUpdate(t *testing.T) {
 
 				m := tc.store.txnWaitMetrics
 				testutils.SucceedsSoon(t, func() error {
-					if act, exp := m.PusherWaiting.Value(), int64(1); act != exp {
+					if act, exp := m.PusherWaiting.Value(), int64(0); act != exp {
 						return errors.Errorf("%d pushers, but want %d", act, exp)
 					}
 					if act, exp := m.PusheeWaiting.Value(), int64(1); act != exp {

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -590,7 +590,7 @@ func (q *Queue) MaybeWaitForPush(
 			pusheeTxnTimer.Read = true
 			// Periodically check whether the pushee txn has been abandoned.
 			updatedPushee, _, pErr := q.queryTxnStatus(
-				ctx, req.PusheeTxn, false, nil, q.cfg.Clock.Now(),
+				ctx, req.PusheeTxn, false, nil,
 			)
 			if pErr != nil {
 				return nil, pErr
@@ -828,7 +828,7 @@ func (q *Queue) startQueryPusherTxn(
 				var pErr *roachpb.Error
 				var updatedPusher *roachpb.Transaction
 				updatedPusher, waitingTxns, pErr = q.queryTxnStatus(
-					ctx, pusher.TxnMeta, true, waitingTxns, q.cfg.Clock.Now(),
+					ctx, pusher.TxnMeta, true, waitingTxns,
 				)
 				if pErr != nil {
 					errCh <- pErr
@@ -889,11 +889,7 @@ func (q *Queue) startQueryPusherTxn(
 // Returns the updated transaction (or nil if not updated) as well as
 // the list of transactions which are waiting on the updated txn.
 func (q *Queue) queryTxnStatus(
-	ctx context.Context,
-	txnMeta enginepb.TxnMeta,
-	wait bool,
-	dependents []uuid.UUID,
-	now hlc.Timestamp,
+	ctx context.Context, txnMeta enginepb.TxnMeta, wait bool, dependents []uuid.UUID,
 ) (*roachpb.Transaction, []uuid.UUID, *roachpb.Error) {
 	b := &kv.Batch{}
 	b.Header.Timestamp = q.cfg.Clock.Now()

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -205,7 +205,7 @@ type TestingKnobs struct {
 type Queue struct {
 	cfg Config
 	mu  struct {
-		syncutil.Mutex
+		syncutil.RWMutex
 		txns    map[uuid.UUID]*pendingTxn
 		queries map[uuid.UUID]*waitingQueries
 	}
@@ -287,8 +287,8 @@ func (q *Queue) Clear(disable bool) {
 
 // IsEnabled is true if the queue is enabled.
 func (q *Queue) IsEnabled() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	return q.mu.txns != nil
 }
 
@@ -372,8 +372,8 @@ func (q *Queue) UpdateTxn(ctx context.Context, txn *roachpb.Transaction) {
 // GetDependents returns a slice of transactions waiting on the specified
 // txn either directly or indirectly.
 func (q *Queue) GetDependents(txnID uuid.UUID) []uuid.UUID {
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	if q.mu.txns == nil {
 		// Not enabled; do nothing.
 		return nil
@@ -967,10 +967,10 @@ func (q *Queue) forcePushAbort(
 // For testing purposes only.
 func (q *Queue) TrackedTxns() map[uuid.UUID]struct{} {
 	m := make(map[uuid.UUID]struct{})
-	q.mu.Lock()
+	q.mu.RLock()
 	for k := range q.mu.txns {
 		m[k] = struct{}{}
 	}
-	q.mu.Unlock()
+	q.mu.RUnlock()
 	return m
 }

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -253,7 +253,6 @@ func (q *Queue) Clear(disable bool) {
 
 	metrics := q.cfg.Metrics
 	metrics.PusheeWaiting.Dec(int64(len(q.mu.txns)))
-	metrics.QueryWaiting.Dec(int64(waitingQueriesCount))
 
 	if log.V(1) {
 		log.Infof(
@@ -415,8 +414,6 @@ func (q *Queue) isTxnUpdated(pending *pendingTxn, req *roachpb.QueryTxnRequest) 
 
 func (q *Queue) releaseWaitingQueriesLocked(ctx context.Context, txnID uuid.UUID) {
 	if w, ok := q.mu.queries[txnID]; ok {
-		metrics := q.cfg.Metrics
-		metrics.QueryWaiting.Dec(int64(w.count))
 		log.VEventf(ctx, 2, "releasing %d waiting queries for %s", w.count, txnID.Short())
 		close(w.pending)
 		delete(q.mu.queries, txnID)
@@ -720,7 +717,6 @@ func (q *Queue) MaybeWaitForQuery(
 	if !req.WaitForUpdate {
 		return nil
 	}
-	metrics := q.cfg.Metrics
 	q.mu.Lock()
 	// If the txn wait queue is not enabled or if the request is not
 	// contained within the replica, do nothing. The request can fall
@@ -760,26 +756,26 @@ func (q *Queue) MaybeWaitForQuery(
 		}
 		q.mu.queries[req.Txn.ID] = query
 	}
-	metrics.QueryWaiting.Inc(1)
 	q.mu.Unlock()
 
-	tBegin := timeutil.Now()
-	defer func() { metrics.QueryWaitTime.RecordValue(timeutil.Since(tBegin).Nanoseconds()) }()
-
-	// When we return, make sure to unregister the query so that it doesn't
-	// leak. If query.pending if closed, the query will have already been
-	// cleaned up, so this will be a no-op.
+	// When we return, make sure to unregister the query. If the query's reference
+	// count drops to 0, remove it from the queries map. Only do so if the map
+	// still contains the same waitingQueries reference, as it may have been
+	// removed already and replaced.
 	defer func() {
 		q.mu.Lock()
-		if query == q.mu.queries[req.Txn.ID] {
-			query.count--
-			metrics.QueryWaiting.Dec(1)
-			if query.count == 0 {
-				delete(q.mu.queries, req.Txn.ID)
-			}
+		query.count--
+		if query.count == 0 && query == q.mu.queries[req.Txn.ID] {
+			delete(q.mu.queries, req.Txn.ID)
 		}
 		q.mu.Unlock()
 	}()
+
+	metrics := q.cfg.Metrics
+	metrics.QueryWaiting.Inc(1)
+	defer metrics.QueryWaiting.Dec(1)
+	tBegin := timeutil.Now()
+	defer func() { metrics.QueryWaitTime.RecordValue(timeutil.Since(tBegin).Nanoseconds()) }()
 
 	log.VEventf(ctx, 2, "waiting on query for %s", req.Txn.ID.Short())
 	select {


### PR DESCRIPTION
Fixes #65828.
Related to #70977 (needs backport).
Related to #70081 (needs backport).

This PR combines two fixes (and a third minor refactor) to reduce lock contention in the transaction wait-queue that was observed to create instability in heavily contended workloads with long transaction dependency chains. This PR comes out of the investigation of the `kv/contention/nodes=4` in #70977. While I don't think it explains the increased frequency of failures in the test (that's still TBD and still difficult to diagnose conclusively), I do believe it explains the lower frequency of failure on the test that we have seen over the past 6 months on `master`, which was making a git bisect very difficult.

`kv/contention/nodes=4` creates severe contention by running 128 concurrent transactions that each write to 4 random keys in parallel out of a set of 512 total keys. This setup results in long lock wait-queues forming behind a random set of keys. Additionally, because locks are acquired in parallel and there is no defined lock order, the test creates long dependency chains and cycles that can only be resolved by the distributed deadlock detection performed by the transaction wait-queue.

While investigating recent failures of this test, I noticed that distributed deadlock detection would occasionally seize up before any cycle was detected, a transaction was aborted, and the workload was able to make forward progress. This was surprising and was leading to test failures. I diagnosed this to inefficiencies in the transaction wait-queue around deadlock detection that was making the process less efficient than it should be and unstable at the extremes, causing it to collapse into a metastable regime where deadlocks reliably took significantly longer than usual to detect.

**The PR resolves this issue with the following commits. Before this change, `kv/contention/nodes=4` was failing about 20% of the time on release-21.2. After this change, the hour-long test has passed 100 out of the 100 times I have run it.**

## kv: don't leak waiting pushes in MaybeWaitForPush

When a PushTxn enters the TxnWaitQueue, it enters a "waiting pushes" set. This allows distributed deadlock detection to track who is waiting on who and to form a dependency graph through which is can detect cycles. Before this commit, waiting pushes would not be removed from this set until the pushee was finalized, regardless of whether the push was still waiting or not. This meant that if the PushTxn's context was canceled, its `waitingPush` would not be removed from the `waitingPushes` list. 

Context cancellation of PushTxn requests is common, especially with recent (as of v20.1) logic in the lock wait-queues. For instance, `lockTableWaiterImpl` will often issue a push while also continuing to listen to local lock state transitions. If it observes one, it cancels the push.

Additionally, the `txnwaitqueue.pusher.waiting` gauge would be incremented when the PushTxn entered the TxnWaitQueue, but would not be decremented until the pushee was finalized. This commit fixes that issue as well by keeping all manipulation of the metric local to `MaybeWaitForPush`, which makes it easier to reason about.

The effect of this was subtle but significant. I originally noticed that something was up when running `kv/contention/nodes=4` and looking at the `txnwaitqueue.pusher.waiting` metric. Around the same time as I saw throughput stall (10s of qps vs. 100s of qps), I saw the metric shoot up to about 5,000 waiting pushers. This did not make sense, because the test runs 128 concurrent transactions with an internal concurrency of 4, so there should only ever be up to 512 pushers in the system at a time, not an order of magnitude more than that.

<img width="1002" alt="Screen Shot 2021-10-08 at 2 58 56 AM" src="https://user-images.githubusercontent.com/5438456/136637430-7023b968-a3a0-4c1f-9574-b0166f4b29a4.png">

<img width="1243" alt="Screen Shot 2021-10-08 at 2 58 46 AM" src="https://user-images.githubusercontent.com/5438456/136637435-db30a65c-91ab-4499-b4be-af95000f13dd.png">

During this same period, I saw that the node with the majority of these pushers was running hotter than other nodes. A CPU profile revealed that the significant amount of this CPU time was spent in `pendingTxn.getDependentsSet`. This was another red flag that something was wrong, as this method iterates over all pushers associated with a pushee txn and collects their transitive dependencies into a set.

<img width="1639" alt="Screen Shot 2021-10-08 at 2 57 30 AM" src="https://user-images.githubusercontent.com/5438456/136637440-cb8d2ba1-a920-4e97-9270-4219074d2693.png">

It then became clear that because we were leaking these `waitingPush` objects in the `waitingPushes` list, a single pusher thread could be responsible for multiple entries in this list. This led to the list being an order of magnitude larger than should have been possible, and `pendingTxn.getDependentsSet` being an order of magnitude more expensive than should have been possible. These calls were then serializes (see the third commit), leading to significant slowdown in the time to detect and resolve a transaction deadlock.

This commit fixes this issue by removing `waitingPush` entries from the `waitingPushes` list on context cancellation or any other early push termination condition. With this change, we never see the `txnwaitqueue.pusher.waiting` gauge exceed expected upper bounds, nor do we see `pendingTxn.getDependentsSet` appear in CPU profiles.

## kv: decrement txnwaitqueue.query.waiting in MaybeWaitForQuery

This commit gives `txnwaitqueue.query.waiting` similar treatment to what that which the previous commit gave to `txnwaitqueue.pusher.waiting`. While the metric was not susceptible to leaking due to that having already been addressed in 7231cb1, it was maintained across functions in an overly complex manner. This commit fixes this by only decrementing the metric in MaybeWaitForQuery, so it uses the presence of the stack trace itself to ensure that it is properly maintained.

## kv: use RWMutex in TxnWaitQueue

This commit replaces the standard mutex in the TxnWaitQueue with a read-write mutex. This allows the structure to serve multiple concurrently calls to `Queue.GetDependents(uuid.UUID)`. In turn, it avoids serializing all `QueryTxn` requests that are issued to a given Range. As we saw in first commit in this PR, this call can be expensive. Even though we've made it cheaper, it's still better to avoid blocking when possible, as this was contributing to the collapse observed in the test. 

----

Release note (performance improvement): the performance of transaction deadlock detection is now more stable.

Release note (bug fix): the `txnwaitqueue.pusher.waiting` metric no longer over-reports the number of pushing transactions in some cases.