### PR TITLE
sql: match postgres for casting 0 to regtype/regproc/regnamespace/regtype

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -264,16 +264,16 @@ WHERE b.v = 'bar' AND a.c = 'foo'
 1  bar  1  foo
 
 query ITI
-SELECT i, i::"char", length(i::"char")
+SELECT i, i::"char"::bytea, length(i::"char")
 FROM (VALUES (32), (97), (127), (0), (-1), (-127), (-128)) v(i);
 ----
-32      1
-97   a  1
-127    1
-0    ¬∑  0
--1   ˇ	1	
--127	Å	1	
--128	Ä	1	
+32           1
+97    a      1
+127         1
+0     ¬∑      0
+-1    [255]  1
+-127  [129]  1
+-128  [128]  1
 
 statement error pgcode 22003 \"char\" out of range
 SELECT 128::"char";
@@ -285,3 +285,34 @@ query IFRB
 SELECT ' 1 '::int, ' 1.2 '::float, ' 2.3 '::decimal, ' true '::bool
 ----
 1  1.2  2.3  true
+
+query IOTOOOOOO
+SELECT i, i::oid, i::oid::text,
+  i::oid::regproc, i::oid::regprocedure, i::oid::regnamespace, i::oid::regclass, i::oid::regtype, i::oid::regrole
+FROM (VALUES (0), (1)) v(i)
+----
+0  0  0  -  -  -  -  -  -
+1  1  1  1  1  1  1  1  1
+
+query TOOOOOOOOOOOO
+SELECT i, i::regproc::oid, i::regprocedure::oid, i::regnamespace::oid, i::regtype::oid, i::regclass::oid, i::regrole::oid,
+  i::regproc, i::regprocedure, i::regnamespace, i::regtype, i::regclass, i::regrole
+FROM (VALUES ('-')) v(i)
+----
+-  0  0  0  0  0  0  -  -  -  -  -  -
+
+statement error invalid input syntax for type oid: "-"
+SELECT i, i::oid FROM (VALUES ('-')) v(i)
+
+statement error invalid input syntax for type oid: "-"
+SELECT '-'::oid
+
+query OOOOOOOOOOOO
+SELECT '-'::regclass, '-'::regclass::oid,
+  '-'::regproc, '-'::regproc::oid,
+  '-'::regprocedure, '-'::regprocedure::oid,
+  '-'::regnamespace, '-'::regnamespace::oid,
+  '-'::regtype, '-'::regtype::oid,
+  '-'::regrole, '-'::regrole::oid
+----
+-  0  -  0  -  0  -  0  -  0  -  0

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5043,6 +5043,10 @@ type DOidWrapper struct {
 	Oid     oid.Oid
 }
 
+// ZeroOidValue represents the 0 oid value as '-', which matches the Postgres
+// representation.
+const ZeroOidValue = "-"
+
 // wrapWithOid wraps a Datum with a custom Oid.
 func wrapWithOid(d Datum, oid oid.Oid) Datum {
 	switch v := d.(type) {
@@ -5064,6 +5068,16 @@ func wrapWithOid(d Datum, oid oid.Oid) Datum {
 		Wrapped: d,
 		Oid:     oid,
 	}
+}
+
+// wrapAsZeroOid wraps ZeroOidValue with a custom Oid.
+func wrapAsZeroOid(t *types.T) Datum {
+	tmpOid := NewDOid(0)
+	tmpOid.semanticType = t
+	if t.Oid() != oid.T_oid {
+		tmpOid.name = ZeroOidValue
+	}
+	return tmpOid
 }
 
 // UnwrapDatum returns the base Datum type for a provided datum, stripping


### PR DESCRIPTION
Fixes #67715 
 
Postgres outputs `-` for calls to
- `select 0::oid::regproc;`
- `select 0::oid::regprocedure;`
- `select 0::oid::regnamespace;`
- `select 0::oid::regclass;`
- `select 0::oid::regtype;`

CockroachDB outputs `0` instead.

In order to be compliant to Postgres behavior we need to change Cockroach to provide the same output for the above mentioned
scenarios.

For this we changed Datum to Format `DInts` as `-` for the special `0` scenario.
Additional tests where added to `cast` testdata and also a new `FakeEventPlanner`struct class was implemented to support the new test scenarios thus avoiding nil pointer exceptions during tests.

Release note: None