### PR TITLE
metric: Add rules endpoint API.

### DIFF
--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "graphite_exporter.go",
         "metric.go",
         "prometheus_exporter.go",
+        "prometheus_rule_exporter.go",
         "registry.go",
         "rule.go",
         "rule_registry.go",
@@ -31,6 +32,7 @@ go_library(
         "@com_github_prometheus_prometheus//promql/parser",
         "@com_github_rcrowley_go_metrics//:go-metrics",
         "@com_github_vividcortex_ewma//:ewma",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
 
@@ -40,6 +42,7 @@ go_test(
     srcs = [
         "metric_test.go",
         "prometheus_exporter_test.go",
+        "prometheus_rule_exporter_test.go",
         "registry_test.go",
         "rule_test.go",
     ],

--- a/pkg/util/metric/prometheus_rule_exporter.go
+++ b/pkg/util/metric/prometheus_rule_exporter.go
@@ -1,0 +1,86 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metric
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	alertRuleGroupName     = "rules/alerts"
+	recordingRuleGroupName = "rules/recording"
+)
+
+// PrometheusRuleNode represents an individual rule node within the YAML output.
+type PrometheusRuleNode struct {
+	Record      string            `yaml:"record,omitempty"`
+	Alert       string            `yaml:"alert,omitempty"`
+	Expr        string            `yaml:"expr"`
+	For         string            `yaml:"for,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// PrometheusRuleGroup is a list of recording and alerting rules.
+type PrometheusRuleGroup struct {
+	Rules []PrometheusRuleNode `yaml:"rules"`
+}
+
+// PrometheusRuleExporter initializes recording and alert rules once from the registry.
+// These initialized values will be reused for every alert/rule scrapes.
+type PrometheusRuleExporter struct {
+	mu struct {
+		syncutil.Mutex
+		RuleGroups map[string]PrometheusRuleGroup
+	}
+}
+
+// NewPrometheusRuleExporter creates a new PrometheusRuleExporter.
+func NewPrometheusRuleExporter() *PrometheusRuleExporter {
+	var pe PrometheusRuleExporter
+	pe.mu.RuleGroups = make(map[string]PrometheusRuleGroup)
+	return &pe
+}
+
+// ScrapeRegistry scrapes the RuleRegistry to convert the list of registered rules
+// to Prometheus compatible rules.
+func (re *PrometheusRuleExporter) ScrapeRegistry(ctx context.Context, rr *RuleRegistry) {
+	re.mu.Lock()
+	defer re.mu.Unlock()
+	rr.Each(func(rule Rule) {
+		ruleGroupName, ruleNode := rule.ToPrometheusRuleNode()
+		if ruleGroupName != alertRuleGroupName && ruleGroupName != recordingRuleGroupName {
+			log.Warning(ctx, "invalid prometheus group name, skipping rule")
+			return
+		}
+		promRuleGroup := re.mu.RuleGroups[ruleGroupName]
+		promRuleGroup.Rules = append(promRuleGroup.Rules, ruleNode)
+		re.mu.RuleGroups[ruleGroupName] = promRuleGroup
+	})
+}
+
+// PrintAsYAMLText returns the rules within PrometheusRuleExporter
+// as YAML text.
+// TODO(rimadeodhar): Pipe through the help field as comments
+// in the exported YAML.
+func (re *PrometheusRuleExporter) PrintAsYAMLText() (string, error) {
+	re.mu.Lock()
+	defer re.mu.Unlock()
+	output, err := yaml.Marshal(re.mu.RuleGroups)
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}

--- a/pkg/util/metric/prometheus_rule_exporter_test.go
+++ b/pkg/util/metric/prometheus_rule_exporter_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metric
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrometheusRuleExporter tests that the PrometheusRuleExporter
+// generates valid YAML output for a given set of alerting and
+// aggregation rules.
+func TestPrometheusRuleExporter(t *testing.T) {
+	ctx := context.Background()
+	rules, expectedYAMLText := getRulesAndExpectedYAML(t)
+	registry := NewRuleRegistry()
+	registry.AddRules(rules)
+	ruleExporter := NewPrometheusRuleExporter()
+	ruleExporter.ScrapeRegistry(ctx, registry)
+	yamlText, err := ruleExporter.PrintAsYAMLText()
+	require.NoError(t, err)
+	require.Equal(t, expectedYAMLText, yamlText)
+}
+
+func getRulesAndExpectedYAML(t *testing.T) (rules []Rule, expectedYAML string) {
+	aggRule, err := NewAggregationRule("test_aggregation_rule_1", "sum without(store) (capacity_available)", nil, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules = append(rules, aggRule)
+	var annotations []LabelPair
+	description := "description"
+	value := "{{ $labels.instance }} for cluster {{ $labels.cluster }} has\n been down for more than 15 minutes."
+	annotation := LabelPair{
+		Name:  &description,
+		Value: &value,
+	}
+	annotations = append(annotations, annotation)
+	alertRule, err := NewAlertingRule("test_alert_rule", "resets(sys_uptime[10m]) > 0 and resets(sys_uptime[10m]) < 5", annotations, nil, time.Minute, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules = append(rules, alertRule)
+	expectedYAML = "rules/alerts:\n    rules:\n        - alert: test_alert_rule\n          " +
+		"expr: resets(sys_uptime[10m]) > 0 and resets(sys_uptime[10m]) < 5\n          for: 1m0s\n          " +
+		"annotations:\n            description: |-\n                {{ $labels.instance }} for " +
+		"cluster {{ $labels.cluster }} has\n                 been down for more than 15 minutes.\nrules/recording:" +
+		"\n    rules:\n        - record: test_aggregation_rule_1\n          expr: sum without(store) (capacity_available)\n"
+
+	return rules, expectedYAML
+}

--- a/pkg/util/metric/rule_registry.go
+++ b/pkg/util/metric/rule_registry.go
@@ -28,9 +28,25 @@ func NewRuleRegistry() *RuleRegistry {
 	}
 }
 
-// AddRule adds a rule to the registry
+// AddRule adds a rule to the registry.
 func (r *RuleRegistry) AddRule(rule Rule) {
 	r.Lock()
 	defer r.Unlock()
 	r.rules = append(r.rules, rule)
+}
+
+// AddRules adds multiple rules to the registry.
+func (r *RuleRegistry) AddRules(rules []Rule) {
+	r.Lock()
+	defer r.Unlock()
+	r.rules = append(r.rules, rules...)
+}
+
+// Each calls the given closure for all rules.
+func (r *RuleRegistry) Each(f func(rule Rule)) {
+	r.Lock()
+	defer r.Unlock()
+	for _, currentRule := range r.rules {
+		f(currentRule)
+	}
 }


### PR DESCRIPTION
In this PR, the API to consume the defined rules and convert
them to YAML has been implemented. The endpoint API uses the
rule registry to build a list of alert and recording rules
and exports them in YAML format.

Release note: None

Resolves: [69798](https://github.com/cockroachdb/cockroach/issues/69798)