### PR TITLE
sql: fix skipped pre-txn-commit validation bug

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -171,6 +171,7 @@ func (tc *Collection) ReleaseAll(ctx context.Context) {
 	tc.kv.reset()
 	tc.synthetic.reset()
 	tc.deletedDescs = nil
+	tc.skipValidationOnWrite = false
 }
 
 // HasUncommittedTables returns true if the Collection contains uncommitted

--- a/pkg/sql/catalog/descs/validate.go
+++ b/pkg/sql/catalog/descs/validate.go
@@ -33,6 +33,7 @@ func (tc *Collection) ValidateUncommittedDescriptors(ctx context.Context, txn *k
 	if tc.skipValidationOnWrite || !ValidateOnWriteEnabled.Get(&tc.settings.SV) {
 		return nil
 	}
+
 	descs := tc.uncommitted.getUncommittedDescriptorsForValidation()
 	if len(descs) == 0 {
 		return nil


### PR DESCRIPTION
Previously, querying a descriptor surgery function with the 'force' flag
set would correctly disable pre-txn-commit descriptor validation for
this transaction, but the validation could incorrectly remain disabled
afterwards.

This commit fixes this bug. In practice, this bug directly impacts the
usefulness of importing a cluster's descriptor state via a 'debug doctor
recreate' dump. This is typically done to practice repairing a corrupted
descriptor, a use case for which this validation is particularly
useful.

Release justification: Low risk bug fix in debug tooling

Release note: None