### PR TITLE
backupccl: disable multi-region TestResolveOldVersions under race

### DIFF
--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -129,6 +129,7 @@ func TestRestoreOldVersions(t *testing.T) {
 	})
 
 	t.Run("multi-region-restore", func(t *testing.T) {
+		skip.UnderRace(t, "very slow as it starts multiple servers")
 		dirs, err := ioutil.ReadDir(multiRegionDirs)
 		require.NoError(t, err)
 		for _, dir := range dirs {


### PR DESCRIPTION
Release note: None