### PR TITLE
storage: reduce the cache size from 128MiB to 8MiB for in-mem temp engine

### DIFF
--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -62,14 +62,16 @@ func newPebbleTempEngine(
 	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (*pebbleTempEngine, fs.FS, error) {
 	var loc Location
+	var cacheSize int64 = 128 << 20 // 128 MiB, arbitrary, but not "too big"
 	if tempStorage.InMemory {
+		cacheSize = 8 << 20 // 8 MiB, smaller for in-memory, still non-zero
 		loc = InMemory()
 	} else {
 		loc = Filesystem(tempStorage.Path)
 	}
 
 	p, err := Open(ctx, loc,
-		CacheSize(128<<20),
+		CacheSize(cacheSize),
 		func(cfg *engineConfig) error {
 			cfg.UseFileRegistry = storeSpec.UseFileRegistry
 			cfg.EncryptionOptions = storeSpec.EncryptionOptions


### PR DESCRIPTION
The change was motivated by a desire to remove the cache altogether. Jackson
pointed out that it's useful to avoid decompression. Comments indicate that a
non-zero cache is required.  Nevertheless, a smaller cache was widely
supported.

Release note: None