### PR TITLE
opt: improve FDs for non-trivial equalities

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -281,6 +281,57 @@ project
                 ├── variable: x:1 [type=int]
                 └── variable: u:7 [type=int]
 
+# Left-join with single row left input: column u should be constant.
+build
+SELECT * FROM (SELECT * FROM xysd WHERE x=123) AS xysd1 LEFT JOIN uv ON y=u
+----
+project
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:7(int) v:8(int)
+ ├── fd: ()-->(1-4,7)
+ ├── prune: (1-4,7,8)
+ ├── reject-nulls: (7,8)
+ └── left-join (hash)
+      ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:7(int) v:8(int) rowid:9(int) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
+      ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      ├── key: (9)
+      ├── fd: ()-->(1-4,7), (9)-->(8,10,11)
+      ├── prune: (1,3,4,8-11)
+      ├── reject-nulls: (7-11)
+      ├── interesting orderings: (+9)
+      ├── project
+      │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1-4)
+      │    ├── prune: (1-4)
+      │    └── select
+      │         ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(1-6)
+      │         ├── prune: (2-6)
+      │         ├── scan xysd
+      │         │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
+      │         │    ├── prune: (1-6)
+      │         │    └── interesting orderings: (+1) (-3,+4,+1)
+      │         └── filters
+      │              └── eq [type=bool, outer=(1), constraints=(/1: [/123 - /123]; tight), fd=()-->(1)]
+      │                   ├── variable: x:1 [type=int]
+      │                   └── const: 123 [type=int]
+      ├── scan uv
+      │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
+      │    ├── key: (9)
+      │    ├── fd: (9)-->(7,8,10,11)
+      │    ├── prune: (7-11)
+      │    ├── interesting orderings: (+9)
+      │    └── unfiltered-cols: (7-11)
+      └── filters
+           └── eq [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+                ├── variable: y:2 [type=int]
+                └── variable: u:7 [type=int]
+
 # Left-join-apply.
 opt
 SELECT * FROM xysd WHERE (SELECT u FROM uv WHERE u=x) IS NULL

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -332,6 +332,63 @@ project
                 ├── variable: y:2 [type=int]
                 └── variable: u:7 [type=int]
 
+# Left-join with single row left input: columns u and v should be constant.
+# Note: we need norm here so that the AND gets normalized to multiple filter items.
+norm
+SELECT * FROM (SELECT * FROM xysd WHERE x=123) AS xysd1 LEFT JOIN uv ON y=u AND v=x+y
+----
+project
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:7(int) v:8(int)
+ ├── immutable
+ ├── fd: ()-->(1-4,7,8)
+ ├── prune: (1-4,7,8)
+ ├── reject-nulls: (7,8)
+ └── left-join (hash)
+      ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:7(int) v:8(int) column12:12(int)
+      ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      ├── immutable
+      ├── fd: ()-->(1-4,7,8,12)
+      ├── prune: (1,3,4)
+      ├── reject-nulls: (7,8)
+      ├── project
+      │    ├── columns: column12:12(int) x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(1-4,12)
+      │    ├── prune: (1-4,12)
+      │    ├── select
+      │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-4)
+      │    │    ├── prune: (2-4)
+      │    │    ├── scan xysd
+      │    │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+      │    │    │    ├── prune: (1-4)
+      │    │    │    └── interesting orderings: (+1) (-3,+4,+1)
+      │    │    └── filters
+      │    │         └── eq [type=bool, outer=(1), constraints=(/1: [/123 - /123]; tight), fd=()-->(1)]
+      │    │              ├── variable: x:1 [type=int]
+      │    │              └── const: 123 [type=int]
+      │    └── projections
+      │         └── plus [as=column12:12, type=int, outer=(1,2), immutable]
+      │              ├── variable: x:1 [type=int]
+      │              └── variable: y:2 [type=int]
+      ├── scan uv
+      │    ├── columns: u:7(int) v:8(int!null)
+      │    ├── prune: (7,8)
+      │    └── unfiltered-cols: (7-11)
+      └── filters
+           ├── eq [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+           │    ├── variable: y:2 [type=int]
+           │    └── variable: u:7 [type=int]
+           └── eq [type=bool, outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+                ├── variable: column12:12 [type=int]
+                └── variable: v:8 [type=int]
+
 # Left-join-apply.
 opt
 SELECT * FROM xysd WHERE (SELECT u FROM uv WHERE u=x) IS NULL

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -10,6 +10,10 @@ exec-ddl
 CREATE TABLE ab (a INT, b INT)
 ----
 
+exec-ddl
+CREATE TABLE abcde (a INT, b INT, c INT, d DECIMAL, e STRING)
+----
+
 build
 SELECT * FROM xy WHERE x=1
 ----
@@ -480,3 +484,117 @@ select
       └── eq [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
            ├── variable: a:1 [type=int]
            └── variable: b:2 [type=int]
+
+# Here we have the FD (b,c)==>(a).
+build
+SELECT * FROM abcde WHERE a=b+c
+----
+project
+ ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(decimal) e:5(string)
+ ├── immutable
+ ├── fd: (2,3)-->(1)
+ ├── prune: (1-5)
+ └── select
+      ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      ├── immutable
+      ├── key: (6)
+      ├── fd: (6)-->(1-5,7,8), (2,3)-->(1)
+      ├── prune: (4-8)
+      ├── interesting orderings: (+6)
+      ├── scan abcde
+      │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(1-5,7,8)
+      │    ├── prune: (1-8)
+      │    └── interesting orderings: (+6)
+      └── filters
+           └── eq [type=bool, outer=(1-3), immutable, constraints=(/1: (/NULL - ]), fd=(2,3)-->(1)]
+                ├── variable: a:1 [type=int]
+                └── plus [type=int]
+                     ├── variable: b:2 [type=int]
+                     └── variable: c:3 [type=int]
+
+# No FD from the equality.
+build
+SELECT * FROM abcde WHERE a=a/2+b
+----
+project
+ ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(decimal) e:5(string)
+ ├── immutable
+ ├── prune: (1-5)
+ └── select
+      ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      ├── immutable
+      ├── key: (6)
+      ├── fd: (6)-->(1-5,7,8)
+      ├── prune: (3-8)
+      ├── interesting orderings: (+6)
+      ├── scan abcde
+      │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(1-5,7,8)
+      │    ├── prune: (1-8)
+      │    └── interesting orderings: (+6)
+      └── filters
+           └── eq [type=bool, outer=(1,2), immutable, constraints=(/1: (/NULL - ])]
+                ├── variable: a:1 [type=int]
+                └── plus [type=decimal]
+                     ├── div [type=decimal]
+                     │    ├── variable: a:1 [type=int]
+                     │    └── const: 2 [type=int]
+                     └── variable: b:2 [type=int]
+
+# (b)==>(e).
+build
+SELECT * FROM abcde WHERE e=b::string
+----
+project
+ ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string!null)
+ ├── immutable
+ ├── fd: (2)-->(5)
+ ├── prune: (1-5)
+ └── select
+      ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string!null) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      ├── immutable
+      ├── key: (6)
+      ├── fd: (6)-->(1-5,7,8), (2)-->(5)
+      ├── prune: (1,3,4,6-8)
+      ├── interesting orderings: (+6)
+      ├── scan abcde
+      │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(1-5,7,8)
+      │    ├── prune: (1-8)
+      │    └── interesting orderings: (+6)
+      └── filters
+           └── eq [type=bool, outer=(2,5), immutable, constraints=(/5: (/NULL - ]), fd=(2)-->(5)]
+                ├── variable: e:5 [type=string]
+                └── cast: STRING [type=string]
+                     └── variable: b:2 [type=int]
+
+# We don't want (d)==>(e), it would not be correct (consider 1.0 and 1.00).
+build
+SELECT * FROM abcde WHERE e=d::string
+----
+project
+ ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string!null)
+ ├── immutable
+ ├── prune: (1-5)
+ └── select
+      ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string!null) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      ├── immutable
+      ├── key: (6)
+      ├── fd: (6)-->(1-5,7,8)
+      ├── prune: (1-3,6-8)
+      ├── interesting orderings: (+6)
+      ├── scan abcde
+      │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(decimal) e:5(string) rowid:6(int!null) crdb_internal_mvcc_timestamp:7(decimal) tableoid:8(oid)
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(1-5,7,8)
+      │    ├── prune: (1-8)
+      │    └── interesting orderings: (+6)
+      └── filters
+           └── eq [type=bool, outer=(4,5), immutable, constraints=(/5: (/NULL - ])]
+                ├── variable: e:5 [type=string]
+                └── cast: STRING [type=string]
+                     └── variable: d:4 [type=decimal]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -57,35 +57,35 @@ project
            ├── cardinality: [0 - 1]
            ├── volatile
            ├── key: (17)
