### PR TITLE
roachtest: add jasyncsql test suite

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -63,6 +63,8 @@ go_library(
         "inconsistency.go",
         "indexes.go",
         "inverted_index.go",
+        "jasyncsql.go",
+        "jasyncsql_blocklist.go",
         "java_helpers.go",
         "jepsen.go",
         "jobs.go",

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -1,0 +1,156 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+var supportedJasyncCommit = "6301aa1b9ef8a0d4c5cf6f3c095b30a388c62dc0"
+
+func registerJasyncSQL(r registry.Registry) {
+	runJasyncSQL := func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		if c.IsLocal() {
+			t.Fatal("can not be run in local mode")
+		}
+		node := c.Node(1)
+		t.Status("setting up cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
+		c.Start(ctx, c.All())
+
+		version, err := fetchCockroachVersion(ctx, c, node[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Status("cloning jasync-sql and installing prerequisites")
+
+		// Remove old jasync folder
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"remove old jasync-sql",
+			`rm -rf /mnt/data1/jasyncsql`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.RunE(
+			ctx,
+			node,
+			"cd /mnt/data1 && git clone https://github.com/jasync-sql/jasync-sql.git",
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		// TODO: Currently we are pointing to a JasyncSQL branch, we will change
+		// this once the official release is available
+		if err := c.RunE(ctx, node, fmt.Sprintf("cd /mnt/data1/jasync-sql && git checkout %s",
+			supportedJasyncCommit)); err != nil {
+			t.Fatal(err)
+		}
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"install java and gradle",
+			`sudo apt-get -qq install default-jre openjdk-11-jdk-headless gradle`,
+		); err != nil {
+			t.Fatal(err)
+		}
+		t.Status("building jasyncsql (without tests)")
+
+		blocklistName, expectedFailures, ignorelistName, ignorelist := jasyncsqlBlocklists.getLists(version)
+		if expectedFailures == nil {
+			t.Fatalf("No jasyncsql blocklist defined for cockroach version %s", version)
+		}
+		status := fmt.Sprintf("running cockraoch version %s, using blocklist %s", version, blocklistName)
+		if ignorelist != nil {
+			status = fmt.Sprintf(
+				"Running cockroach %s, using blocklist %s, using ignorelist %s",
+				version,
+				blocklistName,
+				ignorelistName)
+		}
+		t.L().Printf("%s", status)
+
+		t.Status("running jasyncsql test suite")
+
+		_ = c.RunE(
+			ctx,
+			node,
+			`cd /mnt/data1/jasync-sql && PGUSER=root PGHOST=localhost PGPORT=26257 PGDATABASE=defaultdb ./gradlew :postgresql-async:test`,
+		)
+
+		_ = c.RunE(ctx, node, `mkdir -p ~/logs/report/jasyncsql-results`)
+
+		t.Status("making test directory")
+
+		_ = c.RunE(ctx, node,
+			`mkdir -p ~/logs/report/jasyncsql-results`,
+		)
+
+		t.Status("collecting the test results")
+
+		if err := repeatRunE(
+			ctx,
+			t,
+			c,
+			node,
+			"copy test result files",
+			`cp /mnt/data1/jasync-sql/postgresql-async/build/test-results/test/*.xml ~/logs/report/jasyncsql-results -a`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		// Load all test results
+		output, err := repeatRunWithBuffer(
+			ctx,
+			c,
+			t,
+			node,
+			"get list of test files",
+			`ls /mnt/data1/jasync-sql/postgresql-async/build/test-results/test/*xml`,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output) == 0 {
+			t.Fatal("could not find any test result files")
+		}
+
+		parseAndSummarizeJavaORMTestsResults(
+			ctx, t, c, node, "jasyncsql", output,
+			blocklistName, expectedFailures, ignorelist, version, supportedJasyncCommit)
+	}
+
+	r.Add(registry.TestSpec{
+		Name:    "jasync",
+		Owner:   registry.OwnerSQLExperience,
+		Cluster: r.MakeClusterSpec(1),
+		Tags:    []string{`default`, `orm`},
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runJasyncSQL(ctx, t, c)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
@@ -1,0 +1,75 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+var jasyncsqlBlocklists = blocklistsForVersion{
+	{"v22.1", "jasyncsqlBlocklist22_1", jasyncBlocklist22_1, "jasyncsqlIgnoreList22_1", jasyncsqlIgnoreList22_1},
+}
+
+var jasyncBlocklist22_1 = blocklist{
+	"com.github.aysnc.sql.db.integration.ArrayTypesSpec.connection should correctly parse the array type":                                                           "unknown",
+	"com.github.aysnc.sql.db.integration.ArrayTypesSpec.connection should correctly send arrays using prepared statements":                                          "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should be able to receive a notification from a pg_notify call":                                "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should be able to receive a notification if listening":                                         "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should be able to receive notify ,out payload":                                                 "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should not receive any notification if not registered to the correct channel":                  "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should not receive notification if listener was removed":                                       "unknown",
+	"com.github.aysnc.sql.db.integration.ListenNotifySpec.connection should not receive notifications if cleared the collection":                                    "unknown",
+	"com.github.aysnc.sql.db.integration.LoginSpec.handler should fail login using , an invalid credential exception":                                               "unknown",
+	"com.github.aysnc.sql.db.integration.LoginSpec.handler should login using MD5 authentication":                                                                   "unknown",
+	"com.github.aysnc.sql.db.integration.LoginSpec.handler should login using SCRAM-SHA-256 authentication":                                                         "unknown",
+	"com.github.aysnc.sql.db.integration.LoginSpec.handler should login using cleartext authentication":                                                             "unknown",
+	"com.github.aysnc.sql.db.integration.NumericSpec.when processing numeric columns should support first update of num column with floating":                       "unknown",
+	"com.github.aysnc.sql.db.integration.NumericSpec.when processing numeric columns should support using first update with queries instead of prepared statements": "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should execute a prepared statement":                                                      "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should execute a prepared statement , parameters":                                         "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should return correct application_name":                                                   "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should select rows in the database":                                                       "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should select rows that has duplicate column names":                                       "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should transaction and flatmap example":                                                   "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLConnectionSpec.handler should use RETURNING in an insert statement":                                              "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should connect to the database in ssl verifying CA":                                "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should connect to the database in ssl verifying CA and hostname":                   "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should connect to the database in ssl without verifying CA":                        "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should connect with a local client cert":                                           "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should throws exception when CA verification fails":                                "unknown",
+	"com.github.aysnc.sql.db.integration.PostgreSQLSSLConnectionSpec.ssl handler should throws exception when hostname verification fails":                          "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should deallocates prepared statements":                                          "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should deallocates prepared statements when release immediately":                 "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should run prepared statement twice with bad and good values":                    "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support handling JSON type":                                               "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support handling of enum types":                                           "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support prepared statement with Option parameters (Some or None)":         "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support prepared statement with escaped placeholders":                     "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support prepared statement with more than 64 characters":                  "unknown",
+	"com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should supports sending null first and then an actual value for the fields":      "unknown",
+	"com.github.aysnc.sql.db.integration.TransactionSpec.transactions should commit simple inserts":                                                                 "unknown",
+	"com.github.aysnc.sql.db.integration.TransactionSpec.transactions should commit simple inserts, prepared statements":                                            "unknown",
+	"com.github.aysnc.sql.db.integration.TransactionSpec.transactions should rollback explicitly":                                                                   "unknown",
+	"com.github.aysnc.sql.db.integration.TransactionSpec.transactions should rollback to savepoint":                                                                 "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should enqueue an action if the pool is full":                                           "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should give me a valid object when I ask for one":                                       "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should it should remove aged out connections once the time limit has been reached":      "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should it should remove idle connections once the time limit has been reached":          "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ConnectionPoolSpec.pool should give you a connection for prepared statements":                                         "unknown",
+	"com.github.aysnc.sql.db.integration.pool.ConnectionPoolSpec.pool should give you a connection when sending statements":                                         "unknown",
+	"com.github.aysnc.sql.db.integration.pool.NextGenConnectionPoolSpec.pool should give you a connection for prepared statements":                                  "unknown",
+	"com.github.aysnc.sql.db.integration.pool.NextGenConnectionPoolSpec.pool should give you a connection when sending statements":                                  "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SingleThreadedAsyncObjectPoolSpec.pool should enqueue an action if the pool is full":                                  "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SingleThreadedAsyncObjectPoolSpec.pool should give me a valid object when I ask for one":                              "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SingleThreadedAsyncObjectPoolSpec.pool should it should remove idle connections once the time limit has been reached": "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.SuspendingConnection pool simple send prepared statement":                                          "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.SuspendingConnection pool simple send query":                                                       "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions should commit simple inserts , prepared statements":                                   "unknown",
+	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions with pool should commit simple inserts , prepared statements":                         "unknown",
+}
+
+var jasyncsqlIgnoreList22_1 = blocklist{}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -51,6 +51,7 @@ func RegisterTests(r registry.Registry) {
 	registerImportNodeShutdown(r)
 	registerInconsistency(r)
 	registerIndexes(r)
+	registerJasyncSQL(r)
 	RegisterJepsen(r)
 	registerJobsMixedVersions(r)
 	registerKV(r)


### PR DESCRIPTION
fixes #71158

Add a new roachtest, jasyncsql. Currently there is not config object
to alter the connection port in the original repo. The test points to
a forked repo, with altered config object, which runs the original
postgreSQL test suite.

Release note: None