### PR TITLE
server: avoid panic in NodesUI

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1411,6 +1411,9 @@ func (s *statusServer) NodesUI(
 	}
 
 	internalResp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
+	if err != nil {
+		return nil, err
+	}
 	resp := &serverpb.NodesResponseExternal{
 		Nodes:            make([]serverpb.NodeResponse, len(internalResp.Nodes)),
 		LivenessByNodeID: internalResp.LivenessByNodeID,


### PR DESCRIPTION
NodesUI wasn't checking an error and could trigger an NPE in that way.
I found this in a most comical way, by standing up a three node
roachprod cluster and creating an asymmetric network partition where
n2 wasn't able to contact n1:

```
iptables -A INPUT --source 10.142.0.80 -j DROP
```

I don't think this was ever released; the problem was introduced in
PR #71181, on 2021-10-11.

Release note (bug fix): CockroachDB could crash if network connectivity
was impaired. The stack trace (in cockroach-stderr.log) would contain
`server.(*statusServer).NodesUI` in that case.
