### PR TITLE
sql/catalog/lease: avoid rate limiting for lease queries

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed:with-mocks",
+        "//pkg/multitenant",
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/settings",


### PR DESCRIPTION
These queries use a single-flight and can block many requests. It seems
possible that there are starvation problems as we use leases in some paths
related to authentication and authorization.

Omitting release note for multi-tenant work.

Release note: None