### PR TITLE
roachtest: fix sequelize tests with upstream fix

### DIFF
--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -20,7 +20,7 @@ import (
 )
 
 var sequelizeCockroachDBReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedSequelizeCockroachDBRelease = "v6.0.2"
+var supportedSequelizeCockroachDBRelease = "v6.0.3"
 
 // This test runs sequelize's full test suite against a single cockroach node.
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71515

The new version has a stable enum ordering so the tests should pass

Release note: None