### PR TITLE
security: prevent PEM decoding errors by careful newline insertation

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -1007,10 +1007,12 @@ func (cm *CertificateManager) GetTenantTLSConfig() (*tls.Config, error) {
 
 	caBlob := ca.FileContents
 
-	// CA used to validate certs provided by other SQL servers.
-	tenantCA, err := cm.getTenantCACertLocked()
-	if err == nil {
-		caBlob = append(caBlob, tenantCA.FileContents...)
+	if cm.tenantCACert != nil {
+		// If it's available, we also include the tenant CA.
+		tenantCA, err := cm.getTenantCACertLocked()
+		if err == nil {
+			caBlob = AppendCertificatesToBlob(caBlob, tenantCA.FileContents)
+		}
 	}
 
 	// Client cert presented to KV nodes.
@@ -1113,10 +1115,12 @@ func (cm *CertificateManager) GetUIClientTLSConfig() (*tls.Config, error) {
 
 	caBlob := uiCA.FileContents
 
-	// If it's available, we also include the tenant CA.
-	tenantCA, err := cm.getTenantCACertLocked()
-	if err == nil {
-		caBlob = append(caBlob, tenantCA.FileContents...)
+	if cm.tenantCACert != nil {
+		// If it's available, we also include the tenant CA.
+		tenantCA, err := cm.getTenantCACertLocked()
+		if err == nil {
+			caBlob = AppendCertificatesToBlob(caBlob, tenantCA.FileContents)
+		}
 	}
 
 	cfg, err := newUIClientTLSConfig(cm.tlsSettings, caBlob)

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -11,6 +11,7 @@
 package security
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/rand"
@@ -560,4 +561,17 @@ func PEMContentsToX509(contents []byte) ([]*x509.Certificate, error) {
 	}
 
 	return certs, nil
+}
+
+// AppendCertificatesToBlob adds the passed PEM encoded certificates to the existing
+// byte slice containing PEM encoded certificates, ensuring that there is a newline
+// separating the original byte slice and each subsequent certificate byte slices.
+func AppendCertificatesToBlob(certBlob []byte, newCerts ...[]byte) []byte {
+	return bytes.Join(
+		append(
+			[][]byte{certBlob},
+			newCerts...,
+		),
+		[]byte{'\n'},
+	)
 }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/71588

> Previously, we assumed that the Tenant CA certificate and the CA
> certificate would not be the same, and that they would be saved as
> files with an end of file newline character.
> 
> This change adds support for not loading the Tenant CA Certificate
> if it will just be a second copy of the CA certificate.
> 
> This change also adds a helper function to concatenate certificates
> with a newline separating each, to ensure that the easiest way to
> make a certificate bundle is the correct way.
> 
> Release note: bugfix for certificate loading logic

The bug in question was introduced in https://github.com/cockroachdb/cockroach/pull/71248 (and back ported in https://github.com/cockroachdb/cockroach/pull/71402).