### PR TITLE
release-21.1: colfetcher: fix reading from unique sec index that used to be primary

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -536,7 +536,6 @@ func (rf *cFetcher) Init(
 			if ok && neededCols.Contains(int(id)) {
 				if compositeColumnIDs.Contains(int(id)) {
 					table.compositeIndexColOrdinals.Add(colIdx)
-				} else {
 					table.neededValueColsByIdx.Remove(colIdx)
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1434,3 +1434,36 @@ table_with_virtual_cols  CREATE TABLE public.table_with_virtual_cols (
                          UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
                          FAMILY fam_0_id_new_pk (id, new_pk)
 )
+
+# Regression tests for incorrectly reading from the unique secondary index that
+# used be a primary index in the vectorized engine (#71553). Note that this
+# reproduction only works on 21.1 and before (because it relies on a bug with
+# incorrectly marking the secondary index as having a primary index encoding
+# #71552).
+statement ok
+CREATE TABLE t71553 (a INT PRIMARY KEY, b INT NOT NULL);
+INSERT INTO t71553 VALUES (1, 1);
+ALTER TABLE t71553 ALTER PRIMARY KEY USING COLUMNS (b);
+
+query II
+SELECT * FROM t71553
+----
+1  1
+
+statement ok
+ALTER TABLE t71553 ALTER PRIMARY KEY USING COLUMNS (a);
+
+query II
+SELECT * FROM t71553
+----
+1  1
+
+query II
+SELECT * FROM t71553@t71553_a_key
+----
+1  1
+
+query II
+SELECT * FROM t71553@t71553_b_key
+----
+1  1


### PR DESCRIPTION
Backport 1/1 commits from #71545.

/cc @cockroachdb/release

---

In #48052 we introduced a bug which made it so that we would remove all
key suffix columns from the set of columns that need to be read unless
the column has a composite encoding. This would make it so that we would
incorrectly read off the unique secondary index in some cases since we
would treat those key suffix columns as not needed for decoding.

In order for the bug to present itself, the following conditions need to
be met:
- we're reading of a unique secondary index
- that index was a primary index that was created via ALTER PRIMARY KEY
command in 21.1.x version or before.

Fixes: #71553.

Release note (bug fix): Previously, CockroachDB could incorrectly read
the data of a unique secondary index that used to be a primary index
that was created via ALTER PRIMARY KEY in 21.1.x or prior versions.
