### PR TITLE
sql/pgwire: add encoding for decimal infinities

### DIFF
--- a/pkg/cmd/generate-binary/main.go
+++ b/pkg/cmd/generate-binary/main.go
@@ -148,6 +148,8 @@ const outputJSON = `[
 var inputs = map[string][]string{
 	"'%s'::decimal": {
 		"NaN",
+		"Inf",
+		"-infinity",
 		"-000.000",
 		"-0000021234.23246346000000",
 		"-1.2",

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -280,3 +280,8 @@ SELECT 128::"char";
 
 statement error pgcode 22003 \"char\" out of range
 SELECT (-129)::"char";
+
+query IFRB
+SELECT ' 1 '::int, ' 1.2 '::float, ' 2.3 '::decimal, ' true '::bool
+----
+1  1.2  2.3  true

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -562,3 +562,15 @@ select exp('nan'::numeric), exp('inf'::numeric), exp('-inf'::numeric)
 ----
 NaN  Infinity  0
 
+query R
+WITH v(x) AS
+(VALUES (' inf '), (' +inf '), (' -inf '), (' Infinity '), (' +inFinity '), (' -INFINITY '))
+SELECT x1::decimal
+FROM v AS v1(x1)
+----
+Infinity
+Infinity
+-Infinity
+Infinity
+Infinity
+-Infinity

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -356,3 +356,209 @@ query R
 SELECT 2.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 ----
 2.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+
+# Test with infinity. Many of these tests come from
+# https://github.com/postgres/postgres/commit/a57d312a7706321d850faa048a562a0c0c01b835
+
+query RR
+SELECT var_pop('inf'::numeric), var_samp('inf'::numeric)
+----
+NaN  NULL
+
+query RR
+SELECT stddev_pop('inf'::numeric), stddev_samp('inf'::numeric)
+----
+NaN  NULL
+
+query RRR
+SELECT sum(x::numeric), avg(x::numeric), var_pop(x::numeric)
+FROM (VALUES ('1'), ('infinity')) v(x)
+----
+Infinity  Infinity  NaN
+
+query RRR
+SELECT sum(x::numeric), avg(x::numeric), var_pop(x::numeric)
+FROM (VALUES ('infinity'), ('1')) v(x)
+----
+Infinity  Infinity  NaN
+
+query RRR
+SELECT sum(x::numeric), avg(x::numeric), var_pop(x::numeric)
+FROM (VALUES ('infinity'), ('infinity')) v(x)
+----
+Infinity  Infinity  NaN
+
+query RRR
+SELECT sum(x::numeric), avg(x::numeric), var_pop(x::numeric)
+FROM (VALUES ('-infinity'), ('infinity')) v(x)
+----
+NaN  NaN  NaN
+
+query RRR
+SELECT sum(x::numeric), avg(x::numeric), var_pop(x::numeric)
+FROM (VALUES ('-infinity'), ('-infinity')) v(x)
+----
+-Infinity  -Infinity  NaN
+
+query RRRRR
+WITH v(x) AS
+  (VALUES('0'::numeric),('1'::numeric),('-1'::numeric),('4.2'::numeric),('inf'::numeric),('-inf'::numeric),('nan'::numeric))
+SELECT x1, x2,
+  x1 + x2 AS sum,
+  x1 - x2 AS diff,
+  x1 * x2 AS prod
+FROM v AS v1(x1), v AS v2(x2)
+----
+0          0          0          0          0
+0          1          1          -1         0
+0          -1         -1         1          -0
+0          4.2        4.2        -4.2       0.0
+0          Infinity   Infinity   -Infinity  NaN
+0          -Infinity  -Infinity  Infinity   NaN
+0          NaN        NaN        NaN        NaN
+1          0          1          1          0
+1          1          2          0          1
+1          -1         0          2          -1
+1          4.2        5.2        -3.2       4.2
+1          Infinity   Infinity   -Infinity  Infinity
+1          -Infinity  -Infinity  Infinity   -Infinity
+1          NaN        NaN        NaN        NaN
+-1         0          -1         -1         -0
+-1         1          0          -2         -1
+-1         -1         -2         0          1
+-1         4.2        3.2        -5.2       -4.2
+-1         Infinity   Infinity   -Infinity  -Infinity
+-1         -Infinity  -Infinity  Infinity   Infinity
+-1         NaN        NaN        NaN        NaN
+4.2        0          4.2        4.2        0.0
+4.2        1          5.2        3.2        4.2
+4.2        -1         3.2        5.2        -4.2
+4.2        4.2        8.4        0.0        17.64
+4.2        Infinity   Infinity   -Infinity  Infinity
+4.2        -Infinity  -Infinity  Infinity   -Infinity
+4.2        NaN        NaN        NaN        NaN
+Infinity   0          Infinity   Infinity   NaN
+Infinity   1          Infinity   Infinity   Infinity
+Infinity   -1         Infinity   Infinity   -Infinity
+Infinity   4.2        Infinity   Infinity   Infinity
+Infinity   Infinity   Infinity   NaN        Infinity
+Infinity   -Infinity  NaN        Infinity   -Infinity
+Infinity   NaN        NaN        NaN        NaN
+-Infinity  0          -Infinity  -Infinity  NaN
+-Infinity  1          -Infinity  -Infinity  -Infinity
+-Infinity  -1         -Infinity  -Infinity  Infinity
+-Infinity  4.2        -Infinity  -Infinity  -Infinity
+-Infinity  Infinity   NaN        -Infinity  -Infinity
+-Infinity  -Infinity  -Infinity  NaN        Infinity
+-Infinity  NaN        NaN        NaN        NaN
+NaN        0          NaN        NaN        NaN
+NaN        1          NaN        NaN        NaN
+NaN        -1         NaN        NaN        NaN
+NaN        4.2        NaN        NaN        NaN
+NaN        Infinity   NaN        NaN        NaN
+NaN        -Infinity  NaN        NaN        NaN
+NaN        NaN        NaN        NaN        NaN
+
+query RRRRR
+WITH v(x) AS
+  (VALUES('0'::numeric),('1'::numeric),('-1'::numeric),('4.2'::numeric),('inf'::numeric),('-inf'::numeric),('nan'::numeric))
+SELECT x1, x2,
+  x1 / x2 AS quot,
+  x1 % x2 AS mod,
+  div(x1, x2) AS div
+FROM v AS v1(x1), v AS v2(x2) WHERE x2 != 0
+----
+0          1          0                        0     0
+0          -1         -0                       0     -0
+0          4.2        0E+1                     0.0   0
+0          Infinity   0E-2019                  0     0
+0          -Infinity  -0E-2019                 0     -0
+0          NaN        NaN                      NaN   NaN
+1          1          1                        0     1
+1          -1         -1                       0     -1
+1          4.2        0.23809523809523809524   1.0   0
+1          Infinity   0E-2019                  1     0
+1          -Infinity  -0E-2019                 1     -0
+1          NaN        NaN                      NaN   NaN
+-1         1          -1                       -0    -1
+-1         -1         1                        -0    1
+-1         4.2        -0.23809523809523809524  -1.0  -0
+-1         Infinity   -0E-2019                 -1    -0
+-1         -Infinity  0E-2019                  -1    0
+-1         NaN        NaN                      NaN   NaN
+4.2        1          4.2                      0.2   4
+4.2        -1         -4.2                     0.2   -4
+4.2        4.2        1                        0.0   1
+4.2        Infinity   0E-2019                  4.2   0
+4.2        -Infinity  -0E-2019                 4.2   -0
+4.2        NaN        NaN                      NaN   NaN
+Infinity   1          Infinity                 NaN   Infinity
+Infinity   -1         -Infinity                NaN   -Infinity
+Infinity   4.2        Infinity                 NaN   Infinity
+Infinity   Infinity   NaN                      NaN   NaN
+Infinity   -Infinity  NaN                      NaN   NaN
+Infinity   NaN        NaN                      NaN   NaN
+-Infinity  1          -Infinity                NaN   -Infinity
+-Infinity  -1         Infinity                 NaN   Infinity
+-Infinity  4.2        -Infinity                NaN   -Infinity
+-Infinity  Infinity   NaN                      NaN   NaN
+-Infinity  -Infinity  NaN                      NaN   NaN
+-Infinity  NaN        NaN                      NaN   NaN
+NaN        1          NaN                      NaN   NaN
+NaN        -1         NaN                      NaN   NaN
+NaN        4.2        NaN                      NaN   NaN
+NaN        Infinity   NaN                      NaN   NaN
+NaN        -Infinity  NaN                      NaN   NaN
+NaN        NaN        NaN                      NaN   NaN
+
+statement error division by zero
+SELECT 'inf'::numeric / '0'
+
+statement error division by zero
+SELECT '-inf'::numeric / '0'
+
+query R
+SELECT 'Infinity'::float8::numeric
+----
+Infinity
+
+query R
+SELECT '-Infinity'::float8::numeric
+----
+-Infinity
+
+query F
+SELECT 'NaN'::numeric::float8
+----
+NaN
+
+query F
+SELECT 'Infinity'::numeric::float8
+----
+Infinity
+
+query F
+SELECT '-Infinity'::numeric::float8
+----
+-Infinity
+
+statement error integer out of range
+SELECT 'NaN'::numeric::int2
+
+statement error integer out of range
+SELECT '-Infinity'::numeric::int8
+
+statement error operand, lower bound, and upper bound cannot be infinity
+SELECT width_bucket('inf', 3.0, 4.0, 888)
+
+statement error operand, lower bound, and upper bound cannot be infinity
+SELECT width_bucket(2.0, 3.0, '-inf', 888)
+
+statement error operand, lower bound, and upper bound cannot be infinity
+SELECT width_bucket(0, '-inf', 4.0, 888)
+
+query RRR
+select exp('nan'::numeric), exp('inf'::numeric), exp('-inf'::numeric)
+----
+NaN  Infinity  0
+

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
-	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
@@ -373,17 +372,5 @@ func BenchmarkEncodings(b *testing.B) {
 				}
 			})
 		})
-	}
-}
-
-func TestEncodingErrorCounts(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	buf := newWriteBuffer(metric.NewCounter(metric.Metadata{}))
-	d, _ := tree.ParseDDecimal("Inf")
-	buf.writeBinaryDatum(context.Background(), d, nil, d.ResolvedType())
-	if count := telemetry.GetRawFeatureCounts()["pgwire.#32489.binary_decimal_infinity"]; count != 1 {
-		t.Fatalf("expected 1 encoding error, got %d", count)
 	}
 }

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -649,6 +649,13 @@ func DecodeDatum(
 			case 0xc000:
 				// https://github.com/postgres/postgres/blob/ffa4cbd623dd69f9fa99e5e92426928a5782cf1a/src/backend/utils/adt/numeric.c#L169
 				return tree.ParseDDecimal("NaN")
+			case 0xd000:
+				// https://github.com/postgres/postgres/blob/a57d312a7706321d850faa048a562a0c0c01b835/src/backend/utils/adt/numeric.c#L201
+				return tree.ParseDDecimal("Inf")
+
+			case 0xf000:
+				// https://github.com/postgres/postgres/blob/a57d312a7706321d850faa048a562a0c0c01b835/src/backend/utils/adt/numeric.c#L200
+				return tree.ParseDDecimal("-Inf")
 			default:
 				return nil, pgerror.Newf(pgcode.Syntax, "unsupported numeric sign: %d", alloc.pgNum.Sign)
 			}

--- a/pkg/sql/pgwire/testdata/encodings.json
+++ b/pkg/sql/pgwire/testdata/encodings.json
@@ -273,6 +273,20 @@
 		"Binary": [0, 0, 0, 0, 192, 0, 0, 0]
 	},
 	{
+		"SQL": "'Inf'::decimal",
+		"Oid": 1700,
+		"Text": "Infinity",
+		"TextAsBinary": [73, 110, 102, 105, 110, 105, 116, 121],
+		"Binary": [0, 0, 0, 0, 208, 0, 0, 32]
+	},
+	{
+		"SQL": "'-infinity'::decimal",
+		"Oid": 1700,
+		"Text": "-Infinity",
+		"TextAsBinary": [45, 73, 110, 102, 105, 110, 105, 116, 121],
+		"Binary": [0, 0, 0, 0, 240, 0, 0, 32]
+	},
+	{
 		"SQL": "'-000.000'::decimal",
 		"Oid": 1700,
 		"Text": "0.000",

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -392,17 +392,23 @@ func writeBinaryDecimal(b *writeBuffer, v *apd.Decimal) {
 		b.putInt32(8)
 		// 0 digits.
 		b.putInt32(0)
-		// https://github.com/postgres/postgres/blob/ffa4cbd623dd69f9fa99e5e92426928a5782cf1a/src/backend/utils/adt/numeric.c#L169
-		b.write([]byte{0xc0, 0, 0, 0})
-
 		if v.Form == apd.Infinite {
-			// TODO(mjibson): #32489
-			// The above encoding is not correct for Infinity, but since that encoding
-			// doesn't exist in postgres, it's unclear what to do. For now use the NaN
-			// encoding and count it to see if anyone even needs this.
+			// The 0x20 in the DScale byte does not actually seem to be part of the
+			// spec, but that's what PostgreSQL outputs.
+			if v.Negative {
+				// https://github.com/postgres/postgres/blob/a57d312a7706321d850faa048a562a0c0c01b835/src/backend/utils/adt/numeric.c#L200
+				b.write([]byte{0xf0, 0, 0, 0x20})
+			} else {
+				// https://github.com/postgres/postgres/blob/a57d312a7706321d850faa048a562a0c0c01b835/src/backend/utils/adt/numeric.c#L201
+				b.write([]byte{0xd0, 0, 0, 0x20})
+			}
+			// Official Infinity support for DECIMAL was added in CockroachDB 22.1,
+			// so let's keep tracking usage.
 			telemetry.Inc(sqltelemetry.BinaryDecimalInfinityCounter)
+		} else {
+			// https://github.com/postgres/postgres/blob/ffa4cbd623dd69f9fa99e5e92426928a5782cf1a/src/backend/utils/adt/numeric.c#L169
+			b.write([]byte{0xc0, 0, 0, 0})
 		}
-
 		return
 	}
 

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -533,6 +533,12 @@ var mathBuiltins = map[string]builtinDefinition{
 				operand, _ := args[0].(*tree.DDecimal).Float64()
 				b1, _ := args[1].(*tree.DDecimal).Float64()
 				b2, _ := args[2].(*tree.DDecimal).Float64()
+				if math.IsInf(operand, 0) || math.IsInf(b1, 0) || math.IsInf(b2, 0) {
+					return nil, pgerror.New(
+						pgcode.InvalidParameterValue,
+						"operand, lower bound, and upper bound cannot be infinity",
+					)
+				}
 				count := int(tree.MustBeDInt(args[3]))
 				return tree.NewDInt(tree.DInt(widthBucket(operand, b1, b2, count))), nil
 			},

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1649,7 +1649,7 @@ func performCastWithoutPrecisionTruncation(
 		case *DDecimal:
 			return MakeDBool(v.Sign() != 0), nil
 		case *DString:
-			return ParseDBool(string(*v))
+			return ParseDBool(strings.TrimSpace(string(*v)))
 		case *DCollatedString:
 			return ParseDBool(v.Contents)
 		case *DJSON:
@@ -1696,7 +1696,7 @@ func performCastWithoutPrecisionTruncation(
 			res = NewDInt(DInt(i))
 		case *DString:
 			var err error
-			if res, err = ParseDInt(string(*v)); err != nil {
+			if res, err = ParseDInt(strings.TrimSpace(string(*v))); err != nil {
 				return nil, err
 			}
 		case *DCollatedString:
@@ -1769,7 +1769,7 @@ func performCastWithoutPrecisionTruncation(
 			}
 			return NewDFloat(DFloat(f)), nil
 		case *DString:
-			return ParseDFloat(string(*v))
+			return ParseDFloat(strings.TrimSpace(string(*v)))
 		case *DCollatedString:
 			return ParseDFloat(v.Contents)
 		case *DTimestamp:
@@ -1824,7 +1824,7 @@ func performCastWithoutPrecisionTruncation(
 			}
 			dd.Set(&v.Decimal)
 		case *DString:
-			err = dd.SetString(string(*v))
+			err = dd.SetString(strings.TrimSpace(string(*v)))
 		case *DCollatedString:
 			err = dd.SetString(v.Contents)
 		case *DTimestamp:

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -11,6 +11,8 @@
 package tree
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
@@ -40,13 +42,13 @@ func ParseAndRequireString(
 	case types.DateFamily:
 		d, dependsOnContext, err = ParseDDate(ctx, s)
 	case types.DecimalFamily:
-		d, err = ParseDDecimal(s)
+		d, err = ParseDDecimal(strings.TrimSpace(s))
 	case types.FloatFamily:
-		d, err = ParseDFloat(s)
+		d, err = ParseDFloat(strings.TrimSpace(s))
 	case types.INetFamily:
 		d, err = ParseDIPAddrFromINetString(s)
 	case types.IntFamily:
-		d, err = ParseDInt(s)
+		d, err = ParseDInt(strings.TrimSpace(s))
 	case types.IntervalFamily:
 		itm, typErr := t.IntervalTypeMetadata()
 		if typErr != nil {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/32489

PostgreSQL 14 added this, so now we can match it.

Release note (sql change): Infinite decimal values can now be encoded
when sending data to/from the client. The encoding matches the
PostgreSQL encoding.