### PR TITLE
build: add TeamCity nightly builds with deadlock detection

### DIFF
--- a/build/teamcity-test-deadlock.sh
+++ b/build/teamcity-test-deadlock.sh
@@ -5,17 +5,16 @@ set -euo pipefail
 source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
-definitely_ccache
 
-export TMPDIR=$PWD/artifacts
+export TMPDIR=$PWD/artifacts/deadlock
 mkdir -p "$TMPDIR"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+# Buffer noisy output and only print it on failure.
+run build/builder.sh make -Otarget c-deps &> artifacts/c-build.log || (cat artifacts/c-build.log && false)
+rm artifacts/c-build.log
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests with deadlock detection enabled"
-run_json_test build/builder.sh \
-  stdbuf -oL -eL \
-  make test GOTESTFLAGS=-json TAGS=deadlock TESTFLAGS='-v'
+run_json_test build/builder.sh stdbuf -oL -eL make test GOTESTFLAGS=-json TAGS=deadlock TESTFLAGS='-v'
 tc_end_block "Run Go tests with deadlock detection enabled"

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -259,6 +259,7 @@ func TestBackupRestoreDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
+	skip.UnderDeadlock(t, "assertion failure under deadlock")
 
 	ctx := context.Background()
 	datadriven.Walk(t, "testdata/backup-restore/", func(t *testing.T, path string) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1464,6 +1464,7 @@ func requireErrorSoon(
 func TestChangefeedFailOnTableOffline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDeadlock(t, "timeout")
 
 	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan/replicaoracle"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -80,6 +81,8 @@ func TestZeroDurationDisablesFollowerReadOffset(t *testing.T) {
 
 func TestCanSendToFollower(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlock(t, "test is flaky under deadlock+stress")
+
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, base.DefaultMaxClockOffset)
 	stale := clock.Now().Add(2*expectedFollowerReadOffset.Nanoseconds(), 0)

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -108,6 +108,11 @@ func runTC(queueBuild func(string, map[string]string)) {
 			maxRuns, maxTime, maxFails, parallelism)
 		queueBuild("Cockroach_Nightlies_Stress", opts)
 
+		// Run non-race build with deadlock detection.
+		opts["env.TAGS"] = "deadlock"
+		queueBuild("Cockroach_Nightlies_Stress", opts)
+		delete(opts, "env.TAGS")
+
 		// Run race build. With run with -p 1 to avoid overloading the machine.
 		noParallelism := 1
 		opts["env.GOFLAGS"] = fmt.Sprintf("-race -parallel=%d", parallelism)

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -71,6 +71,13 @@ func Example_runTC() {
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
 	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
+	//   env.GOFLAGS:     -parallel=4
+	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
+	//   env.TAGS:        deadlock
+	//   env.TESTTIMEOUT: 40m0s
+	//
+	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
+	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
 	//   env.GOFLAGS:     -race -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 40m0s
@@ -81,6 +88,12 @@ func Example_runTC() {
 	//   env.TESTTIMEOUT: 2h0m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/sql/logictest
+	//   env.GOFLAGS:     -parallel=2
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 3h0m0s -maxfails 1 -p 2
+	//   env.TAGS:        deadlock
+	//   env.TESTTIMEOUT: 2h0m0s
+	//
+	// github.com/cockroachdb/cockroach/pkg/sql/logictest
 	//   env.GOFLAGS:     -race -parallel=2
 	//   env.STRESSFLAGS: -maxruns 100 -maxtime 3h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 2h0m0s
@@ -88,6 +101,12 @@ func Example_runTC() {
 	// github.com/cockroachdb/cockroach/pkg/storage
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 4
+	//   env.TESTTIMEOUT: 40m0s
+	//
+	// github.com/cockroachdb/cockroach/pkg/storage
+	//   env.GOFLAGS:     -parallel=4
+	//   env.STRESSFLAGS: -maxruns 100 -maxtime 1h0m0s -maxfails 1 -p 4
+	//   env.TAGS:        deadlock
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/storage


### PR DESCRIPTION
This adds stress builds with deadlock detection to the `master` nightlies, which will become active once this is merged.

In addition, I've set up a regular non-stress test build with deadlock detection as [`Cockroach_UnitTests_Deadlock`](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests_Deadlock). This might be useful to run deadlock detection for tests that are skipped under stress, but not sure if it's needed. Hooking it up to the nightly would cause it to run for all release branches, so we'd have to backport the deadlock detection changes.

I'll note that f4721603efc740d2387212f864aef843234c8d6c disabled the deadlock stress builds because they took up too much CI resources.

---

***: skip some tests that fail under deadlock**

Release note: None

**build: tweak teamcity-test-deadlock.sh**

Release note: None

**build: add TeamCity stress build with deadlock detection**

Resolves #66764.

Release note: None
