### PR TITLE
release-21.1: sql: more aggressive releasing of memory while collecting histograms

### DIFF
--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -267,8 +266,7 @@ func (sr *SampleReservoir) copyRow(
 			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
 			afterSize = dst[i].Size()
 		} else {
-			if enc, ok := src[i].Encoding(); ok && enc != descpb.DatumEncoding_VALUE {
-				// Only datums that were key-encoded might reference the kv batch.
+			if _, ok := src[i].Encoding(); ok {
 				dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
 			}
 		}

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -266,9 +266,7 @@ func (sr *SampleReservoir) copyRow(
 			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
 			afterSize = dst[i].Size()
 		} else {
-			if _, ok := src[i].Encoding(); ok {
-				dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
-			}
+			dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
 		}
 
 		// Perform memory accounting.


### PR DESCRIPTION
Backport 1/1 commits from #69051.
Backport 1/1 commits from #71775.

/cc @cockroachdb/release

Release justification: low-risk change to existing functionality.

---

**sql: more aggressive releasing of memory while collecting histograms**

We added a deep copy in some cases when sampling rows to avoid hanging
onto a KV batch. This fixed some large OOMs during table statistics
collection. But when we don't deep copy, we are hanging onto DatumAlloc
arrays, which could be the cause of some small OOMs. So let's always
deep copy when sampling rows.

Release note (performance improvement): reduce memory usage slightly
during ANALYZE or CREATE STATISTICS statements.

---

**sql: always copy datums when sampling rows for histograms**

It was pointed out in #69051 that we should always copy datums when
sampling rows. This reduces the chance that we're holding onto any
memory from decoding datums.

Release note: None