### PR TITLE
cli: deflake TestRemoveDeadReplicas

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -132,7 +132,6 @@ func TestOpenReadOnlyStore(t *testing.T) {
 
 func TestRemoveDeadReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 71789, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// This test is pretty slow under race (200+ cpu-seconds) because it

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -88,6 +88,8 @@ func isErrRetryLiveness(ctx context.Context, err error) bool {
 		// returned an AmbiguousResultError.
 		// TODO(andrei): Remove this in 22.2.
 		return true
+	} else if errors.Is(err, kv.OnePCNotAllowedError{}) {
+		return true
 	}
 	return false
 }

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
@@ -1059,67 +1060,75 @@ func TestNodeLivenessRetryAmbiguousResultOnCreateError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var injectError atomic.Value
-	type injectErrorData struct {
-		shouldError bool
-		count       int32
+	errorsToTest := []error{
+		roachpb.NewAmbiguousResultError("test"),
+		roachpb.NewTransactionStatusError(roachpb.TransactionStatusError_REASON_UNKNOWN, "foo"),
+		kv.OnePCNotAllowedError{},
 	}
 
-	injectError.Store(map[roachpb.NodeID]injectErrorData{
-		roachpb.NodeID(1): {true, 0},
-		roachpb.NodeID(2): {true, 0},
-		roachpb.NodeID(3): {true, 0},
-	})
-	testingEvalFilter := func(args kvserverbase.FilterArgs) *roachpb.Error {
-		if req, ok := args.Req.(*roachpb.ConditionalPutRequest); ok {
-			if val := injectError.Load(); val != nil {
-				var liveness livenesspb.Liveness
-				if err := req.Value.GetProto(&liveness); err != nil {
-					return nil
-				}
-				injectErrorMap := val.(map[roachpb.NodeID]injectErrorData)
-				if injectErrorMap[liveness.NodeID].shouldError {
-					if liveness.NodeID != 1 {
-						// We expect this to come from the create code path on all nodes
-						// except the first. Make sure that is actually true.
-						assert.Equal(t, liveness.Epoch, int64(0))
+	for _, errorToTest := range errorsToTest {
+		var injectError atomic.Value
+		type injectErrorData struct {
+			shouldError bool
+			count       int32
+		}
+
+		injectError.Store(map[roachpb.NodeID]injectErrorData{
+			roachpb.NodeID(1): {true, 0},
+			roachpb.NodeID(2): {true, 0},
+			roachpb.NodeID(3): {true, 0},
+		})
+		testingEvalFilter := func(args kvserverbase.FilterArgs) *roachpb.Error {
+			if req, ok := args.Req.(*roachpb.ConditionalPutRequest); ok {
+				if val := injectError.Load(); val != nil {
+					var liveness livenesspb.Liveness
+					if err := req.Value.GetProto(&liveness); err != nil {
+						return nil
 					}
-					injectErrorMap[liveness.NodeID] = injectErrorData{false, injectErrorMap[liveness.NodeID].count + 1}
-					injectError.Store(injectErrorMap)
-					return roachpb.NewError(roachpb.NewAmbiguousResultError("test"))
+					injectErrorMap := val.(map[roachpb.NodeID]injectErrorData)
+					if injectErrorMap[liveness.NodeID].shouldError {
+						if liveness.NodeID != 1 {
+							// We expect this to come from the create code path on all nodes
+							// except the first. Make sure that is actually true.
+							assert.Equal(t, liveness.Epoch, int64(0))
+						}
+						injectErrorMap[liveness.NodeID] = injectErrorData{false, injectErrorMap[liveness.NodeID].count + 1}
+						injectError.Store(injectErrorMap)
+						return roachpb.NewError(errorToTest)
+					}
 				}
 			}
+			return nil
 		}
-		return nil
-	}
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 3,
-		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-			ServerArgs: base.TestServerArgs{
-				Knobs: base.TestingKnobs{
-					Store: &kvserver.StoreTestingKnobs{
-						EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
-							TestingEvalFilter: testingEvalFilter,
+		ctx := context.Background()
+		tc := testcluster.StartTestCluster(t, 3,
+			base.TestClusterArgs{
+				ReplicationMode: base.ReplicationManual,
+				ServerArgs: base.TestServerArgs{
+					Knobs: base.TestingKnobs{
+						Store: &kvserver.StoreTestingKnobs{
+							EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+								TestingEvalFilter: testingEvalFilter,
+							},
 						},
 					},
 				},
-			},
-		})
-	defer tc.Stopper().Stop(ctx)
+			})
+		defer tc.Stopper().Stop(ctx)
 
-	for _, s := range tc.Servers {
-		// Verify retry of the ambiguous result for heartbeat loop.
-		testutils.SucceedsSoon(t, func() error {
-			return verifyLivenessServer(s, 3)
-		})
-		nl := s.NodeLiveness().(*liveness.NodeLiveness)
-		_, ok := nl.Self()
-		assert.True(t, ok)
+		for _, s := range tc.Servers {
+			// Verify retry of the ambiguous result for heartbeat loop.
+			testutils.SucceedsSoon(t, func() error {
+				return verifyLivenessServer(s, 3)
+			})
+			nl := s.NodeLiveness().(*liveness.NodeLiveness)
+			_, ok := nl.Self()
+			assert.True(t, ok)
 
-		injectErrorMap := injectError.Load().(map[roachpb.NodeID]injectErrorData)
-		assert.NotNil(t, injectErrorMap)
-		assert.Equal(t, int32(1), injectErrorMap[s.NodeID()].count)
+			injectErrorMap := injectError.Load().(map[roachpb.NodeID]injectErrorData)
+			assert.NotNil(t, injectErrorMap)
+			assert.Equal(t, int32(1), injectErrorMap[s.NodeID()].count)
+		}
 	}
 }
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1637,3 +1637,13 @@ func (txn *Txn) AdmissionHeader() roachpb.AdmissionHeader {
 	}
 	return h
 }
+
+// OnePCNotAllowedError signifies that a request had the Require1PC flag set,
+// but 1PC evaluation was not possible for one reason or another.
+type OnePCNotAllowedError struct{}
+
+var _ error = OnePCNotAllowedError{}
+
+func (OnePCNotAllowedError) Error() string {
+	return "could not commit in one phase as requested"
+}


### PR DESCRIPTION
Fixes #71789
In 69501 we introduced retry logic to the creation of liveness records.
This logic only retries certain errors and was not covering the condition
when we encounter OnePCNotAllowedError. This PR moves OnePCNotAllowedError
to the kv package to avoid duplicate loops ands adds it to the list of
retryable errors for liveness creation and updates.

Release note: none