### PR TITLE
codeowners: add prodsec team as an owner for the security package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -219,7 +219,7 @@
 /pkg/roachpb/index*          @cockroachdb/sql-observability
 /pkg/rpc/                    @cockroachdb/server-prs
 /pkg/scheduledjobs/          @cockroachdb/bulk-prs
-/pkg/security/               @cockroachdb/server-prs
+/pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/settings/               @cockroachdb/server-prs
 /pkg/spanconfig/             @cockroachdb/multiregion
 /pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
@@ -235,6 +235,14 @@
 /pkg/util/stop               @cockroachdb/server-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
 /pkg/workload/               @cockroachdb/sql-experience
+
+# Allow the security team to have insight into changes to
+# authn/authz code.
+/pkg/cmd/roachprod/vm/azure/auth.go    @cockroachdb/prodsec
+/pkg/cli/auth.go                       @cockroachdb/prodsec
+/pkg/rpc/auth.go                       @cockroachdb/prodsec
+/pkg/sql/pgwire/auth.go                @cockroachdb/prodsec
+               
 
 # Own all bazel files to dev-inf, but don't request reviews for them
 # as they are mostly - but not only - generated code that changes with

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -51,6 +51,8 @@ cockroachdb/test-eng:
   triage_column_id: 14041337
 cockroachdb/security:
   triage_column_id: 0 # TODO
+cockroachdb/prodsec:
+  triage_column_id: 0 # TODO as well
 cockroachdb/bulk-io:
   aliases:
     cockroachdb/bulk-prs: other


### PR DESCRIPTION
This PR adds the new ProdSec team as a code owner to the security package as well as the authentication specific code.