### PR TITLE
ci: install cmake on TeamCity agents

### DIFF
--- a/build/packer/teamcity-agent-public-prs.json
+++ b/build/packer/teamcity-agent-public-prs.json
@@ -8,7 +8,7 @@
       "project_id": "cockroach-teamcity-public-prs",
       "source_image_family": "ubuntu-1804-lts",
       "zone": "us-east1-b",
-      "machine_type": "n1-standard-32",
+      "machine_type": "n2-standard-32",
       "image_name": "{{user `image_id`}}",
       "image_description": "{{user `image_id`}}",
       "ssh_username": "packer",

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -8,7 +8,7 @@
       "project_id": "cockroach-teamcity",
       "source_image_family": "ubuntu-1804-lts",
       "zone": "us-east1-b",
-      "machine_type": "n1-standard-32",
+      "machine_type": "n2-standard-32",
       "image_name": "{{user `image_id`}}",
       "image_description": "{{user `image_id`}}",
       "ssh_username": "packer",

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -31,10 +31,13 @@ apt-get update --yes
 apt-get install --yes sudo
 
 apt-get install --yes \
+  autoconf \
+  bison \
   build-essential \
   curl \
   docker-ce \
   docker-compose \
+  flex \
   gnome-keyring \
   gnupg2 \
   git \
@@ -42,6 +45,13 @@ apt-get install --yes \
   openjdk-11-jre-headless \
   pass \
   unzip
+
+curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-x86_64.tar.gz -o /tmp/cmake.tar.gz
+sha256sum -c - <<EOF
+97bf730372f9900b2dfb9206fccbcf92f5c7f3b502148b832e77451aa0f9e0e6 /tmp/cmake.tar.gz
+EOF
+tar --strip-components=1 -C /usr -xzf /tmp/cmake.tar.gz
+rm -f /tmp/cmake.tar.gz
 
 curl -fsSL https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF


### PR DESCRIPTION
Related: #71735

Previously, with #71735 we stopped relying on bazel installed cmake and
started using system-wide cmake. cmake is installed in the builder and
bazelbuilder images, but not on TeamCity agents.

The make based acceptance test uses builder.sh to build the acceptance
test binary and runs it without docker.

Running the acceptance test under Bazel requires running the whole thing
either without docker or using docker-in-docker. The latter may lead to
unexpected issues with the tests.

The patch installs cmake, autoconf, bison, and flex system-wide on
TeamCity agents. Also, bump the instance type to decrease the build time
from 45m to 35m.

Release note: None