### PR TITLE
sql,jobs: fix de-interleaving ALTER PRIMARY KEY revert, revert-failed in mixed version

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -106,6 +106,7 @@ go_test(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/execinfra",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlliveness",

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1292,6 +1293,9 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
 		// All reverting jobs are retried.
+		if !r.settings.Version.IsActive(ctx, clusterversion.RetryJobsWithExponentialBackoff) {
+			return r.stepThroughStateMachine(ctx, execCtx, resumer, job, StatusRevertFailed, err)
+		}
 		return onExecutionFailed(err)
 	case StatusFailed:
 		if jobErr == nil {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2125,55 +2125,18 @@ func runSchemaChangesInTxn(
 		// extra work that needs to be done. Note that we don't need to create
 		// a job to clean up the dropped indexes because those mutations can
 		// get processed in this txn on the new table.
-		if pkSwap := m.AsPrimaryKeySwap(); pkSwap != nil {
-			// If any old index had an interleaved parent, remove the
-			// backreference from the parent.
-			// N.B. This logic needs to be kept up to date with the
-			// corresponding piece in (*SchemaChanger).done. It is slightly
-			// different because of how it access tables and how it needs to
-			// write the modified table descriptors explicitly.
-			err := pkSwap.ForEachOldIndexIDs(func(idxID descpb.IndexID) error {
-				oldIndex, err := tableDesc.FindIndexWithID(idxID)
-				if err != nil {
-					return err
-				}
-				if oldIndex.NumInterleaveAncestors() != 0 {
-					ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
-					ancestor, err := planner.Descriptors().GetMutableTableVersionByID(ctx, ancestorInfo.TableID, planner.txn)
-					if err != nil {
-						return err
-					}
-					ancestorIdxI, err := ancestor.FindIndexWithID(ancestorInfo.IndexID)
-					if err != nil {
-						return err
-					}
-					ancestorIdx := ancestorIdxI.IndexDesc()
-					foundAncestor := false
-					for k, ref := range ancestorIdx.InterleavedBy {
-						if ref.Table == tableDesc.ID && ref.Index == oldIndex.GetID() {
-							if foundAncestor {
-								return errors.AssertionFailedf(
-									"ancestor entry in %s for %s@%s found more than once",
-									ancestor.Name, tableDesc.Name, oldIndex.GetName())
-							}
-							ancestorIdx.InterleavedBy = append(
-								ancestorIdx.InterleavedBy[:k], ancestorIdx.InterleavedBy[k+1:]...)
-							foundAncestor = true
-							if err := planner.writeSchemaChange(ctx, ancestor, descpb.InvalidMutationID,
-								fmt.Sprintf("remove interleaved backreference from table %s(%d) "+
-									"for primary key swap of table %s(%d)",
-									ancestor.Name, ancestor.ID, tableDesc.Name, tableDesc.ID,
-								)); err != nil {
-								return err
-							}
-						}
-					}
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
+		if err := maybeRemoveInterleaveBackreference(
+			ctx, planner.txn, planner.Descriptors(), m, tableDesc, func(
+				ctx context.Context, ancestor *tabledesc.Mutable,
+			) error {
+				return planner.writeSchemaChange(ctx, ancestor, descpb.InvalidMutationID,
+					fmt.Sprintf("remove interleaved backreference from table %s(%d) "+
+						"for primary key swap of table %s(%d)",
+						ancestor.Name, ancestor.ID, tableDesc.Name, tableDesc.GetID(),
+					))
+			},
+		); err != nil {
+			return err
 		}
 	}
 	// Clear all the mutations except for adding constraints.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1205,10 +1205,12 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							}
 							col.ColumnDesc().DefaultExpr = lcSwap.NewRegionalByRowColumnDefaultExpr
 						}
+
 					} else {
 						// DROP is hit on cancellation, in which case we must roll back.
 						localityConfigToSwapTo = lcSwap.OldLocalityConfig
 					}
+
 					if err := setNewLocalityConfig(
 						ctx, scTable, txn, b, localityConfigToSwapTo, kvTrace, descsCol); err != nil {
 						return err
@@ -1227,48 +1229,14 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					}
 				}
 
-				// If any old index had an interleaved parent, remove the
-				// backreference from the parent.
-				// N.B. This logic needs to be kept up to date with the
-				// corresponding piece in runSchemaChangesInTxn.
-				err := pkSwap.ForEachOldIndexIDs(func(idxID descpb.IndexID) error {
-					oldIndex, err := scTable.FindIndexWithID(idxID)
-					if err != nil {
-						return err
-					}
-					if oldIndex.NumInterleaveAncestors() != 0 {
-						ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
-						ancestor, err := descsCol.GetMutableTableVersionByID(ctx, ancestorInfo.TableID, txn)
-						if err != nil {
-							return err
-						}
-						ancestorIdxI, err := ancestor.FindIndexWithID(ancestorInfo.IndexID)
-						if err != nil {
-							return err
-						}
-						ancestorIdx := ancestorIdxI.IndexDesc()
-						foundAncestor := false
-						for k, ref := range ancestorIdx.InterleavedBy {
-							if ref.Table == scTable.ID && ref.Index == oldIndex.GetID() {
-								if foundAncestor {
-									return errors.AssertionFailedf(
-										"ancestor entry in %s for %s@%s found more than once",
-										ancestor.Name, scTable.Name, oldIndex.GetName())
-								}
-								ancestorIdx.InterleavedBy = append(
-									ancestorIdx.InterleavedBy[:k], ancestorIdx.InterleavedBy[k+1:]...)
-								foundAncestor = true
-								if err := descsCol.WriteDescToBatch(ctx, kvTrace, ancestor, b); err != nil {
-									return err
-								}
-							}
-						}
-					}
-					return nil
-				})
-				if err != nil {
+				if err := maybeRemoveInterleaveBackreference(ctx, txn, descsCol, m, scTable, func(
+					ctx context.Context, ancestor *tabledesc.Mutable,
+				) error {
+					return descsCol.WriteDescToBatch(ctx, kvTrace, ancestor, b)
+				}); err != nil {
 					return err
 				}
+
 				// If we performed MakeMutationComplete on a PrimaryKeySwap mutation, then we need to start
 				// a job for the index deletion mutations that the primary key swap mutation added, if any.
 				if err := sc.queueCleanupJobs(ctx, scTable, txn); err != nil {
@@ -1394,6 +1362,57 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// If this mutation is a primary key swap and the old index had an
+// interleaved parent, remove the backreference from the parent.
+func maybeRemoveInterleaveBackreference(
+	ctx context.Context,
+	txn *kv.Txn,
+	descsCol *descs.Collection,
+	mutation catalog.Mutation,
+	scTable *tabledesc.Mutable,
+	writeFunc func(ctx context.Context, ancestor *tabledesc.Mutable) error,
+) error {
+	pkSwap := mutation.AsPrimaryKeySwap()
+	if pkSwap == nil {
+		return nil
+	}
+	return pkSwap.ForEachOldIndexIDs(func(id descpb.IndexID) error {
+		oldIndex, err := scTable.FindIndexWithID(id)
+		if err != nil {
+			return err
+		}
+		if oldIndex.NumInterleaveAncestors() != 0 {
+			ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
+			ancestor, err := descsCol.GetMutableTableVersionByID(ctx, ancestorInfo.TableID, txn)
+			if err != nil {
+				return err
+			}
+			ancestorIdxI, err := ancestor.FindIndexWithID(ancestorInfo.IndexID)
+			if err != nil {
+				return err
+			}
+			ancestorIdx := ancestorIdxI.IndexDesc()
+			foundAncestor := false
+			for k, ref := range ancestorIdx.InterleavedBy {
+				if ref.Table == scTable.ID && ref.Index == oldIndex.GetID() {
+					if foundAncestor {
+						return errors.AssertionFailedf(
+							"ancestor entry in %s for %s@%s found more than once",
+							ancestor.Name, scTable.Name, oldIndex.GetName())
+					}
+					ancestorIdx.InterleavedBy = append(
+						ancestorIdx.InterleavedBy[:k], ancestorIdx.InterleavedBy[k+1:]...)
+					foundAncestor = true
+					if err := writeFunc(ctx, ancestor); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // maybeUpdateZoneConfigsForPKChange moves zone configs for any rewritten

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1364,8 +1364,9 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	return nil
 }
 
-// If this mutation is a primary key swap and the old index had an
-// interleaved parent, remove the backreference from the parent.
+// If this mutation is a primary key swap that is not being rolled back,
+// and the old index had an interleaved parent, remove the backreference
+// from the parent.
 func maybeRemoveInterleaveBackreference(
 	ctx context.Context,
 	txn *kv.Txn,
@@ -1374,6 +1375,9 @@ func maybeRemoveInterleaveBackreference(
 	scTable *tabledesc.Mutable,
 	writeFunc func(ctx context.Context, ancestor *tabledesc.Mutable) error,
 ) error {
+	if !mutation.Adding() {
+		return nil
+	}
 	pkSwap := mutation.AsPrimaryKeySwap()
 	if pkSwap == nil {
 		return nil

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -7534,4 +7536,57 @@ func TestJobsWithoutMutationsAreCancelable(t *testing.T) {
 		`SELECT job_id FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE'`,
 	).Scan(&id)
 	require.Equal(t, scJobID, id)
+}
+
+// TestDeinterleaveRevert tests that schema changes which fail during an alter
+// primary key to remove an interleave in an unrecoverable way.
+func TestDeinterleaveRevert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// Override the version because in 21.2, interleaves are not permitted.
+	v21_1 := clusterversion.ByKey(clusterversion.V21_1)
+	settings := cluster.MakeTestingClusterSettingsWithVersions(
+		v21_1, v21_1, true, /* initializeVersion */
+	)
+	sql.InterleavedTablesEnabled.Override(ctx, &settings.SV, true)
+	const shortInterval = 100 * time.Millisecond
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithIntervals(
+				shortInterval, shortInterval, time.Second, time.Hour, // retryMaxDelay
+			),
+			DistSQL: &execinfra.TestingKnobs{
+				RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+					return errors.New("boom")
+				},
+			},
+			Server: &server.TestingKnobs{
+				BinaryVersionOverride:          v21_1,
+				DisableAutomaticVersionUpgrade: 1,
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `
+CREATE TABLE parent (i INT PRIMARY KEY);
+CREATE TABLE child (i INT, j INT, k INT, PRIMARY KEY (i, j)) INTERLEAVE IN PARENT "parent" (i);
+INSERT INTO parent VALUES (1);
+INSERT INTO child VALUES (1, 1, 1);
+`)
+
+	errCh := make(chan error)
+	go func() {
+		_, err := sqlDB.Exec(`ALTER TABLE child ALTER PRIMARY KEY USING COLUMNS (i, j)`)
+		errCh <- err
+	}()
+
+	const errMsg = `relation "child" (53): missing interleave back reference to "child"@"child_pkey" from "parent"@"parent_pkey"`
+	tdb.CheckQueryResultsRetry(t, "SELECT status, error FROM crdb_internal.jobs WHERE description LIKE '%ALTER PRIMARY KEY%'", [][]string{
+		{"revert-failed", errMsg},
+	})
+	require.EqualError(t, <-errCh, `pq: failed to construct index entries during backfill: boom`)
 }


### PR DESCRIPTION
The first commit fixes an important, but incidentally discovered problem in jobs when in the mixed version state. The second commit refactors the code to make the fix in the third commit more obvious. The third commit fixes the bug. 

**jobs: don't unconditionally retry in the mixed version state**

Release note (bug fix): In 21.2, jobs which fail to revert are retried
unconditionally, but with exponential backoff. In the mixed version state
there is no exponential backoff, so it'd be bad to retry unconditionally.
The behavior has been changed such that before 21.2 is finalized, these
jobs will enter the revert-failed state as in 21.1.

**sql: fix reverting de-interleaving primary key swap**

We should only remove the backreference in the forward direction.

Release note (bug fix): Fixed a bug which prevented rollback of ALTER PRIMARY
KEY when the old primary key was interleaved.