### PR TITLE
sql: always show CACHE 1 on sequences which don't have a value set

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -140,14 +140,14 @@ CREATE SEQUENCE show_create_test
 query ITTITTTTTTTBBBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions  is_multi_region  is_virtual  is_temporary
-52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false           false            false       false
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                             state   create_nofks                                                                                                 alter_statements  validate_statements  has_partitions  is_multi_region  is_virtual  is_temporary
+52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1  {}                {}                   false           false            false       false
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test
 ----
 table_name        create_statement
-show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1
 
 # DML ERRORS
 
@@ -972,7 +972,7 @@ CREATE SEQUENCE sv VIRTUAL
 query T
 SELECT create_statement FROM [SHOW CREATE SEQUENCE sv]
 ----
-CREATE SEQUENCE public.sv MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL
+CREATE SEQUENCE public.sv MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL CACHE 1
 
 statement ok
 CREATE TABLE svals(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -128,7 +128,7 @@ serial  CREATE TABLE public.serial (
 query TT
 SHOW CREATE SEQUENCE serial_a_seq
 ----
-serial_a_seq  CREATE SEQUENCE public.serial_a_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL
+serial_a_seq  CREATE SEQUENCE public.serial_a_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL CACHE 1
 
 statement ok
 INSERT INTO serial (a, b) VALUES (1, 2), (DEFAULT, DEFAULT), (DEFAULT, 3)
@@ -233,7 +233,7 @@ serial  CREATE TABLE public.serial (
 query TT
 SHOW CREATE SEQUENCE serial_a_seq1
 ----
-serial_a_seq1  CREATE SEQUENCE public.serial_a_seq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+serial_a_seq1  CREATE SEQUENCE public.serial_a_seq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1
 
 query TT
 SELECT pg_get_serial_sequence('serial', 'a'), pg_get_serial_sequence('serial', 'b')

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
@@ -56,16 +56,16 @@ CREATE TABLE public.parent (
     FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+                                                                                                                                                                     x INT8 NULL,
+                                                                                                                                                                     y INT8 NULL,
+                                                                                                                                                                     z INT8 NULL,
+                                                                                                                                                                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                                                                                                     UNIQUE INDEX full_test_x_key (x ASC),
+                                                                                                                                                                     FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
@@ -104,16 +104,16 @@ CREATE TABLE public.parent (
     FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+                                                                                                                                                                     x INT8 NULL,
+                                                                                                                                                                     y INT8 NULL,
+                                                                                                                                                                     z INT8 NULL,
+                                                                                                                                                                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                                                                                                     UNIQUE INDEX full_test_x_key (x ASC),
+                                                                                                                                                                     FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
@@ -201,17 +201,17 @@ CREATE TABLE public.d (
     FAMILY f1 (i, e, f)
 );
 CREATE TABLE public.c (
-    i INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    FAMILY "primary" (i, rowid)
+                                                                                               i INT8 NULL,
+                                                                                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                               FAMILY "primary" (i, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 CREATE TABLE public.s_tbl (
-    id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (id ASC),
-    FAMILY f1 (id, v)
+                                                                                                                     id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+                                                                                                                     v INT8 NULL,
+                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (id ASC),
+                                                                                                                     FAMILY f1 (id, v)
 );
 ALTER TABLE public.a ADD CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES public.b(i);
 ALTER TABLE public.f ADD CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES public.g(i);
@@ -385,7 +385,7 @@ query T colnames
 SHOW CREATE ALL TABLES
 ----
 create_statement
-CREATE SEQUENCE public.s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1;
+CREATE SEQUENCE public.s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1 CACHE 1;
 
 # Test with UDTs.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -54,16 +54,16 @@ CREATE TABLE public.parent (
     FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+                                                                                                                                                                     x INT8 NULL,
+                                                                                                                                                                     y INT8 NULL,
+                                                                                                                                                                     z INT8 NULL,
+                                                                                                                                                                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                                                                                                     UNIQUE INDEX full_test_x_key (x ASC),
+                                                                                                                                                                     FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
@@ -100,16 +100,16 @@ CREATE TABLE public.parent (
     FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+                                                                                                                                                                     x INT8 NULL,
+                                                                                                                                                                     y INT8 NULL,
+                                                                                                                                                                     z INT8 NULL,
+                                                                                                                                                                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                                                                                                     UNIQUE INDEX full_test_x_key (x ASC),
+                                                                                                                                                                     FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
@@ -195,17 +195,17 @@ CREATE TABLE public.d (
     FAMILY f1 (i, e, f)
 );
 CREATE TABLE public.c (
-    i INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-    FAMILY "primary" (i, rowid)
+                                                                                               i INT8 NULL,
+                                                                                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                                                                               CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                                                                                               FAMILY "primary" (i, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 CACHE 1;
 CREATE TABLE public.s_tbl (
-    id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-    v INT8 NULL,
-    CONSTRAINT "primary" PRIMARY KEY (id ASC),
-    FAMILY f1 (id, v)
+                                                                                                                     id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+                                                                                                                     v INT8 NULL,
+                                                                                                                     CONSTRAINT "primary" PRIMARY KEY (id ASC),
+                                                                                                                     FAMILY f1 (id, v)
 );
 ALTER TABLE public.a ADD CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES public.b(i);
 ALTER TABLE public.f ADD CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES public.g(i);
@@ -368,7 +368,7 @@ CREATE SEQUENCE s1 INCREMENT 123;
 query T
 SELECT crdb_internal.show_create_all_tables('test_sequence')
 ----
-CREATE SEQUENCE public.s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1;
+CREATE SEQUENCE public.s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1 CACHE 1;
 
 # Ensure that the builtin can be run in unused and used transactions.
 

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -343,9 +343,7 @@ func ShowCreateSequence(
 	if opts.Virtual {
 		f.Printf(" VIRTUAL")
 	}
-	if opts.CacheSize > 1 {
-		f.Printf(" CACHE %d", opts.CacheSize)
-	}
+	f.Printf(" CACHE %d", opts.EffectiveCacheSize())
 	return f.CloseAndGetString(), nil
 }
 


### PR DESCRIPTION
The default is 1. We didn't show it before for sequences which did
not have it explicitly specified.

Definitely not the fix for #71136. 

Release note: SHOW CREATE statements for sequences which were created without
a CACHE clause will now show CACHE 1 instead of no CACHE clause. A sequence
with `CACHE 1` does not do any caching.