### PR TITLE
ui: use push instead of replace on browser history on SQL Activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/query/query.ts
@@ -68,6 +68,7 @@ export function getMatchParamByName(
 export function syncHistory(
   params: Record<string, string | undefined>,
   history: History,
+  push?: boolean,
 ): void {
   const nextSearchParams = new URLSearchParams(history.location.search);
 
@@ -80,10 +81,9 @@ export function syncHistory(
   });
 
   history.location.search = nextSearchParams.toString();
-  history.replace(history.location);
-}
-
-export function clearHistory(history: History): void {
-  history.location.search = "";
-  history.replace(history.location);
+  if (push) {
+    history.push(history.location);
+  } else {
+    history.replace(history.location);
+  }
 }

--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -11,7 +11,7 @@
 // All changes made on this file, should also be done on the equivalent
 // file on managed-service repo.
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Tabs } from "antd";
 import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import SessionsPageConnected from "src/views/sessions/sessionsPage";
@@ -23,13 +23,20 @@ const { TabPane } = Tabs;
 
 const SQLActivityPage = (props: RouteComponentProps) => {
   const defaultTab = util.queryByName(props.location, "tab") || "sessions";
-  const [currentTab, setCurrentTab] = React.useState(defaultTab);
+  const [currentTab, setCurrentTab] = useState(defaultTab);
 
   const onTabChange = (tabId: string): void => {
     setCurrentTab(tabId);
-    util.clearHistory(props.history);
-    util.syncHistory({ tab: tabId }, props.history);
+    props.history.location.search = "";
+    util.syncHistory({ tab: tabId }, props.history, true);
   };
+
+  useEffect(() => {
+    const queryTab = util.queryByName(props.location, "tab") || "sessions";
+    if (queryTab !== currentTab) {
+      setCurrentTab(queryTab);
+    }
+  }, [props.location, currentTab]);
 
   return (
     <div>


### PR DESCRIPTION
Previously, when changing tabs on SQL Activity page the history
would be replaced, this commits change to push to history, meaning
when the user clicks Back on the browser it will return for the
previous tab.

Release note: None