### PR TITLE
release-21.1: sql: do not plan zig-zag joins with implicit, nullable equality columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -62,6 +62,41 @@ SELECT n,a,b FROM a WHERE a = 4 AND b = 1;
 statement ok
 SELECT n FROM a WHERE b = 1 AND (((a < 1) AND (a > 1)) OR (a >= 2 AND a <= 2))
 
+# Regression test for #71655. Zig-zag joins should only be planned with implicit
+# equality columns that are non-nullable.
+statement ok
+CREATE TABLE t71655 (
+    k INT PRIMARY KEY,
+    a INT,
+    b INT,
+    c INT,
+    d INT NOT NULL,
+    INDEX ac (a, c),
+    INDEX bc (b, c)
+);
+INSERT INTO t71655 VALUES (1, 10, 20, NULL, 11);
+INSERT INTO t71655 VALUES (2, 10, 20, NULL, 12)
+
+# A zig-zag join is not performed here with ac and bc because c is nullable and
+# cannot be an implicit equality column.
+query I rowsort
+SELECT k FROM t71655 WHERE a = 10 AND b = 20
+----
+1
+2
+
+statement ok
+CREATE INDEX ad ON t71655 (a, d);
+CREATE INDEX bd ON t71655 (b, d)
+
+# A zig-zag join is performed here with ad and bd because d is non-nullable and
+# can be an implicit equality column.
+query I rowsort
+SELECT k FROM t71655 WHERE a = 10 AND b = 20
+----
+1
+2
+
 # ------------------------------------------------------------------------------
 # Zigzag join tests on inverted indexes.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1166,26 +1166,32 @@ func eqColsForZigzag(
 		i++
 		j++
 
+		// If the columns are not equated in their filters, but they have the
+		// same ID, then they are assumed to be implicitly equal. This is only
+		// true if they are non-nullable because NULL != NULL. See issue #71655.
 		if leftColID == rightColID {
-			leftEqPrefix = append(leftEqPrefix, leftColID)
-			rightEqPrefix = append(rightEqPrefix, rightColID)
-			continue
+			col := tab.Column(tabID.ColumnOrdinal(leftColID))
+			if !col.IsNullable() {
+				leftEqPrefix = append(leftEqPrefix, leftColID)
+				rightEqPrefix = append(rightEqPrefix, rightColID)
+				continue
+			}
 		}
+
+		// If both columns are at the same index in their respective EqCols
+		// lists, they were explicitly equated in the filters.
 		leftIdx, leftOk := leftEqCols.Find(leftColID)
 		rightIdx, rightOk := rightEqCols.Find(rightColID)
-		// If both columns are at the same index in their respective
-		// EqCols lists, they were equated in the filters.
 		if leftOk && rightOk && leftIdx == rightIdx {
 			leftEqPrefix = append(leftEqPrefix, leftColID)
 			rightEqPrefix = append(rightEqPrefix, rightColID)
 			continue
-		} else {
-			// We've reached the first non-equal column; the zigzag
-			// joiner does not support non-contiguous/non-prefix equal
-			// columns.
-			break
 		}
 
+		// We've reached the first non-equal column; the zigzag
+		// joiner does not support non-contiguous/non-prefix equal
+		// columns.
+		break
 	}
 
 	return leftEqPrefix, rightEqPrefix

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -4272,6 +4272,8 @@ CREATE TABLE pqr
     r INT,
     s STRING,
     t STRING,
+    u STRING NOT NULL,
+    v STRING,
     INDEX q (q),
     INDEX r (r),
     INDEX s (s) STORING (r),
@@ -4358,22 +4360,22 @@ memo (optimized, ~13KB, required=[presentation: q:2,r:3])
  ├── G2: (scan pqr,cols=(2,3))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,3))
