### PR TITLE
opt: fix TestExecBuild/local/limit flake

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -511,7 +511,7 @@ ANALYZE a;
 statement ok
 ANALYZE b;
 
-query T
+query T retry
 EXPLAIN ANALYZE SELECT * FROM a INNER LOOKUP JOIN b ON k = j ORDER BY i LIMIT 5;
 ----
 planning time: 10µs


### PR DESCRIPTION
The stats cache is updated asynchronously. We can fix this flake using
`retry`.

Fixes #71549.

Release note: None