### PR TITLE
kvserver: handle lock table spans during spanset assertions

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -619,12 +619,6 @@ func (g *Guard) LatchSpans() *spanset.SpanSet {
 	return g.Req.LatchSpans
 }
 
-// LockSpans returns the maximal set of lock spans that the request will access.
-// The returned spanset is not safe for use after the guard has been finished.
-func (g *Guard) LockSpans() *spanset.SpanSet {
-	return g.Req.LockSpans
-}
-
 // TakeSpanSets transfers ownership of the Guard's LatchSpans and LockSpans
 // SpanSets to the caller, ensuring that the SpanSets are not destroyed with the
 // Guard. The method is only safe if called immediately before passing the Guard

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -774,7 +774,7 @@ func (r *Replica) evaluateProposal(
 	idKey kvserverbase.CmdIDKey,
 	ba *roachpb.BatchRequest,
 	lul hlc.Timestamp,
-	latchSpans, lockSpans *spanset.SpanSet,
+	latchSpans *spanset.SpanSet,
 ) (*result.Result, bool, *roachpb.Error) {
 	if ba.Timestamp.IsEmpty() {
 		return nil, false, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
@@ -790,7 +790,7 @@ func (r *Replica) evaluateProposal(
 	//
 	// TODO(tschottdorf): absorb all returned values in `res` below this point
 	// in the call stack as well.
-	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, lul, latchSpans, lockSpans)
+	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, lul, latchSpans)
 
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
@@ -918,9 +918,9 @@ func (r *Replica) requestToProposal(
 	ba *roachpb.BatchRequest,
 	st kvserverpb.LeaseStatus,
 	lul hlc.Timestamp,
-	latchSpans, lockSpans *spanset.SpanSet,
+	latchSpans *spanset.SpanSet,
 ) (*ProposalData, *roachpb.Error) {
-	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, lul, latchSpans, lockSpans)
+	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, lul, latchSpans)
 
 	// Fill out the results even if pErr != nil; we'll return the error below.
 	proposal := &ProposalData{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -86,7 +86,7 @@ func (r *Replica) evalAndPropose(
 ) (chan proposalResult, func(), kvserverbase.CmdIDKey, *roachpb.Error) {
 	defer tok.DoneIfNotMoved(ctx)
 	idKey := makeIDKey()
-	proposal, pErr := r.requestToProposal(ctx, idKey, ba, st, lul, g.LatchSpans(), g.LockSpans())
+	proposal, pErr := r.requestToProposal(ctx, idKey, ba, st, lul, g.LatchSpans())
 	log.Event(proposal.ctx, "evaluated request")
 
 	// If the request hit a server-side concurrency retry error, immediately

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8238,7 +8238,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(id)}})
 		st := r.CurrentLeaseStatus(ctx)
-		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), &ba, st, hlc.Timestamp{}, allSpans(), allSpans())
+		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), &ba, st, hlc.Timestamp{}, allSpans())
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -8360,7 +8360,7 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 
 	incCmdID = makeIDKey()
 	atomic.StoreInt32(&filterActive, 1)
-	proposal, pErr := repl.requestToProposal(ctx, incCmdID, &ba, repl.CurrentLeaseStatus(ctx), hlc.Timestamp{}, allSpans(), allSpans())
+	proposal, pErr := repl.requestToProposal(ctx, incCmdID, &ba, repl.CurrentLeaseStatus(ctx), hlc.Timestamp{}, allSpans())
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -8821,7 +8821,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	assignSeqNumsForReqs(txn, &txnPut, &txnPut2)
 	origTxn := txn.Clone()
 
-	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), &ba, hlc.Timestamp{}, allSpans(), allSpans())
+	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), &ba, hlc.Timestamp{}, allSpans())
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -12990,7 +12990,7 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 		ba.Timestamp = tc.Clock().Now()
 		req := putArgs(roachpb.Key("some-key"), []byte("some-value"))
 		ba.Add(&req)
