### PR TITLE
bazel: run `gazelle` before `generate-test-suites`

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -8,6 +8,6 @@ set -euo pipefail
 # invoked. For now, this is left as an exercise for the user.
 
 bazel run //:gazelle -- update-repos -from_file=go.mod -build_file_proto_mode=disable_global -to_macro=DEPS.bzl%go_deps -prune=true
+bazel run //:gazelle
 CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")
 echo "$CONTENTS" > pkg/BUILD.bazel
-bazel run //:gazelle


### PR DESCRIPTION
This will create `BUILD` files that `generate-test-suites` consumes
later.

Closes #71683.

Release note: None