### PR TITLE
sql: consistent aggregated timestamp when flushing sql stats

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/consistent_flush_timestamp
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/consistent_flush_timestamp
@@ -1,0 +1,99 @@
+exec-sql
+SET application_name = 'consistent-test'
+----
+
+register-callback event=stmt-stats-flushed callbackCmd=set-time callbackCmdArgKey=time callbackCmdArgValue=2021-09-20T15:00:01Z
+----
+
+set-time time=2021-09-20T14:59:59Z
+----
+2021-09-20 14:59:59 +0000 UTC
+
+exec-sql
+SELECT 1
+----
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata -> 'stmtFingerprintIDs'
+FROM
+  crdb_internal.transaction_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,705fcdf3f12803ec,["df3c70bf7729b433"]
+
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata ->> 'query'
+FROM
+  crdb_internal.statement_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,df3c70bf7729b433,SELECT _
+
+sql-stats-flush
+----
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata ->> 'query'
+FROM
+  crdb_internal.statement_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,df3c70bf7729b433,SELECT _
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata -> 'stmtFingerprintIDs'
+FROM
+  crdb_internal.transaction_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,705fcdf3f12803ec,["df3c70bf7729b433"]
+
+exec-sql
+SELECT 1
+----
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata ->> 'query'
+FROM
+  crdb_internal.statement_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,df3c70bf7729b433,SELECT _
+2021-09-20 15:00:00 +0000 UTC,df3c70bf7729b433,SELECT _
+
+observe-sql
+SELECT
+  aggregated_ts,
+  encode(fingerprint_id, 'hex'),
+  metadata -> 'stmtFingerprintIDs'
+FROM
+  crdb_internal.transaction_statistics
+WHERE
+  app_name = 'consistent-test'
+----
+2021-09-20 14:00:00 +0000 UTC,705fcdf3f12803ec,["df3c70bf7729b433"]
+2021-09-20 15:00:00 +0000 UTC,705fcdf3f12803ec,["df3c70bf7729b433"]
+
+unregister-callback event=stmt-stats-flushed
+----

--- a/pkg/sql/sqlstats/test_utils.go
+++ b/pkg/sql/sqlstats/test_utils.go
@@ -14,9 +14,13 @@ import "time"
 
 // TestingKnobs provides hooks and knobs for unit tests.
 type TestingKnobs struct {
-	// OnStatsFlushFinished is a callback that is triggered when a single
-	// statistics object is flushed.
-	OnStatsFlushFinished func(error)
+	// OnStmtStatsFlushFinished is a callback that is triggered when stmt stats
+	// finishes flushing.
+	OnStmtStatsFlushFinished func()
+
+	// OnTxnStatsFlushFinished is a callback that is triggered when txn stats
+	// finishes flushing.
+	OnTxnStatsFlushFinished func()
 
 	// StubTimeNow allows tests to override the timeutil.Now() function used
 	// by the flush operation to calculate aggregated_ts timestamp.


### PR DESCRIPTION
Previously, when SQL Stats are flushed to system table, the
aggregatedTs column for SQL Stats is calculated for each stats
entry individually. This means that if a flush starts near
the end of each hour, it is possible that different stats
rows will be assigned two different aggregated timestamp.
Currently, flusher flushes statement statistics first, and only
when statement statistics are flushed, transaction statistics
will be flushed into system table. This means that it is likely
the transaction statistics will get assigned a different
aggregatedTs than the statement statistics.
Consequentially, when the frontend fetches SQL Stats through
the CombinedStmtStats handler, the frontend default performs
range scan at 1 hour interval. This triggers a range scan
on the system table for that 1 hour range. This causes the
statement statisitcs that got assigned a different aggregatedTs
to be omitted from the result.

This commit changed the flusher to only compute aggregatedTs once
before the flush actually happen, and assign that aggregatedTs
too *all* stmt/txn stats rows. Statements executed in the same
aggregation interval can be looked up by the corresponding
statement fingerprint ID stored in transaction stats metadata.

Follow up to #71596

Release note: None