### PR TITLE
util: deflake TestSpanRecordStructuredLimit

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -310,8 +310,15 @@ func (s *crdbSpan) recordStructured(item Structured) {
 		// are unlikely to happen.
 		return
 	}
+
+	var now time.Time
+	if clock := s.testing.Clock; clock != nil {
+		now = clock.Now()
+	} else {
+		now = time.Now()
+	}
 	sr := &tracingpb.StructuredRecord{
-		Time:    time.Now(),
+		Time:    now,
 		Payload: p,
 	}
 	s.recordInternal(sr, &s.mu.recording.structured)

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -228,7 +228,10 @@ func TestSpanRecordStructured(t *testing.T) {
 // TestSpanRecordStructuredLimit tests recording behavior when the size of
 // structured data recorded into the span exceeds the configured limit.
 func TestSpanRecordStructuredLimit(t *testing.T) {
-	tr := NewTracer()
+	now := timeutil.Now()
+	clock := timeutil.NewManualTime(now)
+	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{Clock: clock}))
+
 	sp := tr.StartSpan("root", WithForceRealSpan())
 	defer sp.Finish()
 
@@ -237,7 +240,7 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 	anyPayload, err := types.MarshalAny(payload(42))
 	require.NoError(t, err)
 	structuredRecord := &tracingpb.StructuredRecord{
-		Time:    timeutil.Now(),
+		Time:    now,
 		Payload: anyPayload,
 	}
 


### PR DESCRIPTION
The protobuf encoding of a timestamp has a variable size because it
stores the time as two integers, both of which will be varint encoded.

This uses the existing Clock testing stub in RecordStructured so that
it can be used in the test.

Fixes #66701

Release note: None