### PR TITLE
release-21.1: workload: Fix TPC-C multi-region partition assignment

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -80,7 +80,7 @@ func newSkipResult(format string, args ...interface{}) auditResult {
 
 // runChecks runs the audit checks and prints warnings to stdout for those that
 // fail.
-func (a *auditor) runChecks() {
+func (a *auditor) runChecks(localWarehouses bool) {
 	type check struct {
 		name string
 		f    func(a *auditor) auditResult
@@ -89,11 +89,19 @@ func (a *auditor) runChecks() {
 		{"9.2.1.7", check9217},
 		{"9.2.2.5.1", check92251},
 		{"9.2.2.5.2", check92252},
-		{"9.2.2.5.3", check92253},
-		{"9.2.2.5.4", check92254},
 		{"9.2.2.5.5", check92255},
 		{"9.2.2.5.6", check92256},
 	}
+
+	// If we're keeping the workload local, these checks are expected to fail.
+	// Bypass them instead of allowing them to fail.
+	if !localWarehouses {
+		checks = append(checks,
+			check{"9.2.2.5.3", check92253},
+			check{"9.2.2.5.4", check92254},
+		)
+	}
+
 	for _, check := range checks {
 		result := check.f(a)
 		msg := fmt.Sprintf("Audit check %s: %s", check.name, result.status)

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -180,7 +180,12 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 			}
 		}
 		// 2.4.1.5.2: 1% of the time, an item is supplied from a remote warehouse.
-		item.remoteWarehouse = rng.Intn(100) == 0
+		// If we're in localWarehouses mode, keep all items local.
+		if n.config.localWarehouses {
+			item.remoteWarehouse = false
+		} else {
+			item.remoteWarehouse = rng.Intn(100) == 0
+		}
 		item.olSupplyWID = wID
 		if item.remoteWarehouse && n.config.activeWarehouses > 1 {
 			allLocal = 0

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -161,8 +161,11 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	}
 
 	// 2.5.1.2: 85% chance of paying through home warehouse, otherwise
-	// remote.
-	if rng.Intn(100) < 85 {
+	// remote. This only applies to the customer update below, and not the
+	// warehouse and district updates.
+	// NOTE: If localWarehouses is set, keep all transactions local. This is for
+	// testing only, as it violates the spec.
+	if p.config.localWarehouses || rng.Intn(100) < 85 {
 		d.cWID = wID
 		d.cDID = d.dID
 	} else {

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -74,8 +74,16 @@ type tpcc struct {
 	clientPartitions   int
 	affinityPartitions []int
 	wPart              *partitioner
+	wMRPart            *partitioner
 	zoneCfg            zoneConfig
 	multiRegionCfg     multiRegionConfig
+
+	// localWarehouses determines whether or not we should force transactions to
+	// operate on a local warehouse (local to where the given transaction
+	// originated). This is only used for multi-region configurations, and is in
+	// violation of the TPC-C spec, so it should only be used for internal
+	// testing purposes.
+	localWarehouses bool
 
 	usePostgres  bool
 	serializable bool
@@ -166,6 +174,7 @@ var tpccMeta = workload.Meta{
 			`workers`:            {RuntimeOnly: true},
 			`conns`:              {RuntimeOnly: true},
 			`expensive-checks`:   {RuntimeOnly: true, CheckConsistencyOnly: true},
+			`local-warehouses`:   {RuntimeOnly: true},
 		}
 
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Random number generator seed`)
@@ -204,6 +213,7 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
 		g.flags.BoolVar(&g.separateColumnFamilies, `families`, false, `Use separate column families for dynamic and static columns`)
 		g.flags.BoolVar(&g.replicateStaticColumns, `replicate-static-columns`, false, "Create duplicate indexes for all static columns in district, items and warehouse tables, such that each zone or rack has them locally.")
+		g.flags.BoolVar(&g.localWarehouses, `local-warehouses`, false, `Force transactions to use a local warehouse in all cases (in violation of the TPC-C specification)`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 
 		// Hardcode this since it doesn't seem like anyone will want to change
@@ -310,18 +320,25 @@ func (w *tpcc) Hooks() workload.Hooks {
 
 			// Create a partitioner to help us partition the warehouses. The base-case is
 			// where w.warehouses == w.activeWarehouses and w.partitions == 1.
-			var err error
+			partitions := w.partitions
 			if w.clientPartitions > 0 {
-				// This partitioner will not actually be used to partiton the data, but instead
-				// is only used to limit the warehouses the client attempts to manipulate.
-				w.wPart, err = makePartitioner(w.warehouses, w.activeWarehouses, w.clientPartitions)
-			} else {
-				w.wPart, err = makePartitioner(w.warehouses, w.activeWarehouses, w.partitions)
+				partitions = w.clientPartitions
 			}
+			var err error
+			// This partitioner will not actually be used to partition the
+			// data, but instead is only used to limit the warehouses the
+			// client attempts to manipulate.
+			w.wPart, err = makePartitioner(w.warehouses, w.activeWarehouses, partitions)
 			if err != nil {
 				return errors.Wrap(err, "error creating partitioner")
 			}
-
+			if len(w.multiRegionCfg.regions) != 0 {
+				// For multi-region workloads, make a multi-region partitioner.
+				w.wMRPart, err = makeMRPartitioner(w.warehouses, w.activeWarehouses, partitions)
+				if err != nil {
+					return errors.Wrap(err, "error creating multi-region partitioner")
+				}
+			}
 			return initializeMix(w)
 		},
 		PreCreate: func(db *gosql.DB) error {
@@ -452,7 +469,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 			return w.partitionAndScatterWithDB(db)
 		},
 		PostRun: func(startElapsed time.Duration) error {
-			w.auditor.runChecks()
+			w.auditor.runChecks(w.localWarehouses)
 			const totalHeader = "\n_elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)"
 			fmt.Println(totalHeader)
 
@@ -782,8 +799,8 @@ func (w *tpcc) Ops(
 
 	} else {
 		// This is making some assumptions about how racks are handed out.
-		// If we have more than one affinityPartion then we assume that the URLs
-		// are mapped to partitions in a round-robin fashion.
+		// If we have more than one affinityPartition then we assume that the
+		// URLs are mapped to partitions in a round-robin fashion.
 		// Imagine there are 5 partitions and 15 urls, this code assumes that urls
 		// 0, 5, and 10 correspond to the 0th partition.
 		for i, db := range dbs {
@@ -819,8 +836,16 @@ func (w *tpcc) Ops(
 	sem := make(chan struct{}, 100)
 	for workerIdx := 0; workerIdx < w.workers; workerIdx++ {
 		workerIdx := workerIdx
-		warehouse := w.wPart.totalElems[workerIdx%len(w.wPart.totalElems)]
-		p := w.wPart.partElemsMap[warehouse]
+		var warehouse int
+		var p int
+		if len(w.multiRegionCfg.regions) == 0 {
+			warehouse = w.wPart.totalElems[workerIdx%len(w.wPart.totalElems)]
+			p = w.wPart.partElemsMap[warehouse]
+		} else {
+			// For multi-region workloads, use the multi-region partitioning.
+			warehouse = w.wMRPart.totalElems[workerIdx%len(w.wMRPart.totalElems)]
+			p = w.wMRPart.partElemsMap[warehouse]
+		}
 
 		// This isn't part of our local partition.
 		if !isMyPart(p) {


### PR DESCRIPTION
Backport 1/1 commits from #70121.

/cc @cockroachdb/release

---

When the initial changes were made to allow the TPC-C
workload to leverage the new 21.1 multi-region syntax,
the partitioning was overlooked. TPC-C by default partitions
in consecutive blocks. For example, if there are 9 warehouses
and 3 partitions, the partition assignment would be as
follows [[0, 1, 2], [3, 4, 5], [6, 7, 8]]. This unfortunately
doesn't work for multi-region workload assignment, as the
warehouses are distributed to regions using a round-robin
algorithm ([0, 3, 6], [1, 4, 7], [2, 5, 8]]. The end result
is that when combined with the --partition-affinity flag, workers
won't be assigned to local partitions and the workload will
instead be fully cross-region.

This change creates a separate partitioning structure to be
used in multi-region setups and ensures that the workers will
operate on local warehouses.

Also adds a new flag (`--region-local`) which allows the user
to override the TPC-C spec and keep all transactions local to
a given region. This was introduced for testing only.

Release note (bug fix): Fixes a problem where the TPC-C workload,
when used in a multi-region setup, will not properly assign workers
to the local partitions.

Release justification: Fixes multi-region TPC-C partitioning, which is
currently broken, thus preventing the use of TPC-C in multi-region
configurations.