### PR TITLE
ui: update url params when switching tabs on sql activity

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -124,12 +124,9 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
   }
 
   backToSessionsPage = (): void => {
-    const { history, location, onBackButtonClick } = this.props;
+    const { history, onBackButtonClick } = this.props;
     onBackButtonClick && onBackButtonClick();
-    history.push({
-      ...location,
-      pathname: "/sql-activity/sessions",
-    });
+    history.push("/sql-activity?tab=sessions");
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -9,9 +9,9 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { forIn, isNil, merge } from "lodash";
+import { isNil, merge } from "lodash";
 
-import { getMatchParamByName } from "src/util/query";
+import { getMatchParamByName, syncHistory } from "src/util/query";
 import { appAttr } from "src/util/constants";
 import {
   makeSessionsColumns,
@@ -43,11 +43,9 @@ import {
   ICancelQueryRequest,
 } from "src/store/terminateQuery";
 
-import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import statementsPageStyles from "src/statementsPage/statementsPage.module.scss";
 import sessionPageStyles from "./sessionPage.module.scss";
 
-const sortableTableCx = classNames.bind(sortedTableStyles);
 const statementsPageCx = classNames.bind(statementsPageStyles);
 const sessionsPageCx = classNames.bind(sessionPageStyles);
 
@@ -113,21 +111,6 @@ export class SessionsPage extends React.Component<
     };
   };
 
-  syncHistory = (params: Record<string, string | undefined>): void => {
-    const { history } = this.props;
-    const currentSearchParams = new URLSearchParams(history.location.search);
-    forIn(params, (value, key) => {
-      if (!value) {
-        currentSearchParams.delete(key);
-      } else {
-        currentSearchParams.set(key, value);
-      }
-    });
-
-    history.location.search = currentSearchParams.toString();
-    history.replace(history.location);
-  };
-
   changeSortSetting = (ss: SortSetting): void => {
     const { onSortingChange } = this.props;
     onSortingChange && onSortingChange(ss.columnTitle);
@@ -136,10 +119,13 @@ export class SessionsPage extends React.Component<
       sortSetting: ss,
     });
 
-    this.syncHistory({
-      ascending: ss.ascending.toString(),
-      columnTitle: ss.columnTitle,
-    });
+    syncHistory(
+      {
+        ascending: ss.ascending.toString(),
+        columnTitle: ss.columnTitle,
+      },
+      this.props.history,
+    );
   };
 
   resetPagination = (): void => {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -386,7 +386,7 @@ export class StatementDetails extends React.Component<
   };
 
   backToStatementsClick = (): void => {
-    this.props.history.push("/sql-activity/statements");
+    this.props.history.push("/sql-activity?tab=statements");
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -36,6 +36,7 @@ import {
   unique,
   containAny,
   queryByName,
+  syncHistory,
 } from "src/util";
 import {
   AggregateStatistics,
@@ -180,31 +181,18 @@ export class StatementsPage extends React.Component<
     };
   };
 
-  syncHistory = (params: Record<string, string | undefined>): void => {
-    const { history } = this.props;
-    const nextSearchParams = new URLSearchParams(history.location.search);
-
-    Object.entries(params).forEach(([key, value]) => {
-      if (!value) {
-        nextSearchParams.delete(key);
-      } else {
-        nextSearchParams.set(key, value);
-      }
-    });
-
-    history.location.search = nextSearchParams.toString();
-    history.replace(history.location);
-  };
-
   changeSortSetting = (ss: SortSetting): void => {
     this.setState({
       sortSetting: ss,
     });
 
-    this.syncHistory({
-      ascending: ss.ascending.toString(),
-      columnTitle: ss.columnTitle,
-    });
+    syncHistory(
+      {
+        ascending: ss.ascending.toString(),
+        columnTitle: ss.columnTitle,
+      },
+      this.props.history,
+    );
     if (this.props.onSortingChange) {
       this.props.onSortingChange("Statements", ss.columnTitle, ss.ascending);
     }
@@ -273,9 +261,12 @@ export class StatementsPage extends React.Component<
   onSubmitSearchField = (search: string): void => {
     this.setState({ search });
     this.resetPagination();
-    this.syncHistory({
-      q: search,
-    });
+    syncHistory(
+      {
+        q: search,
+      },
+      this.props.history,
+    );
   };
 
   onSubmitFilters = (filters: Filters): void => {
@@ -288,22 +279,28 @@ export class StatementsPage extends React.Component<
     });
 
     this.resetPagination();
