### PR TITLE
caller: modernize Lookup

### DIFF
--- a/pkg/util/caller/resolver_test.go
+++ b/pkg/util/caller/resolver_test.go
@@ -11,7 +11,6 @@
 package caller
 
 import (
-	"fmt"
 	"path"
 	"regexp"
 	"testing"
@@ -55,22 +54,9 @@ func TestDefaultCallResolver(t *testing.T) {
 	}
 }
 
-func BenchmarkFormattedCaller(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		file, line, _ := Lookup(1)
-		s := fmt.Sprintf("%s:%d", file, line)
-		if testing.Verbose() {
-			b.Log(s)
-		}
-	}
-}
-
 func BenchmarkSimpleCaller(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		file, line, _ := Lookup(1)
-		if testing.Verbose() {
-			s := fmt.Sprintf("%s:%d", file, line)
-			b.Log(s)
-		}
+		_, _, _ = Lookup(1)
 	}
 }


### PR DESCRIPTION
When we use verbose tracing, we spend lots of time in `log.Event{,f}`
and optimizing `caller.Lookup` can matter. The old code was also ripe
for some cleanup.

```
$ benchstat old.txt new.txt 
name            old time/op    new time/op    delta
SimpleCaller-8     764ns ± 3%     504ns ± 4%   -33.98%  (p=0.008 n=5+5)

name            old alloc/op   new alloc/op   delta
SimpleCaller-8      216B ± 0%        0B       -100.00%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
SimpleCaller-8      2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```

Extracted from #71610.

Release note: None
