### PR TITLE
roachprod: fix roachprod gc docker build

### DIFF
--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -1,5 +1,19 @@
-FROM golang:1.16
+ARG BAZEL_IMAGE
+FROM $BAZEL_IMAGE AS builder
+# ARGs used by the BUILD stage have to be declared after FROM
+ARG OWNER
+ARG REPO
+ARG SHA
+
+RUN git clone https://github.com/$OWNER/$REPO /build
 WORKDIR /build
-COPY . .
+RUN git checkout $SHA
+RUN bazel build --config=crosslinux //pkg/cmd/roachprod:roachprod
+# Copy the roachprod binary to a stable location
+RUN cp $(bazel info bazel-bin --config=crosslinux)/pkg/cmd/roachprod/roachprod_/roachprod ./
+
+FROM golang:1.16
+COPY entrypoint.sh build.sh /build/
 RUN ["/build/build.sh"]
+COPY --from=builder /build/roachprod /usr/local/bin/roachprod
 ENTRYPOINT ["/build/entrypoint.sh"]

--- a/pkg/cmd/roachprod/docker/README.md
+++ b/pkg/cmd/roachprod/docker/README.md
@@ -1,11 +1,12 @@
 # Roachprod Docker Image
 
-This dockerfile will build roachprod from master and create an image
-with the supporting CLI toolchains. The entrypoint for the image will
-configure the CLI tools using files to be mounted into the `/secrets`
+This dockerfile will build roachprod and create an image with the supporting
+CLI toolchains. The entrypoint for the image will configure the CLI tools using
+files to be mounted into the `/secrets` directory.
+
+In order to update the kubernetes cron job, run `./push.sh` in the current
 directory.
 
-The easiest way to build this is to run the following from this directory.
-```
-gcloud builds submit -t gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
-```
+In order to test the docker build process, you can run the same script with
+`OWNER` and/or `REPO` set: `OWNER=rail ./push.sh`. Note, that the built image
+won't replace the existing Kubernetes image.

--- a/pkg/cmd/roachprod/docker/build.sh
+++ b/pkg/cmd/roachprod/docker/build.sh
@@ -28,5 +28,3 @@ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packa
 apt-get update -y
 apt-get install google-cloud-sdk awscli azure-cli -y
 rm -rf /var/lib/apt/lists/*
-
-go get github.com/cockroachdb/cockroach/pkg/cmd/roachprod

--- a/pkg/cmd/roachprod/docker/cloudbuild.yaml
+++ b/pkg/cmd/roachprod/docker/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+         '--tag', 'gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:$_SHA',
+         '--build-arg', 'SHA=$_SHA',
+         '--build-arg', 'OWNER=$_OWNER',
+         '--build-arg', 'REPO=$_REPO',
+         '--build-arg', 'BAZEL_IMAGE=$_BAZEL_IMAGE',
+         '.']
+images:
+  - 'gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:$_SHA'
+options:
+  machineType: 'E2_HIGHCPU_8'

--- a/pkg/cmd/roachprod/docker/entrypoint.sh
+++ b/pkg/cmd/roachprod/docker/entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-# Unpack all of the keys, configs, etc. and then start roachperf
+# Unpack all of the keys, configs, etc. and then run roachprod
 gcloud auth activate-service-account --key-file /secrets/gcloud.json
 aws configure set aws_access_key_id $(cat /secrets/aws_access_key_id)
 aws configure set aws_secret_access_key $(cat /secrets/aws_secret_access_key)
+# The default profile has to contain a region name in order for the AWS Go SDK
+# library to work
+aws configure set region us-east-1
 az login --service-principal -u $(cat /secrets/azure_user_id) -p $(cat /secrets/azure_password) -t $(cat /secrets/azure_tenant_id)
-exec roachprod $@
+exec /usr/local/bin/roachprod $@

--- a/pkg/cmd/roachprod/docker/push.sh
+++ b/pkg/cmd/roachprod/docker/push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# root is the absolute path to the root directory of the repository.
+root="$(cd ../../../../ &> /dev/null && pwd)"
+source "$root/build/teamcity-bazel-support.sh"  # For BAZEL_IMAGE
+
+if [[ -z ${OWNER+x} ]]; then
+    OWNER=cockroachdb
+fi
+if [[ -z ${REPO+x} ]]; then
+    REPO=cockroach
+fi
+
+SHA=$(git rev-parse --short HEAD)
+gcloud --project cockroach-dev-inf builds submit \
+  --substitutions=_BAZEL_IMAGE=$BAZEL_IMAGE,_SHA=$SHA,_OWNER=$OWNER,_REPO=$REPO \
+  --timeout=30m
+
+# Patch the existing cronjob configuration only for official builds
+if [[ "$OWNER" == "cockroachdb" && "$REPO" == "cockroach" ]]; then
+  kubectl set image cronjob/roachprod-gc-cronjob roachprod-gc-cronjob=gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:$SHA
+fi


### PR DESCRIPTION
Previously, the roachprod garbage collector docker image build process
was using the `go get` approach to build roachprod.

Currently, this method doesn't work, because it doesn't use any pinning,
so the build ends up with all kind of deprecation warnings and failures.

* Use multi-stage docker build in order to separate build and runtime.
  It also reduces the image size from 1.9G to 700M.
* Build roachprod using the checked out commit SHA.
* Use the Bazel build image we use in CI to build roachprod.
* Use Bazel to build roachprod.
* Added `cloudbuild.yaml` to publish the docker image to GCR and use a
  beefier instance type.
* Modify the entrypoint script to set the default region, required by
  the AWS Go SDK library.
* Add `push.sh` to script deployment.

Release note: None