### PR TITLE
opt: take advantage of partial ordering in the hash aggregator

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1217,7 +1217,7 @@ LIMIT 1] OFFSET 2
         │ estimated row count: 333,300
         │ filter: count_rows > 1
         │
-        └── • group
+        └── • group (streaming)
             │ columns: (a, b, count_rows)
             │ estimated row count: 999,900
             │ aggregate 0: count_rows()
@@ -1299,7 +1299,7 @@ LIMIT 1] OFFSET 2
         │ estimated row count: 111,111
         │ filter: count_rows > 1
         │
-        └── • group
+        └── • group (streaming)
             │ columns: (b, count_rows)
             │ estimated row count: 333,333
             │ aggregate 0: count_rows()
@@ -1367,7 +1367,7 @@ LIMIT 1] OFFSET 2
         │ estimated row count: 111,111
         │ filter: count_rows > 1
         │
-        └── • group
+        └── • group (streaming)
             │ columns: (c, count_rows)
             │ estimated row count: 333,333
             │ aggregate 0: count_rows()

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -549,6 +549,7 @@ func (e *distSQLSpecExecFactory) ConstructGroupBy(
 	groupColOrdering colinfo.ColumnOrdering,
 	aggregations []exec.AggInfo,
 	reqOrdering exec.OutputOrdering,
+	groupingOrderType exec.GroupingOrderType,
 ) (exec.Node, error) {
 	return e.constructAggregators(
 		input,

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1355,8 +1355,9 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			&groupBy.GroupingPrivate, &groupBy.RequiredPhysical().Ordering,
 		))
 		reqOrdering := ep.reqOrdering(groupBy)
+		orderType := exec.GroupingOrderType(groupBy.GroupingOrderType(&groupBy.RequiredPhysical().Ordering))
 		ep.root, err = b.factory.ConstructGroupBy(
-			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrdering,
+			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrdering, orderType,
 		)
 	}
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -194,7 +194,7 @@ EXPLAIN (TYPES) SELECT count(*), k FROM kv GROUP BY 2
 distribution: local
 vectorized: true
 ·
-• group
+• group (streaming)
 │ columns: (count int, k int)
 │ estimated row count: 1,000 (missing stats)
 │ aggregate 0: count_rows()
@@ -215,7 +215,7 @@ EXPLAIN (TYPES) SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 distribution: local
 vectorized: true
 ·
-• group
+• group (hash)
 │ columns: (count int, r int)
 │ estimated row count: 1,000 (missing stats)
 │ aggregate 0: count_rows()
@@ -245,7 +245,7 @@ vectorized: true
 │ render r: ((k)[int] + (any_not_null)[int])[int]
 │ render count_rows: (count_rows)[int]
 │
-└── • group
+└── • group (streaming)
     │ columns: (k int, count_rows int, any_not_null int)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: count_rows()
@@ -365,7 +365,7 @@ vectorized: true
 │ columns: (min)
 │ estimated row count: 1,000 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (k, min)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: min(k)
@@ -397,7 +397,7 @@ vectorized: true
 │ columns: (min)
 │ estimated row count: 1,000 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (k, min)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: min(k)
@@ -430,7 +430,7 @@ vectorized: true
 │ columns: (min)
 │ estimated row count: 1,000 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (k, min)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: min(k)
@@ -1180,7 +1180,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +count_rows
 │
-└── • group
+└── • group (hash)
     │ columns: (v int, count_rows int)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: count_rows()
@@ -1204,7 +1204,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +count_rows
 │
-└── • group
+└── • group (hash)
     │ columns: (v int, count_rows int)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: count_rows()
@@ -1231,7 +1231,7 @@ vectorized: true
     │ estimated row count: 100 (missing stats)
     │ order: +count_rows
     │
-    └── • group
+    └── • group (hash)
         │ columns: (v int, count int, count_rows int)
         │ estimated row count: 100 (missing stats)
         │ aggregate 0: count(column7)
@@ -1257,7 +1257,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, count(NULL) FROM kv GROUP BY v) WHERE
 distribution: local
 vectorized: true
 ·
-• group
+• group (hash)
 │ columns: (v, count)
 │ estimated row count: 33 (missing stats)
 │ aggregate 0: count(column7)
@@ -1300,7 +1300,7 @@ vectorized: true
 │ columns: (count, max)
 │ estimated row count: 100 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (v, count, max)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: count(column7) FILTER (WHERE column8)
@@ -1330,7 +1330,7 @@ vectorized: true
 │ columns: (count)
 │ estimated row count: 100 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (v, count)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: count(column7) FILTER (WHERE column8)
@@ -1377,7 +1377,7 @@ vectorized: true
 │ columns: (sum decimal)
 │ estimated row count: 1,000 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (k int, sum decimal)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: sum(d)
@@ -1505,7 +1505,7 @@ vectorized: true
 │ columns: (min int)
 │ estimated row count: 1,000 (missing stats)
 │
-└── • group
+└── • group (streaming)
     │ columns: (k int, min int)
     │ estimated row count: 1,000 (missing stats)
     │ aggregate 0: min(v)
@@ -1551,7 +1551,7 @@ vectorized: true
 │ render r: (((any_not_null)[int], (a)[int]))[tuple{int, int}]
 │ render min: (min)[string]
 │
-└── • group
+└── • group (hash)
     │ columns: (a int, x string, min string, any_not_null int)
     │ estimated row count: 100,000 (missing stats)
     │ aggregate 0: min(y)
@@ -1736,7 +1736,7 @@ vectorized: true
 │ columns: (m)
 │ estimated row count: 100 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (column7, min)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: min(a)
@@ -1764,7 +1764,7 @@ vectorized: true
 │ columns: (m)
 │ estimated row count: 100 (missing stats)
 │
-└── • group
+└── • group (hash)
     │ columns: (column7, min)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: min(a)
@@ -1937,7 +1937,7 @@ EXPLAIN (VERBOSE) SELECT u, v, array_agg(w) AS s FROM (SELECT * FROM uvw ORDER B
 distribution: local
 vectorized: true
 ·
-• group
+• group (streaming)
 │ columns: (u, v, s)
 │ estimated row count: 1,000 (missing stats)
 │ aggregate 0: array_agg(w)
@@ -2001,7 +2001,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
-└── • group
+└── • group (hash)
     │ columns: (company_id, string_agg)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: string_agg(employee, column6)
@@ -2040,7 +2040,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
-└── • group
+└── • group (hash)
     │ columns: (company_id, string_agg)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: string_agg(column6, column7)
@@ -2079,7 +2079,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
-└── • group
+└── • group (hash)
     │ columns: (company_id, string_agg)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: string_agg(employee, column6)
@@ -2118,7 +2118,7 @@ vectorized: true
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
-└── • group
+└── • group (hash)
     │ columns: (company_id, string_agg)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: string_agg(column6, column7)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -404,7 +404,7 @@ vectorized: true
 • project
 │ columns: (min)
 │
-└── • group
+└── • group (hash)
     │ columns: (y, min)
     │ estimated row count: 100 (missing stats)
     │ aggregate 0: min(x)
@@ -436,7 +436,7 @@ vectorized: true
         │ estimated row count: 1 (missing stats)
         │ filter: min = 1
         │
-        └── • group
+        └── • group (hash)
             │ columns: (y, min)
             │ estimated row count: 100 (missing stats)
             │ aggregate 0: min(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -52,7 +52,7 @@ FROM data GROUP BY b
 distribution: full
 vectorized: true
 ·
-• group
+• group (hash)
 │ group by: b
 │
 └── • scan
@@ -513,7 +513,7 @@ vectorized: true
 ·
 • render
 │
-└── • group
+└── • group (hash)
     │ group by: c, d
     │
     └── • render
@@ -533,7 +533,7 @@ vectorized: true
 ·
 • render
 │
-└── • group
+└── • group (streaming)
     │ group by: c, d
     │ ordered: +c,+d
     │
@@ -558,7 +558,7 @@ vectorized: true
 ·
 • render
 │
-└── • group
+└── • group (hash)
     │ group by: c, d
     │
     └── • render
@@ -579,7 +579,7 @@ vectorized: true
 • filter
 │ filter: sum > 10
 │
-└── • group
+└── • group (hash)
     │ group by: d
     │
     └── • render
@@ -597,7 +597,7 @@ EXPLAIN (DISTSQL) SELECT avg(a+b), c FROM data GROUP BY c, d HAVING c = d
 distribution: full
 vectorized: true
 ·
-• group
+• group (hash)
 │ group by: d
 │
 └── • render
@@ -618,7 +618,7 @@ EXPLAIN (DISTSQL) SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTE
 distribution: full
 vectorized: true
 ·
-• group
+• group (hash)
 │ group by: d
 │
 └── • render
@@ -637,7 +637,7 @@ EXPLAIN (DISTSQL) SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTE
 distribution: full
 vectorized: true
 ·
-• group
+• group (hash)
 │ group by: d
 │
 └── • render
@@ -793,7 +793,7 @@ EXPLAIN (DISTSQL) SELECT a, max(b) FROM sorted_data GROUP BY a
 distribution: full
 vectorized: true
 ·
-• group
+• group (hash)
 │ group by: a
 │
 └── • scan
@@ -809,7 +809,7 @@ EXPLAIN (DISTSQL) SELECT a, max(b) FROM sorted_data GROUP BY a ORDER BY a
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: a
 │ ordered: +a
 │
@@ -826,7 +826,7 @@ EXPLAIN (DISTSQL) SELECT c, min(b), a FROM sorted_data GROUP BY a, c
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: a
 │ ordered: +a
 │
@@ -843,7 +843,7 @@ EXPLAIN (DISTSQL) SELECT c, min(b), a FROM sorted_data GROUP BY a, c ORDER BY a
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: a
 │ ordered: +a
 │
@@ -860,7 +860,7 @@ EXPLAIN (DISTSQL) SELECT b, max(c) FROM sorted_data@foo GROUP BY b
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: b
 │ ordered: +b
 │
@@ -885,7 +885,7 @@ vectorized: true
 │ left cols are key
 │ right cols are key
 │
-├── • group
+├── • group (streaming)
 │   │ group by: a
 │   │ ordered: +a
 │   │
@@ -894,7 +894,7 @@ vectorized: true
 │         table: sorted_data@sorted_data_pkey
 │         spans: FULL SCAN
 │
-└── • group
+└── • group (streaming)
     │ group by: b
     │ ordered: +b
     │
@@ -915,7 +915,7 @@ EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) GRO
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: a
 │ ordered: +a
 │
@@ -934,7 +934,7 @@ EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) WHE
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: a
 │ ordered: +a
 │
@@ -981,7 +981,7 @@ NULL       /1/1     {2}       2
 query T
 EXPLAIN (opt,verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
 ----
-group-by
+group-by (streaming)
  ├── columns: b:2 count:5
  ├── grouping columns: b:2
  ├── internal-ordering: +2 opt(1)
@@ -1009,7 +1009,7 @@ EXPLAIN (verbose) SELECT b, count(*), corr(a, b) FROM data2 WHERE a=1 GROUP BY b
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ columns: (b, count, corr)
 │ estimated row count: 10 (missing stats)
 │ aggregate 0: count_rows()
@@ -1030,7 +1030,7 @@ EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b;
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: b
 │ ordered: +b
 │
@@ -1052,7 +1052,7 @@ EXPLAIN (DISTSQL) SELECT sum(v) FROM data INNER LOOKUP JOIN uv ON (a=u) GROUP BY
 distribution: full
 vectorized: true
 ·
-• group
+• group (streaming)
 │ group by: u
 │ ordered: +u
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -424,7 +424,7 @@ vectorized: true
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
         │
         └── • window
@@ -517,7 +517,7 @@ vectorized: true
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: username
         │
         └── • sort
@@ -527,7 +527,7 @@ vectorized: true
                 │ equality: (username) = (member)
                 │ left cols are key
                 │
-                ├── • group
+                ├── • group (hash)
                 │   │ group by: username
                 │   │
                 │   └── • window

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -69,7 +69,7 @@ maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
 ·
-• group
+• group (streaming)
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -324,7 +324,7 @@ vectorized: true
 │   │ render count: @S2
 │   │ render count_rows: count_rows
 │   │
-│   └── • group
+│   └── • group (hash)
 │       │ columns: (lk, count_rows)
 │       │ estimated row count: 333 (missing stats)
 │       │ aggregate 0: count_rows()

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
@@ -272,7 +272,7 @@ vectorized: true
 │
 ├── • render
 │   │
-│   └── • group
+│   └── • group (hash)
 │       │ group by: lk
 │       │
 │       └── • lookup join (left outer)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -160,7 +160,7 @@ vectorized: true
         │ order: -any_not_null
         │ k: 10
         │
-        └── • group
+        └── • group (streaming)
             │ columns: (k, sum, any_not_null)
             │ estimated row count: 1,000 (missing stats)
             │ aggregate 0: sum(w)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -1713,7 +1713,7 @@ vectorized: true
 │ order: -count_rows,+s_name
 │ k: 100
 │
-└── • group
+└── • group (hash)
     │ estimated row count: 0
     │ group by: s_name
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -921,7 +921,7 @@ vectorized: true
 • sort
 │ order: -count_rows
 │
-└── • group
+└── • group (streaming)
     │ group by: resource_key
     │ ordered: +resource_key
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -431,7 +431,7 @@ vectorized: true
 │ order: +any_not_null
 │ k: 10
 │
-└── • group
+└── • group (hash)
     │ columns: (id, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null, any_not_null)
     │ estimated row count: 14 (missing stats)
     │ aggregate 0: any_not_null(body)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
@@ -27,7 +27,7 @@ vectorized: true
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: c_id
         │
         └── • sort

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -290,7 +290,7 @@ vectorized: true
                 │ estimated row count: 1,000 (missing stats)
                 │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
                 │
-                └── • group
+                └── • group (hash)
                     │ columns: (v int, d decimal, max int)
                     │ estimated row count: 1,000 (missing stats)
                     │ aggregate 0: max(k)
@@ -323,7 +323,7 @@ vectorized: true
         │ estimated row count: 1,000 (missing stats)
         │ window 0: (stddev((d)[decimal]) OVER (PARTITION BY (v)[int] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))[decimal]
         │
-        └── • group
+        └── • group (hash)
             │ columns: (v int, d decimal, max int)
             │ estimated row count: 1,000 (missing stats)
             │ aggregate 0: max(k)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -201,6 +201,19 @@ func (e *emitter) nodeName(n *Node) (string, error) {
 			return "values", nil
 		}
 
+	case groupByOp:
+		a := n.args.(*groupByArgs)
+		switch a.groupingOrderType {
+		case exec.Streaming:
+			return "group (streaming)", nil
+		case exec.PartialStreaming:
+			return "group (partial streaming)", nil
+		case exec.NoStreaming:
+			return "group (hash)", nil
+		default:
+			return "", errors.AssertionFailedf("unhandled group by order type %d", a.groupingOrderType)
+		}
+
 	case hashJoinOp:
 		a := n.args.(*hashJoinArgs)
 		if len(n.args.(*hashJoinArgs).LeftEqCols) == 0 {
@@ -280,7 +293,7 @@ var nodeNames = [...]string{
 	explainOptOp:           "explain",
 	exportOp:               "export",
 	filterOp:               "filter",
-	groupByOp:              "group",
+	groupByOp:              "", // This node does not have a fixed name.
 	hashJoinOp:             "", // This node does not have a fixed name.
 	indexJoinOp:            "index join",
 	insertFastPathOp:       "insert fast path",

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -208,7 +208,7 @@ SELECT c, count(*) FROM foo, bar WHERE a = 1 GROUP BY c
 hash: 6889256940365688364
 plan-gist: AgFsAgAAAAAAAWoCAAUCAAAJAAAAAAEFAgsABgQ=
 explain(shape):
-• group
+• group (streaming)
 │
 └── • cross join
     │
@@ -222,7 +222,7 @@ explain(shape):
           table: foo@foo_pkey
           spans: 1 span
 explain(gist):
-• group
+• group (hash)
 │
 └── • cross join
     │

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -29,7 +29,7 @@ explain(shape):
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: b_name
         │
         └── • render
@@ -71,7 +71,7 @@ explain(gist):
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: _
         │
         └── • render
@@ -126,7 +126,7 @@ explain(shape):
 │
 └── • render
     │
-    └── • group
+    └── • group (streaming)
         │ group by: ca_id
         │ ordered: +ca_id
         │
@@ -154,7 +154,7 @@ explain(gist):
 │
 └── • render
     │
-    └── • group
+    └── • group (hash)
         │ group by: _
         │
         └── • render

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -342,3 +342,18 @@ type ExecutionStats struct {
 // BuildPlanForExplainFn builds an execution plan against the given
 // base factory.
 type BuildPlanForExplainFn func(f Factory) (Plan, error)
+
+// GroupingOrderType is the grouping column order type for group by and distinct
+// operations.
+type GroupingOrderType int
+
+const (
+	// NoStreaming means that the grouping columns have no useful order, so a
+	// hash aggregator should be used.
+	NoStreaming GroupingOrderType = iota
+	// PartialStreaming means that the grouping columns are partially ordered, so
+	// some optimizations can be done during aggregation.
+	PartialStreaming
+	// Streaming means that the grouping columns are fully ordered.
+	Streaming
+)

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -138,6 +138,10 @@ define GroupBy {
     # If set, the output must have this ordering, but it is guaranteed that
     # ReqOrdering is a prefix of GroupColOrdering.
     ReqOrdering exec.OutputOrdering
+
+    # The grouping column order type (Streaming, PartialStreaming, or
+    # NoStreaming).
+    groupingOrderType exec.GroupingOrderType
 }
 
 # ScalarGroupBy runs a scalar aggregation, i.e.  one which performs a set of

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -216,6 +216,17 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
+	case *GroupByExpr:
+		fmt.Fprintf(f.Buffer, "%v ", e.Op())
+		groupingColOrderType := e.Private().(*GroupingPrivate).GroupingOrderType(&required.Ordering)
+		if groupingColOrderType == Streaming {
+			fmt.Fprintf(f.Buffer, "(streaming)")
+		} else if groupingColOrderType == PartialStreaming {
+			fmt.Fprintf(f.Buffer, "(partial streaming)")
+		} else {
+			fmt.Fprintf(f.Buffer, "(hash)")
+		}
+
 	case *SortExpr:
 		if t.InputOrdering.Any() {
 			fmt.Fprintf(f.Buffer, "%v", e.Op())

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -23,7 +23,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: t.public.t.a:1(int) min:6(int!null)
  │         ├── grouping columns: t.public.t.a:1(int)
  │         ├── immutable
@@ -75,7 +75,7 @@ project
  │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=1]
  │    ├── cost: 1122.50329
  │    ├── ordering: +1
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: t.public.t.a:1(int) min:6(int!null)
  │         ├── grouping columns: t.public.t.a:1(int)
  │         ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=1]
@@ -119,7 +119,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: a:1(int) min:6(int!null)
  │         ├── grouping columns: a:1(int)
  │         ├── immutable
@@ -163,7 +163,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: a:1 min:6!null
  │         ├── grouping columns: a:1
  │         ├── immutable
@@ -207,7 +207,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: a:1(int) min:6(int)
  │         ├── grouping columns: a:1(int)
  │         ├── immutable
@@ -251,7 +251,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: a:1 min:6
  │         ├── grouping columns: a:1
  │         ├── immutable
@@ -293,7 +293,7 @@ project
  │    ├── key: (1)
  │    ├── fd: (1)-->(6)
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=1]
  │         ├── cost: 1105.5623
  │         ├── key: (1)
@@ -331,7 +331,7 @@ SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
 ----
 project
  ├── sort
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── select
  │         │    ├── scan t
  │         │    └── filters
@@ -411,7 +411,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: t.public.t.a:1(int) min:6(int!null)
  │         ├── grouping columns: t.public.t.a:1(int)
  │         ├── immutable
@@ -476,7 +476,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: t.public.t.a:1(int) min:6(int!null)
  │         ├── grouping columns: t.public.t.a:1(int)
  │         ├── immutable
@@ -535,7 +535,7 @@ project
  │    ├── fd: (1)-->(6)
  │    ├── ordering: +1
  │    ├── prune: (6)
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: t.public.t.a:1(int) min:6(int!null)
  │         ├── grouping columns: t.public.t.a:1(int)
  │         ├── immutable

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -19,7 +19,7 @@ project
  ├── fd: ()-->(12), (1)-->(2,7,9,11)
  ├── prune: (1,2,7,9,11,12)
  ├── interesting orderings: (+1 opt(12))
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: x:1(int!null) y:2(int) sum:7(float!null) avg:9(float) string_agg:11(string!null)
  │    ├── grouping columns: x:1(int!null) y:2(int)
  │    ├── key: (1)
@@ -105,7 +105,7 @@ project
  ├── columns: s:4(string)
  ├── prune: (4)
  ├── interesting orderings: (-4)
- └── group-by
+ └── group-by (hash)
       ├── columns: z:3(float!null) s:4(string)
       ├── grouping columns: z:3(float!null) s:4(string)
       ├── key: (3,4)
@@ -129,7 +129,7 @@ SELECT y, sum(z) FROM xyzs GROUP BY z, y
 project
  ├── columns: y:2(int) sum:7(float!null)
  ├── prune: (2,7)
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) z:3(float!null) sum:7(float!null)
       ├── grouping columns: y:2(int) z:3(float!null)
       ├── key: (2,3)
@@ -152,7 +152,7 @@ project
 build
 SELECT z, max(s) FROM xyzs GROUP BY z
 ----
-group-by
+group-by (hash)
  ├── columns: z:3(float!null) max:7(string)
  ├── grouping columns: z:3(float!null)
  ├── key: (3)
@@ -181,7 +181,7 @@ project
  ├── columns: s:4(string)
  ├── prune: (4)
  ├── interesting orderings: (-4)
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
       ├── grouping columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
       ├── key: (1)
@@ -207,7 +207,7 @@ SELECT (SELECT sum(x) FROM (SELECT y, u FROM kuv) GROUP BY u) FROM xyzs GROUP BY
 project
  ├── columns: sum:16(decimal)
  ├── prune: (16)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: xyzs.y:2(int) sum:14(decimal!null)
  │    ├── grouping columns: xyzs.y:2(int)
  │    ├── key: (2)
@@ -244,7 +244,7 @@ project
                      ├── outer: (2,14)
                      ├── fd: ()-->(15)
                      ├── prune: (15)
-                     ├── group-by
+                     ├── group-by (hash)
                      │    ├── columns: u:8(float)
                      │    ├── grouping columns: u:8(float)
                      │    ├── outer: (2)
@@ -273,7 +273,7 @@ project
 build
 SELECT * FROM (VALUES (1), (2), (1), (NULL)) GROUP BY column1
 ----
-group-by
+group-by (hash)
  ├── columns: column1:1(int)
  ├── grouping columns: column1:1(int)
  ├── cardinality: [1 - 4]
@@ -298,7 +298,7 @@ group-by
 opt
 SELECT x, count(y) FROM xyzs GROUP BY x HAVING x=1
 ----
-group-by
+group-by (streaming)
  ├── columns: x:1(int!null) count:7(int!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -327,7 +327,7 @@ GROUP BY x, y
 project
  ├── columns: variance:7(decimal) stddev:8(decimal) corr:9(float)
  ├── prune: (7-9)
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) y:2(int) variance:7(decimal) stddev:8(decimal) corr:9(float)
       ├── grouping columns: x:1(int!null) y:2(int)
       ├── key: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1294,7 +1294,7 @@ project
       │    ├── prune: (1-6)
       │    ├── interesting orderings: (+1) (-3,+4,+1)
       │    └── unfiltered-cols: (1-6)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:7(int) sum:12(decimal!null)
       │    ├── grouping columns: u:7(int)
       │    ├── key: (7)
@@ -1342,7 +1342,7 @@ project
       │    ├── prune: (1-6)
       │    ├── interesting orderings: (+1) (-3,+4,+1)
       │    └── unfiltered-cols: (1-6)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:7(int!null) sum:12(decimal!null)
       │    ├── grouping columns: u:7(int!null)
       │    ├── key: (7)
@@ -1391,7 +1391,7 @@ project
       ├── prune: (6-12)
       ├── reject-nulls: (1,6)
       ├── interesting orderings: (+7) (-9,+10,+7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:1(int) sum:6(decimal!null)
       │    ├── grouping columns: u:1(int)
       │    ├── key: (1)
@@ -1438,7 +1438,7 @@ project
       ├── prune: (6-12)
       ├── reject-nulls: (1,6)
       ├── interesting orderings: (+7) (-9,+10,+7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:1(int!null) sum:6(decimal!null)
       │    ├── grouping columns: u:1(int!null)
       │    ├── key: (1)
@@ -1500,7 +1500,7 @@ project
       │    ├── prune: (1-6)
       │    ├── interesting orderings: (+1) (-3,+4,+1)
       │    └── unfiltered-cols: (1-6)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:7(int) sum:12(decimal!null)
       │    ├── grouping columns: u:7(int)
       │    ├── key: (7)
@@ -1541,7 +1541,7 @@ project
       ├── prune: (6-12)
       ├── reject-nulls: (1,6-12)
       ├── interesting orderings: (+7) (-9,+10,+7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: u:1(int) sum:6(decimal!null)
       │    ├── grouping columns: u:1(int)
       │    ├── key: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -216,7 +216,7 @@ INNER JOIN (SELECT * FROM uv WHERE now() > '2018-01-01')
 ON x=u
 GROUP BY div
 ----
-group-by
+group-by (hash)
  ├── columns: sum:11(decimal!null) div:5(decimal)
  ├── grouping columns: div:5(decimal)
  ├── stable

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -39,7 +39,7 @@ project
  ├── columns: x:1(int!null)
  ├── stats: [rows=2000]
  ├── key: (1)
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) y:2(int)
       ├── grouping columns: x:1(int!null) y:2(int)
       ├── stats: [rows=2000, distinct(1,2)=2000, null(1,2)=0]
@@ -63,7 +63,7 @@ SELECT max(y) FROM a GROUP BY x
 project
  ├── columns: max:7(int)
  ├── stats: [rows=2000]
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) max:7(int)
       ├── grouping columns: x:1(int!null)
       ├── stats: [rows=2000, distinct(1)=2000, null(1)=0]
@@ -87,7 +87,7 @@ project
 build
 SELECT y, sum(z) FROM a GROUP BY y
 ----
-group-by
+group-by (hash)
  ├── columns: y:2(int) sum:7(float!null)
  ├── grouping columns: y:2(int)
  ├── stats: [rows=400, distinct(2)=400, null(2)=0]
@@ -111,7 +111,7 @@ SELECT max(x) FROM a GROUP BY y, z, s
 project
  ├── columns: max:7(int!null)
  ├── stats: [rows=600]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) z:3(float!null) s:4(string) max:7(int!null)
       ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       ├── stats: [rows=600, distinct(2-4)=600, null(2-4)=0]
@@ -137,7 +137,7 @@ SELECT min(x) FROM a GROUP BY y, z
 project
  ├── columns: min:7(int!null)
  ├── stats: [rows=2000]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) z:3(float!null) min:7(int!null)
       ├── grouping columns: y:2(int) z:3(float!null)
       ├── stats: [rows=2000, distinct(2,3)=2000, null(2,3)=0]
