### PR TITLE
sql: don't use canonical type for placeholders

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
+++ b/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
@@ -38,7 +38,7 @@ ReadyForQuery
 # planner transaction but never set it. This was pretty much the only
 # way you could do such a thing.
 
-send
+send crdb_only
 Query {"String": "BEGIN AS OF SYSTEM TIME '1s'"}
 Sync
 ----
@@ -46,7 +46,7 @@ Sync
 
 # TODO(ajwerner): Why are there two ReadyForQuery?
 
-until
+until crdb_only
 ErrorResponse
 ReadyForQuery
 ReadyForQuery
@@ -55,13 +55,14 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send
+# This checks the OID of a table using a cast, which will differ between CRDB and Postgres.
+send crdb_only
 Bind {"DestinationPortal": "p7", "PreparedStatement": "s7", "ParameterFormatCodes": [0], "Parameters": [{"text":"T"}]}
 Execute {"Portal": "p7"}
 Sync
 ----
 
-until
+until crdb_only
 ReadyForQuery
 ----
 {"Type":"BindComplete"}

--- a/pkg/sql/pgwire/testdata/pgtest/char
+++ b/pkg/sql/pgwire/testdata/pgtest/char
@@ -62,7 +62,7 @@ until
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ParameterDescription","ParameterOIDs":[20,25]}
+{"Type":"ParameterDescription","ParameterOIDs":[23,18]}
 {"Type":"NoData"}
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
@@ -110,7 +110,7 @@ ReadyForQuery
 # Use the binary format for the "char" parameter.
 # ParameterFormatCodes = [1] for binary format
 send
-Bind {"PreparedStatement": "s1", "ParameterFormatCodes": [1,1], "ResultFormatCodes": [0], "Parameters":[{"binary":"0000000000000004"}, {"binary":"46"}]}
+Bind {"PreparedStatement": "s1", "ParameterFormatCodes": [1,1], "ResultFormatCodes": [0], "Parameters":[{"binary":"00000004"}, {"binary":"46"}]}
 Execute
 Sync
 ----
@@ -164,7 +164,7 @@ ReadyForQuery
 # Pass in a null byte.
 # ParameterFormatCodes = [1] for binary format
 send
-Bind {"PreparedStatement": "s1", "ParameterFormatCodes": [1,1], "ResultFormatCodes": [0], "Parameters":[{"binary":"0000000000000006"}, {"binary":"00"}]}
+Bind {"PreparedStatement": "s1", "ParameterFormatCodes": [1,1], "ResultFormatCodes": [0], "Parameters":[{"binary":"00000006"}, {"binary":"00"}]}
 Execute
 Sync
 ----
@@ -184,7 +184,7 @@ until ignore_table_oids
 ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":[{"Name":"a","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"b","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":18,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"6"},{"binary":"00"}]}
+{"Type":"DataRow","Values":[{"text":"6"},null]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 

--- a/pkg/sql/pgwire/testdata/pgtest/parameter_description
+++ b/pkg/sql/pgwire/testdata/pgtest/parameter_description
@@ -113,3 +113,41 @@ ReadyForQuery
 ----
 {"Type":"ErrorResponse","Code":"42P18"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS tab2 CASCADE"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send
+Query {"String": "CREATE TABLE tab2 (a INT2)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# 'S' for Statement
+send
+Parse {"Name": "s7", "Query": "SELECT a FROM tab2 WHERE a = $1"}
+Describe {"ObjectType": "S", "Name": "s7"}
+Sync
+----
+
+# Make sure the ParameterDescription shows OID 21 (INT2). Drivers
+# (e.g. rust-postgres) rely on this matching the column type.
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[21]}
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":21,"DataTypeSize":2,"TypeModifier":-1,"Format":0}]}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1561,12 +1561,6 @@ func (expr *ArrayFlatten) TypeCheck(
 func (expr *Placeholder) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	// When we populate placeholder values from pgwire, there is no special
-	// handling of type details like widths. Therefore, we infer the types of
-	// placeholders as only canonical types. This is safe to do because a value
-	// can always be losslessly converted to its canonical type.
-	canonicalDesired := desired.CanonicalType()
-
 	// Perform placeholder typing. This function is only called during Prepare,
 	// when there are no available values for the placeholders yet, because
 	// during Execute all placeholders are replaced from the AST before type
@@ -1584,7 +1578,7 @@ func (expr *Placeholder) TypeCheck(
 			// the type system expects. Then, when the value is actually sent to us
 			// later, we cast the input value (whose type is the expected type) to the
 			// desired type here.
-			typ = canonicalDesired
+			typ = desired
 		}
 		// We call SetType regardless of the above condition to inform the
 		// placeholder struct that this placeholder is locked to its type and cannot
@@ -1598,10 +1592,10 @@ func (expr *Placeholder) TypeCheck(
 	if desired.IsAmbiguous() {
 		return nil, placeholderTypeAmbiguityError(expr.Idx)
 	}
-	if err := semaCtx.Placeholders.SetType(expr.Idx, canonicalDesired); err != nil {
+	if err := semaCtx.Placeholders.SetType(expr.Idx, desired); err != nil {
 		return nil, err
 	}
-	expr.typ = canonicalDesired
+	expr.typ = desired
 	return expr, nil
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71576

This caused the ParameterDescription in pgwire to differ from that which
Postgres would return, and this turns out to be incompatible with what
some drivers expect.

No release note since this wasn't in any released version.

Release note: None