### PR TITLE
release-20.2: rpc: restore 20s connect timeout for grpc dialer

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -73,6 +73,10 @@ const (
 	initialConnWindowSize = initialWindowSize * 16 // for a connection
 )
 
+// GRPC Dialer connection timeout. 20s matches default value that is
+// suppressed when backoff config is provided.
+const minConnectionTimeout = 20 * time.Second
+
 // sourceAddr is the environment-provided local address for outgoing
 // connections.
 var sourceAddr = func() net.Addr {
@@ -977,7 +981,9 @@ func (ctx *Context) grpcDialRaw(
 	// ~second range.
 	backoffConfig := backoff.DefaultConfig
 	backoffConfig.MaxDelay = maxBackoff
-	dialOpts = append(dialOpts, grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoffConfig}))
+	dialOpts = append(dialOpts, grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff:           backoffConfig,
+		MinConnectTimeout: minConnectionTimeout}))
 	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(clientKeepalive))
 	dialOpts = append(dialOpts,
 		grpc.WithInitialWindowSize(initialWindowSize),


### PR DESCRIPTION
Backport 1/1 commits from #71417.

Release justification: Without this fix, client on slow network can not upgrade past v20.1

/cc @cockroachdb/release

---

Changes in #49114 lead to default connect timeout value
dropping to 0 instead of default 20s.
This is not always enough for multiregion clients with hub spoke
network topologies as connections don't have enough time to initially
go through.
This change restores initial value that matches grpc defaults.

Release note (bug fix): Connect timeout for grpc connections is
set to 20s to match pre 20.2 default value.

Fixes #71411
