### PR TITLE
sql, opt: add telemetry for nulls reordering on ORDER BY

### DIFF
--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -13,12 +13,14 @@ package optbuilder
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -166,6 +168,7 @@ func (b *Builder) analyzeOrderByArg(
 			((order.NullsOrder == tree.NullsFirst && order.Direction == tree.Descending) ||
 				(order.NullsOrder == tree.NullsLast && order.Direction != tree.Descending))) {
 		nullsDefaultOrder = false
+		telemetry.Inc(sqltelemetry.OrderByNullsNonStandardCounter)
 	}
 
 	// Analyze the ORDER BY column(s).

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -120,6 +120,11 @@ var ExplainOptVerboseUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt
 // run of CREATE STATISTICS occurs.
 var CreateStatisticsUseCounter = telemetry.GetCounterOnce("sql.plan.stats.created")
 
+// OrderByNullsNonStandardCounter is to be incremented whenever a non-standard
+// ordering of nulls is used for ORDER BY (either ASC NULLS LAST or DESC NULLS
+// FIRST).
+var OrderByNullsNonStandardCounter = telemetry.GetCounterOnce("sql.plan.opt.order-by-nulls-non-standard")
+
 // TurnAutoStatsOnUseCounter is to be incremented whenever automatic stats
 // collection is explicitly enabled.
 var TurnAutoStatsOnUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.enabled")

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -1,7 +1,7 @@
 # This file contains telemetry tests for sql.plan.* counters.
 
 exec
-CREATE TABLE x (a INT PRIMARY KEY)
+CREATE TABLE x (a INT PRIMARY KEY, b INT)
 ----
 
 exec
@@ -261,3 +261,45 @@ SELECT x1.a FROM x x1 INNER LOOKUP JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0
 ----
 sql.plan.opt.partial-index.lookup-join
 sql.plan.opt.partial-index.scan
+
+# ORDER BY nulls non-standard tests.
+
+feature-allowlist
+sql.plan.opt.order-by-nulls-non-standard
+----
+
+feature-usage
+SELECT a FROM x ORDER BY b NULLS LAST
+----
+sql.plan.opt.order-by-nulls-non-standard
+
+feature-usage
+SELECT a FROM x ORDER BY b DESC NULLS FIRST
+----
+sql.plan.opt.order-by-nulls-non-standard
+
+# Should not use non-standard nulls ordering here because it's standard order.
+feature-usage
+SELECT a FROM x ORDER BY b ASC NULLS FIRST
+----
+
+# Test null ordering with null_ordered_last session variable.
+# Expect default ordering to be non-standard.
+exec
+SET null_ordered_last = true
+----
+
+feature-usage
+SELECT a FROM x ORDER BY b
+----
+sql.plan.opt.order-by-nulls-non-standard
+
+feature-usage
+SELECT a FROM x ORDER BY b DESC
+----
+sql.plan.opt.order-by-nulls-non-standard
+
+# Should not use non-standard nulls ordering here because it's standard order.
+feature-usage
+SELECT a FROM x ORDER BY b DESC NULLS LAST
+----


### PR DESCRIPTION
Previously, there was no tracking of the usage of NULLS FIRST/LAST
modifiers for ORDER BY. Since we are adding this feature in the
next major release, we should track this. This will also help
determine the urgency/necessity of adding nulls reordering for indexes.

Fixes #71461.

Release note: None.