### PR TITLE
ui: show gaps on metrics charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -16,7 +16,7 @@ import * as sinon from "sinon";
 import uPlot from "uplot";
 import _ from "lodash";
 
-import { LineGraph, LineGraphProps } from "./index";
+import { fillGaps, LineGraph, LineGraphProps } from "./index";
 import * as timewindow from "src/redux/timewindow";
 import * as protos from "src/js/protos";
 import { Axis } from "src/views/shared/components/metricQuery";
@@ -173,5 +173,27 @@ describe("<LineGraph>", function() {
       },
     });
     assert.isTrue(setDataSpy.called);
+  });
+});
+
+describe("fillGaps", () => {
+  it("fills gaps with missed points", () => {
+    const sampleDuration = Long.fromNumber(10000);
+    const data: uPlot.AlignedData[0] = [
+      1634735320000,
+      1634735330000,
+      1634735340000,
+      1634735350000,
+      1634735360000,
+      1634735370000,
+      1634735380000,
+      1634735390000, // missed 39 points after
+      1634735780000,
+      1634735790000,
+      1634735800000, // missed 1 data point after
+      1634735810000,
+    ];
+    const result = fillGaps(data, sampleDuration);
+    assert.equal(result.length, 50);
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -635,6 +635,7 @@ export function configureUPlotLineChart(
           // value determines how these values show up in the legend
           value: (_u: uPlot, rawValue: number) =>
             getLatestYAxisDomain().guideFormat(rawValue),
+          spanGaps: false,
         };
       }),
     ],


### PR DESCRIPTION
Before, data for uPlot graphs were based on all available
data points were provided for specific metrics, so data included
the only point where at least one data point. But when for some
period of time no data was provided then this range was skipped
and the next date point was provided.
With this change, for a particular date range xAxis contains
all date points with respect to provided sample duration.
It allows to explicitly specify all date points for X-Axis
and then fill Y-Axis null values so uPlot can translate
them as gaps.

Depends on PR https://github.com/cockroachdb/cockroach/pull/70594 to fix issue
with correct behavior when zoom-in with mouse.

Release note (ui change): Show gaps for metrics graphs
instead of data interpolation.

**Before:**
<img width="984" alt="Screen Shot 2021-10-21 at 5 13 16 PM" src="https://user-images.githubusercontent.com/3106437/138295781-5de9d2ed-23b7-4adf-9675-0e08c9616bb2.png">

**After:**
<img width="983" alt="Screen Shot 2021-10-21 at 5 13 22 PM" src="https://user-images.githubusercontent.com/3106437/138295816-ae649a7f-6640-4cc6-8a23-55f490ac089e.png">
