### PR TITLE
backupccl: remove some used code

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1161,12 +1161,6 @@ func backupPlanHook(
 		if err := checkForPreviousBackup(ctx, defaultStore, defaultURI); err != nil {
 			return err
 		}
-		// TODO (pbardea): For partitioned backups, also add verification for other
-		// stores we are writing to in addition to the default.
-		baseURI := collectionURI
-		if baseURI == "" {
-			baseURI = defaultURI
-		}
 
 		// Write backup manifest into a temporary checkpoint file.
 		// This accomplishes 2 purposes:
@@ -1174,6 +1168,9 @@ func backupPlanHook(
 		//  2. Verifies we can write to destination location.
 		// This temporary checkpoint file gets renamed to real checkpoint
 		// file when the backup jobs starts execution.
+		//
+		// TODO (pbardea): For partitioned backups, also add verification for other
+		// stores we are writing to in addition to the default.
 		doWriteBackupManifestCheckpoint := func(ctx context.Context, jobID jobspb.JobID) error {
 			if err := writeBackupManifest(
 				ctx, p.ExecCfg().Settings, defaultStore, tempCheckpointFileNameForJob(jobID),


### PR DESCRIPTION
The baseURI variable was used by a function call that was removed in
28e4cea7ed704acfc2aab2640bcd5dea1dcdbd9f. The TODO still seems
relevant.

Release note: None