### PR TITLE
sql: fix bug setting sequence CACHE to 1

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -1,6 +1,11 @@
 # see also file `sequences`
 
 statement ok
+GRANT admin TO testuser
+
+user testuser
+
+statement ok
 CREATE SEQUENCE foo
 
 query I
@@ -20,3 +25,38 @@ query I
 SELECT nextval('foo')
 ----
 7
+
+statement ok
+ALTER SEQUENCE foo CACHE 100
+
+query I
+SELECT nextval('foo');
+----
+12
+
+user root
+
+query I
+SELECT nextval('foo');
+----
+512
+
+user testuser
+
+query I
+SELECT nextval('foo');
+----
+17
+
+query T
+SELECT create_statement FROM [SHOW CREATE SEQUENCE foo]
+----
+CREATE SEQUENCE public.foo MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 5 START 1 CACHE 100
+
+statement ok
+ALTER SEQUENCE foo CACHE 1
+
+query T
+SELECT create_statement FROM [SHOW CREATE SEQUENCE foo]
+----
+CREATE SEQUENCE public.foo MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 5 START 1

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -400,15 +400,11 @@ func assignSequenceOptions(
 		case tree.SeqOptNoCycle:
 			// Do nothing; this is the default.
 		case tree.SeqOptCache:
-			v := *option.IntVal
-			switch {
-			case v < 1:
+			if v := *option.IntVal; v >= 1 {
+				opts.CacheSize = v
+			} else {
 				return pgerror.Newf(pgcode.InvalidParameterValue,
 					"CACHE (%d) must be greater than zero", v)
-			case v == 1:
-				// Do nothing; this is the default.
-			case v > 1:
-				opts.CacheSize = *option.IntVal
 			}
 		case tree.SeqOptIncrement:
 			// Do nothing; this has already been set.


### PR DESCRIPTION
Fixes #71136.

Release note (bug fix): Fixed a bug whereby setting the CACHE for a
sequence to 1 was ignored. Before this change ALTER SEQUENCE ... CACHE 1
would succeed but would not modify the cache value.