### PR TITLE
sql/builtin: add crdb_internal.increment_orm_version_counter

### DIFF
--- a/pkg/sql/testdata/telemetry/hashed
+++ b/pkg/sql/testdata/telemetry/hashed
@@ -8,3 +8,13 @@ feature-usage
 SELECT crdb_internal.increment_feature_counter('abc');
 ----
 sql.hashed.ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+feature-usage
+SELECT crdb_internal.increment_orm_version_counter('SQLAlchemy 1.4.25');
+----
+sql.hashed.02da1babdbf411bb46832b6aa131e58d63b01291eaa027b3f5c583e47bfcdcba
+
+feature-usage
+SELECT crdb_internal.increment_orm_version_counter('SQLAlchemy 1.4.24');
+----
+sql.hashed.02da1babdbf411bb46832b6aa131e58d63b01291eaa027b3f5c583e47bfcdcba


### PR DESCRIPTION
fixes #71072

Added a builtin `crdb_internal.increment_orm_version_counter`,
for the telemetry of an orm version.
Note that we only record the version string with the minor release
truncated. E.g. both `SQLAlchemy 1.4.25` and `SQLAlchemy 1.4.24`
will be registered as the hash of `SQLAlchemy 1.4`.

Release note: None
Release justification: None