### PR TITLE
sql: always copy datums when sampling rows for histograms

### DIFF
--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -264,9 +264,7 @@ func (sr *SampleReservoir) copyRow(
 			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
 			afterSize = dst[i].Size()
 		} else {
-			if _, ok := src[i].Encoding(); ok {
-				dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
-			}
+			dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
 		}
 
 		// Perform memory accounting.


### PR DESCRIPTION
It was pointed out in #69051 that we should always copy datums when
sampling rows. This reduces the chance that we're holding onto any
memory from decoding datums.

Release note: None