-    this.syncHistory({
-      app: filters.app,
-      timeNumber: filters.timeNumber,
-      timeUnit: filters.timeUnit,
-      sqlType: filters.sqlType,
-      database: filters.database,
-      regions: filters.regions,
-      nodes: filters.nodes,
-    });
+    syncHistory(
+      {
+        app: filters.app,
+        timeNumber: filters.timeNumber,
+        timeUnit: filters.timeUnit,
+        sqlType: filters.sqlType,
+        database: filters.database,
+        regions: filters.regions,
+        nodes: filters.nodes,
+      },
+      this.props.history,
+    );
   };
 
   onClearSearchField = (): void => {
     this.setState({ search: "" });
-    this.syncHistory({
-      q: undefined,
-    });
+    syncHistory(
+      {
+        q: undefined,
+      },
+      this.props.history,
+    );
   };
 
   onClearFilters = (): void => {
@@ -314,15 +311,18 @@ export class StatementsPage extends React.Component<
       activeFilters: 0,
     });
     this.resetPagination();
-    this.syncHistory({
-      app: undefined,
-      timeNumber: undefined,
-      timeUnit: undefined,
-      sqlType: undefined,
-      database: undefined,
-      regions: undefined,
-      nodes: undefined,
-    });
+    syncHistory(
+      {
+        app: undefined,
+        timeNumber: undefined,
+        timeUnit: undefined,
+        sqlType: undefined,
+        database: undefined,
+        regions: undefined,
+        nodes: undefined,
+      },
+      this.props.history,
+    );
   };
 
   filteredStatementsData = (): AggregateStatistics[] => {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -34,15 +34,12 @@ import {
   generateRegionNode,
   getTrxAppFilterOptions,
   statementFingerprintIdsToText,
-} from "./utils";
-import {
   searchTransactionsData,
   filterTransactions,
   getStatementsByFingerprintIdAndTime,
 } from "./utils";
-import { forIn } from "lodash";
 import Long from "long";
-import { getSearchParams, unique } from "src/util";
+import { getSearchParams, unique, syncHistory } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
@@ -152,30 +149,17 @@ export class TransactionsPage extends React.Component<
     this.refreshData();
   }
 
-  syncHistory = (params: Record<string, string | undefined>): void => {
-    const { history } = this.props;
-    const currentSearchParams = new URLSearchParams(history.location.search);
-
-    forIn(params, (value, key) => {
-      if (!value) {
-        currentSearchParams.delete(key);
-      } else {
-        currentSearchParams.set(key, value);
-      }
-    });
-
-    history.location.search = currentSearchParams.toString();
-    history.replace(history.location);
-  };
-
   onChangeSortSetting = (ss: SortSetting): void => {
     this.setState({
       sortSetting: ss,
     });
-    this.syncHistory({
-      ascending: ss.ascending.toString(),
-      columnTitle: ss.columnTitle,
-    });
+    syncHistory(
+      {
+        ascending: ss.ascending.toString(),
+        columnTitle: ss.columnTitle,
+      },
+      this.props.history,
+    );
   };
 
   onChangePage = (current: number): void => {
@@ -196,17 +180,23 @@ export class TransactionsPage extends React.Component<
 
   onClearSearchField = (): void => {
     this.setState({ search: "" });
-    this.syncHistory({
-      q: undefined,
-    });
+    syncHistory(
+      {
+        q: undefined,
+      },
+      this.props.history,
+    );
   };
 
   onSubmitSearchField = (search: string): void => {
     this.setState({ search });
     this.resetPagination();
-    this.syncHistory({
-      q: search,
-    });
+    syncHistory(
+      {
+        q: search,
+      },
+      this.props.history,
+    );
   };
 
   onSubmitFilters = (filters: Filters): void => {
@@ -217,13 +207,16 @@ export class TransactionsPage extends React.Component<
       },
     });
     this.resetPagination();
-    this.syncHistory({
-      app: filters.app,
-      timeNumber: filters.timeNumber,
-      timeUnit: filters.timeUnit,
-      regions: filters.regions,
-      nodes: filters.nodes,
-    });
+    syncHistory(
+      {
+        app: filters.app,
+        timeNumber: filters.timeNumber,
+        timeUnit: filters.timeUnit,
+        regions: filters.regions,
+        nodes: filters.nodes,
+      },
+      this.props.history,
+    );
   };
 
   onClearFilters = (): void => {
@@ -233,13 +226,16 @@ export class TransactionsPage extends React.Component<
       },
     });
     this.resetPagination();
