### PR TITLE
cli: debug backup should show subcommands when none were provided

### DIFF
--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -181,9 +181,8 @@ func init() {
 		Use:   "backup [command]",
 		Short: "debug backups",
 		Long:  "Shows information about a SQL backup.",
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Usage()
+			return cli.UsageAndErr(cmd, args)
 		},
 	}
 

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -218,7 +218,7 @@ var authCmds = []*cobra.Command{
 var authCmd = &cobra.Command{
 	Use:   "auth-session",
 	Short: "log in and out of HTTP sessions",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 func init() {

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -301,7 +301,7 @@ var certCmd = func() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cert",
 		Short: "create ca, node, and client certs",
-		RunE:  usageAndErr,
+		RunE:  UsageAndErr,
 	}
 	cmd.AddCommand(certCmds...)
 	return cmd

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -283,10 +283,10 @@ func Run(args []string) error {
 	return cockroachCmd.Execute()
 }
 
-// usageAndErr informs the user about the usage of the command
+// UsageAndErr informs the user about the usage of the command
 // and returns an error. This ensures that the top-level command
 // has a suitable exit status.
-func usageAndErr(cmd *cobra.Command, args []string) error {
+func UsageAndErr(cmd *cobra.Command, args []string) error {
 	if err := cmd.Usage(); err != nil {
 		return err
 	}

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -36,7 +36,7 @@ var connectCmd = &cobra.Command{
 	Short: "Create certificates for securely connecting with clusters\n",
 	Long: `
 Bootstrap security certificates for connecting to new or existing clusters.`,
-	RunE: usageAndErr,
+	RunE: UsageAndErr,
 }
 
 func init() {

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -600,14 +600,14 @@ var debugDecodeProtoCmd = &cobra.Command{
 Read from stdin and attempt to decode any hex or base64 encoded proto fields and
 output them as JSON. All other fields will be outputted unchanged. Output fields
 will be separated by tabs.
-	
+
 The default value for --schema is 'cockroach.sql.sqlbase.Descriptor'.
 For example:
 
 $ decode-proto < cat debug/system.decsriptor.txt
 id	descriptor	hex_descriptor
 1	\022!\012\006system\020\001\032\025\012\011\012\005admin\0200\012\010\012\004root\0200	{"database": {"id": 1, "modificationTime": {}, "name": "system", "privileges": {"users": [{"privileges": 48, "user": "admin"}, {"privileges": 48, "user": "root"}]}}}
-...	
+...
 `,
 	Args: cobra.ArbitraryArgs,
 	RunE: runDebugDecodeProto,
@@ -1538,7 +1538,7 @@ var DebugCmd = &cobra.Command{
 These commands are useful for extracting data from the data files of a
 process that has failed and cannot restart.
 `,
-	RunE: usageAndErr,
+	RunE: UsageAndErr,
 }
 
 // mvccValueFormatter is a fmt.Formatter for MVCC values.

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -253,7 +253,7 @@ var genCmd = &cobra.Command{
 	Use:   "gen [command]",
 	Short: "generate auxiliary files",
 	Long:  "Generate manpages, example shell settings, example databases, etc.",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 var genCmds = []*cobra.Command{

--- a/pkg/cli/import.go
+++ b/pkg/cli/import.go
@@ -234,7 +234,7 @@ var importCmd = &cobra.Command{
 	Use:   "import [command]",
 	Short: "import a db or table from a local PGDUMP or MYSQLDUMP file",
 	Long:  "import a db or table from a local PGDUMP or MYSQLDUMP file",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 func init() {

--- a/pkg/cli/mt.go
+++ b/pkg/cli/mt.go
@@ -35,7 +35,7 @@ Commands related to multi-tenancy.
 
 This functionality is **experimental** and for internal use only.
 `,
-	RunE:   usageAndErr,
+	RunE:   UsageAndErr,
 	Hidden: true,
 }
 
@@ -50,5 +50,5 @@ command.
 
 This functionality is **experimental** and for internal use only.
 `,
-	RunE: usageAndErr,
+	RunE: UsageAndErr,
 }

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -648,7 +648,7 @@ var nodeCmd = &cobra.Command{
 	Use:   "node [command]",
 	Short: "list, inspect, drain or remove nodes\n",
 	Long:  "List, inspect, drain or remove nodes.",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 func init() {

--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -146,7 +146,7 @@ var nodeLocalCmd = &cobra.Command{
 	Use:   "nodelocal [command]",
 	Short: "upload and delete nodelocal files",
 	Long:  "Upload and delete files on the gateway node's local file system.",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 func init() {

--- a/pkg/cli/statement_diag.go
+++ b/pkg/cli/statement_diag.go
@@ -32,7 +32,7 @@ var stmtDiagCmd = &cobra.Command{
 	Long: `This set of commands can be used to manage and download statement diagnostic
 bundles, and to cancel outstanding diagnostics activation requests. Statement
 diagnostics can be activated from the UI or using EXPLAIN ANALYZE (DEBUG).`,
-	RunE: usageAndErr,
+	RunE: UsageAndErr,
 }
 
 var stmtDiagListCmd = &cobra.Command{

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -697,7 +697,7 @@ var userFileCmd = &cobra.Command{
 	Use:   "userfile [command]",
 	Short: "upload, list and delete user scoped files",
 	Long:  "Upload, list and delete files from the user scoped file storage.",
-	RunE:  usageAndErr,
+	RunE:  UsageAndErr,
 }
 
 func init() {


### PR DESCRIPTION
Previously, `cockroach debug backup` would fail with

```
ERROR: requires at least 1 arg(s), only received 0
Failed running "debug backup"
```

Now, it will print its usage and exit with an error like other
subcommands.

Release note: None