### PR TITLE
changefeedccl: Fix a deadlock when closing blocking buffer.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4760,7 +4760,6 @@ func (s *memoryHoggingSink) Close() error {
 func TestChangefeedFlushesSinkToReleaseMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDeadlockWithIssue(t, 71364)
 
 	s, db, stopServer := startTestServer(t, newTestOptions())
 	defer stopServer()

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
         "//pkg/sql/types",
-        "//pkg/testutils/skip",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -106,6 +106,10 @@ func (b *blockingBuffer) pop() (e *bufferEntry, err error) {
 func (b *blockingBuffer) notifyOutOfQuota() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.mu.closed {
+		return
+	}
 	b.mu.blocked = true
 
 	select {
@@ -153,11 +157,17 @@ func (b *blockingBuffer) ensureOpenedLocked(ctx context.Context) error {
 	return nil
 }
 
-func (b *blockingBuffer) enqueue(ctx context.Context, be *bufferEntry) error {
+func (b *blockingBuffer) enqueue(ctx context.Context, be *bufferEntry) (err error) {
 	// Enqueue message, and signal if anybody is waiting.
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if err := b.ensureOpenedLocked(ctx); err != nil {
+	defer func() {
+		if err != nil {
+			bufferEntryPool.Put(be)
+		}
+	}()
+
+	if err = b.ensureOpenedLocked(ctx); err != nil {
 		return err
 	}
 
@@ -232,27 +242,8 @@ func (b *blockingBuffer) Drain(ctx context.Context) error {
 
 // Close implements Writer interface.
 func (b *blockingBuffer) Close(ctx context.Context) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.mu.closed {
-		logcrash.ReportOrPanic(ctx, b.sv, "close called multiple times")
-		return errors.AssertionFailedf("close called multiple times")
-	}
-
-	b.mu.closed = true
-	close(b.signalCh)
-
 	// Close quota pool -- any requests waiting to acquire will receive an error.
-	// It would be nice if we can logcrash if anybody was waiting.
 	b.qp.Close("blocking buffer closing")
-
-	// Release all resources we have queued up.
-	var alloc Alloc
-	for be := b.mu.queue.dequeue(); be != nil; be = b.mu.queue.dequeue() {
-		alloc.Merge(&be.e.alloc)
-	}
-	alloc.Release(ctx)
 
 	// Mark memory quota closed, and close the underlying bound account,
 	// releasing all of its allocated resources at once.
@@ -275,6 +266,24 @@ func (b *blockingBuffer) Close(ctx context.Context) error {
 		quota.acc.Close(ctx)
 		return false
 	})
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.mu.closed {
+		logcrash.ReportOrPanic(ctx, b.sv, "close called multiple times")
+		return errors.AssertionFailedf("close called multiple times")
+	}
+
+	b.mu.closed = true
+	close(b.signalCh)
+
+	// Return all queued up entries to the buffer pool.
+	// Note: we do not need to release their resources since we are going to close
+	// bound account anyway.
+	for be := b.mu.queue.dequeue(); be != nil; be = b.mu.queue.dequeue() {
+		bufferEntryPool.Put(be)
+	}
 
 	return nil
 }

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -65,7 +64,6 @@ func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup 
 func TestBlockingBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDeadlockWithIssue(t, 71364)
 
 	metrics := kvevent.MakeMetrics(time.Minute)
 	ba, release := getBoundAccountWithBudget(4096)
@@ -117,7 +115,6 @@ func TestBlockingBuffer(t *testing.T) {
 func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDeadlockWithIssue(t, 71364)
 
 	metrics := kvevent.MakeMetrics(time.Minute)
 	ba, release := getBoundAccountWithBudget(4096)


### PR DESCRIPTION
A deadlock can occur during shutdown when we attempt
to release buffered events.  In such situation, we could
wind up notifying blocking buffer of an out of quota situation,
and that lead to a deadlock.

In addition to not needing to release event resources, this change
also identified and fixed a bug where buffered events were not released
to the buffer pool.

Fixes #71364

Release Justification: low danger logic/correctness bug fix (category 4).
Release Notes: None