### PR TITLE
randgen: add random DEFAULT, ON UPDATE exprs

### DIFF
--- a/pkg/sql/randgen/expr.go
+++ b/pkg/sql/randgen/expr.go
@@ -124,12 +124,12 @@ func randAndOrExpr(rng *rand.Rand, left, right tree.Expr) tree.Expr {
 	}
 }
 
-// randExpr produces a random expression that refers to columns in
+// randColumnExpr produces a random expression that refers to columns in
 // normalColDefs. It can be used to generate random computed columns and
 // expression indexes. The return type is the type of the expression. The
 // returned nullability is NotNull if all columns referenced in the expression
 // have a NotNull nullability.
-func randExpr(
+func randColumnExpr(
 	rng *rand.Rand, normalColDefs []*tree.ColumnTableDef, nullOk bool,
 ) (_ tree.Expr, _ *types.T, _ tree.Nullability, referencedCols map[tree.Name]struct{}) {
 	nullability := tree.NotNull
@@ -197,35 +197,98 @@ func randExpr(
 	nullability = x.Nullable.Nullability
 	nullOk = nullOk && nullability != tree.NotNull
 
-	var expr tree.Expr
-	var typ *types.T
-	switch xTyp.Family() {
+	expr, typ := randExpr(rng, tree.NewUnresolvedName(string(x.Name)), xTyp, true, /* canChangeType */
+		true /* needsImmutable */, nullOk)
+	return expr, typ, nullability, referencedCols
+}
+
+// randExpr generates a random expression that includes the input expr that has
+// the given type exprType. If canChangeType is true, we may cast the input expr
+// to a different type. nullOk controls whether generating NULL is allowed.
+// If needsImmutable is true, we won't generate any scalar expressions that
+// are not immutable (always returning the same value given the same inputs).
+func randExpr(
+	rng *rand.Rand,
+	expr tree.Expr,
+	exprType *types.T,
+	canChangeType bool,
+	needsImmutable bool,
+	nullOk bool,
+) (tree.Expr, *types.T) {
+	typ := exprType
+	switch exprType.Family() {
 	case types.IntFamily, types.FloatFamily, types.DecimalFamily:
-		typ = xTyp
 		expr = &tree.BinaryExpr{
-			Operator: treebin.MakeBinaryOperator(treebin.Plus),
-			Left:     tree.NewUnresolvedName(string(x.Name)),
-			Right:    RandDatum(rng, xTyp, nullOk),
+			Operator: tree.MakeBinaryOperator(treebin.Plus),
+			Left:     expr,
+			Right:    RandDatum(rng, exprType, nullOk),
 		}
 
 	case types.StringFamily:
-		typ = types.String
 		expr = &tree.FuncExpr{
 			Func:  tree.WrapFunction("lower"),
-			Exprs: tree.Exprs{tree.NewUnresolvedName(string(x.Name))},
+			Exprs: tree.Exprs{expr},
+		}
+
+	case types.IntervalFamily:
+		if !needsImmutable && rng.Intn(3) == 0 {
+			// We don't have builtin expressions that just return intervals, so
+			// return the result of adding the input expression to now()-now(), to
+			// make sure that we're at least forcing the engine to evaluate something
+			// non-constant.
+			expr = &tree.BinaryExpr{
+				Operator: tree.MakeBinaryOperator(tree.Plus),
+				Left:     expr,
+				Right: &tree.BinaryExpr{
+					Operator: tree.MakeBinaryOperator(tree.Minus),
+					Left: &tree.FuncExpr{
+						Func: tree.WrapFunction("now"),
+					},
+					Right: &tree.FuncExpr{
+						Func: tree.WrapFunction("now"),
+					},
+				},
+			}
+		}
+
+	case types.TimestampFamily, types.DateFamily, types.TimestampTZFamily:
+		if !needsImmutable {
+			// input expr + now() - now(), a random expression that is slightly
+			// more complex that still involves the input expr. There's no great
+			// reason why this expression should be used rather than any other -
+			// it's just an example of something that requires expression evaluation.
+			expr = &tree.CastExpr{
+				Expr: &tree.BinaryExpr{
+					Operator: tree.MakeBinaryOperator(tree.Plus),
+					Left:     expr,
+					Right: &tree.BinaryExpr{
+						Operator: tree.MakeBinaryOperator(tree.Minus),
+						Left: &tree.FuncExpr{
+							Func: tree.WrapFunction("now"),
+						},
+						Right: &tree.FuncExpr{
+							Func: tree.WrapFunction("now"),
+						},
+					},
+				},
+				Type: exprType,
+			}
 		}
 
 	default:
-		volatility, ok := tree.LookupCastVolatility(xTyp, types.String, nil /* sessionData */)
+		if !canChangeType {
+			return expr, exprType
+		}
+		volatility, ok := tree.LookupCastVolatility(exprType, types.String, nil /* sessionData */)
+		typ = types.String
 		if ok && volatility <= tree.VolatilityImmutable &&
 			!typeToStringCastHasIncorrectVolatility(xTyp) {
 			// We can cast to string; use lower(x::string)
-			typ = types.String
 			expr = &tree.FuncExpr{
 				Func: tree.WrapFunction("lower"),
 				Exprs: tree.Exprs{
 					&tree.CastExpr{
-						Expr: tree.NewUnresolvedName(string(x.Name)),
+						Expr: expr,
 						Type: types.String,
 					},
 				},
@@ -233,12 +296,11 @@ func randExpr(
 		} else {
 			// We cannot cast this type to string in a computed column expression.
 			// Use CASE WHEN x IS NULL THEN 'foo' ELSE 'bar'.
-			typ = types.String
 			expr = &tree.CaseExpr{
 				Whens: []*tree.When{
 					{
 						Cond: &tree.IsNullExpr{
-							Expr: tree.NewUnresolvedName(string(x.Name)),
+							Expr: expr,
 						},
 						Val: RandDatum(rng, types.String, nullOk),
 					},
@@ -247,8 +309,7 @@ func randExpr(
 			}
 		}
 	}
-
-	return expr, typ, nullability, referencedCols
+	return expr, typ
 }
 
 // typeToStringCastHasIncorrectVolatility returns true for a given type if the
@@ -268,7 +329,6 @@ func typeToStringCastHasIncorrectVolatility(t *types.T) bool {
 	case types.OidFamily:
 		return t == types.RegClass || t == types.RegNamespace || t == types.RegProc ||
 			t == types.RegProcedure || t == types.RegRole || t == types.RegType
-	default:
-		return false
 	}
+    return false
 }


### PR DESCRIPTION
This commit updates randgen to sometimes generate random DEFAULT and ON
UPDATE exprs when creating random table column definitions.

The expression creation logic is extracted from the function that's used
to create random partial index expressions. We pass in a random datum
which is sometimes wrapped in further same-type scalar expressions.

Release note: None