@@ -168,7 +168,7 @@ project
       ├── stats: [rows=120, distinct(4)=2, null(4)=0]
       ├── key: (3,4)
       ├── fd: (3,4)-->(2), (2-4)-->(7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: y:2(int) z:3(float!null) s:4(string) max:7(int!null)
       │    ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       │    ├── stats: [rows=600, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=0, distinct(7)=600, null(7)=0, distinct(2-4)=600, null(2-4)=0]
@@ -200,7 +200,7 @@ select
  ├── stats: [rows=1, distinct(7)=1, null(7)=0]
  ├── key: (4)
  ├── fd: ()-->(7)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: s:4(string) sum:7(decimal!null)
  │    ├── grouping columns: s:4(string)
  │    ├── stats: [rows=10, distinct(4)=10, null(4)=0, distinct(7)=10, null(7)=0]
@@ -295,7 +295,7 @@ project
  ├── columns: x:1(int!null)
  ├── stats: [rows=2000]
  ├── key: (1)
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) y:2(int)
       ├── grouping columns: x:1(int!null) y:2(int)
       ├── stats: [rows=2000, distinct(1,2)=2000, null(1,2)=0]
@@ -319,7 +319,7 @@ SELECT max(y) FROM a GROUP BY x
 project
  ├── columns: max:7(int)
  ├── stats: [rows=2000]
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) max:7(int)
       ├── grouping columns: x:1(int!null)
       ├── stats: [rows=2000, distinct(1)=2000, null(1)=0]
@@ -343,7 +343,7 @@ project
 build
 SELECT y, sum(z) FROM a GROUP BY y
 ----
-group-by
+group-by (hash)
  ├── columns: y:2(int) sum:7(float!null)
  ├── grouping columns: y:2(int)
  ├── stats: [rows=400, distinct(2)=400, null(2)=1]
@@ -367,7 +367,7 @@ SELECT max(x) FROM a GROUP BY y, z, s
 project
  ├── columns: max:7(int!null)
  ├── stats: [rows=600]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) z:3(float!null) s:4(string) max:7(int!null)
       ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       ├── stats: [rows=600, distinct(2-4)=600, null(2-4)=0]
@@ -393,7 +393,7 @@ SELECT min(x) FROM a GROUP BY y, z
 project
  ├── columns: min:7(int!null)
  ├── stats: [rows=2000]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) z:3(float!null) min:7(int!null)
       ├── grouping columns: y:2(int) z:3(float!null)
       ├── stats: [rows=2000, distinct(2,3)=2000, null(2,3)=0]
