### PR TITLE
rttanalysis: allow selecting benchmark expectation subtests

### DIFF
--- a/pkg/bench/rttanalysis/validate_benchmark_data.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data.go
@@ -74,30 +74,32 @@ func RunBenchmarkExpectationTests(t *testing.T) {
 	}()
 
 	for _, b := range benchmarks {
-		flags := []string{
-			"--test.run=^$",
-			"--test.bench=" + b,
-			"--test.benchtime=1x",
-		}
-		if testing.Verbose() {
-			flags = append(flags, "--test.v")
-		}
-		results := runBenchmarks(t, flags...)
+		t.Run(b, func(t *testing.T) {
+			flags := []string{
+				"--test.run=^$",
+				"--test.bench=" + b,
+				"--test.benchtime=1x",
+			}
+			if testing.Verbose() {
+				flags = append(flags, "--test.v")
+			}
+			results := runBenchmarks(t, flags...)
 
-		for _, r := range results {
-			exp, ok := expectations.find(r.name)
-			if !ok {
-				t.Logf("no expectation for benchmark %s, got %d", r.name, r.result)
-				continue
+			for _, r := range results {
+				exp, ok := expectations.find(r.name)
+				if !ok {
+					t.Logf("no expectation for benchmark %s, got %d", r.name, r.result)
+					continue
+				}
+				if !exp.matches(r.result) {
+					t.Errorf("fail: expected %s to perform KV lookups in [%d, %d], got %d",
+						r.name, exp.min, exp.max, r.result)
+				} else {
+					t.Logf("success: expected %s to perform KV lookups in [%d, %d], got %d",
+						r.name, exp.min, exp.max, r.result)
+				}
 			}
-			if !exp.matches(r.result) {
-				t.Errorf("fail: expected %s to perform KV lookups in [%d, %d], got %d",
-					r.name, exp.min, exp.max, r.result)
-			} else {
-				t.Logf("success: expected %s to perform KV lookups in [%d, %d], got %d",
-					r.name, exp.min, exp.max, r.result)
-			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
This allows us to run a smaller set of the benchmarks using a filter
such as `TestBenchmarkExpectation/BenchmarkAlterTableAddColumn`. This
is nice when trying to reproduce an error seen in CI using `make
stress`.

Release note: None