### PR TITLE
bazel: mirror a bunch of repos to our cloud storage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,35 +3,41 @@
 workspace(
     name = "cockroach",
     managed_directories = {
-       "@npm": ["pkg/ui/node_modules"],
+        "@npm": ["pkg/ui/node_modules"],
     },
 )
 
 # Load the things that let us load other things.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "4a7bcc9b9051eb6a12bcb03a9bf38138c4bbc2ea",
-    remote = "https://github.com/cockroachdb/rules_go",
+    sha256 = "f0af9c876235d2bc69bddb9c33126f78d95f0bc9cec2d5aa497d5cab6325e733",
+    strip_prefix = "rules_go-4a7bcc9b9051eb6a12bcb03a9bf38138c4bbc2ea",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_go-4a7bcc9b9051eb6a12bcb03a9bf38138c4bbc2ea.tar.gz",
+    ],
 )
 
 # Like the above, but for nodeJS.
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "b32a4713b45095e9e1921a7fcb1adf584bc05959f3336e7351bcf77f015a2d7c",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.1.0/rules_nodejs-4.1.0.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_nodejs-4.1.0.tar.gz",
+    ],
 )
 
 # Load gazelle. This lets us auto-generate BUILD.bazel files throughout the
 # repo.
-git_repository(
+http_archive(
     name = "bazel_gazelle",
-    commit = "0ac66c98675a24d58f89a614b84dcd920a7e1762",
-    remote = "https://github.com/bazelbuild/bazel-gazelle",
-    shallow_since = "1626107853 -0400",
+    sha256 = "2f3cf903386c2a841522af9ee916f7c33fa27e113033a1ccae8e9dcedb09a99e",
+    strip_prefix = "bazel-gazelle-0ac66c98675a24d58f89a614b84dcd920a7e1762",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/bazel-gazelle-0ac66c98675a24d58f89a614b84dcd920a7e1762.tar.gz",
+    ],
 )
 
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
@@ -46,53 +52,255 @@ load("//:DEPS.bzl", "go_deps")
 # `go_rules_dependencies`, `gazelle_dependencies`, etc.
 go_deps()
 
+####### THIRD-PARTY DEPENDENCIES #######
+# Below we need to call into various helper macros to pull dependencies for
+# helper libraries like rules_go, rules_nodejs, and rules_foreign_cc. However,
+# calling into those helper macros can cause the build to pull from sources not
+# under CRDB's control. To avoid this, we pre-emptively declare each repository
+# as an http_archive/go_repository *before* calling into the macro where it
+# would otherwise be defined. In doing so we "override" the URL the macro will
+# point to.
+#
+# When upgrading any of these helper libraries, you will have to manually
+# inspect the definition of the macro to see what's changed. If the helper
+# library has defined any new dependencies, check whether we've already defined
+# that repository somewhere (either in this file or in `DEPS.bzl`). If it is
+# already defined somewhere, then add a note like "$REPO handled in DEPS.bzl"
+# for future maintainers. Otherwise, mirror the .tar.gz and add an http_archive
+# pointing to the mirror. For dependencies that were updated, check whether we
+# need to pull a new version of that dependency and mirror it and update the URL
+# accordingly.
+
+###############################
+# begin rules_go dependencies #
+###############################
+
+# For those rules_go dependencies that are NOT handled in DEPS.bzl, we point to
+# CRDB mirrors.
+
+http_archive(
+    name = "platforms",
+    sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/platforms-0.0.4.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/bazel-skylib-1.0.3.tar.gz",
+    ],
+)
+
+# org_golang_x_tools handled in DEPS.bzl.
+# org_golang_x_xerrors handled in DEPS.bzl.
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "92a89a2bbe6c6db2a8b87da4ce723aff6253656e8417f37e50d362817c39b98b",
+    strip_prefix = "rules_cc-88ef31b429631b787ceb5e4556d773b20ad797c8",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/88ef31b429631b787ceb5e4556d773b20ad797c8.zip",
+    ],
+)
+
+# org_golang_google_protobuf handled in DEPS.bzl.
+# com_github_golang_protobuf handled in DEPS.bzl.
+# com_github_mwitkow_go_proto_validators handled in DEPS.bzl.
+# com_github_gogo_protobuf handled in DEPS.bzl.
+# org_golang_google_genproto handled in DEPS.bzl.
+
+http_archive(
+    name = "go_googleapis",
+    patch_args = [
+        "-E",
+        "-p1",
+    ],
+    patches = [
+        "@io_bazel_rules_go//third_party:go_googleapis-deletebuild.patch",
+        "@io_bazel_rules_go//third_party:go_googleapis-directives.patch",
+        "@io_bazel_rules_go//third_party:go_googleapis-gazelle.patch",
+    ],
+    sha256 = "711bc79bd40406dda685a8633f7478979baabaab19eeac664d53f7621866bebc",
+    strip_prefix = "googleapis-d4cd8d96ed6eb5dd7c997aab68a1d6bb0825090c",
+    # master, as of 2021-03-05
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/d4cd8d96ed6eb5dd7c997aab68a1d6bb0825090c.zip",
+    ],
+)
+
 # Load the go dependencies and invoke them.
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load(
+    "@io_bazel_rules_go//go:deps.bzl",
+    "go_download_sdk",
+    "go_register_toolchains",
+    "go_rules_dependencies",
+)
+
+go_download_sdk(
+    name = "go_sdk",
+    urls = ["https://storage.googleapis.com/public-bazel-artifacts/go/{}"],
+    version = "1.16.6",
+)
 
 go_rules_dependencies()
 
