### PR TITLE
*: format BUILD.bazel files using buildifier

### DIFF
--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -1,23 +1,23 @@
 # stringer lets us define the equivalent of `//go:generate stringer` files
 # within bazel sandbox.
 def stringer(src, typ, name):
-   native.genrule(
-      name = name,
-      srcs = [src], # Accessed below using `$<`.
-      outs = [typ.lower() + "_string.go"],
-      # golang.org/x/tools executes commands via
-      # golang.org/x/sys/execabs which requires all PATH lookups to
-      # result in absolute paths. To account for this, we resolve the
-      # relative path returned by location to an absolute path.
-      cmd = """
+    native.genrule(
+        name = name,
+        srcs = [src],  # Accessed below using `$<`.
+        outs = [typ.lower() + "_string.go"],
+        # golang.org/x/tools executes commands via
+        # golang.org/x/sys/execabs which requires all PATH lookups to
+        # result in absolute paths. To account for this, we resolve the
+        # relative path returned by location to an absolute path.
+        cmd = """
          GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
          GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
          # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
          env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
          $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
       """.format(typ),
-      tools = [
-         "@go_sdk//:bin/go",
-         "@org_golang_x_tools//cmd/stringer",
-       ],
-   )
+        tools = [
+            "@go_sdk//:bin/go",
+            "@org_golang_x_tools//cmd/stringer",
+        ],
+    )

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -30,7 +30,8 @@ _gen_script = rule(
         "test": attr.label(mandatory = True),
         "_template": attr.label(
             default = "@cockroach//build/bazelutil:lint.sh.in",
-            allow_single_file = True)
+            allow_single_file = True,
+        ),
     },
 )
 

--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -1,9 +1,15 @@
-load("//build/toolchains:dev/darwin-x86_64/toolchain.bzl",
-     _dev_darwin_x86_repo = "dev_darwin_x86_repo")
-load("//build/toolchains:crosstool-ng/toolchain.bzl",
-     _crosstool_toolchain_repo = "crosstool_toolchain_repo")
-load("//build/toolchains:darwin-x86_64/toolchain.bzl",
-     _macos_toolchain_repo = "macos_toolchain_repo")
+load(
+    "//build/toolchains:dev/darwin-x86_64/toolchain.bzl",
+    _dev_darwin_x86_repo = "dev_darwin_x86_repo",
+)
+load(
+    "//build/toolchains:crosstool-ng/toolchain.bzl",
+    _crosstool_toolchain_repo = "crosstool_toolchain_repo",
+)
+load(
+    "//build/toolchains:darwin-x86_64/toolchain.bzl",
+    _macos_toolchain_repo = "macos_toolchain_repo",
+)
 
 def toolchain_dependencies():
     _dev_darwin_x86_repo(name = "toolchain_dev_darwin_x86-64")

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -2,7 +2,8 @@ def _impl(rctx):
     rctx.download_and_extract(
         url = [
             "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/20210601-231954/{}.tar.gz".format(
-                rctx.attr.target),
+                rctx.attr.target,
+            ),
         ],
         sha256 = rctx.attr.tarball_sha256,
         stripPrefix = "x-tools/{}/".format(rctx.attr.target),
@@ -10,19 +11,23 @@ def _impl(rctx):
 
     repo_path = str(rctx.path(""))
 
-    rctx.template("BUILD",
-                  Label("@cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
-                  substitutions = {
-                      "%{target}": rctx.attr.target,
-                  },
-                  executable = False)
-    rctx.template("cc_toolchain_config.bzl",
-                  Label("@cockroach//build:toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl"),
-                  substitutions = {
-                      "%{target}": rctx.attr.target,
-                      "%{repo_path}": repo_path,
-                  },
-                  executable = False)
+    rctx.template(
+        "BUILD",
+        Label("@cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
+        substitutions = {
+            "%{target}": rctx.attr.target,
+        },
+        executable = False,
+    )
+    rctx.template(
+        "cc_toolchain_config.bzl",
+        Label("@cockroach//build:toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl"),
+        substitutions = {
+            "%{target}": rctx.attr.target,
+            "%{repo_path}": repo_path,
+        },
+        executable = False,
+    )
 
 crosstool_toolchain_repo = repository_rule(
     implementation = _impl,

--- a/build/toolchains/darwin-x86_64/toolchain.bzl
+++ b/build/toolchains/darwin-x86_64/toolchain.bzl
@@ -9,15 +9,19 @@ def _impl(rctx):
 
     repo_path = str(rctx.path(""))
 
-    rctx.template("BUILD",
-                  Label("@cockroach//build:toolchains/darwin-x86_64/BUILD.tmpl"),
-                  executable = False)
-    rctx.template("cc_toolchain_config.bzl",
-                  Label("@cockroach//build:toolchains/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
-                  substitutions = {
-                      "%{repo_path}": repo_path,
-                  },
-                  executable = False)
+    rctx.template(
+        "BUILD",
+        Label("@cockroach//build:toolchains/darwin-x86_64/BUILD.tmpl"),
+        executable = False,
+    )
+    rctx.template(
+        "cc_toolchain_config.bzl",
+        Label("@cockroach//build:toolchains/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
+        substitutions = {
+            "%{repo_path}": repo_path,
+        },
+        executable = False,
+    )
 
 macos_toolchain_repo = repository_rule(
     implementation = _impl,

--- a/build/toolchains/dev/darwin-x86_64/toolchain.bzl
+++ b/build/toolchains/dev/darwin-x86_64/toolchain.bzl
@@ -3,7 +3,9 @@ def _impl(rctx):
     result = rctx.execute(["/usr/bin/xcodebuild", "-version"])
     if result.return_code:
         fail("XCode appears to not be installed: Got stdout {0}, stderr {1}".format(
-            result.stdout, result.stderr))
+            result.stdout,
+            result.stderr,
+        ))
 
     rctx.download_and_extract(
         url = [
@@ -17,20 +19,26 @@ def _impl(rctx):
     result = rctx.execute(["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"])
     if result.return_code:
         fail("Could not find path to macOS SDK: Got stdout {0}, stderr {1}".format(
-            result.stdout, result.stderr))
+            result.stdout,
+            result.stderr,
+        ))
     sdk_path = result.stdout.strip()
     repo_path = str(rctx.path(""))
 
-    rctx.template("BUILD",
-                  Label("@cockroach//build:toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64"),
-                  executable = False)
-    rctx.template("cc_toolchain_config.bzl",
-                  Label("@cockroach//build:toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
-                  substitutions = {
-                      "%{repo_path}": repo_path,
-                      "%{sdk_path}": sdk_path,
-                  },
-                  executable = False)
+    rctx.template(
+        "BUILD",
+        Label("@cockroach//build:toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64"),
+        executable = False,
+    )
+    rctx.template(
+        "cc_toolchain_config.bzl",
+        Label("@cockroach//build:toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
+        substitutions = {
+            "%{repo_path}": repo_path,
+            "%{sdk_path}": sdk_path,
+        },
+        executable = False,
+    )
 
 dev_darwin_x86_repo = repository_rule(
     implementation = _impl,

--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -1,6 +1,6 @@
 # Generating the code for `sort_partitioner.eg.go` requires special handling
 # because the template lives in a subpackage.
-def gen_sort_partitioner_rule(name, target, visibility=["//visibility:private"]):
+def gen_sort_partitioner_rule(name, target, visibility = ["//visibility:private"]):
     native.genrule(
         name = name,
         srcs = ["//pkg/sql/colexec/colexecbase:distinct_tmpl.go"],

--- a/pkg/sql/colexecop/EXECGEN.bzl
+++ b/pkg/sql/colexecop/EXECGEN.bzl
@@ -8,7 +8,7 @@
 def eg_go_filegroup(name, targets):
     native.filegroup(
         name = name,
-        srcs = [':{}'.format(rule_name_for(target)) for target, _ in targets],
+        srcs = [":{}".format(rule_name_for(target)) for target, _ in targets],
     )
 
 # Define gen rules for individual eg.go files.
@@ -51,4 +51,4 @@ def gen_eg_go_rules(targets):
 
 def rule_name_for(target):
     # e.g. 'vec_comparators.eg.go' -> 'gen-vec-comparators'
-    return 'gen-{}'.format(target.replace('.eg.go', '').replace('_', '-'))
+    return "gen-{}".format(target.replace(".eg.go", "").replace("_", "-"))

--- a/pkg/ui/workspaces/db-console/src/js/defs.bzl
+++ b/pkg/ui/workspaces/db-console/src/js/defs.bzl
@@ -32,7 +32,7 @@ _PROTOBUFJS_CLI_DEPS = ["@npm//%s" % s for s in [
 
 def _proto_sources_impl(ctx):
     return DefaultInfo(files = depset(
-      transitive = [p[ProtoInfo].transitive_sources for p in ctx.attr.protos]
+        transitive = [p[ProtoInfo].transitive_sources for p in ctx.attr.protos],
     ))
 
 _proto_sources = rule(
@@ -76,7 +76,7 @@ def protobufjs_library(name, out_name, protos, **kwargs):
         args = [
             "--target=static-module",
             "--wrap=es6",
-            "--strict-long",   # Force usage of Long type with int64 fields
+            "--strict-long",  # Force usage of Long type with int64 fields
             "--keep-case",
             "--out=$@",
             "$(execpaths %s)" % proto_target,

--- a/pkg/util/fsm/gen/REPORTS.bzl
+++ b/pkg/util/fsm/gen/REPORTS.bzl
@@ -1,9 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "go_library", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "go_binary", "go_library")
 
 def _gen_template_impl(ctx):
     archive = ctx.attr.dep[GoArchive]
     importpath = archive.data.importpath
-    basepkg = importpath.split('/')[-1]
+    basepkg = importpath.split("/")[-1]
     ctx.actions.expand_template(
         template = ctx.file._template,
         output = ctx.outputs.write_reports,
@@ -35,7 +35,7 @@ def gen_reports(name, dep, transitions_variable, starting_state_name):
         name = template_name,
         dep = dep,
         transitions_variable = transitions_variable,
-        starting_state_name = starting_state_name
+        starting_state_name = starting_state_name,
     )
     go_library(
         name = template_name + "_lib",
@@ -53,7 +53,10 @@ def gen_reports(name, dep, transitions_variable, starting_state_name):
     native.genrule(
         name = name,
         cmd = "$(location :{template_name}_bin) $(location {lower}_diagram.gv) $(location {lower}_report.txt) 'bazel build {name}'".format(
-            template_name=template_name, lower=lower, name=name),
+            template_name = template_name,
+            lower = lower,
+            name = name,
+        ),
         outs = [
             lower + "_diagram.gv",
             lower + "_report.txt",

--- a/pkg/util/interval/generic/gen.bzl
+++ b/pkg/util/interval/generic/gen.bzl
@@ -16,5 +16,5 @@ def gen_interval_btree(name, type, package):
         $$SCRIPT_LOC {type} {package}
         mv {src_out} $(location {src_out})
         mv {test_out} $(location {test_out})
-""".format(type=type, package=package, src_out=src_out, test_out=test_out)
+""".format(type = type, package = package, src_out = src_out, test_out = test_out),
     )


### PR DESCRIPTION
It's the gofmt for BUILD files; from github.com/bazelbuild/buildtools.
Probably worth including in CI at some point.

Release note: None