-           ├── fd: ()-->(7,8,12,13,20), (17)-->(14-16,18,19,23-26), (14)-->(15-19), (15,16)~~>(14,17-19), (15)~~>(16), (16)-->(21), (21)-->(22)
+           ├── fd: ()-->(7,8,12,13,15,16,20-22), (17)-->(14,18,19,23-26), (14)-->(17-19), (15,16)~~>(14,17-19)
            ├── prune: (7,8,12-26)
            ├── reject-nulls: (14-19,21,22)
-           ├── interesting orderings: (+17 opt(7,8,12,13,20)) (+14 opt(7,8,12,13,20)) (+15,+17 opt(7,8,12,13,20))
+           ├── interesting orderings: (+17 opt(7,8,12,13,15,16,20-22)) (+14 opt(7,8,12,13,15,16,20-22))
            ├── project
            │    ├── columns: c_comp:22(int) x:7(int!null) y:8(int!null) rowid_default:12(int) c_comp:13(int!null) a:14(int) b:15(int) c:16(int) rowid:17(int) abc.crdb_internal_mvcc_timestamp:18(decimal) abc.tableoid:19(oid) a_new:20(int!null) b_new:21(int)
            │    ├── cardinality: [0 - 1]
            │    ├── volatile
            │    ├── key: (17)