-		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, &ba, tc.repl.CurrentLeaseStatus(ctx), hlc.Timestamp{}, allSpans(), allSpans())
+		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, &ba, tc.repl.CurrentLeaseStatus(ctx), hlc.Timestamp{}, allSpans())
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -26,11 +26,15 @@ go_library(
 go_test(
     name = "spanset_test",
     size = "small",
-    srcs = ["spanset_test.go"],
+    srcs = [
+        "batch_test.go",
+        "spanset_test.go",
+    ],
     embed = [":spanset"],
     deps = [
         "//pkg/keys",
         "//pkg/roachpb:with-mocks",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/spanset/batch_test.go
+++ b/pkg/kv/kvserver/spanset/batch_test.go
@@ -1,0 +1,127 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanset_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadWriterDeclareLockTable tests that lock table spans
+// are declared for a ReadWriter or Batch.
+func TestReadWriterDeclareLockTable(t *testing.T) {
+	startKey := roachpb.Key("a")
+	endKey := roachpb.Key("z")
+	ltStartKey, _ := keys.LockTableSingleKey(startKey, nil)
+	ltEndKey, _ := keys.LockTableSingleKey(endKey, nil)
+	ts := hlc.Timestamp{}
+
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	fns := map[string]func(*spanset.SpanSet, storage.Batch) storage.ReadWriter{
+		"NewBatch": func(ss *spanset.SpanSet, b storage.Batch) storage.ReadWriter {
+			return spanset.NewBatch(b, ss)
+		},
+		"NewBatchAt": func(ss *spanset.SpanSet, b storage.Batch) storage.ReadWriter {
+			return spanset.NewBatchAt(b, ss, hlc.Timestamp{})
+		},
+		"NewReadWriterAt": func(ss *spanset.SpanSet, b storage.Batch) storage.ReadWriter {
+			return spanset.NewReadWriterAt(b, ss, hlc.Timestamp{})
+		},
+	}
+	for fnName, fn := range fns {
+		for _, sa := range []spanset.SpanAccess{spanset.SpanReadOnly, spanset.SpanReadWrite} {
+			for _, mvcc := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s,access=%s,mvcc=%t", fnName, sa, mvcc), func(t *testing.T) {
+					span := roachpb.Span{Key: startKey, EndKey: endKey}
+					ss := spanset.New()
+					if mvcc {
+						ss.AddMVCC(sa, span, ts)
+					} else {
+						ss.AddNonMVCC(sa, span)
+					}
+					b := eng.NewBatch()
+					defer b.Close()
+					rw := fn(ss, b)
+
+					require.NoError(t, rw.MVCCIterate(ltStartKey, ltEndKey, storage.MVCCKeyIterKind, nil))
+					require.Error(t, rw.MVCCIterate(ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, nil))
+
+					err := rw.PutUnversioned(ltStartKey, []byte("value"))
+					if sa == spanset.SpanReadWrite {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+					require.Error(t, rw.PutUnversioned(ltEndKey, []byte("value")))
+				})
+			}
+		}
+	}
+}
+
+// TestReadWriterDeclareLockTablePanic tests that declaring lock table
+// spans for a ReadWriter or Batch will panic.
+func TestReadWriterDeclareLockTablePanic(t *testing.T) {
+	lockKey, _ := keys.LockTableSingleKey(roachpb.Key("foo"), nil)
+	testcases := []struct {
+		span        roachpb.Span
+		expectPanic bool
+	}{
+		{span: roachpb.Span{Key: lockKey}, expectPanic: true},
+		{span: roachpb.Span{EndKey: lockKey}, expectPanic: true},
+		{span: roachpb.Span{Key: keys.LockTableSingleKeyStart}, expectPanic: true},
+		{span: roachpb.Span{Key: keys.LockTableSingleKeyEnd}, expectPanic: true},
+		{span: roachpb.Span{Key: keys.LocalRangeLockTablePrefix}, expectPanic: true},
+		// Declaring spans over the entire range is allowed. We assume the caller
+		// knows what they're doing.
+		{span: roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey}, expectPanic: false},
+		{span: roachpb.Span{Key: keys.LocalPrefix, EndKey: keys.LocalMax}, expectPanic: false},
+	}
+	fns := map[string]func(*spanset.SpanSet){
+		"NewBatch":        func(ss *spanset.SpanSet) { spanset.NewBatch(nil, ss) },
+		"NewBatchAt":      func(ss *spanset.SpanSet) { spanset.NewBatchAt(nil, ss, hlc.Timestamp{}) },
+		"NewReadWriterAt": func(ss *spanset.SpanSet) { spanset.NewReadWriterAt(nil, ss, hlc.Timestamp{}) },
+	}
+	for _, tc := range testcases {
+		for fnName, fn := range fns {
+			for _, sa := range []spanset.SpanAccess{spanset.SpanReadOnly, spanset.SpanReadWrite} {
+				for _, mvcc := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s,span=%s,access=%s,mvcc=%t", fnName, tc.span, sa, mvcc), func(t *testing.T) {
+						ss := spanset.New()
+						if mvcc {
+							ss.AddMVCC(sa, tc.span, hlc.Timestamp{})
+						} else {
+							ss.AddNonMVCC(sa, tc.span)
+						}
+
+						if tc.expectPanic {
+							msg := fmt.Sprintf(
+								"declaring raw lock table spans is illegal, use main key spans instead (found %s)",
+								tc.span)
+							require.PanicsWithValue(t, msg, func() { fn(ss) })
+						} else {
+							require.NotPanics(t, func() { fn(ss) })
+						}
+					})
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Spanset assertions are enabled during race builds. These check that
commands only access keys that they have declared and latched.

However, raw access to separated intents in the lock table are not
explicitly declared and latched, and are instead implicitly declared via
the intent's main key (typically accessed internally in MVCC). To get
around this, we had ad-hoc code to modify the declared spans to also
include lock table spans.

This patch instead moves this logic into the spanset asserter itself,
reflecting the implicit access that commands have to separated intents
via MVCC. It also asserts that no commands attempt to declare lock table
keys, since this would not provide sufficient isolation from concurrent
requests, e.g. if a command only declares a lock table key but not the
main key.

The `lockSpans` parameter is also removed from the write path, as this
was introduced and used only to propagate lock spans to the spanset
asserter.

Resolves #71077.

Release note: None