### PR TITLE
jobs: small fix to bad log line

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -180,7 +180,7 @@ func (j *Job) update(ctx context.Context, txn *kv.Txn, useReadLock bool, updateF
 					j.ID(), statusString, j.sessionID, storedSession)
 			}
 		} else {
-			log.VInfof(ctx, 1, "job %s: update called with no session ID", j.sessionID.String())
+			log.VInfof(ctx, 1, "job %d: update called with no session ID", j.ID())
 		}
 		if payload, err = UnmarshalPayload(row[1]); err != nil {
 			return err


### PR DESCRIPTION
This was logging the session ID as the job ID.

Release note: None