### PR TITLE
release-21.2: backupccl: fix bug when restoring a table with existing UDT

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8759,3 +8759,26 @@ DROP TABLE foo;
 	defer cleanupEmptyCluster()
 	sqlDBRestore.Exec(t, "RESTORE FROM $1 AS OF SYSTEM TIME "+aost, LocalFoo)
 }
+
+// TestRestoreRemappingOfExistingUDTInColExpr is a regression test for a nil
+// pointer exception when restoring tables that point to existing types. When
+// updating the back references of the existing types we would index into a map
+// keyed on pre-rewrite IDs using a post rewrite ID.
+func TestRestoreRemappingOfExistingUDTInColExpr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+CREATE TABLE foo (id INT PRIMARY KEY, what status default 'open');
+BACKUP DATABASE data to 'nodelocal://0/foo';
+DROP TABLE foo CASCADE;
+DROP TYPE status;
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+RESTORE TABLE foo FROM 'nodelocal://0/foo';
+`)
+}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -666,8 +666,8 @@ func allocateDescriptorRewrites(
 
 				if parentDB.IsMultiRegion() && table.GetLocalityConfig() != nil {
 					// We're restoring a table and not its parent database. We may block
-					// restoring multi-region tables to multi-region databases since regions
-					// may mismatch.
+					// restoring multi-region tables to multi-region databases since
+					// regions may mismatch.
 					if err := checkMultiRegionCompatible(ctx, txn, p.ExecCfg().Codec, table, parentDB); err != nil {
 						return pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
 					}


### PR DESCRIPTION
Backport 1/1 commits from #71161.

/cc @cockroachdb/release

---

This change fixes a nil pointer exception, when restoring tables that
point to existing types. Particularly tables that have column expressions
(computed, default etc) that reference the UDT.

When updating the back references of the existing types in
the restoring cluster, we would index into a map keyed on pre-rewrite
IDs using a post rewrite ID. This change fixes the map to be
keyed on post rewrite IDs.

Informs: #71145

Release note: None