-go_register_toolchains(go_version = "1.16.6")
+go_register_toolchains()
+
+###############################
+# end rules_go dependencies #
+###############################
+
+###################################
+# begin rules_nodejs dependencies #
+###################################
 
 # Configure nodeJS.
-load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install", "node_repositories")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
-node_repositories(package_json = ["//pkg/ui:package.json"])
+node_repositories(
+    node_urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/js/node/v{version}/{filename}",
+    ],
+    node_version = "14.17.5",
+    package_json = ["//pkg/ui:package.json"],
+    yarn_urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/js/yarn/v{version}/{filename}",
+    ],
+    yarn_version = "1.22.11",
+)
 
 # install external dependencies for pkg/ui package
 yarn_install(
     name = "npm",
-    package_json = "//pkg/ui:package.json",
-    yarn_lock = "//pkg/ui:yarn.lock",
-    strict_visibility = False,
     args = [
         "--ignore-optional",
         "--offline",
     ],
+    package_json = "//pkg/ui:package.json",
+    strict_visibility = False,
+    yarn_lock = "//pkg/ui:yarn.lock",
 )
+
+#################################
+# end rules_nodejs dependencies #
+#################################
+
+##############################
+# begin gazelle dependencies #
+##############################
 
 # Load gazelle dependencies.
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
+# bazel_skylib handled above.
+
+# com_github_bazelbuild_rules_go handled in DEPS.bzl.
+
+# com_github_burntsushi_toml handled in DEPS.bzl.
+# com_github_davecgh_go_spew handled in DEPS.bzl.
+# com_github_fsnotify_fsnotify handled in DEPS.bzl.
+# com_github_google_go_cmp handled in DEPS.bzl.
+# com_github_kr_pretty handled in DEPS.bzl.
+# com_github_kr_pty handled in DEPS.bzl.
+# com_github_kr_text handled in DEPS.bzl.
+# com_github_pelletier_go_toml handled in DEPS.bzl.
+# com_github_pmezard_go_difflib handled in DEPS.bzl.
+# in_gopkg_check_v1 handled in DEPS.bzl.
+# in_gopkg_yaml_v2 handled in DEPS.bzl.
+# org_golang_x_crypto handled in DEPS.bzl.
+# org_golang_x_mod handled in DEPS.bzl.
+# org_golang_x_net handled in DEPS.bzl.
+# org_golang_x_sync handled in DEPS.bzl.
+# org_golang_x_sys handled in DEPS.bzl.
+# org_golang_x_text handled in DEPS.bzl.
+# org_golang_x_tools handled in DEPS.bzl.
+# org_golang_x_xerrors handled in DEPS.bzl.
+
 gazelle_dependencies()
+
+############################
+# end gazelle dependencies #
+############################
+
+###############################
+# begin protobuf dependencies #
+###############################
 
 # Load the protobuf dependency.
 #
 # Ref: https://github.com/bazelbuild/rules_go/blob/0.19.0/go/workspace.rst#proto-dependencies
 #      https://github.com/bazelbuild/bazel-gazelle/issues/591
-git_repository(
+http_archive(
     name = "com_google_protobuf",
-    commit = "e809d75ecb5770fdc531081eef306b3e672bcdd2",
-    remote = "https://github.com/cockroachdb/protobuf",
+    sha256 = "071ccf561d127d5702910340cf038cb869aa239683544e1cca68a78ea865099e",
+    strip_prefix = "protobuf-e809d75ecb5770fdc531081eef306b3e672bcdd2",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/protobuf-e809d75ecb5770fdc531081eef306b3e672bcdd2.tar.gz",
+    ],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/zlib/zlib-1.2.11.tar.gz",
+    ],
+)
+
+# NB: we don't use six for anything. We're just including it here so we don't
+# incidentally pull it from pypi.
+http_archive(
+    name = "six",
+    build_file = "@com_google_protobuf//:six.BUILD",
+    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/python/six-1.10.0.tar.gz",
+    ],
+)
+
+# rules_cc handled above.
+
+# NB: we don't use rules_java for anything. We're just including it here so we
+# don't incidentally pull it from github.
+http_archive(
+    name = "rules_java",
+    sha256 = "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
+    strip_prefix = "rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
+    strip_prefix = "rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
+    ],
+)
+
 protobuf_deps()
+
+#############################
+# end protobuf dependencies #
+#############################
 
 # Loading c-deps third party dependencies.
 load("//c-deps:REPOSITORIES.bzl", "c_deps")
 
 c_deps()
