### PR TITLE
ui: fix stmt not being found

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -75,7 +75,7 @@ export const statementFingerprintIdsToText = (
   statements: Statement[],
 ): string => {
   return statementFingerprintIds
-    .map(s => statements.find(stmt => stmt.id.eq(s)).key.key_data.query)
+    .map(s => statements.find(stmt => stmt.id.eq(s))?.key.key_data.query)
     .join("\n");
 };
 


### PR DESCRIPTION
When creating a transaction fingerprint text based on
statement ids, if the statement was not found, it was
crashing and making the Transactions Page to not load.
This commit handles the case.

Release note (bug fix): Transaction page no longer crashes when
a statement is not found.