### PR TITLE
release-21.1: backport 21.2's backup processor, streaming file writes

### DIFF
--- a/pkg/blobs/BUILD.bazel
+++ b/pkg/blobs/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",
+        "//pkg/util",
         "//pkg/util/fileutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
         "//pkg/sql/roleoption",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
+        "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -11,9 +11,14 @@ package backupccl
 import (
 	"bytes"
 	"context"
+	fmt "fmt"
+	io "io"
+	"sort"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -24,7 +29,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -59,6 +66,14 @@ var (
 		"bulkio.backup.proxy_file_writes.enabled",
 		"return files to the backup coordination processes to write to "+
 			"external storage instead of writing them directly from the storage layer",
+		false,
+	)
+)
+
+var (
+	useNewProc = settings.RegisterBoolSetting(
+		"bulkio.backup.experimental_21_2_mode.enabled",
+		"use the backported 21.2 version of backup data handling which adds post-processing of exported data to producer fewer but larger files",
 		false,
 	)
 )
@@ -116,7 +131,11 @@ func (bp *backupDataProcessor) Start(ctx context.Context) {
 	ctx = bp.StartInternal(ctx, backupProcessorName)
 	go func() {
 		defer close(bp.progCh)
-		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
+		if useNewProc.Get(&bp.EvalCtx.Settings.SV) {
+			bp.backupErr = runNewBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
+		} else {
+			bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
+		}
 	}()
 }
 
@@ -446,6 +465,550 @@ func writeFile(
 		return errors.Wrap(err, "writing SST")
 	}
 	return nil
