### PR TITLE
release-21.1: clusterversion: add an assertion that binary version is latest

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -549,6 +549,15 @@ var (
 	binaryVersion = versionsSingleton[len(versionsSingleton)-1].Version
 )
 
+func init() {
+	const isReleaseBranch = true
+	if isReleaseBranch {
+		if binaryVersion != ByKey(V21_1) {
+			panic("unexpected cluster version greater than release's binary version")
+		}
+	}
+}
+
 // ByKey returns the roachpb.Version for a given key.
 // It is a fatal error to use an invalid key.
 func ByKey(key Key) roachpb.Version {


### PR DESCRIPTION
Backport 1/1 commits from #71625.

/cc @cockroachdb/release

---

This is intended to be flipped on and the release version updated when the cluster version mint
commit is backported to a release branch. Doing so would then prevent accidentally backporting
any future cluster versions without causing this to panic in all tests.

Release note: none.

Release justification: low risk (should never fire), high impact (prevent bugs).
