### PR TITLE
TEAMS.yaml: use obs-inf-prs rather than non-existent obs-inf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -193,7 +193,7 @@
 /pkg/cmd/urlcheck/           @cockroachdb/docs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
 /pkg/cmd/workload/           @cockroachdb/sql-experience
-/pkg/cmd/wraprules/          @cockroachdb/obs-inf-noreview
+/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
 /pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
 /pkg/compose/                @cockroachdb/sql-experience

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -69,9 +69,7 @@ cockroachdb/cluster-ui:
   aliases:
     cockroachdb/cluster-ui-prs: other
   triage_column_id: 6598672
-cockroachdb/obs-inf:
-  aliases:
-    cockroachdb/obs-inf-prs: other
+cockroachdb/obs-inf-prs:
   triage_column_id: 14196277
 cockroachdb/unowned:
   aliases:


### PR DESCRIPTION
It appears that obs-inf-prs is the only github team for observability
infrastructure. We were mapping obs-inf-prs back to obs-inf, which
doesn't exist.

We could alternatively change the teams on GitHub, but I don't have
sufficient permission to do that.

Release note: None