+
+#######################################
+# begin rules_foreign_cc dependencies #
+#######################################
 
 # Load the bazel utility that lets us build C/C++ projects using
 # cmake/make/etc. We point to our fork which adds BSD support
@@ -101,15 +309,24 @@ c_deps()
 #
 # TODO(irfansharif): Point to an upstream SHA once maintainers pick up the
 # aforementioned PRs.
-git_repository(
+http_archive(
     name = "rules_foreign_cc",
-    commit = "67211f9083234f51ef1d9c21a791ee93bc538143",
-    remote = "https://github.com/cockroachdb/rules_foreign_cc",
+    sha256 = "66ab1d53be0a7292e3838b3042ec51a228dbe901972ae57b4a8a7c4336b39ed7",
+    strip_prefix = "rules_foreign_cc-67211f9083234f51ef1d9c21a791ee93bc538143",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_foreign_cc-67211f9083234f51ef1d9c21a791ee93bc538143.tar.gz",
+    ],
 )
+
+# TODO(ricky): need to mirror cmake/GNU make source
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
+
+#####################################
+# end rules_foreign_cc dependencies #
+#####################################
 
 # Load custom toolchains.
 load("//build/toolchains:REPOSITORIES.bzl", "toolchain_dependencies")
@@ -128,11 +345,11 @@ http_archive(
     sha256 = "692421b0c5e04ae4bc0bfff42fb1ce8671fe68daee2b8d8ea94657bb1fcddc0a",
     strip_prefix = "bazel_gomock-fde78c91cf1783cc1e33ba278922ba67a6ee2a84",
     urls = [
-        "https://github.com/jmhodges/bazel_gomock/archive/fde78c91cf1783cc1e33ba278922ba67a6ee2a84.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/bazel_gomock-fde78c91cf1783cc1e33ba278922ba67a6ee2a84.tar.gz",
     ],
 )
 
-new_git_repository(
+http_archive(
     name = "com_github_cockroachdb_sqllogictest",
     build_file_content = """
 filegroup(
@@ -140,13 +357,18 @@ filegroup(
     srcs = glob(["test/**/*.test"]),
     visibility = ["//visibility:public"],
 )""",
-    commit = "96138842571462ed9a697bff590828d8f6356a2f",
-    remote = "https://github.com/cockroachdb/sqllogictest",
+    sha256 = "f7e0d659fbefb65f32d4c5d146cba4c73c43e0e96f9b217a756c82be17451f97",
+    strip_prefix = "sqllogictest-96138842571462ed9a697bff590828d8f6356a2f",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/sqllogictest-96138842571462ed9a697bff590828d8f6356a2f.tar.gz",
+    ],
 )
 
 http_archive(
     name = "railroadjar",
-    urls = ["https://storage.googleapis.com/public-bazel-artifacts/java/railroad/rr-1.63-java8.zip"],
-    sha256 = "d2791cd7a44ea5be862f33f5a9b3d40aaad9858455828ebade7007ad7113fb41",
     build_file_content = """exports_files(["rr.war"])""",
+    sha256 = "d2791cd7a44ea5be862f33f5a9b3d40aaad9858455828ebade7007ad7113fb41",
+    urls = [
+        "https://storage.googleapis.com/public-bazel-artifacts/java/railroad/rr-1.63-java8.zip",
+    ],
 )

--- a/build/README.md
+++ b/build/README.md
@@ -109,7 +109,8 @@ back to this document and perform these steps:
 * [ ] Adjust version in Docker image ([source](./builder/Dockerfile)).
 * [ ] Adjust version in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
 * [ ] Rebuild and push the Docker image (following [Basic Process](#basic-process))
-* [ ] Bump the version in `WORKSPACE` under `go_register_toolchains`. You may need to bump [rules_go](https://github.com/bazelbuild/rules_go/releases).
+/* [ ] Download ALL the archives (`.tar.gz`, `.zip`) for the new Go version from https://golang.org/dl/ and mirror them in the `public-bazel-artifacts` bucket in the `Bazel artifacts` project in GCP (sub-directory `go`, next to the other Go SDK's).
+* [ ] Bump the version in `WORKSPACE` under `go_download_sdk`. You may need to bump [rules_go](https://github.com/bazelbuild/rules_go/releases).
 * [ ] Bump the version in `builder.sh` accordingly ([source](./builder.sh#L6)).
 * [ ] Bump the version in `go-version-check.sh` ([source](./go-version-check.sh)), unless bumping to a new patch release.
 * [ ] Bump the go version in `go.mod`. You may also need to rerun `make vendor_rebuild` if vendoring has changed.


### PR DESCRIPTION
I manually went through all of our dependencies, ensured that all repos
point to a mirror that we control, and updated the comments in
`WORKSPACE` to reflect the upkeep that must be performed.

Also update the instructions to upgrade Go.

We haven't pulled any new versions of any tools here; all the
dependencies are exactly as they were, just pointing to a mirror.

Part of #66163. A follow-up PR will introduce infrastructure to mirror
Go packages.

Release note: None