### PR TITLE
roachtest: pass CRDB version to sequelize test

### DIFF
--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -140,7 +141,7 @@ func registerSequelize(r registry.Registry) {
 		// Version telemetry is already disabled in the sequelize-cockroachdb test suite.
 		t.Status("running Sequelize test suite")
 		rawResults, err := c.RunWithBuffer(ctx, t.L(), node,
-			`cd /mnt/data1/sequelize/ && npm test`,
+			fmt.Sprintf(`cd /mnt/data1/sequelize/ && CRDB_VERSION=%s npm test`, version),
 		)
 		rawResultsStr := string(rawResults)
 		t.L().Printf("Test Results: %s", rawResultsStr)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71903

The sequelize test suite needs to be told which version it's running
against.

Release note: None