### PR TITLE
sql/catalog/nstree: optimize with lazy initialization, pooling btrees

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -53,8 +53,6 @@ func makeCollection(
 		hydratedTables: hydratedTables,
 		virtual:        makeVirtualDescriptors(virtualSchemas),
 		leased:         makeLeasedDescriptors(leaseMgr),
-		synthetic:      makeSyntheticDescriptors(),
-		uncommitted:    makeUncommittedDescriptors(),
 		kv:             makeKVDescriptors(codec),
 		temporary:      makeTemporaryDescriptors(codec, temporarySchemaProvider),
 	}

--- a/pkg/sql/catalog/descs/leased_descriptors.go
+++ b/pkg/sql/catalog/descs/leased_descriptors.go
@@ -64,8 +64,7 @@ func (m maxTimestampBoundDeadlineHolder) UpdateDeadline(
 
 func makeLeasedDescriptors(lm leaseManager) leasedDescriptors {
 	return leasedDescriptors{
-		lm:    lm,
-		cache: nstree.MakeMap(),
+		lm: lm,
 	}
 }
 

--- a/pkg/sql/catalog/descs/synthetic_descriptors.go
+++ b/pkg/sql/catalog/descs/synthetic_descriptors.go
@@ -20,10 +20,6 @@ type syntheticDescriptors struct {
 	descs nstree.Map
 }
 
-func makeSyntheticDescriptors() syntheticDescriptors {
-	return syntheticDescriptors{descs: nstree.MakeMap()}
-}
-
 func (sd *syntheticDescriptors) set(descs []catalog.Descriptor) {
 	sd.descs.Clear()
 	for _, desc := range descs {

--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -82,15 +82,6 @@ type uncommittedDescriptors struct {
 	descNames nstree.Set
 }
 
-func makeUncommittedDescriptors() uncommittedDescriptors {
-	ud := uncommittedDescriptors{
-		descs:     nstree.MakeMap(),
-		descNames: nstree.MakeSet(),
-	}
-	ud.reset()
-	return ud
-}
-
 func (ud *uncommittedDescriptors) reset() {
 	ud.descs.Clear()
 	ud.descNames.Clear()

--- a/pkg/sql/catalog/lease/name_cache.go
+++ b/pkg/sql/catalog/lease/name_cache.go
@@ -21,7 +21,7 @@ import (
 )
 
 func makeNameCache() nameCache {
-	return nameCache{descriptors: nstree.MakeMap()}
+	return nameCache{}
 }
 
 // nameCache is a cache of descriptor name -> latest version mappings.

--- a/pkg/sql/catalog/nstree/map.go
+++ b/pkg/sql/catalog/nstree/map.go
@@ -19,7 +19,8 @@ import (
 // Map is a lookup structure for descriptors. It is used to provide
 // indexed access to a set of entries either by name or by ID. The
 // entries' properties are indexed; they must not change or else the
-// index will be corrupted.
+// index will be corrupted. Safe for use without initialization. Calling
+// Clear will return memory to a sync.Pool.
 type Map struct {
 	byID   byIDMap
 	byName byNameMap
@@ -31,22 +32,10 @@ type Map struct {
 // stop but no error will be returned.
 type EntryIterator func(entry catalog.NameEntry) error
 
-// MakeMap makes a new Map.
-func MakeMap() Map {
-	const (
-		degree       = 8 // arbitrary
-		initialNodes = 2 // one per tree
-	)
-	freeList := btree.NewFreeList(initialNodes)
-	return Map{
-		byName: byNameMap{t: btree.NewWithFreeList(degree, freeList)},
-		byID:   byIDMap{t: btree.NewWithFreeList(degree, freeList)},
-	}
-}
-
 // Upsert adds the descriptor to the tree. If any descriptor exists in the
 // tree with the same name or id, it will be removed.
 func (dt *Map) Upsert(d catalog.NameEntry) {
+	dt.maybeInitialize()
 	if replaced := dt.byName.upsert(d); replaced != nil {
 		dt.byID.delete(replaced.GetID())
 	}
@@ -58,6 +47,7 @@ func (dt *Map) Upsert(d catalog.NameEntry) {
 // Remove removes the descriptor with the given ID from the tree and
 // returns it if it exists.
 func (dt *Map) Remove(id descpb.ID) catalog.NameEntry {
+	dt.maybeInitialize()
 	if d := dt.byID.delete(id); d != nil {
 		dt.byName.delete(d)
 		return d
@@ -67,26 +57,58 @@ func (dt *Map) Remove(id descpb.ID) catalog.NameEntry {
 
 // GetByID gets a descriptor from the tree by id.
 func (dt *Map) GetByID(id descpb.ID) catalog.NameEntry {
+	if !dt.initialized() {
+		return nil
+	}
 	return dt.byID.get(id)
 }
 
 // GetByName gets a descriptor from the tree by name.
 func (dt *Map) GetByName(parentID, parentSchemaID descpb.ID, name string) catalog.NameEntry {
+	if !dt.initialized() {
+		return nil
+	}
 	return dt.byName.getByName(parentID, parentSchemaID, name)
 }
 
-// Clear removes all entries.
+// Clear removes all entries, returning any held memory to the sync.Pool.
 func (dt *Map) Clear() {
+	if !dt.initialized() {
+		return
+	}
 	dt.byID.clear()
 	dt.byName.clear()
+	btreeSyncPool.Put(dt.byName.t)
+	btreeSyncPool.Put(dt.byID.t)
+	*dt = Map{}
 }
 
 // IterateByID iterates the descriptors by ID, ascending.
 func (dt *Map) IterateByID(f EntryIterator) error {
+	if !dt.initialized() {
+		return nil
+	}
 	return dt.byID.ascend(f)
 }
 
 // Len returns the number of descriptors in the tree.
 func (dt *Map) Len() int {
+	if !dt.initialized() {
+		return 0
+	}
 	return dt.byID.len()
+}
+
+func (dt Map) initialized() bool {
+	return dt != (Map{})
+}
+
+func (dt *Map) maybeInitialize() {
+	if dt.initialized() {
+		return
+	}
+	*dt = Map{
+		byName: byNameMap{t: btreeSyncPool.Get().(*btree.BTree)},
+		byID:   byIDMap{t: btreeSyncPool.Get().(*btree.BTree)},
+	}
 }

--- a/pkg/sql/catalog/nstree/map_test.go
+++ b/pkg/sql/catalog/nstree/map_test.go
@@ -53,14 +53,14 @@ import (
 //
 func TestMapDataDriven(t *testing.T) {
 	datadriven.Walk(t, "testdata/map", func(t *testing.T, path string) {
-		tr := MakeMap()
+		var tr Map
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-			return testMapDataDriven(t, d, tr)
+			return testMapDataDriven(t, d, &tr)
 		})
 	})
 }
 
-func testMapDataDriven(t *testing.T, d *datadriven.TestData, tr Map) string {
+func testMapDataDriven(t *testing.T, d *datadriven.TestData, tr *Map) string {
 	switch d.Cmd {
 	case "add":
 		a := parseArgs(t, d, argID|argName, argParentID|argParentSchemaID)

--- a/pkg/sql/catalog/nstree/set_test.go
+++ b/pkg/sql/catalog/nstree/set_test.go
@@ -36,14 +36,14 @@ import (
 //
 func TestSetDataDriven(t *testing.T) {
 	datadriven.Walk(t, "testdata/set", func(t *testing.T, path string) {
-		tr := MakeSet()
+		var tr Set
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-			return testSetDataDriven(t, d, tr)
+			return testSetDataDriven(t, d, &tr)
 		})
 	})
 }
 
-func testSetDataDriven(t *testing.T, d *datadriven.TestData, tr Set) string {
+func testSetDataDriven(t *testing.T, d *datadriven.TestData, tr *Set) string {
 	switch d.Cmd {
 	case "add":
 		a := parseArgs(t, d, argName, argParentID|argParentSchemaID)

--- a/pkg/sql/catalog/nstree/tree.go
+++ b/pkg/sql/catalog/nstree/tree.go
@@ -13,6 +13,8 @@
 package nstree
 
 import (
+	"sync"
+
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/google/btree"
 )
@@ -21,6 +23,15 @@ type item interface {
 	btree.Item
 	put()
 	value() interface{}
+}
+
+// degree is totally arbitrary, used for the btree.
+const degree = 8
+
+var btreeSyncPool = sync.Pool{
+	New: func() interface{} {
+		return btree.New(degree)
+	},
 }
 
 func upsert(t *btree.BTree, toUpsert item) interface{} {


### PR DESCRIPTION
This change comes in response to
https://github.com/cockroachdb/cockroach/pull/66112#issuecomment-950196996.

The thrust of the change is to lazily initialize the data structures so that
when they are not used, they do not incur cost. Additionally, pool the
underlying tree so that when they are used, the allocations are effectively
free. This was originally deemed unimportant because the connExecutor
descs.Collection is long-lived. Unfortunately, others, as used for the
type resolve in distsql, are not.

```
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-16       145µs ± 2%     139µs ± 3%   -3.94%  (p=0.000 n=19+20)
FlowSetup/vectorize=true/distribute=false-16      141µs ± 3%     134µs ± 2%   -4.66%  (p=0.000 n=18+19)
FlowSetup/vectorize=false/distribute=true-16      138µs ± 4%     132µs ± 4%   -4.23%  (p=0.000 n=20+20)
FlowSetup/vectorize=false/distribute=false-16     133µs ± 3%     127µs ± 3%   -4.41%  (p=0.000 n=20+19)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-16      38.1kB ± 3%    36.7kB ± 2%   -3.58%  (p=0.000 n=18+18)
FlowSetup/vectorize=true/distribute=false-16     36.2kB ± 0%    34.9kB ± 0%   -3.66%  (p=0.000 n=18+16)
FlowSetup/vectorize=false/distribute=true-16     42.6kB ± 0%    41.3kB ± 0%   -3.11%  (p=0.000 n=17+17)
FlowSetup/vectorize=false/distribute=false-16    41.0kB ± 0%    39.7kB ± 0%   -3.22%  (p=0.000 n=17+17)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-16         368 ± 0%       314 ± 0%  -14.67%  (p=0.000 n=16+17)
FlowSetup/vectorize=true/distribute=false-16        354 ± 0%       300 ± 0%  -15.25%  (p=0.000 n=17+17)
FlowSetup/vectorize=false/distribute=true-16        338 ± 1%       283 ± 1%  -16.13%  (p=0.000 n=19+19)
FlowSetup/vectorize=false/distribute=false-16       325 ± 0%       271 ± 0%  -16.62%  (p=0.000 n=18+18)
```

Omitting a release note because I'm doubtful this meaningfully shows up on its
own.

Release note: None