### PR TITLE
backup/restore: Remove dependencies on defaultdb and postgres for full cluster destore

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -181,11 +181,14 @@ CREATE TABLE data2.foo (a int);
 	// Check that zones are restored during pre-restore.
 	t.Run("ensure zones are restored during pre-restore", func(t *testing.T) {
 		<-restoredZones
-		checkZones := "SELECT * FROM system.zones"
+		// Not specifying the schema makes the query search using defaultdb first.
+		// which ends up returning the error
+		// pq: database "defaultdb" is offline: restoring
+		checkZones := "SELECT * FROM system.public.zones"
 		sqlDBRestore.CheckQueryResults(t, checkZones, sqlDB.QueryStr(t, checkZones))
 
 		// Check that the user tables are still offline.
-		sqlDBRestore.ExpectErr(t, "database \"data\" is offline: restoring", "SELECT * FROM data.bank")
+		sqlDBRestore.ExpectErr(t, "database \"data\" is offline: restoring", "SELECT * FROM data.public.bank")
 
 		// Check there is no data in the span that we expect user data to be imported.
 		store := tcRestore.GetFirstStoreFromServer(t, 0)
@@ -610,7 +613,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 		// Note that the system tables here correspond to the temporary tables
 		// imported, not the system tables themselves.
 		sqlDBRestore.CheckQueryResults(t,
-			`SELECT name FROM crdb_internal.tables WHERE state = 'DROP' ORDER BY name`,
+			`SELECT name FROM system.crdb_internal.tables WHERE state = 'DROP' ORDER BY name`,
 			[][]string{
 				{"bank"},
 				{"comments"},
@@ -700,7 +703,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 		// Note that the system tables here correspond to the temporary tables
 		// imported, not the system tables themselves.
 		sqlDBRestore.CheckQueryResults(t,
-			`SELECT name FROM crdb_internal.tables WHERE state = 'DROP' ORDER BY name`,
+			`SELECT name FROM system.crdb_internal.tables WHERE state = 'DROP' ORDER BY name`,
 			[][]string{
 				{"bank"},
 				{"comments"},
@@ -1028,4 +1031,76 @@ BACKUP TO 'nodelocal://1/foo' WITH revision_history;
 CREATE TABLE bar (id INT);
 BACKUP TO 'nodelocal://1/foo' WITH revision_history;
 `)
+}
+
+func TestRestoreWithRecreatedDefaultDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	sqlDB.Exec(t, `
+DROP DATABASE defaultdb;
+CREATE DATABASE defaultdb; 
+`)
+	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+
+	sqlDBRestore.Exec(t, `RESTORE FROM $1`, LocalFoo)
+
+	// Since we dropped and recreated defaultdb, defaultdb has the next available
+	// id which is 52.
+	expectedDefaultDBID := "52"
+
+	sqlDBRestore.CheckQueryResults(t, `SELECT * FROM system.namespace WHERE name = 'defaultdb'`, [][]string{
+		{"0", "0", "defaultdb", expectedDefaultDBID},
+	})
+}
+
+func TestRestoreWithDroppedDefaultDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	sqlDB.Exec(t, `
+DROP DATABASE defaultdb;
+`)
+	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+
+	sqlDBRestore.Exec(t, `RESTORE FROM $1`, LocalFoo)
+
+	sqlDBRestore.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'defaultdb'`, [][]string{
+		{"0"},
+	})
+}
+
+func TestRestoreToClusterWithDroppedDefaultDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupFn()
+	defer cleanupEmptyCluster()
+
+	expectedRow := sqlDB.QueryRow(t, `SELECT * FROM system.namespace WHERE name = 'defaultdb'`)
+	var parentID, parentSchemaID, ID int
+	var name string
+	expectedRow.Scan(&parentID, &parentSchemaID, &name, &ID)
+
+	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+
+	sqlDBRestore.Exec(t, `
+DROP DATABASE defaultdb;
+`)
+	sqlDBRestore.Exec(t, `RESTORE FROM $1`, LocalFoo)
+	sqlDBRestore.CheckQueryResults(t, `SELECT * FROM system.namespace WHERE name = 'defaultdb'`, [][]string{
+		{fmt.Sprint(parentID), fmt.Sprint(parentSchemaID), name, fmt.Sprint(ID)},
+	})
 }

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -143,10 +143,12 @@ func expectedSCJobCount(scName string, isClusterRestore, after bool) int {
 		numBackgroundSCJobs = 1
 	}
 
+	// We drop defaultdb and postgres for full cluster restores
+	numBackgroundDropDatabaseSCJobs := 2
 	// Since we're doing a cluster restore, we need to account for all of
 	// the schema change jobs that existed in the backup.
 	if isClusterRestore {
-		expNumSCJobs += numBackgroundSCJobs
+		expNumSCJobs += numBackgroundSCJobs + numBackgroundDropDatabaseSCJobs
 
 		// If we're performing a cluster restore, we also need to include the drop
 		// crdb_temp_system job.

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
@@ -264,19 +265,12 @@ func maybeFilterMissingViews(
 }
 
 func synthesizePGTempSchema(
-	ctx context.Context, p sql.PlanHookState, schemaName string,
-) (descpb.ID, descpb.ID, error) {
+	ctx context.Context, p sql.PlanHookState, schemaName string, dbID descpb.ID,
+) (descpb.ID, error) {
 	var synthesizedSchemaID descpb.ID
-	var defaultDBID descpb.ID
 	err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
-		defaultDBID, err = lookupDatabaseID(ctx, txn, p.ExecCfg().Codec,
-			catalogkeys.DefaultDatabaseName)
-		if err != nil {
-			return err
-		}
-
-		sKey := catalogkeys.NewNameKeyComponents(defaultDBID, keys.RootNamespaceID, schemaName)
+		sKey := catalogkeys.NewNameKeyComponents(dbID, keys.RootNamespaceID, schemaName)
 		schemaID, err := catalogkv.GetDescriptorID(ctx, txn, p.ExecCfg().Codec, sKey)
 		if err != nil {
 			return err
@@ -292,15 +286,7 @@ func synthesizePGTempSchema(
 		return p.CreateSchemaNamespaceEntry(ctx, catalogkeys.EncodeNameKey(p.ExecCfg().Codec, sKey), synthesizedSchemaID)
 	})
 
-	return synthesizedSchemaID, defaultDBID, err
-}
-
-// dbSchemaKey is used when generating fake pg_temp schemas for the purpose of
-// restoring temporary objects. Detailed comments can be found where it is being
-// used.
-type dbSchemaKey struct {
-	parentID descpb.ID
-	schemaID descpb.ID
+	return synthesizedSchemaID, err
 }
 
 // allocateDescriptorRewrites determines the new ID and parentID (a "DescriptorRewrite")
@@ -481,26 +467,17 @@ func allocateDescriptorRewrites(
 		// represented as a descriptor and thus is not picked up during a full
 		// cluster BACKUP.
 		// To overcome this orphaned schema pointer problem, when restoring a
-		// temporary object we create a "fake" pg_temp schema in defaultdb and add
-		// it to the namespace table. We then remap the temporary object descriptors
-		// to point to this schema. This allows us to piggy back on the temporary
+		// temporary object we create a "fake" pg_temp schema in temp table's db and
+		// add it to the namespace table.
+		// We then remap the temporary object descriptors to point to this schema.
+		// This allows us to piggy back on the temporary
 		// reconciliation job which looks for "pg_temp" schemas linked to temporary
 		// sessions and properly cleans up the temporary objects in it.
-		haveSynthesizedTempSchema := make(map[dbSchemaKey]bool)
-		var defaultDBID descpb.ID
+		haveSynthesizedTempSchema := make(map[descpb.ID]bool)
 		var synthesizedTempSchemaCount int
 		for _, table := range tablesByID {
 			if table.IsTemporary() {
-				// We generate a "fake" temporary schema for every unique
-				// <dbID,schemaID> tuple of the backed-up temporary table descriptors.
-				// This is important because post rewrite all the "fake" schemas and
-				// consequently temp table objects are going to be in defaultdb. Placing
-				// them under different "fake" schemas prevents name collisions if the
-				// backed up tables had the same names but were in different temp
-				// schemas/databases in the cluster which was backed up.
-				dbSchemaIDKey := dbSchemaKey{parentID: table.GetParentID(),
-					schemaID: table.GetParentSchemaID()}
-				if _, ok := haveSynthesizedTempSchema[dbSchemaIDKey]; !ok {
+				if _, ok := haveSynthesizedTempSchema[table.GetParentSchemaID()]; !ok {
 					var synthesizedSchemaID descpb.ID
 					var err error
 					// NB: TemporarySchemaNameForRestorePrefix is a special value that has
@@ -514,7 +491,7 @@ func allocateDescriptorRewrites(
 					// which the cluster was started.
 					schemaName := sql.TemporarySchemaNameForRestorePrefix +
 						strconv.Itoa(synthesizedTempSchemaCount)
-					synthesizedSchemaID, defaultDBID, err = synthesizePGTempSchema(ctx, p, schemaName)
+					synthesizedSchemaID, err = synthesizePGTempSchema(ctx, p, schemaName, table.GetParentID())
 					if err != nil {
 						return nil, err
 					}
@@ -523,13 +500,9 @@ func allocateDescriptorRewrites(
 					// specific pg_temp schema to point to this synthesized schema when we
 					// are performing the table rewrites.
 					descriptorRewrites[table.GetParentSchemaID()] = &jobspb.RestoreDetails_DescriptorRewrite{ID: synthesizedSchemaID}
-					haveSynthesizedTempSchema[dbSchemaIDKey] = true
+					haveSynthesizedTempSchema[table.GetParentSchemaID()] = true
 					synthesizedTempSchemaCount++
 				}
-
-				// Remap the temp table descriptors to belong to the defaultdb where we
-				// have synthesized the temp schema.
-				descriptorRewrites[table.GetID()] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: defaultDBID}
 			}
 		}
 	}
@@ -888,6 +861,25 @@ func allocateDescriptorRewrites(
 	return descriptorRewrites, nil
 }
 
+// If we're doing a full cluster restore - to treat defaultdb and postgres
+// as regular databases, we drop them before restoring them again in the
+// restore.
+func dropDefaultUserDBs(ctx context.Context, execCfg *sql.ExecutorConfig) error {
+	return sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		ie := execCfg.InternalExecutor
+		_, err := ie.Exec(ctx, "drop-defaultdb", nil, "DROP DATABASE IF EXISTS defaultdb")
+		if err != nil {
+			return err
+		}
+
+		_, err = ie.Exec(ctx, "drop-postgres", nil, "DROP DATABASE IF EXISTS postgres")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 func resolveTargetDB(
 	ctx context.Context,
 	txn *kv.Txn,
@@ -901,27 +893,12 @@ func resolveTargetDB(
 		return intoDB, nil
 	}
 
-	if descriptorCoverage == tree.AllDescriptors && descriptor.GetParentID() < catalogkeys.MaxDefaultDescriptorID {
-		// This is a table that is in a database that already existed at
-		// cluster creation time.
-		defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.DefaultDatabaseName)
-		if err != nil {
-			return "", err
-		}
-		postgresDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec, catalogkeys.PgDatabaseName)
-		if err != nil {
-			return "", err
-		}
-
+	if descriptorCoverage == tree.AllDescriptors && descriptor.GetParentID() < keys.MaxReservedDescID {
 		var targetDB string
 		if descriptor.GetParentID() == systemschema.SystemDB.GetID() {
 			// For full cluster backups, put the system tables in the temporary
 			// system table.
 			targetDB = restoreTempSystemDB
-		} else if descriptor.GetParentID() == defaultDBID {
-			targetDB = catalogkeys.DefaultDatabaseName
-		} else if descriptor.GetParentID() == postgresDBID {
-			targetDB = catalogkeys.PgDatabaseName
 		}
 		return targetDB, nil
 	}
@@ -1882,6 +1859,7 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
+
 	sqlDescs = append(sqlDescs, newTypeDescs...)
 
 	if err := maybeUpgradeDescriptors(ctx, sqlDescs, restoreStmt.Options.SkipMissingFKs); err != nil {
@@ -1960,6 +1938,17 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
+
+	// When running a full cluster restore, we drop the defaultdb and postgres
+	// databases that are present in a new cluster.
+	// This is done so that they can be restored the same way any other user
+	// defined database would be restored from the backup.
+	if restoreStmt.DescriptorCoverage == tree.AllDescriptors {
+		if err := dropDefaultUserDBs(ctx, p.ExecCfg()); err != nil {
+			return err
+		}
+	}
+
 	descriptorRewrites, err := allocateDescriptorRewrites(
 		ctx,
 		p,

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -123,6 +123,10 @@ exec-sql
 SET CLUSTER SETTING sql.defaults.primary_region = 'eu-north-1';
 RESTORE FROM 'nodelocal://1/no_region_cluster_backup/';
 ----
+NOTICE: setting the PRIMARY REGION as eu-north-1 on database defaultdb
+HINT: to change the default primary region, use SET CLUSTER SETTING sql.defaults.primary_region = 'region' or use RESET CLUSTER SETTING sql.defaults.primary_region to disable this behavior
+NOTICE: setting the PRIMARY REGION as eu-north-1 on database postgres
+HINT: to change the default primary region, use SET CLUSTER SETTING sql.defaults.primary_region = 'region' or use RESET CLUSTER SETTING sql.defaults.primary_region to disable this behavior
 NOTICE: setting the PRIMARY REGION as eu-north-1 on database no_region_db
 HINT: to change the default primary region, use SET CLUSTER SETTING sql.defaults.primary_region = 'region' or use RESET CLUSTER SETTING sql.defaults.primary_region to disable this behavior
 NOTICE: setting the PRIMARY REGION as eu-north-1 on database no_region_db_2
@@ -131,10 +135,10 @@ HINT: to change the default primary region, use SET CLUSTER SETTING sql.defaults
 query-sql
 SHOW DATABASES;
 ----
-defaultdb root <nil> {} <nil>
+defaultdb root eu-north-1 {eu-north-1} zone
 no_region_db root eu-north-1 {eu-north-1} zone
 no_region_db_2 root eu-north-1 {eu-north-1} zone
-postgres root <nil> {} <nil>
+postgres root eu-north-1 {eu-north-1} zone
 system node <nil> {} <nil>
 
 query-sql
@@ -151,9 +155,9 @@ RESTORE DATABASE eu_central_db FROM 'nodelocal://1/eu_central_database_backup/';
 query-sql
 SHOW DATABASES;
 ----
-defaultdb root <nil> {} <nil>
+defaultdb root eu-north-1 {eu-north-1} zone
 eu_central_db root eu-central-1 {eu-central-1} zone
 no_region_db root eu-north-1 {eu-north-1} zone
 no_region_db_2 root eu-north-1 {eu-north-1} zone
-postgres root <nil> {} <nil>
+postgres root eu-north-1 {eu-north-1} zone
 system node <nil> {} <nil>

--- a/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
+++ b/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
@@ -105,21 +105,9 @@ USE defaultdb;
 RESTORE FROM 'nodelocal://0/full_cluster_backup/';
 ----
 
-# The pg_temp schema from the BACKUP should not show up after restoration.
+# The pg_temp schema from the BACKUP should show up in its original database.
 query-sql
 USE d1;
-SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
-----
-crdb_internal
-information_schema
-pg_catalog
-pg_extension
-public
-
-
-# We should see a synthesized pg_temp schema.
-query-sql
-USE defaultdb;
 SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
 ----
 crdb_internal
@@ -129,18 +117,23 @@ pg_extension
 pg_temp_0_0
 public
 
-# On full cluster restore we remap the temp tables to defaultdb so we should not
-# see them in the restored db.
+
+query-sql
+USE defaultdb;
+SELECT schema_name FROM [SHOW SCHEMAS] ORDER BY schema_name
+----
+crdb_internal
+information_schema
+pg_catalog
+pg_extension
+public
+
+# On full cluster restore we restore temp tables to its original database.
 query-sql
 USE d1;
 SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
 ----
 perm_table
-
-query-sql
-USE defaultdb;
-SELECT table_name FROM [SHOW TABLES] ORDER BY table_name
-----
 temp_seq
 temp_table
 

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -33,14 +33,13 @@ const (
 )
 
 // DefaultUserDBs is a set of the databases which are present in a new cluster.
-var DefaultUserDBs = map[string]struct{}{
-	DefaultDatabaseName: {},
-	PgDatabaseName:      {},
+var DefaultUserDBs = []string{
+	DefaultDatabaseName, PgDatabaseName,
 }
 
 // MaxDefaultDescriptorID is the maximum ID of a descriptor that exists in a
 // new cluster.
-var MaxDefaultDescriptorID = keys.MaxReservedDescID + descpb.ID(len(DefaultUserDBs))
+var MaxDefaultDescriptorID = descpb.ID(keys.MaxReservedDescID) + descpb.ID(len(DefaultUserDBs))
 
 // IsDefaultCreatedDescriptor returns whether or not a given descriptor ID is
 // present at the time of starting a cluster.


### PR DESCRIPTION
Previously we hardcoded some cases where defaultdb and postgres were
assumed to be present during the full cluster restore.

With this change, we make it so we treat defaultdb/postgres to be
regular databases for restore - they are dropped before the restore
happens.

Additionally pg_temp_schemas are now restored to their original
parent db and not defaultdb.

Release note (bulkio): temporary tables are now restored to their
original database instead of defaultdb during a full cluster restore.

Resolve https://github.com/cockroachdb/cockroach/issues/71479