### PR TITLE
sql: make sure pgwire bind always happens in a transaction

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -428,7 +428,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		var err error
-		pinfo, err = fillInPlaceholders(ctx, ps, name, e.Params, ex.sessionData().SearchPath)
+		pinfo, err = ex.planner.fillInPlaceholders(ctx, ps, name, e.Params)
 		if err != nil {
 			return makeErrEvent(err)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1545,3 +1545,27 @@ ORDER BY a.id, b.id
 {a,b}  {a}    false  false  false  false
 {a,b}  {b}    false  true   true   false
 {a,b}  {a,b}  true   false  true   true
+
+# Make sure that adding a new enum value works well with PREPARE/EXECUTE.
+subtest regression_70378
+
+statement ok
+CREATE TYPE enum_70378 AS ENUM ('a', 'b');
+CREATE TABLE enum_table (a enum_70378);
+PREPARE q AS INSERT INTO enum_table VALUES($1);
+EXECUTE q('a')
+
+query T
+SELECT * FROM enum_table
+----
+a
+
+statement ok
+ALTER TYPE enum_70378 ADD VALUE 'c';
+EXECUTE q('c')
+
+query T rowsort
+SELECT * FROM enum_table
+----
+a
+c

--- a/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
+++ b/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
@@ -38,15 +38,14 @@ ReadyForQuery
 # planner transaction but never set it. This was pretty much the only
 # way you could do such a thing.
 
-send
+# This is crdb_only because Postgres does not support AS OF SYSTEM TIME.
+send crdb_only
 Query {"String": "BEGIN AS OF SYSTEM TIME '1s'"}
 Sync
 ----
 
-
-# TODO(ajwerner): Why are there two ReadyForQuery?
-
-until
+# There are two ReadyForQuerys because a simple query was followed by Sync.
+until crdb_only
 ErrorResponse
 ReadyForQuery
 ReadyForQuery
@@ -55,16 +54,93 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send
+send crdb_only
 Bind {"DestinationPortal": "p7", "PreparedStatement": "s7", "ParameterFormatCodes": [0], "Parameters": [{"text":"T"}]}
 Execute {"Portal": "p7"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"52"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS tab"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "BEGIN"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Parse {"Name": "s8", "Query": "SELECT relname FROM pg_class WHERE oid = $1::regclass"}
+Bind {"DestinationPortal": "p8", "PreparedStatement": "s8", "ResultFormatCodes": [0], "Parameters": [{"text":"t"}]}
 Sync
 ----
 
 until
 ReadyForQuery
 ----
+{"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Type":"DataRow","Values":[{"text":"52"}]}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "ALTER TABLE t RENAME TO tab"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ALTER TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Execute {"Portal": "p8"}
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"t"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Currently, CRDB differs in that it returns the new table name here, but the
+# important part of this test is that it asserts that binding the placeholder
+# parameter occurred before the table rename, which matches the Postgres
+# behavior.
+# TODO(rafi): To be fully correct, we still should return table name 't' here.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"tab"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -106,15 +106,30 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+send noncrdb_only
+Parse {"Name": "s1", "Query": "INSERT INTO tb VALUES ($1)"}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [{"text":"hi"}]}
+Execute {"Portal": "p"}
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # Ensure that our value was successfully inserted.
-send crdb_only
+send
 Query {"String": "SELECT * FROM tb"}
 ----
 
-until crdb_only
+until ignore_type_oids ignore_table_oids ignore_data_type_sizes
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":54,"TableAttributeNumber":1,"DataTypeOID":100052,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
 {"Type":"DataRow","Values":[{"text":"hi"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -192,4 +207,41 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "ALTER TYPE te ADD VALUE 'hola'"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ALTER TYPE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Reuse original prepared statement now that there's a new enum value.
+send
+Bind {"DestinationPortal": "p", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [{"text":"hola"}]}
+Execute {"Portal": "p"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Ensure that our value was successfully inserted.
+send
+Query {"String": "SELECT * FROM tb WHERE x = 'hola'"}
+----
+
+until ignore_type_oids ignore_table_oids ignore_data_type_sizes
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"x","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":0,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"hola"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70378
and maybe https://github.com/cockroachdb/cockroach/issues/64140

The approach of using a transaction matches what we do for pgwire Parse
messages already. This is important to make sure that user-defined types
are leased correctly.

This also updated the SQL EXECUTE command to resolve user-defined types
so that it gets the latest changes.

Release note (bug fix): Adding new values to a user-defined enum type
will previously would cause a prepared statement using that type to not
work. This now works as expected.