### PR TITLE
ui: use $internal instead of (internal) for filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -153,13 +153,13 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
 
   dropdownRef: React.RefObject<HTMLDivElement> = React.createRef();
 
-  componentDidMount() {
+  componentDidMount(): void {
     window.addEventListener("click", this.outsideClick, false);
   }
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     window.removeEventListener("click", this.outsideClick, false);
   }
-  componentDidUpdate(prevProps: QueryFilter) {
+  componentDidUpdate(prevProps: QueryFilter): void {
     if (prevProps.filters !== this.props.filters) {
       this.setState({
         filters: {
@@ -168,21 +168,21 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
       });
     }
   }
-  outsideClick = (event: any) => {
+  outsideClick = (event: any): void => {
     this.setState({ hide: true });
   };
 
-  insideClick = (event: any) => {
+  insideClick = (event: any): void => {
     event.stopPropagation();
   };
 
-  toggleFilters = () => {
+  toggleFilters = (): void => {
     this.setState({
       hide: !this.state.hide,
     });
   };
 
-  handleSubmit = () => {
+  handleSubmit = (): void => {
     this.props.onSubmitFilters(this.state.filters);
     this.setState({ hide: true });
   };
@@ -220,14 +220,14 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
   };
 
-  validateInput = (value: string) => {
+  validateInput = (value: string): string => {
     const isInteger = /^[0-9]+$/;
     return (value === "" || isInteger.test(value)) && value.length <= 3
       ? value
       : this.state.filters.timeNumber;
   };
 
-  clearInput = () => {
+  clearInput = (): void => {
     this.setState({
       filters: {
         ...this.state.filters,
@@ -238,11 +238,10 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
 
   isOptionSelected = (option: string, field: string) => {
     const selection = field.split(",");
-    if (selection.length > 0 && selection.includes(option)) return true;
-    return false;
+    return selection.length > 0 && selection.includes(option);
   };
 
-  render() {
+  render(): React.ReactElement {
     const { hide, filters } = this.state;
     const {
       appNames,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -117,7 +117,7 @@ function filterByRouterParamsPredicate(
     app = "";
   }
 
-  if (app === "(internal)") {
+  if (app === internalAppNamePrefix) {
     return (stmt: ExecutionStatistics) =>
       filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
   }
@@ -152,7 +152,9 @@ export const selectStatement = createSelector(
       byNode: coalesceNodeStats(results),
       app: _.uniq(
         results.map(s =>
-          s.app.startsWith(internalAppNamePrefix) ? "(internal)" : s.app,
+          s.app.startsWith(internalAppNamePrefix)
+            ? internalAppNamePrefix
+            : s.app,
         ),
       ),
       database: queryByName(props.location, databaseAttr),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -629,7 +629,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   ],
   statementsError: null,
   dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
-  apps: ["(internal)", "movr", "$ cockroach demo"],
+  apps: ["$ internal", "movr", "$ cockroach demo"],
   totalFingerprints: 95,
   lastReset: "2020-04-13 07:22:23",
   columns: null,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -84,7 +84,9 @@ export const selectApps = createSelector(
       },
     );
     return []
-      .concat(sawInternal ? ["(internal)"] : [])
+      .concat(
+        sawInternal ? [statementsState.data.internal_app_name_prefix] : [],
+      )
       .concat(sawBlank ? ["(unset)"] : [])
       .concat(Object.keys(apps));
   },
@@ -153,7 +155,7 @@ export const selectStatements = createSelector(
       let showInternal = false;
       if (criteria === "(unset)") {
         criteria = "";
-      } else if (criteria === "(internal)") {
+      } else if (criteria === state.data.internal_app_name_prefix) {
         showInternal = true;
       }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -28,7 +28,7 @@ storiesOf("StatementsSortedTable", module)
       data={statements}
       columns={makeStatementsColumns(
         statements,
-        "(internal)",
+        "$ internal",
         calculateTotalWorkload(statements),
         { "1": "gcp-europe-west1", "2": "gcp-us-east1", "3": "gcp-us-west1" },
         "statement",

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -319,14 +319,14 @@ describe("Routing to", () => {
 
   describe("'/statements/:${appAttr}' path", () => {
     it("routes to <StatementsPage> component", () => {
-      navigateToPath("/statements/(internal)");
+      navigateToPath("/statements/%24+internal");
       assert.lengthOf(appWrapper.find(StatementsPage), 1);
     });
   });
 
   describe("'/statements/:${appAttr}/:${statementAttr}' path", () => {
     it("routes to <StatementDetails> component", () => {
-      navigateToPath("/statements/(internal)/true");
+      navigateToPath("/statements/%24+internal/true");
       assert.lengthOf(appWrapper.find(StatementDetails), 1);
     });
   });

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -151,7 +151,7 @@ function filterByRouterParamsPredicate(
     app = "";
   }
 
-  if (app === "(internal)") {
+  if (app === internalAppNamePrefix) {
     return (stmt: ExecutionStatistics) =>
       filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
   }
@@ -186,7 +186,9 @@ export const selectStatement = createSelector(
       byNode: coalesceNodeStats(results),
       app: _.uniq(
         results.map(s =>
-          s.app.startsWith(internalAppNamePrefix) ? "(internal)" : s.app,
+          s.app.startsWith(internalAppNamePrefix)
+            ? internalAppNamePrefix
+            : s.app,
         ),
       ),
       database: queryByName(props.location, databaseAttr),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -148,13 +148,13 @@ describe("selectStatements", () => {
     assert.equal(result.length, 1);
   });
 
-  it('filters out statements with app set when app param is "(internal)"', () => {
+  it('filters out statements with app set when app param is "$ internal"', () => {
     const state = makeStateWithStatements([
       makeFingerprint(1, "$ internal_stmnt_app"),
       makeFingerprint(2, "bar"),
       makeFingerprint(3, "baz"),
     ]);
-    const props = makeRoutePropsWithApp("(internal)");
+    const props = makeRoutePropsWithApp("$ internal");
     const result = selectStatements(state, props);
     assert.equal(result.length, 1);
   });
@@ -423,7 +423,7 @@ describe("selectStatement", () => {
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
-  it('filters out statements with app set when app param is "(internal)"', () => {
+  it('filters out statements with app set when app param is "$ internal"', () => {
     const stmtA = makeFingerprint(1, "$ internal_stmnt_app");
     const state = makeStateWithStatements([
       stmtA,
@@ -432,15 +432,15 @@ describe("selectStatement", () => {
     ]);
     const props = makeRoutePropsWithStatementAndApp(
       stmtA.key.key_data.query,
-      "(internal)",
+      "$ internal",
     );
 
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
-    // Statements with internal app prefix should have "(internal)" as app name
-    assert.deepEqual(result.app, ["(internal)"]);
+    // Statements with internal app prefix should have "$ internal" as app name
+    assert.deepEqual(result.app, ["$ internal"]);
     assert.deepEqual(result.distSQL, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.vec, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.failed, { numerator: 0, denominator: 1 });

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -546,7 +546,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
   ],
   statementsError: null,
-  apps: ["(internal)", "movr", "$ cockroach demo"],
+  apps: ["$ internal", "movr", "$ cockroach demo"],
   totalFingerprints: 95,
   lastReset: "2020-04-13 07:22:23",
   dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -88,7 +88,7 @@ export const selectStatements = createSelector(
       let showInternal = false;
       if (criteria === "(unset)") {
         criteria = "";
-      } else if (criteria === "(internal)") {
+      } else if (criteria === state.data.internal_app_name_prefix) {
         showInternal = true;
       }
 
@@ -160,7 +160,7 @@ export const selectApps = createSelector(
       },
     );
     return []
-      .concat(sawInternal ? ["(internal)"] : [])
+      .concat(sawInternal ? [state.data.internal_app_name_prefix] : [])
       .concat(sawBlank ? ["(unset)"] : [])
       .concat(Object.keys(apps));
   },


### PR DESCRIPTION
Previously we were using `(internal)` and `$ internal`
to identify internal statements and transactions.
This commits aligns all usages, with all places using
`$ internal` now.

Release note (ui change): Replace `(internal)` on filter and details
on Statements page for `$ internal` to align with Transactions Page.