### PR TITLE
roachtest/tests: fix DROP style TPC-C tests referencing bad FK

### DIFF
--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -73,7 +73,7 @@ func registerDrop(r registry.Registry) {
 			run(false, `SET CLUSTER SETTING trace.debug.enable = true`)
 
 			// Drop a constraint that would get in the way of deleting from tpcc.stock.
-			const stmtDropConstraint = "ALTER TABLE tpcc.order_line DROP CONSTRAINT fk_ol_supply_w_id_ref_stock"
+			const stmtDropConstraint = "ALTER TABLE tpcc.order_line DROP CONSTRAINT order_line_ol_supply_w_id_ol_i_id_fkey"
 			run(false, stmtDropConstraint)
 
 			var rows, minWarehouse, maxWarehouse int

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -461,7 +461,7 @@ func makeSchemaChangeDuringTPCC(
 
 						// The FK constraint on tpcc.district referencing tpcc.warehouse is
 						// unvalidated, thus this operation will not be a noop.
-						`ALTER TABLE tpcc.district VALIDATE CONSTRAINT fk_d_w_id_ref_warehouse;`,
+						`ALTER TABLE tpcc.district VALIDATE CONSTRAINT district_d_w_id_fkey;`,
 
 						`ALTER TABLE tpcc.orderpks RENAME TO tpcc.readytodrop;`,
 						`TRUNCATE TABLE tpcc.readytodrop CASCADE;`,


### PR DESCRIPTION
Follow up to FK name changes - some of these DROP CONSTRAINTS use the
legacy name and were not caught by regular CI testing. Fixed now!

Resolves #71614, Resolves #71607

Release note: None