### PR TITLE
sql: increase http timeout for TestExplainAnalyzeDebug

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -157,6 +158,8 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 // arbitrary number of strings; each string contains one or more filenames
 // separated by a space.
 func checkBundle(t *testing.T, text, tableName string, expectedFiles ...string) {
+	httpClient := httputil.NewClientWithTimeout(30 * time.Second)
+
 	t.Helper()
 	reg := regexp.MustCompile("http://[a-zA-Z0-9.:]*/_admin/v1/stmtbundle/[0-9]*")
 	url := reg.FindString(text)
@@ -164,7 +167,7 @@ func checkBundle(t *testing.T, text, tableName string, expectedFiles ...string) 
 		t.Fatalf("couldn't find URL in response '%s'", text)
 	}
 	// Download the zip to a BytesBuffer.
-	resp, err := httputil.Get(context.Background(), url)
+	resp, err := httpClient.Get(context.Background(), url)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The default httputil timeout of 3s can lead to flakes; this change
increases this timeout.

Fixes #71568.

Release note: None