### PR TITLE
[wip] migrations,server: allow tests to override minimum supported version

### DIFF
--- a/pkg/migration/migrations/delete_deprecated_namespace_tabledesc_external_test.go
+++ b/pkg/migration/migrations/delete_deprecated_namespace_tabledesc_external_test.go
@@ -39,8 +39,9 @@ func TestDeleteDeprecatedNamespaceDescriptorMigration(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.DeleteDeprecatedNamespaceTableDescriptorMigration - 1),
+					DisableAutomaticVersionUpgrade:    1,
+					BinaryVersionOverride:             clusterversion.ByKey(clusterversion.DeleteDeprecatedNamespaceTableDescriptorMigration - 1),
+					BinaryMinSupportedVersionOverride: clusterversion.ByKey(clusterversion.DeleteDeprecatedNamespaceTableDescriptorMigration - 1),
 				},
 			},
 		},

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -616,7 +616,7 @@ type initServerCfg struct {
 	testingKnobs base.TestingKnobs
 }
 
-func newInitServerConfig(cfg Config, dialOpts []grpc.DialOption) initServerCfg {
+func newInitServerConfig(ctx context.Context, cfg Config, dialOpts []grpc.DialOption) initServerCfg {
 	binaryVersion := cfg.Settings.Version.BinaryVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		if ov := knobs.(*TestingKnobs).BinaryVersionOverride; ov != (roachpb.Version{}) {
@@ -624,6 +624,11 @@ func newInitServerConfig(cfg Config, dialOpts []grpc.DialOption) initServerCfg {
 		}
 	}
 	binaryMinSupportedVersion := cfg.Settings.Version.BinaryMinSupportedVersion()
+	if binaryVersion.Less(binaryMinSupportedVersion) {
+		log.Fatalf(ctx, "binary version (%s) less than min supported version (%s)",
+			binaryVersion, binaryMinSupportedVersion)
+	}
+
 	bootstrapAddresses := cfg.FilterGossipBootstrapAddresses(context.Background())
 	return initServerCfg{
 		advertiseAddr:             cfg.AdvertiseAddr,

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -618,12 +618,15 @@ type initServerCfg struct {
 
 func newInitServerConfig(ctx context.Context, cfg Config, dialOpts []grpc.DialOption) initServerCfg {
 	binaryVersion := cfg.Settings.Version.BinaryVersion()
+	binaryMinSupportedVersion := cfg.Settings.Version.BinaryMinSupportedVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		if ov := knobs.(*TestingKnobs).BinaryVersionOverride; ov != (roachpb.Version{}) {
 			binaryVersion = ov
 		}
+		if ov := knobs.(*TestingKnobs).BinaryMinSupportedVersionOverride; ov != (roachpb.Version{}) {
+			binaryMinSupportedVersion = ov
+		}
 	}
-	binaryMinSupportedVersion := cfg.Settings.Version.BinaryMinSupportedVersion()
 	if binaryVersion.Less(binaryMinSupportedVersion) {
 		log.Fatalf(ctx, "binary version (%s) less than min supported version (%s)",
 			binaryVersion, binaryMinSupportedVersion)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1277,7 +1277,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 			return err
 		}
 
-		initConfig := newInitServerConfig(s.cfg, dialOpts)
+		initConfig := newInitServerConfig(ctx, s.cfg, dialOpts)
 		inspectedDiskState, err := inspectEngines(
 			ctx,
 			s.engines,

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -59,6 +59,7 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
 	stickyEngineRegistry := NewStickyInMemEnginesRegistry()
 	defer stickyEngineRegistry.CloseAllStickyInMemEngines()
 
@@ -105,7 +106,7 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 		dialOpts, err := s.rpcContext.GRPCDialOptions()
 		require.NoError(t, err)
 
-		initConfig := newInitServerConfig(s.cfg, dialOpts)
+		initConfig := newInitServerConfig(ctx, s.cfg, dialOpts)
 		inspectState, err := inspectEngines(
 			context.Background(),
 			s.engines,

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -74,11 +74,15 @@ type TestingKnobs struct {
 	// out join requests.
 	//
 	// NB: When setting this, you probably also want to set
-	// DisableAutomaticVersionUpgrade.
+	// DisableAutomaticVersionUpgrade and BinaryMinSupportedVersionOverride.
 	//
 	// TODO(irfansharif): Update users of this testing knob to use the
 	// appropriate clusterversion.Handle instead.
 	BinaryVersionOverride roachpb.Version
+	// BinaryMinSupportedVersionOverride overrides the minimum supported binary
+	// version. See BinaryVersionOverride.
+	BinaryMinSupportedVersionOverride roachpb.Version
+
 	// An (additional) callback invoked whenever a
 	// node is permanently removed from the cluster.
 	OnDecommissionedCallback func(livenesspb.Liveness)


### PR DESCRIPTION
Certain tests override the binary version (for e.g. in order to test the
execution of a specific migration association with a specific cluster
version). For these tests we also want to bypass the bootstrap ("is too
old for running version") version check, especially as we bump the
minimum supported version past a bunch of cluster versions that were
introduced in the last release cycle (#69828).

We could technically delete all the past-release cluster version
handling code before introducing next release development versions,
but it's easy to keep it around to simplify backports (and also it's a
lot of code to get rid of, only to allow next-release versions to be
added). Allowing these tests to override the minimum supported
version is a convenient workaround.

---

This commit updates one of the many failing tests blocking #69828, but
not all of them. The approach in this commit of providing a sister testing
knob `BinaryMinSupportedVersion` might not be sufficient due to
interactions with the cluster version setting (see comments on #69828).
It's possible we want to go all the way and all tests to install a
clusterversion.Handle instead. Leaving this PR up for posterity.

Release note: None