-           │    ├── fd: ()-->(7,8,12,13,20), (17)-->(14-16,18,19), (14)-->(15-19), (15,16)~~>(14,17-19), (15)~~>(16), (16)-->(21), (21)-->(22)
+           │    ├── fd: ()-->(7,8,12,13,15,16,20-22), (17)-->(14,18,19), (14)-->(17-19), (15,16)~~>(14,17-19)
            │    ├── prune: (7,8,12-22)
            │    ├── reject-nulls: (14-19,21,22)
-           │    ├── interesting orderings: (+17 opt(7,8,12,13,20)) (+14 opt(7,8,12,13,20)) (+15,+17 opt(7,8,12,13,20))
+           │    ├── interesting orderings: (+17 opt(7,8,12,13,15,16,20-22)) (+14 opt(7,8,12,13,15,16,20-22))
            │    ├── project
            │    │    ├── columns: a_new:20(int!null) b_new:21(int) x:7(int!null) y:8(int!null) rowid_default:12(int) c_comp:13(int!null) a:14(int) b:15(int) c:16(int) rowid:17(int) abc.crdb_internal_mvcc_timestamp:18(decimal) abc.tableoid:19(oid)
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── volatile
            │    │    ├── key: (17)
-           │    │    ├── fd: ()-->(7,8,12,13,20), (17)-->(14-16,18,19), (14)-->(15-19), (15,16)~~>(14,17-19), (15)~~>(16), (16)-->(21)
+           │    │    ├── fd: ()-->(7,8,12,13,15,16,20,21), (17)-->(14,18,19), (14)-->(17-19), (15,16)~~>(14,17-19)
            │    │    ├── prune: (7,8,12-21)
            │    │    ├── reject-nulls: (14-19,21)
-           │    │    ├── interesting orderings: (+17 opt(7,8,12,13,20)) (+14 opt(7,8,12,13,20)) (+15,+17 opt(7,8,12,13,20))
+           │    │    ├── interesting orderings: (+17 opt(7,8,12,13,15,16,20,21)) (+14 opt(7,8,12,13,15,16,20,21))
            │    │    ├── left-join (hash)
            │    │    │    ├── columns: x:7(int!null) y:8(int!null) rowid_default:12(int) c_comp:13(int!null) a:14(int) b:15(int) c:16(int) rowid:17(int) abc.crdb_internal_mvcc_timestamp:18(decimal) abc.tableoid:19(oid)
            │    │    │    ├── cardinality: [0 - 1]
            │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
            │    │    │    ├── volatile
            │    │    │    ├── key: (17)
