### PR TITLE
flowinfra: add telemetry about remote DistSQL flows

### DIFF
--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -25,6 +25,7 @@ type DistSQLMetrics struct {
 	FlowsActive           *metric.Gauge
 	FlowsTotal            *metric.Counter
 	FlowsQueued           *metric.Gauge
+	FlowsScheduled        *metric.Counter
 	QueueWaitHist         *metric.Histogram
 	MaxBytesHist          *metric.Histogram
 	CurBytesCount         *metric.Gauge
@@ -75,6 +76,12 @@ var (
 	metaFlowsQueued = metric.Metadata{
 		Name:        "sql.distsql.flows.queued",
 		Help:        "Number of distributed SQL flows currently queued",
+		Measurement: "Flows",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaFlowsScheduled = metric.Metadata{
+		Name:        "sql.distsql.flows.scheduled",
+		Help:        "Number of distributed SQL flows scheduled",
 		Measurement: "Flows",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -147,6 +154,7 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		FlowsActive:           metric.NewGauge(metaFlowsActive),
 		FlowsTotal:            metric.NewCounter(metaFlowsTotal),
 		FlowsQueued:           metric.NewGauge(metaFlowsQueued),
+		FlowsScheduled:        metric.NewCounter(metaFlowsScheduled),
 		QueueWaitHist:         metric.NewLatency(metaQueueWaitHist, histogramWindow),
 		MaxBytesHist:          metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
 		CurBytesCount:         metric.NewGauge(metaMemCurBytes),

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
+        "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
@@ -26,6 +27,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",
+        "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util/admission",
         "//pkg/util/cancelchecker",

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -16,10 +16,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -168,6 +170,8 @@ func (fs *FlowScheduler) runFlowNow(ctx context.Context, f Flow, locked bool) er
 func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
 	return fs.stopper.RunTaskWithErr(
 		ctx, "flowinfra.FlowScheduler: scheduling flow", func(ctx context.Context) error {
+			fs.metrics.FlowsScheduled.Inc(1)
+			telemetry.Inc(sqltelemetry.DistSQLFlowsScheduled)
 			if fs.canRunFlow(f) {
 				return fs.runFlowNow(ctx, f, false /* locked */)
 			}
@@ -175,6 +179,7 @@ func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
 			defer fs.mu.Unlock()
 			log.VEventf(ctx, 1, "flow scheduler enqueuing flow %s to be run later", f.GetID())
 			fs.metrics.FlowsQueued.Inc(1)
+			telemetry.Inc(sqltelemetry.DistSQLFlowsQueued)
 			fs.mu.queue.PushBack(&flowWithCtx{
 				ctx:         ctx,
 				flow:        f,

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -37,3 +37,13 @@ var CascadesLimitReached = telemetry.GetCounterOnce("sql.exec.cascade-limit-reac
 // HashAggregationDiskSpillingDisabled is to be incremented whenever the disk
 // spilling of the vectorized hash aggregator is disabled.
 var HashAggregationDiskSpillingDisabled = telemetry.GetCounterOnce("sql.exec.hash-agg-spilling-disabled")
+
+// DistSQLFlowsScheduled is to be incremented whenever a remote DistSQL flow is
+// scheduled for running (regardless of whether it is being run right away or
+// queued).
+var DistSQLFlowsScheduled = telemetry.GetCounterOnce("sql.distsql.flows.scheduled")
+
+// DistSQLFlowsQueued is to be incremented whenever a remote DistSQL flow is
+// queued rather is run right away (because the node has reached
+// 'sql.distsql.max_running_flows' limit).
+var DistSQLFlowsQueued = telemetry.GetCounterOnce("sql.distsql.flows.queued")

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1625,6 +1625,10 @@ var charts = []sectionDescription{
 				Title:   "Total",
 				Metrics: []string{"sql.distsql.flows.total"},
 			},
+			{
+				Title:   "Scheduled",
+				Metrics: []string{"sql.distsql.flows.scheduled"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This commit adds a couple of telemetry counters around scheduling the
remote DistSQL flows: namely, we now count how many flows we have
scheduled total and how many of those were queued. The idea is that this
will tell us how often the nodes are hitting `max_running_flows` limit
on the number of remote flows.

It additionally introduces a metric for the number of flow scheduled
(there is already one for queued flows in place).

Release note: None