-    this.syncHistory({
-      app: undefined,
-      timeNumber: undefined,
-      timeUnit: undefined,
-      regions: undefined,
-      nodes: undefined,
-    });
+    syncHistory(
+      {
+        app: undefined,
+        timeNumber: undefined,
+        timeUnit: undefined,
+        regions: undefined,
+        nodes: undefined,
+      },
+      this.props.history,
+    );
   };
 
   handleDetails = (transaction?: TransactionInfo): void => {

--- a/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Location } from "history";
+import { Location, History } from "history";
 import { match as Match } from "react-router-dom";
 
 interface ParamsObj {
@@ -63,4 +63,27 @@ export function getMatchParamByName(
     return decodeURIComponent(param);
   }
   return null;
+}
+
+export function syncHistory(
+  params: Record<string, string | undefined>,
+  history: History,
+): void {
+  const nextSearchParams = new URLSearchParams(history.location.search);
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (!value) {
+      nextSearchParams.delete(key);
+    } else {
+      nextSearchParams.set(key, value);
+    }
+  });
+
+  history.location.search = nextSearchParams.toString();
+  history.replace(history.location);
+}
+
+export function clearHistory(history: History): void {
+  history.location.search = "";
+  history.replace(history.location);
 }

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -339,10 +339,13 @@ describe("Routing to", () => {
   });
 
   describe("'/statement' path", () => {
-    it("redirected to '/sql-activity/statements'", () => {
+    it("redirected to '/sql-activity?tab=statements'", () => {
       navigateToPath("/statement");
       const location = history.location;
-      assert.equal(location.pathname, "/sql-activity/statements");
+      assert.equal(
+        location.pathname + location.search,
+        "/sql-activity?tab=statements",
+      );
     });
   });
 
@@ -584,26 +587,35 @@ describe("Routing to", () => {
   });
 
   describe("'/statements' path", () => {
-    it("redirected to '/sql-activity/statements'", () => {
+    it("redirected to '/sql-activity?tab=statements'", () => {
       navigateToPath("/statements");
       const location = history.location;
-      assert.equal(location.pathname, "/sql-activity/statements");
+      assert.equal(
+        location.pathname + location.search,
+        "/sql-activity?tab=statements",
+      );
     });
   });
 
   describe("'/sessions' path", () => {
-    it("redirected to '/sql-activity/sessions'", () => {
+    it("redirected to '/sql-activity?tab=sessions'", () => {
       navigateToPath("/sessions");
       const location = history.location;
-      assert.equal(location.pathname, "/sql-activity/sessions");
+      assert.equal(
+        location.pathname + location.search,
+        "/sql-activity?tab=sessions",
+      );
     });
   });
 
   describe("'/transactions' path", () => {
-    it("redirected to '/sql-activity/transactions'", () => {
+    it("redirected to '/sql-activity?tab=transactions'", () => {
       navigateToPath("/transactions");
       const location = history.location;
-      assert.equal(location.pathname, "/sql-activity/transactions");
+      assert.equal(
+        location.pathname + location.search,
+        "/sql-activity?tab=transactions",
+      );
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -178,17 +178,12 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
 
                 {/* SQL activity */}
                 <Route exact path="/sql-activity" component={SQLActivityPage} />
-                <Route
-                  exact
-                  path={`/sql-activity/:${tabAttr}`}
-                  component={SQLActivityPage}
-                />
 
                 {/* statement statistics */}
                 <Redirect
                   exact
                   from={`/statements`}
-                  to={`/sql-activity/statements`}
+                  to={`/sql-activity?${tabAttr}=statements`}
                 />
                 <Redirect
                   exact
@@ -228,14 +223,14 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/statement`}
-                  to={`/sql-activity/statements`}
+                  to={`/sql-activity?${tabAttr}=statements`}
                 />
 
                 {/* sessions */}
                 <Redirect
                   exact
                   from={`/sessions`}
-                  to={`/sql-activity/sessions`}
+                  to={`/sql-activity?${tabAttr}=sessions`}
                 />
                 <Route
                   exact
@@ -247,7 +242,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/transactions`}
-                  to={`/sql-activity/transactions`}
+                  to={`/sql-activity?${tabAttr}=transactions`}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -13,21 +13,22 @@
 
 import React from "react";
 import { Tabs } from "antd";
-import { commonStyles } from "@cockroachlabs/cluster-ui";
+import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import SessionsPageConnected from "src/views/sessions/sessionsPage";
 import TransactionsPageConnected from "src/views/transactions/transactionsPage";
 import StatementsPageConnected from "src/views/statements/statementsPage";
-import { getMatchParamByName } from "src/util/query";
 import { RouteComponentProps } from "react-router-dom";
 
 const { TabPane } = Tabs;
 
 const SQLActivityPage = (props: RouteComponentProps) => {
-  const defaultTab = getMatchParamByName(props.match, "tab") || "sessions";
+  const defaultTab = util.queryByName(props.location, "tab") || "sessions";
   const [currentTab, setCurrentTab] = React.useState(defaultTab);
 
   const onTabChange = (tabId: string): void => {
     setCurrentTab(tabId);
+    util.clearHistory(props.history);
+    util.syncHistory({ tab: tabId }, props.history);
   };
 
   return (


### PR DESCRIPTION
When the user clicks on a tab on the new SQL Activity page
now the search params on the url is updated with the tab
selection.
This commit also create a common function to sync history
so all the pages can use it and remove duplicate code.

Release note: None