-           │    │    │    ├── fd: ()-->(7,8,12,13), (17)-->(14-16,18,19), (14)-->(15-19), (15,16)~~>(14,17-19), (15)~~>(16)
+           │    │    │    ├── fd: ()-->(7,8,12,13,15,16), (17)-->(14,18,19), (14)-->(17-19), (15,16)~~>(14,17-19)
            │    │    │    ├── prune: (14,17-19)
            │    │    │    ├── reject-nulls: (14-19)
            │    │    │    ├── interesting orderings: (+17) (+14) (+15,+17)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4078,7 +4078,7 @@ project
       │    ├── left-join (hash)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-      │    │    ├── fd: ()-->(1-5)
+      │    │    ├── fd: ()-->(1-5,9)
       │    │    ├── limit hint: 1.00
       │    │    ├── select
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
@@ -4722,7 +4722,7 @@ values
                 ├── left-join (hash)
                 │    ├── columns: k:1!null i:2 y:9 true:13
                 │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-                │    ├── fd: ()-->(1,2)
+                │    ├── fd: ()-->(1,2,9)
                 │    ├── limit hint: 1.00
                 │    ├── limit
                 │    │    ├── columns: k:1!null i:2

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1734,7 +1734,7 @@ project
  │         ├── columns: k:1!null i:2!null xy.x:8 y:9
  │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
  │         ├── key: (8)
- │         ├── fd: ()-->(1,2), (8)-->(9)
+ │         ├── fd: ()-->(1,2,9)
  │         ├── select
  │         │    ├── columns: k:1!null i:2!null
  │         │    ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -908,7 +908,7 @@ project
       ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8!null y:9 "?column?":16
       ├── immutable
       ├── key: (8)
-      ├── fd: (1)-->(2-5), (1,8)-->(9,16), (1)==(8), (8)==(1)
+      ├── fd: (1)-->(2-5), (1,8)-->(9,16), (1)==(8), (8)==(1), (8)-->(16)
       ├── scan a
       │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
       │    ├── key: (1)
@@ -946,7 +946,7 @@ project
       │              └── "?column?":16
       └── filters
            ├── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-           └── "?column?":16 = (x:8 * i:2) [outer=(2,8,16), immutable, constraints=(/16: (/NULL - ])]
