### PR TITLE
util/log: fix a rare deadlock condition

### DIFF
--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
         "//pkg/server",
         "//pkg/sql/logictest",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -23,7 +22,6 @@ const logictestGlob = "logic_test/[^.]*"
 
 func TestCCLLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderDeadlockWithIssue(t, 71366)
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, filepath.Join("testdata/", logictestGlob))
 }
 
@@ -33,7 +31,6 @@ func TestCCLLogic(t *testing.T) {
 // configuration (i.e. "# LogicTest: !3node-tenant") are not run.
 func TestTenantLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderDeadlockWithIssue(t, 71366)
 
 	testdataDir := "../../sql/logictest/testdata/"
 	if bazel.BuiltWithBazel() {

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -13,7 +13,6 @@ package logictest
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -27,7 +26,6 @@ import (
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderDeadlockWithIssue(t, 71366)
 	RunLogicTest(t, TestServerArgs{}, "testdata/logic_test/[^.]*")
 }
 
@@ -35,7 +33,6 @@ func TestLogic(t *testing.T) {
 // for runSQLLiteLogicTest for more detail on these tests.
 func TestSqlLiteLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderDeadlockWithIssue(t, 71366)
 	RunSQLLiteLogicTest(t, "" /* configOverride */)
 }
 

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -67,7 +67,6 @@ go_test(
         "//pkg/sql/opt",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -28,6 +27,5 @@ import (
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	skip.UnderDeadlockWithIssue(t, 71366)
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/[^.]*")
 }

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -221,6 +221,12 @@ func FatalChan() <-chan struct{} {
 	return logging.mu.fatalCh
 }
 
+func (l *loggingT) idPayload() idPayload {
+	l.idMu.RLock()
+	defer l.idMu.RUnlock()
+	return l.idMu.idPayload
+}
+
 // s ignalFatalCh signals the listeners of l.mu.fatalCh by closing the
 // channel.
 // l.mu is not held.

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -156,9 +156,7 @@ func makeUnsafePayload(m string) entryPayload {
 
 // makeEntry creates a logEntry.
 func makeEntry(ctx context.Context, s Severity, c Channel, depth int) (res logEntry) {
-	logging.idMu.RLock()
-	ids := logging.idMu.idPayload
-	logging.idMu.RUnlock()
+	ids := logging.idPayload()
 
 	res = logEntry{
 		idPayload: ids,
@@ -252,20 +250,19 @@ func (l *sinkInfo) getStartLines(now time.Time) []*buffer {
 		makeStartLine(f, "arguments: %s", os.Args),
 	)
 
-	logging.idMu.RLock()
-	if logging.idMu.clusterID != "" {
+	ids := logging.idPayload()
+	if ids.clusterID != "" {
 		messages = append(messages, makeStartLine(f, "clusterID: %s", logging.idMu.clusterID))
 	}
-	if logging.idMu.nodeID != 0 {
+	if ids.nodeID != 0 {
 		messages = append(messages, makeStartLine(f, "nodeID: n%d", logging.idMu.nodeID))
 	}
-	if logging.idMu.tenantID != "" {
+	if ids.tenantID != "" {
 		messages = append(messages, makeStartLine(f, "tenantID: %s", logging.idMu.tenantID))
 	}
-	if logging.idMu.sqlInstanceID != 0 {
+	if ids.sqlInstanceID != 0 {
 		messages = append(messages, makeStartLine(f, "instanceID: %d", logging.idMu.sqlInstanceID))
 	}
-	logging.idMu.RUnlock()
 
 	// Including a non-ascii character in the first 1024 bytes of the log helps
 	// viewers that attempt to guess the character encoding.


### PR DESCRIPTION
Fixes #71366.

On paper, multiple calls to `RLock()` on the same RWMutex by the same
goroutine are not valid and can yield deadlocks.

There was such a pairing in `makeStartLine()`, which this patch fixes.

In practice however, the implementation of RWMutex only makes readers
wait (and thus deadlock) if there are concurrent writers holding
`Lock()` at the time `RLock()` is called.

So inside CockroachDB the deadlock in `makeStartLine()` can only
occur in either of the following two scenarios:

- the following conditions are met simultaneously:
  1. there is a log call.
  2. the log call causes a file creation/rotation.
  3. asynchronously the server initialization code populates the server identifiers in
     logging via `SetXXXIDs()`.

- the following conditions are met simultaneously:
  1. there is a log call.
  2. the log call causes a file creation/rotation.
  3. asynchronously a test calls `TestingClearServerIdentifiers()`.

Especially the condition "the log call causes a file
creation/rotation, concurrently with that other special condition"
makes either situation extremely unlikely.

Release note (bug fix): A bug that could cause a CockroachDB node to
deadlock upon startup in extremely rare cases has been fixed. If
encountered, a stack trace generated by SIGQUIT would show the
function `makeStartLine()` near the top. This bug had existed since
v21.1.