### PR TITLE
sql: change multi-row bounded staleness errors to reference rows, not ranges

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -123,10 +123,10 @@ SELECT with_max_staleness(-'1s')
 # Tests for optimizer bounded staleness checks.
 #
 
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
 
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
 
 statement error unimplemented: cannot use bounded staleness for MERGE JOIN
@@ -167,7 +167,7 @@ statement ok
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 2
 
 # Scan from a secondary index is not supported if it requires an index join.
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2
 
 # No index join or zigzag join is produced.
@@ -207,11 +207,11 @@ select
       └── j = 2
 
 # Scan may produce multiple rows.
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL
 
 # Scan may produce multiple rows.
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL LIMIT 10
 
 # Even though the scan is limited to 1 row, from KV's perspective, this is a
@@ -219,7 +219,7 @@ SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL LIMI
 # ranges, but we expect it to short-circuit once it hits the first row. In
 # practice, we expect that to very often be in the first range we hit, but
 # there's no guarantee of that - we could have empty ranges.
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k IS NULL LIMIT 1
 
 # Subquery contains the only scan, so it succeeds.
@@ -231,7 +231,7 @@ statement ok
 SELECT (SELECT random()) FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 1
 
 # Subqueries that perform an additional scan are not supported.
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 SELECT (SELECT k FROM t WHERE i = 1) FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE k = 1
 
 # Bounded staleness function must match outer query if used in subquery.
@@ -306,11 +306,11 @@ EXECUTE with_max_staleness_prep
 statement ok
 PREPARE bad_max_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
 
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 EXECUTE bad_max_staleness_stmt
 
 statement ok
 PREPARE bad_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1ms')
 
-statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
+statement error unimplemented: cannot use bounded staleness for queries that may touch more than one row or require an index join
 EXECUTE bad_min_timestamp_stmt

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -595,7 +595,7 @@ func (b *Builder) scanParams(
 		}
 		if !valid {
 			return exec.ScanParams{}, opt.ColMap{}, unimplemented.NewWithIssuef(67562,
-				"cannot use bounded staleness for queries that may touch more than one range or require an index join",
+				"cannot use bounded staleness for queries that may touch more than one row or require an index join",
 			)
 		}
 		b.containsBoundedStalenessScan = true


### PR DESCRIPTION
The number of ranges is an implementation detail. The condition for
bounded staleness reads to be accepted in v21.2 is that they touch up
to a single row.

Suggested by @rmloveland in https://github.com/cockroachdb/docs/pull/11896.