### PR TITLE
changefeedccl: fix two ineffective assignments

### DIFF
--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -161,7 +161,6 @@ func (e *jsonEncoder) encodeKeyRaw(row encodeRow) ([]interface{}, error) {
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}
-		datum := row.datums[idx]
 		datum, col := row.datums[idx], row.tableDesc.PublicColumns()[idx]
 		if err := datum.EnsureDecoded(col.GetType(), &e.alloc); err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -211,7 +211,7 @@ func (u *sinkURL) remainingQueryParams() (res []string) {
 	return
 }
 
-func (u sinkURL) String() string {
+func (u *sinkURL) String() string {
 	if u.q != nil {
 		// If we changed query params, re-encode them.
 		u.URL.RawQuery = u.q.Encode()


### PR DESCRIPTION
This fixes two assignments that had no effect. In the first case, we
re-assign the variable immediately on the next line. In the second
case, we were assigning to a struct member in a function with a value
receiver, so we were modifying a copy of the struct that would never
be used again.

Release note: None