@@ -424,7 +424,7 @@ project
       ├── stats: [rows=133.111111, distinct(4)=2, null(4)=0]
       ├── key: (3,4)
       ├── fd: (3,4)-->(2), (2-4)-->(7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: y:2(int) z:3(float!null) s:4(string) max:7(int!null)
       │    ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       │    ├── stats: [rows=600, distinct(3)=200, null(3)=0, distinct(4)=10, null(4)=1, distinct(7)=600, null(7)=0, distinct(2-4)=600, null(2-4)=0]
@@ -456,7 +456,7 @@ select
  ├── stats: [rows=1, distinct(7)=1, null(7)=0]
  ├── key: (4)
  ├── fd: ()-->(7)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: s:4(string) sum:7(decimal!null)
  │    ├── grouping columns: s:4(string)
  │    ├── stats: [rows=10, distinct(4)=10, null(4)=1, distinct(7)=10, null(7)=0]
@@ -498,7 +498,7 @@ project
  │    ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  │    ├── key: (4)
  │    ├── fd: ()-->(5)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: b:4(int) bool_or:5(bool!null)
  │    │    ├── grouping columns: b:4(int)
  │    │    ├── cardinality: [0 - 3]

--- a/pkg/sql/opt/memo/testdata/stats/index-join
+++ b/pkg/sql/opt/memo/testdata/stats/index-join
@@ -41,7 +41,7 @@ project
  ├── columns: count:7(int!null)
  ├── immutable
  ├── stats: [rows=28.5478625]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:7(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -756,7 +756,7 @@ project
  ├── columns: count:21(int!null)
  ├── immutable
  ├── stats: [rows=0.333333333]
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2(geography!null) count_rows:21(int!null)
       ├── grouping columns: b:2(geography!null)
       ├── immutable

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -282,7 +282,7 @@ project
 build
 SELECT sum(v), x, v FROM xysd, uv GROUP BY x, v
 ----
-group-by
+group-by (hash)
  ├── columns: sum:12(decimal!null) x:1(int!null) v:8(int!null)
  ├── grouping columns: x:1(int!null) v:8(int!null)
  ├── stats: [rows=500000, distinct(1,8)=500000, null(1,8)=0]
@@ -315,7 +315,7 @@ group-by
 norm
 SELECT sum(v), x, v FROM xysd, uv WHERE x=u GROUP BY x, v
 ----
-group-by
+group-by (hash)
  ├── columns: sum:12(decimal!null) x:1(int!null) v:8(int!null)
  ├── grouping columns: x:1(int!null) v:8(int!null)
  ├── stats: [rows=10000, distinct(1,8)=10000, null(1,8)=0]
@@ -439,7 +439,7 @@ project
  ├── columns: count:12(int!null)
  ├── immutable
  ├── stats: [rows=138.170075]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:12(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
@@ -476,7 +476,7 @@ project
  ├── columns: count:12(int!null)
  ├── immutable
  ├── stats: [rows=400]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:12(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
@@ -513,7 +513,7 @@ project
  ├── columns: count:12(int!null)
  ├── immutable
  ├── stats: [rows=400]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:12(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
@@ -550,7 +550,7 @@ project
  ├── columns: count:12(int!null)
  ├── immutable
  ├── stats: [rows=399.903879]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:12(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
@@ -587,7 +587,7 @@ project
  ├── columns: count:12(int!null)
  ├── immutable
  ├── stats: [rows=400]
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2(int) count_rows:12(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -62,7 +62,7 @@ SELECT count(*) FROM (SELECT x, y FROM a) GROUP BY x, y
 project
  ├── columns: count:7(int!null)
  ├── stats: [rows=2000]
- └── group-by
+ └── group-by (hash)
       ├── columns: x:1(int!null) y:2(int) count_rows:7(int!null)
       ├── grouping columns: x:1(int!null) y:2(int)
       ├── stats: [rows=2000, distinct(1,2)=2000, null(1,2)=0]
@@ -108,7 +108,7 @@ select
 build
 SELECT * FROM (SELECT concat(s, y::string), x FROM a) AS q(v, x) GROUP BY v, x
 ----
-group-by
+group-by (hash)
  ├── columns: v:7(string) x:1(int!null)
  ├── grouping columns: x:1(int!null) concat:7(string)
  ├── immutable
@@ -193,7 +193,7 @@ project
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       └── filters
            └── exists [type=bool, outer=(3), correlated-subquery]
-                └── group-by
+                └── group-by (hash)
                      ├── columns: column12:12(bool)
                      ├── grouping columns: column12:12(bool)
                      ├── outer: (3)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -132,7 +132,7 @@ scan a
 opt
 SELECT count(*), y, x FROM a WHERE x > 0 AND x <= 100 GROUP BY x, y
 ----
-group-by
+group-by (streaming)
  ├── columns: count:8(int!null) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null)
  ├── internal-ordering: +1

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -150,7 +150,7 @@ SELECT sum(x) FROM b WHERE x > 1000 AND x <= 2000 GROUP BY z
 project
  ├── columns: sum:6(decimal!null)
  ├── stats: [rows=100]
- └── group-by
+ └── group-by (hash)
       ├── columns: z:2(int!null) sum:6(decimal!null)
       ├── grouping columns: z:2(int!null)
       ├── stats: [rows=100, distinct(2)=100, null(2)=0]
@@ -236,7 +236,7 @@ SELECT count(*) FROM (SELECT * FROM tab0 WHERE col3 = 10) GROUP BY col0
 project
  ├── columns: count:10(int!null)
  ├── stats: [rows=0.999973439]
- └── group-by
+ └── group-by (hash)
       ├── columns: col0:2(int) count_rows:10(int!null)
       ├── grouping columns: col0:2(int)
       ├── stats: [rows=0.999973439, distinct(2)=0.999973439, null(2)=0.999973439]
@@ -1364,7 +1364,7 @@ project
  │    ├── stats: [rows=1, distinct(4)=1, null(4)=0]
  │    ├── key: (2,3)
  │    ├── fd: ()-->(4)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: column2:2(string) column3:3(varbit) min:4(bool!null)
  │    │    ├── grouping columns: column2:2(string) column3:3(varbit)
  │    │    ├── cardinality: [1 - 2]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -738,7 +738,7 @@ scalar-group-by
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    └── ordering: +1
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── save-table-name: consistency_01_group_by_4
  │    │    ├── columns: d_w_id:13(int!null) sum:25(decimal)
  │    │    ├── grouping columns: d_w_id:13(int!null)
@@ -852,7 +852,7 @@ GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
 ----
-group-by
+group-by (streaming)
  ├── save-table-name: consistency_03_group_by_1
  ├── columns: max:6(int!null)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
@@ -907,7 +907,7 @@ GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
 ----
-group-by
+group-by (streaming)
  ├── save-table-name: consistency_04_group_by_1
  ├── columns: max:11(int!null)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
@@ -981,7 +981,7 @@ scalar-group-by
  │    ├── stats: [rows=33.3333333, distinct(2)=9.8265847, null(2)=0, distinct(3)=9.8265847, null(3)=0, distinct(6)=33.3333333, null(6)=0, distinct(7)=33.3333333, null(7)=0, distinct(8)=33.3333333, null(8)=0]
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(6-8)
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── save-table-name: consistency_05_group_by_3
  │    │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:6(int!null) min:7(int!null) count_rows:8(int!null)
  │    │    ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
@@ -1069,7 +1069,7 @@ GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
 ----
-group-by
+group-by (streaming)
  ├── save-table-name: consistency_06_group_by_1
  ├── columns: sum:11(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
@@ -1123,7 +1123,7 @@ GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
 ----
-group-by
+group-by (streaming)
  ├── save-table-name: consistency_07_group_by_1
  ├── columns: count:13(int!null)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
@@ -1434,7 +1434,7 @@ except-all
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    └── ordering: +3,+2,-1
- └── group-by
+ └── group-by (streaming)
       ├── save-table-name: consistency_10_group_by_3
       ├── columns: ol_o_id:11(int!null) ol_d_id:12(int!null) ol_w_id:13(int!null) count_rows:23(int!null)
       ├── grouping columns: ol_o_id:11(int!null) ol_d_id:12(int!null) ol_w_id:13(int!null)
@@ -1532,7 +1532,7 @@ except-all
  ├── stats: [rows=295745, distinct(1)=2999, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(13)=295745, null(13)=0]
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── save-table-name: consistency_11_group_by_2
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:13(int!null)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q01
@@ -49,7 +49,7 @@ sort
  ├── key: (9,10)
  ├── fd: (9,10)-->(19,20,22,24-28)
  ├── ordering: +9,+10
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q1_group_by_2
       ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum:19(float!null) sum:20(float!null) sum:22(float!null) sum:24(float!null) avg:25(float!null) avg:26(float!null) avg:27(float!null) count_rows:28(int!null)
       ├── grouping columns: l_returnflag:9(char!null) l_linestatus:10(char!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q02
@@ -92,7 +92,7 @@ project
            ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(3)=1, null(3)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0, distinct(16)=1, null(16)=0, distinct(17)=1, null(17)=0, distinct(18)=1, null(18)=0, distinct(21)=0.999912293, null(21)=0, distinct(22)=0.999982117, null(22)=0, distinct(24)=1, null(24)=0, distinct(29)=1, null(29)=0, distinct(66)=1, null(66)=0]
            ├── key: (21,22)
            ├── fd: (1)-->(3), (21,22)-->(1,3,13,14,16-18,24,29,66), (1)==(21), (21)==(1), (22)-->(13,14,16-18,29), (24)==(66), (66)==(24)
-           ├── group-by
+           ├── group-by (hash)
            │    ├── save-table-name: q2_group_by_4
            │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) s_name:13(char!null) s_address:14(varchar!null) s_phone:16(char!null) s_acctbal:17(float!null) s_comment:18(varchar!null) ps_partkey:21(int!null) ps_suppkey:22(int!null) ps_supplycost:24(float!null) n_name:29(char!null) min:66(float!null)
            │    ├── grouping columns: ps_partkey:21(int!null) ps_suppkey:22(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q03
@@ -52,7 +52,7 @@ top-k
  ├── key: (22)
  ├── fd: (22)-->(15,18,41)
  ├── ordering: -41,+15
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q3_group_by_2
       ├── columns: o_orderdate:15(date!null) o_shippriority:18(int!null) l_orderkey:22(int!null) sum:41(float!null)
       ├── grouping columns: l_orderkey:22(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
@@ -46,7 +46,7 @@ sort
  ├── key: (6)
  ├── fd: (6)-->(30)
  ├── ordering: +6
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q4_group_by_2
       ├── columns: o_orderpriority:6(char!null) count_rows:30(int!null)
       ├── grouping columns: o_orderpriority:6(char!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q05
@@ -53,7 +53,7 @@ sort
  ├── key: (50)
  ├── fd: (50)-->(61)
  ├── ordering: -61
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q5_group_by_2
       ├── columns: n_name:50(char!null) sum:61(float!null)
       ├── grouping columns: n_name:50(char!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q07
@@ -65,7 +65,7 @@ sort
  ├── key: (50,56,61)
  ├── fd: (50,56,61)-->(63)
  ├── ordering: +50,+56,+61
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q7_group_by_2
       ├── columns: n1.n_name:50(char!null) n2.n_name:56(char!null) l_year:61(float) sum:63(float!null)
       ├── grouping columns: n1.n_name:50(char!null) n2.n_name:56(char!null) l_year:61(float)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q08
@@ -71,7 +71,7 @@ sort
       ├── stats: [rows=728.862489, distinct(77)=728.862489, null(77)=0, distinct(82)=728.862489, null(82)=0]
       ├── key: (77)
       ├── fd: (77)-->(82)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── save-table-name: q8_group_by_3
       │    ├── columns: o_year:77(float) sum:80(float!null) sum:81(float!null)
       │    ├── grouping columns: o_year:77(float)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q09
@@ -62,7 +62,7 @@ sort
  ├── key: (58,63)
  ├── fd: (58,63)-->(65)
  ├── ordering: +58,-63
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q9_group_by_2
       ├── columns: n_name:58(char!null) o_year:63(float) sum:65(float!null)
       ├── grouping columns: n_name:58(char!null) o_year:63(float)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q10
@@ -64,7 +64,7 @@ top-k
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,41,47)
  ├── ordering: -47
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q10_group_by_2
       ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:41(char!null) sum:47(float!null)
       ├── grouping columns: c_custkey:1(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q11
@@ -59,7 +59,7 @@ sort
       ├── stats: [rows=9927.82897, distinct(1)=9927.82897, null(1)=0, distinct(24)=9927.82897, null(24)=0]
       ├── key: (1)
       ├── fd: (1)-->(24)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── save-table-name: q11_group_by_3
       │    ├── columns: ps_partkey:1(int!null) sum:24(float!null)
       │    ├── grouping columns: ps_partkey:1(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q12
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q12
@@ -56,7 +56,7 @@ sort
  ├── key: (26)
  ├── fd: (26)-->(31,33)
  ├── ordering: +26
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q12_group_by_2
       ├── columns: l_shipmode:26(char!null) sum:31(decimal!null) sum:33(decimal!null)
       ├── grouping columns: l_shipmode:26(char!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q13
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q13
@@ -43,14 +43,14 @@ sort
  ├── key: (22)
  ├── fd: (22)-->(23)
  ├── ordering: -23,-22
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q13_group_by_2
       ├── columns: count:22(int!null) count_rows:23(int!null)
       ├── grouping columns: count:22(int!null)
       ├── stats: [rows=148813, distinct(22)=148813, null(22)=0, distinct(23)=148813, null(23)=0]
       ├── key: (22)
       ├── fd: (22)-->(23)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── save-table-name: q13_group_by_3
       │    ├── columns: c_custkey:1(int!null) count:22(int!null)
       │    ├── grouping columns: c_custkey:1(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q15
@@ -99,7 +99,7 @@ project
       │         ├── stats: [rows=3306.66667, distinct(12)=3306.66667, null(12)=0, distinct(29)=3306.66667, null(29)=0]
       │         ├── key: (12)
       │         ├── fd: (12)-->(29)
-      │         ├── group-by
+      │         ├── group-by (hash)
       │         │    ├── save-table-name: q15_group_by_6
       │         │    ├── columns: l_suppkey:12(int!null) sum:29(float!null)
       │         │    ├── grouping columns: l_suppkey:12(int!null)
@@ -148,7 +148,7 @@ project
       │                             ├── stats: [rows=1, distinct(50)=1, null(50)=0]
       │                             ├── key: ()
       │                             ├── fd: ()-->(50)
-      │                             ├── group-by
+      │                             ├── group-by (hash)
       │                             │    ├── save-table-name: q15_group_by_11
       │                             │    ├── columns: l_suppkey:32(int!null) sum:49(float!null)
       │                             │    ├── grouping columns: l_suppkey:32(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
@@ -58,7 +58,7 @@ sort
  ├── key: (11-13)
  ├── fd: (11-13)-->(28)
  ├── ordering: -28,+11,+12,+13
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q16_group_by_2
       ├── columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null) count:28(int!null)
       ├── grouping columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q17
@@ -79,7 +79,7 @@ project
  │    │    │    │    ├── stats: [rows=284.037462, distinct(19)=284.037462, null(19)=0, distinct(49)=284.037462, null(49)=0]
  │    │    │    │    ├── key: (19)
  │    │    │    │    ├── fd: (19)-->(49)
- │    │    │    │    ├── group-by
+ │    │    │    │    ├── group-by (streaming)
  │    │    │    │    │    ├── save-table-name: q17_group_by_6
  │    │    │    │    │    ├── columns: p_partkey:19(int!null) avg:48(float!null)
  │    │    │    │    │    ├── grouping columns: p_partkey:19(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
@@ -61,7 +61,7 @@ top-k
  ├── key: (11)
  ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
  ├── ordering: -14,+15
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q18_group_by_2
       ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:11(int!null) o_totalprice:14(float!null) o_orderdate:15(date!null) sum:59(float!null)
       ├── grouping columns: o_orderkey:11(int!null)
@@ -121,7 +121,7 @@ top-k
       │    │    │    │    ├── key: (40)
       │    │    │    │    ├── fd: (40)-->(58)
       │    │    │    │    ├── ordering: +40
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── save-table-name: q18_group_by_9
       │    │    │    │    │    ├── columns: l_orderkey:40(int!null) sum:58(float!null)
       │    │    │    │    │    ├── grouping columns: l_orderkey:40(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q20
@@ -117,7 +117,7 @@ sort
            │         │         │    ├── stats: [rows=127.585211, distinct(16)=127.585211, null(16)=0, distinct(17)=127.585211, null(17)=0, distinct(18)=127.585211, null(18)=0, distinct(52)=127.585211, null(52)=0]
            │         │         │    ├── key: (16,17)
            │         │         │    ├── fd: (16,17)-->(18,52)
-           │         │         │    ├── group-by
+           │         │         │    ├── group-by (hash)
            │         │         │    │    ├── save-table-name: q20_group_by_9
            │         │         │    │    ├── columns: ps_partkey:16(int!null) ps_suppkey:17(int!null) ps_availqty:18(int!null) sum:52(float!null)
            │         │         │    │    ├── grouping columns: ps_partkey:16(int!null) ps_suppkey:17(int!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
@@ -67,7 +67,7 @@ top-k
  ├── key: (2)
  ├── fd: (2)-->(81)
  ├── ordering: -81,+2
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q21_group_by_2
       ├── columns: s_name:2(char!null) count_rows:81(int!null)
       ├── grouping columns: s_name:2(char!null)

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
@@ -62,7 +62,7 @@ sort
  ├── key: (33)
  ├── fd: (33)-->(34,35)
  ├── ordering: +33
- └── group-by
+ └── group-by (hash)
       ├── save-table-name: q22_group_by_2
       ├── columns: cntrycode:33(string) count_rows:34(int!null) sum:35(float!null)
       ├── grouping columns: cntrycode:33(string)

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -385,7 +385,7 @@ project
  ├── columns: x:1(int!null) x:5(string!null) y:2(int!null)
  ├── select
  │    ├── columns: a.x:1(int!null) y:2(int!null) max:10(string!null)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: a.x:1(int!null) y:2(int!null) max:10(string!null)
  │    │    ├── grouping columns: a.x:1(int!null)
  │    │    ├── inner-join (hash)
@@ -416,7 +416,7 @@ SELECT EXISTS(SELECT * FROM a WHERE expr<0) FROM (SELECT x+1 AS expr FROM a)
 ----
 project
  ├── columns: exists:10(bool!null)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: true_agg:12(bool) rownum:14(int!null)
  │    ├── grouping columns: rownum:14(int!null)
  │    ├── left-join (cross)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1907,7 +1907,7 @@ TryDecorrelateScalarGroupBy
   + │    │    │    │    ├── columns: x:1!null bool_or:14
   + │    │    │    │    ├── key: (1)
   + │    │    │    │    ├── fd: (1)-->(14)
-  + │    │    │    │    └── group-by
+  + │    │    │    │    └── group-by (hash)
   + │    │    │    │         ├── columns: x:1!null bool_or:14
   + │    │    │    │         ├── grouping columns: x:1!null
   + │    │    │    │         ├── key: (1)
@@ -1972,7 +1972,7 @@ TryDecorrelateProjectSelect
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2058,7 +2058,7 @@ DecorrelateJoin
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2121,7 +2121,7 @@ PushFilterIntoJoinRight
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2196,7 +2196,7 @@ PushSelectIntoProject
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2271,7 +2271,7 @@ EliminateSelect
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2353,7 +2353,7 @@ PruneJoinRightCols
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2423,7 +2423,7 @@ EliminateGroupByProject
     │    │    │    │    ├── columns: x:1!null bool_or:14
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-    │    │    │    │    └── group-by
+    │    │    │    │    └── group-by (hash)
     │    │    │    │         ├── columns: x:1!null bool_or:14
     │    │    │    │         ├── grouping columns: x:1!null
     │    │    │    │         ├── key: (1)
@@ -2511,12 +2511,12 @@ EliminateProject
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(14)
   - │    │    │    ├── project
-  + │    │    │    ├── group-by
+  + │    │    │    ├── group-by (hash)
     │    │    │    │    ├── columns: x:1!null bool_or:14
   + │    │    │    │    ├── grouping columns: x:1!null
     │    │    │    │    ├── key: (1)
     │    │    │    │    ├── fd: (1)-->(14)
-  - │    │    │    │    └── group-by
+  - │    │    │    │    └── group-by (hash)
   - │    │    │    │         ├── columns: x:1!null bool_or:14
   - │    │    │    │         ├── grouping columns: x:1!null
   - │    │    │    │         ├── key: (1)
@@ -2600,12 +2600,12 @@ EliminateSelect
     │    │    ├── key: (1)
     │    │    ├── fd: (1)-->(15)
   - │    │    ├── select
-  + │    │    ├── group-by
+  + │    │    ├── group-by (hash)
     │    │    │    ├── columns: x:1!null bool_or:14
   + │    │    │    ├── grouping columns: x:1!null
     │    │    │    ├── key: (1)
     │    │    │    ├── fd: (1)-->(14)
-  - │    │    │    ├── group-by
+  - │    │    │    ├── group-by (hash)
   - │    │    │    │    ├── columns: x:1!null bool_or:14
   - │    │    │    │    ├── grouping columns: x:1!null
   + │    │    │    ├── left-join (hash)
@@ -2684,12 +2684,12 @@ EliminateSelect
     │    ├── fd: (1)-->(15)
   - │    ├── project
   - │    │    ├── columns: case:15 x:1!null
-  + │    ├── group-by
+  + │    ├── group-by (hash)
   + │    │    ├── columns: x:1!null bool_or:14
   + │    │    ├── grouping columns: x:1!null
     │    │    ├── key: (1)
   - │    │    ├── fd: (1)-->(15)
-  - │    │    ├── group-by
+  - │    │    ├── group-by (hash)
   - │    │    │    ├── columns: x:1!null bool_or:14
   - │    │    │    ├── grouping columns: x:1!null
   + │    │    ├── fd: (1)-->(14)
@@ -2767,7 +2767,7 @@ PruneProjectCols
   - │    ├── key: (1)
   - │    ├── fd: (1)-->(15)
   + │    ├── columns: case:15
-    │    ├── group-by
+    │    ├── group-by (hash)
     │    │    ├── columns: x:1!null bool_or:14
     │    │    ├── grouping columns: x:1!null
     │    │    ├── key: (1)
@@ -2813,10 +2813,10 @@ InlineProjectInProject
     ├── columns: r:12
   - ├── project
   - │    ├── columns: case:15
-  - │    ├── group-by
+  - │    ├── group-by (hash)
   - │    │    ├── columns: x:1!null bool_or:14
   - │    │    ├── grouping columns: x:1!null
-  + ├── group-by
+  + ├── group-by (hash)
   + │    ├── columns: x:1!null bool_or:14
   + │    ├── grouping columns: x:1!null
   + │    ├── key: (1)
@@ -2905,7 +2905,7 @@ CommuteLeftJoin (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -2951,7 +2951,7 @@ GenerateMergeJoins
 ================================================================================
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3002,7 +3002,7 @@ HoistProjectFromLeftJoin (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3064,7 +3064,7 @@ CommuteLeftJoin (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3109,7 +3109,7 @@ GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3160,7 +3160,7 @@ GenerateLookupJoinsWithFilter (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3210,7 +3210,7 @@ GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3260,7 +3260,7 @@ GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
    project
     ├── columns: r:12
-    ├── group-by
+    ├── group-by (hash)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
     │    ├── key: (1)
@@ -3321,7 +3321,8 @@ GenerateStreamingGroupBy
 ================================================================================
    project
     ├── columns: r:12
-    ├── group-by
+  - ├── group-by (hash)
+  + ├── group-by (streaming)
     │    ├── columns: x:1!null bool_or:14
     │    ├── grouping columns: x:1!null
   + │    ├── internal-ordering: +1
@@ -3369,7 +3370,7 @@ Final best expression
 ================================================================================
   project
    ├── columns: r:12
-   ├── group-by
+   ├── group-by (streaming)
    │    ├── columns: x:1!null bool_or:14
    │    ├── grouping columns: x:1!null
    │    ├── internal-ordering: +1

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -896,7 +896,7 @@ SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null bool_or:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -979,7 +979,7 @@ SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null bool_or:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -1022,7 +1022,7 @@ SELECT i=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null i:2 bool_or:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -1064,7 +1064,7 @@ SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 project
  ├── columns: r:12
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null scalar:13 bool_or:15
  │    ├── grouping columns: k:1!null
  │    ├── immutable
@@ -1308,7 +1308,7 @@ SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 project
  ├── columns: sum:18
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null sum:17
  │    ├── grouping columns: k:1!null
  │    ├── immutable
@@ -1434,7 +1434,7 @@ project
       ├── columns: k:1!null count_rows:16!null
       ├── key: (1)
       ├── fd: (1)-->(16)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null count_rows:16!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -1633,7 +1633,7 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT count(*) AS cnt, sum(v) FROM uv WHERE i=5 GROUP BY v) ON x=cnt
 )
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -1642,7 +1642,7 @@ group-by
  │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null v:13 count_rows:16!null
  │    ├── key: (1,8,13)
  │    ├── fd: ()-->(2), (1)-->(3-5), (1,8,13)-->(3-5,16), (8)==(16), (16)==(8)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null v:13 count_rows:16!null
  │    │    ├── grouping columns: k:1!null x:8!null v:13
  │    │    ├── key: (1,8,13)
@@ -1699,7 +1699,7 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT count(DISTINCT uv.v) AS cnt, sum(v) FROM uv WHERE i=5 GROUP BY v) ON x=cnt
 )
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -1708,7 +1708,7 @@ group-by
  │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null v:13 count:16!null
  │    ├── key: (1,8,13)
  │    ├── fd: ()-->(2), (1)-->(3-5), (1,8,13)-->(3-5,16), (8)==(16), (16)==(8)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null v:13 count:16!null
  │    │    ├── grouping columns: k:1!null x:8!null v:13
  │    │    ├── key: (1,8,13)
@@ -1773,7 +1773,7 @@ project
       ├── columns: x:1!null y:2 u:5!null v:6!null max:16!null
       ├── key: (5)
       ├── fd: (1)-->(2), (5)-->(1,2,6), (1)==(6), (6)==(1), (5)==(16), (16)==(5)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: x:1!null y:2 u:5!null v:6!null max:16!null
       │    ├── grouping columns: u:5!null
       │    ├── key: (5)
@@ -1837,7 +1837,7 @@ project
       ├── columns: x:1!null y:2 u:5!null v:6!null max:16
       ├── key: (5)
       ├── fd: (1)-->(2), (5)-->(1,2,6,16), (1)==(6), (6)==(1)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: x:1!null y:2 u:5!null v:6!null max:16
       │    ├── grouping columns: u:5!null
       │    ├── key: (5)
@@ -1896,7 +1896,7 @@ project
  │    ├── columns: x:1!null y:2!null max:13!null
  │    ├── key: (1)
  │    ├── fd: ()-->(2,13)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: x:1!null y:2!null max:13
  │    │    ├── grouping columns: x:1!null
  │    │    ├── key: (1)
@@ -1944,7 +1944,7 @@ WHERE EXISTS
     ) ON x=u
 )
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -2081,7 +2081,7 @@ with &1 (w0)
       │    │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23 t1.rowid:25!null t2._bool:31 t2.rowid:34!null t3._int2:37!null t3._timestamptz:39!null t3.rowid:43!null t4._int8:54!null t4._timestamptz:55!null
       │    │    │    ├── outer: (6)
       │    │    │    ├── fd: (25)-->(23), (34)-->(31), (43)-->(37,39), (16,25,34,43)-->(23,31,37,39), (39)==(55), (55)==(39), (37)==(54), (54)==(37)
-      │    │    │    ├── group-by
+      │    │    │    ├── group-by (hash)
       │    │    │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23 t1.rowid:25!null t2._bool:31 t2.rowid:34!null t3._int2:37 t3._timestamptz:39 t3.rowid:43!null
       │    │    │    │    ├── grouping columns: tab_orig.rowid:16!null t1.rowid:25!null t2.rowid:34!null t3.rowid:43!null
       │    │    │    │    ├── outer: (6)
@@ -2153,7 +2153,7 @@ WHERE EXISTS
     SELECT * FROM xy INNER JOIN (SELECT sum(v), count(*) AS cnt FROM uv WHERE i=5) ON x=cnt
 )
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null i:2 f:3 s:4 j:5
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -2162,7 +2162,7 @@ group-by
  │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8!null count_rows:17!null
  │    ├── key: (1,8)
  │    ├── fd: (1)-->(2-5), (1,8)-->(2-5,17), (8)==(17), (17)==(8)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8!null count_rows:17!null
  │    │    ├── grouping columns: k:1!null x:8!null
  │    │    ├── key: (1,8)
@@ -2224,7 +2224,7 @@ project
  │    ├── columns: k:1!null i:2!null max:13!null
  │    ├── key: (1)
  │    ├── fd: ()-->(13), (1)-->(2)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null i:2!null max:13!null
  │    │    ├── grouping columns: k:1!null
  │    │    ├── key: (1)
@@ -2269,7 +2269,7 @@ project
  ├── columns: k:1!null array_agg:13
  ├── key: (1)
  ├── fd: (1)-->(13)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null y:9 array_agg:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -2300,7 +2300,7 @@ project
  ├── columns: k:1!null "?column?":15
  ├── key: (1)
  ├── fd: (1)-->(15)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null y:9 max:13 array_agg:16
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -2334,7 +2334,7 @@ project
  ├── columns: k:1!null array:13
  ├── key: (1)
  ├── fd: (1)-->(13)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null canary:14 array_agg:15
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -2369,7 +2369,7 @@ SELECT i, ARRAY(SELECT y FROM xy WHERE xy.y = a.k OR xy.y IS NULL ORDER BY y) FR
 ----
 project
  ├── columns: i:2 array:13
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null i:2 canary:14 array_agg:15
  │    ├── grouping columns: k:1!null
  │    ├── internal-ordering: +9
@@ -2428,7 +2428,7 @@ project
       ├── columns: k:1!null i:2 f:3 s:4 j:5 max:17
       ├── key: (1)
       ├── fd: ()-->(17), (1)-->(2-5)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 max:17
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -2441,7 +2441,7 @@ project
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── group-by
+      │    │    ├── group-by (hash)
       │    │    │    ├── columns: x:8!null y:9 max:16
       │    │    │    ├── grouping columns: x:8!null
       │    │    │    ├── outer: (1)
@@ -2506,7 +2506,7 @@ project
       │    ├── columns: array_agg:9 c:1!null d:2!null
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,9)
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: c:1!null d:2!null x:5 array_agg:10
       │    │    ├── grouping columns: c:1!null
       │    │    ├── key: (1)
@@ -2556,7 +2556,7 @@ project
       │    ├── immutable
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,13)
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 canary:14 concat_agg:15
       │    │    ├── grouping columns: k:1!null
       │    │    ├── immutable
@@ -2612,7 +2612,7 @@ project
  ├── columns: k:1!null string_agg:17
  ├── key: (1)
  ├── fd: (1)-->(17)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: a2.k:1!null string_agg:16
  │    ├── grouping columns: a2.k:1!null
  │    ├── key: (1)
@@ -2658,7 +2658,7 @@ WHERE EXISTS
     SELECT * FROM a WHERE i=(SELECT max(i) FROM a WHERE f=y::float)
 )
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
  ├── immutable
@@ -2669,7 +2669,7 @@ group-by
  │    ├── immutable
  │    ├── key: (1,5)
  │    ├── fd: (1)-->(2), (5)-->(6), (1,5)-->(2,6,19), (6)==(19), (19)==(6)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: x:1!null y:2 k:5!null i:6 max:19!null
  │    │    ├── grouping columns: x:1!null k:5!null
  │    │    ├── immutable
@@ -2729,7 +2729,7 @@ WHERE EXISTS
     SELECT * FROM (SELECT DISTINCT ON (f) i FROM a WHERE y > f) WHERE x=i
 )
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null y:2!null
  ├── grouping columns: x:1!null
  ├── key: (1)
@@ -2815,7 +2815,7 @@ project
 norm expect=TryDecorrelateSemiJoin
 SELECT * FROM xy WHERE EXISTS(SELECT generate_series(x, 10), generate_series(y, 10))
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
  ├── immutable
@@ -3217,7 +3217,7 @@ WHERE EXISTS
     ON x=u
 )
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null i:2!null f:3 s:4 j:5
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -4156,7 +4156,7 @@ project
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2-5,12)
-      │    │    │    ├── group-by
+      │    │    │    ├── group-by (hash)
       │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null
       │    │    │    │    ├── grouping columns: k:1!null
       │    │    │    │    ├── key: (1)
@@ -4219,7 +4219,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-5,12)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 count_rows:12!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -4264,7 +4264,7 @@ project
       ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:13
       ├── key: (1)
       ├── fd: (1)-->(2-5,13)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:13
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -4315,7 +4315,7 @@ project
       │    ├── columns: case:14 k:1!null i:2 f:3 s:4 j:5
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-5,14)
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
       │    │    ├── grouping columns: k:1!null
       │    │    ├── key: (1)
@@ -4385,7 +4385,7 @@ SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 project
  ├── columns: r:12 s:4
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null s:4 scalar:13 bool_or:15
  │    ├── grouping columns: k:1!null
  │    ├── immutable
@@ -4444,7 +4444,7 @@ project
       ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:17
       ├── key: (1)
       ├── fd: (1)-->(2-5,17)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:17
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -4534,7 +4534,7 @@ FROM a
 project
  ├── columns: a:29!null x:30 y:31 b:32 exists:33 count:34!null
  ├── fd: ()-->(29)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null xy.x:8 count_rows:28!null
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -4639,7 +4639,7 @@ SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
  ├── columns: exists:12!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null true_agg:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -4672,7 +4672,7 @@ SELECT 5 < ANY(SELECT y FROM xy WHERE y=i) AS r FROM a
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null bool_or:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -4808,7 +4808,7 @@ project
       │    ├── columns: exists:18!null x:8!null
       │    ├── key: (8)
       │    ├── fd: (8)-->(18)
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: x:8!null true_agg:17
       │    │    ├── grouping columns: x:8!null
       │    │    ├── key: (8)
@@ -4853,7 +4853,7 @@ project
       ├── project
       │    ├── columns: case:18 j:5 x:8!null y:9
       │    ├── fd: (8)-->(9)
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
       │    │    ├── grouping columns: k:1!null x:8!null
       │    │    ├── key: (1,8)
@@ -4962,7 +4962,7 @@ SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
  ├── columns: column1:16!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null true_agg:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -4998,7 +4998,7 @@ SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
  ├── columns: column1:16
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null bool_or:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
@@ -5070,7 +5070,7 @@ project
 norm expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
  ├── immutable
@@ -5269,7 +5269,7 @@ limit
  │    ├── fd: (1)-->(2-9)
  │    ├── ordering: +8
  │    ├── limit hint: 10.00
- │    └── group-by
+ │    └── group-by (hash)
  │         ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9
  │         ├── grouping columns: id:1!null
  │         ├── immutable
@@ -5326,7 +5326,7 @@ project
       ├── immutable
       ├── key: (1,12)
       ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,21)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:21
       │    ├── grouping columns: id:1!null x:12!null
       │    ├── immutable

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -98,7 +98,7 @@ distinct-on
 norm expect-not=ConvertGroupByToDistinct
 SELECT s, f, sum(f) FROM a GROUP BY s, f
 ----
-group-by
+group-by (hash)
  ├── columns: s:4!null f:3 sum:8
  ├── grouping columns: f:3 s:4!null
  ├── key: (3,4)
@@ -138,7 +138,7 @@ scan xy
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT k, max(r1) FROM fks INNER JOIN (SELECT * FROM (VALUES (1), (2)) f(t)) ON True GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null max:8!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -174,7 +174,7 @@ scalar-group-by
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null max:11
  ├── grouping columns: x:1!null
  ├── key: (1)
@@ -191,7 +191,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
 SELECT k, sum(r1) FROM fks LEFT JOIN xy ON x=r1 GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:11!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -210,7 +210,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
 SELECT x, sum(y) FROM xy LEFT JOIN fks ON x=k GROUP BY x
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null sum:11
  ├── grouping columns: x:1!null
  ├── key: (1)
@@ -230,7 +230,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
 SELECT k, sum(r1) FROM fks LEFT JOIN xy ON x=r2 GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:11!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -248,7 +248,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
 SELECT k, sum(r1) FROM fks INNER JOIN xy ON x=r1 GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:11!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -265,7 +265,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT max(y) FROM xy LEFT JOIN fks ON True GROUP BY x ORDER BY x
 ----
-group-by
+group-by (streaming)
  ├── columns: max:11  [hidden: x:1!null]
  ├── grouping columns: x:1!null
  ├── key: (1)
@@ -345,7 +345,7 @@ distinct-on
 norm expect-not=EliminateJoinUnderGroupByLeft
 SELECT k, sum(r1) FROM fks INNER JOIN xy ON True GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:11!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -369,7 +369,7 @@ group-by
 norm expect-not=EliminateJoinUnderGroupByLeft
 SELECT k, sum(r1) FROM fks INNER JOIN xy ON x=r2 GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:11!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -396,7 +396,7 @@ group-by
 norm expect-not=EliminateJoinUnderGroupByLeft
 SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x, k ORDER BY x, k
 ----
-group-by
+group-by (streaming)
  ├── columns: x:1!null max:11  [hidden: k:5]
  ├── grouping columns: x:1!null k:5
  ├── key: (1,5)
@@ -432,7 +432,7 @@ group-by
 norm expect=EliminateJoinUnderGroupByRight disable=EliminateJoinUnderProjectRight
 SELECT k, sum(r1) FROM xy INNER JOIN fks ON x = r1 GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:5!null sum:11!null
  ├── grouping columns: k:5!null
  ├── key: (5)
@@ -604,7 +604,7 @@ SELECT min(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a)) GR
 ----
 project
  ├── columns: min:20!null
- └── group-by
+ └── group-by (hash)
       ├── columns: i:16!null min:20!null
       ├── grouping columns: i:16!null
       ├── key: (16)
@@ -790,7 +790,7 @@ SELECT min(s) FROM (SELECT i+1 AS i2, s FROM a) GROUP BY i2
 project
  ├── columns: min:9!null
  ├── immutable
- └── group-by
+ └── group-by (hash)
       ├── columns: i2:8!null min:9!null
       ├── grouping columns: i2:8!null
       ├── immutable
@@ -814,7 +814,7 @@ project
 norm expect=ReduceGroupingCols
 SELECT k, min(i), f, s FROM a GROUP BY s, f, k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null min:8!null f:3 s:4!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -834,7 +834,7 @@ group-by
 norm expect=ReduceGroupingCols
 SELECT k, sum(DISTINCT i), f, s FROM a, xy GROUP BY s, f, k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null sum:12!null f:3 s:4!null
  ├── grouping columns: k:1!null
  ├── key: (1)
@@ -863,7 +863,7 @@ SELECT min(f) FROM a GROUP BY i, s, k
 ----
 project
  ├── columns: min:8
- └── group-by
+ └── group-by (hash)
       ├── columns: i:2!null s:4!null min:8
       ├── grouping columns: i:2!null s:4!null
       ├── key: (2,4)
@@ -880,7 +880,7 @@ project
 norm expect=ReduceGroupingCols
 SELECT sum(f), i FROM a GROUP BY k, i, f HAVING k=1
 ----
-group-by
+group-by (streaming)
  ├── columns: sum:8 i:2!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1297,7 +1297,7 @@ SELECT sum(DISTINCT k) FROM a GROUP BY i
 ----
 project
  ├── columns: sum:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: i:2!null sum:8!null
       ├── grouping columns: i:2!null
       ├── key: (2)
@@ -1317,7 +1317,7 @@ SELECT sum(DISTINCT a) FROM abc GROUP BY b
 ----
 project
  ├── columns: sum:6!null
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2!null sum:6!null
       ├── grouping columns: b:2!null
       ├── key: (2)
@@ -1338,7 +1338,7 @@ SELECT sum(DISTINCT a) FROM abc GROUP BY b, c
 ----
 project
  ├── columns: sum:6!null
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2!null c:3!null sum:6!null
       ├── grouping columns: b:2!null c:3!null
       ├── key: (2,3)
@@ -1356,7 +1356,7 @@ SELECT sum(DISTINCT i), avg(DISTINCT f) FROM a GROUP BY k
 ----
 project
  ├── columns: sum:8!null avg:9
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null sum:8!null avg:9
       ├── grouping columns: k:1!null
       ├── key: (1)
@@ -1378,7 +1378,7 @@ SELECT sum(DISTINCT u), stddev(DISTINCT w), avg(DISTINCT z) FROM uvwz GROUP BY v
 ----
 project
  ├── columns: sum:8!null stddev:9 avg:10!null
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2!null sum:8!null stddev:9 avg:10!null
       ├── grouping columns: v:2!null
       ├── key: (2)
@@ -1465,7 +1465,7 @@ SELECT sum(DISTINCT k) FILTER (WHERE f > 0) FROM a GROUP BY i
 ----
 project
  ├── columns: sum:9
- └── group-by
+ └── group-by (hash)
       ├── columns: i:2!null sum:9
       ├── grouping columns: i:2!null
       ├── key: (2)
@@ -1492,7 +1492,7 @@ SELECT sum(DISTINCT a) FILTER (WHERE c > 0) FROM abc GROUP BY b
 ----
 project
  ├── columns: sum:7
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2!null sum:7
       ├── grouping columns: b:2!null
       ├── key: (2)
@@ -1517,7 +1517,7 @@ SELECT sum(DISTINCT a) FILTER (WHERE c > 0) FROM abc GROUP BY b, c
 ----
 project
  ├── columns: sum:7
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2!null c:3!null sum:7
       ├── grouping columns: b:2!null c:3!null
       ├── key: (2,3)
@@ -1543,7 +1543,7 @@ SELECT sum(DISTINCT i) FILTER (WHERE f > 0), avg(DISTINCT f) FILTER (WHERE i > 0
 ----
 project
  ├── columns: sum:9 avg:11
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null sum:9 avg:11
       ├── grouping columns: k:1!null
       ├── key: (1)
@@ -1581,7 +1581,7 @@ GROUP BY v
 ----
 project
  ├── columns: sum:9 stddev:11 avg:13
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2!null sum:9 stddev:11 avg:13
       ├── grouping columns: v:2!null
       ├── key: (2)
@@ -2709,7 +2709,7 @@ scalar-group-by
 norm expect=PushAggDistinctIntoGroupBy
 SELECT b, count(DISTINCT y) FROM xyzbs GROUP BY b
 ----
-group-by
+group-by (hash)
  ├── columns: b:4!null count:8!null
  ├── grouping columns: b:4!null
  ├── cardinality: [0 - 2]
@@ -2729,7 +2729,7 @@ group-by
 norm expect=PushAggDistinctIntoGroupBy
 SELECT b, s, count(DISTINCT y) FROM xyzbs GROUP BY b, s
 ----
-group-by
+group-by (hash)
  ├── columns: b:4!null s:5 count:8!null
  ├── grouping columns: b:4!null s:5
  ├── key: (4,5)
@@ -2748,7 +2748,7 @@ group-by
 norm expect=PushAggDistinctIntoGroupBy
 SELECT s, corr(DISTINCT y, z) FROM xyzbs GROUP BY s
 ----
-group-by
+group-by (hash)
  ├── columns: s:5 corr:8
  ├── grouping columns: s:5
  ├── key: (5)
@@ -2772,7 +2772,7 @@ SELECT array_agg(DISTINCT s) FROM (SELECT * FROM a ORDER BY i) GROUP BY f
 ----
 project
  ├── columns: array_agg:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: f:3 array_agg:8!null
       ├── grouping columns: f:3
       ├── internal-ordering: +2 opt(3)
@@ -3180,7 +3180,7 @@ SELECT count(z) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: count:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 count:8!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3195,7 +3195,7 @@ SELECT count(1) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: count:9!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 count:9!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3210,7 +3210,7 @@ SELECT count(1+z) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: count:9!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 count:9!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3265,7 +3265,7 @@ SELECT count(DISTINCT y) FROM xyzbs GROUP BY z
 ----
 project
  ├── columns: count:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: z:3!null count:8!null
       ├── grouping columns: z:3!null
       ├── key: (3)
@@ -3327,7 +3327,7 @@ SELECT regr_count(z, x) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: regr_count:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 regr_count:8!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3342,7 +3342,7 @@ SELECT regr_count(1, 1) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: regr_count:9!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 regr_count:9!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3357,7 +3357,7 @@ SELECT regr_count(1+z, x) FROM xyzbs GROUP BY s
 ----
 project
  ├── columns: regr_count:9!null
- └── group-by
+ └── group-by (hash)
       ├── columns: s:5 regr_count:9!null
       ├── grouping columns: s:5
       ├── key: (5)
@@ -3558,7 +3558,7 @@ SELECT sum(s) FROM (SELECT y, sum(x) AS s FROM xy GROUP BY x) GROUP BY y
 ----
 project
  ├── columns: sum:6!null
- └── group-by
+ └── group-by (hash)
       ├── columns: y:2 sum:6!null
       ├── grouping columns: y:2
       ├── key: (2)
@@ -3577,7 +3577,7 @@ SELECT sum(s) FROM (SELECT a, sum(c) AS s FROM abc GROUP BY a, b) GROUP BY a
 ----
 project
  ├── columns: sum:7!null
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1!null sum:7!null
       ├── grouping columns: a:1!null
       ├── key: (1)
@@ -3629,7 +3629,7 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(6)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: y:2 avg:5!null
  │    ├── grouping columns: y:2
  │    ├── key: (2)
@@ -3654,7 +3654,7 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(7-9)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: y:2 sum:5!null count:6!null
  │    ├── grouping columns: y:2
  │    ├── key: (2)
@@ -3683,12 +3683,12 @@ SELECT max(m) FROM (SELECT max(x) AS m, sum(x) AS s FROM xy GROUP BY y) GROUP BY
 ----
 project
  ├── columns: max:7!null
- └── group-by
+ └── group-by (hash)
       ├── columns: sum:6!null max:7!null
       ├── grouping columns: sum:6!null
       ├── key: (6)
       ├── fd: (6)-->(7)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: y:2 max:5!null sum:6!null
       │    ├── grouping columns: y:2
       │    ├── key: (2)
@@ -3716,7 +3716,7 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(10)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: u:1!null sum:8!null
  │    ├── grouping columns: u:1!null
  │    ├── internal-ordering: -3 opt(1)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1019,7 +1019,7 @@ SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 project
  ├── columns: exists:13!null
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: true_agg:15 rownum:17!null
  │    ├── grouping columns: rownum:17!null
  │    ├── immutable

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1442,7 +1442,7 @@ project
  │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true_agg:48
  │    │    ├── key: (12-15)
  │    │    ├── fd: (12-15)-->(21,48)
- │    │    ├── group-by
+ │    │    ├── group-by (hash)
  │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true_agg:48
  │    │    │    ├── grouping columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null
  │    │    │    ├── key: (12-15)
@@ -2181,7 +2181,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2-5)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null i:2 f:3!null s:4 j:5 sum:9
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -2633,7 +2633,7 @@ values
 norm expect=EliminateJoinNoColsRight
 SELECT * FROM xy WHERE EXISTS(SELECT generate_series(x, 10))
 ----
-group-by
+group-by (hash)
  ├── columns: x:1!null y:2
  ├── grouping columns: x:1!null
  ├── immutable

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -112,7 +112,7 @@ offset
 norm
 SELECT array_agg(b), a, c FROM abcde GROUP BY b, a, c ORDER BY a, b, c
 ----
-group-by
+group-by (streaming)
  ├── columns: array_agg:8 a:1!null c:3
  ├── grouping columns: a:1!null
  ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -470,7 +470,7 @@ project
  │    ├── immutable
  │    ├── key: (1)
  │    ├── fd: ()-->(7), (1)-->(3)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null f:3 sum:7!null
  │    │    ├── grouping columns: k:1!null
  │    │    ├── key: (1)
@@ -1357,7 +1357,7 @@ distinct-on
 norm expect=PruneAggCols
 SELECT s, sumi FROM (SELECT sum(i) sumi, s, min(s||'foo') FROM a GROUP BY s) a
 ----
-group-by
+group-by (hash)
  ├── columns: s:4 sumi:7
  ├── grouping columns: s:4
  ├── key: (4)
@@ -1480,7 +1480,7 @@ scalar-group-by
 norm expect=PruneGroupByCols
 SELECT s, sum(i) FROM a GROUP BY s, s||'foo'
 ----
-group-by
+group-by (hash)
  ├── columns: s:4 sum:7
  ├── grouping columns: s:4
  ├── key: (4)
@@ -1495,7 +1495,7 @@ group-by
 norm expect=PruneGroupByCols
 SELECT avg(s::int+i), s, i FROM a GROUP BY s, i, i+1
 ----
-group-by
+group-by (hash)
  ├── columns: avg:8 s:4 i:2
  ├── grouping columns: i:2 s:4
  ├── immutable
@@ -1533,12 +1533,12 @@ project
 norm expect=PruneGroupByCols
 SELECT min(sm), i FROM (SELECT s, i, sum(k) sm, avg(k) av FROM a GROUP BY i, s) a GROUP BY i, i+1
 ----
-group-by
+group-by (hash)
  ├── columns: min:9!null i:2
  ├── grouping columns: i:2
  ├── key: (2)
  ├── fd: (2)-->(9)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: i:2 s:4 sum:7!null
  │    ├── grouping columns: i:2 s:4
  │    ├── key: (2,4)
@@ -1684,7 +1684,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(8)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null sum:8
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -221,7 +221,7 @@ project
       ├── columns: k:1!null max:11!null
       ├── key: (1)
       ├── fd: ()-->(11)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null max:11!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -260,7 +260,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(11), (1)-->(12)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null sum:11!null max:12!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -333,7 +333,7 @@ project
       ├── columns: k:1!null min:11!null max:12!null
       ├── key: (1)
       ├── fd: ()-->(11), (1)-->(12)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null min:11!null max:12!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -372,7 +372,7 @@ project
       ├── columns: k:1!null sum:11!null max:12!null
       ├── key: (1)
       ├── fd: ()-->(12), (1)-->(11)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null sum:11!null max:12!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -471,7 +471,7 @@ project
       ├── columns: k:1!null min:11!null max:12
       ├── key: (1)
       ├── fd: ()-->(11), (1)-->(12)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null min:11 max:12
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -513,7 +513,7 @@ project
       ├── columns: k:1!null count:11!null
       ├── key: (1)
       ├── fd: ()-->(11)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null count:11!null
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
@@ -552,7 +552,7 @@ project
  │    ├── project
  │    │    ├── columns: exists:22!null
  │    │    ├── outer: (4)
- │    │    ├── group-by
+ │    │    ├── group-by (hash)
  │    │    │    ├── columns: ref_1.k:7!null true_agg:21
  │    │    │    ├── grouping columns: ref_1.k:7!null
  │    │    │    ├── outer: (4)
@@ -605,7 +605,7 @@ project
       ├── columns: k:5!null string_agg:12!null
       ├── key: (5)
       ├── fd: ()-->(12)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:5!null string_agg:12!null
       │    ├── grouping columns: k:5!null
       │    ├── key: (5)
@@ -656,7 +656,7 @@ project
       ├── immutable
       ├── key: (5)
       ├── fd: ()-->(13)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:5 string_agg:13
       │    ├── grouping columns: k:5
       │    ├── immutable

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1562,7 +1562,7 @@ SELECT ARRAY(SELECT k FROM a WHERE a.k = b.k) FROM a AS b
 ----
 project
  ├── columns: array:16
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b.k:1!null a.k:8!null array_agg:17!null
  │    ├── grouping columns: b.k:1!null
  │    ├── key: (8)
@@ -1594,7 +1594,7 @@ SELECT ARRAY(SELECT k FROM a WHERE a.i = b.i ORDER BY a.k) FROM a AS b
 ----
 project
  ├── columns: array:16
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b.k:1!null a.k:8 array_agg:17
  │    ├── grouping columns: b.k:1!null
  │    ├── internal-ordering: +8 opt(9)
@@ -1633,7 +1633,7 @@ SELECT ARRAY(SELECT generate_series(1, a.k) ORDER BY 1 DESC) FROM a
 project
  ├── columns: array:10
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null canary:11 array_agg:12
  │    ├── grouping columns: k:1!null
  │    ├── internal-ordering: -8
@@ -1682,7 +1682,7 @@ SELECT ARRAY(SELECT ARRAY(SELECT k FROM a)[1] FROM a as b WHERE b.k = c.k) FROM 
 ----
 project
  ├── columns: array:24
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: c.k:1!null canary:25!null array_agg:26
  │    ├── grouping columns: c.k:1!null
  │    ├── key: (1)
@@ -1726,7 +1726,7 @@ SELECT ARRAY(SELECT ARRAY(SELECT k FROM a WHERE a.k = b.k)[1] FROM a as b WHERE 
 ----
 project
  ├── columns: array:26
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: c.k:1!null canary:27 array_agg:28
  │    ├── grouping columns: c.k:1!null
  │    ├── key: (1)
@@ -1744,7 +1744,7 @@ project
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(23,27)
- │    │    │    ├── group-by
+ │    │    │    ├── group-by (streaming)
  │    │    │    │    ├── columns: a.k:15!null array_agg:24!null
  │    │    │    │    ├── outer: (1)
  │    │    │    │    ├── cardinality: [0 - 1]
@@ -1863,7 +1863,7 @@ project
  │    ├── columns: rel.oid:1 inhrelid:32 array_agg:71
  │    ├── scan pg_class [as=rel]
  │    │    └── columns: rel.oid:1
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: inhrelid:32 array_agg:71
  │    │    ├── internal-ordering: +34 opt(32)
  │    │    ├── outer: (1)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -703,7 +703,7 @@ project
  │    ├── columns: i:2 f:3 sum:8!null
  │    ├── key: (2,3)
  │    ├── fd: ()-->(8)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: i:2 f:3 sum:8
  │    │    ├── grouping columns: i:2 f:3
  │    │    ├── key: (2,3)
@@ -1266,7 +1266,7 @@ inner-join (hash)
 norm expect=PushSelectIntoGroupBy
 SELECT * FROM (SELECT i, count(*) FROM a GROUP BY i) a WHERE i=1
 ----
-group-by
+group-by (streaming)
  ├── columns: i:2!null count:8!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1311,7 +1311,7 @@ select
  ├── columns: k:1!null i:2!null m:8!null
  ├── key: (1)
  ├── fd: ()-->(8), (1)==(2), (2)==(1), (1)-->(2)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null i:2!null max:8
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -41,7 +41,7 @@ SELECT avg(f) FROM a WHERE i=5 GROUP BY i+(random()*10)::int, i+1
 project
  ├── columns: avg:8
  ├── volatile
- └── group-by
+ └── group-by (hash)
       ├── columns: avg:8 column9:9
       ├── grouping columns: column9:9
       ├── volatile

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -192,7 +192,7 @@ SELECT 1 r FROM kv GROUP BY v
 ----
 project
  ├── columns: r:7!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: v:2
  │    ├── grouping columns: v:2
  │    └── project
@@ -287,7 +287,7 @@ error (22023): unsupported comparison operator: <string> < <int>
 build
 SELECT count(*), k FROM kv GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null k:1!null
  ├── grouping columns: k:1!null
  ├── project
@@ -301,7 +301,7 @@ group-by
 build
 SELECT count(*), k FROM kv GROUP BY 2
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null k:1!null
  ├── grouping columns: k:1!null
  ├── project
@@ -355,7 +355,7 @@ error (42601): non-integer constant in GROUP BY: 'a'
 build
 SELECT count(*), kv.s FROM kv GROUP BY s
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null s:4
  ├── grouping columns: s:4
  ├── project
@@ -368,7 +368,7 @@ group-by
 build
 SELECT count(*), s FROM kv GROUP BY kv.s
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null s:4
  ├── grouping columns: s:4
  ├── project
@@ -381,7 +381,7 @@ group-by
 build
 SELECT count(*), kv.s FROM kv GROUP BY kv.s
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null s:4
  ├── grouping columns: s:4
  ├── project
@@ -394,7 +394,7 @@ group-by
 build
 SELECT count(*), s FROM kv GROUP BY s
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null s:4
  ├── grouping columns: s:4
  ├── project
@@ -408,7 +408,7 @@ group-by
 build
 SELECT v, count(*), w FROM kv GROUP BY v, w
 ----
-group-by
+group-by (hash)
  ├── columns: v:2 count:7!null w:3
  ├── grouping columns: v:2 w:3
  ├── project
@@ -422,7 +422,7 @@ group-by
 build
 SELECT v, count(*), w FROM kv GROUP BY 1, 3
 ----
-group-by
+group-by (hash)
  ├── columns: v:2 count:7!null w:3
  ├── grouping columns: v:2 w:3
  ├── project
@@ -436,7 +436,7 @@ group-by
 build
 SELECT count(*), upper(s) FROM kv GROUP BY upper(s)
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null upper:8
  ├── grouping columns: column8:8
  ├── project
@@ -454,7 +454,7 @@ SELECT count(*) FROM kv GROUP BY 1+2
 ----
 project
  ├── columns: count:7!null
- └── group-by
+ └── group-by (hash)
       ├── columns: count_rows:7!null column8:8!null
       ├── grouping columns: column8:8!null
       ├── project
@@ -471,7 +471,7 @@ SELECT count(*) FROM kv GROUP BY length('abc')
 ----
 project
  ├── columns: count:7!null
- └── group-by
+ └── group-by (hash)
       ├── columns: count_rows:7!null column8:8
       ├── grouping columns: column8:8
       ├── project
@@ -489,7 +489,7 @@ SELECT count(*), upper(s) FROM kv GROUP BY s
 ----
 project
  ├── columns: count:7!null upper:8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: s:4 count_rows:7!null
  │    ├── grouping columns: s:4
  │    ├── project
@@ -511,7 +511,7 @@ error (42803): column "s" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT count(*), k+v AS r FROM kv GROUP BY k+v
 ----
-group-by
+group-by (hash)
  ├── columns: count:7!null r:8
  ├── grouping columns: column8:8
  ├── project
@@ -530,7 +530,7 @@ SELECT count(*), k+v AS r FROM kv GROUP BY k, v
 ----
 project
  ├── columns: count:7!null r:8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null v:2 count_rows:7!null
  │    ├── grouping columns: k:1!null v:2
  │    ├── project
@@ -566,7 +566,7 @@ error (42803): max(): avg(): aggregate function calls cannot be nested
 build
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM kv GROUP BY kv.v + kv.w
 ----
-group-by
+group-by (hash)
  ├── columns: count_1:7!null lx:8
  ├── grouping columns: column8:8
  ├── project
@@ -643,7 +643,7 @@ SELECT v, count(k) FROM kv GROUP BY v ORDER BY v
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: +2
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:7!null
       ├── grouping columns: v:2
       ├── project
@@ -660,7 +660,7 @@ SELECT v, count(k) FROM kv GROUP BY v ORDER BY v DESC
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: -2
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:7!null
       ├── grouping columns: v:2
       ├── project
@@ -677,7 +677,7 @@ SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k) DESC
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: -7
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:7!null
       ├── grouping columns: v:2
       ├── project
@@ -696,7 +696,7 @@ sort
  ├── ordering: +8
  └── project
       ├── columns: column8:8 v:2 count:7!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: v:2 count:7!null
       │    ├── grouping columns: v:2
       │    ├── project
@@ -715,7 +715,7 @@ SELECT v FROM kv GROUP BY v ORDER BY sum(k)
 sort
  ├── columns: v:2  [hidden: sum:7!null]
  ├── ordering: +7
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 sum:7!null
       ├── grouping columns: v:2
       ├── project
@@ -732,7 +732,7 @@ SELECT v, count(k) FROM kv GROUP BY v ORDER BY 1 DESC
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: -2
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:7!null
       ├── grouping columns: v:2
       ├── project
@@ -794,7 +794,7 @@ scalar-group-by
 build
 SELECT upper(s), count(DISTINCT k), count(DISTINCT v), count(DISTINCT (v)) FROM kv GROUP BY upper(s)
 ----
-group-by
+group-by (hash)
  ├── columns: upper:9 count:7!null count:8!null count:8!null
  ├── grouping columns: column9:9
  ├── project
@@ -1703,7 +1703,7 @@ SELECT 1 r FROM kv GROUP BY kv.*;
 ----
 project
  ├── columns: r:7!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null v:2 w:3 s:4
  │    ├── grouping columns: k:1!null v:2 w:3 s:4
  │    └── project
@@ -1744,7 +1744,7 @@ sort
  ├── ordering: +2
  └── project
       ├── columns: to_hex:9 b:2 xor_agg:8
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: b:2 xor_agg:7 xor_agg:8
       │    ├── grouping columns: b:2
       │    ├── project
@@ -1858,7 +1858,7 @@ SELECT (b, a) AS r FROM ab GROUP BY (b, a)
 ----
 project
  ├── columns: r:5
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: a:1!null b:2
  │    ├── grouping columns: a:1!null b:2
  │    └── project
@@ -1874,7 +1874,7 @@ SELECT min(y), (b, a) AS r
 ----
 project
  ├── columns: min:10 r:11
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: a:1!null b:2 x:5 min:10
  │    ├── grouping columns: a:1!null b:2 x:5
  │    ├── project
@@ -1898,7 +1898,7 @@ SELECT v, count(k) FROM kv GROUP BY v ORDER BY count(k)
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: +7
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:7!null
       ├── grouping columns: v:2
       ├── project
@@ -1915,7 +1915,7 @@ SELECT v, count(*) FROM kv GROUP BY v ORDER BY count(*)
 sort
  ├── columns: v:2 count:7!null
  ├── ordering: +7
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count_rows:7!null
       ├── grouping columns: v:2
       ├── project
@@ -1931,7 +1931,7 @@ SELECT v, count(1) FROM kv GROUP BY v ORDER BY count(1)
 sort
  ├── columns: v:2 count:8!null
  ├── ordering: +8
- └── group-by
+ └── group-by (hash)
       ├── columns: v:2 count:8!null
       ├── grouping columns: v:2
       ├── project
@@ -1949,7 +1949,7 @@ SELECT (k+v)/(v+w) AS r FROM kv GROUP BY k+v, v+w;
 ----
 project
  ├── columns: r:9
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: column7:7 column8:8
  │    ├── grouping columns: column7:7 column8:8
  │    └── project
@@ -1968,7 +1968,7 @@ SELECT sum(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 ----
 project
  ├── columns: sum:7 v:2
- └── group-by
+ └── group-by (hash)
       ├── columns: t.public.kv.v:2 sum:7 column8:8
       ├── grouping columns: t.public.kv.v:2 column8:8
       ├── project
@@ -1986,7 +1986,7 @@ SELECT sum(t.kv.w), lower(s), t.kv.v + k * t.kv.w AS r, t.kv.v FROM t.kv GROUP B
 ----
 project
  ├── columns: sum:7 lower:8 r:10 v:2
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: t.public.kv.v:2 sum:7 column8:8 column9:9
  │    ├── grouping columns: t.public.kv.v:2 column8:8 column9:9
  │    ├── project
@@ -2008,7 +2008,7 @@ SELECT b1.b AND abc.c AND b2.b AS r FROM bools b1, bools b2, abc GROUP BY b1.b A
 ----
 project
  ├── columns: r:16
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b2.b:5 column15:15
  │    ├── grouping columns: b2.b:5 column15:15
  │    └── project
@@ -2040,7 +2040,7 @@ SELECT b1.b OR abc.c OR b2.b AS r FROM bools b1, bools b2, abc GROUP BY b1.b OR 
 ----
 project
  ├── columns: r:16
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b2.b:5 column15:15
  │    ├── grouping columns: b2.b:5 column15:15
  │    └── project
@@ -2072,7 +2072,7 @@ SELECT k % w % v AS r FROM kv GROUP BY k % w, v
 ----
 project
  ├── columns: r:8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: v:2 column7:7
  │    ├── grouping columns: v:2 column7:7
  │    └── project
@@ -2089,7 +2089,7 @@ SELECT concat(concat(s, a), a) FROM kv, abc GROUP BY concat(s, a), a
 ----
 project
  ├── columns: concat:14
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: a:7!null column13:13
  │    ├── grouping columns: a:7!null column13:13
  │    └── project
@@ -2116,7 +2116,7 @@ SELECT k < w AND v != 5 AS r FROM kv GROUP BY k < w, v
 ----
 project
  ├── columns: r:8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: v:2 column7:7
  │    ├── grouping columns: v:2 column7:7
  │    └── project
@@ -2142,7 +2142,7 @@ SELECT a.bar @> b.baz AND b.baz @> b.baz AS r FROM foo AS a, foo AS b GROUP BY a
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b.baz:7 column11:11
  │    ├── grouping columns: b.baz:7 column11:11
  │    └── project
@@ -2169,7 +2169,7 @@ SELECT b.baz <@ a.bar AND b.baz <@ b.baz AS r FROM foo AS a, foo AS b GROUP BY b
 ----
 project
  ├── columns: r:12
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b.baz:7 column11:11
  │    ├── grouping columns: b.baz:7 column11:11
  │    └── project
@@ -2196,7 +2196,7 @@ SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) AS r FROM times a, 
 ----
 project
  ├── columns: r:9
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: column7:7 column8:8
  │    ├── grouping columns: column7:7 column8:8
  │    └── project
@@ -2223,7 +2223,7 @@ error (42803): column "t" must appear in the GROUP BY clause or be used in an ag
 build
 SELECT NOT b AS r FROM bools GROUP BY NOT b
 ----
-group-by
+group-by (hash)
  ├── columns: r:5
  ├── grouping columns: column5:5
  └── project
@@ -2243,7 +2243,7 @@ SELECT NOT b AS r FROM bools GROUP BY b
 ----
 project
  ├── columns: r:5
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: b:1
  │    ├── grouping columns: b:1
  │    └── project
@@ -2258,7 +2258,7 @@ SELECT +k * (-w) AS r FROM kv GROUP BY +k, -w
 ----
 project
  ├── columns: r:8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null column7:7
  │    ├── grouping columns: k:1!null column7:7
  │    └── project
@@ -2275,7 +2275,7 @@ SELECT k * (-w) FROM kv GROUP BY +k, -w
 ----
 project
  ├── columns: "?column?":8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null column7:7
  │    ├── grouping columns: k:1!null column7:7
  │    └── project
@@ -2292,7 +2292,7 @@ SELECT +k * (-w) AS r FROM kv GROUP BY k, w
 ----
 project
  ├── columns: r:7
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null w:3
  │    ├── grouping columns: k:1!null w:3
  │    └── project
@@ -2307,7 +2307,7 @@ SELECT 1 + min(v*2) AS r FROM kv GROUP BY k+3
 ----
 project
  ├── columns: r:10
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: min:8 column9:9!null
  │    ├── grouping columns: column9:9!null
  │    ├── project
@@ -2328,7 +2328,7 @@ SELECT count(*) FROM kv GROUP BY k, k
 ----
 project
  ├── columns: count:7!null
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null count_rows:7!null
       ├── grouping columns: k:1!null
       ├── project
@@ -2343,7 +2343,7 @@ SELECT count(upper(s)) FROM kv GROUP BY upper(s)
 ----
 project
  ├── columns: count:8!null
- └── group-by
+ └── group-by (hash)
       ├── columns: column7:7 count:8!null
       ├── grouping columns: column7:7
       ├── project
@@ -2361,7 +2361,7 @@ SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
 ----
 project
  ├── columns: sum:13!null
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null v:2 w:3 s:4 sum:13!null
       ├── grouping columns: k:1!null v:2 w:3 s:4
       ├── project
@@ -2493,7 +2493,7 @@ scalar-group-by
 build
 SELECT y, count(*) FILTER (WHERE x > 5) FROM xyz GROUP BY y
 ----
-group-by
+group-by (hash)
  ├── columns: y:2 count:8!null
  ├── grouping columns: y:2
  ├── project
@@ -2524,7 +2524,7 @@ sort
  ├── ordering: +7
  └── project
       ├── columns: max:7!null
-      └── group-by
+      └── group-by (hash)
            ├── columns: v:2 max:7!null
            ├── grouping columns: v:2
            ├── project
@@ -2543,7 +2543,7 @@ sort
  ├── ordering: +7
  └── project
       ├── columns: max:7!null
-      └── group-by
+      └── group-by (hash)
            ├── columns: v:2 max:7!null
            ├── grouping columns: v:2
            ├── project
@@ -2562,7 +2562,7 @@ sort
  ├── ordering: +7
  └── project
       ├── columns: max:7!null
-      └── group-by
+      └── group-by (hash)
            ├── columns: v:2 max:7!null
            ├── grouping columns: v:2
            ├── project
@@ -2581,7 +2581,7 @@ sort
  ├── ordering: +7
  └── project
       ├── columns: max:7!null
-      └── group-by
+      └── group-by (hash)
            ├── columns: v:2 max:7!null
            ├── grouping columns: v:2
            ├── project
@@ -2600,7 +2600,7 @@ sort
  ├── ordering: +8
  └── project
       ├── columns: mk2:8!null max:7!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: v:2 max:7!null
       │    ├── grouping columns: v:2
       │    ├── project
@@ -2621,7 +2621,7 @@ SELECT max((k+v)/(k-v)) AS r, (k+v)*(k-v) AS s FROM kv GROUP BY k+v, k-v
 ----
 project
  ├── columns: r:8 s:11
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: max:8 column9:9 column10:10
  │    ├── grouping columns: column9:9 column10:10
  │    ├── project
@@ -2643,7 +2643,7 @@ SELECT max((k+v)/(k-v)) AS r, (k+v)*(k-v) AS s FROM kv GROUP BY k+v, (k+v)/(k-v)
 ----
 project
  ├── columns: r:8 s:10
- └── group-by
+ └── group-by (hash)
       ├── columns: column7:7 max:8 column9:9 column10:10
       ├── grouping columns: column7:7 column9:9 column10:10
       ├── project
@@ -3659,7 +3659,7 @@ FROM
 GROUP BY
 firstCol, secondCol, thirdCol;
 ----
-group-by
+group-by (hash)
  ├── columns: firstcol:1(int!null) secondcol:2(int) thirdcol:2(int)
  ├── grouping columns: t.public.xyz.x:1(int!null) t.public.xyz.y:2(int)
  ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0]
@@ -3794,7 +3794,7 @@ SELECT array_agg(col1 ORDER BY col1) FROM tab GROUP BY col2
 ----
 project
  ├── columns: array_agg:7
- └── group-by
+ └── group-by (hash)
       ├── columns: col2:2!null array_agg:7
       ├── grouping columns: col2:2!null
       ├── window partition=(2) ordering=+1
@@ -3813,7 +3813,7 @@ SELECT array_agg(col1 ORDER BY col1), array_agg(col3 ORDER BY col1) FROM tab GRO
 ----
 project
  ├── columns: array_agg:7 array_agg:8
- └── group-by
+ └── group-by (hash)
       ├── columns: col2:2!null array_agg:7 array_agg:8
       ├── grouping columns: col2:2!null
       ├── window partition=(2) ordering=+1
@@ -3838,7 +3838,7 @@ project
  ├── columns: array_agg:7 array_agg:8
  └── select
       ├── columns: col2:2!null array_agg:7 array_agg:8
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: col2:2!null array_agg:7 array_agg:8
       │    ├── grouping columns: col2:2!null
       │    ├── window partition=(2) ordering=+1
@@ -3900,7 +3900,7 @@ SELECT array_agg(col1 ORDER BY col1) FROM tab GROUP BY upper(col3)
 ----
 project
  ├── columns: array_agg:7
- └── group-by
+ └── group-by (hash)
       ├── columns: array_agg:7 column8:8
       ├── grouping columns: column8:8
       ├── window partition=(8) ordering=+1
@@ -3921,7 +3921,7 @@ project
 build
 SELECT array_agg(col1 ORDER BY col1), upper(col3) FROM tab GROUP BY upper(col3)
 ----
-group-by
+group-by (hash)
  ├── columns: array_agg:7 upper:8
  ├── grouping columns: column8:8
  ├── window partition=(8) ordering=+1
@@ -3944,7 +3944,7 @@ SELECT array_agg(lower(col3)) FROM tab GROUP BY upper(col3)
 ----
 project
  ├── columns: array_agg:8
- └── group-by
+ └── group-by (hash)
       ├── columns: array_agg:8 column9:9
       ├── grouping columns: column9:9
       ├── project
@@ -4031,7 +4031,7 @@ SELECT v FROM kv GROUP BY k
 ----
 project
  ├── columns: v:2
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null v:2
       ├── grouping columns: k:1!null v:2
       └── project
@@ -4045,7 +4045,7 @@ SELECT v FROM kv GROUP BY k, v
 ----
 project
  ├── columns: v:2
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1!null v:2
       ├── grouping columns: k:1!null v:2
       └── project
@@ -4058,7 +4058,7 @@ SELECT count(*), k+v FROM kv GROUP BY k
 ----
 project
  ├── columns: count:7!null "?column?":8
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: k:1!null v:2 count_rows:7!null
  │    ├── grouping columns: k:1!null v:2
  │    ├── project
@@ -4077,7 +4077,7 @@ project
  ├── columns: count:7!null
  └── select
       ├── columns: k:1!null v:2!null count_rows:7!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: k:1!null v:2 count_rows:7!null
       │    ├── grouping columns: k:1!null v:2
       │    ├── project
@@ -4092,7 +4092,7 @@ project
 build
 SELECT k, v, count(*) FROM kv JOIN ab ON a=k GROUP BY k
 ----
-group-by
+group-by (hash)
  ├── columns: k:1!null v:2 count:11!null
  ├── grouping columns: k:1!null v:2
  ├── project
@@ -4119,7 +4119,7 @@ SELECT x, y FROM abxy GROUP BY a, b
 ----
 project
  ├── columns: x:3 y:4
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1!null b:2!null x:3 y:4
       ├── grouping columns: a:1!null b:2!null x:3 y:4
       └── project
@@ -4133,7 +4133,7 @@ SELECT x, y FROM abxy GROUP BY x, a, b
 ----
 project
  ├── columns: x:3 y:4
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1!null b:2!null x:3 y:4
       ├── grouping columns: a:1!null b:2!null x:3 y:4
       └── project
@@ -4146,7 +4146,7 @@ SELECT x, y FROM abxy GROUP BY x, y, a, b
 ----
 project
  ├── columns: x:3 y:4
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1!null b:2!null x:3 y:4
       ├── grouping columns: a:1!null b:2!null x:3 y:4
       └── project
@@ -4159,7 +4159,7 @@ SELECT x, y FROM abxy NATURAL JOIN ab GROUP BY a, b
 ----
 project
  ├── columns: x:3 y:4
- └── group-by
+ └── group-by (hash)
       ├── columns: abxy.a:1!null abxy.b:2!null x:3 y:4
       ├── grouping columns: abxy.a:1!null abxy.b:2!null x:3 y:4
       └── project
@@ -4180,7 +4180,7 @@ SELECT x, y FROM abxy NATURAL JOIN ab GROUP BY a, b, x
 ----
 project
  ├── columns: x:3 y:4
- └── group-by
+ └── group-by (hash)
       ├── columns: abxy.a:1!null abxy.b:2!null x:3 y:4
       ├── grouping columns: abxy.a:1!null abxy.b:2!null x:3 y:4
       └── project
@@ -4198,7 +4198,7 @@ project
 build
 SELECT abxy.*, ab.* FROM abxy, ab GROUP BY abxy.a, abxy.b, ab.a
 ----
-group-by
+group-by (hash)
  ├── columns: a:1!null b:2!null x:3 y:4 a:7!null b:8
  ├── grouping columns: abxy.a:1!null abxy.b:2!null x:3 y:4 ab.a:7!null ab.b:8
  └── project
@@ -4223,7 +4223,7 @@ SELECT x FROM (SELECT a, b, x FROM abxy EXCEPT SELECT a, b, 1 FROM ab) GROUP BY 
 ----
 project
  ├── columns: x:3
- └── group-by
+ └── group-by (hash)
       ├── columns: abxy.a:1!null abxy.b:2 x:3
       ├── grouping columns: abxy.a:1!null abxy.b:2 x:3
       └── except
@@ -4249,7 +4249,7 @@ SELECT v, w FROM kv FULL JOIN ab ON k=a GROUP BY k
 ----
 project
  ├── columns: v:2 w:3
- └── group-by
+ └── group-by (hash)
       ├── columns: k:1 v:2 w:3
       ├── grouping columns: k:1 v:2 w:3
       └── project
@@ -4273,7 +4273,7 @@ error (42803): column "table_schema" must appear in the GROUP BY clause or be us
 build
 SELECT x + 1 AS z FROM abxy GROUP BY z
 ----
-group-by
+group-by (hash)
  ├── columns: z:7
  ├── grouping columns: z:7
  └── project
@@ -4289,7 +4289,7 @@ SELECT (x % 10) AS x FROM abxy GROUP BY x
 ----
 project
  ├── columns: x:7
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: abxy.x:3
  │    ├── grouping columns: abxy.x:3
  │    └── project
@@ -4312,7 +4312,7 @@ project
       └── subquery [as=x:13]
            └── max1-row
                 ├── columns: v:8
-                └── group-by
+                └── group-by (hash)
                      ├── columns: v:8
                      ├── grouping columns: v:8
                      └── project
@@ -4329,7 +4329,7 @@ error (42803): sum(): aggregate functions are not allowed in GROUP BY
 build
 SELECT x + 1 FROM abxy GROUP BY "?column?"
 ----
-group-by
+group-by (hash)
  ├── columns: "?column?":7
  ├── grouping columns: "?column?":7
  └── project
@@ -4361,7 +4361,7 @@ error (42702): GROUP BY "x" is ambiguous
 build
 SELECT (x + 1) AS u, (x + 1) AS u FROM abxy GROUP BY u
 ----
-group-by
+group-by (hash)
  ├── columns: u:7 u:7
  ├── grouping columns: u:7
  └── project
@@ -4382,7 +4382,7 @@ SELECT sum(x + 1) AS x, sum(y + 1) AS x FROM abxy GROUP BY x
 ----
 project
  ├── columns: x:8 x:10
- └── group-by
+ └── group-by (hash)
       ├── columns: x:3 sum:8 sum:10
       ├── grouping columns: x:3
       ├── project
@@ -4420,7 +4420,7 @@ project
  ├── columns: sum:7
  └── select
       ├── columns: t.y:4 sum:7
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: t.y:4 sum:7
       │    ├── grouping columns: t.y:4
       │    ├── project
@@ -4475,7 +4475,7 @@ GROUP BY ten
 ----
 select
  ├── columns: ten:5 sum:20
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: a.ten:5 sum:20
  │    ├── grouping columns: a.ten:5
  │    ├── project
@@ -4698,7 +4698,7 @@ project
  ├── columns: c0:1(int)
  └── select
       ├── columns: c0:1(int) min:6(float!null)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: c0:1(int) min:6(float)
       │    ├── grouping columns: c0:1(int)
       │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -215,7 +215,7 @@ distinct-on
  ├── grouping columns: max:6!null
  └── project
       ├── columns: max:6!null
-      └── group-by
+      └── group-by (hash)
            ├── columns: x:1!null max:6!null
            ├── grouping columns: x:1!null
            ├── project
@@ -275,7 +275,7 @@ distinct-on
       ├── columns: r:7!null s:8!null max:6
       ├── select
       │    ├── columns: x:1!null y:2!null max:6
-      │    ├── group-by
+      │    ├── group-by (hash)
       │    │    ├── columns: x:1!null y:2 max:6
       │    │    ├── grouping columns: x:1!null y:2
       │    │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -278,7 +278,7 @@ SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 distinct-on
  ├── columns: min:8  [hidden: y:2]
  ├── grouping columns: y:2
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: y:2 min:8
  │    ├── grouping columns: y:2
  │    ├── project
@@ -302,7 +302,7 @@ distinct-on
       ├── columns: min:8!null
       └── select
            ├── columns: y:2 min:8!null
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: y:2 min:8
            │    ├── grouping columns: y:2
            │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -30,7 +30,7 @@ SELECT s, count(*) FROM kv GROUP BY s HAVING count(*) > 1
 ----
 select
  ├── columns: s:4 count:7!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: s:4 count_rows:7!null
  │    ├── grouping columns: s:4
  │    ├── project
@@ -108,7 +108,7 @@ project
  ├── columns: "?column?":7!null
  ├── select
  │    ├── columns: k:1!null v:2!null
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: k:1!null v:2
  │    │    ├── grouping columns: k:1!null v:2
  │    │    └── project
@@ -130,7 +130,7 @@ SELECT count(*), k+w AS r FROM kv GROUP BY k+w HAVING (k+w) > 5
 ----
 select
  ├── columns: count:7!null r:8!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: count_rows:7!null column8:8
  │    ├── grouping columns: column8:8
  │    ├── project
@@ -157,7 +157,7 @@ project
  ├── columns: max:7
  └── select
       ├── columns: v:2!null max:7
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: v:2 max:7
       │    ├── grouping columns: v:2
       │    ├── project
@@ -177,7 +177,7 @@ project
  ├── columns: sum:7
  └── select
       ├── columns: sum:7 column8:8!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: sum:7 column8:8
       │    ├── grouping columns: column8:8
       │    ├── project
@@ -199,7 +199,7 @@ project
  ├── columns: sum:7!null
  └── select
       ├── columns: sum:7!null column8:8
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: sum:7 column8:8
       │    ├── grouping columns: column8:8
       │    ├── project
@@ -221,7 +221,7 @@ project
  ├── columns: v:2
  └── select
       ├── columns: t.public.kv.v:2 column7:7!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: t.public.kv.v:2 column7:7
       │    ├── grouping columns: t.public.kv.v:2 column7:7
       │    └── project
@@ -243,7 +243,7 @@ SELECT upper(s), count(s), count(upper(s)) FROM t.kv GROUP BY upper(s) HAVING co
 ----
 select
  ├── columns: upper:8 count:7!null count:9!null
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: count:7!null column8:8 count:9!null
  │    ├── grouping columns: column8:8
  │    ├── project
@@ -269,7 +269,7 @@ project
  ├── ordering: +7
  └── select
       ├── columns: v:2 sum:7!null
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: v:2 sum:7!null
       │    ├── grouping columns: v:2
       │    ├── project
@@ -292,7 +292,7 @@ sort
       ├── columns: sum:7!null
       └── select
            ├── columns: v:2 sum:7!null max:8!null
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: v:2 sum:7!null max:8!null
            │    ├── grouping columns: v:2
            │    ├── project
@@ -317,7 +317,7 @@ sort
       ├── columns: sum:7!null
       └── select
            ├── columns: v:2!null sum:7!null
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: v:2 sum:7!null
            │    ├── grouping columns: v:2
            │    ├── project
@@ -340,7 +340,7 @@ sort
       ├── columns: max:7!null
       └── select
            ├── columns: v:2 max:7!null
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: v:2 max:7!null
            │    ├── grouping columns: v:2
            │    ├── project
@@ -363,7 +363,7 @@ sort
       ├── columns: max:7!null
       └── select
            ├── columns: v:2 max:7!null
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: v:2 max:7!null
            │    ├── grouping columns: v:2
            │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -136,22 +136,26 @@ limit
  ├── columns: sum:6  [hidden: v:2]
  ├── internal-ordering: -2
  ├── ordering: -2
- ├── sort
+ ├── project
  │    ├── columns: v:2 sum:6
  │    ├── ordering: -2
  │    ├── limit hint: 10.00
- │    └── project
- │         ├── columns: v:2 sum:6
- │         └── group-by
- │              ├── columns: k:1!null v:2 sum:6
- │              ├── grouping columns: k:1!null v:2
- │              ├── project
- │              │    ├── columns: k:1!null v:2 w:3
- │              │    └── scan t
- │              │         └── columns: k:1!null v:2 w:3 crdb_internal_mvcc_timestamp:4 tableoid:5
- │              └── aggregations
- │                   └── sum [as=sum:6]
- │                        └── w:3
+ │    └── group-by (partial streaming)
+ │         ├── columns: k:1!null v:2 sum:6
+ │         ├── grouping columns: k:1!null v:2
+ │         ├── ordering: -2
+ │         ├── limit hint: 10.00
+ │         ├── sort
+ │         │    ├── columns: k:1!null v:2 w:3
+ │         │    ├── ordering: -2
+ │         │    ├── limit hint: 10.00
+ │         │    └── project
+ │         │         ├── columns: k:1!null v:2 w:3
+ │         │         └── scan t
+ │         │              └── columns: k:1!null v:2 w:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         └── aggregations
+ │              └── sum [as=sum:6]
+ │                   └── w:3
  └── 10
 
 build

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -70,7 +70,7 @@ sort
 build
 SELECT random(), random() FROM ab GROUP BY random()
 ----
-group-by
+group-by (hash)
  ├── columns: random:6 random:6
  ├── grouping columns: column6:6
  └── project

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1475,7 +1475,7 @@ project
                                     ├── columns: count_rows:16!null
                                     └── project
                                          ├── columns: count_rows:16!null
-                                         └── group-by
+                                         └── group-by (hash)
                                               ├── columns: count_rows:16!null a:17
                                               ├── grouping columns: a:17
                                               ├── project
@@ -1506,7 +1506,7 @@ project
                           └── subquery [as=y:17]
                                └── max1-row
                                     ├── columns: column16:16
-                                    └── group-by
+                                    └── group-by (hash)
                                          ├── columns: column16:16
                                          ├── grouping columns: column16:16
                                          └── project
@@ -1539,7 +1539,7 @@ project
                                          ├── columns: r:18!null
                                          ├── select
                                          │    ├── columns: a:16!null a:17!null
-                                         │    ├── group-by
+                                         │    ├── group-by (hash)
                                          │    │    ├── columns: a:16 a:17
                                          │    │    ├── grouping columns: a:16 a:17
                                          │    │    └── project
@@ -1569,7 +1569,7 @@ project
                      ├── columns: array:13
                      ├── select
                      │    ├── columns: t1.a:6 count_rows:11!null a:12!null
-                     │    ├── group-by
+                     │    ├── group-by (hash)
                      │    │    ├── columns: t1.a:6 count_rows:11!null a:12
                      │    │    ├── grouping columns: t1.a:6 a:12
                      │    │    ├── project
@@ -1618,7 +1618,7 @@ project
                                     ├── columns: r:21
                                     └── project
                                          ├── columns: r:21
-                                         ├── group-by
+                                         ├── group-by (hash)
                                          │    ├── columns: a:20
                                          │    ├── grouping columns: a:20
                                          │    └── project
@@ -1662,7 +1662,7 @@ project
                                     │    ├── columns: i:9 max:15
                                     │    ├── ordering: +9
                                     │    ├── limit hint: 1.00
-                                    │    └── group-by
+                                    │    └── group-by (hash)
                                     │         ├── columns: i:9 max:15
                                     │         ├── grouping columns: i:9
                                     │         ├── project
@@ -1849,7 +1849,7 @@ SELECT (SELECT row(max(t1.a), max(t2.a), max(t1.a + t2.a)) FROM t1) FROM t2 GROU
 ----
 project
  ├── columns: row:17
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: t2.a:1 max:13
  │    ├── grouping columns: t2.a:1
  │    ├── project
@@ -1936,7 +1936,7 @@ project
       │         ├── columns: max:11
       │         └── project
       │              ├── columns: max:11
-      │              └── group-by
+      │              └── group-by (hash)
       │                   ├── columns: t1.b:7 max:11
       │                   ├── grouping columns: t1.b:7
       │                   ├── project
@@ -1951,7 +1951,7 @@ project
                 ├── columns: max:19
                 └── project
                      ├── columns: max:19
-                     ├── group-by
+                     ├── group-by (hash)
                      │    ├── columns: t1.b:13
                      │    ├── grouping columns: t1.b:13
                      │    └── project
@@ -1971,7 +1971,7 @@ GROUP BY t2.b;
 ----
 project
  ├── columns: array:20 array:21
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: t2.b:2 max:18
  │    ├── grouping columns: t2.b:2
  │    ├── project
@@ -2013,7 +2013,7 @@ GROUP BY t2.a, t2.b;
 ----
 project
  ├── columns: array:30 array:31 array:32
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: t2.a:1 t2.b:2 max:19
  │    ├── grouping columns: t2.a:1 t2.b:2
  │    ├── project
@@ -2029,7 +2029,7 @@ project
       ├── array-flatten [as=array:30]
       │    └── project
       │         ├── columns: max:11
-      │         └── group-by
+      │         └── group-by (hash)
       │              ├── columns: max:11 b:12
       │              ├── grouping columns: b:12
       │              ├── project
@@ -2044,7 +2044,7 @@ project
       ├── array-flatten [as=array:31]
       │    └── project
       │         ├── columns: max:21
-      │         ├── group-by
+      │         ├── group-by (hash)
       │         │    ├── columns: b:20
       │         │    ├── grouping columns: b:20
       │         │    └── project
@@ -2058,7 +2058,7 @@ project
       └── array-flatten [as=array:32]
            └── project
                 ├── columns: max:28
-                └── group-by
+                └── group-by (hash)
                      ├── columns: max:28 b:29
                      ├── grouping columns: b:29
                      ├── project
@@ -2106,7 +2106,7 @@ project
  │    │                   ├── columns: max:23
  │    │                   └── project
  │    │                        ├── columns: max:23
- │    │                        └── group-by
+ │    │                        └── group-by (hash)
  │    │                             ├── columns: max:23 b:24
  │    │                             ├── grouping columns: b:24
  │    │                             ├── project
@@ -2186,7 +2186,7 @@ error (42803): aggregate functions are not allowed in WHERE
 build
 SELECT s FROM a WHERE (SELECT count(i) >= 100 FROM a) GROUP BY s
 ----
-group-by
+group-by (hash)
  ├── columns: s:4
  ├── grouping columns: s:4
  └── project

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -659,7 +659,7 @@ project
  ├── columns: v:2 row_number:11
  └── window partition=(10)
       ├── columns: v:2 avg:10!null row_number:11
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: v:2 avg:10!null
       │    ├── grouping columns: v:2
       │    ├── project

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -946,7 +946,7 @@ with &2 (included_parts)
  │              │    └── filters (true)
  │              └── filters
  │                   └── p.part:13 = sub_part:10
- └── group-by
+ └── group-by (hash)
       ├── columns: sub_part:19 sum:22
       ├── grouping columns: sub_part:19
       ├── project

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -200,6 +200,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"WithID":              {fullName: "opt.WithID", passByVal: true},
 		"Ordering":            {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice":      {fullName: "props.OrderingChoice", passByVal: true},
+		"GroupingOrder":       {fullName: "memo.GroupingOrder", passByVal: true},
 		"TupleOrdinal":        {fullName: "memo.TupleOrdinal", passByVal: true},
 		"ScanLimit":           {fullName: "memo.ScanLimit", passByVal: true},
 		"ScanFlags":           {fullName: "memo.ScanFlags", passByVal: true},

--- a/pkg/sql/opt/optgen/exprgen/testdata/groupby
+++ b/pkg/sql/opt/optgen/exprgen/testdata/groupby
@@ -23,7 +23,7 @@ expr
   (NoOrdering)
 )
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1(int)
  ├── grouping columns: t.public.abc.a:1(int)
  ├── internal-ordering: +1
@@ -61,7 +61,7 @@ expr
   (NoOrdering)
 )
 ----
-group-by
+group-by (hash)
  ├── columns: a:1(int)
  ├── grouping columns: t.public.abc.a:1(int)
  ├── cardinality: [0 - 10]

--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -108,7 +108,7 @@ func StreamingGroupingColOrdering(
 	for i := range inputOrdering.Columns {
 		// Get any grouping column from the set. Normally there would be at most one
 		// because we have rules that remove redundant grouping columns.
-		cols := inputOrdering.Columns[i].Group.Intersection(g.GroupingCols)
+		cols := inputOrdering.Group(i).Intersection(g.GroupingCols)
 		colID, ok := cols.Next(0)
 		if !ok {
 			// This group refers to a column that is not a grouping column.

--- a/pkg/sql/opt/ordering/scan.go
+++ b/pkg/sql/opt/ordering/scan.go
@@ -146,7 +146,7 @@ func scanBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Or
 			// Column not in output; we are done.
 			break
 		}
-		direction := (indexCol.Descending != reverse) // != is bool XOR
+		direction := indexCol.Descending != reverse // != is bool XOR
 		provided = append(provided, opt.MakeOrderingColumn(colID, direction))
 	}
 

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -189,7 +189,7 @@ func ParseOrdering(str string) opt.Ordering {
 		panic(errors.AssertionFailedf("invalid ordering %s", str))
 	}
 	for i := range prov.Columns {
-		if prov.Columns[i].Group.Len() != 1 {
+		if prov.Group(i).Len() != 1 {
 			panic(errors.AssertionFailedf("invalid ordering %s", str))
 		}
 	}
@@ -247,7 +247,7 @@ func (oc *OrderingChoice) ToOrdering() opt.Ordering {
 func (oc *OrderingChoice) ColSet() opt.ColSet {
 	var cs opt.ColSet
 	for i := range oc.Columns {
-		cs.UnionWith(oc.Columns[i].Group)
+		cs.UnionWith(oc.Group(i))
 	}
 	return cs
 }
@@ -581,7 +581,7 @@ func (oc *OrderingChoice) SubsetOfCols(cs opt.ColSet) bool {
 		return false
 	}
 	for i := range oc.Columns {
-		if !oc.Columns[i].Group.SubsetOf(cs) {
+		if !oc.Group(i).SubsetOf(cs) {
 			return false
 		}
 	}
@@ -603,7 +603,7 @@ func (oc *OrderingChoice) SubsetOfCols(cs opt.ColSet) bool {
 //
 func (oc *OrderingChoice) CanProjectCols(cs opt.ColSet) bool {
 	for i := range oc.Columns {
-		if !oc.Columns[i].Group.Intersects(cs) {
+		if !oc.Group(i).Intersects(cs) {
 			return false
 		}
 	}
@@ -797,9 +797,9 @@ func (oc *OrderingChoice) RestrictToCols(cols opt.ColSet) {
 		oc.Optional = oc.Optional.Intersection(cols)
 	}
 	for i := range oc.Columns {
-		if !oc.Columns[i].Group.SubsetOf(cols) {
-			oc.Columns[i].Group = oc.Columns[i].Group.Intersection(cols)
-			if oc.Columns[i].Group.Empty() {
+		if !oc.Group(i).SubsetOf(cols) {
+			oc.Columns[i].Group = oc.Group(i).Intersection(cols)
+			if oc.Group(i).Empty() {
 				oc.Columns = oc.Columns[:i]
 				break
 			}
@@ -849,22 +849,22 @@ func (oc OrderingChoice) PrefixIntersection(
 			result.Columns = append(result.Columns, suffix...)
 			return result, true
 		case prefixHelper.empty() && len(oc.Columns) > 0 && len(suffix) > 0 &&
-			oc.Columns[0].Group.Intersects(suffix[0].Group) &&
+			oc.Group(0).Intersects(suffix[0].Group) &&
 			oc.Columns[0].Descending == suffix[0].Descending:
 			// <prefix> is empty, and <suffix> and <oc> agree on the first column, so
 			// emit that column, remove it from both, and loop.
 			newCol := oc.Columns[0]
-			newCol.Group = oc.Columns[0].Group.Intersection(suffix[0].Group)
+			newCol.Group = oc.Group(0).Intersection(suffix[0].Group)
 			result.Columns = append(result.Columns, newCol)
 
 			oc.Columns = oc.Columns[1:]
 			suffix = suffix[1:]
-		case len(oc.Columns) > 0 && prefixHelper.intersects(oc.Columns[0].Group):
+		case len(oc.Columns) > 0 && prefixHelper.intersects(oc.Group(0)):
 			// <prefix> contains the first column in <oc>, so emit it and remove it
 			// from both.
 			result.Columns = append(result.Columns, oc.Columns[0])
 
-			prefixHelper.differenceWith(oc.Columns[0].Group)
+			prefixHelper.differenceWith(oc.Group(0))
 			oc.Columns = oc.Columns[1:]
 		default:
 			// If no rule applied, fail.
@@ -895,6 +895,14 @@ func (oc *OrderingChoice) Equals(rhs *OrderingChoice) bool {
 		}
 	}
 	return true
+}
+
+// Group returns the group of this instance's column col.
+func (oc *OrderingChoice) Group(col int) opt.ColSet {
+	if col < 0 || col >= len(oc.Columns) {
+		return opt.ColSet{}
+	}
+	return oc.Columns[col].Group
 }
 
 func (oc OrderingChoice) String() string {

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -195,7 +195,7 @@ func (c *CustomFuncs) SplitLimitedScanIntoUnionScans(
 	}
 	keyPrefixLength := cons.Columns.Count()
 	for i := 0; i < cons.Columns.Count(); i++ {
-		if limitOrdering.Columns[0].Group.Contains(cons.Columns.Get(i).ID()) {
+		if limitOrdering.Group(0).Contains(cons.Columns.Get(i).ID()) {
 			keyPrefixLength = i
 			break
 		}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -134,7 +134,8 @@ func BuildChildPhysicalProps(
 
 		// For streaming GroupBy expressions we can estimate the number of input
 		// rows needed to produce LimitHint output rows.
-		if isStreamingAggregation(private, parentProps) {
+		streamingType := private.GroupingOrderType(&parentProps.Ordering)
+		if streamingType != memo.NoStreaming {
 			if input, ok := parent.Child(nth).(memo.RelExpr); ok {
 				inputRows := input.Relational().Stats.RowCount
 				childProps.LimitHint = streamingGroupByInputLimitHint(inputRows, outputRows, parentProps.LimitHint)

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -339,3 +339,72 @@
         (ErrorOnDup $private)
     )
 )
+
+# GenerateLimitedGroupByScans generates a set of Scan alternatives for
+# each matching index on the scanned table, and an IndexJoin to supply columns
+# missing from the index. This differs from GenerateIndexScans, which does not
+# generate index joins for non-covering indexes.
+#
+# This rule is useful when we have a partially ordered GROUP BY column and a
+# LIMIT that limits how many rows to aggregate, as in the following example:
+#
+# CREATE TABLE t (a INT, b INT, INDEX (a))
+# SELECT a, b, count(*) FROM t GROUP BY a, b LIMIT 10
+#
+# Without this rule, the following expression with a full scan would be
+# generated:
+#  limit
+#   ├── columns: a:1 b:2 count:6!null
+#   ├── group-by
+#   │    ├── columns: a:1 b:2 count_rows:6!null
+#   │    ├── grouping columns: a:1 b:2
+#   │    ├── limit hint: 10.00
+#   │    ├── scan t
+#   │    │    └── columns: a:1 b:2
+#   │    └── aggregations
+#   │         └── count-rows [as=count_rows:6]
+#   └── 10
+#
+# When GenerateLimitedGroupByScans is applied, we can explore the following
+# expression:
+#  limit
+#   ├── columns: a:1 b:2 count:6!null
+#   ├── group-by
+#   │    ├── columns: a:1 b:2 count_rows:6!null
+#   │    ├── grouping columns: a:1 b:2
+#   │    ├── limit hint: 10.00
+#   │    ├── index-join t
+#   │    │    ├── columns: a:1 b:2
+#   │    │    ├── ordering: +1
+#   │    │    ├── limit hint: 10.00
+#   │    │    └── scan t@secondary
+#   │    │         ├── columns: a:1 rowid:3!null
+#   │    │         ├── ordering: +1
+#   │    │         └── limit hint: 10.00
+#   │    └── aggregations
+#   │         └── count-rows [as=count_rows:6]
+#   └── 10
+#
+# This can have better performance than the original expression, since this
+# allows us to explore a group by with partially ordered grouping columns
+# provided by the index and use an index join to supply the remaining grouping
+# columns. Then we would not necessarily need a full scan on t due to the limit
+# hint.
+[GenerateLimitedGroupByScans, Explore]
+(Limit
+    (GroupBy
+        (Scan $scanPrivate:* & (IsCanonicalScan $scanPrivate))
+        $aggs:*
+        $groupbyPrivate:* & (IsCanonicalGroupBy $groupbyPrivate)
+    )
+    $limitExpr:(Const $limit:*) & (IsPositiveInt $limit)
+    $ordering:*
+)
+=>
+(GenerateLimitedGroupByScans
+    $scanPrivate
+    $aggs
+    $groupbyPrivate
+    $limitExpr
+    $ordering
+)

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -34,7 +34,8 @@ import (
 //       up", when the Scan operator is wrapped by an operator that constrains
 //       or limits scan output in some way (e.g. Select, Limit, InnerJoin).
 //       Index joins are only lower cost when their input does not include all
-//       rows from the table. See ConstrainScans and LimitScans for cases where
+//       rows from the table. See GenerateConstrainedScans,
+//       GenerateLimitedScans, and GenerateLimitedGroupByScans for cases where
 //       index joins are introduced into the memo.
 func (c *CustomFuncs) GenerateIndexScans(grp memo.RelExpr, scanPrivate *memo.ScanPrivate) {
 	// Iterate over all non-inverted and non-partial secondary indexes.

--- a/pkg/sql/opt/xform/testdata/coster/groupby
+++ b/pkg/sql/opt/xform/testdata/coster/groupby
@@ -3,13 +3,17 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, s STRING, d DECIMAL NOT NULL)
 ----
 
 exec-ddl
-CREATE TABLE b (k INT PRIMARY KEY, a INT, b INT, c INT, INDEX (a, b))
+CREATE TABLE b (k INT PRIMARY KEY, a INT, b INT, c INT, INDEX (a, b), INDEX (a, b, c))
+----
+
+exec-ddl
+CREATE TABLE c (a INT, b INT, c INT, d INT, INDEX (a), INDEX (b, c, d))
 ----
 
 opt
 SELECT max(k), min(k), i, s FROM a GROUP BY i, s
 ----
-group-by
+group-by (hash)
  ├── columns: max:7!null min:8!null i:2 s:3
  ├── grouping columns: i:2 s:3
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
@@ -31,7 +35,7 @@ group-by
 opt
 SELECT a, count(*) FROM b GROUP BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: a:2 count:7!null
  ├── grouping columns: a:2
  ├── internal-ordering: +2
@@ -50,7 +54,7 @@ group-by
 opt
 SELECT a, b, count(*) FROM b GROUP BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:2 b:3 count:7!null
  ├── grouping columns: a:2 b:3
  ├── internal-ordering: +2,+3
@@ -77,7 +81,7 @@ limit
  ├── cost: 121.16
  ├── key: (2)
  ├── fd: (2)-->(7)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: a:2 count_rows:7!null
  │    ├── grouping columns: a:2
  │    ├── internal-ordering: +2
@@ -106,7 +110,7 @@ limit
  ├── cost: 34.96
  ├── key: (2,3)
  ├── fd: (2,3)-->(7)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: a:2 b:3 count_rows:7!null
  │    ├── grouping columns: a:2 b:3
  │    ├── internal-ordering: +2,+3
@@ -124,3 +128,204 @@ limit
  │    └── aggregations
  │         └── count-rows [as=count_rows:7]
  └── 10
+
+# Partially ordered group by with a limit hint.
+opt
+SELECT a, c, count(*) FROM c GROUP BY a, c LIMIT 10
+----
+limit
+ ├── columns: a:1 c:3 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 641.98
+ ├── key: (1,3)
+ ├── fd: (1,3)-->(8)
+ ├── group-by (partial streaming)
+ │    ├── columns: a:1 c:3 count_rows:8!null
+ │    ├── grouping columns: a:1 c:3
+ │    ├── internal-ordering: +1
+ │    ├── stats: [rows=1000, distinct(1,3)=1000, null(1,3)=0.1]
+ │    ├── cost: 641.87
+ │    ├── key: (1,3)
+ │    ├── fd: (1,3)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── index-join c
+ │    │    ├── columns: a:1 c:3
+ │    │    ├── stats: [rows=1000, distinct(1,3)=1000, null(1,3)=0.1]
+ │    │    ├── cost: 631.44
+ │    │    ├── ordering: +1
+ │    │    ├── limit hint: 10.00
+ │    │    └── scan c@c_a_idx
+ │    │         ├── columns: a:1 rowid:5!null
+ │    │         ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │         ├── cost: 24.42
+ │    │         ├── key: (5)
+ │    │         ├── fd: (5)-->(1)
+ │    │         ├── ordering: +1
+ │    │         └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+opt
+SELECT b, d, count(*) FROM c GROUP BY b, d LIMIT 10
+----
+limit
+ ├── columns: b:2 d:4 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 35.16
+ ├── key: (2,4)
+ ├── fd: (2,4)-->(8)
+ ├── group-by (partial streaming)
+ │    ├── columns: b:2 d:4 count_rows:8!null
+ │    ├── grouping columns: b:2 d:4
+ │    ├── internal-ordering: +2
+ │    ├── stats: [rows=1000, distinct(2,4)=1000, null(2,4)=0.1]
+ │    ├── cost: 35.05
+ │    ├── key: (2,4)
+ │    ├── fd: (2,4)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── scan c@c_b_c_d_idx
+ │    │    ├── columns: b:2 d:4
+ │    │    ├── stats: [rows=1000, distinct(2,4)=1000, null(2,4)=0.1]
+ │    │    ├── cost: 24.62
+ │    │    ├── ordering: +2
+ │    │    └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+opt
+SELECT b, a, count(*) FROM c GROUP BY b, a LIMIT 10
+----
+limit
+ ├── columns: b:2 a:1 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 641.98
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(8)
+ ├── group-by (partial streaming)
+ │    ├── columns: a:1 b:2 count_rows:8!null
+ │    ├── grouping columns: a:1 b:2
+ │    ├── internal-ordering: +1
+ │    ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0.1]
+ │    ├── cost: 641.87
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── index-join c
+ │    │    ├── columns: a:1 b:2
+ │    │    ├── stats: [rows=1000, distinct(1,2)=1000, null(1,2)=0.1]
+ │    │    ├── cost: 631.44
+ │    │    ├── ordering: +1
+ │    │    ├── limit hint: 10.00
+ │    │    └── scan c@c_a_idx
+ │    │         ├── columns: a:1 rowid:5!null
+ │    │         ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │         ├── cost: 24.42
+ │    │         ├── key: (5)
+ │    │         ├── fd: (5)-->(1)
+ │    │         ├── ordering: +1
+ │    │         └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+opt
+SELECT b, c, a, count(*) FROM c GROUP BY b, c, a LIMIT 10
+----
+limit
+ ├── columns: b:2 c:3 a:1 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 642.38
+ ├── key: (1-3)
+ ├── fd: (1-3)-->(8)
+ ├── group-by (partial streaming)
+ │    ├── columns: a:1 b:2 c:3 count_rows:8!null
+ │    ├── grouping columns: a:1 b:2 c:3
+ │    ├── internal-ordering: +2,+3
+ │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0.001]
+ │    ├── cost: 642.27
+ │    ├── key: (1-3)
+ │    ├── fd: (1-3)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── index-join c
+ │    │    ├── columns: a:1 b:2 c:3
+ │    │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0.001]
+ │    │    ├── cost: 631.74
+ │    │    ├── ordering: +2,+3
+ │    │    ├── limit hint: 10.00
+ │    │    └── scan c@c_b_c_d_idx
+ │    │         ├── columns: b:2 c:3 rowid:5!null
+ │    │         ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ │    │         ├── cost: 24.72
+ │    │         ├── key: (5)
+ │    │         ├── fd: (5)-->(2,3)
+ │    │         ├── ordering: +2,+3
+ │    │         └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+exec-ddl
+CREATE TABLE f (
+  filename
+    STRING PRIMARY KEY,
+  file_id
+    UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+  file_size
+    INT8 NOT NULL,
+  username
+    STRING NOT NULL,
+  upload_time
+    TIMESTAMP DEFAULT now()
+)
+----
+
+exec-ddl
+CREATE TABLE p (file_id UUID, byte_offset INT8, payload BYTES, PRIMARY KEY (file_id, byte_offset))
+----
+
+# Non-scalar group-by with no grouping columns should be streaming: #71768
+opt
+SELECT f.file_id, sum_int(length(p.payload)) FROM f f LEFT OUTER JOIN p p ON p.file_id = f.file_id WHERE f.filename = 'abc' GROUP BY f.file_id
+----
+group-by (streaming)
+ ├── columns: file_id:2!null sum_int:14
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── cost: 46.15
+ ├── key: ()
+ ├── fd: ()-->(2,14)
+ ├── project
+ │    ├── columns: column13:13 f.file_id:2!null
+ │    ├── immutable
+ │    ├── stats: [rows=10]
+ │    ├── cost: 45.92
+ │    ├── fd: ()-->(2)
+ │    ├── left-join (lookup p)
+ │    │    ├── columns: filename:1!null f.file_id:2!null p.file_id:8 payload:10
+ │    │    ├── key columns: [2] = [8]
+ │    │    ├── stats: [rows=10, distinct(8)=1, null(8)=0]
+ │    │    ├── cost: 45.7
+ │    │    ├── fd: ()-->(1,2,8)
+ │    │    ├── scan f
+ │    │    │    ├── columns: filename:1!null f.file_id:2!null
+ │    │    │    ├── constraint: /1: [/'abc' - /'abc']
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
+ │    │    │    ├── cost: 5.08
+ │    │    │    ├── key: ()
+ │    │    │    └── fd: ()-->(1,2)
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── length(payload:10) [as=column13:13, outer=(10), immutable]
+ └── aggregations
+      ├── sum-int [as=sum_int:14, outer=(13)]
+      │    └── column13:13
+      └── const-agg [as=f.file_id:2, outer=(2)]
+           └── f.file_id:2

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -283,7 +283,7 @@ CREATE TABLE vehicles (
 opt
 select v.owner_id, count(*) from rides r, vehicles v where v.id = r.vehicle_id group by v.owner_id
 ----
-group-by
+group-by (hash)
  ├── columns: owner_id:14 count:20!null
  ├── grouping columns: owner_id:14
  ├── key: (14)
@@ -327,7 +327,7 @@ CREATE TABLE data (
 opt
 SELECT id, sum(value) FROM data GROUP BY id
 ----
-group-by
+group-by (streaming)
  ├── columns: id:1 sum:16
  ├── grouping columns: id:1
  ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -395,7 +395,7 @@ project
       ├── has-placeholder
       ├── key: (1,2)
       ├── fd: (1,2)-->(3-6,17), (2)==(17), (17)==(2)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: defaultaud0_.id:1!null defaultaud0_.rev:2!null defaultaud0_.revtype:3!null defaultaud0_.created_on:4 defaultaud0_.firstname:5 defaultaud0_.lastname:6 max:17!null
       │    ├── grouping columns: defaultaud0_.id:1!null defaultaud0_.rev:2!null
       │    ├── has-placeholder
@@ -510,7 +510,7 @@ sort
            ├── has-placeholder
            ├── key: (1,2)
            ├── fd: (1,2)-->(3-8,21), (2)==(21), (21)==(2)
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: queryaudit0_.id:1!null queryaudit0_.rev:2!null queryaudit0_.revtype:3!null queryaudit0_.revend:4 queryaudit0_.created_on:5 queryaudit0_.firstname:6 queryaudit0_.lastname:7 queryaudit0_.address_id:8 max:21!null
            │    ├── grouping columns: queryaudit0_.id:1!null queryaudit0_.rev:2!null
            │    ├── has-placeholder
@@ -740,7 +740,7 @@ project
       ├── has-placeholder
       ├── key: (1)
       ├── fd: ()-->(14), (1)-->(2-4)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 max:14!null
       │    ├── grouping columns: phone0_.id:1!null
       │    ├── key: (1)
@@ -800,7 +800,7 @@ project
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null count:16!null
       ├── key: (1)
       ├── fd: ()-->(16), (1)-->(2-6)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null count:16!null
       │    ├── grouping columns: person0_.id:1!null
       │    ├── key: (1)
@@ -861,7 +861,7 @@ project
       ├── has-placeholder
       ├── key: (1)
       ├── fd: ()-->(14), (1)-->(2-4)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 min:14!null
       │    ├── grouping columns: phone0_.id:1!null
       │    ├── key: (1)
@@ -921,7 +921,7 @@ project
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null max:16!null
       ├── key: (1)
       ├── fd: ()-->(16), (1)-->(2-6)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null max:16!null
       │    ├── grouping columns: person0_.id:1!null
       │    ├── key: (1)
@@ -1215,7 +1215,7 @@ project
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null phones2_.id:9!null phones2_.order_id:13!null max:23!null
       ├── key: (9)
       ├── fd: (1)-->(2-6), (9)-->(1-6,13,23), (13)==(23), (23)==(13)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null phones2_.id:9!null phones2_.order_id:13 max:23!null
       │    ├── grouping columns: phones2_.id:9!null
       │    ├── key: (9)
@@ -1501,7 +1501,7 @@ project
       ├── columns: id:1!null email:2 currentproject_id:3 count:11!null
       ├── key: (1)
       ├── fd: ()-->(11), (1)-->(2,3)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: id:1!null email:2 currentproject_id:3 count:11!null
       │    ├── grouping columns: id:1!null
       │    ├── key: (1)
@@ -1874,7 +1874,7 @@ project
  ├── has-placeholder
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,13)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null true_agg:15
  │    ├── grouping columns: bids0_.id:1!null
  │    ├── has-placeholder
@@ -1999,7 +1999,7 @@ project
  ├── immutable
  ├── key: (8)
  ├── fd: ()-->(1-3,6,7), (8)-->(9,26)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 sum:25
  │    ├── grouping columns: lineitems1_.productid:8
  │    ├── immutable
@@ -2126,7 +2126,7 @@ project
  ├── immutable
  ├── key: (1,6,7,11-13)
  ├── fd: (1)-->(2,3), (6,7)-->(8), (11-13)-->(14), (17)-->(18-20), (1,6,7,11-13)-->(2,3,8,14,17-20,44,45)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:6 orders1_.ordernumber:7 orderdate:8 lineitems2_.customerid:11 lineitems2_.ordernumber:12 lineitems2_.productid:13 lineitems2_.quantity:14 product3_.productid:17 product3_.description:18 product3_.cost:19 product3_.numberavailable:20 sum:36 sum:43
  │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:6 orders1_.ordernumber:7 lineitems2_.customerid:11 lineitems2_.ordernumber:12 lineitems2_.productid:13
  │    ├── immutable
@@ -2136,7 +2136,7 @@ project
  │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:6 orders1_.ordernumber:7 orderdate:8 lineitems2_.customerid:11 lineitems2_.ordernumber:12 lineitems2_.productid:13 lineitems2_.quantity:14 product3_.productid:17 product3_.description:18 product3_.cost:19 product3_.numberavailable:20 sum:36 li.productid:39 li.quantity:40
  │    │    ├── immutable
  │    │    ├── fd: (1)-->(2,3), (6,7)-->(8), (11-13)-->(14), (17)-->(18-20), (1,6,7,11-13)-->(2,3,8,14,17-20,36)
- │    │    ├── group-by
+ │    │    ├── group-by (hash)
  │    │    │    ├── columns: customer0_.customerid:1!null name:2!null address:3!null orders1_.customerid:6 orders1_.ordernumber:7 orderdate:8 lineitems2_.customerid:11 lineitems2_.ordernumber:12 lineitems2_.productid:13 lineitems2_.quantity:14 product3_.productid:17 product3_.description:18 product3_.cost:19 product3_.numberavailable:20 sum:36
  │    │    │    ├── grouping columns: customer0_.customerid:1!null orders1_.customerid:6 orders1_.ordernumber:7 lineitems2_.customerid:11 lineitems2_.ordernumber:12 lineitems2_.productid:13
  │    │    │    ├── immutable
@@ -2295,7 +2295,7 @@ project
  ├── immutable
  ├── key: (8)
  ├── fd: ()-->(1-3,6,7), (8)-->(9,26)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 sum:25
  │    ├── grouping columns: lineitems1_.productid:8
  │    ├── immutable
@@ -2389,7 +2389,7 @@ project
  ├── immutable
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,20)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null sum:19
  │    ├── grouping columns: order0_.customerid:1!null order0_.ordernumber:2!null
  │    ├── immutable
@@ -2491,7 +2491,7 @@ WHERE
         )
   );
 ----
-group-by
+group-by (hash)
  ├── columns: studenti1_26_0_:1!null name2_26_0_:2!null address_3_26_0_:3 address_4_26_0_:4 preferre5_26_0_:5!null
  ├── grouping columns: this_.studentid:1!null
  ├── key: (1)
@@ -2500,7 +2500,7 @@ group-by
  │    ├── columns: this_.studentid:1!null name:2!null address_city:3 address_state:4 preferredcoursecode:5!null enrolment_.studentid:8!null enrolment_.coursecode:9!null enrolment_.year:11!null max:20!null
  │    ├── key: (1,8,9)
  │    ├── fd: (1)-->(2-5), (8,9)-->(11), (1,8,9)-->(2-5,11,20), (11)==(20), (20)==(11)
- │    ├── group-by
+ │    ├── group-by (hash)
  │    │    ├── columns: this_.studentid:1!null name:2!null address_city:3 address_state:4 preferredcoursecode:5!null enrolment_.studentid:8!null enrolment_.coursecode:9!null enrolment_.year:11!null max:20!null
  │    │    ├── grouping columns: this_.studentid:1!null enrolment_.studentid:8!null enrolment_.coursecode:9!null
  │    │    ├── key: (1,8,9)

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -164,7 +164,7 @@ project
  ├── columns: oid:1!null schemaname:31!null tablename:2!null relacl:26 tableowner:155 description:156 relkind:17!null cluster:106 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:37 param:27 hastriggers:23!null unlogged:15!null ftoptions:136 srvname:140 reltuples:10!null inhtable:157!null inhschemaname:79 inhtablename:50
  ├── stable
  ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37,155,156), (2)-->(1,10,13,15,17,20,22,23,26,27,37,155,156)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null rownum:158!null
  │    ├── grouping columns: rownum:158!null
  │    ├── key: (158)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -168,7 +168,7 @@ sort
       ├── columns: tableowner:155 description:156 inhtable:157!null c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
       ├── stable
       ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37,155,156), (2)-->(1,10,13,15,17,20,22,23,26,27,37,155,156)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null rownum:158!null
       │    ├── grouping columns: rownum:158!null
       │    ├── key: (158)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -193,7 +193,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -365,7 +365,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
            │    │    │         │    ├── grouping columns: flavors.id:1!null
            │    │    │         │    ├── internal-ordering: +1 opt(11)
@@ -386,7 +386,7 @@ sort
            │    │    │         │    │    │    ├── key: (1)
            │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,35), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-           │    │    │         │    │    │    ├── group-by
+           │    │    │         │    │    │    ├── group-by (streaming)
            │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
            │    │    │         │    │    │    │    ├── grouping columns: flavors.id:1!null
            │    │    │         │    │    │    │    ├── has-placeholder
@@ -623,7 +623,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
            │    │    │         │    ├── internal-ordering: +1 opt(13)
@@ -785,7 +785,7 @@ sort
            │    ├── has-placeholder
            │    ├── key: (1)
            │    ├── fd: ()-->(13), (1)-->(2-12,14-16,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    ├── group-by
+           │    ├── group-by (streaming)
            │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
            │    │    ├── grouping columns: instance_types.id:1!null
            │    │    ├── internal-ordering: +1 opt(13)
@@ -977,7 +977,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -1157,7 +1157,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -1322,7 +1322,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -1479,7 +1479,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -1648,7 +1648,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
            │    │    │         │    ├── grouping columns: flavors.id:1!null
            │    │    │         │    ├── internal-ordering: +1
@@ -1833,7 +1833,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
            │    │    │         │    ├── internal-ordering: +1 opt(13)
@@ -2027,7 +2027,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -2167,7 +2167,7 @@ sort
            │    ├── has-placeholder
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-12,14,15,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    ├── group-by
+           │    ├── group-by (streaming)
            │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
            │    │    ├── grouping columns: flavors.id:1!null
            │    │    ├── internal-ordering: +1
@@ -2359,7 +2359,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
            │    │    │         │    ├── internal-ordering: +1 opt(13)
@@ -2540,7 +2540,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
            │    │    │         │    ├── grouping columns: flavors.id:1!null
            │    │    │         │    ├── internal-ordering: +1
@@ -2739,7 +2739,7 @@ sort
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
            │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         ├── group-by
+           │    │    │         ├── group-by (streaming)
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
            │    │    │         │    ├── internal-ordering: +1 opt(11,13)
@@ -2760,7 +2760,7 @@ sort
            │    │    │         │    │    │    ├── key: (1)
            │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-           │    │    │         │    │    │    ├── group-by
+           │    │    │         │    │    │    ├── group-by (streaming)
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
            │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1!null
            │    │    │         │    │    │    │    ├── has-placeholder
@@ -3005,7 +3005,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -3176,7 +3176,7 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
@@ -3334,7 +3334,7 @@ sort
            │    │         ├── has-placeholder
            │    │         ├── key: (1)
            │    │         ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │         ├── group-by
+           │    │         ├── group-by (streaming)
            │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27
            │    │         │    ├── grouping columns: flavors.id:1!null
            │    │         │    ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/external/postgis-tutorial
+++ b/pkg/sql/opt/xform/testdata/external/postgis-tutorial
@@ -236,7 +236,7 @@ sort
       ├── immutable
       ├── key: (3)
       ├── fd: (3)-->(19,22,23)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: name:3 sum:19 sum:20 sum:21
       │    ├── grouping columns: name:3
       │    ├── immutable
@@ -349,7 +349,7 @@ sort
       ├── immutable
       ├── key: (31)
       ├── fd: (31)-->(36,38,39)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: route:31 sum:35 sum:36 sum:37
       │    ├── grouping columns: route:31
       │    ├── immutable
@@ -510,7 +510,7 @@ sort
  └── project
       ├── columns: popn_per_sqkm:20 name:15!null
       ├── immutable
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: name:15!null n.geom:16!null sum:19
       │    ├── grouping columns: name:15!null n.geom:16!null
       │    ├── immutable

--- a/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
+++ b/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
@@ -312,7 +312,7 @@ sort
       ├── immutable
       ├── key: (3)
       ├── fd: (3)-->(21,24,25)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: name:3 sum:21 sum:22 sum:23
       │    ├── grouping columns: name:3
       │    ├── immutable
@@ -437,7 +437,7 @@ sort
       ├── immutable
       ├── key: (33)
       ├── fd: (33)-->(38,40,41)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: route:33 sum:37 sum:38 sum:39
       │    ├── grouping columns: route:33
       │    ├── immutable
@@ -621,7 +621,7 @@ sort
  └── project
       ├── columns: popn_per_sqkm:22 name:16!null
       ├── immutable
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: name:16!null n.geom:17!null sum:21
       │    ├── grouping columns: name:16!null n.geom:17!null
       │    ├── immutable

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1101,7 +1101,7 @@ scalar-group-by
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    └── ordering: +1
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: d_w_id:13!null sum:25
  │    │    ├── grouping columns: d_w_id:13!null
  │    │    ├── key: (13)
@@ -1135,7 +1135,7 @@ FROM new_order
 GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:6!null  [hidden: no_d_id:2!null no_w_id:3!null]
  ├── grouping columns: no_d_id:2!null no_w_id:3!null
  ├── key: (2,3)
@@ -1155,7 +1155,7 @@ FROM "order"
 GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:11!null  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1190,7 +1190,7 @@ scalar-group-by
  │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(6-8)
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: no_d_id:2!null no_w_id:3!null max:6!null min:7!null count_rows:8!null
  │    │    ├── grouping columns: no_d_id:2!null no_w_id:3!null
  │    │    ├── internal-ordering: +3,+2
@@ -1217,7 +1217,7 @@ FROM "order"
 GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: sum:11  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1236,7 +1236,7 @@ FROM order_line
 GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: count:13!null  [hidden: ol_d_id:2!null ol_w_id:3!null]
  ├── grouping columns: ol_d_id:2!null ol_w_id:3!null
  ├── key: (2,3)
@@ -1328,7 +1328,7 @@ except-all
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    └── ordering: +3,+2,-1
- └── group-by
+ └── group-by (streaming)
       ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null count_rows:23!null
       ├── grouping columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
       ├── key: (11-13)
@@ -1361,7 +1361,7 @@ except-all
  ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null count_rows:13!null
  │    ├── grouping columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null
  │    ├── key: (1-3)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -1103,7 +1103,7 @@ scalar-group-by
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    └── ordering: +1
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: d_w_id:13!null sum:25
  │    │    ├── grouping columns: d_w_id:13!null
  │    │    ├── key: (13)
@@ -1137,7 +1137,7 @@ FROM new_order
 GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:6!null  [hidden: no_d_id:2!null no_w_id:3!null]
  ├── grouping columns: no_d_id:2!null no_w_id:3!null
  ├── key: (2,3)
@@ -1157,7 +1157,7 @@ FROM "order"
 GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:11!null  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1192,7 +1192,7 @@ scalar-group-by
  │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(6-8)
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: no_d_id:2!null no_w_id:3!null max:6!null min:7!null count_rows:8!null
  │    │    ├── grouping columns: no_d_id:2!null no_w_id:3!null
  │    │    ├── internal-ordering: +3,+2
@@ -1219,7 +1219,7 @@ FROM "order"
 GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: sum:11  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1238,7 +1238,7 @@ FROM order_line
 GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: count:13!null  [hidden: ol_d_id:2!null ol_w_id:3!null]
  ├── grouping columns: ol_d_id:2!null ol_w_id:3!null
  ├── key: (2,3)
@@ -1330,7 +1330,7 @@ except-all
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    └── ordering: +3,+2,-1
- └── group-by
+ └── group-by (streaming)
       ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null count_rows:23!null
       ├── grouping columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
       ├── key: (11-13)
@@ -1363,7 +1363,7 @@ except-all
  ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null count_rows:13!null
  │    ├── grouping columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null
  │    ├── key: (1-3)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -1097,7 +1097,7 @@ scalar-group-by
  │    ├── immutable
  │    ├── key: (13)
  │    ├── fd: (1)-->(9), (13)-->(25), (1)==(13), (13)==(1)
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: d_w_id:13!null sum:25
  │    │    ├── grouping columns: d_w_id:13!null
  │    │    ├── internal-ordering: +13
@@ -1131,7 +1131,7 @@ FROM new_order
 GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:6!null  [hidden: no_d_id:2!null no_w_id:3!null]
  ├── grouping columns: no_d_id:2!null no_w_id:3!null
  ├── key: (2,3)
@@ -1151,7 +1151,7 @@ FROM "order"
 GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: max:11!null  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1186,7 +1186,7 @@ scalar-group-by
  │    ├── immutable
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(6-8)
- │    ├── group-by
+ │    ├── group-by (streaming)
  │    │    ├── columns: no_d_id:2!null no_w_id:3!null max:6!null min:7!null count_rows:8!null
  │    │    ├── grouping columns: no_d_id:2!null no_w_id:3!null
  │    │    ├── internal-ordering: +3,+2
@@ -1213,7 +1213,7 @@ FROM "order"
 GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: sum:11  [hidden: o_d_id:2!null o_w_id:3!null]
  ├── grouping columns: o_d_id:2!null o_w_id:3!null
  ├── key: (2,3)
@@ -1232,7 +1232,7 @@ FROM order_line
 GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
-group-by
+group-by (streaming)
  ├── columns: count:13!null  [hidden: ol_d_id:2!null ol_w_id:3!null]
  ├── grouping columns: ol_d_id:2!null ol_w_id:3!null
  ├── key: (2,3)
@@ -1342,7 +1342,7 @@ except-all
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    └── ordering: +3,+2,-1
- └── group-by
+ └── group-by (streaming)
       ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null count_rows:23!null
       ├── grouping columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
       ├── key: (11-13)
@@ -1375,7 +1375,7 @@ except-all
  ├── internal-ordering: +3,+2,-1,+13
  ├── key: (1-3)
  ├── fd: (1-3)-->(13)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null count_rows:13!null
  │    ├── grouping columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null
  │    ├── key: (1-3)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -46,7 +46,7 @@ sort
       ├── immutable
       ├── key: (49)
       ├── fd: (49)-->(56)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: b_name:49!null sum:55!null
       │    ├── grouping columns: b_name:49!null
       │    ├── immutable
@@ -137,7 +137,7 @@ sort
       ├── immutable
       ├── key: (3)
       ├── fd: (3)-->(56)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: b_name:3!null sum:55!null
       │    ├── grouping columns: b_name:3!null
       │    ├── immutable
@@ -320,7 +320,7 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(23,24)
-      ├── group-by
+      ├── group-by (streaming)
       │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:22
       │    ├── grouping columns: ca_id:1!null
       │    ├── internal-ordering: +1
@@ -396,7 +396,7 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(23,24)
-      ├── group-by
+      ├── group-by (streaming)
       │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:22
       │    ├── grouping columns: ca_id:1!null
       │    ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -43,7 +43,7 @@ sort
       ├── immutable
       ├── key: (49)
       ├── fd: (49)-->(56)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: b_name:49!null sum:55!null
       │    ├── grouping columns: b_name:49!null
       │    ├── immutable
@@ -134,7 +134,7 @@ sort
       ├── immutable
       ├── key: (3)
       ├── fd: (3)-->(56)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: b_name:3!null sum:55!null
       │    ├── grouping columns: b_name:3!null
       │    ├── immutable
@@ -342,7 +342,7 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(23,24)
-      ├── group-by
+      ├── group-by (streaming)
       │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:22
       │    ├── grouping columns: ca_id:1!null
       │    ├── internal-ordering: +1
@@ -418,7 +418,7 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(23,24)
-      ├── group-by
+      ├── group-by (streaming)
       │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null sum:22
       │    ├── grouping columns: ca_id:1!null
       │    ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -46,7 +46,7 @@ sort
  ├── key: (9,10)
  ├── fd: (9,10)-->(19,20,22,24-28)
  ├── ordering: +9,+10
- └── group-by
+ └── group-by (hash)
       ├── columns: l_returnflag:9!null l_linestatus:10!null sum:19!null sum:20!null sum:22!null sum:24!null avg:25!null avg:26!null avg:27!null count_rows:28!null
       ├── grouping columns: l_returnflag:9!null l_linestatus:10!null
       ├── immutable
@@ -159,7 +159,7 @@ project
            ├── columns: p_partkey:1!null p_mfgr:3!null s_name:13!null s_address:14!null s_phone:16!null s_acctbal:17!null s_comment:18!null ps_partkey:21!null ps_suppkey:22!null ps_supplycost:24!null n_name:29!null min:66!null
            ├── key: (21,22)
            ├── fd: (1)-->(3), (21,22)-->(1,3,13,14,16-18,24,29,66), (1)==(21), (21)==(1), (22)-->(13,14,16-18,29), (24)==(66), (66)==(24)
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: p_partkey:1!null p_mfgr:3!null s_name:13!null s_address:14!null s_phone:16!null s_acctbal:17!null s_comment:18!null ps_partkey:21!null ps_suppkey:22!null ps_supplycost:24!null n_name:29!null min:66!null
            │    ├── grouping columns: ps_partkey:21!null ps_suppkey:22!null
            │    ├── key: (21,22)
@@ -324,7 +324,7 @@ top-k
  ├── key: (22)
  ├── fd: (22)-->(15,18,41)
  ├── ordering: -41,+15
- └── group-by
+ └── group-by (hash)
       ├── columns: o_orderdate:15!null o_shippriority:18!null l_orderkey:22!null sum:41!null
       ├── grouping columns: l_orderkey:22!null
       ├── immutable
@@ -416,7 +416,7 @@ sort
  ├── key: (6)
  ├── fd: (6)-->(30)
  ├── ordering: +6
- └── group-by
+ └── group-by (hash)
       ├── columns: o_orderpriority:6!null count_rows:30!null
       ├── grouping columns: o_orderpriority:6!null
       ├── key: (6)
@@ -486,7 +486,7 @@ sort
  ├── key: (50)
  ├── fd: (50)-->(61)
  ├── ordering: -61
- └── group-by
+ └── group-by (hash)
       ├── columns: n_name:50!null sum:61!null
       ├── grouping columns: n_name:50!null
       ├── immutable
@@ -671,7 +671,7 @@ sort
  ├── key: (50,56,61)
  ├── fd: (50,56,61)-->(63)
  ├── ordering: +50,+56,+61
- └── group-by
+ └── group-by (hash)
       ├── columns: n1.n_name:50!null n2.n_name:56!null l_year:61 sum:63!null
       ├── grouping columns: n1.n_name:50!null n2.n_name:56!null l_year:61
       ├── immutable
@@ -799,7 +799,7 @@ sort
       ├── immutable
       ├── key: (77)
       ├── fd: (77)-->(82)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: o_year:77 sum:80!null sum:81!null
       │    ├── grouping columns: o_year:77
       │    ├── immutable
@@ -956,7 +956,7 @@ sort
  ├── key: (58,63)
  ├── fd: (58,63)-->(65)
  ├── ordering: +58,-63
- └── group-by
+ └── group-by (hash)
       ├── columns: n_name:58!null o_year:63 sum:65!null
       ├── grouping columns: n_name:58!null o_year:63
       ├── immutable
@@ -1091,7 +1091,7 @@ top-k
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,41,47)
  ├── ordering: -47
- └── group-by
+ └── group-by (hash)
       ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:41!null sum:47!null
       ├── grouping columns: c_custkey:1!null
       ├── immutable
@@ -1204,7 +1204,7 @@ sort
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(24)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: ps_partkey:1!null sum:24!null
       │    ├── grouping columns: ps_partkey:1!null
       │    ├── immutable
@@ -1351,7 +1351,7 @@ sort
  ├── key: (26)
  ├── fd: (26)-->(31,33)
  ├── ordering: +26
- └── group-by
+ └── group-by (hash)
       ├── columns: l_shipmode:26!null sum:31!null sum:33!null
       ├── grouping columns: l_shipmode:26!null
       ├── key: (26)
@@ -1423,12 +1423,12 @@ sort
  ├── key: (22)
  ├── fd: (22)-->(23)
  ├── ordering: -23,-22
- └── group-by
+ └── group-by (hash)
       ├── columns: count:22!null count_rows:23!null
       ├── grouping columns: count:22!null
       ├── key: (22)
       ├── fd: (22)-->(23)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: c_custkey:1!null count:22!null
       │    ├── grouping columns: c_custkey:1!null
       │    ├── key: (1)
@@ -1603,7 +1603,7 @@ project
       │         ├── immutable
       │         ├── key: (12)
       │         ├── fd: (12)-->(29)
-      │         ├── group-by
+      │         ├── group-by (hash)
       │         │    ├── columns: l_suppkey:12!null sum:29!null
       │         │    ├── grouping columns: l_suppkey:12!null
       │         │    ├── immutable
@@ -1634,7 +1634,7 @@ project
       │                             ├── immutable
       │                             ├── key: ()
       │                             ├── fd: ()-->(50)
-      │                             ├── group-by
+      │                             ├── group-by (hash)
       │                             │    ├── columns: l_suppkey:32!null sum:49!null
       │                             │    ├── grouping columns: l_suppkey:32!null
       │                             │    ├── immutable
@@ -1711,7 +1711,7 @@ sort
  ├── key: (11-13)
  ├── fd: (11-13)-->(28)
  ├── ordering: -28,+11,+12,+13
- └── group-by
+ └── group-by (hash)
       ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:28!null
       ├── grouping columns: p_brand:11!null p_type:12!null p_size:13!null
       ├── key: (11-13)
@@ -1818,7 +1818,7 @@ project
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (19)
  │    │    │    │    ├── fd: (19)-->(49)
- │    │    │    │    ├── group-by
+ │    │    │    │    ├── group-by (streaming)
  │    │    │    │    │    ├── columns: p_partkey:19!null avg:48!null
  │    │    │    │    │    ├── grouping columns: p_partkey:19!null
  │    │    │    │    │    ├── internal-ordering: +(19|31) opt(22,25)
@@ -1919,7 +1919,7 @@ top-k
  ├── key: (11)
  ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
  ├── ordering: -14,+15
- └── group-by
+ └── group-by (hash)
       ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:59!null
       ├── grouping columns: o_orderkey:11!null
       ├── key: (11)
@@ -1953,7 +1953,7 @@ top-k
       │    │    │    │    ├── key: (40)
       │    │    │    │    ├── fd: (40)-->(58)
       │    │    │    │    ├── ordering: +40
-      │    │    │    │    ├── group-by
+      │    │    │    │    ├── group-by (streaming)
       │    │    │    │    │    ├── columns: l_orderkey:40!null sum:58!null
       │    │    │    │    │    ├── grouping columns: l_orderkey:40!null
       │    │    │    │    │    ├── key: (40)
@@ -2172,7 +2172,7 @@ sort
            │         │         │    ├── immutable
            │         │         │    ├── key: (16,17)
            │         │         │    ├── fd: (16,17)-->(18,52)
-           │         │         │    ├── group-by
+           │         │         │    ├── group-by (hash)
            │         │         │    │    ├── columns: ps_partkey:16!null ps_suppkey:17!null ps_availqty:18!null sum:52!null
            │         │         │    │    ├── grouping columns: ps_partkey:16!null ps_suppkey:17!null
            │         │         │    │    ├── key: (16,17)
@@ -2268,7 +2268,7 @@ top-k
  ├── key: (2)
  ├── fd: (2)-->(81)
  ├── ordering: -81,+2
- └── group-by
+ └── group-by (hash)
       ├── columns: s_name:2!null count_rows:81!null
       ├── grouping columns: s_name:2!null
       ├── key: (2)
@@ -2387,7 +2387,7 @@ sort
  ├── key: (33)
  ├── fd: (33)-->(34,35)
  ├── ordering: +33
- └── group-by
+ └── group-by (hash)
       ├── columns: cntrycode:33 count_rows:34!null sum:35!null
       ├── grouping columns: cntrycode:33
       ├── immutable

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -37,7 +37,7 @@ ORDER BY
     l_returnflag,
     l_linestatus;
 ----
-group-by
+group-by (streaming)
  ├── columns: l_returnflag:9!null l_linestatus:10!null sum_qty:19!null sum_base_price:20!null sum_disc_price:22!null sum_charge:24!null avg_qty:25!null avg_price:26!null avg_disc:27!null count_order:28!null
  ├── grouping columns: l_returnflag:9!null l_linestatus:10!null
  ├── immutable
@@ -160,7 +160,7 @@ project
            ├── columns: p_partkey:1!null p_mfgr:3!null s_name:13!null s_address:14!null s_phone:16!null s_acctbal:17!null s_comment:18!null ps_partkey:21!null ps_suppkey:22!null ps_supplycost:24!null n_name:29!null min:66!null
            ├── key: (21,22)
            ├── fd: (1)-->(3), (21,22)-->(1,3,13,14,16-18,24,29,66), (1)==(21), (21)==(1), (22)-->(13,14,16-18,29), (24)==(66), (66)==(24)
-           ├── group-by
+           ├── group-by (hash)
            │    ├── columns: p_partkey:1!null p_mfgr:3!null s_name:13!null s_address:14!null s_phone:16!null s_acctbal:17!null s_comment:18!null ps_partkey:21!null ps_suppkey:22!null ps_supplycost:24!null n_name:29!null min:66!null
            │    ├── grouping columns: ps_partkey:21!null ps_suppkey:22!null
            │    ├── key: (21,22)
@@ -301,7 +301,7 @@ top-k
  ├── key: (22)
  ├── fd: (22)-->(15,18,41)
  ├── ordering: -41,+15
- └── group-by
+ └── group-by (hash)
       ├── columns: o_orderdate:15!null o_shippriority:18!null l_orderkey:22!null sum:41!null
       ├── grouping columns: l_orderkey:22!null
       ├── immutable
@@ -402,7 +402,7 @@ sort
  ├── key: (6)
  ├── fd: (6)-->(30)
  ├── ordering: +6
- └── group-by
+ └── group-by (hash)
       ├── columns: o_orderpriority:6!null count_rows:30!null
       ├── grouping columns: o_orderpriority:6!null
       ├── key: (6)
@@ -477,7 +477,7 @@ sort
  ├── key: (50)
  ├── fd: (50)-->(61)
  ├── ordering: -61
- └── group-by
+ └── group-by (hash)
       ├── columns: n_name:50!null sum:61!null
       ├── grouping columns: n_name:50!null
       ├── immutable
@@ -648,7 +648,7 @@ ORDER BY
     cust_nation,
     l_year;
 ----
-group-by
+group-by (streaming)
  ├── columns: supp_nation:50!null cust_nation:56!null l_year:61 revenue:63!null
  ├── grouping columns: n1.n_name:50!null n2.n_name:56!null l_year:61
  ├── immutable
@@ -794,7 +794,7 @@ sort
       ├── immutable
       ├── key: (77)
       ├── fd: (77)-->(82)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: o_year:77 sum:80!null sum:81!null
       │    ├── grouping columns: o_year:77
       │    ├── immutable
@@ -943,7 +943,7 @@ sort
  ├── key: (58,63)
  ├── fd: (58,63)-->(65)
  ├── ordering: +58,-63
- └── group-by
+ └── group-by (hash)
       ├── columns: n_name:58!null o_year:63 sum:65!null
       ├── grouping columns: n_name:58!null o_year:63
       ├── immutable
@@ -1054,7 +1054,7 @@ top-k
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,41,47)
  ├── ordering: -47
- └── group-by
+ └── group-by (hash)
       ├── columns: c_custkey:1!null c_name:2!null c_address:3!null c_phone:5!null c_acctbal:6!null c_comment:8!null n_name:41!null sum:47!null
       ├── grouping columns: c_custkey:1!null
       ├── immutable
@@ -1158,7 +1158,7 @@ sort
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(24)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: ps_partkey:1!null sum:24!null
       │    ├── grouping columns: ps_partkey:1!null
       │    ├── immutable
@@ -1299,7 +1299,7 @@ sort
  ├── key: (26)
  ├── fd: (26)-->(31,33)
  ├── ordering: +26
- └── group-by
+ └── group-by (hash)
       ├── columns: l_shipmode:26!null sum:31!null sum:33!null
       ├── grouping columns: l_shipmode:26!null
       ├── key: (26)
@@ -1367,12 +1367,12 @@ sort
  ├── key: (22)
  ├── fd: (22)-->(23)
  ├── ordering: -23,-22
- └── group-by
+ └── group-by (hash)
       ├── columns: count:22!null count_rows:23!null
       ├── grouping columns: count:22!null
       ├── key: (22)
       ├── fd: (22)-->(23)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: c_custkey:1!null count:22!null
       │    ├── grouping columns: c_custkey:1!null
       │    ├── key: (1)
@@ -1542,7 +1542,7 @@ project
       │         ├── immutable
       │         ├── key: (12)
       │         ├── fd: (12)-->(29)
-      │         ├── group-by
+      │         ├── group-by (hash)
       │         │    ├── columns: l_suppkey:12!null sum:29!null
       │         │    ├── grouping columns: l_suppkey:12!null
       │         │    ├── immutable
@@ -1572,7 +1572,7 @@ project
       │                             ├── immutable
       │                             ├── key: ()
       │                             ├── fd: ()-->(50)
-      │                             ├── group-by
+      │                             ├── group-by (hash)
       │                             │    ├── columns: l_suppkey:32!null sum:49!null
       │                             │    ├── grouping columns: l_suppkey:32!null
       │                             │    ├── immutable
@@ -1648,7 +1648,7 @@ sort
  ├── key: (11-13)
  ├── fd: (11-13)-->(28)
  ├── ordering: -28,+11,+12,+13
- └── group-by
+ └── group-by (hash)
       ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:28!null
       ├── grouping columns: p_brand:11!null p_type:12!null p_size:13!null
       ├── key: (11-13)
@@ -1756,7 +1756,7 @@ project
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: (19)
  │    │    │    │    ├── fd: (19)-->(49)
- │    │    │    │    ├── group-by
+ │    │    │    │    ├── group-by (streaming)
  │    │    │    │    │    ├── columns: p_partkey:19!null avg:48!null
  │    │    │    │    │    ├── grouping columns: p_partkey:19!null
  │    │    │    │    │    ├── internal-ordering: +(19|31) opt(22,25)
@@ -1857,7 +1857,7 @@ top-k
  ├── key: (11)
  ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
  ├── ordering: -14,+15
- └── group-by
+ └── group-by (streaming)
       ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:59!null
       ├── grouping columns: o_orderkey:11!null
       ├── internal-ordering: +(11|22)
@@ -1901,7 +1901,7 @@ top-k
       │    │    │              │    ├── key: (40)
       │    │    │              │    ├── fd: (40)-->(58)
       │    │    │              │    ├── ordering: +40
-      │    │    │              │    ├── group-by
+      │    │    │              │    ├── group-by (streaming)
       │    │    │              │    │    ├── columns: l_orderkey:40!null sum:58!null
       │    │    │              │    │    ├── grouping columns: l_orderkey:40!null
       │    │    │              │    │    ├── key: (40)
@@ -2106,7 +2106,7 @@ sort
            │         │         │    ├── immutable
            │         │         │    ├── key: (16,17)
            │         │         │    ├── fd: (16,17)-->(18,52)
-           │         │         │    ├── group-by
+           │         │         │    ├── group-by (hash)
            │         │         │    │    ├── columns: ps_partkey:16!null ps_suppkey:17!null ps_availqty:18!null sum:52!null
            │         │         │    │    ├── grouping columns: ps_partkey:16!null ps_suppkey:17!null
            │         │         │    │    ├── key: (16,17)
@@ -2201,7 +2201,7 @@ top-k
  ├── key: (2)
  ├── fd: (2)-->(81)
  ├── ordering: -81,+2
- └── group-by
+ └── group-by (hash)
       ├── columns: s_name:2!null count_rows:81!null
       ├── grouping columns: s_name:2!null
       ├── key: (2)
@@ -2302,7 +2302,7 @@ GROUP BY
 ORDER BY
     cntrycode;
 ----
-group-by
+group-by (streaming)
  ├── columns: cntrycode:33 numcust:34!null totacctbal:35!null
  ├── grouping columns: cntrycode:33
  ├── immutable

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -812,7 +812,7 @@ project
  │    ├── key: (10)
  │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,30), (17)-->(10-16), (1)==(10), (10)==(1)
  │    ├── ordering: +2,+4,+5
- │    └── group-by
+ │    └── group-by (streaming)
  │         ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:30
  │         ├── grouping columns: cardsinfo.cardid:10!null
  │         ├── internal-ordering: +(1|10) opt(9)
@@ -949,7 +949,7 @@ sort
  ├── key: (45)
  ├── fd: (45)-->(40,42,44)
  ├── ordering: +45
- └── group-by
+ └── group-by (hash)
       ├── columns: sum:40!null sum:42!null sum:44!null column45:45
       ├── grouping columns: column45:45
       ├── stable
@@ -1099,7 +1099,7 @@ top-k
  ├── key: (10)
  ├── fd: (10)-->(16)
  ├── ordering: -16
- └── group-by
+ └── group-by (hash)
       ├── columns: accountname:10!null sum:16!null
       ├── grouping columns: accountname:10!null
       ├── key: (10)
@@ -1483,7 +1483,7 @@ update cardsinfo [as=ci]
       ├── columns: actualinventory_new:39 ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null
       ├── key: (18)
       ├── fd: ()-->(17), (18)-->(19-25,28,29,39), (25)-->(18-24), (18)==(28), (28)==(18)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: ci.dealerid:17!null ci.cardid:18!null buyprice:19!null sellprice:20!null discount:21!null desiredinventory:22!null actualinventory:23!null maxinventory:24!null ci.version:25!null c:28!null q:29!null sum_int:37
       │    ├── grouping columns: ci.cardid:18!null
       │    ├── key: (18)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -816,7 +816,7 @@ project
  │    ├── key: (10)
  │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,36), (17)-->(10-16), (1)==(10), (10)==(1)
  │    ├── ordering: +2,+4,+5
- │    └── group-by
+ │    └── group-by (streaming)
  │         ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:36
  │         ├── grouping columns: cardsinfo.cardid:10!null
  │         ├── internal-ordering: +(1|10) opt(9)
@@ -953,7 +953,7 @@ sort
  ├── key: (53)
  ├── fd: (53)-->(48,50,52)
  ├── ordering: +53
- └── group-by
+ └── group-by (hash)
       ├── columns: sum:48!null sum:50!null sum:52!null column53:53
       ├── grouping columns: column53:53
       ├── stable
@@ -1103,7 +1103,7 @@ top-k
  ├── key: (10)
  ├── fd: (10)-->(18)
  ├── ordering: -18
- └── group-by
+ └── group-by (hash)
       ├── columns: accountname:10!null sum:18!null
       ├── grouping columns: accountname:10!null
       ├── key: (10)
@@ -1500,7 +1500,7 @@ update cardsinfo [as=ci]
       ├── immutable
       ├── key: (22)
       ├── fd: ()-->(21,50,51), (22)-->(23-33,36,37,49,53), (29)-->(22-28,30-33), (22)==(36), (36)==(22)
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: ci.dealerid:21!null ci.cardid:22!null buyprice:23!null sellprice:24!null discount:25!null desiredinventory:26!null actualinventory:27!null maxinventory:28!null ci.version:29!null discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33 c:36!null q:37!null sum_int:47
       │    ├── grouping columns: ci.cardid:22!null
       │    ├── key: (22)

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -288,7 +288,7 @@ limit
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(2,6)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: y:2 count_rows:6!null
  │    ├── grouping columns: y:2
  │    ├── internal-ordering: +2
@@ -318,7 +318,7 @@ limit
  ├── stats: [rows=1e-07]
  ├── key: (2)
  ├── fd: (2)-->(6)
- ├── group-by
+ ├── group-by (streaming)
  │    ├── columns: y:2 count_rows:6!null
  │    ├── grouping columns: y:2
  │    ├── internal-ordering: +2 opt(3)
@@ -350,7 +350,7 @@ limit
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3,6)
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: z:3 count_rows:6!null
  │    ├── grouping columns: z:3
  │    ├── key: (3)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -427,7 +427,7 @@ scalar-group-by
 opt
 SELECT a, min(b) FROM abc GROUP BY a ORDER BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null min:6!null
  ├── grouping columns: a:1!null
  ├── key: (1)
@@ -443,7 +443,7 @@ group-by
 opt
 SELECT a, b, min(c) FROM abc GROUP BY a, b ORDER BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null min:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── internal-ordering: +1,+2
@@ -461,7 +461,7 @@ group-by
 opt
 SELECT a, b, min(c) FROM abc GROUP BY a, b ORDER BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null min:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── key: (1,2)
@@ -478,7 +478,7 @@ group-by
 opt
 SELECT a, b, min(c) FROM abc GROUP BY b, a ORDER BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null min:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── key: (1,2)
@@ -501,7 +501,7 @@ sort (segmented)
  ├── key: (1,2)
  ├── fd: (1,2)-->(6)
  ├── ordering: +1,+6
- └── group-by
+ └── group-by (streaming)
       ├── columns: a:1!null b:2!null min:6!null
       ├── grouping columns: a:1!null b:2!null
       ├── internal-ordering: +1,+2
@@ -520,7 +520,7 @@ sort (segmented)
 opt
 SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY c) GROUP BY a, b ORDER BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null array_agg:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── internal-ordering: +3 opt(1,2)
@@ -538,7 +538,7 @@ group-by
 opt
 SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY a, b, c) GROUP BY a, b ORDER BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null array_agg:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── internal-ordering: +3 opt(1,2)
@@ -556,7 +556,7 @@ group-by
 opt
 SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY b, c, a) GROUP BY b, a ORDER BY a, b
 ----
-group-by
+group-by (streaming)
  ├── columns: a:1!null b:2!null array_agg:6!null
  ├── grouping columns: a:1!null b:2!null
  ├── internal-ordering: +3 opt(1,2)
@@ -576,7 +576,7 @@ group-by
 opt
 SELECT sum(c) FROM abc WHERE a = 1 GROUP BY b ORDER BY b
 ----
-group-by
+group-by (streaming)
  ├── columns: sum:6!null  [hidden: b:2!null]
  ├── grouping columns: b:2!null
  ├── key: (2)
@@ -598,7 +598,7 @@ SELECT sum(d) FROM abcd GROUP BY a, b, c
 ----
 project
  ├── columns: sum:8
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1 b:2 c:3 sum:8
       ├── grouping columns: a:1 b:2 c:3
       ├── key: (1-3)
@@ -615,7 +615,7 @@ SELECT sum(a) FROM abcd GROUP BY b, c, d
 ----
 project
  ├── columns: sum:8
- └── group-by
+ └── group-by (hash)
       ├── columns: b:2 c:3 d:4 sum:8
       ├── grouping columns: b:2 c:3 d:4
       ├── key: (2-4)
@@ -631,7 +631,7 @@ SELECT array_agg(d) FROM (SELECT * FROM abcd ORDER BY c) GROUP BY a, b
 ----
 project
  ├── columns: array_agg:8
- └── group-by
+ └── group-by (hash)
       ├── columns: a:1 b:2 array_agg:8
       ├── grouping columns: a:1 b:2
       ├── internal-ordering: +3 opt(1,2)

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -68,7 +68,7 @@ inner-join (cross)
 opt
 SELECT max(y), y, y, x FROM a GROUP BY a.x, a.y
 ----
-group-by
+group-by (streaming)
  ├── columns: max:5 y:2 y:2 x:1!null
  ├── grouping columns: x:1!null
  ├── internal-ordering: +1

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -73,7 +73,7 @@ project
 opt
 SELECT min(b), a FROM abc GROUP BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: min:7 a:1
  ├── grouping columns: a:1
  ├── internal-ordering: +1
@@ -93,7 +93,7 @@ group-by
 opt
 SELECT min(b), c FROM abc GROUP BY c
 ----
-group-by
+group-by (hash)
  ├── columns: min:7 c:3
  ├── grouping columns: c:3
  ├── key: (3)
@@ -114,7 +114,7 @@ group-by
 opt
 SELECT array_agg(a), b, c FROM (SELECT * FROM abc ORDER BY b, a) GROUP BY b, c
 ----
-group-by
+group-by (hash)
  ├── columns: array_agg:7 b:2 c:3
  ├── grouping columns: b:2 c:3
  ├── internal-ordering: +1 opt(2,3)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -303,7 +303,7 @@ SELECT min(y) FROM xyz GROUP BY y
 ----
 project
  ├── columns: min:6
- └── group-by
+ └── group-by (streaming)
       ├── columns: y:2 min:6
       ├── grouping columns: y:2
       ├── internal-ordering: +2
@@ -323,7 +323,7 @@ SELECT max(y) FROM xyz GROUP BY y
 ----
 project
  ├── columns: max:6
- └── group-by
+ └── group-by (streaming)
       ├── columns: y:2 max:6
       ├── grouping columns: y:2
       ├── internal-ordering: +2
@@ -343,7 +343,7 @@ SELECT min(y) FROM xyz GROUP BY x
 ----
 project
  ├── columns: min:6
- └── group-by
+ └── group-by (streaming)
       ├── columns: x:1!null min:6
       ├── grouping columns: x:1!null
       ├── internal-ordering: +1
@@ -363,7 +363,7 @@ project
 opt expect-not=ReplaceScalarMinMaxWithLimit
 SELECT x,min(y) FROM xyz GROUP BY x,y
 ----
-group-by
+group-by (streaming)
  ├── columns: x:1!null min:6
  ├── grouping columns: x:1!null
  ├── internal-ordering: +1
@@ -383,7 +383,7 @@ group-by
 opt expect-not=ReplaceScalarMinMaxWithLimit
 SELECT x,max(y) FROM xyz GROUP BY x,y
 ----
-group-by
+group-by (streaming)
  ├── columns: x:1!null max:6
  ├── grouping columns: x:1!null
  ├── internal-ordering: +1
@@ -405,7 +405,7 @@ SELECT min(x), count(y) FROM xyz GROUP BY x,y
 ----
 project
  ├── columns: min:6!null count:7!null
- └── group-by
+ └── group-by (streaming)
       ├── columns: x:1!null min:6!null count:7!null
       ├── grouping columns: x:1!null
       ├── internal-ordering: +1
@@ -429,7 +429,7 @@ SELECT max(x), count(y) FROM xyz GROUP BY x,y
 ----
 project
  ├── columns: max:6!null count:7!null
- └── group-by
+ └── group-by (streaming)
       ├── columns: x:1!null max:6!null count:7!null
       ├── grouping columns: x:1!null
       ├── internal-ordering: +1
@@ -889,7 +889,7 @@ SELECT min(k) FROM kuvw WHERE v = 5 GROUP BY v, w
 ----
 project
  ├── columns: min:7!null
- └── group-by
+ └── group-by (streaming)
       ├── columns: w:4 min:7!null
       ├── grouping columns: w:4
       ├── internal-ordering: +4 opt(3)
@@ -911,7 +911,7 @@ SELECT max(k) FROM kuvw WHERE v = 5 GROUP BY v, w
 ----
 project
  ├── columns: max:7!null
- └── group-by
+ └── group-by (streaming)
       ├── columns: w:4 max:7!null
       ├── grouping columns: w:4
       ├── internal-ordering: +4 opt(3)
@@ -935,7 +935,7 @@ SELECT min(w) FROM kuvw WHERE v > 5 AND w IS NOT NULL GROUP BY v
 ----
 project
  ├── columns: min:7!null
- └── group-by
+ └── group-by (streaming)
       ├── columns: v:3!null min:7!null
       ├── grouping columns: v:3!null
       ├── internal-ordering: +3
@@ -962,7 +962,7 @@ SELECT max(w) FROM kuvw WHERE v > 5 GROUP BY v
 ----
 project
  ├── columns: max:7
- └── group-by
+ └── group-by (streaming)
       ├── columns: v:3!null max:7
       ├── grouping columns: v:3!null
       ├── internal-ordering: +3
@@ -981,7 +981,7 @@ project
 opt expect-not=ReplaceMinWithLimit
 SELECT min(w), min(k) FROM kuvw WHERE v = 5 AND w IS NOT NULL GROUP BY v
 ----
-group-by
+group-by (streaming)
  ├── columns: min:7!null min:8!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1002,7 +1002,7 @@ group-by
 opt expect-not=ReplaceMaxWithLimit
 SELECT max(w), max(k) FROM kuvw WHERE v = 5 GROUP BY v
 ----
-group-by
+group-by (streaming)
  ├── columns: max:7 max:8!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1022,7 +1022,7 @@ group-by
 opt expect-not=ReplaceMinWithLimit
 SELECT min(k), max(k) FROM kuvw WHERE w = 5 GROUP BY w
 ----
-group-by
+group-by (streaming)
  ├── columns: min:7!null max:8!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1042,7 +1042,7 @@ group-by
 opt expect-not=ReplaceMaxWithLimit
 SELECT max(w), count(w) FROM kuvw WHERE v = 5 GROUP BY v
 ----
-group-by
+group-by (streaming)
  ├── columns: max:7 count:8!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -1063,7 +1063,7 @@ group-by
 opt expect-not=ReplaceMinWithLimit
 SELECT min(w) FROM kuvw WHERE v = 5 GROUP BY v
 ----
-group-by
+group-by (streaming)
  ├── columns: min:7
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -2453,7 +2453,7 @@ project
       │    ├── key: (2,3)
       │    ├── fd: (2,3)-->(10)
       │    ├── limit hint: 1.00
-      │    ├── group-by
+      │    ├── group-by (streaming)
       │    │    ├── columns: a:2!null b:3!null count_rows:10!null
       │    │    ├── grouping columns: a:2!null b:3!null
       │    │    ├── internal-ordering: +2,+3
@@ -2509,7 +2509,7 @@ project
       │    ├── key: (5,6)
       │    ├── fd: (5,6)-->(10)
       │    ├── limit hint: 1.00
-      │    ├── group-by
+      │    ├── group-by (streaming)
       │    │    ├── columns: d:5!null e:6!null count_rows:10!null
       │    │    ├── grouping columns: d:5!null e:6!null
       │    │    ├── internal-ordering: +5,+6
@@ -2575,7 +2575,7 @@ project
       │    ├── key: (2)
       │    ├── fd: (2)-->(10)
       │    ├── limit hint: 1.00
-      │    ├── group-by
+      │    ├── group-by (streaming)
       │    │    ├── columns: a:2!null count_rows:10!null
       │    │    ├── grouping columns: a:2!null
       │    │    ├── internal-ordering: +2
@@ -2633,7 +2633,7 @@ project
       │    ├── key: (5)
       │    ├── fd: (5)-->(10)
       │    ├── limit hint: 1.00
-      │    ├── group-by
+      │    ├── group-by (streaming)
       │    │    ├── columns: d:5!null count_rows:10!null
       │    │    ├── grouping columns: d:5!null
       │    │    ├── internal-ordering: +5
@@ -2877,7 +2877,7 @@ SELECT a, array_agg(b)
 FROM (SELECT * FROM regional ORDER BY b)
 GROUP BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: a:2!null array_agg:10!null
  ├── grouping columns: a:2!null
  ├── internal-ordering: +2,+3
@@ -2908,7 +2908,7 @@ SELECT a, array_agg(c)
 FROM (SELECT * FROM regional ORDER BY c)
 GROUP BY a
 ----
-group-by
+group-by (hash)
  ├── columns: a:2!null array_agg:10
  ├── grouping columns: a:2!null
  ├── internal-ordering: +4 opt(2)
@@ -2944,7 +2944,7 @@ SELECT a, array_agg(r)
 FROM (SELECT * FROM regional ORDER BY r)
 GROUP BY a
 ----
-group-by
+group-by (hash)
  ├── columns: a:2!null array_agg:10!null
  ├── grouping columns: a:2!null
  ├── internal-ordering: +1 opt(2)
@@ -2976,7 +2976,7 @@ CREATE TABLE abcd (
 opt expect=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT max(b), a FROM abcd WHERE c > 0 GROUP BY a
 ----
-group-by
+group-by (streaming)
  ├── columns: max:8 a:1
  ├── grouping columns: a:1
  ├── internal-ordering: +1
@@ -2995,7 +2995,7 @@ group-by
 opt expect=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT count(*), c FROM abcd WHERE d = 1 GROUP BY c
 ----
-group-by
+group-by (streaming)
  ├── columns: count:8!null c:3
  ├── grouping columns: c:3
  ├── internal-ordering: +3
@@ -3150,7 +3150,7 @@ upsert xyz
 opt expect-not=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT max(b), c FROM abcd WHERE c > 0 GROUP BY c
 ----
-group-by
+group-by (hash)
  ├── columns: max:8 c:3!null
  ├── grouping columns: c:3!null
  ├── key: (3)
@@ -3174,7 +3174,7 @@ group-by
 opt expect-not=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT count(*), d FROM abcd WHERE d = 1 GROUP BY d
 ----
-group-by
+group-by (streaming)
  ├── columns: count:8!null d:4!null
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -3194,7 +3194,7 @@ group-by
 opt expect-not=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT max(c), a FROM abcd WHERE c > 0 GROUP BY a
 ----
-group-by
+group-by (hash)
  ├── columns: max:8!null a:1
  ├── grouping columns: a:1
  ├── key: (1)
@@ -3218,7 +3218,7 @@ group-by
 opt expect-not=EliminateIndexJoinOrProjectInsideGroupBy
 SELECT max(d), c FROM abcd WHERE d = 1 GROUP BY c
 ----
-group-by
+group-by (streaming)
  ├── columns: max:8!null c:3
  ├── grouping columns: c:3
  ├── internal-ordering: +3 opt(4)
@@ -3243,7 +3243,7 @@ SELECT a, array_agg(b)
 FROM (SELECT a, b FROM abcd WHERE c > 0 ORDER BY c)
 GROUP BY a
 ----
-group-by
+group-by (hash)
  ├── columns: a:1 array_agg:8
  ├── grouping columns: a:1
  ├── internal-ordering: +3 opt(1)
@@ -3266,3 +3266,230 @@ group-by
  └── aggregations
       └── array-agg [as=array_agg:8, outer=(2)]
            └── b:2
+
+# --------------------------------------------------
+# GenerateLimitedGroupByScans
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE defg (
+d INT,
+e INT,
+f INT,
+g INT,
+INDEX dd (d),
+INDEX dfg (d, f, g),
+INDEX df (d, f),
+INDEX gd (g, d),
+INDEX gg (g)
+)
+----
+
+memo
+SELECT d, e, count(*) FROM defg GROUP BY d, e LIMIT 10
+----
+memo (optimized, ~16KB, required=[presentation: d:1,e:2,count:8])
+ ├── G1: (limit G2 G3) (limit G4 G3) (limit G5 G3) (limit G6 G3)
+ │    └── [presentation: d:1,e:2,count:8]
+ │         ├── best: (limit G4="[limit hint: 10.00]" G3)
+ │         └── cost: 641.98
+ ├── G2: (group-by G7 G8 cols=(1,2)) (group-by G7 G8 cols=(1,2),ordering=+1)
+ │    └── [limit hint: 10.00]
+ │         ├── best: (group-by G7 G8 cols=(1,2))
+ │         └── cost: 1144.90
+ ├── G3: (const 10)
+ ├── G4: (group-by G9 G8 cols=(1,2)) (group-by G9 G8 cols=(1,2),ordering=+1)
+ │    └── [limit hint: 10.00]
+ │         ├── best: (group-by G9="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
+ │         └── cost: 641.87
+ ├── G5: (group-by G10 G8 cols=(1,2)) (group-by G10 G8 cols=(1,2),ordering=+1)
+ │    └── [limit hint: 10.00]
+ │         ├── best: (group-by G10="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
+ │         └── cost: 642.07
+ ├── G6: (group-by G11 G8 cols=(1,2)) (group-by G11 G8 cols=(1,2),ordering=+1)
+ │    └── [limit hint: 10.00]
+ │         ├── best: (group-by G11="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
+ │         └── cost: 641.97
+ ├── G7: (scan defg,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (sort G7)
+ │    │    └── cost: 1334.20
+ │    └── []
+ │         ├── best: (scan defg,cols=(1,2))
+ │         └── cost: 1094.72
+ ├── G8: (aggregations G12)
+ ├── G9: (index-join G13 defg,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (index-join G13="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
+ │    │    └── cost: 631.44
+ │    └── []
+ │         ├── best: (index-join G13 defg,cols=(1,2))
+ │         └── cost: 7134.44
+ ├── G10: (index-join G14 defg,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (index-join G14="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
+ │    │    └── cost: 631.64
+ │    └── []
+ │         ├── best: (index-join G14 defg,cols=(1,2))
+ │         └── cost: 7154.64
+ ├── G11: (index-join G15 defg,cols=(1,2))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (index-join G15="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
+ │    │    └── cost: 631.54
+ │    └── []
+ │         ├── best: (index-join G15 defg,cols=(1,2))
+ │         └── cost: 7144.54
+ ├── G12: (count-rows)
+ ├── G13: (scan defg@dd,cols=(1,5))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (scan defg@dd,cols=(1,5))
+ │    │    └── cost: 24.42
+ │    └── []
+ │         ├── best: (scan defg@dd,cols=(1,5))
+ │         └── cost: 1064.42
+ ├── G14: (scan defg@dfg,cols=(1,5))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (scan defg@dfg,cols=(1,5))
+ │    │    └── cost: 24.62
+ │    └── []
+ │         ├── best: (scan defg@dfg,cols=(1,5))
+ │         └── cost: 1084.62
+ └── G15: (scan defg@df,cols=(1,5))
+      ├── [ordering: +1] [limit hint: 10.00]
+      │    ├── best: (scan defg@df,cols=(1,5))
+      │    └── cost: 24.52
+      └── []
+           ├── best: (scan defg@df,cols=(1,5))
+           └── cost: 1074.52
+
+# Rule will trigger, but because no order is specified and an index matches,
+# this will result in a streaming group by.
+opt expect=GenerateLimitedGroupByScans
+SELECT d, g, count(*) FROM defg GROUP BY d, g LIMIT 10
+----
+limit
+ ├── columns: d:1 g:4 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1,4)
+ ├── fd: (1,4)-->(8)
+ ├── group-by (streaming)
+ │    ├── columns: d:1 g:4 count_rows:8!null
+ │    ├── grouping columns: d:1 g:4
+ │    ├── internal-ordering: +4,+1
+ │    ├── key: (1,4)
+ │    ├── fd: (1,4)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── scan defg@gd
+ │    │    ├── columns: d:1 g:4
+ │    │    ├── ordering: +4,+1
+ │    │    └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+opt expect=GenerateLimitedGroupByScans
+SELECT d, e, count(*) FROM defg GROUP BY d, e ORDER BY d LIMIT 10
+----
+limit
+ ├── columns: d:1 e:2 count:8!null
+ ├── internal-ordering: +1
+ ├── cardinality: [0 - 10]
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(8)
+ ├── ordering: +1
+ ├── group-by (partial streaming)
+ │    ├── columns: d:1 e:2 count_rows:8!null
+ │    ├── grouping columns: d:1 e:2
+ │    ├── key: (1,2)
+ │    ├── fd: (1,2)-->(8)
+ │    ├── ordering: +1
+ │    ├── limit hint: 10.00
+ │    ├── index-join defg
+ │    │    ├── columns: d:1 e:2
+ │    │    ├── ordering: +1
+ │    │    ├── limit hint: 10.00
+ │    │    └── scan defg@dd
+ │    │         ├── columns: d:1 rowid:5!null
+ │    │         ├── key: (5)
+ │    │         ├── fd: (5)-->(1)
+ │    │         ├── ordering: +1
+ │    │         └── limit hint: 10.00
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10
+
+# GenerateLimitedGroupByScans will not result in an index scan since the order
+# by is a column not in an index.
+opt expect-not=GenerateLimitedGroupByScans
+SELECT d, e, count(*) FROM defg GROUP BY d, e ORDER BY e LIMIT 10
+----
+top-k
+ ├── columns: d:1 e:2 count:8!null
+ ├── internal-ordering: +2
+ ├── k: 10
+ ├── cardinality: [0 - 10]
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(8)
+ ├── ordering: +2
+ └── group-by (hash)
+      ├── columns: d:1 e:2 count_rows:8!null
+      ├── grouping columns: d:1 e:2
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(8)
+      ├── scan defg
+      │    └── columns: d:1 e:2
+      └── aggregations
+           └── count-rows [as=count_rows:8]
+
+# GenerateLimitedGroupByScans will be triggered, but not add an index
+# scan to the memo since the order by and group by don't share columns.
+memo
+SELECT d, e, count(*) FROM defg GROUP BY d, e ORDER BY count(*) LIMIT 10
+----
+memo (optimized, ~5KB, required=[presentation: d:1,e:2,count:8] [ordering: +8])
+ ├── G1: (limit G2 G3 ordering=+8) (top-k G2 &{10 +8})
+ │    ├── [presentation: d:1,e:2,count:8] [ordering: +8]
+ │    │    ├── best: (top-k G2 &{10 +8})
+ │    │    └── cost: 1231.64
+ │    └── []
+ │         ├── best: (top-k G2 &{10 +8})
+ │         └── cost: 1231.64
+ ├── G2: (group-by G4 G5 cols=(1,2)) (group-by G4 G5 cols=(1,2),ordering=+1)
+ │    ├── [ordering: +8] [limit hint: 10.00]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1394.38
+ │    └── []
+ │         ├── best: (group-by G4 G5 cols=(1,2))
+ │         └── cost: 1144.90
+ ├── G3: (const 10)
+ ├── G4: (scan defg,cols=(1,2))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (sort G4)
+ │    │    └── cost: 1334.20
+ │    └── []
+ │         ├── best: (scan defg,cols=(1,2))
+ │         └── cost: 1094.72
+ ├── G5: (aggregations G6)
+ └── G6: (count-rows)
+
+# Rule does not apply because the grouping columns are not the first columns of
+# an index.
+opt expect-not=GenerateLimitedGroupByScans
+SELECT f, e, count(*) FROM defg GROUP BY f, e LIMIT 10
+----
+limit
+ ├── columns: f:3 e:2 count:8!null
+ ├── cardinality: [0 - 10]
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(8)
+ ├── group-by (hash)
+ │    ├── columns: e:2 f:3 count_rows:8!null
+ │    ├── grouping columns: e:2 f:3
+ │    ├── key: (2,3)
+ │    ├── fd: (2,3)-->(8)
+ │    ├── limit hint: 10.00
+ │    ├── scan defg
+ │    │    └── columns: e:2 f:3
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:8]
+ └── 10

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5457,7 +5457,7 @@ GROUP BY n.name, n.geom
 project
  ├── columns: name:16!null popn_per_sqkm:22
  ├── immutable
- ├── group-by
+ ├── group-by (hash)
  │    ├── columns: name:16!null n.geom:17!null sum:21
  │    ├── grouping columns: name:16!null n.geom:17!null
  │    ├── immutable
@@ -6055,7 +6055,7 @@ with &1 (q)
  └── project
       ├── columns: count:43 count_rows:31!null
       ├── immutable
-      ├── group-by
+      ├── group-by (hash)
       │    ├── columns: n.boroname:25 count_rows:31!null
       │    ├── grouping columns: n.boroname:25
       │    ├── immutable

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -462,9 +462,12 @@ func (ef *execFactory) ConstructGroupBy(
 	groupColOrdering colinfo.ColumnOrdering,
 	aggregations []exec.AggInfo,
 	reqOrdering exec.OutputOrdering,
+	groupingOrderType exec.GroupingOrderType,
 ) (exec.Node, error) {
 	inputPlan := input.(planNode)
 	inputCols := planColumns(inputPlan)
+	// TODO(harding): Use groupingOrder to determine when to use a hash
+	// aggregator.
 	n := &groupNode{
 		plan:             inputPlan,
 		funcs:            make([]*aggregateFuncHolder, 0, len(groupCols)+len(aggregations)),

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -94,7 +94,7 @@ network usage: 0 B (0 messages)
         │ render cid: (cid)[int]
         │ render sum: (sum)[decimal]
         │
-        └── • group
+        └── • group (hash)
             │ columns: (cid int, sum decimal)
             │ estimated row count: 98 (missing stats)
             │ aggregate 0: sum(value)
@@ -127,7 +127,7 @@ children:
 - name: render
   attrs: []
   children:
-  - name: group
+  - name: group (hash)
     attrs:
     - key: group by
       value: cid


### PR DESCRIPTION
Before this change, the optimizer cost model for group by included
overhead for processing all input rows for all non-streaming
aggregation. Recent changes in the vectorized execution engine added
optimizations for aggregation with partially ordered grouping columns
that does not require all input rows to be processed if there is a
limit, but still requires a hash table, unlike streaming aggregation.

This change adds checks for whether an aggregation has a subset of
grouping columns that are ordered, and costs it similarly to
streaming aggregation by reflecting the limit hint on the number of both
input rows and output rows. We also pass the limit hint property to
child nodes of the aggregation if the grouping columns are partially
ordered.

We also add a new exploration rule, `GenerateLimitedGroupByScans`, to
enable the optimizer to explore scans on secondary indexes that lead
to partially ordered grouping columns. Previously, fully ordered
grouping columns could be found by exploring secondary indexes with full
cover over the columns via `GenerateIndexScans`. When introducing
partially ordered grouping columns, however, not all grouping columns
may be part of an index, so we may need to construct an IndexJoin to add
the missing columns. The new exploration rule is triggered when there is
a limit expression with a positive constant limit, a canonical group by,
and a canonical scan.

Fixes: #63049
Fixes: #71768
    
Release note (performance improvement): Improves performance of some
GROUP BY queries with a LIMIT if there is an index ordering that matches
a subset of the grouping columns. In this case the total number of
aggregations needed to satisfy the LIMIT can be emitted without scanning
the entire input, enabling the execution to be more effective.