### PR TITLE
release-21.1: sql,jobs: fix de-interleaving ALTER PRIMARY KEY revert, revert-failed in mixed version

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1404,8 +1404,9 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	return nil
 }
 
-// If this mutation is a primary key swap and the old index had an
-// interleaved parent, remove the backreference from the parent.
+// If this mutation is a primary key swap that is not being rolled back,
+// and the old index had an interleaved parent, remove the backreference
+// from the parent.
 func maybeRemoveInterleaveBackreference(
 	ctx context.Context,
 	txn *kv.Txn,
@@ -1414,6 +1415,9 @@ func maybeRemoveInterleaveBackreference(
 	scTable *tabledesc.Mutable,
 	writeFunc func(ctx context.Context, ancestor *tabledesc.Mutable) error,
 ) error {
+	if mutation.Direction != descpb.DescriptorMutation_ADD {
+		return nil
+	}
 	pkSwap := mutation.GetPrimaryKeySwap()
 	if pkSwap == nil {
 		return nil

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1230,10 +1230,12 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							}
 							col.ColumnDesc().DefaultExpr = lcSwap.NewRegionalByRowColumnDefaultExpr
 						}
+
 					} else {
 						// DROP is hit on cancellation, in which case we must roll back.
 						localityConfigToSwapTo = lcSwap.OldLocalityConfig
 					}
+
 					if err := setNewLocalityConfig(
 						ctx, scTable, txn, b, localityConfigToSwapTo, kvTrace, descsCol); err != nil {
 						return err
@@ -1252,45 +1254,18 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					}
 				}
 
-				// If any old index had an interleaved parent, remove the
-				// backreference from the parent.
-				// N.B. This logic needs to be kept up to date with the
-				// corresponding piece in runSchemaChangesInTxn.
-				for _, idxID := range append(
-					[]descpb.IndexID{pkSwap.OldPrimaryIndexId}, pkSwap.OldIndexes...) {
-					oldIndex, err := scTable.FindIndexWithID(idxID)
-					if err != nil {
-						return err
-					}
-					if oldIndex.NumInterleaveAncestors() != 0 {
-						ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
-						ancestor, err := descsCol.GetMutableTableVersionByID(ctx, ancestorInfo.TableID, txn)
-						if err != nil {
-							return err
-						}
-						ancestorIdxI, err := ancestor.FindIndexWithID(ancestorInfo.IndexID)
-						if err != nil {
-							return err
-						}
-						ancestorIdx := ancestorIdxI.IndexDesc()
-						foundAncestor := false
-						for k, ref := range ancestorIdx.InterleavedBy {
-							if ref.Table == scTable.ID && ref.Index == oldIndex.GetID() {
-								if foundAncestor {
-									return errors.AssertionFailedf(
-										"ancestor entry in %s for %s@%s found more than once",
-										ancestor.Name, scTable.Name, oldIndex.GetName())
-								}
-								ancestorIdx.InterleavedBy = append(
-									ancestorIdx.InterleavedBy[:k], ancestorIdx.InterleavedBy[k+1:]...)
-								foundAncestor = true
-								if err := descsCol.WriteDescToBatch(ctx, kvTrace, ancestor, b); err != nil {
-									return err
-								}
-							}
-						}
-					}
+				if err := maybeRemoveInterleaveBackreference(ctx, txn, descsCol, &mutation, scTable, func(
+					ctx context.Context, ancestor *tabledesc.Mutable,
+				) error {
+					return descsCol.WriteDescToBatch(ctx, kvTrace, ancestor, b)
+				}); err != nil {
+					return err
+					// If any old index had an interleaved parent, remove the
+					// backreference from the parent.
+					// N.B. This logic needs to be kept up to date with the
+					// corresponding piece in runSchemaChangesInTxn.
 				}
+
 				// If we performed MakeMutationComplete on a PrimaryKeySwap mutation, then we need to start
 				// a job for the index deletion mutations that the primary key swap mutation added, if any.
 				if err := sc.queueCleanupJobs(ctx, scTable, txn); err != nil {
@@ -1426,6 +1401,58 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		return errors.Wrap(err, "A dependent transaction failed for this schema change")
 	}
 
+	return nil
+}
+
+// If this mutation is a primary key swap and the old index had an
+// interleaved parent, remove the backreference from the parent.
+func maybeRemoveInterleaveBackreference(
+	ctx context.Context,
+	txn *kv.Txn,
+	descsCol *descs.Collection,
+	mutation *descpb.DescriptorMutation,
+	scTable *tabledesc.Mutable,
+	writeFunc func(ctx context.Context, ancestor *tabledesc.Mutable) error,
+) error {
+	pkSwap := mutation.GetPrimaryKeySwap()
+	if pkSwap == nil {
+		return nil
+	}
+	for _, idxID := range append(
+		[]descpb.IndexID{pkSwap.OldPrimaryIndexId}, pkSwap.OldIndexes...) {
+		oldIndex, err := scTable.FindIndexWithID(idxID)
+		if err != nil {
+			return err
+		}
+		if oldIndex.NumInterleaveAncestors() != 0 {
+			ancestorInfo := oldIndex.GetInterleaveAncestor(oldIndex.NumInterleaveAncestors() - 1)
+			ancestor, err := descsCol.GetMutableTableVersionByID(ctx, ancestorInfo.TableID, txn)
+			if err != nil {
+				return err
+			}
+			ancestorIdxI, err := ancestor.FindIndexWithID(ancestorInfo.IndexID)
+			if err != nil {
+				return err
+			}
+			ancestorIdx := ancestorIdxI.IndexDesc()
+			foundAncestor := false
+			for k, ref := range ancestorIdx.InterleavedBy {
+				if ref.Table == scTable.ID && ref.Index == oldIndex.GetID() {
+					if foundAncestor {
+						return errors.AssertionFailedf(
+							"ancestor entry in %s for %s@%s found more than once",
+							ancestor.Name, scTable.Name, oldIndex.GetName())
+					}
+					ancestorIdx.InterleavedBy = append(
+						ancestorIdx.InterleavedBy[:k], ancestorIdx.InterleavedBy[k+1:]...)
+					foundAncestor = true
+					if err := writeFunc(ctx, ancestor); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Backport 2/3 commits from #71780.

/cc @cockroachdb/release

---

The first commit fixes an important, but incidentally discovered problem in jobs when in the mixed version state. The second commit refactors the code to make the fix in the third commit more obvious. The third commit fixes the bug. 

**sql: fix reverting de-interleaving primary key swap**

We should only remove the backreference in the forward direction.

Release justification: this makes reverting `ALTER PRIMARY KEY` possible for interleaved tables.

Release note (bug fix): Fixed a bug which prevented rollback of ALTER PRIMARY
KEY when the old primary key was interleaved.