+}
+
+var (
+	targetFileSize = settings.RegisterByteSizeSetting(
+		"bulkio.backup.file_size",
+		"target file size (only used when experimental_21_2_mode is enabled)",
+		128<<20,
+	)
+	smallFileBuffer = settings.RegisterByteSizeSetting(
+		"bulkio.backup.merge_file_buffer_size",
+		"size limit used when buffering backup files before merging them (only used when experimental_21_2_mode is enabled)",
+		16<<20,
+		settings.NonNegativeInt,
+	)
+)
+
+// maxSinkQueueFiles is how many replies we'll queue up before flushing to allow
+// some re-ordering, unless we hit smallFileBuffer size first.
+const maxSinkQueueFiles = 24
+
+var _ execinfra.Processor = &backupDataProcessor{}
+var _ execinfra.RowSource = &backupDataProcessor{}
+
+type returnedSST struct {
+	f              BackupManifest_File
+	sst            []byte
+	revStart       hlc.Timestamp
+	completedSpans int32
+}
+
+func runNewBackupProcessor(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	spec *execinfrapb.BackupDataSpec,
+	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+) error {
+	clusterSettings := flowCtx.Cfg.Settings
+
+	totalSpans := len(spec.Spans) + len(spec.IntroducedSpans)
+	todo := make(chan spanAndTime, totalSpans)
+	var spanIdx int
+	for _, s := range spec.IntroducedSpans {
+		todo <- spanAndTime{spanIdx: spanIdx, span: s, start: hlc.Timestamp{},
+			end: spec.BackupStartTime}
+		spanIdx++
+	}
+	for _, s := range spec.Spans {
+		todo <- spanAndTime{spanIdx: spanIdx, span: s, start: spec.BackupStartTime,
+			end: spec.BackupEndTime}
+		spanIdx++
+	}
+
+	destURI := spec.DefaultURI
+	var destLocalityKV string
+
+	if len(spec.URIsByLocalityKV) > 0 {
+		var localitySinkURI string
+		// When matching, more specific KVs in the node locality take precedence
+		// over less specific ones so search back to front.
+		for i := len(flowCtx.EvalCtx.Locality.Tiers) - 1; i >= 0; i-- {
+			tier := flowCtx.EvalCtx.Locality.Tiers[i].String()
+			if dest, ok := spec.URIsByLocalityKV[tier]; ok {
+				localitySinkURI = dest
+				destLocalityKV = tier
+				break
+			}
+		}
+		if localitySinkURI != "" {
+			log.Infof(ctx, "backing up %d spans to destination specified by locality %s", totalSpans, destLocalityKV)
+			destURI = localitySinkURI
+		} else {
+			nodeLocalities := make([]string, 0, len(flowCtx.EvalCtx.Locality.Tiers))
+			for _, i := range flowCtx.EvalCtx.Locality.Tiers {
+				nodeLocalities = append(nodeLocalities, i.String())
+			}
+			backupLocalities := make([]string, 0, len(spec.URIsByLocalityKV))
+			for i := range spec.URIsByLocalityKV {
+				backupLocalities = append(backupLocalities, i)
+			}
+			log.Infof(ctx, "backing up %d spans to default locality because backup localities %s have no match in node's localities %s", totalSpans, backupLocalities, nodeLocalities)
+		}
+	}
+	dest, err := cloudimpl.ExternalStorageConfFromURI(destURI, spec.User())
+	if err != nil {
+		return err
+	}
+
+	returnedSSTs := make(chan returnedSST, 1)
+
+	grp := ctxgroup.WithContext(ctx)
+	// Start a goroutine that will then start a group of goroutines which each
+	// pull spans off of `todo` and send export requests. Any resume spans are put
+	// back on `todo`. Any returned SSTs are put on a  `returnedSSTs` to be routed
+	// to a buffered sink that merges them until they are large enough to flush.
+	grp.GoCtx(func(ctx context.Context) error {
+		defer close(returnedSSTs)
+		// TODO(pbardea): Check to see if this benefits from any tuning (e.g. +1, or
+		//  *2). See #49798.
+		numSenders := int(kvserver.ExportRequestsLimit.Get(&clusterSettings.SV)) * 2
+
+		return ctxgroup.GroupWorkers(ctx, numSenders, func(ctx context.Context, _ int) error {
+			readTime := spec.BackupEndTime.GoTime()
+
+			// priority becomes true when we're sending re-attempts of reads far enough
+			// in the past that we want to run them with priority.
+			var priority bool
+			timer := timeutil.NewTimer()
+			defer timer.Stop()
+
+			ctxDone := ctx.Done()
+			for {
+				select {
+				case <-ctxDone:
+					return ctx.Err()
+				case span := <-todo:
+					header := roachpb.Header{Timestamp: span.end}
+					req := &roachpb.ExportRequest{
+						RequestHeader:                       roachpb.RequestHeaderFromSpan(span.span),
+						StartTime:                           span.start,
+						EnableTimeBoundIteratorOptimization: useTBI.Get(&clusterSettings.SV),
+						MVCCFilter:                          spec.MVCCFilter,
+						TargetFileSize:                      storageccl.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
+						ReturnSST:                           true,
+					}
+
+					// If we're doing re-attempts but are not yet in the priority regime,
+					// check to see if it is time to switch to priority.
+					if !priority && span.attempts > 0 {
+						// Check if this is starting a new pass and we should delay first.
+						// We're okay with delaying this worker until then since we assume any
+						// other work it could pull off the queue will likely want to delay to
+						// a similar or later time anyway.
+						if delay := delayPerAttmpt.Get(&clusterSettings.SV) - timeutil.Since(span.lastTried); delay > 0 {
+							timer.Reset(delay)
+							log.Infof(ctx, "waiting %s to start attempt %d of remaining spans", delay, span.attempts+1)
+							select {
+							case <-ctxDone:
+								return ctx.Err()
+							case <-timer.C:
+								timer.Read = true
+							}
+						}
+
+						priority = timeutil.Since(readTime) > priorityAfter.Get(&clusterSettings.SV)
+					}
+
+					if priority {
+						// This re-attempt is reading far enough in the past that we just want
+						// to abort any transactions it hits.
+						header.UserPriority = roachpb.MaxUserPriority
+					} else {
+						// On the initial attempt to export this span and re-attempts that are
+						// done while it is still less than the configured time above the read
+						// time, we set WaitPolicy to Error, so that the export will return an
+						// error to us instead of instead doing blocking wait if it hits any
+						// other txns. This lets us move on to other ranges we have to export,
+						// provide an indication of why we're blocked, etc instead and come
+						// back to this range later.
+						header.WaitPolicy = lock.WaitPolicy_Error
+					}
+
+					// We set the DistSender response target bytes field to a sentinel
+					// value. The sentinel value of 1 forces the ExportRequest to paginate
+					// after creating a single SST.
+					header.TargetBytes = 1
+					log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",
+						span.span, span.attempts+1, header.UserPriority.String())
+					rawRes, pErr := kv.SendWrappedWith(ctx, flowCtx.Cfg.DB.NonTransactionalSender(), header, req)
+
+					if pErr != nil {
+						if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); ok {
+							span.lastTried = timeutil.Now()
+							span.attempts++
+							todo <- span
+							// TODO(dt): send a progress update to update job progress to note
+							// the intents being hit.
+							continue
+						}
+						return errors.Wrapf(pErr.GoError(), "exporting %s", span.span)
+					}
+					res := rawRes.(*roachpb.ExportResponse)
+
+					// If the reply has a resume span, put the remaining span on
+					// todo to be picked up again in the next round.
+					if res.ResumeSpan != nil {
+						if !res.ResumeSpan.Valid() {
+							return errors.Errorf("invalid resume span: %s", res.ResumeSpan)
+						}
+
+						// Taking resume timestamp from the last file of response since files must
+						// always be consecutive even if we currently expect only one.
+						resumeSpan := spanAndTime{
+							span:      *res.ResumeSpan,
+							start:     span.start,
+							end:       span.end,
+							attempts:  span.attempts,
+							lastTried: span.lastTried,
+						}
+						todo <- resumeSpan
+					}
+
+					if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+						if backupKnobs.RunAfterExportingSpanEntry != nil {
+							backupKnobs.RunAfterExportingSpanEntry(ctx)
+						}
+					}
+
+					var completedSpans int32
+					if res.ResumeSpan == nil {
+						completedSpans = 1
+					}
+					if len(res.Files) > 1 {
+						log.Warning(ctx, "unexpected multi-file response using header.TargetBytes = 1")
+					}
+
+					for i, file := range res.Files {
+						f := BackupManifest_File{
+							Span:        file.Span,
+							Path:        file.Path,
+							EntryCounts: countRows(file.Exported, spec.PKIDs),
+						}
+						if span.start != spec.BackupStartTime {
+							f.StartTime = span.start
+							f.EndTime = span.end
+						}
+						ret := returnedSST{f: f, sst: file.SST, revStart: res.StartTime}
+						// If multiple files were returned for this span, only one -- the
+						// last -- should count as completing the requested span.
+						if i == len(res.Files)-1 {
+							ret.completedSpans = completedSpans
+						}
+						select {
+						case returnedSSTs <- ret:
+						case <-ctxDone:
+							return ctx.Err()
+						}
+					}
+
+				default:
+					// No work left to do, so we can exit. Note that another worker could
+					// still be running and may still push new work (a retry) on to todo but
+					// that is OK, since that also means it is still running and thus can
+					// pick up that work on its next iteration.
+					return nil
+				}
+			}
+		})
+	})
+
+	// Start another goroutine which will read from returnedSSTs ch and push
+	// ssts from it into an sstSink responsible for actually writing their
+	// contents to cloud storage.
+	grp.GoCtx(func(ctx context.Context) error {
+		sinkConf := sstSinkConf{
+			id:       flowCtx.NodeID.SQLInstanceID(),
+			enc:      spec.Encryption,
+			progCh:   progCh,
+			settings: &flowCtx.Cfg.Settings.SV,
+		}
+
+		storage, err := flowCtx.Cfg.ExternalStorage(ctx, dest)
+		if err != nil {
+			return err
+		}
+
+		sink := &sstSink{conf: sinkConf, dest: storage}
+
+		defer func() {
+			err := sink.Close()
+			err = errors.CombineErrors(storage.Close(), err)
+			if err != nil {
+				log.Warningf(ctx, "failed to close backup sink(s): %+v", err)
+			}
+		}()
+
+		for res := range returnedSSTs {
+			res.f.LocalityKV = destLocalityKV
+			if err := sink.push(ctx, res); err != nil {
+				return err
+			}
+		}
+		return sink.flush(ctx)
+	})
+
+	return grp.Wait()
+}
+
+type sstSinkConf struct {
+	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	enc      *roachpb.FileEncryptionOptions
+	id       base.SQLInstanceID
+	settings *settings.Values
+}
+
+type sstSink struct {
+	dest cloud.ExternalStorage
+	conf sstSinkConf
+
+	queue     []returnedSST
+	queueSize int
+
+	sst     storage.SSTWriter
+	ctx     context.Context
+	cancel  func()
+	out     io.WriteCloser
+	outName string
+
+	flushedFiles    []BackupManifest_File
+	flushedSize     int64
+	flushedRevStart hlc.Timestamp
+	completedSpans  int32
+
+	stats struct {
+		files       int
+		flushes     int
+		oooFlushes  int
+		sizeFlushes int
+		spanGrows   int
+	}
+}
+
+func (s *sstSink) Close() error {
+	if log.V(1) && s.ctx != nil {
+		log.Infof(s.ctx, "backup sst sink recv'd %d files, wrote %d (%d due to size, %d due to re-ordering), %d recv files extended prior span",
+			s.stats.files, s.stats.flushes, s.stats.sizeFlushes, s.stats.oooFlushes, s.stats.spanGrows)
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.out != nil {
+		return s.out.Close()
+	}
+	return nil
+}
+
+// push pushes one returned backup file into the sink. Returned files can arrive
+// out of order, but must be written to an underlying file in-order or else a
+// new underlying file has to be opened. The queue allows buffering up files and
+// sorting them before pushing them to the underlying file to try to avoid this.
+// When the queue length or sum of the data sizes in it exceeds thresholds the
+// queue is sorted and the first half is flushed.
+func (s *sstSink) push(ctx context.Context, resp returnedSST) error {
+	s.queue = append(s.queue, resp)
+	s.queueSize += len(resp.sst)
+
+	if len(s.queue) >= maxSinkQueueFiles || s.queueSize >= int(smallFileBuffer.Get(s.conf.settings)) {
+		sort.Slice(s.queue, func(i, j int) bool { return s.queue[i].f.Span.Key.Compare(s.queue[j].f.Span.Key) < 0 })
+
+		// Drain the first half.
+		drain := len(s.queue) / 2
+		if drain < 1 {
+			drain = 1
+		}
+		for i := range s.queue[:drain] {
+			if err := s.write(ctx, s.queue[i]); err != nil {
+				return err
+			}
+			s.queueSize -= len(s.queue[i].sst)
+		}
+
+		// Shift down the remainder of the queue and slice off the tail.
+		copy(s.queue, s.queue[drain:])
+		s.queue = s.queue[:len(s.queue)-drain]
+	}
+	return nil
+}
+
+func (s *sstSink) flush(ctx context.Context) error {
+	for i := range s.queue {
+		if err := s.write(ctx, s.queue[i]); err != nil {
+			return err
+		}
+	}
+	s.queue = nil
+	return s.flushFile(ctx)
+}
+
+func (s *sstSink) flushFile(ctx context.Context) error {
+	if s.out == nil {
+		return nil
+	}
+	s.stats.flushes++
+
+	if err := s.sst.Finish(); err != nil {
+		return err
+	}
+	if err := s.out.Close(); err != nil {
+		return errors.Wrap(err, "writing SST")
+	}
+	s.outName = ""
+	s.out = nil
+
+	progDetails := BackupManifest_Progress{
+		RevStartTime:   s.flushedRevStart,
+		Files:          s.flushedFiles,
+		CompletedSpans: s.completedSpans,
+	}
+	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	details, err := gogotypes.MarshalAny(&progDetails)
+	if err != nil {
+		return err
+	}
+	prog.ProgressDetails = *details
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.conf.progCh <- prog:
+	}
+
+	s.flushedFiles = nil
+	s.flushedSize = 0
+	s.flushedRevStart.Reset()
+	s.completedSpans = 0
+
+	return nil
+}
+
+// noopSyncCloser is used to wrap io.Writers for sstable.Writer so that callers
+// can decide when to close/sync.
+type noopSyncCloser struct {
+	io.Writer
+}
+
+func (noopSyncCloser) Sync() error {
+	return nil
+}
+
+func (noopSyncCloser) Close() error {
+	return nil
+}
+func (s *sstSink) open(ctx context.Context) error {
+	s.outName = generateUniqueSSTName(s.conf.id)
+	if s.ctx == nil {
+		s.ctx, s.cancel = context.WithCancel(ctx)
+	}
+	w, err := s.dest.Writer(s.ctx, s.outName)
+	if err != nil {
+		return err
+	}
+	if s.conf.enc != nil {
+		var err error
+		w, err = storageccl.EncryptingWriter(w, s.conf.enc.Key)
+		if err != nil {
+			return err
+		}
+	}
+	s.out = w
+	s.sst = storage.MakeBackupSSTWriter(noopSyncCloser{s.out})
+	return nil
+}
+
+func (s *sstSink) write(ctx context.Context, resp returnedSST) error {
+	s.stats.files++
+
+	span := resp.f.Span
+
+	// If this span starts before the last buffered span ended, we need to flush
+	// since it overlaps but SSTWriter demands writes in-order.
+	if len(s.flushedFiles) > 0 {
+		last := s.flushedFiles[len(s.flushedFiles)-1].Span.EndKey
+		if span.Key.Compare(last) < 0 {
+			log.VEventf(ctx, 1, "flushing backup file %s of size %d because span %s cannot append before %s",
+				s.outName, s.flushedSize, span, last,
+			)
+			s.stats.oooFlushes++
+			if err := s.flushFile(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Initialize the writer if needed.
+	if s.out == nil {
+		if err := s.open(ctx); err != nil {
+			return err
+		}
+	}
+
+	log.VEventf(ctx, 2, "writing %s to backup file %s", span, s.outName)
+
+	// Copy SST content.
+	sst, err := storage.NewMemSSTIterator(resp.sst, false)
+	if err != nil {
+		return err
+	}
+	defer sst.Close()
+
+	sst.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+	for {
+		if valid, err := sst.Valid(); !valid || err != nil {
+			if err != nil {
+				return err
+			}
+			break
+		}
+		k := sst.UnsafeKey()
+		if k.Timestamp.IsEmpty() {
+			if err := s.sst.PutUnversioned(k.Key, sst.UnsafeValue()); err != nil {
+				return err
+			}
+		} else {
+			if err := s.sst.PutMVCC(sst.UnsafeKey(), sst.UnsafeValue()); err != nil {
+				return err
+			}
+		}
+		sst.Next()
+	}
+
+	// If this span extended the last span added -- that is, picked up where it
+	// ended and has the same time-bounds -- then we can simply extend that span
+	// and add to its entry counts. Otherwise we need to record it separately.
+	if l := len(s.flushedFiles) - 1; l > 0 && s.flushedFiles[l].Span.EndKey.Equal(span.Key) &&
+		s.flushedFiles[l].EndTime.EqOrdering(resp.f.EndTime) &&
+		s.flushedFiles[l].StartTime.EqOrdering(resp.f.StartTime) {
+		s.flushedFiles[l].Span.EndKey = span.EndKey
+		s.flushedFiles[l].EntryCounts.add(resp.f.EntryCounts)
+		s.stats.spanGrows++
+	} else {
+		f := resp.f
+		f.Path = s.outName
+		s.flushedFiles = append(s.flushedFiles, f)
+	}
+	s.flushedRevStart.Forward(resp.revStart)
+	s.completedSpans += resp.completedSpans
+	s.flushedSize += int64(len(resp.sst))
+
+	// If our accumulated SST is now big enough, and we are positioned at the end
+	// of a range flush it.
+	if s.flushedSize > targetFileSize.Get(s.conf.settings) {
+		s.stats.sizeFlushes++
+		log.VEventf(ctx, 2, "flushing backup file %s with size %d", s.outName, s.flushedSize)
+		if err := s.flushFile(ctx); err != nil {
+			return err
+		}
+	} else {
+		log.VEventf(ctx, 3, "continuing to write to backup file %s of size %d", s.outName, s.flushedSize)
+	}
+	return nil
+}
+
+func generateUniqueSSTName(nodeID base.SQLInstanceID) string {
+	// The data/ prefix, including a /, is intended to group SSTs in most of the
+	// common file/bucket browse UIs.
+	return fmt.Sprintf("data/%d.sst", builtins.GenerateUniqueInt(nodeID))
 }
 
 func init() {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -398,6 +398,20 @@ func TestBackupRestoreMultiNodeRemote(t *testing.T) {
 	backupAndRestore(ctx, t, tc, []string{remoteFoo}, []string{LocalFoo}, numAccounts)
 }
 
+func TestNewStyleBackupRestoreMultiNodeRemote(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+	ctx, tc, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	// Backing up to node2's local file system
+	remoteFoo := "nodelocal://2/foo"
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.experimental_21_2_mode.enabled = true")
+	backupAndRestore(ctx, t, tc, []string{remoteFoo}, []string{LocalFoo}, numAccounts)
+}
+
 func TestBackupRestorePartitioned(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -277,6 +277,12 @@ func (es *generatorExternalStorage) WriteFile(
 	return errors.New("unsupported")
 }
 
+func (es *generatorExternalStorage) Writer(
+	ctx context.Context, basename string,
+) (io.WriteCloser, error) {
+	return nil, errors.New("unsupported")
+}
+
 func (es *generatorExternalStorage) ListFiles(ctx context.Context, _ string) ([]string, error) {
 	return nil, errors.New("unsupported")
 }

--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -88,6 +88,15 @@ type ExternalStorage interface {
 
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
+
+	// Writer returns a writer for the requested name.
+	//
+	// A Writer *must* be closed via either Close, and if closing returns a
+	// non-nil error, that error should be handled or reported to the user -- an
+	// implementation may buffer written data until Close and only then return
+	// an error, or Write may retrun an opaque io.EOF with the underlying cause
+	// returned by the subsequent Close().
+	Writer(ctx context.Context, basename string) (io.WriteCloser, error)
 }
 
 // ListingFn describes functions passed to ExternalStorage.ListFiles.

--- a/pkg/storage/cloudimpl/BUILD.bazel
+++ b/pkg/storage/cloudimpl/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql",
         "//pkg/storage/cloud",
         "//pkg/storage/cloudimpl/filetable",
+        "//pkg/util",
         "//pkg/util/contextutil",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/external_storage_test.go
@@ -245,6 +245,34 @@ func testExportStoreWithExternalIOConfig(
 			t.Fatalf("wrong content")
 		}
 
+		testingFilename += "-stream"
+
+		w, err := s.Writer(ctx, testingFilename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(w, bytes.NewReader(testingContent)); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Attempt to read (or fetch) it back.
+		streamRes, err := s.ReadFile(ctx, testingFilename)
+		if err != nil {
+			t.Fatalf("Could not get reader for %s: %+v", testingFilename, err)
+		}
+		defer res.Close()
+		streamContent, err := ioutil.ReadAll(streamRes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify the result contains what we wrote.
+		if !bytes.Equal(streamContent, testingContent) {
+			t.Fatalf("wrong content")
+		}
+
 		t.Run("rand-readats", func(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				t.Run("", func(t *testing.T) {

--- a/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
@@ -114,7 +114,7 @@ func TestPutHttp(t *testing.T) {
 		srv, files, cleanup := makeServer()
 		defer cleanup()
 		testExportStore(t, srv.String(), false, user, nil, nil)
-		if expected, actual := 14, files(); expected != actual {
+		if expected, actual := 15, files(); expected != actual {
 			t.Fatalf("expected %d files to be written to single http store, got %d", expected, actual)
 		}
 	})
@@ -137,7 +137,7 @@ func TestPutHttp(t *testing.T) {
 		if expected, actual := 4, files2(); expected != actual {
 			t.Fatalf("expected %d files written to http host 2, got %d", expected, actual)
 		}
-		if expected, actual := 4, files3(); expected != actual {
+		if expected, actual := 5, files3(); expected != actual {
 			t.Fatalf("expected %d files written to http host 3, got %d", expected, actual)
 		}
 	})

--- a/pkg/storage/cloudimpl/file_table_storage.go
+++ b/pkg/storage/cloudimpl/file_table_storage.go
@@ -405,3 +405,20 @@ func (f *fileTableStorage) Size(ctx context.Context, basename string) (int64, er
 	}
 	return f.fs.FileSize(ctx, filepath)
 }
+
+// Writer implements the ExternalStorage interface and writes the file to the
+// user scoped FileToTableSystem.
+func (f *fileTableStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	filepath, err := checkBaseAndJoinFilePath(f.prefix, basename)
+	if err != nil {
+		return nil, err
+	}
+
+	// This is only possible if the method is invoked by a SQLConnFileTableStorage
+	// which should never be the case.
+	if f.ie == nil {
+		return nil, errors.New("cannot Write without a configured internal executor")
+	}
+
+	return f.fs.NewFileWriter(ctx, filepath, filetable.ChunkDefaultSize)
+}

--- a/pkg/storage/cloudimpl/gcs_storage.go
+++ b/pkg/storage/cloudimpl/gcs_storage.go
@@ -313,3 +313,11 @@ func (g *gcsStorage) Size(ctx context.Context, basename string) (int64, error) {
 func (g *gcsStorage) Close() error {
 	return g.client.Close()
 }
+
+func (g *gcsStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	w := g.bucket.Object(path.Join(g.prefix, basename)).NewWriter(ctx)
+	if !gcsChunkingEnabled.Get(&g.settings.SV) {
+		w.ChunkSize = 0
+	}
+	return w, nil
+}

--- a/pkg/storage/cloudimpl/http_storage.go
+++ b/pkg/storage/cloudimpl/http_storage.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -345,4 +346,11 @@ func (h *httpStorage) req(
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (h *httpStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	return util.BackgroundPipe(ctx, func(ctx context.Context, r io.Reader) error {
+		_, err := h.reqNoBody(ctx, "PUT", basename, r)
+		return err
+	}), nil
 }

--- a/pkg/storage/cloudimpl/nodelocal_storage.go
+++ b/pkg/storage/cloudimpl/nodelocal_storage.go
@@ -206,3 +206,7 @@ func (l *localFileStorage) Size(ctx context.Context, basename string) (int64, er
 func (*localFileStorage) Close() error {
 	return nil
 }
+
+func (l *localFileStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	return l.blobClient.Writer(ctx, joinRelativePath(l.base, basename))
+}

--- a/pkg/storage/cloudimpl/workload_storage.go
+++ b/pkg/storage/cloudimpl/workload_storage.go
@@ -168,3 +168,7 @@ func ParseWorkloadConfig(uri *url.URL) (*roachpb.ExternalStorage_Workload, error
 	}
 	return c, nil
 }
+
+func (s *workloadStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	return nil, errors.Errorf(`workload storage does not support writing`)
+}

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "fast_int_set_str.go",
         "hash.go",
         "nocopy.go",
+        "pipe.go",
         "pluralize.go",
         "race_off.go",
         "race_on.go",
@@ -29,6 +30,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",

--- a/pkg/util/ctxgroup/BUILD.bazel
+++ b/pkg/util/ctxgroup/BUILD.bazel
@@ -12,8 +12,8 @@ go_test(
     name = "ctxgroup_test",
     size = "small",
     srcs = ["ctxgroup_test.go"],
-    embed = [":ctxgroup"],
     deps = [
+        ":ctxgroup",
         "//pkg/testutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/ctxgroup/ctxgroup_test.go
+++ b/pkg/util/ctxgroup/ctxgroup_test.go
@@ -8,13 +8,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package ctxgroup
+package ctxgroup_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
 )
@@ -26,7 +27,7 @@ func TestErrorAfterCancel(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		g := WithContext(ctx)
+		g := ctxgroup.WithContext(ctx)
 		g.Go(func() error {
 			return nil
 		})

--- a/pkg/util/pipe.go
+++ b/pkg/util/pipe.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package util
+
+import (
+	"context"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/errors"
+)
+
+// BackgroundPipe is a helper for providing a Writer that is backed by a pipe
+// that has a background process reading from it. It *must* be Closed().
+func BackgroundPipe(
+	ctx context.Context, fn func(ctx context.Context, pr io.Reader) error,
+) io.WriteCloser {
+	pr, pw := io.Pipe()
+	w := &backgroundPipe{w: pw, grp: ctxgroup.WithContext(ctx), ctx: ctx}
+	w.grp.GoCtx(func(ctc context.Context) error {
+		err := fn(ctx, pr)
+		if err != nil {
+			closeErr := pr.CloseWithError(err)
+			err = errors.CombineErrors(err, closeErr)
+		} else {
+			err = pr.Close()
+		}
+		return err
+	})
+	return w
+}
+
+type backgroundPipe struct {
+	w   *io.PipeWriter
+	grp ctxgroup.Group
+	ctx context.Context
+}
+
+// Write writes to the writer.
+func (s *backgroundPipe) Write(p []byte) (int, error) {
+	return s.w.Write(p)
+}
+
+// Close closes the writer, finishing the write operation.
+func (s *backgroundPipe) Close() error {
+	err := s.w.CloseWithError(s.ctx.Err())
+	return errors.CombineErrors(err, s.grp.Wait())
+}


### PR DESCRIPTION
see commits.

Release justification: intended to be low risk as it is backported behind an opt-in experimental flag and is only additive, and is considered to potentially be high impact if it can help customers with larger clusters avoid OOMs related to large backup metadata.