### PR TITLE
release-21.2: sql: CREATE TABLE AS can now refer to nextval('seq')

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1190,7 +1190,9 @@ var CreatePartitioningCCL = func(
 		"creating or manipulating partitions requires a CCL binary"))
 }
 
-func getFinalSourceQuery(source *tree.Select, evalCtx *tree.EvalContext) string {
+func getFinalSourceQuery(
+	params runParams, source *tree.Select, evalCtx *tree.EvalContext,
+) (string, error) {
 	// Ensure that all the table names pretty-print as fully qualified, so we
 	// store that in the table descriptor.
 	//
@@ -1229,7 +1231,13 @@ func getFinalSourceQuery(source *tree.Select, evalCtx *tree.EvalContext) string 
 	)
 	ctx.FormatNode(source)
 
-	return ctx.CloseAndGetString()
+	// Use IDs instead of sequence names because name resolution depends on
+	// session data, and the internal executor has different session data.
+	sequenceReplacedQuery, err := replaceSeqNamesWithIDs(params.ctx, params.p, ctx.CloseAndGetString())
+	if err != nil {
+		return "", err
+	}
+	return sequenceReplacedQuery, nil
 }
 
 // newTableDescIfAs is the NewTableDesc method for when we have a table
@@ -1288,7 +1296,11 @@ func newTableDescIfAs(
 	if err != nil {
 		return nil, err
 	}
-	desc.CreateQuery = getFinalSourceQuery(p.AsSource, evalContext)
+	createQuery, err := getFinalSourceQuery(params, p.AsSource, evalContext)
+	if err != nil {
+		return nil, err
+	}
+	desc.CreateQuery = createQuery
 	return desc, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -362,3 +362,13 @@ SELECT * FROM t
 ----
 1  1  false
 2  2  true
+
+# Test CREATE TABLE AS referring to a sequence.
+statement ok
+CREATE SEQUENCE seq;
+CREATE TABLE tab_from_seq AS (SELECT nextval('seq'))
+
+query I
+SELECT * FROM tab_from_seq
+----
+2

--- a/pkg/sql/logictest/testdata/logic_test/materialized_view
+++ b/pkg/sql/logictest/testdata/logic_test/materialized_view
@@ -201,3 +201,13 @@ user testuser
 # testuser should now be able to refresh the materialized view as the owner.
 statement ok
 REFRESH MATERIALIZED VIEW with_options WITH NO DATA
+
+# Test CREATE MATERIALIZED VIEW referring to a sequence.
+statement ok
+CREATE SEQUENCE seq;
+CREATE MATERIALIZED VIEW view_from_seq AS (SELECT nextval('seq'))
+
+query I
+SELECT * FROM view_from_seq
+----
+1


### PR DESCRIPTION
Backport 1/1 commits from #71222.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/53819

This also adds a test for CREATE MATERIALIZED VIEW to make sure that
works. According to #53819 this didn't work before, but it does now.

Release note (bug fix): Previously, using CREATE TABLE AS with a source
query that referred to a sequence would not work. This is fixed now.
