### PR TITLE
backupccl: Support RESTORE SYSTEM USERS from a backup

### DIFF
--- a/docs/generated/sql/bnf/restore.bnf
+++ b/docs/generated/sql/bnf/restore.bnf
@@ -23,3 +23,15 @@ restore_stmt ::=
 	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' restore_options_list
 	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' 'OPTIONS' '(' restore_options_list ')'
 	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' ) 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' subdirectory 'IN' ( destination | '(' partitioned_backup_location ( ',' partitioned_backup_location )* ')' )  

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -188,6 +188,8 @@ restore_stmt ::=
 	| 'RESTORE' 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 	| 'RESTORE' targets 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 	| 'RESTORE' targets 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
 	| 'RESTORE' targets 'FROM' 'REPLICATION' 'STREAM' 'FROM' string_or_placeholder_opt_list opt_as_of_clause
 
 resume_stmt ::=

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1630,6 +1630,15 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := r.cleanupTempSystemTables(ctx, nil /* txn */); err != nil {
 			return err
 		}
+	} else if details.RestoreSystemUsers {
+		if err := r.restoreSystemUsers(ctx, p.ExecCfg().DB, mainData.systemTables); err != nil {
+			return err
+		}
+		details = r.job.Details().(jobspb.RestoreDetails)
+
+		if err := r.cleanupTempSystemTables(ctx, nil /* txn */); err != nil {
+			return err
+		}
 	}
 
 	if fn := r.testingKnobs.afterPublishingDescriptors; fn != nil {
@@ -1784,7 +1793,7 @@ func (r *restoreResumer) notifyStatsRefresherOfNewTables() {
 // This is the last of the IDs pre-allocated by the restore planner.
 // TODO(postamar): Store it directly in the details instead? This is brittle.
 func tempSystemDatabaseID(details jobspb.RestoreDetails) descpb.ID {
-	if details.DescriptorCoverage != tree.AllDescriptors {
+	if details.DescriptorCoverage != tree.AllDescriptors && !details.RestoreSystemUsers {
 		return descpb.InvalidID
 	}
 	var maxPreAllocatedID descpb.ID
@@ -2518,6 +2527,59 @@ type systemTableNameWithConfig struct {
 	systemTableName  string
 	stagingTableName string
 	config           systemBackupConfiguration
+}
+
+// Restore system.users from the backup into the restoring cluster. Only recreate users
+// which are in a backup of system.users but do not currently exist (ignoring those who do)
+// and re-grant roles for users if the backup has system.role_members.
+func (r *restoreResumer) restoreSystemUsers(
+	ctx context.Context, db *kv.DB, systemTables []catalog.TableDescriptor,
+) error {
+	executor := r.execCfg.InternalExecutor
+	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		selectNonExistentUsers := "SELECT * FROM crdb_temp_system.users temp " +
+			"WHERE NOT EXISTS (SELECT * FROM system.users u WHERE temp.username = u.username)"
+		users, err := executor.QueryBuffered(ctx, "get-users",
+			txn, selectNonExistentUsers)
+		if err != nil {
+			return err
+		}
+
+		insertUser := `INSERT INTO system.users ("username", "hashedPassword", "isRole") VALUES ($1, $2, $3)`
+		newUsernames := make(map[string]bool)
+		for _, user := range users {
+			newUsernames[user[0].String()] = true
+			if _, err = executor.Exec(ctx, "insert-non-existent-users", txn, insertUser,
+				user[0], user[1], user[2]); err != nil {
+				return err
+			}
+		}
+
+		// We skip granting roles if the backup does not contain system.role_members.
+		if len(systemTables) == 1 {
+			return nil
+		}
+
+		selectNonExistentRoleMembers := "SELECT * FROM crdb_temp_system.role_members temp_rm WHERE " +
+			"NOT EXISTS (SELECT * FROM system.role_members rm WHERE temp_rm.role = rm.role AND temp_rm.member = rm.member)"
+		roleMembers, err := executor.QueryBuffered(ctx, "get-role-members",
+			txn, selectNonExistentRoleMembers)
+		if err != nil {
+			return err
+		}
+
+		insertRoleMember := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3)`
+		for _, roleMember := range roleMembers {
+			// Only grant roles to users that don't currently exist, i.e., new users we just added
+			if _, ok := newUsernames[roleMember[1].String()]; ok {
+				if _, err = executor.Exec(ctx, "insert-non-existent-role-members", txn, insertRoleMember,
+					roleMember[0], roleMember[1], roleMember[2]); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // restoreSystemTables atomically replaces the contents of the system tables

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -308,6 +308,7 @@ func allocateDescriptorRewrites(
 	opts tree.RestoreOptions,
 	intoDB string,
 	newDBName string,
+	restoreSystemUsers bool,
 ) (DescRewriteMap, error) {
 	descriptorRewrites := make(DescRewriteMap)
 
@@ -419,38 +420,47 @@ func allocateDescriptorRewrites(
 	}
 
 	needsNewParentIDs := make(map[string][]descpb.ID)
-	// Increment the DescIDSequenceKey so that it is higher than the max desc ID
-	// in the backup. This generator keeps produced the next descriptor ID.
+
+	// Increment the DescIDSequenceKey so that it is higher than both the max desc ID
+	// in the backup and current max desc ID in the restoring cluster. This generator
+	// keeps produced the next descriptor ID.
 	var tempSysDBID descpb.ID
-	if descriptorCoverage == tree.AllDescriptors {
+	if descriptorCoverage == tree.AllDescriptors || restoreSystemUsers {
 		var err error
-		// Restore the key which generates descriptor IDs.
-		if err = p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			v, err := txn.Get(ctx, p.ExecCfg().Codec.DescIDSequenceKey())
+		if descriptorCoverage == tree.AllDescriptors {
+			// Restore the key which generates descriptor IDs.
+			if err = p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				v, err := txn.Get(ctx, p.ExecCfg().Codec.DescIDSequenceKey())
+				if err != nil {
+					return err
+				}
+				newValue := maxDescIDInBackup + 1
+				if newValue <= v.ValueInt() {
+					// This case may happen when restoring backups from older versions.
+					newValue = v.ValueInt() + 1
+				}
+				b := txn.NewBatch()
+				// N.B. This key is usually mutated using the Inc command. That
+				// command warns that if the key was every Put directly, Inc will
+				// return an error. This is only to ensure that the type of the key
+				// doesn't change. Here we just need to be very careful that we only
+				// write int64 values.
+				// The generator's value should be set to the value of the next ID
+				// to generate.
+				b.Put(p.ExecCfg().Codec.DescIDSequenceKey(), newValue)
+				return txn.Run(ctx, b)
+			}); err != nil {
+				return nil, err
+			}
+			tempSysDBID, err = descidgen.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			newValue := maxDescIDInBackup + 1
-			if newValue <= v.ValueInt() {
-				// This case may happen when restoring backups from older versions.
-				newValue = v.ValueInt() + 1
+		} else if restoreSystemUsers {
+			tempSysDBID, err = descidgen.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
+			if err != nil {
+				return nil, err
 			}
-			b := txn.NewBatch()
-			// N.B. This key is usually mutated using the Inc command. That
-			// command warns that if the key was every Put directly, Inc will
-			// return an error. This is only to ensure that the type of the key
-			// doesn't change. Here we just need to be very careful that we only
-			// write int64 values.
-			// The generator's value should be set to the value of the next ID
-			// to generate.
-			b.Put(p.ExecCfg().Codec.DescIDSequenceKey(), newValue)
-			return txn.Run(ctx, b)
-		}); err != nil {
-			return nil, err
-		}
-		tempSysDBID, err = descidgen.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
-		if err != nil {
-			return nil, err
 		}
 		// Remap all of the descriptor belonging to system tables to the temp system
 		// DB.
@@ -829,7 +839,7 @@ func allocateDescriptorRewrites(
 	// backup should have the same ID as they do in the backup.
 	descriptorsToRemap := make([]catalog.Descriptor, 0, len(tablesByID))
 	for _, table := range tablesByID {
-		if descriptorCoverage == tree.AllDescriptors {
+		if descriptorCoverage == tree.AllDescriptors || restoreSystemUsers {
 			if table.ParentID == systemschema.SystemDB.GetID() {
 				// This is a system table that should be marked for descriptor creation.
 				descriptorsToRemap = append(descriptorsToRemap, table)
@@ -1429,6 +1439,7 @@ func restoreJobDescription(
 	kmsURIs []string,
 ) (string, error) {
 	r := &tree.Restore{
+		SystemUsers:        restore.SystemUsers,
 		DescriptorCoverage: restore.DescriptorCoverage,
 		AsOf:               restore.AsOf,
 		Targets:            restore.Targets,
@@ -1505,6 +1516,9 @@ func restorePlanHook(
 
 	var intoDBFn func() (string, error)
 	if restoreStmt.Options.IntoDB != nil {
+		if restoreStmt.SystemUsers {
+			return nil, nil, nil, false, errors.New("cannot set into_db option when only restoring system users")
+		}
 		intoDBFn, err = p.TypeAsString(ctx, restoreStmt.Options.IntoDB, "RESTORE")
 		if err != nil {
 			return nil, nil, nil, false, err
@@ -1539,6 +1553,9 @@ func restorePlanHook(
 			err = errors.New("new_db_name can only be used for RESTORE DATABASE with a single target" +
 				" database")
 			return nil, nil, nil, false, err
+		}
+		if restoreStmt.SystemUsers {
+			return nil, nil, nil, false, errors.New("cannot set new_db_name option when only restoring system users")
 		}
 		newDBNameFn, err = p.TypeAsString(ctx, restoreStmt.Options.NewDBName, "RESTORE")
 		if err != nil {
@@ -1926,7 +1943,7 @@ func doRestorePlan(
 	}
 
 	sqlDescs, restoreDBs, tenants, err := selectTargets(
-		ctx, p, mainBackupManifests, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime,
+		ctx, p, mainBackupManifests, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime, restoreStmt.SystemUsers,
 	)
 	if err != nil {
 		return errors.Wrap(err,
@@ -2054,7 +2071,8 @@ func doRestorePlan(
 		restoreStmt.DescriptorCoverage,
 		restoreStmt.Options,
 		intoDB,
-		newDBName)
+		newDBName,
+		restoreStmt.SystemUsers)
 	if err != nil {
 		return err
 	}
@@ -2137,6 +2155,7 @@ func doRestorePlan(
 			RevalidateIndexes:  revalidateIndexes,
 			DatabaseModifiers:  databaseModifiers,
 			DebugPauseOn:       debugPauseOn,
+			RestoreSystemUsers: restoreStmt.SystemUsers,
 		},
 		Progress: jobspb.RestoreProgress{},
 	}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -317,8 +317,9 @@ message RestoreDetails {
 
   // DebugPauseOn describes the events that the job should pause itself on for debugging purposes.
   string debug_pause_on = 20;
+  bool restore_system_users = 22;
 
-  // NEXT ID: 22.
+  // NEXT ID: 23.
 }
 
 message RestoreProgress {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2995,6 +2995,10 @@ opt_with_schedule_options:
 // RESTORE <targets...> FROM <location...>
 //         [ AS OF SYSTEM TIME <expr> ]
 //         [ WITH <option> [= <value>] [, ...] ]
+// or
+// RESTORE SYSTEM USERS FROM <location...>
+//         [ AS OF SYSTEM TIME <expr> ]
+//         [ WITH <option> [= <value>] [, ...] ]
 //
 // Targets:
 //    TABLE <pattern> [, ...]
@@ -3053,6 +3057,25 @@ restore_stmt:
       From: $6.listOfStringOrPlaceholderOptList(),
       AsOf: $7.asOfClause(),
       Options: *($8.restoreOptions()),
+    }
+  }
+| RESTORE SYSTEM USERS FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+  {
+    $$.val = &tree.Restore{
+      SystemUsers: true,
+      From: $5.listOfStringOrPlaceholderOptList(),
+      AsOf: $6.asOfClause(),
+      Options: *($7.restoreOptions()),
+    }
+  }
+| RESTORE SYSTEM USERS FROM string_or_placeholder IN list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
+  {
+    $$.val = &tree.Restore{
+      SystemUsers: true,
+      Subdir: $5.expr(),
+      From: $7.listOfStringOrPlaceholderOptList(),
+      AsOf: $8.asOfClause(),
+      Options: *($9.restoreOptions()),
     }
   }
 | RESTORE targets FROM REPLICATION STREAM FROM string_or_placeholder_opt_list opt_as_of_clause

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -138,7 +138,9 @@ var _ NodeFormatter = &RestoreOptions{}
 
 // Restore represents a RESTORE statement.
 type Restore struct {
-	Targets            TargetList
+	Targets TargetList
+	// Whether this is the RESTORE SYSTEM USERS variant of RESTORE statement.
+	SystemUsers        bool
 	DescriptorCoverage DescriptorCoverage
 
 	// From contains the URIs for the backup(s) we seek to restore.

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -44,6 +44,8 @@ type TargetList struct {
 	Types     []*UnresolvedObjectName
 	// If the target is for all tables in a set of schemas.
 	AllTablesInSchema bool
+	// Whether the target is only system users and roles_members table
+	SystemUser bool
 
 	// ForRoles and Roles are used internally in the parser and not used
 	// in the AST. Therefore they do not participate in pretty-printing,


### PR DESCRIPTION
Support a new variant of RESTORE that recreates system users that don't exist in current cluster from a backup that contains system.users and also grant roles for these users. Example invocation: RESTORE SYSTEM USERS FROM 'nodelocal://foo/1';

Similar with full cluster restore, we firstly restore a temp system database which contains system.users and system.role_members into the restoring cluster and insert users and roles into the current system table from the temp system table.

Fixes: #45358

Release note (sql change): A special flavor of RESTORE, RESTORE SYSTEM USERS FROM ..., is added to support restoring system users from a backup. When executed, the statement recreates those users which are in a backup of system.users but do not currently exist (ignoring those who do) and re-grant roles for users if the backup contains system.role_members.