### PR TITLE
clusterversion: set binaryMinSupportedVersion on master to v21_2

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -521,7 +521,7 @@ var (
 	// version than binaryMinSupportedVersion, then the binary will exit with
 	// an error. This typically trails the current release by one (see top-level
 	// comment).
-	binaryMinSupportedVersion = ByKey(V21_1)
+	binaryMinSupportedVersion = ByKey(V21_2)
 
 	// binaryVersion is the version of this binary.
 	//


### PR DESCRIPTION
Bump binaryMinSupportedVersion to `v21_2`, as part of #70751 (Perform all steps relevant to creating a release branch).

Fixes: #71708

Release note: None