### PR TITLE
release-21.1: backupccl: fix bug where cluster backups were exporting opt-out system tables

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -974,7 +974,7 @@ func backupPlanHook(
 		var revs []BackupManifest_DescriptorRevision
 		if mvccFilter == MVCCFilter_All {
 			priorIDs = make(map[descpb.ID]descpb.ID)
-			revs, err = getRelevantDescChanges(ctx, p.ExecCfg().Codec, p.ExecCfg().DB, startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.Coverage())
+			revs, err = getRelevantDescChanges(ctx, p.ExecCfg(), startTime, endTime, targetDescs, completeDBs, priorIDs, backupStmt.Coverage())
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8098,7 +8098,7 @@ func TestBackupWorkerFailure(t *testing.T) {
 // Regression test for #66797 ensuring that the span merging optimization
 // doesn't produce an error when there are span-merging opportunities on
 // descriptor revisions from before the GC threshold of the table.
-func TestSpanMergeingBeforeGCThreshold(t *testing.T) {
+func TestSpanMergingBeforeGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -992,3 +992,31 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 		destDB.ExpectErr(t, `relation "restoredb.bank" does not exist`, `SELECT count(*) FROM restoredb.bank`)
 	})
 }
+
+// TestClusterRevisionDoesNotBackupOptOutSystemTables is a regression test for a
+// bug that was introduced where we would include revisions for descriptors that
+// are not supposed to be backed up egs: system tables that are opted out.
+//
+// The test would previously fail with an error that the descriptors table (an
+// opt out system table) did not have a span covering the time between the
+// `EndTime` of the first backup and second backup, since there are no revisions
+// to it between those backups.
+func TestClusterRevisionDoesNotBackupOptOutSystemTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, tc, _, _, cleanup := BackupRestoreTestSetup(t, singleNode, 10, InitManualReplication)
+	conn := tc.Conns[0]
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+	defer cleanup()
+
+	sqlDB.Exec(t, `
+CREATE DATABASE test;
+USE test;
+CREATE TABLE foo (id INT);
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+CREATE TABLE bar (id INT);
+BACKUP TO 'nodelocal://1/foo' WITH revision_history;
+`)
+}

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -350,6 +352,49 @@ func GetSystemTablesToIncludeInClusterBackup() map[string]struct{} {
 	}
 
 	return systemTablesToInclude
+}
+
+// GetSystemTableIDsToExcludeFromClusterBackup returns a set of system table ids
+// that should be excluded from a cluster backup.
+func GetSystemTableIDsToExcludeFromClusterBackup(
+	ctx context.Context, execCfg *sql.ExecutorConfig,
+) (map[descpb.ID]struct{}, error) {
+	systemTableIDsToExclude := make(map[descpb.ID]struct{})
+	for systemTableName, backupConfig := range systemTableBackupConfiguration {
+		if backupConfig.shouldIncludeInClusterBackup == optOutOfClusterBackup {
+			// In versions >20.1, resolving the table ID for the
+			// DeprecatedNamespaceTable by name, returns the ID of the "new"
+			// NamespaceTable. This results in the systemTableIDsToExclude missing an
+			// entry for table ID 2 that corresponds to the DeprecatedNamespaceTable.
+			// We explicitly add an entry for this ID as a workaround.
+			if systemTableName == systemschema.DeprecatedNamespaceTable.GetName() {
+				systemTableIDsToExclude[systemschema.DeprecatedNamespaceTable.GetID()] = struct{}{}
+				continue
+			}
+			err := descs.Txn(ctx, execCfg.Settings, execCfg.LeaseManager, execCfg.InternalExecutor, execCfg.DB,
+				func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+					tn := tree.MakeTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(systemTableName))
+					found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
+					if err != nil {
+						return err
+					}
+					// Some system tables are not present when running inside a secondary
+					// tenant egs: `systemschema.TenantsTable`. In such situations we are
+					// print a warning and move on.
+					if !found {
+						log.Warningf(ctx, "could not find system table descriptor %s", systemTableName)
+						return nil
+					}
+					systemTableIDsToExclude[desc.ID] = struct{}{}
+					return nil
+				})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return systemTableIDsToExclude, nil
 }
 
 // getSystemTablesToRestoreBeforeData returns the set of system tables that

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -39,8 +39,7 @@ import (
 // a descriptor the ID by which it was previously known (e.g pre-TRUNCATE).
 func getRelevantDescChanges(
 	ctx context.Context,
-	codec keys.SQLCodec,
-	db *kv.DB,
+	execCfg *sql.ExecutorConfig,
 	startTime, endTime hlc.Timestamp,
 	descs []catalog.Descriptor,
 	expanded []descpb.ID,
@@ -48,7 +47,7 @@ func getRelevantDescChanges(
 	descriptorCoverage tree.DescriptorCoverage,
 ) ([]BackupManifest_DescriptorRevision, error) {
 
-	allChanges, err := getAllDescChanges(ctx, codec, db, startTime, endTime, priorIDs)
+	allChanges, err := getAllDescChanges(ctx, execCfg.Codec, execCfg.DB, startTime, endTime, priorIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +67,22 @@ func getRelevantDescChanges(
 	// point in the interval.
 	interestingIDs := make(map[descpb.ID]struct{}, len(descs))
 
+	systemTableIDsToExcludeFromBackup, err := GetSystemTableIDsToExcludeFromClusterBackup(ctx, execCfg)
+	if err != nil {
+		return nil, err
+	}
+	isExcludedDescriptor := func(id descpb.ID) bool {
+		if _, isOptOutSystemTable := systemTableIDsToExcludeFromBackup[id]; id == keys.SystemDatabaseID || isOptOutSystemTable {
+			return true
+		}
+		return false
+	}
+
 	isInterestingID := func(id descpb.ID) bool {
 		// We're interested in changes to all descriptors if we're targeting all
-		// descriptors except for the system database itself.
-		if descriptorCoverage == tree.AllDescriptors && id != keys.SystemDatabaseID {
+		// descriptors except for the descriptors that we do not include in a
+		// cluster backup.
+		if descriptorCoverage == tree.AllDescriptors && !isExcludedDescriptor(id) {
 			return true
 		}
 		// A change to an ID that we're interested in is obviously interesting.
@@ -103,7 +114,7 @@ func getRelevantDescChanges(
 	}
 
 	if !startTime.IsEmpty() {
-		starting, err := backupresolver.LoadAllDescs(ctx, codec, db, startTime)
+		starting, err := backupresolver.LoadAllDescs(ctx, execCfg.Codec, execCfg.DB, startTime)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #71288.

/cc @cockroachdb/release

---

This change fixes a bug that was introduced where we would include
revisions for descriptors that are not supposed to be backed up
egs: system tables that are opted out. This was introduced in
https://github.com/cockroachdb/cockroach/pull/68983 when we fixed
cluster backup to include dropped database descriptors.

The test would previously fail with an error that the descriptors table (an
opt out system table) did not have a span covering the time between the
`EndTime` of the first backup and second backup, since there are no revisions
to it between those backups.

Fixes: #71277

Release note (bug fix): Fix a bug where cluster backups were
backing up opt-out system tables unexpectedly.
