### PR TITLE
changefeedccl: introduce 'min_checkpoint_frequency' to adjust sink flush frequency

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -515,6 +515,14 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 		}
 	}
 	{
+		const opt = changefeedbase.OptMinCheckpointFrequency
+		if o, ok := details.Opts[opt]; ok && o != `` {
+			if err := validateNonNegativeDuration(opt, o); err != nil {
+				return jobspb.ChangefeedDetails{}, err
+			}
+		}
+	}
+	{
 		const opt = changefeedbase.OptSchemaChangeEvents
 		switch v := changefeedbase.SchemaChangeEventClass(details.Opts[opt]); v {
 		case ``, changefeedbase.OptSchemaChangeEventClassDefault:

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -38,6 +38,7 @@ const (
 	OptKeyInValue               = `key_in_value`
 	OptTopicInValue             = `topic_in_value`
 	OptResolvedTimestamps       = `resolved`
+	OptMinCheckpointFrequency   = `min_checkpoint_frequency`
 	OptUpdatedTimestamps        = `updated`
 	OptMVCCTimestamps           = `mvcc_timestamp`
 	OptDiff                     = `diff`
@@ -152,6 +153,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptKeyInValue:               sql.KVStringOptRequireNoValue,
 	OptTopicInValue:             sql.KVStringOptRequireNoValue,
 	OptResolvedTimestamps:       sql.KVStringOptAny,
+	OptMinCheckpointFrequency:   sql.KVStringOptRequireValue,
 	OptUpdatedTimestamps:        sql.KVStringOptRequireNoValue,
 	OptMVCCTimestamps:           sql.KVStringOptRequireNoValue,
 	OptDiff:                     sql.KVStringOptRequireNoValue,
@@ -184,7 +186,8 @@ var CommonOptions = makeStringSet(OptCursor, OptEnvelope,
 	OptMVCCTimestamps, OptDiff,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
-	OptInitialScan, OptNoInitialScan)
+	OptInitialScan, OptNoInitialScan,
+	OptMinCheckpointFrequency)
 
 // SQLValidOptions is options exclusive to SQL sink
 var SQLValidOptions map[string]struct{} = nil

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -28,16 +28,16 @@ var TableDescriptorPollInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
-// DefaultFlushFrequency is the default frequency to flush sink.
+// DefaultMinCheckpointFrequency is the default frequency to flush sink.
 // See comment in newChangeAggregatorProcessor for explanation on the value.
-var DefaultFlushFrequency = 5 * time.Second
+var DefaultMinCheckpointFrequency = 30 * time.Second
 
-// TestingSetDefaultFlushFrequency changes defaultFlushFrequency for tests.
+// TestingSetDefaultMinCheckpointFrequency changes DefaultMinCheckpointFrequency for tests.
 // Returns function to restore flush frequency to its original value.
-func TestingSetDefaultFlushFrequency(f time.Duration) func() {
-	old := DefaultFlushFrequency
-	DefaultFlushFrequency = f
-	return func() { DefaultFlushFrequency = old }
+func TestingSetDefaultMinCheckpointFrequency(f time.Duration) func() {
+	old := DefaultMinCheckpointFrequency
+	DefaultMinCheckpointFrequency = f
+	return func() { DefaultMinCheckpointFrequency = old }
 }
 
 // PerChangefeedMemLimit controls how much data can be buffered by

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -59,7 +59,7 @@ func TestTenantStreaming(t *testing.T) {
 	sourceSQL := sqlutils.MakeSQLRunner(tenantConn)
 
 	// Make changefeeds run faster.
-	resetFreq := changefeedbase.TestingSetDefaultFlushFrequency(50 * time.Millisecond)
+	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
 	defer resetFreq()
 	// Set required cluster settings.
 	_, err := sourceDB.Exec(`

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -188,7 +188,7 @@ func NewReplicationHelper(t *testing.T) (*ReplicationHelper, func()) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 
 	// Make changefeeds run faster.
-	resetFreq := changefeedbase.TestingSetDefaultFlushFrequency(50 * time.Millisecond)
+	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
 
 	// Set required cluster settings.
 	_, err := db.Exec(`


### PR DESCRIPTION
Previously, for latency-sensitive sinks like cloud storage, users want to achieve better throughput by adjusting flush frequencies and use 'resolved=X' for this purpose. However, 'resolved' has a different meaning, controlling what time we should at least wait to emit a resolved timestamp event.

This patch disentangles 'resolved' option from this purpose.

Fixes: cockroachdb#69161

Release note (sql change): An option “min_checkpoint_frequency” has been added to CREATE CHANGEFEED statement. When this option is set, changefeed will wait for at least the specified duration before a flush to the external sink. If set empty, changefeed will flush as long as it has local frontier advancement. If not set, it will default to 30 seconds. This option helps high latency sinks to control flush frequency to achieve better throughput.