### PR TITLE
kvclient: only set `ResumeReason` with `ResumeSpan`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1727,7 +1727,6 @@ func fillSkippedResponses(
 			continue
 		}
 		hdr := resp.GetInner().Header()
-		hdr.ResumeReason = resumeReason
 		origSpan := req.Header().Span()
 		if isReverse {
 			if hdr.ResumeSpan != nil {
@@ -1765,6 +1764,9 @@ func fillSkippedResponses(
 					}
 				}
 			}
+		}
+		if hdr.ResumeSpan != nil {
+			hdr.ResumeReason = resumeReason
 		}
 		br.Responses[i].GetInner().SetHeader(hdr)
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -206,6 +206,10 @@ func checkResumeSpanScanResults(
 				t.Fatalf("satisfied scan %d (%s) has ResumeSpan: %v",
 					i, spans[i], res.ResumeSpan)
 			}
+			if res.ResumeReason != 0 {
+				t.Fatalf("satisfied scan %d (%s) has ResumeReason: %v",
+					i, spans[i], res.ResumeReason)
+			}
 			continue
 		}
 
@@ -547,6 +551,7 @@ func TestMultiRangeBoundedBatchScan(t *testing.T) {
 						if res.ResumeSpan != nil {
 							b.Results[i].Rows = append(b.Results[i].Rows, newB.Results[j].Rows...)
 							b.Results[i].ResumeSpan = newB.Results[j].ResumeSpan
+							b.Results[i].ResumeReason = newB.Results[j].ResumeReason
 							j++
 						}
 					}

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -230,7 +230,6 @@ func evalExport(
 				targetSize = curSizeOfExportedSSTs
 			}
 			reply.NumBytes = targetSize
-			reply.ResumeReason = roachpb.RESUME_BYTE_LIMIT
 			// NB: This condition means that we will allow another SST to be created
 			// even if we have less room in our TargetBytes than the target size of
 			// the next SST. In the worst case this could lead to us exceeding our
@@ -241,6 +240,7 @@ func evalExport(
 						Key:    resume,
 						EndKey: args.EndKey,
 					}
