### PR TITLE
tree: support ARRAY cast placeholders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2019,3 +2019,9 @@ query T
 SELECT array_remove(ARRAY[(1,'cat'),(2,'dog')], (3,'\xc03b4478eb'::BYTEA))
 ----
 {"(1,cat)","(2,dog)"}
+
+query T
+PREPARE regression_71394 AS SELECT ARRAY[$1]::int[];
+EXECUTE regression_71394(71394)
+----
+{71394}

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -506,7 +506,7 @@ project
  ├── values
  │    └── () [type=tuple]
  └── projections
-      └── ARRAY['red','green']::color[] [as=array:1, type=color[]]
+      └── ARRAY['red','green'] [as=array:1, type=color[]]
 
 norm
 SELECT ARRAY['red', 'green']::color[]
@@ -519,19 +519,12 @@ values
 build
 SELECT ARRAY['foo']::color[]
 ----
-project
- ├── columns: array:1(color[]!null)
- ├── values
- │    └── () [type=tuple]
- └── projections
-      └── ARRAY['foo']::color[] [as=array:1, type=color[]]
+error (22P02): invalid input value for enum color: "foo"
 
 norm
 SELECT ARRAY['foo']::color[]
 ----
-values
- ├── columns: array:1(color[])
- └── (ARRAY['foo']::color[],) [type=tuple{color[]}]
+error (22P02): invalid input value for enum color: "foo"
 
 # Regression tests for #68233.
 build

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -4655,7 +4655,7 @@ scalar-group-by
  │    │    ├── scan abc
  │    │    │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
  │    │    └── projections
- │    │         └── ARRAY[0.90,0.95]::FLOAT8[] [as=column7:7]
+ │    │         └── ARRAY[0.9,0.95] [as=column7:7]
  │    └── windows
  │         └── percentile-disc [as=percentile_disc:8, frame="range from unbounded to unbounded"]
  │              ├── column7:7
@@ -4676,7 +4676,7 @@ scalar-group-by
  │    │    ├── scan abc
  │    │    │    └── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
  │    │    └── projections
- │    │         └── ARRAY[0.90,0.95]::FLOAT8[] [as=column7:7]
+ │    │         └── ARRAY[0.9,0.95] [as=column7:7]
  │    └── windows
  │         └── percentile-cont [as=percentile_cont:8, frame="range from unbounded to unbounded"]
  │              ├── column7:7


### PR DESCRIPTION
Resolves #71394

Release note (sql change): Previously, placeholders in ARRAY would
resolve in an ambiguous error (e.g. `SELECT ARRAY[$1]::int[]`). This is
now fixed.