### PR TITLE
roachtest: fix multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -34,15 +34,13 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 	kvAddrs, err := c.ExternalAddr(ctx, c.All())
 	require.NoError(t, err)
 
-	tenantCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	const (
 		tenantHTTPPort = 8081
 		tenantSQLPort  = 30258
 	)
 	const tenantNode = 1
-	tenant := createTenantNode(tenantCtx, t, c, "./cockroach", kvAddrs,
-		tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
+	tenant := createTenantNode(kvAddrs, tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
+	tenant.start(ctx, t, c, "./cockroach")
 
 	t.Status("checking that a client can connect to the tenant server")
 


### PR DESCRIPTION
In #71040 we added disk spilling for tenants which added the following
call to the `mt start-sql` code path:

https://github.com/cockroachdb/cockroach/blob/af5a5a5065ce80c5e6568b4b422bf5c3a179e173/pkg/cli/mt_start_sql.go#L90-L89

The defaults for the store match that of a regular CockroachDB node, and
the tenant will thus attempt to clean up temp dirs for `cockroach-data`
if no store is specified:

https://github.com/cockroachdb/cockroach/blob/6999e5fded43f59eb5839dc8b943fd1e2a33a3fd/pkg/cli/start.go#L223-L227

In the `multitenant-upgrade` roachtest, as it happens there was actually
a cockroach host instance running under `cockroach-data`, and so the
tenant would fail to try to remove its (locked) temp dirs.

Fix that by passing the `--store` flag to the tenants in this test. This
is mildly annoying since the predecessor version doesn't understand it
and so the test has to figure out when it is legal to pass it. Anyway,
it is done now.

I will point out that it isn't the greatest choice to have tenants
default to `cockroach-data` as the resulting interaction with a CRDB
server results in an unfortunate UX. I filed #71603 to that effect.

Closes #69920

Release note: None
