### PR TITLE
tree: make "rename" stmt tags match postgres

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -305,7 +305,7 @@ FROM system.eventlog
 WHERE "eventType" = 'rename_table'
   AND info::JSONB->>'Statement' LIKE 'ALTER TABLE %toberenamed% RENAME TO %renamedtable%'
 ----
-1  {"EventType": "rename_table", "NewTableName": "test.public.renamedtable", "Statement": "ALTER TABLE toberenamed RENAME TO renamedtable", "TableName": "test.public.toberenamed", "Tag": "RENAME TABLE", "User": "root"}
+1  {"EventType": "rename_table", "NewTableName": "test.public.renamedtable", "Statement": "ALTER TABLE toberenamed RENAME TO renamedtable", "TableName": "test.public.toberenamed", "Tag": "ALTER TABLE", "User": "root"}
 
 
 ##################
@@ -413,7 +413,7 @@ FROM system.eventlog
 WHERE "eventType" = 'rename_database'
   AND info::JSONB->>'Statement' LIKE 'ALTER DATABASE %eventlogtorename% RENAME TO %eventlogtonewname%'
 ----
-1  {"DatabaseName": "eventlogtorename", "EventType": "rename_database", "NewDatabaseName": "eventlogtonewname", "Statement": "ALTER DATABASE eventlogtorename RENAME TO eventlogtonewname", "Tag": "RENAME DATABASE", "User": "root"}
+1  {"DatabaseName": "eventlogtorename", "EventType": "rename_database", "NewDatabaseName": "eventlogtonewname", "Statement": "ALTER DATABASE eventlogtorename RENAME TO eventlogtonewname", "Tag": "ALTER DATABASE", "User": "root"}
 
 statement ok
 SET DATABASE = test

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -187,7 +187,7 @@ EXPLAIN ALTER DATABASE v RENAME TO x
 distribution: local
 vectorized: true
 ·
-• rename database
+• alter database
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -157,7 +157,7 @@ EXPLAIN ALTER INDEX users@bar RENAME TO woo
 distribution: local
 vectorized: true
 ·
-• rename index
+• alter index
 
 statement ok
 RESET vectorize

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -260,7 +260,7 @@ EXPLAIN ALTER TABLE kv RENAME TO kv2
 distribution: local
 vectorized: true
 ·
-• rename table
+• alter table
 
 statement ok
 RESET vectorize

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -916,7 +916,7 @@ func (*RenameColumn) StatementReturnType() StatementReturnType { return DDL }
 func (*RenameColumn) StatementType() StatementType { return TypeDDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*RenameColumn) StatementTag() string { return "RENAME COLUMN" }
+func (*RenameColumn) StatementTag() string { return "ALTER TABLE" }
 
 // StatementReturnType implements the Statement interface.
 func (*RenameDatabase) StatementReturnType() StatementReturnType { return DDL }
@@ -925,7 +925,7 @@ func (*RenameDatabase) StatementReturnType() StatementReturnType { return DDL }
 func (*RenameDatabase) StatementType() StatementType { return TypeDDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*RenameDatabase) StatementTag() string { return "RENAME DATABASE" }
+func (*RenameDatabase) StatementTag() string { return "ALTER DATABASE" }
 
 // StatementReturnType implements the Statement interface.
 func (*ReparentDatabase) StatementReturnType() StatementReturnType { return DDL }
@@ -943,7 +943,7 @@ func (*RenameIndex) StatementReturnType() StatementReturnType { return DDL }
 func (*RenameIndex) StatementType() StatementType { return TypeDDL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*RenameIndex) StatementTag() string { return "RENAME INDEX" }
+func (*RenameIndex) StatementTag() string { return "ALTER INDEX" }
 
 // StatementReturnType implements the Statement interface.
 func (*RenameTable) StatementReturnType() StatementReturnType { return DDL }
@@ -954,11 +954,11 @@ func (*RenameTable) StatementType() StatementType { return TypeDDL }
 // StatementTag returns a short string identifying the type of statement.
 func (n *RenameTable) StatementTag() string {
 	if n.IsView {
-		return "RENAME VIEW"
+		return "ALTER VIEW"
 	} else if n.IsSequence {
-		return "RENAME SEQUENCE"
+		return "ALTER SEQUENCE"
 	}
-	return "RENAME TABLE"
+	return "ALTER TABLE"
 }
 
 // StatementReturnType implements the Statement interface.


### PR DESCRIPTION
This makes ALTER statements that rename objects use the correct
statement tag to match Postgres.

Release note: None