### PR TITLE
roachtest: improve `rapid-restart` by using `c.Start`

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -173,7 +173,6 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/search",
-        "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/version",
         "//pkg/workload/histogram",


### PR DESCRIPTION
Fixes #70559.

This test manually started CRDB with `c.Run`. This patch uses `c.Start` instead of `c.Run`, avoiding
incorrect test failures from unexpected SSH exit codes resulting from using `c.Run`.

Release note: None