### PR TITLE
roachtest: fix schemachange/during/kv

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -133,7 +133,7 @@ func waitForSchemaChanges(ctx context.Context, l *logger.Logger, db *gosql.DB) e
 	}
 	// Queries to hone in on index validation problems.
 	indexValidationQueries := []string{
-		"SELECT count(k) FROM test.kv@primary AS OF SYSTEM TIME %s WHERE created_at > $1 AND created_at <= $2",
+		"SELECT count(k) FROM test.kv@kv_pkey AS OF SYSTEM TIME %s WHERE created_at > $1 AND created_at <= $2",
 		"SELECT count(v) FROM test.kv@foo AS OF SYSTEM TIME %s WHERE created_at > $1 AND created_at <= $2",
 	}
 	return runValidationQueries(ctx, l, db, start, validationQueries, indexValidationQueries)


### PR DESCRIPTION
Resolves #71608

Some more fallout from the PRIMARY KEY rename.

Release note: None