### PR TITLE
rpc: record high latency on heartbeat errors

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1283,6 +1283,7 @@ func (ctx *Context) runHeartbeat(
 				// Only update the clock offset measurement if we actually got a
 				// successful response from the server.
 				pingDuration := receiveTime.Sub(sendTime)
+				ctx.RemoteClocks.updateLatencyMetrics(target, pingDuration)
 				maxOffset := ctx.Clock.MaxOffset()
 				if pingDuration > maximumPingDurationMult*maxOffset {
 					request.Offset.Reset()
@@ -1297,7 +1298,7 @@ func (ctx *Context) runHeartbeat(
 					remoteTimeNow := timeutil.Unix(0, response.ServerTime).Add(pingDuration / 2)
 					request.Offset.Offset = remoteTimeNow.Sub(receiveTime).Nanoseconds()
 				}
-				ctx.RemoteClocks.UpdateOffset(ctx.masterCtx, target, request.Offset, pingDuration)
+				ctx.RemoteClocks.UpdateOffset(ctx.masterCtx, target, request.Offset)
 
 				if cb := ctx.HeartbeatCB; cb != nil {
 					cb()

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -177,7 +177,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
-	hs.remoteClockMonitor.UpdateOffset(ctx, args.OriginAddr, serverOffset, 0 /* roundTripLatency */)
+	hs.remoteClockMonitor.UpdateOffset(ctx, args.OriginAddr, serverOffset)
 	return &PingResponse{
 		Pong:                           args.Ping,
 		ServerTime:                     hs.clock.PhysicalNow(),


### PR DESCRIPTION
This PR is a simple way to address #58033. Prior to this PR, we
would only ever record latencies incurred during *successful*
RPC heartbeats. However, we also want to detect network outages
using these measurements.

With this commit, we record a hard-coded high latency whenever a
heartbeat fails. That means metrics and observability tools (in
particular the node latency page in the UI) will clearly highlight
inter-node connections that are in an unhealthy state.

Just by looking at the diff one wants to be doing a lot more work to
clean this code up. This approach is intentionally not taken here. The
diff is small, can be backported, and should get the job done with the
bandwidth that I feel I can spend on this now.

Release note (bug fix): The network latency page now registers a high
latency measurement when network connections between nodes cannot
established. It would previously rely on the most recent measurements on
a healthy connection, thus obscuring the network issues. The same
improvement is bestowed upon the `round-trip-latency` family of metrics.
