### PR TITLE
sql: fix bugs with sequence and setval

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -395,7 +395,7 @@ func (so *importSequenceOperators) GetLatestValueInSessionForSequenceByID(
 
 // SetSequenceValueByID implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) SetSequenceValueByID(
-	ctx context.Context, seqID int64, newVal int64, isCalled bool,
+	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	return errSequenceOperators
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2891,7 +2891,7 @@ func (m *sessionDataMutator) SetStreamReplicationEnabled(val bool) {
 	m.data.EnableStreamReplication = val
 }
 
-// RecordLatestSequenceValue records that value to which the session incremented
+// RecordLatestSequenceVal records that value to which the session incremented
 // a sequence.
 func (m *sessionDataMutator) RecordLatestSequenceVal(seqID uint32, val int64) {
 	m.data.SequenceState.RecordValue(seqID, val)

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -106,7 +106,7 @@ func (so *DummySequenceOperators) GetLatestValueInSessionForSequenceByID(
 
 // SetSequenceValueByID implements the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) SetSequenceValueByID(
-	ctx context.Context, seqID int64, newVal int64, isCalled bool,
+	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	return errors.WithStack(errSequenceOperators)
 }

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -85,7 +85,7 @@ func TestInternalExecutor(t *testing.T) {
 	}
 
 	// Reset the sequence to a clear value. Next nextval() will return 2.
-	if _, err := db.Exec("SELECT setval('test.seq', 1)"); err != nil {
+	if _, err := db.Exec("SELECT setval('test.seq', 1, true)"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -422,7 +422,8 @@ SELECT setval('setval_test', 10)
 ----
 10
 
-# Calling setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+# Calling setval with is_called=false doesn't affect currval or lastval; they
+# return the last value obtained with nextval.
 query I
 SELECT currval('setval_test')
 ----
@@ -436,31 +437,36 @@ SELECT lastval()
 query I
 SELECT nextval('setval_test')
 ----
-11
+10
 
 query I
 SELECT currval('setval_test')
 ----
-11
+10
 
 query I
 SELECT lastval()
 ----
-11
+10
 
 let $setval_test_id
 SELECT 'setval_test'::regclass::int
 
 query I
-SELECT setval($setval_test_id::regclass, 20)
+SELECT setval($setval_test_id::regclass, 20, true)
 ----
 20
 
-# Calling setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+# Calling setval with is_called=true does affect currval and lastval.
 query I
 SELECT currval($setval_test_id::regclass)
 ----
-11
+20
+
+query I
+SELECT lastval()
+----
+20
 
 query I
 SELECT nextval($setval_test_id::regclass)
@@ -951,11 +957,13 @@ user testuser
 
 # After the grant, testuser can select, increment, and set.
 
-statement ok
+query I
 SELECT nextval('priv_test')
+----
+1
 
 statement ok
-SELECT setval('priv_test', 5)
+SELECT setval('priv_test', 5, true)
 
 query I
 SELECT last_value FROM priv_test
@@ -1870,3 +1878,24 @@ query I
 SELECT nextval('seq71135')
 ----
 201
+
+# The 2-parameter version of setval uses is_called=false.
+query I
+SELECT setval('seq71135'::regclass::oid, 500)
+----
+500
+
+query I
+SELECT lastval()
+----
+201
+
+query I
+SELECT currval('seq71135')
+----
+201
+
+query I
+SELECT nextval('seq71135')
+----
+500

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1899,3 +1899,48 @@ query I
 SELECT nextval('seq71135')
 ----
 500
+
+subtest sequence_in_txn
+
+# Make sure that setval and next work even if the transaction is rolled back;
+# they do not respect transaction boundaries.
+
+statement ok
+CREATE SEQUENCE seq_txn
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 600, true)
+----
+600
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+601
+
+statement ok
+BEGIN
+
+query I
+SELECT setval('seq_txn', 610, true)
+----
+610
+
+query I
+SELECT nextval('seq_txn')
+----
+611
+
+statement ok
+ROLLBACK
+
+query I
+SELECT nextval('seq_txn')
+----
+612

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1837,3 +1837,36 @@ CREATE SEQUENCE db4.s;
 
 statement error pq: sequence references cannot come from other databases; \(see the 'sql\.cross_db_sequence_references\.enabled' cluster setting\)
 CREATE TABLE tDb4Ref (i INT PRIMARY KEY DEFAULT (nextval('db4.s')));
+
+subtest cached_sequences_invalidate
+
+# Test for #71135 -- make sure that setval invalidates the cached sequence
+# values.
+
+statement ok
+CREATE SEQUENCE seq71135 CACHE 100
+
+query I
+SELECT nextval('seq71135')
+----
+1
+
+query I
+SELECT setval('seq71135', 200, true)
+----
+200
+
+query I
+SELECT lastval()
+----
+200
+
+query I
+SELECT currval('seq71135')
+----
+200
+
+query I
+SELECT nextval('seq71135')
+----
+201

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2154,7 +2154,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(dOid.DInt), int64(newVal), true); err != nil {
+					evalCtx.Ctx(), uint32(dOid.DInt), int64(newVal), false /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2170,7 +2170,7 @@ var builtins = map[string]builtinDefinition{
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(oid.DInt), int64(newVal), true); err != nil {
+					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), false /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2194,7 +2194,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(dOid.DInt), int64(newVal), isCalled); err != nil {
+					evalCtx.Ctx(), uint32(dOid.DInt), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2214,7 +2214,7 @@ var builtins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), int64(oid.DInt), int64(newVal), isCalled); err != nil {
+					evalCtx.Ctx(), uint32(oid.DInt), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3358,7 +3358,7 @@ type SequenceOperators interface {
 	// `newVal` is returned. Otherwise, the next call to nextval will return
 	// `newVal + seqOpts.Increment`.
 	// Takes in a sequence ID rather than a name, unlike SetSequenceValue.
-	SetSequenceValueByID(ctx context.Context, seqID int64, newVal int64, isCalled bool) error
+	SetSequenceValueByID(ctx context.Context, seqID uint32, newVal int64, isCalled bool) error
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -139,8 +139,11 @@ func (p *planner) incrementSequenceUsingCache(
 	fetchNextValues := func() (currentValue, incrementAmount, sizeOfCache int64, err error) {
 		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(descriptor.GetID()))
 
+		// We *do not* use the planner txn here, since nextval does not respect
+		// transaction boundaries. This matches the specification at
+		// https://www.postgresql.org/docs/14/functions-sequence.html
 		endValue, err := kv.IncrementValRetryable(
-			ctx, p.txn.DB(), seqValueKey, seqOpts.Increment*cacheSize)
+			ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
 
 		if err != nil {
 			if errors.HasType(err, (*roachpb.IntegerOverflowError)(nil)) {
@@ -310,10 +313,13 @@ func setSequenceValueHelper(
 		return err
 	}
 
+	// We *do not* use the planner txn here, since setval does not respect
+	// transaction boundaries. This matches the specification at
+	// https://www.postgresql.org/docs/14/functions-sequence.html
 	// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,
 	// according to comments on Inc operation. Switch to Inc if `desired-current`
 	// overflows correctly.
-	return p.txn.Put(ctx, seqValueKey, newVal)
+	return p.ExecCfg().DB.Put(ctx, seqValueKey, newVal)
 }
 
 // MakeSequenceKeyVal returns the key and value of a sequence being set

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -249,7 +249,7 @@ func getLatestValueInSessionForSequenceHelper(
 
 // SetSequenceValueByID implements the tree.SequenceOperators interface.
 func (p *planner) SetSequenceValueByID(
-	ctx context.Context, seqID int64, newVal int64, isCalled bool,
+	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	if p.EvalContext().TxnReadOnly {
 		return readOnlyError("setval()")
@@ -275,7 +275,7 @@ func (p *planner) SetSequenceValueByID(
 	p.sessionDataMutatorIterator.applyOnEachMutator(func(m sessionDataMutator) {
 		m.initSequenceCache()
 		if isCalled {
-			m.RecordLatestSequenceVal(uint32(seqID), newVal)
+			m.RecordLatestSequenceVal(seqID, newVal)
 		}
 	})
 	return nil


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71135

See individual commits:
- sql: invalidate sequence cache when calling setval -- safe to backport
- sql: fix 2-param version of setval to use isCalled -- matches the PG behavior
- sql: make setval/nextval cross over transaction boundaries -- matches PG, and
  also fixes a possible deadlock