### PR TITLE
flowinfra: unify CleanupBeforeRun and Cleanup

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -32,9 +32,9 @@ type flowStatus int
 
 // Flow status indicators.
 const (
-	FlowNotStarted flowStatus = iota
-	FlowRunning
-	FlowFinished
+	flowNotStarted flowStatus = iota
+	flowRunning
+	flowFinished
 )
 
 // Startable is any component that can be started (a router or an outbox).
@@ -122,11 +122,10 @@ type Flow interface {
 	// GetID returns the flow ID.
 	GetID() execinfrapb.FlowID
 
-	// Cleanup should be called when the flow completes (after all processors and
-	// mailboxes exited).
+	// Cleanup should be called when the flow completes (after all processors
+	// and mailboxes exited). The implementations must be safe to execute in
+	// case the Flow is never Run() or Start()ed.
 	Cleanup(context.Context)
-	// CleanupBeforeRun should be called if the flow will never be run.
-	CleanupBeforeRun(context.Context)
 
 	// ConcurrentTxnUse returns true if multiple processors/operators in the flow
 	// will execute concurrently (i.e. if not all of them have been fused) and
@@ -229,6 +228,11 @@ func (f *FlowBase) SetStartedGoroutines(val bool) {
 	f.startedGoroutines = val
 }
 
+// Started returns true if f has either been Run() or Start()ed.
+func (f *FlowBase) Started() bool {
+	return f.status != flowNotStarted
+}
+
 var _ Flow = &FlowBase{}
 
 // NewFlowBase creates a new FlowBase.
@@ -253,7 +257,7 @@ func NewFlowBase(
 		admissionInfo.Priority = admission.WorkPriority(h.Priority)
 		admissionInfo.CreateTime = h.CreateTime
 	}
-	base := &FlowBase{
+	return &FlowBase{
 		FlowCtx:               flowCtx,
 		flowRegistry:          flowReg,
 		rowSyncFlowConsumer:   rowSyncFlowConsumer,
@@ -261,9 +265,8 @@ func NewFlowBase(
 		localProcessors:       localProcessors,
 		admissionInfo:         admissionInfo,
 		onFlowCleanup:         onFlowCleanup,
+		status:                flowNotStarted,
 	}
-	base.status = FlowNotStarted
-	return base
 }
 
 // GetFlowCtx is part of the Flow interface.
@@ -370,7 +373,7 @@ func (f *FlowBase) StartInternal(
 		}
 	}
 
-	f.status = FlowRunning
+	f.status = flowRunning
 
 	if log.V(1) {
 		log.Infof(ctx, "registered flow %s", f.ID.Short())
@@ -471,7 +474,7 @@ func (f *FlowBase) Wait() {
 // NOTE: this implements only the shared clean up logic between row-based and
 // vectorized flows.
 func (f *FlowBase) Cleanup(ctx context.Context) {
-	if f.status == FlowFinished {
+	if f.status == flowFinished {
 		panic("flow cleanup called twice")
 	}
 
@@ -511,10 +514,10 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 		log.Infof(ctx, "cleaning up")
 	}
 	// Local flows do not get registered.
-	if !f.IsLocal() && f.status != FlowNotStarted {
+	if !f.IsLocal() && f.Started() {
 		f.flowRegistry.UnregisterFlow(f.ID)
 	}
-	f.status = FlowFinished
+	f.status = flowFinished
 	f.ctxCancel()
 	if f.onFlowCleanup != nil {
 		f.onFlowCleanup()
@@ -522,11 +525,6 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 	if f.doneFn != nil {
 		f.doneFn()
 	}
-}
-
-// CleanupBeforeRun is part of the Flow interface.
-func (f *FlowBase) CleanupBeforeRun(ctx context.Context) {
-	f.Cleanup(ctx)
 }
 
 // cancel iterates through all unconnected streams of this flow and marks them canceled.

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -81,12 +81,12 @@ type flowWithCtx struct {
 	enqueueTime time.Time
 }
 
-// CleanupBeforeRun cleans up the flow's resources in case this flow will never
+// cleanupBeforeRun cleans up the flow's resources in case this flow will never
 // run.
-func (f *flowWithCtx) CleanupBeforeRun() {
+func (f *flowWithCtx) cleanupBeforeRun() {
 	// Note: passing f.ctx is important; that's the context that has the flow's
 	// span in it, and that span needs Finish()ing.
-	f.flow.CleanupBeforeRun(f.ctx)
+	f.flow.Cleanup(f.ctx)
 }
 
 // NewFlowScheduler creates a new FlowScheduler which must be initialized before
@@ -248,7 +248,7 @@ func (fs *FlowScheduler) CancelDeadFlows(req *execinfrapb.CancelDeadFlowsRequest
 			fs.mu.queue.Remove(e)
 			fs.metrics.FlowsQueued.Dec(1)
 			numCanceled++
-			f.CleanupBeforeRun()
+			f.cleanupBeforeRun()
 		}
 	}
 }
@@ -277,7 +277,7 @@ func (fs *FlowScheduler) Start() {
 					fs.mu.queue.Remove(e)
 					n := e.Value.(*flowWithCtx)
 					// TODO(radu): somehow send an error to whoever is waiting on this flow.
-					n.CleanupBeforeRun()
+					n.cleanupBeforeRun()
 				}
 
 				if atomic.LoadInt32(&fs.atomics.numRunning) == 0 {

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -106,8 +106,7 @@ func (m *mockFlow) GetID() execinfrapb.FlowID {
 	return execinfrapb.FlowID{UUID: m.flowID}
 }
 
-func (m *mockFlow) Cleanup(_ context.Context)          {}
-func (m *mockFlow) CleanupBeforeRun(_ context.Context) {}
+func (m *mockFlow) Cleanup(_ context.Context) {}
 
 func (m *mockFlow) ConcurrentTxnUse() bool {
 	return false

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -440,11 +440,6 @@ func (f *rowBasedFlow) Cleanup(ctx context.Context) {
 	f.Release()
 }
 
-// CleanupBeforeRun is part of the Flow interface.
-func (f *rowBasedFlow) CleanupBeforeRun(ctx context.Context) {
-	f.Cleanup(ctx)
-}
-
 type copyingRowReceiver struct {
 	execinfra.RowReceiver
 	alloc rowenc.EncDatumRowAlloc


### PR DESCRIPTION
We recently introduced `CleanupBeforeRun` to the `Flow` interface which
should be called in case the flow is never `Run()` or `Start()`ed. Its
implementation is the same as `Cleanup` for the row-based flows but is
slightly different from `vectorizedFlow.Cleanup` for the vectorized
flow. This commit unifies the two methods into one: namely, we only need
to be careful to not assert that all closers have been closed if the
flow is not started. I think it is acceptable given that the idea with
closers is that they need to release the resources which are supposed to
be allocated only when the closers become used (for example, we always
instantiate disk queues lazily, behind the spilling queue implementation
which starts out with no disk resources used in the constructor).

Release note: None