### PR TITLE
roachtest: disable prometheus for scrub

### DIFF
--- a/pkg/cmd/roachtest/tests/scrub.go
+++ b/pkg/cmd/roachtest/tests/scrub.go
@@ -88,8 +88,9 @@ func makeScrubTPCCTest(
 					}
 					return nil
 				},
-				Duration:  length,
-				SetupType: usingImport,
+				DisablePrometheus: true,
+				Duration:          length,
+				SetupType:         usingImport,
 			})
 		},
 	}


### PR DESCRIPTION
I'm unable to reproduce the error running roachtest myself, and it's the
only set of tests affected.

Resolves #71979

Release note: None