### PR TITLE
sql: Make --local-warehouses runtime only

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -177,7 +177,7 @@ var tpccMeta = workload.Meta{
 			`conns`:              {RuntimeOnly: true},
 			`idle-conns`:         {RuntimeOnly: true},
 			`expensive-checks`:   {RuntimeOnly: true, CheckConsistencyOnly: true},
-			`region-local`:       {RuntimeOnly: true},
+			`local-warehouses`:   {RuntimeOnly: true},
 		}
 
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Random number generator seed`)


### PR DESCRIPTION
Due to a rename late in the orginal PR, the TPC-C flag which was meant to
enforce local warehouse access wasn't correctly marked as runtime only. This
commit fixes that, and should address an issues we're seeing in
import/mixed-versions.

Resolves #71689.

Release note: None