### PR TITLE
clusterversion: add a (disabled) assertion that binary version is latest

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -517,6 +517,15 @@ var (
 	binaryVersion = versionsSingleton[len(versionsSingleton)-1].Version
 )
 
+func init() {
+	const isReleaseBranch = false
+	if isReleaseBranch {
+		if binaryVersion != ByKey(V21_2) {
+			panic("unexpected cluster version greater than release's binary version")
+		}
+	}
+}
+
 // ByKey returns the roachpb.Version for a given key.
 // It is a fatal error to use an invalid key.
 func ByKey(key Key) roachpb.Version {


### PR DESCRIPTION
This is intended to be flipped on and the release version updated when the cluster version mint
commit is backported to a release branch. Doing so would then prevent accidentally backporting
any future cluster versions without causing this to panic in all tests.

Release note: none.