### PR TITLE
cli: pass fake StoreSpec in mt start-sql

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -87,7 +88,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	}
 
 	if serverCfg.SQLConfig.TempStorageConfig, err = initTempStorageConfig(
-		ctx, serverCfg.Settings, stopper, serverCfg.Stores,
+		ctx, serverCfg.Settings, stopper, base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true}}},
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
In #71040 we added disk spilling which in particular added the following
call to the `mt start-sql` code path:

https://github.com/cockroachdb/cockroach/blob/af5a5a5065ce80c5e6568b4b422bf5c3a179e173/pkg/cli/mt_start_sql.go#L90-L89

The tenant doesn't support the `--store` flag, and so this will always
be the default of `cockroach-data`.

This has the unfortunate effect of trying to clean up the temp dirs for
that directory, even if `--temp-dir` is supplied:

https://github.com/cockroachdb/cockroach/blob/6999e5fded43f59eb5839dc8b943fd1e2a33a3fd/pkg/cli/start.go#L223-L227

In the `multitenant-upgrade` roachtest, as it happens there was actually
a cockroach host instance running under `cockroach-data`, and so the
tenant would fail to try to remove its (locked) temp dirs.

This commit fixes that issue by making start-sql use an in-memory store
spec. This fixes the test flake, but I wonder if the temp storage
feature for tenants is working properly. I worry about this because
the concept of a "temp engine" always seems to require a store:

https://github.com/cockroachdb/cockroach/blob/6999e5fded43f59eb5839dc8b943fd1e2a33a3fd/pkg/cli/start.go#L274-L280

and I am not sure how deep this goes. Frankly I don't understand why
if you are providing a Path you also need to provide a StoreSpec. I
will leave untangling this to @knz and @jaylim-crl, who know this
code better than I do.

Fixes #69920.

Release note: None