+           └── "?column?":16 = (x:8 * i:2) [outer=(2,8,16), immutable, constraints=(/16: (/NULL - ]), fd=(2,8)-->(16)]
 
 # Ensure that we do not map filters for types with composite key encoding.
 norm expect-not=(PushFilterIntoJoinLeftAndRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
@@ -3196,7 +3196,7 @@ project
       │    ├── key: (5)
       │    └── fd: (5)-->(6)
       └── filters
-           ├── v:6 = (x:1 + u:5) [outer=(1,5,6), immutable, constraints=(/6: (/NULL - ])]
+           ├── v:6 = (x:1 + u:5) [outer=(1,5,6), immutable, constraints=(/6: (/NULL - ]), fd=(1,5)-->(6)]
            └── column9:9 = u:5 [outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
 
 # Cases with non-extractable equality.

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -455,7 +455,7 @@ project
       │    └── projections
       │         └── a.f:3 / 2.0 [as=f:7, outer=(3)]
       └── filters
-           └── f:7 = i:2::FLOAT8 [outer=(2,7), immutable, constraints=(/7: (/NULL - ])]
+           └── f:7 = i:2::FLOAT8 [outer=(2,7), immutable, constraints=(/7: (/NULL - ]), fd=(2)-->(7)]
 
 # Detect PruneSelectCols and PushSelectIntoProject dependency cycle.
 norm

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -137,7 +137,7 @@ project
  └── select
       ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
       ├── key: (1)
-      ├── fd: (1)-->(2-5,8,9), (8)-->(9)
+      ├── fd: (1)-->(2-5,8,9), (8)-->(9), (2,9)-->(1)
       ├── left-join (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
@@ -154,7 +154,7 @@ project
       │    └── filters
       │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
       └── filters
-           └── k:1 = CASE WHEN i:2 < 0 THEN 5 ELSE y:9 END [outer=(1,2,9), constraints=(/1: (/NULL - ])]
+           └── k:1 = CASE WHEN i:2 < 0 THEN 5 ELSE y:9 END [outer=(1,2,9), constraints=(/1: (/NULL - ]), fd=(2,9)-->(1)]
 
 # Don't decorrelate CASE WHEN branch if there are side effects.
 norm
@@ -302,7 +302,7 @@ project
       ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
       ├── immutable
       ├── key: (1)
-      ├── fd: (1)-->(2-5,8,9), (8)-->(9)
+      ├── fd: (1)-->(2-5,8,9), (8)-->(9), (9)-->(1)
       ├── left-join (hash)
       │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
@@ -319,4 +319,4 @@ project
       │    └── filters
       │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
       └── filters
-           └── k:1 = IFERROR((1 / 0)::INT8, y:9) [outer=(1,9), immutable, constraints=(/1: (/NULL - ])]
+           └── k:1 = IFERROR((1 / 0)::INT8, y:9) [outer=(1,9), immutable, constraints=(/1: (/NULL - ]), fd=(9)-->(1)]

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -149,7 +149,7 @@ inner-join-apply
  │    │    ├── cost: 1094.72
  │    │    └── prune: (7-9)
  │    └── filters
- │         └── eq [type=bool, outer=(1,7,8), immutable, constraints=(/1: (/NULL - ])]
+ │         └── eq [type=bool, outer=(1,7,8), immutable, constraints=(/1: (/NULL - ]), fd=(7,8)-->(1)]
  │              ├── variable: t.public.abc.a:1 [type=int]
  │              └── plus [type=int]
  │                   ├── variable: t.public.def.d:7 [type=int]

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -1192,6 +1192,22 @@ func TestFuncDeps_MakeLeftOuter(t *testing.T) {
 	verifyFD(t, &loj, "(1)-->(2-5), (2,3)~~>(1,4,5), (1,12,13)-->(14)")
 	loj.MakeLeftOuter(abcde, &props.FuncDepSet{}, preservedCols, nullExtendedCols, c(1))
 	verifyFD(t, &loj, "(1)-->(2-5), (2,3)~~>(1,4,5)")
+
+	// Special case where left side has at most one row.
+	abcde = makeAbcdeFD(t)
+	abcde.MakeMax1Row(abcde.ColSet())
+	verifyFD(t, abcde, "key(); ()-->(1-5)")
+	mnpq = makeMnpqFD(t)
+	verifyFD(t, mnpq, "key(10,11); (10,11)-->(12,13)")
+	filterFDs := &props.FuncDepSet{}
+	filterFDs.AddEquivalency(2, 12)
+	filterFDs.AddSynthesizedCol(c(1, 2, 3), 13)
+	loj.CopyFrom(abcde)
+	loj.MakeProduct(mnpq)
+	verifyFD(t, &loj, "key(10,11); ()-->(1-5), (10,11)-->(12,13)")
+	loj.MakeLeftOuter(abcde, filterFDs, abcde.ColSet(), mnpq.ColSet(), c())
+	// 12 and 13 should be constant columns.
+	verifyFD(t, &loj, "key(10,11); ()-->(1-5,12,13)")
 }
 
 func TestFuncDeps_MakeFullOuter(t *testing.T) {

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1998,21 +1998,21 @@ project
  ├── columns: customer1_1_0_:1!null ordernum2_1_0_:2!null orderdat3_1_0_:3!null formula101_0_:26 customer1_2_1_:6 ordernum2_2_1_:7 producti3_2_1_:8 customer1_2_2_:6 ordernum2_2_2_:7 producti3_2_2_:8 quantity4_2_2_:9
  ├── immutable
  ├── key: (8)
- ├── fd: ()-->(1-3), (8)-->(6,7,9,26)
+ ├── fd: ()-->(1-3,6,7), (8)-->(9,26)
  ├── group-by
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 sum:25
  │    ├── grouping columns: lineitems1_.productid:8
  │    ├── immutable
  │    ├── key: (8)
- │    ├── fd: ()-->(1-3), (8)-->(1-3,6,7,9,25)
+ │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
  │    ├── project
  │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
  │    │    ├── immutable
- │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9)
+ │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    ├── right-join (hash)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
  │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2033,7 +2033,7 @@ project
  │    │    │    │    ├── left ordering: +1,+2
  │    │    │    │    ├── right ordering: +6,+7
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9)
+ │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    │    │    ├── scan customerorder [as=order0_]
  │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
  │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
@@ -2294,21 +2294,21 @@ project
  ├── columns: customer1_1_0_:1!null ordernum2_1_0_:2!null orderdat3_1_0_:3!null formula105_0_:26 customer1_2_1_:6 ordernum2_2_1_:7 producti3_2_1_:8 customer1_2_2_:6 ordernum2_2_2_:7 producti3_2_2_:8 quantity4_2_2_:9
  ├── immutable
  ├── key: (8)
- ├── fd: ()-->(1-3), (8)-->(6,7,9,26)
+ ├── fd: ()-->(1-3,6,7), (8)-->(9,26)
  ├── group-by
  │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 sum:25
  │    ├── grouping columns: lineitems1_.productid:8
  │    ├── immutable
  │    ├── key: (8)
- │    ├── fd: ()-->(1-3), (8)-->(1-3,6,7,9,25)
+ │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
  │    ├── project
  │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
  │    │    ├── immutable
- │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9)
+ │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    ├── right-join (hash)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
  │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2329,7 +2329,7 @@ project
  │    │    │    │    ├── left ordering: +1,+2
  │    │    │    │    ├── right ordering: +6,+7
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3), (8)-->(6,7,9)
+ │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
  │    │    │    │    ├── scan customerorder [as=order0_]
  │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
  │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -161,20 +161,20 @@ project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
  ├── key: (29)
