### PR TITLE
dev: add Lint/ prefix to lint test filter

### DIFF
--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -54,7 +54,7 @@ func (d *dev) lint(cmd *cobra.Command, _ []string) error {
 		args = append(args, "-test.timeout", timeout.String())
 	}
 	if filter != "" {
-		args = append(args, "-test.run", filter)
+		args = append(args, "-test.run", fmt.Sprintf("Lint/%s", filter))
 	}
 
 	logCommand("bazel", args...)


### PR DESCRIPTION
Currently, the documented command

    dev lint --filter=TestLowercaseFunctionNames --short --timeout=1m

doesn't run any tests.  This is because all of the lint tests are
prefixed with `TestLint`

Here I've added the same `Lint/` prefix we use in the Makefile, but we
could alternatively update the example instead if we don't want to
carry over this behaviour.