### PR TITLE
row: pass in account instead of monitor for KV fetcher

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -762,10 +762,13 @@ func NewColOperator(
 			cFetcherMemAcc := result.createUnlimitedMemAccount(
 				ctx, flowCtx, "cfetcher" /* opName */, spec.ProcessorID,
 			)
+			kvFetcherMemAcc := result.createUnlimitedMemAccount(
+				ctx, flowCtx, "kvfetcher" /* opName */, spec.ProcessorID,
+			)
 			estimatedRowCount := spec.EstimatedRowCount
 			scanOp, err := colfetcher.NewColBatchScan(
-				ctx, colmem.NewAllocator(ctx, cFetcherMemAcc, factory), flowCtx,
-				evalCtx, core.TableReader, post, estimatedRowCount,
+				ctx, colmem.NewAllocator(ctx, cFetcherMemAcc, factory), kvFetcherMemAcc,
+				flowCtx, evalCtx, core.TableReader, post, estimatedRowCount,
 			)
 			if err != nil {
 				return r, err
@@ -786,11 +789,14 @@ func NewColOperator(
 			cFetcherMemAcc := result.createUnlimitedMemAccount(
 				ctx, flowCtx, "cfetcher" /* opName */, spec.ProcessorID,
 			)
+			kvFetcherMemAcc := result.createUnlimitedMemAccount(
+				ctx, flowCtx, "kvfetcher" /* opName */, spec.ProcessorID,
+			)
 			semaCtx := flowCtx.TypeResolverFactory.NewSemaContext(evalCtx.Txn)
 			inputTypes := make([]*types.T, len(spec.Input[0].ColumnTypes))
 			copy(inputTypes, spec.Input[0].ColumnTypes)
 			indexJoinOp, err := colfetcher.NewColIndexJoin(
-				ctx, streamingAllocator, colmem.NewAllocator(ctx, cFetcherMemAcc, factory),
+				ctx, streamingAllocator, colmem.NewAllocator(ctx, cFetcherMemAcc, factory), kvFetcherMemAcc,
 				flowCtx, evalCtx, semaCtx, inputs[0].Root, core.JoinReader, post, inputTypes)
 			if err != nil {
 				return r, err

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v2//:apd",

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -184,6 +185,7 @@ var colBatchScanPool = sync.Pool{
 func NewColBatchScan(
 	ctx context.Context,
 	allocator *colmem.Allocator,
+	kvFetcherMemAcc *mon.BoundAccount,
 	flowCtx *execinfra.FlowCtx,
 	evalCtx *tree.EvalContext,
 	spec *execinfrapb.TableReaderSpec,
@@ -218,7 +220,7 @@ func NewColBatchScan(
 	}
 
 	fetcher, err := initCFetcher(
-		flowCtx, allocator, table, table.ActiveIndexes()[spec.IndexIdx],
+		flowCtx, allocator, kvFetcherMemAcc, table, table.ActiveIndexes()[spec.IndexIdx],
 		neededColumns, columnIdxMap, invertedColumn,
 		cFetcherArgs{
 			visibility:        spec.Visibility,

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -385,6 +386,7 @@ func NewColIndexJoin(
 	ctx context.Context,
 	allocator *colmem.Allocator,
 	fetcherAllocator *colmem.Allocator,
+	kvFetcherMemAcc *mon.BoundAccount,
 	flowCtx *execinfra.FlowCtx,
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
@@ -458,7 +460,7 @@ func NewColIndexJoin(
 	}
 
 	fetcher, err := initCFetcher(
-		flowCtx, fetcherAllocator, table, index, neededColumns, columnIdxMap, nil, /* invertedColumn */
+		flowCtx, fetcherAllocator, kvFetcherMemAcc, table, index, neededColumns, columnIdxMap, nil, /* invertedColumn */
 		cFetcherArgs{
 			visibility:        spec.Visibility,
 			lockingStrength:   spec.LockingStrength,

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -119,12 +119,6 @@ func NewAllocator(
 	}
 }
 
-// GetMonitor returns the bytes monitor which the allocator's memory account is
-// bound to.
-func (a *Allocator) GetMonitor() *mon.BytesMonitor {
-	return a.acc.Monitor()
-}
-
 // NewMemBatchWithFixedCapacity allocates a new in-memory coldata.Batch with the
 // given vector capacity.
 // Note: consider whether you want the dynamic batch size behavior (in which

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -44,10 +44,10 @@ type KVFetcher struct {
 }
 
 // NewKVFetcher creates a new KVFetcher.
-// If mon is non-nil, this fetcher will track its fetches and must be Closed.
+// If acc is non-nil, this fetcher will track its fetches and must be Closed.
 //
 // The fetcher takes ownership of the spans slice - it can modify the slice and
-// will perform the memory accounting accordingly (if mon is non-nil). The
+// will perform the memory accounting accordingly (if acc is non-nil). The
 // caller can only reuse the spans slice after the fetcher has been closed, and
 // if the caller does, it becomes responsible for the memory accounting.
 func NewKVFetcher(
@@ -61,7 +61,7 @@ func NewKVFetcher(
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	lockTimeout time.Duration,
-	mon *mon.BytesMonitor,
+	acc *mon.BoundAccount,
 	forceProductionKVBatchSize bool,
 ) (*KVFetcher, error) {
 	var sendFn sendFunc
@@ -100,7 +100,7 @@ func NewKVFetcher(
 		lockStrength,
 		lockWaitPolicy,
 		lockTimeout,
-		mon,
+		acc,
 		forceProductionKVBatchSize,
 		txn.AdmissionHeader(),
 		txn.DB().SQLKVResponseAdmissionQ,


### PR DESCRIPTION
This commit switches the KV fetcher to expect a memory account rather
than a memory monitor. It additionally creates a separate memory account
for the KV fetcher when it is used by the cFetcher (previously, we were
reusing the monitor from the allocator).

Note that we don't need to update multiple places where we call methods
on possibly nil memory account because all methods have been taught to
be noops when the receiver is `nil`.

Fixes: #55481.

Release note: None