### PR TITLE
ui: update return route from stmt details not found

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -451,7 +451,9 @@ export class StatementDetails extends React.Component<
 
     if (!stats) {
       const sourceApp = queryByName(this.props.location, appAttr);
-      const listUrl = "/statements" + (sourceApp ? "/" + sourceApp : "");
+      const listUrl =
+        "/sql-activity?tab=statements" +
+        (sourceApp ? "&" + appAttr + "=" + sourceApp : "");
 
       return (
         <React.Fragment>


### PR DESCRIPTION
When a statement was not found, the return to statements
link was returning to the SQL Activity page without the
Statement tab selected.
This commit adds the right tab to the return option.

Release note: None