### PR TITLE
release-21.2: util: deflake TestSpanRecordStructuredLimit

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -313,8 +313,15 @@ func (s *crdbSpan) recordStructured(item Structured) {
 		// are unlikely to happen.
 		return
 	}
+
+	var now time.Time
+	if s.testing != nil && s.testing.clock != nil {
+		now = s.testing.clock.Now()
+	} else {
+		now = time.Now()
+	}
 	sr := &tracingpb.StructuredRecord{
-		Time:    time.Now(),
+		Time:    now,
 		Payload: p,
 	}
 	s.recordInternal(sr, &s.mu.recording.structured)

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -232,7 +232,11 @@ func TestSpanRecordStructured(t *testing.T) {
 // TestSpanRecordStructuredLimit tests recording behavior when the size of
 // structured data recorded into the span exceeds the configured limit.
 func TestSpanRecordStructuredLimit(t *testing.T) {
+	now := timeutil.Now()
+	clock := timeutil.NewManualTime(now)
 	tr := NewTracer()
+	tr.testing = &testingKnob{clock}
+
 	sp := tr.StartSpan("root", WithForceRealSpan())
 	defer sp.Finish()
 
@@ -241,7 +245,7 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 	anyPayload, err := types.MarshalAny(payload(42))
 	require.NoError(t, err)
 	structuredRecord := &tracingpb.StructuredRecord{
-		Time:    timeutil.Now(),
+		Time:    now,
 		Payload: anyPayload,
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #71456.

/cc @cockroachdb/release

---

The protobuf encoding of a timestamp has a variable size because it
stores the time as two integers, both of which will be varint encoded.

This uses the existing Clock testing stub in RecordStructured so that
it can be used in the test.

Fixes #66701

Release note: None

Release justification: Test-only change to reduce tests flakes.