- ├── fd: ()-->(1-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27), (29)-->(30,32), (30,32)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
       │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    ├── cardinality: [0 - 1]
@@ -945,20 +945,20 @@ project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
  ├── key: (32)
- ├── fd: ()-->(1-16), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
       │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30), (32)-->(33,35,36), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    ├── cardinality: [0 - 1]
@@ -1125,20 +1125,20 @@ project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
  ├── key: (32)
- ├── fd: ()-->(1-16), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30), (32)-->(33,35,36), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    ├── cardinality: [0 - 1]
@@ -1290,20 +1290,20 @@ project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
  ├── key: (29)
- ├── fd: ()-->(1-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27), (29)-->(30,32), (30,32)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
       │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    ├── cardinality: [0 - 1]
@@ -1447,20 +1447,20 @@ project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
  ├── key: (29)
- ├── fd: ()-->(1-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27), (29)-->(30,32), (30,32)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
       │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    ├── cardinality: [0 - 1]
@@ -1995,20 +1995,20 @@ project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
  ├── key: (32)
- ├── fd: ()-->(1-16), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30), (32)-->(33,35,36), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    ├── cardinality: [0 - 1]
@@ -2973,20 +2973,20 @@ project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
  ├── key: (32)
- ├── fd: ()-->(1-16), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30), (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30), (32)-->(33,35,36), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
       │    │    ├── cardinality: [0 - 1]
@@ -3144,20 +3144,20 @@ project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
  ├── key: (29)
- ├── fd: ()-->(1-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
       │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27), (29)-->(30,32), (30,32)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
       │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
       │    │    ├── cardinality: [0 - 1]


### PR DESCRIPTION
#### opt: improve FDs for left join with single-row left input

This change improves the left join FDs when the left input has at most
one row. This is useful in cases like:
```
SELECT FROM a LEFT JOIN b ON a.v = b.v WHERE f.key = $1
```

In this case, we can declare the `b.v` column as constant: it is
either always equal to `a.v`, or the output has a single row. If we
have a `GROUP BY b.v` on top, this FD can be helpful.

Informs #71768.

Release note: None

#### opt: improve FDs for non-trivial equalities

This change implements a minor improvement to FDs: extract a
functional dependency from equalities of the form
`x = <some expression>`. The logic is the same with that creating FDs
for a projection of that expression: the expression must be immutable
and composite-insensitive.

Release note: None