### PR TITLE
ui: fix issue with updating timeRange for metrics page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/test-utils/fakeMetricsDataGenerationMiddleware.ts
+++ b/pkg/ui/workspaces/db-console/src/test-utils/fakeMetricsDataGenerationMiddleware.ts
@@ -17,9 +17,9 @@ import { PayloadAction } from "src/interfaces/action";
 import { cockroach } from "src/js/protos";
 import ITimeSeriesDatapoint = cockroach.ts.tspb.ITimeSeriesDatapoint;
 
-function fakeTimeSeriesDatapoint(): ITimeSeriesDatapoint {
+function fakeTimeSeriesDatapoint(timestamp?: Long): ITimeSeriesDatapoint {
   return {
-    timestamp_nanos: Long.fromNumber(Date.now() * 1000000),
+    timestamp_nanos: timestamp || Long.fromNumber(Date.now() * 1000000),
     value: Math.ceil(Math.random() * 100),
   };
 }
@@ -57,7 +57,7 @@ export const fakeMetricsDataGenerationMiddleware = (
       const samplePoint =
         actualDatapointsCount > 0
           ? clone(res.datapoints[0])
-          : fakeTimeSeriesDatapoint();
+          : fakeTimeSeriesDatapoint(end_nanos);
 
       const datapoints = Array(expectedDatapointsCount - actualDatapointsCount)
         .fill(1)

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timescale/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timescale/index.tsx
@@ -293,7 +293,7 @@ export const TimeScaleDropdown: React.FC<TimeScaleDropdownProps> = ({
       key: "Custom",
     });
     setTimeRange({
-      ...window,
+      ...currentWindow,
       start,
       end,
     });


### PR DESCRIPTION
`setDateRange` function was recently refactored and one issue was introduced,
that doesn't affect business logic but might affect performance. The argument
of this function (time window) was named before as `window` local variable, and
then during refactoring, this variable was removed and this caused to refer to
DOM window.
Current change uses `currentWindow` as a proper variable to destruct an object.

Release note: none