- │         └── cost: 10724.72
+ │         └── cost: 10924.92
  ├── G3: (filters G9 G10)
  ├── G4: (index-join G11 pqr,cols=(2,3))
  │    └── []
  │         ├── best: (index-join G11 pqr,cols=(2,3))
- │         └── cost: 84.50
+ │         └── cost: 84.70
  ├── G5: (filters G10)
  ├── G6: (index-join G12 pqr,cols=(2,3))
  │    └── []
  │         ├── best: (index-join G12 pqr,cols=(2,3))
- │         └── cost: 725.04
+ │         └── cost: 727.04
  ├── G7: (filters G9)
  ├── G8: (index-join G13 pqr,cols=(2,3))
  │    └── []
  │         ├── best: (index-join G13 pqr,cols=(2,3))
- │         └── cost: 726.04
+ │         └── cost: 728.04
  ├── G9: (eq G14 G15)
  ├── G10: (eq G16 G17)
  ├── G11: (scan pqr@q,cols=(1,2),constrained)
@@ -4435,26 +4437,26 @@ memo (optimized, ~15KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
- │         └── cost: 17.49
+ │         └── cost: 17.51
  ├── G2: (scan pqr,cols=(2-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2-4))
- │         └── cost: 10824.82
+ │         └── cost: 11025.02
  ├── G3: (filters G11 G12)
  ├── G4: (index-join G13 pqr,cols=(2-4))
  │    └── []
  │         ├── best: (index-join G13 pqr,cols=(2-4))
- │         └── cost: 84.60
+ │         └── cost: 84.80
  ├── G5: (filters G12)
  ├── G6: (index-join G14 pqr,cols=(2-4))
  │    └── []
  │         ├── best: (index-join G14 pqr,cols=(2-4))
- │         └── cost: 726.04
+ │         └── cost: 728.04
  ├── G7: (filters G11)
  ├── G8: (index-join G15 pqr,cols=(2-4))
  │    └── []
  │         ├── best: (index-join G15 pqr,cols=(2-4))
- │         └── cost: 727.04
+ │         └── cost: 729.04
  ├── G9: (zigzag-join G3 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
@@ -4504,17 +4506,17 @@ memo (optimized, ~11KB, required=[presentation: q:2,s:4])
  ├── G2: (scan pqr,cols=(2,4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,4))
- │         └── cost: 10724.72
+ │         └── cost: 10924.92
  ├── G3: (filters G8 G9)
  ├── G4: (index-join G10 pqr,cols=(2,4))
  │    └── []
  │         ├── best: (index-join G10 pqr,cols=(2,4))
- │         └── cost: 84.50
+ │         └── cost: 84.70
  ├── G5: (filters G9)
  ├── G6: (index-join G11 pqr,cols=(2,4))
  │    └── []
  │         ├── best: (index-join G11 pqr,cols=(2,4))
- │         └── cost: 7134.04
+ │         └── cost: 7154.04
  ├── G7: (filters G8)
  ├── G8: (eq G12 G13)
  ├── G9: (eq G14 G15)
@@ -4531,15 +4533,41 @@ memo (optimized, ~11KB, required=[presentation: q:2,s:4])
  ├── G14: (variable s)
  └── G15: (const 'foo')
 
-# Zigzag with implicit equality column in addition to primary key:
-# indexes on (r,s) and (t,s) should be chosen even though s is not being fixed
-# in the ON clause.
-opt
+# A zig-zag join cannot be planned on rs and ts because s is nullable, so it
+# cannot be an implicit equality column.
+opt expect-not=GenerateZigzagJoins
 SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 ----
-inner-join (zigzag pqr@rs pqr@ts)
+select
  ├── columns: r:3!null t:5!null
- ├── eq columns: [4 1] = [4 1]
+ ├── fd: ()-->(3,5)
+ ├── index-join pqr
+ │    ├── columns: r:3 t:5
+ │    ├── fd: ()-->(5)
+ │    └── scan pqr@ts
+ │         ├── columns: p:1!null t:5!null
+ │         ├── constraint: /5/4/1: [/'foo' - /'foo']
+ │         ├── key: (1)
+ │         └── fd: ()-->(5)
+ └── filters
+      └── r:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+
+exec-ddl
+CREATE INDEX ru ON pqr (r, u)
+----
+
+exec-ddl
+CREATE INDEX tu ON pqr (t, u)
+----
+
+# A zig-zag join can be planned on ru and tu because u is non-nullable, so it
+# is an implicit equality column in addition to the primary key.
+opt expect=GenerateZigzagJoins
+SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
+----
+inner-join (zigzag pqr@ru pqr@tu)
+ ├── columns: r:3!null t:5!null
+ ├── eq columns: [6 1] = [6 1]
  ├── left fixed columns: [3] = [1]
  ├── right fixed columns: [5] = ['foo']
  ├── fd: ()-->(3,5)
@@ -4547,51 +4575,40 @@ inner-join (zigzag pqr@rs pqr@ts)
       ├── r:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
       └── t:5 = 'foo' [outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
 
-memo
-SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
+exec-ddl
+DROP INDEX ru
 ----
-memo (optimized, ~13KB, required=[presentation: r:3,t:5])
- ├── G1: (select G2 G3) (select G4 G5) (select G6 G5) (select G7 G8) (zigzag-join G3 pqr@rs pqr@ts)
- │    └── [presentation: r:3,t:5]
- │         ├── best: (zigzag-join G3 pqr@rs pqr@ts)
- │         └── cost: 11.96
- ├── G2: (scan pqr,cols=(3,5))
- │    └── []
- │         ├── best: (scan pqr,cols=(3,5))
- │         └── cost: 10724.72
- ├── G3: (filters G9 G10)
- ├── G4: (index-join G11 pqr,cols=(3,5))
- │    └── []
- │         ├── best: (index-join G11 pqr,cols=(3,5))
- │         └── cost: 725.04
- ├── G5: (filters G10)
- ├── G6: (index-join G12 pqr,cols=(3,5))
- │    └── []
- │         ├── best: (index-join G12 pqr,cols=(3,5))
- │         └── cost: 726.04
- ├── G7: (index-join G13 pqr,cols=(3,5))
- │    └── []
- │         ├── best: (index-join G13 pqr,cols=(3,5))
- │         └── cost: 84.60
- ├── G8: (filters G9)
- ├── G9: (eq G14 G15)
- ├── G10: (eq G16 G17)
- ├── G11: (scan pqr@r,cols=(1,3),constrained)
- │    └── []
- │         ├── best: (scan pqr@r,cols=(1,3),constrained)
- │         └── cost: 118.02
- ├── G12: (scan pqr@rs,cols=(1,3),constrained)
- │    └── []
- │         ├── best: (scan pqr@rs,cols=(1,3),constrained)
- │         └── cost: 119.02
- ├── G13: (scan pqr@ts,cols=(1,5),constrained)
- │    └── []
- │         ├── best: (scan pqr@ts,cols=(1,5),constrained)
- │         └── cost: 24.43
- ├── G14: (variable r)
- ├── G15: (const 1)
- ├── G16: (variable t)
- └── G17: (const 'foo')
+
+exec-ddl
+DROP INDEX tu
+----
+
+exec-ddl
+CREATE INDEX tv ON pqr (t, v)
+----
+
+# A zig-zag join can be planned on rs and tv even though s and v are nullable
+# because they are explicit equality columns. The query filters out rows where s
+# IS NULL or v IS NULL.
+opt expect=GenerateZigzagJoins
+SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo' AND s = v
+----
+project
+ ├── columns: r:3!null t:5!null
+ ├── fd: ()-->(3,5)
+ └── inner-join (zigzag pqr@rs pqr@tv)
+      ├── columns: r:3!null s:4!null t:5!null v:7!null
+      ├── eq columns: [4 1] = [7 1]
+      ├── left fixed columns: [3] = [1]
+      ├── right fixed columns: [5] = ['foo']
+      ├── fd: ()-->(3,5), (4)==(7), (7)==(4)
+      └── filters
+           ├── r:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+           └── t:5 = 'foo' [outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
+
+exec-ddl
+DROP INDEX tv
+----
 
 # Zigzag with choice between indexes for multiple equality predicates.
 opt
@@ -4960,27 +4977,27 @@ memo (optimized, ~31KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G2: (scan pqr,cols=(1-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(1-4))
- │         └── cost: 10924.92
+ │         └── cost: 11125.12
  ├── G3: (filters G14 G15 G16)
  ├── G4: (index-join G17 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G17 pqr,cols=(1-4))
- │         └── cost: 84.60
+ │         └── cost: 84.80
  ├── G5: (filters G15 G16)
  ├── G6: (index-join G18 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G18 pqr,cols=(1-4))
- │         └── cost: 726.04
+ │         └── cost: 728.04
  ├── G7: (filters G14 G16)
  ├── G8: (index-join G19 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G19 pqr,cols=(1-4))
- │         └── cost: 1144.77
+ │         └── cost: 1144.97
  ├── G9: (filters G14)
  ├── G10: (index-join G20 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G20 pqr,cols=(1-4))
- │         └── cost: 85.34
+ │         └── cost: 85.54
  ├── G11: (zigzag-join G21 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G21 pqr@q pqr@r)
@@ -5048,21 +5065,21 @@ memo (optimized, ~9KB, required=[presentation: q:2,t:5])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: q:2,t:5]
  │         ├── best: (select G4 G5)
- │         └── cost: 84.63
+ │         └── cost: 84.83
  ├── G2: (scan pqr,cols=(2,5))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,5))
- │         └── cost: 10724.72
+ │         └── cost: 10924.92
  ├── G3: (filters G8 G9)
  ├── G4: (index-join G10 pqr,cols=(2,5))
  │    └── []
  │         ├── best: (index-join G10 pqr,cols=(2,5))
- │         └── cost: 84.50
+ │         └── cost: 84.70
  ├── G5: (filters G9)
  ├── G6: (index-join G11 pqr,cols=(2,5))
  │    └── []
  │         ├── best: (index-join G11 pqr,cols=(2,5))
- │         └── cost: 84.60
+ │         └── cost: 84.80
  ├── G7: (filters G8)
  ├── G8: (eq G12 G13)
  ├── G9: (eq G14 G15)


### PR DESCRIPTION
Backport 1/1 commits from #71758.

/cc @cockroachdb/release

---

Zig-zag joins are no longer planned with implicit equality columns that
are nullable. For example:

    CREATE TABLE t (
        k INT PRIMARY KEY,
        a INT,
        b INT,
        c INT,
        d INT NOT NULL,
        INDEX ac (a, c),
        INDEX bc (b, c),
        INDEX ad (a, d),
        INDEX bd (b, d)
    )

    SELECT k FROM t WHERE a = 1 AND b = 2

Prior to this commit, the optimizer would generate a zig-zag join using
indexes `ac` and `bc`, with `a` and `b` as fixed columns and `c` and `k`
as implicit equality columns. This zig-zag join incorrectly discards any
rows where the value of `c` is `NULL` because `NULL != NULL`.

Now the optimizer only generates a zig-zag join if the implicit equality
columns are non-nullable. In the example above a zig-zag join using `ad`
and `bd` can be generated with `d` and `k` as implicit equality columns
because they are guaranteed to not contain `NULL` values.

Fixes #71655

Release note (bug fix): A bug has been fixed which caused incorrect
results for some queries that utilized a zig-zag join. The bug could
only reproduce on tables with at least two multi-column indexes with
nullable columns. The bug was present since version 19.2.0.
