### PR TITLE
roachprod: wait for 3x replication before starting job survival tests

### DIFF
--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -27,12 +27,16 @@ type jobStarter func(c cluster.Cluster) (string, error)
 // jobSurvivesNodeShutdown is a helper that tests that a given job,
 // running on the specified gatewayNode will still complete successfully
 // if nodeToShutdown is shutdown partway through execution.
+//
 // This helper assumes:
 // - That the job is long running and will take a least a minute to complete.
 // - That the necessary setup is done (e.g. any data that the job relies on is
 // already loaded) so that `query` can be run on its own to kick off the job.
 // - That the statement running the job is a detached statement, and does not
 // block until the job completes.
+//
+// The helper waits for 3x replication on existing ranges before
+// running the provided jobStarter.
 func jobSurvivesNodeShutdown(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodeToShutdown int, startJob jobStarter,
 ) {
@@ -46,7 +50,17 @@ func jobSurvivesNodeShutdown(
 	m := c.NewMonitor(ctx)
 	m.Go(func(ctx context.Context) error {
 		defer close(jobIDCh)
-		t.Status(`running job`)
+
+		watcherDB := c.Conn(ctx, watcherNode)
+		defer watcherDB.Close()
+
+		// Wait for 3x replication to ensure that the cluster
+		// is in a healthy state before we start bringing any
+		// nodes down.
+		t.Status("waiting for cluster to be 3x replicated")
+		WaitFor3XReplication(t, watcherDB)
+
+		t.Status("running job")
 		var jobID string
 		jobID, err := startJob(c)
 		if err != nil {
@@ -57,9 +71,6 @@ func jobSurvivesNodeShutdown(
 
 		pollInterval := 5 * time.Second
 		ticker := time.NewTicker(pollInterval)
-
-		watcherDB := c.Conn(ctx, watcherNode)
-		defer watcherDB.Close()
 
 		var status string
 		for {


### PR DESCRIPTION
At system startup, ranges for system tables take time to be
up-replicated to all the nodes.

Further, it appears that until all of the system tables are fully
replicated, we are at risk of creating new ranges with low initial
replication factors as the new ranges will be split off ranges with
low replication factors. This can result in test failures in tests
that kill nodes during RESTORE.

See #71377 for more context and continued investigation.

Release note: None