### PR TITLE
dev: fix support for `--rewrite` tests

### DIFF
--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -176,5 +176,20 @@ bazel info workspace --color=no
 ----
 go/src/github.com/cockroachdb/cockroach
 
-bazel test //pkg/testutils:testutils_test --run_under 'cd go/src/github.com/cockroachdb/cockroach/pkg/testutils && ' --test_env=YOU_ARE_IN_THE_WORKSPACE=1 --test_arg -rewrite --test_output errors
+bazel test //pkg/testutils:testutils_test --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --test_output errors
+----
+
+bazel query 'kind(go_test, //pkg/testutils:all)'
+----
+//pkg/testutils:testutils_test
+
+bazel query 'kind(go_test, //pkg/other/test:all)'
+----
+//pkg/other/test:test_test
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+bazel test //pkg/testutils:testutils_test //pkg/other/test:test_test --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/other/test --test_output errors
 ----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -61,4 +61,11 @@ dev test //pkg/testutils --rewrite
 ----
 bazel query 'kind(go_test, //pkg/testutils:all)'
 bazel info workspace --color=no
-bazel test //pkg/testutils:testutils_test --run_under 'cd go/src/github.com/cockroachdb/cockroach/pkg/testutils && ' --test_env=YOU_ARE_IN_THE_WORKSPACE=1 --test_arg -rewrite --test_output errors
+bazel test //pkg/testutils:testutils_test --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --test_output errors
+
+dev test //pkg/testutils pkg/other/test --rewrite
+----
+bazel query 'kind(go_test, //pkg/testutils:all)'
+bazel query 'kind(go_test, //pkg/other/test:all)'
+bazel info workspace --color=no
+bazel test //pkg/testutils:testutils_test //pkg/other/test:test_test --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/other/test --test_output errors

--- a/pkg/spanconfig/spanconfigstore/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigstore/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/roachpb:with-mocks",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigtestutils",
+        "//pkg/testutils",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/datadriven"
@@ -47,7 +48,7 @@ func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
 		store := New(spanconfigtestutils.ParseConfig(t, "FALLBACK"))
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var (

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/security",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
+        "//pkg/util/envutil",
         "//pkg/util/fileutil",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/testutils/data_path.go
+++ b/pkg/testutils/data_path.go
@@ -11,12 +11,12 @@
 package testutils
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +29,12 @@ func TestDataPath(t testing.TB, relative ...string) string {
 	relative = append([]string{"testdata"}, relative...)
 	// dev notifies the library that the test is running in a subdirectory of the
 	// workspace with the environment variable below.
-	if bazel.BuiltWithBazel() && os.Getenv("YOU_ARE_IN_THE_WORKSPACE") != "" {
+	if bazel.BuiltWithBazel() {
+		//lint:ignore SA4006 apparently a linter bug.
+		cockroachWorkspace, set := envutil.EnvString("COCKROACH_WORKSPACE", 0)
+		if set {
+			return path.Join(cockroachWorkspace, bazel.RelativeTestTargetPath(), path.Join(relative...))
+		}
 		runfiles, err := bazel.RunfilesPath()
 		require.NoError(t, err)
 		return path.Join(runfiles, bazel.RelativeTestTargetPath(), path.Join(relative...))


### PR DESCRIPTION
The `--run_under 'cd $DIR && '` trick didn't work, so instead we inject
the path to the workspace via an environment variable and set the
sandbox writable paths accordingly.

Also update `pkg/spanconfig/spanconfigstore` test to use the
Bazel-friendly utils for finding `testdata`.

Closes #69570.

Release note: None