### PR TITLE
sql: mark flow registry draining errors as retriable

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -189,6 +190,10 @@ func IsPermanentSchemaChangeError(err error) bool {
 		errSchemaChangeNotFirstInLine,
 		errTableVersionMismatchSentinel,
 	) {
+		return false
+	}
+
+	if flowinfra.IsFlowRetryableError(err) {
 		return false
 	}
 


### PR DESCRIPTION
Release note (bug fix): Schema changes running during node shutdown could
sometimes fail permanently when they should not.