### PR TITLE
tree: fix ambiguity with enum overloads

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1522,8 +1522,31 @@ subtest regression_71388
 
 statement ok
 CREATE TYPE enum_test AS ENUM ('a', 'b');
+CREATE TABLE enum_table (id SERIAL PRIMARY KEY, elem enum_test);
+INSERT INTO enum_table (elem) VALUES ('a'), ('b');
 CREATE TABLE enum_array_table (id SERIAL PRIMARY KEY, elems enum_test[]);
 INSERT INTO enum_array_table (elems) VALUES (array['a']), (array['b']), (array['a', 'b'])
+
+query TB
+SELECT
+  elem,
+  elem = 'a'
+FROM enum_table
+ORDER BY id
+----
+a  true
+b  false
+
+query TB
+SELECT
+  elems,
+  elems = '{a}'
+FROM enum_array_table
+ORDER BY id
+----
+{a}    true
+{b}    false
+{a,b}  false
 
 query TTBBBB
 SELECT
@@ -1545,6 +1568,14 @@ ORDER BY a.id, b.id
 {a,b}  {a}    false  false  false  false
 {a,b}  {b}    false  true   true   false
 {a,b}  {a,b}  true   false  true   true
+
+query B
+SELECT '{a,b}'::enum_test[] = '{a,b}'
+----
+true
+
+statement ok
+DROP TABLE enum_table
 
 # Make sure that adding a new enum value works well with PREPARE/EXECUTE.
 subtest regression_70378

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1188,7 +1188,7 @@ SELECT * FROM v14
 {a,b}
 
 statement ok
-CREATE VIEW v15 AS (SELECT ('{a, b}'::view_type_new[])[2])
+CREATE VIEW v15 AS (SELECT ('{a, b}'::view_type_new[])[2] AS view_type_new)
 
 statement ok
 ALTER TYPE view_type_new RENAME TO view_type
@@ -1196,7 +1196,7 @@ ALTER TYPE view_type_new RENAME TO view_type
 query TT
 SHOW CREATE VIEW v15
 ----
-v15  CREATE VIEW public.v15 (view_type_new) AS (SELECT ('{a, b}':::STRING::public.view_type[])[2:::INT8])
+v15  CREATE VIEW public.v15 (view_type_new) AS (SELECT ARRAY['a':::public.view_type, 'b':::public.view_type][2:::INT8] AS view_type_new)
 
 query T
 SELECT * FROM v15

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -492,6 +492,7 @@ var (
 		types.Jsonb,
 		types.VarBit,
 		types.AnyEnum,
+		types.AnyEnumArray,
 		types.INetArray,
 		types.VarBitArray,
 	}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -579,6 +579,10 @@ var (
 	VarBitArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: VarBit, Oid: oid.T__varbit, Locale: &emptyLocale}}
 
+	// AnyEnumArray is the type of an array value having AnyEnum-typed elements.
+	AnyEnumArray = &T{InternalType: InternalType{
+		Family: ArrayFamily, ArrayContents: AnyEnum, Oid: oid.T_anyarray, Locale: &emptyLocale}}
+
 	// Int2Vector is a type-alias for an array of Int2 values with a different
 	// OID (T_int2vector instead of T__int2). It is a special VECTOR type used
 	// by Postgres in system tables. Int2vectors are 0-indexed, unlike normal arrays.


### PR DESCRIPTION
Resolves #71446 

Release note (sql change): Previously, certain enum builtins or
operators required an explicit enum cast. This has been reduced in some
cases.