### PR TITLE
.github: update CODEOWNERS for roachpb

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,9 +215,27 @@
 /pkg/migration/              @cockroachdb/kv-prs-noreview @cockroachdb/sql-schema
 /pkg/multitenant             @cockroachdb/unowned
 /pkg/release/                @cockroachdb/dev-inf
-/pkg/roachpb/                @cockroachdb/kv-prs
+/pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
+/pkg/roachpb/api*            @cockroachdb/kv-prs
+/pkg/roachpb/batch*          @cockroachdb/kv-prs
+/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview
+/pkg/roachpb/data*           @cockroachdb/kv-prs
+/pkg/roachpb/dep_test.go     @cockroachdb/dev-inf
+/pkg/roachpb/error*          @cockroachdb/kv-prs
+/pkg/roachpb/gen             @cockroachdb/dev-inf
 /pkg/roachpb/app*            @cockroachdb/sql-observability
 /pkg/roachpb/index*          @cockroachdb/sql-observability
+/pkg/roachpb/internal*       @cockroachdb/kv-prs
+/pkg/roachpb/io-formats*     @cockroachdb/bulk-io
+/pkg/roachpb/main_test.go    @cockroachdb/kv-prs-noreview
+/pkg/roachpb/merge_spans*    @cockroachdb/kv-prs
+/pkg/roachpb/metadata*       @cockroachdb/kv-prs
+/pkg/roachpb/method*         @cockroachdb/kv-prs
+/pkg/roachpb/mocks*          @cockroachdb/kv-prs
+/pkg/roachpb/span*           @cockroachdb/kv-prs
+/pkg/roachpb/string_test.go  @cockroachdb/kv-prs
+/pkg/roachpb/tenant*         @cockroachdb/kv-prs
+/pkg/roachpb/version*        @cockroachdb/server
 /pkg/rpc/                    @cockroachdb/server-prs
 /pkg/scheduledjobs/          @cockroachdb/bulk-prs
 /pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec

--- a/pkg/internal/codeowners/lint.go
+++ b/pkg/internal/codeowners/lint.go
@@ -59,8 +59,8 @@ func LintEverythingIsOwned(
 	// - ./pkg/asd/generated.go
 	skip := map[string]struct{}{
 		filepath.Join("ccl", "ccl_init.go"): {},
-		filepath.Join("ui", "node_modules"): {},
-		filepath.Join("ui", "yarn-vendor"):  {},
+		filepath.Join("node_modules"):       {},
+		filepath.Join("yarn-vendor"):        {},
 		"Makefile":                          {},
 		"BUILD.bazel":                       {},
 		".gitignore":                        {},


### PR DESCRIPTION
- codeowners: skip `node_modules` everywhere
- .github: tighten CODEOWNERS for roachpb

Release note: None
