### PR TITLE
roachtest: add kv95/enc=false/nodes=3/tracing

### DIFF
--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -21,6 +21,7 @@ const (
 	OwnerCDC           Owner = `cdc`
 	OwnerKV            Owner = `kv`
 	OwnerMultiRegion   Owner = `multiregion`
+	OwnerObsInf        Owner = `obs-inf-prs`
 	OwnerServer        Owner = `server`
 	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`


### PR DESCRIPTION
We don't have a good grasp on what it means for performance to turn on
tracing globally. A kv95 (read-mostly) workload is a good baseline here
as we expect it to be among the most severely impacted.

Touches #71694.
Touches #58610.

Release note: None
