### PR TITLE
sql: fix nil access in ArrowToBatch

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -306,6 +306,10 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		vec := b.ColVec(i)
 		d := data[i]
 
+		if d == nil {
+			return nil
+		}
+
 		// Eagerly release our data references to make sure they can be collected
 		// as quickly as possible as we copy each (or simply reference each) by
 		// coldata.Vecs below.


### PR DESCRIPTION
Enable the BenchmarkArrowBatchConverter test to run.

Release note: None