### PR TITLE
sql: skip logic tests under deadlock detector

### DIFF
--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -13,6 +13,7 @@ package logictest
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -26,6 +27,7 @@ import (
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlock(t, "times out and/or hangs")
 	RunLogicTest(t, TestServerArgs{}, "testdata/logic_test/[^.]*")
 }
 

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/sql/opt",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/logictest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -27,5 +28,6 @@ import (
 func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, "testdata/[^.]*")
 }


### PR DESCRIPTION
These tests hang and/or time out under the deadlock detector.

Resolves #71605.
Resolves #71636.
Resolves #71637.
Resolves #71649.

Release note: None