### PR TITLE
sql: add a cluster setting to avoid system config triggers

### DIFF
--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -25,6 +26,21 @@ import (
 )
 
 var errTwoVersionInvariantViolated = errors.Errorf("two version invariant violated")
+
+// UnsafeSkipSystemConfigTrigger will prevent setting the system config
+// trigger for transactions which write to tables in the system config. The
+// implication of setting this to true is that various subsystems which
+// rely on that trigger, such as zone configs and replication reports, will
+// not work. This can be used to accelerate high-frequency schema changes
+// like during an ORM test suite.
+var UnsafeSkipSystemConfigTrigger = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"sql.catalog.unsafe_skip_system_config_trigger.enabled",
+	"avoid setting the system config trigger in transactions which write to "+
+		"the system config. This will unlock performance at the cost of breaking "+
+		"table splits, zone configuration propagation, and cluster settings",
+	false,
+)
 
 // Txn enables callers to run transactions with a *Collection such that all
 // retrieved immutable descriptors are properly leased and all mutable
@@ -78,8 +94,10 @@ func (cf *CollectionFactory) Txn(
 			deletedDescs = nil
 			descsCol = cf.MakeCollection(nil)
 			defer descsCol.ReleaseAll(ctx)
-			if err := txn.SetSystemConfigTrigger(cf.leaseMgr.Codec().ForSystemTenant()); err != nil {
-				return err
+			if !UnsafeSkipSystemConfigTrigger.Get(&cf.settings.SV) {
+				if err := txn.SetSystemConfigTrigger(cf.leaseMgr.Codec().ForSystemTenant()); err != nil {
+					return err
+				}
 			}
 			if err := f(ctx, txn, &descsCol); err != nil {
 				return err

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -73,8 +73,10 @@ func deleteDatabaseZoneConfig(
 		return nil
 	}
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		if err := txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
-			return err
+		if !descs.UnsafeSkipSystemConfigTrigger.Get(&settings.SV) {
+			if err := txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
+				return err
+			}
 		}
 		b := &kv.Batch{}
 

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -73,7 +73,9 @@ func gcTables(
 		}
 
 		// Finished deleting all the table data, now delete the table meta data.
-		if err := sql.DeleteTableDescAndZoneConfig(ctx, execCfg.DB, execCfg.Codec, table); err != nil {
+		if err := sql.DeleteTableDescAndZoneConfig(
+			ctx, execCfg.DB, execCfg.Settings, execCfg.Codec, table,
+		); err != nil {
 			return errors.Wrapf(err, "dropping table descriptor for table %d", table.GetID())
 		}
 

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/lexbase",
         "//pkg/sql/mutations",
         "//pkg/sql/opt",

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -540,7 +541,8 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 // Mark transaction as operating on the system DB if the descriptor id
 // is within the SystemConfig range.
 func (p *planner) maybeSetSystemConfig(id descpb.ID) error {
-	if !descpb.IsSystemConfigID(id) {
+	if !descpb.IsSystemConfigID(id) ||
+		descs.UnsafeSkipSystemConfigTrigger.Get(&p.EvalContext().Settings.SV) {
 		return nil
 	}
 	// Mark transaction as operating on the system DB.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -658,7 +658,9 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 		} else {
 			// We've dropped a non-physical table, no need for a GC job, let's delete
 			// its descriptor and zone config immediately.
-			if err := DeleteTableDescAndZoneConfig(ctx, sc.db, sc.execCfg.Codec, tableDesc); err != nil {
+			if err := DeleteTableDescAndZoneConfig(
+				ctx, sc.db, sc.settings, sc.execCfg.Codec, tableDesc,
+			); err != nil {
 				return err
 			}
 		}
@@ -2463,12 +2465,18 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 
 // DeleteTableDescAndZoneConfig removes a table's descriptor and zone config from the KV database.
 func DeleteTableDescAndZoneConfig(
-	ctx context.Context, db *kv.DB, codec keys.SQLCodec, tableDesc catalog.TableDescriptor,
+	ctx context.Context,
+	db *kv.DB,
+	settings *cluster.Settings,
+	codec keys.SQLCodec,
+	tableDesc catalog.TableDescriptor,
 ) error {
 	log.Infof(ctx, "removing table descriptor and zone config for table %d", tableDesc.GetID())
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		if err := txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
-			return err
+		if !descs.UnsafeSkipSystemConfigTrigger.Get(&settings.SV) {
+			if err := txn.SetSystemConfigTrigger(codec.ForSystemTenant()); err != nil {
+				return err
+			}
 		}
 		b := &kv.Batch{}
 


### PR DESCRIPTION
This is intended as a short-term workaround to improve performance in
situations of repeated schema changes, like ORM tests.

We have a plan to disable the system config trigger altogether in 22.1 with
#70560. 

This PR provides a cluster setting which allows schema change transactions
to bypass triggerring an update to the system config span. These updates
currently drive only the propagation of zone configs to KV and cluster
settings. The cluster setting behavior is retained until we address #70566.

We have a history of these sorts of unsafe settings in
`kv.raft_log.disable_synchronization_unsafe`.

Release note: None