### PR TITLE
sql: implement WITH RECURSIVE with UNION

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -108,7 +108,7 @@ func (a *applyJoinNode) startExec(params runParams) error {
 		}
 	}
 	a.run.out = make(tree.Datums, len(a.columns))
-	a.run.rightRows.init(a.rightTypes, params.extendedEvalCtx, "apply-join" /* opName */)
+	a.run.rightRows.Init(a.rightTypes, params.extendedEvalCtx, "apply-join" /* opName */)
 	return nil
 }
 
@@ -123,7 +123,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 			for {
 				// Note that if a.rightTypes has zero length, non-nil rrow is
 				// returned the correct number of times.
-				rrow, err := a.run.rightRowsIterator.next()
+				rrow, err := a.run.rightRowsIterator.Next()
 				if err != nil {
 					return false, err
 				}
@@ -229,10 +229,10 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 // clearRightRows clears rightRows and resets rightRowsIterator. This function
 // must be called before reusing rightRows and rightRowIterator.
 func (a *applyJoinNode) clearRightRows(params runParams) error {
-	if err := a.run.rightRows.clear(params.ctx); err != nil {
+	if err := a.run.rightRows.Clear(params.ctx); err != nil {
 		return err
 	}
-	a.run.rightRowsIterator.close()
+	a.run.rightRowsIterator.Close()
 	a.run.rightRowsIterator = nil
 	return nil
 }
@@ -325,9 +325,9 @@ func (a *applyJoinNode) Values() tree.Datums {
 
 func (a *applyJoinNode) Close(ctx context.Context) {
 	a.input.plan.Close(ctx)
-	a.run.rightRows.close(ctx)
+	a.run.rightRows.Close(ctx)
 	if a.run.rightRowsIterator != nil {
-		a.run.rightRowsIterator.close()
+		a.run.rightRowsIterator.Close()
 		a.run.rightRowsIterator = nil
 	}
 }

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -34,7 +34,7 @@ type bufferNode struct {
 
 func (n *bufferNode) startExec(params runParams) error {
 	n.typs = planTypes(n.plan)
-	n.rows.init(n.typs, params.extendedEvalCtx, n.label)
+	n.rows.Init(n.typs, params.extendedEvalCtx, n.label)
 	return nil
 }
 
@@ -50,7 +50,7 @@ func (n *bufferNode) Next(params runParams) (bool, error) {
 		return false, nil
 	}
 	n.currentRow = n.plan.Values()
-	if err = n.rows.addRow(params.ctx, n.currentRow); err != nil {
+	if err = n.rows.AddRow(params.ctx, n.currentRow); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -62,7 +62,7 @@ func (n *bufferNode) Values() tree.Datums {
 
 func (n *bufferNode) Close(ctx context.Context) {
 	n.plan.Close(ctx)
-	n.rows.close(ctx)
+	n.rows.Close(ctx)
 }
 
 // scanBufferNode behaves like an iterator into the bufferNode it is
@@ -85,7 +85,7 @@ func (n *scanBufferNode) startExec(params runParams) error {
 
 func (n *scanBufferNode) Next(runParams) (bool, error) {
 	var err error
-	n.currentRow, err = n.iterator.next()
+	n.currentRow, err = n.iterator.Next()
 	if n.currentRow == nil || err != nil {
 		return false, err
 	}
@@ -98,7 +98,7 @@ func (n *scanBufferNode) Values() tree.Datums {
 
 func (n *scanBufferNode) Close(context.Context) {
 	if n.iterator != nil {
-		n.iterator.close()
+		n.iterator.Close()
 		n.iterator = nil
 	}
 }

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -20,28 +20,25 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // rowContainerHelper is a wrapper around a disk-backed row container that
 // should be used by planNodes (or similar components) whenever they need to
-// buffer data. init must be called before the first use.
+// buffer data. init or initWithDedup must be called before the first use.
 type rowContainerHelper struct {
-	rows        *rowcontainer.DiskBackedRowContainer
-	scratch     rowenc.EncDatumRow
 	memMonitor  *mon.BytesMonitor
 	diskMonitor *mon.BytesMonitor
+	rows        *rowcontainer.DiskBackedRowContainer
+	scratch     rowenc.EncDatumRow
 }
 
 func (c *rowContainerHelper) init(
 	typs []*types.T, evalContext *extendedEvalContext, opName string,
 ) {
+	c.initMonitors(evalContext, opName)
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
-	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
-		evalContext.Context, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
-		fmt.Sprintf("%s-limited", opName),
-	)
-	c.diskMonitor = execinfra.NewMonitor(evalContext.Context, distSQLCfg.ParentDiskMonitor, fmt.Sprintf("%s-disk", opName))
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
 		colinfo.NoOrdering, typs, &evalContext.EvalContext,
@@ -50,12 +47,62 @@ func (c *rowContainerHelper) init(
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
 }
 
-// addRow adds a given row to the helper and returns any error it encounters.
+// initWithDedup is a variant of init that is used if row deduplication
+// functionality is needed (see addRowWithDedup).
+func (c *rowContainerHelper) initWithDedup(
+	typs []*types.T, evalContext *extendedEvalContext, opName string,
+) {
+	c.initMonitors(evalContext, opName)
+	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
+	c.rows = &rowcontainer.DiskBackedRowContainer{}
+	// The DiskBackedRowContainer can be configured to deduplicate along the
+	// columns in the ordering (these columns form the "key" if the container has
+	// to spill to disk).
+	ordering := make(colinfo.ColumnOrdering, len(typs))
+	for i := range ordering {
+		ordering[i].ColIdx = i
+		ordering[i].Direction = encoding.Ascending
+	}
+	c.rows.Init(
+		ordering, typs, &evalContext.EvalContext,
+		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+	)
+	c.rows.DoDeDuplicate()
+	c.scratch = make(rowenc.EncDatumRow, len(typs))
+}
+
+func (c *rowContainerHelper) initMonitors(evalContext *extendedEvalContext, opName string) {
+	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
+	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
+		evalContext.Context, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
+		fmt.Sprintf("%s-limited", opName),
+	)
+	c.diskMonitor = execinfra.NewMonitor(
+		evalContext.Context, distSQLCfg.ParentDiskMonitor, fmt.Sprintf("%s-disk", opName),
+	)
+}
+
+// addRow adds the given row to the container.
 func (c *rowContainerHelper) addRow(ctx context.Context, row tree.Datums) error {
 	for i := range row {
 		c.scratch[i].Datum = row[i]
 	}
 	return c.rows.AddRow(ctx, c.scratch)
+}
+
+// addRowWithDedup adds the given row if not already present in the container.
+// To use this method, initWithDedup must be used first.
+func (c *rowContainerHelper) addRowWithDedup(
+	ctx context.Context, row tree.Datums,
+) (added bool, _ error) {
+	for i := range row {
+		c.scratch[i].Datum = row[i]
+	}
+	lenBefore := c.rows.Len()
+	if _, err := c.rows.AddRowWithDeDup(ctx, c.scratch); err != nil {
+		return false, err
+	}
+	return c.rows.Len() > lenBefore, nil
 }
 
 // len returns the number of rows buffered so far.

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -34,7 +34,7 @@ type rowContainerHelper struct {
 	scratch     rowenc.EncDatumRow
 }
 
-func (c *rowContainerHelper) init(
+func (c *rowContainerHelper) Init(
 	typs []*types.T, evalContext *extendedEvalContext, opName string,
 ) {
 	c.initMonitors(evalContext, opName)
@@ -47,9 +47,9 @@ func (c *rowContainerHelper) init(
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
 }
 
-// initWithDedup is a variant of init that is used if row deduplication
+// InitWithDedup is a variant of init that is used if row deduplication
 // functionality is needed (see addRowWithDedup).
-func (c *rowContainerHelper) initWithDedup(
+func (c *rowContainerHelper) InitWithDedup(
 	typs []*types.T, evalContext *extendedEvalContext, opName string,
 ) {
 	c.initMonitors(evalContext, opName)
@@ -82,17 +82,17 @@ func (c *rowContainerHelper) initMonitors(evalContext *extendedEvalContext, opNa
 	)
 }
 
-// addRow adds the given row to the container.
-func (c *rowContainerHelper) addRow(ctx context.Context, row tree.Datums) error {
+// AddRow adds the given row to the container.
+func (c *rowContainerHelper) AddRow(ctx context.Context, row tree.Datums) error {
 	for i := range row {
 		c.scratch[i].Datum = row[i]
 	}
 	return c.rows.AddRow(ctx, c.scratch)
 }
 
-// addRowWithDedup adds the given row if not already present in the container.
-// To use this method, initWithDedup must be used first.
-func (c *rowContainerHelper) addRowWithDedup(
+// AddRowWithDedup adds the given row if not already present in the container.
+// To use this method, InitWithDedup must be used first.
+func (c *rowContainerHelper) AddRowWithDedup(
 	ctx context.Context, row tree.Datums,
 ) (added bool, _ error) {
 	for i := range row {
@@ -105,21 +105,21 @@ func (c *rowContainerHelper) addRowWithDedup(
 	return c.rows.Len() > lenBefore, nil
 }
 
-// len returns the number of rows buffered so far.
-func (c *rowContainerHelper) len() int {
+// Len returns the number of rows buffered so far.
+func (c *rowContainerHelper) Len() int {
 	return c.rows.Len()
 }
 
-// clear prepares the helper for reuse (it resets the underlying container which
+// Clear prepares the helper for reuse (it resets the underlying container which
 // will delete all buffered data; also, the container will be using the
 // in-memory variant even if it spilled on the previous usage).
-func (c *rowContainerHelper) clear(ctx context.Context) error {
+func (c *rowContainerHelper) Clear(ctx context.Context) error {
 	return c.rows.UnsafeReset(ctx)
 }
 
-// close must be called once the helper is no longer needed to clean up any
+// Close must be called once the helper is no longer needed to clean up any
 // resources.
-func (c *rowContainerHelper) close(ctx context.Context) {
+func (c *rowContainerHelper) Close(ctx context.Context) {
 	if c.rows != nil {
 		c.rows.Close(ctx)
 		c.memMonitor.Stop(ctx)
@@ -153,9 +153,9 @@ func newRowContainerIterator(
 	return i
 }
 
-// next returns the next row of the iterator or an error if encountered. It
+// Next returns the next row of the iterator or an error if encountered. It
 // returns nil, nil when the iterator has been exhausted.
-func (i *rowContainerIterator) next() (tree.Datums, error) {
+func (i *rowContainerIterator) Next() (tree.Datums, error) {
 	defer i.iter.Next()
 	if valid, err := i.iter.Valid(); err != nil {
 		return nil, err
@@ -173,6 +173,6 @@ func (i *rowContainerIterator) next() (tree.Datums, error) {
 	return i.datums, nil
 }
 
-func (i *rowContainerIterator) close() {
+func (i *rowContainerIterator) Close() {
 	i.iter.Close()
 }

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1016,7 +1016,7 @@ func (e *distSQLSpecExecFactory) ConstructScanBuffer(
 }
 
 func (e *distSQLSpecExecFactory) ConstructRecursiveCTE(
-	initial exec.Node, fn exec.RecursiveCTEIterationFn, label string,
+	initial exec.Node, fn exec.RecursiveCTEIterationFn, label string, deduplicate bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: recursive CTE")
 }

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -358,20 +358,19 @@ EXECUTE z5(3, 5)
 3
 5
 
-# TODO(justin): re-enable this, we don't allow WITHs having outer columns.
-# statement ok
-# PREPARE z6(int) AS
-#     SELECT * FROM
-#     (VALUES (1), (2)) v(x),
-#     LATERAL (SELECT * FROM
-#       (WITH foo AS (SELECT $1 + x) SELECT * FROM foo)
-#     )
+statement ok
+PREPARE z6(int) AS
+    SELECT * FROM
+    (VALUES (1), (2)) v(x),
+    LATERAL (SELECT * FROM
+      (WITH foo AS (SELECT $1 + x) SELECT * FROM foo)
+    )
 
-# query II
-# EXECUTE z6(3)
-# ----
-# 1 4
-# 2 5
+query II
+EXECUTE z6(3)
+----
+1 4
+2 5
 
 # Recursive CTE example from postgres docs.
 query T
@@ -379,6 +378,18 @@ WITH RECURSIVE t(n) AS (
     VALUES (1)
   UNION ALL
     SELECT n+1 FROM t WHERE n < 100
+)
+SELECT sum(n) FROM t
+----
+5050
+
+# Similar example where many duplicate rows are generated but we use UNION to
+# deduplicate them.
+query T
+WITH RECURSIVE t(n) AS (
+    VALUES (1)
+  UNION
+    SELECT n+y FROM t, (VALUES (1), (2)) AS v(y) WHERE n < 99
 )
 SELECT sum(n) FROM t
 ----
@@ -553,6 +564,66 @@ WITH RECURSIVE points AS (
 ····························································oo····························································
 ··························································································································
 ··························································································································
+
+# Test that we deduplicate rows from the initial expression.
+query II rowsort
+WITH RECURSIVE cte(a, b) AS (
+    VALUES (2, 2), (1, 1), (1, 2), (1, 1), (1, 3), (1, 2), (2, 2)
+  UNION
+    SELECT a+10, b+10 FROM cte WHERE a < 20
+) SELECT * FROM cte;
+----
+2   2
+1   1
+1   2
+1   3
+12  12
+11  11
+11  12
+11  13
+22  22
+21  21
+21  22
+21  23
+
+# Test that we deduplicate rows from a single iteration.
+query II rowsort
+WITH RECURSIVE cte(a, b) AS (
+    VALUES (1, 1), (1, 2), (2, 2)
+  UNION
+    SELECT 4-a, 4-a FROM cte
+) SELECT * FROM cte;
+----
+1  1
+1  2
+2  2
+3  3
+
+# Test that we deduplicate rows across iterations.
+query II rowsort
+WITH RECURSIVE cte(a, b) AS (
+    VALUES (1, 1), (1, 2), (2, 2)
+  UNION
+    SELECT (a+i) % 4, (b+1-i) % 4 FROM cte, (VALUES (0), (1)) AS v(i)
+) SELECT * FROM cte;
+----
+1  1
+1  2
+2  2
+2  1
+1  3
+2  3
+3  2
+3  1
+1  0
+2  0
+3  3
+0  2
+0  1
+3  0
+0  3
+0  0
+
 
 # Regression test for #45869 (CTE inside recursive CTE).
 query T rowsort

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2055,7 +2055,7 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 
 	label := fmt.Sprintf("working buffer (%s)", rec.Name)
 	var ep execPlan
-	ep.root, err = b.factory.ConstructRecursiveCTE(initial.root, fn, label)
+	ep.root, err = b.factory.ConstructRecursiveCTE(initial.root, fn, label, rec.Deduplicate)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -166,6 +166,38 @@ vectorized: true
               size: 1 column, 1 row
               row 0, expr 0: 1
 
+query T
+EXPLAIN (VERBOSE)
+  WITH RECURSIVE t(n) AS (
+      VALUES (1)
+    UNION
+      SELECT n+1 FROM t WHERE n < 100
+  )
+  SELECT sum(n) FROM t
+----
+distribution: local
+vectorized: true
+·
+• group (scalar)
+│ columns: (sum)
+│ estimated row count: 1 (missing stats)
+│ aggregate 0: sum(n)
+│
+└── • render
+    │ columns: (n)
+    │ estimated row count: 10 (missing stats)
+    │ render n: column1
+    │
+    └── • recursive cte
+        │ columns: (column1)
+        │ estimated row count: 10 (missing stats)
+        │ deduplicate
+        │
+        └── • values
+              columns: (column1)
+              size: 1 column, 1 row
+              row 0, expr 0: 1
+
 # Tests with correlated CTEs.
 query T
 EXPLAIN

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -789,6 +789,12 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		}
 		e.emitSpans("spans", a.Table, a.Table.Index(cat.PrimaryIndex), params)
 
+	case recursiveCTEOp:
+		a := n.args.(*recursiveCTEArgs)
+		if e.ob.flags.Verbose && a.Deduplicate {
+			ob.Attrf("deduplicate", "")
+		}
+
 	case simpleProjectOp,
 		serializingProjectOp,
 		ordinalityOp,
@@ -809,7 +815,6 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		alterTableUnsplitOp,
 		alterTableUnsplitAllOp,
 		alterTableRelocateOp,
-		recursiveCTEOp,
 		controlJobsOp,
 		controlSchedulesOp,
 		cancelQueriesOp,

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -689,11 +689,13 @@ define ScanBuffer {
 #       function. The returned plan uses this reference with a
 #       ConstructScanBuffer call.
 #     - the plan is executed; the results are emitted and also saved in a new
-#       buffer for the next iteration.
+#       buffer for the next iteration. If Deduplicate is true, only rows that
+#       haven't been returned yet are emitted and saved.
 define RecursiveCTE {
     Initial exec.Node
     Fn exec.RecursiveCTEIterationFn
     Label string
+    Deduplicate bool
 }
 
 # ControlJobs implements PAUSE/CANCEL/RESUME JOBS.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -701,6 +701,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *RecursiveCTEExpr:
 		if !f.HasFlags(ExprFmtHideColumns) {
+			if t.Deduplicate {
+				tp.Childf("deduplicate")
+			}
 			tp.Childf("working table binding: &%d", t.WithID)
 			f.formatColList(e, tp, "initial columns:", t.InitialCols)
 			f.formatColList(e, tp, "recursive columns:", t.RecursiveCols)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1262,6 +1262,10 @@ define RecursiveCTEPrivate {
     # These columns are also used by the Recursive query to refer to the working
     # table (see WithID).
     OutCols ColList
+
+    # Deduplicate indicates if output rows should be deduplicated against all
+    # previous output rows (UNION variant, not UNION ALL).
+    Deduplicate bool
 }
 
 # FakeRel is a mock relational operator used for testing and as a dummy binding

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -853,6 +853,49 @@ with &2 (t)
            └── sum [as=sum:6]
                 └── n:5
 
+build
+WITH RECURSIVE t(n) AS (
+    VALUES (1)
+  UNION
+    SELECT n+1 FROM t WHERE n < 100
+)
+SELECT sum(n) FROM t
+----
+with &2 (t)
+ ├── columns: sum:6
+ ├── recursive-c-t-e
+ │    ├── columns: n:2
+ │    ├── deduplicate
+ │    ├── working table binding: &1
+ │    ├── initial columns: column1:1
+ │    ├── recursive columns: "?column?":4
+ │    ├── fake-rel
+ │    │    └── columns: n:2
+ │    ├── values
+ │    │    ├── columns: column1:1!null
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── select
+ │         │    ├── columns: n:3!null
+ │         │    ├── with-scan &1 (t)
+ │         │    │    ├── columns: n:3
+ │         │    │    └── mapping:
+ │         │    │         └──  n:2 => n:3
+ │         │    └── filters
+ │         │         └── n:3 < 100
+ │         └── projections
+ │              └── n:3 + 1 [as="?column?":4]
+ └── scalar-group-by
+      ├── columns: sum:6
+      ├── with-scan &2 (t)
+      │    ├── columns: n:5
+      │    └── mapping:
+      │         └──  n:2 => n:5
+      └── aggregations
+           └── sum [as=sum:6]
+                └── n:5
+
 exec-ddl
 CREATE TABLE parts (part STRING, sub_part STRING, quantity INT)
 ----
@@ -1139,11 +1182,11 @@ WITH RECURSIVE cte(a, b) AS (
 ) SELECT * FROM cte;
 ----
 with &2 (cte)
- ├── columns: a:7!null b:8!null
+ ├── columns: a:9!null b:10!null
  ├── union
- │    ├── columns: "?column?":5!null "?column?":6!null
+ │    ├── columns: "?column?":7!null "?column?":8!null
  │    ├── left columns: "?column?":1 "?column?":2
- │    ├── right columns: "?column?":3 "?column?":4
+ │    ├── right columns: "?column?":5 "?column?":6
  │    ├── project
  │    │    ├── columns: "?column?":1!null "?column?":2!null
  │    │    ├── values
@@ -1152,17 +1195,17 @@ with &2 (cte)
  │    │         ├── 1 [as="?column?":1]
  │    │         └── 2 [as="?column?":2]
  │    └── project
- │         ├── columns: "?column?":3!null "?column?":4!null
+ │         ├── columns: "?column?":5!null "?column?":6!null
  │         ├── values
  │         │    └── ()
  │         └── projections
- │              ├── 3 [as="?column?":3]
- │              └── 4 [as="?column?":4]
+ │              ├── 3 [as="?column?":5]
+ │              └── 4 [as="?column?":6]
  └── with-scan &2 (cte)
-      ├── columns: a:7!null b:8!null
+      ├── columns: a:9!null b:10!null
       └── mapping:
-           ├──  "?column?":5 => a:7
-           └──  "?column?":6 => b:8
+           ├──  "?column?":7 => a:9
+           └──  "?column?":8 => b:10
 
 # Error cases.
 build
@@ -1170,16 +1213,7 @@ WITH RECURSIVE cte(a, b) AS (
   SELECT 1+a, 1+b FROM cte
 ) SELECT * FROM cte;
 ----
-error (42601): recursive query "cte" does not have the form non-recursive-term UNION ALL recursive-term
-
-build
-WITH RECURSIVE cte(a, b) AS (
-    SELECT 1, 2
-  UNION
-    SELECT 1+a, 1+b FROM cte
-) SELECT * FROM cte;
-----
-error (0A000): unimplemented: recursive query "cte" uses UNION which is not implemented (only UNION ALL is supported)
+error (42601): recursive query "cte" does not have the form non-recursive-term UNION [ALL] recursive-term
 
 build
 WITH RECURSIVE cte(a, b) AS (

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1029,12 +1029,13 @@ func (ef *execFactory) ConstructScanBuffer(ref exec.Node, label string) (exec.No
 
 // ConstructRecursiveCTE is part of the exec.Factory interface.
 func (ef *execFactory) ConstructRecursiveCTE(
-	initial exec.Node, fn exec.RecursiveCTEIterationFn, label string,
+	initial exec.Node, fn exec.RecursiveCTEIterationFn, label string, deduplicate bool,
 ) (exec.Node, error) {
 	return &recursiveCTENode{
 		initial:        initial.(planNode),
 		genIterationFn: fn,
 		label:          label,
+		deduplicate:    deduplicate,
 	}, nil
 }
 

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -420,14 +420,17 @@ func (f *DiskBackedRowContainer) Init(
 }
 
 // DoDeDuplicate causes DiskBackedRowContainer to behave as an implementation
-// of DeDupingRowContainer. It should not be mixed with calls to AddRow(). It
-// de-duplicates the keys such that only the first row with the given key will
-// be stored. The index returned in AddRowWithDedup() is a dense index
-// starting from 0, representing when that key was first added. This feature
-// does not combine with Sort(), Reorder() etc., and only to be used for
-// assignment of these dense indexes. The main reason to add this to
-// DiskBackedRowContainer is to avoid significant code duplication in
-// constructing another row container.
+// of DeDupingRowContainer. It should not be mixed with calls to AddRow().
+//
+// The rows are deduplicated along the columns in the ordering (the values on
+// those columns are the key). Only the first row with a given key will be
+// stored. The index returned in AddRowWithDedup() is a dense index starting
+// from 0, representing when that key was first added. This feature does not
+// combine with Sort(), Reorder() etc., and only to be used for assignment of
+// these dense indexes.
+//
+// The main reason to add this to DiskBackedRowContainer is to avoid significant
+// code duplication in constructing another row container.
 func (f *DiskBackedRowContainer) DoDeDuplicate() {
 	f.deDuplicate = true
 	f.keyToIndex = make(map[string]int)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -475,7 +475,7 @@ func scrubRunDistSQL(
 	ctx context.Context, planCtx *PlanningCtx, p *planner, plan *PhysicalPlan, columnTypes []*types.T,
 ) (*rowContainerHelper, error) {
 	var rowContainer rowContainerHelper
-	rowContainer.init(columnTypes, &p.extendedEvalCtx, "scrub" /* opName */)
+	rowContainer.Init(columnTypes, &p.extendedEvalCtx, "scrub" /* opName */)
 	rowResultWriter := NewRowResultWriter(&rowContainer)
 	recv := MakeDistSQLReceiver(
 		ctx,
@@ -496,10 +496,10 @@ func scrubRunDistSQL(
 		planCtx, p.txn, plan, recv, &evalCtxCopy, nil, /* finishedSetupFn */
 	)()
 	if rowResultWriter.Err() != nil {
-		rowContainer.close(ctx)
+		rowContainer.Close(ctx)
 		return nil, rowResultWriter.Err()
-	} else if rowContainer.len() == 0 {
-		rowContainer.close(ctx)
+	} else if rowContainer.Len() == 0 {
+		rowContainer.Close(ctx)
 		return nil, nil
 	}
 

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -142,7 +142,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	o.run.rows = rows
 	o.run.iterator = newRowContainerIterator(ctx, *rows, rowexec.ScrubTypes)
-	o.run.currentRow, err = o.run.iterator.next()
+	o.run.currentRow, err = o.run.iterator.Next()
 	return err
 }
 
@@ -172,7 +172,7 @@ func (o *physicalCheckOperation) Next(params runParams) (tree.Datums, error) {
 	}
 
 	// Advance to the next row.
-	o.run.currentRow, err = o.run.iterator.next()
+	o.run.currentRow, err = o.run.iterator.Next()
 	return res, err
 }
 
@@ -189,11 +189,11 @@ func (o *physicalCheckOperation) Done(context.Context) bool {
 // Close implements the checkOperation interface.
 func (o *physicalCheckOperation) Close(ctx context.Context) {
 	if o.run.rows != nil {
-		o.run.rows.close(ctx)
+		o.run.rows.Close(ctx)
 		o.run.rows = nil
 	}
 	if o.run.iterator != nil {
-		o.run.iterator.close()
+		o.run.iterator.Close()
 		o.run.iterator = nil
 	}
 }


### PR DESCRIPTION
#### sql: implement WITH RECURSIVE with UNION

This change implements the UNION variant of WITH RECURSIVE, where rows
are deduplicated. We achieve this by storing all rows in a
deduplicating container and inserting in that container first,
detecting if the row is a duplicate.

Fixes #46642.

Release note (sql change): The WITH RECURSIVE variant that uses UNION
(as opposed to UNION ALL) is now supported.

#### sql: capitalize rowContainerHelper API

This change capitalizes the API of `rowContainerHelper` and
`rowContainerIterator` to make it more clear what functions are not
internal to the structure.

Release note: None