### PR TITLE
ui: include node for all Overload labels

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -88,13 +88,13 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.granter.total_slots.kv"
-              title="Total Slots"
+              title={"Total Slots " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
             />
             <Metric
               key={nid}
               name="cr.node.admission.granter.used_slots.kv"
-              title="Used Slots"
+              title={"Used Slots " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
             />
           </>
@@ -111,7 +111,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.admission.granter.io_tokens_exhausted_duration.kv"
-            title="IO Exhausted"
+            title={"IO Exhausted " + nodeDisplayName(nodesSummary, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -126,28 +126,34 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.admitted.kv"
-              title="KV request rate"
+              title={"KV request rate " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.admitted.kv-stores"
-              title="KV write request rate"
+              title={
+                "KV write request rate " + nodeDisplayName(nodesSummary, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.admitted.sql-kv-response"
-              title="SQL-KV response rate"
+              title={
+                "SQL-KV response rate " + nodeDisplayName(nodesSummary, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.admitted.sql-sql-response"
-              title="SQL-SQL response rate"
+              title={
+                "SQL-SQL response rate " + nodeDisplayName(nodesSummary, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
@@ -163,28 +169,28 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv"
-              title="KV"
+              title={"KV " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv-stores"
-              title="KV write"
+              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-kv-response"
-              title="SQL-KV response"
+              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-sql-response"
-              title="SQL-SQL response"
+              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               nonNegativeRate
             />
@@ -200,28 +206,28 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-p75"
-              title="KV"
+              title={"KV " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-stores-p75"
-              title="KV write"
+              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-kv-response-p75"
-              title="SQL-KV response"
+              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-sql-response-p75"
-              title="SQL-SQL response"
+              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
               sources={[nid]}
               downsampleMax
             />

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -1627,6 +1627,7 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	usedSlots = metric.Metadata{
+		// Note: we append a WorkKind string to this name.
 		Name:        "admission.granter.used_slots.",
 		Help:        "Used slots",
 		Measurement: "Slots",


### PR DESCRIPTION
This change adds the node to various labels in the Overload dashboard.

Release note: None

Fixes #70764.

![image](https://user-images.githubusercontent.com/16544120/136843414-e7e58593-0d68-4b39-a34a-8a06f6117860.png)
