### PR TITLE
bazel: use preinstalled cmake/make for rules_foreign_cc tasks 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -318,11 +318,15 @@ http_archive(
     ],
 )
 
-# TODO(ricky): need to mirror cmake/GNU make source
-
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies()
+# bazel_skylib is handled above.
+
+rules_foreign_cc_dependencies(
+    register_built_tools = False,
+    register_default_tools = False,
+    register_preinstalled_tools = True,
+)
 
 #####################################
 # end rules_foreign_cc dependencies #


### PR DESCRIPTION
This allows us to avoid bootstrapping `make` and `cmake` for `c-deps`
builds. It does require you to have `cmake` and `make` installed
locally, but I don't think that's a huge deal.

Closes #65894.
Closes #71734.

Release note: None