### PR TITLE
sql: remove remnant of gossip-based stats cache update

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -955,9 +955,6 @@ func parseGossipValues(gossipInfo *gossip.InfoStatus) (string, error) {
 				return "", errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
 			output = append(output, fmt.Sprintf("%q: %+v", key, drainingInfo))
-		} else if strings.HasPrefix(key, gossip.KeyTableStatAddedPrefix) {
-			gossipedTime := timeutil.Unix(0, info.OrigStamp)
-			output = append(output, fmt.Sprintf("%q: %v", key, gossipedTime))
 		} else if strings.HasPrefix(key, gossip.KeyGossipClientsPrefix) {
 			output = append(output, fmt.Sprintf("%q: %v", key, string(bytes)))
 		}

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -75,11 +75,6 @@ const (
 	// draining state.
 	KeyDistSQLDrainingPrefix = "distsql-draining"
 
-	// KeyTableStatAddedPrefix is the prefix for keys that indicate a new table
-	// statistic was computed. The statistics themselves are not stored in gossip;
-	// the keys are used to notify nodes to invalidate table statistic caches.
-	KeyTableStatAddedPrefix = "table-stat-added"
-
 	// KeyGossipClientsPrefix is the prefix for keys that indicate which gossip
 	// client connections a node has open. This is used by other nodes in the
 	// cluster to build a map of the gossip network.
@@ -178,12 +173,6 @@ func MakeDistSQLNodeVersionKey(nodeID roachpb.NodeID) string {
 // draining state.
 func MakeDistSQLDrainingKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyDistSQLDrainingPrefix, nodeID.String())
-}
-
-// MakeTableStatAddedKey returns the gossip key used to notify that a new
-// statistic is available for the given table.
-func MakeTableStatAddedKey(tableID uint32) string {
-	return MakeKey(KeyTableStatAddedPrefix, strconv.FormatUint(uint64(tableID), 10 /* base */))
 }
 
 // removePrefixFromKey removes the key prefix and separator and returns what's

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1537,14 +1537,10 @@ func injectTableStats(
 	}
 
 	// Invalidate the local cache synchronously; this guarantees that the next
-	// statement in the same session won't use a stale cache (whereas the gossip
-	// update is handled asynchronously).
+	// statement in the same session won't use a stale cache (the cache would
+	// normally be updated asynchronously).
 	params.extendedEvalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(params.ctx, desc.GetID())
 
-	// Use Gossip to refresh the caches on other nodes.
-	if g, ok := params.extendedEvalCtx.ExecCfg.Gossip.Optional(47925); ok {
-		return stats.GossipTableStatAdded(g, desc.GetID())
-	}
 	return nil
 }
 

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -516,10 +516,6 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 		return err
 	}
 
-	if g, ok := s.FlowCtx.Cfg.Gossip.Optional(47925); ok {
-		// Gossip refresh of the stat caches for this table.
-		return stats.GossipTableStatAdded(g, s.tableID)
-	}
 	return nil
 }
 

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/gossip",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",


### PR DESCRIPTION
This change removes the last remnant of the gossip-based stats cache
invalidation. This code was necessary only during 21.1->21.2 upgrade.

Release note: None