### PR TITLE
ui: fix default value of filter to All

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -69,7 +69,7 @@ const timeUnit = [
 ];
 
 export const defaultFilters: Filters = {
-  app: "",
+  app: "All",
   timeNumber: "0",
   timeUnit: "seconds",
   fullScan: false,
@@ -116,7 +116,7 @@ export const getFiltersFromQueryString = (
  * we want to consider 0 active Filters
  */
 export const inactiveFiltersState: Filters = {
-  app: "",
+  app: "All",
   timeNumber: "0",
   fullScan: false,
   sqlType: "",


### PR DESCRIPTION
A recent commit changed the default value of filter
to be an empty string, but we do have transactions that have
no associated app names to it, so All and empty string
should be treated as different cases. This commit reverse
that changes and use All

Release note (bug fix): Show All statements when filter All is
selected and not only the ones with empty string