### PR TITLE
sql: enable byte arrays to be evaluated from a constant

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -154,3 +154,12 @@ query T
 EXECUTE r1('abc')
 ----
 \0226\012\011defaultdb\0202\032\035\012\011\012\005admin\020\002\012\010\012\004root\020\002\022\004root\030\002"\000(\001@\000J\000Z\000
+
+statement ok
+create table regression_71444 (col bytes[]);
+insert into regression_71444 VALUES ('{"a"}'), ('{"b", "c"}')
+
+query T
+SELECT * FROM regression_71444 WHERE col = '{"a"}'
+----
+{"\\x61"}

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -467,6 +467,7 @@ var (
 		types.Decimal,
 		types.Date,
 		types.StringArray,
+		types.BytesArray,
 		types.IntArray,
 		types.FloatArray,
 		types.DecimalArray,

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -381,6 +381,7 @@ var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.Geometry:         mustParseDGeometry,
 	types.INet:             mustParseDINet,
 	types.VarBit:           mustParseDVarBit,
+	types.BytesArray:       mustParseDArrayOfType(types.Bytes),
 	types.DecimalArray:     mustParseDArrayOfType(types.Decimal),
 	types.FloatArray:       mustParseDArrayOfType(types.Float),
 	types.IntArray:         mustParseDArrayOfType(types.Int),
@@ -494,6 +495,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			parseOptions: typeSet(
 				types.String,
 				types.Bytes,
+				types.BytesArray,
 				types.StringArray,
 				types.IntArray,
 				types.FloatArray,
@@ -505,6 +507,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			parseOptions: typeSet(
 				types.String,
 				types.Bytes,
+				types.BytesArray,
 				types.StringArray,
 				types.FloatArray,
 				types.DecimalArray,
@@ -512,7 +515,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c:            tree.NewStrVal(`{a,b}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray),
 		},
 		{
 			c:            tree.NewBytesStrVal(string([]byte{0xff, 0xfe, 0xfd})),
@@ -524,21 +527,22 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c:            tree.NewStrVal(`{18e7b17e-4ead-4e27-bfd5-bb6d11261bb6, 18e7b17e-4ead-4e27-bfd5-bb6d11261bb7}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray, types.UUIDArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.UUIDArray),
 		},
 		{
 			c:            tree.NewStrVal("{true, false}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray, types.BoolArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.BoolArray),
 		},
 		{
 			c:            tree.NewStrVal("{2010-09-28, 2010-09-29}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray, types.DateArray, types.TimestampArray, types.TimestampTZArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.DateArray, types.TimestampArray, types.TimestampTZArray),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28 12:00:00.1, 2010-09-29 12:00:00.1}"),
 			parseOptions: typeSet(
 				types.String,
 				types.Bytes,
+				types.BytesArray,
 				types.StringArray,
 				types.TimeArray,
 				types.TimeTZArray,
@@ -551,6 +555,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			parseOptions: typeSet(
 				types.String,
 				types.Bytes,
+				types.BytesArray,
 				types.StringArray,
 				types.TimeArray,
 				types.TimeTZArray,
@@ -560,17 +565,18 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c:            tree.NewStrVal("{PT12H2M, -23:00:00}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray, types.IntervalArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.IntervalArray),
 		},
 		{
 			c:            tree.NewStrVal("{192.168.100.128, ::ffff:10.4.3.2}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.StringArray, types.INetArray),
+			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray, types.INetArray),
 		},
 		{
 			c: tree.NewStrVal("{0101, 11}"),
 			parseOptions: typeSet(
 				types.String,
 				types.Bytes,
+				types.BytesArray,
 				types.StringArray,
 				types.IntArray,
 				types.FloatArray,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -514,6 +514,10 @@ var (
 	StringArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: String, Oid: oid.T__text, Locale: &emptyLocale}}
 
+	// BytesArray is the type of an array value having Byte-typed elements.
+	BytesArray = &T{InternalType: InternalType{
+		Family: ArrayFamily, ArrayContents: Bytes, Oid: oid.T__bytea, Locale: &emptyLocale}}
+
 	// IntArray is the type of an array value having Int-typed elements.
 	IntArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: Int, Oid: oid.T__int8, Locale: &emptyLocale}}


### PR DESCRIPTION
Resolves #71444

Release note (sql change): Previously, comparing against `bytea[]`
without a cast (e.g. `SELECT * FROM t WHERE byteaarrcol = '{}'`) would
result in an ambiguous error. This has now been resolved.