+					reply.ResumeReason = roachpb.RESUME_BYTE_LIMIT
 				}
 				break
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -311,14 +311,10 @@ INTO
 		res7 = exportAndSlurp(t, res5.end, maxResponseSSTBytes)
 		expect(t, res7, 2, 100, 2, 100)
 		latestRespHeader := roachpb.ResponseHeader{
-			ResumeSpan:   nil,
-			ResumeReason: roachpb.RESUME_BYTE_LIMIT,
-			NumBytes:     maxResponseSSTBytes,
+			NumBytes: maxResponseSSTBytes,
 		}
 		allRespHeader := roachpb.ResponseHeader{
-			ResumeSpan:   nil,
-			ResumeReason: roachpb.RESUME_BYTE_LIMIT,
-			NumBytes:     maxResponseSSTBytes,
+			NumBytes: maxResponseSSTBytes,
 		}
 		expectResponseHeader(t, res7, latestRespHeader, allRespHeader)
 

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -128,45 +128,38 @@ func TestExportCmd(t *testing.T) {
 		t *testing.T, res ExportAndSlurpResult,
 		mvccLatestFilesLen int, mvccLatestKVsLen int, mvccAllFilesLen int, mvccAllKVsLen int,
 	) {
-		if len(res.mvccLatestFiles) != mvccLatestFilesLen {
-			t.Errorf("expected %d files in latest export got %d", mvccLatestFilesLen, len(res.mvccLatestFiles))
-		}
-		if len(res.mvccLatestKVs) != mvccLatestKVsLen {
-			t.Errorf("expected %d kvs in latest export got %d", mvccLatestKVsLen, len(res.mvccLatestKVs))
-		}
-		if len(res.mvccAllFiles) != mvccAllFilesLen {
-			t.Errorf("expected %d files in all export got %d", mvccAllFilesLen, len(res.mvccAllFiles))
-		}
-		if len(res.mvccAllKVs) != mvccAllKVsLen {
-			t.Errorf("expected %d kvs in all export got %d", mvccAllKVsLen, len(res.mvccAllKVs))
-		}
+		t.Helper()
+		require.Len(t, res.mvccLatestFiles, mvccLatestFilesLen, "unexpected files in latest export")
+		require.Len(t, res.mvccLatestKVs, mvccLatestKVsLen, "unexpected kvs in latest export")
+		require.Len(t, res.mvccAllFiles, mvccAllFilesLen, "unexpected files in all export")
+		require.Len(t, res.mvccAllKVs, mvccAllKVsLen, "unexpected kvs in all export")
 	}
 
 	expectResponseHeader := func(
 		t *testing.T, res ExportAndSlurpResult, mvccLatestResponseHeader roachpb.ResponseHeader,
 		mvccAllResponseHeader roachpb.ResponseHeader) {
-		isSpanEqual := func(spanOne, spanTwo *roachpb.Span) bool {
-			if spanOne == nil || spanTwo == nil {
-				return spanOne == spanTwo
+		t.Helper()
+		requireResumeSpan := func(expect, actual *roachpb.Span, msgAndArgs ...interface{}) {
+			t.Helper()
+			if expect == nil {
+				require.Nil(t, actual, msgAndArgs...)
+			} else {
+				require.NotNil(t, actual, msgAndArgs...)
+				require.Equal(t, expect.String(), actual.String(), msgAndArgs...)
 			}
-			return spanOne.String() == spanTwo.String()
 		}
-		if res.mvccAllResponseHeader.NumBytes != mvccAllResponseHeader.NumBytes {
-			t.Errorf("expected %d NumBytes in all export got %d", mvccAllResponseHeader.NumBytes,
-				res.mvccAllResponseHeader.NumBytes)
-		}
-		if !isSpanEqual(res.mvccAllResponseHeader.ResumeSpan, mvccAllResponseHeader.ResumeSpan) {
-			t.Errorf("expected %s span in all export got %s", mvccAllResponseHeader.ResumeSpan.String(),
-				res.mvccAllResponseHeader.ResumeSpan.String())
-		}
-		if res.mvccLatestResponseHeader.NumBytes != mvccLatestResponseHeader.NumBytes {
-			t.Errorf("expected %d NumBytes in all export got %d", mvccLatestResponseHeader.NumBytes,
-				res.mvccLatestResponseHeader.NumBytes)
-		}
-		if !isSpanEqual(res.mvccLatestResponseHeader.ResumeSpan, mvccLatestResponseHeader.ResumeSpan) {
-			t.Errorf("expected %s span in all export got %s",
-				mvccLatestResponseHeader.ResumeSpan.String(), res.mvccLatestResponseHeader.ResumeSpan.String())
-		}
+		require.Equal(t, mvccLatestResponseHeader.NumBytes, res.mvccLatestResponseHeader.NumBytes,
+			"unexpected NumBytes in latest export")
+		requireResumeSpan(mvccLatestResponseHeader.ResumeSpan, res.mvccLatestResponseHeader.ResumeSpan,
+			"unexpected ResumeSpan in latest export")
+		require.Equal(t, mvccLatestResponseHeader.ResumeReason, res.mvccLatestResponseHeader.ResumeReason,
+			"unexpected ResumeReason in latest export")
+		require.Equal(t, mvccAllResponseHeader.NumBytes, res.mvccAllResponseHeader.NumBytes,
+			"unexpected NumBytes in all export")
+		requireResumeSpan(mvccAllResponseHeader.ResumeSpan, res.mvccAllResponseHeader.ResumeSpan,
+			"unexpected ResumeSpan in all export")
+		require.Equal(t, mvccAllResponseHeader.ResumeReason, res.mvccAllResponseHeader.ResumeReason,
+			"unexpected ResumeReason in latest export")
 	}
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
@@ -409,14 +402,10 @@ INTO
 		res7 = exportAndSlurp(t, res5.end, maxResponseSSTBytes)
 		expect(t, res7, 100, 100, 100, 100)
 		latestRespHeader = roachpb.ResponseHeader{
-			ResumeSpan:   nil,
-			ResumeReason: roachpb.RESUME_BYTE_LIMIT,
-			NumBytes:     100 * kvByteSize,
+			NumBytes: 100 * kvByteSize,
 		}
 		allRespHeader = roachpb.ResponseHeader{
-			ResumeSpan:   nil,
-			ResumeReason: roachpb.RESUME_BYTE_LIMIT,
-			NumBytes:     100 * kvByteSize,
+			NumBytes: 100 * kvByteSize,
 		}
 		expectResponseHeader(t, res7, latestRespHeader, allRespHeader)
 	})


### PR DESCRIPTION
**batcheval: only set `ResumeReason` with `ResumeSpan` for `Export`**

`Export` would set `ResumeReason = RESUME_BYTE_LIMIT` if `TargetBytes`
was given regardless of whether a resume span was actually returned.
This patch only sets the reason when there is a resume span.

Release note: None

**kvclient: only set `ResumeReason` with `ResumeSpan` in DistSender**

Previously, the DistSender would set `ResumeReason` on all responses in
a batch if any response had a `ResumeSpan`. This changes the DistSender
to only set `ResumeReason` for responses that have a non-empty
`ResumeSpan`.

Release note: None