### PR TITLE
server: fix panic on invalid session cookie.

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -614,7 +614,7 @@ func (am *authenticationMux) getSession(
 		}
 		break
 	}
-	if !found {
+	if err != nil || !found {
 		return "", nil, http.ErrNoCookie
 	}
 

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -704,7 +704,7 @@ func TestAuthenticationMux(t *testing.T) {
 	} {
 		t.Run("path="+tc.path, func(t *testing.T) {
 			// Verify normal client returns 401 Unauthorized.
-			if err := runRequest(normalClient, tc.method, tc.path, tc.body, "", http.StatusUnauthorized); err != nil {
+			if err := runRequest(normalClient, tc.method, tc.path, tc.body, tc.cookieHeader, http.StatusUnauthorized); err != nil {
 				t.Fatalf("request %s failed when not authorized: %s", tc.path, err)
 			}
 


### PR DESCRIPTION
A recent change (#70792) added some code to deal with duplicate cookies
in the HTTP header on DB Console requests to account for situations
where someone may have multiple `session` cookies in addition to the
CRDB one. That change failed to properly check for a dangling `err`
value outside of a loop before proceeding.

The tests have been modified to exercise the code that resulted in a
panic. The bad cookie header is now also appended to unauthenticated
requests in the test to manufacture a situation where only invalid
cookies are in the header.

Resolves #71728

Release note: None