### PR TITLE
storage: enable sstable validation on ingestion

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -371,6 +371,8 @@ func DefaultPebbleOptions() *pebble.Options {
 		}
 		return nil
 	}
+	// Queue sstables for validation upon ingestion.
+	opts.Experimental.ValidateOnIngest = true
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]


### PR DESCRIPTION
Enable sstable validation on ingestion via the experimental Pebble
option, `ValidateOnIngest`.

See cockroachdb/pebble#1203.

Release note: None.