### PR TITLE
util/tracing: remove handling for impossible error

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -957,9 +957,6 @@ func (r *Replica) getTraceData(ctx context.Context) map[string]string {
 	traceCarrier := tracing.MapCarrier{
 		Map: make(map[string]string),
 	}
-	if err := r.AmbientContext.Tracer.InjectMetaInto(sp.Meta(), traceCarrier); err != nil {
-		log.Errorf(ctx, "failed to inject sp context (%+v) as trace data: %s", sp.Meta(), err)
-		return nil
-	}
+	r.AmbientContext.Tracer.InjectMetaInto(sp.Meta(), traceCarrier)
 	return traceCarrier.Map
 }

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -207,11 +207,7 @@ func injectSpanMeta(ctx context.Context, tracer *Tracer, clientSpan *Span) conte
 	} else {
 		md = md.Copy()
 	}
-
-	if err := tracer.InjectMetaInto(clientSpan.Meta(), metadataCarrier{md}); err != nil {
-		// We have no better place to record an error than the Span itself.
-		clientSpan.Recordf("error: %s", err)
-	}
+	tracer.InjectMetaInto(clientSpan.Meta(), metadataCarrier{md})
 	return metadata.NewOutgoingContext(ctx, md)
 }
 

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -50,7 +50,7 @@ func TestRecordingString(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	carrier := metadataCarrier{MD: metadata.MD{}}
-	require.NoError(t, tr.InjectMetaInto(root.Meta(), carrier))
+	tr.InjectMetaInto(root.Meta(), carrier)
 
 	wireSpanMeta, err := tr2.ExtractMetaFrom(carrier)
 	require.NoError(t, err)

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -788,17 +788,17 @@ func (c MapCarrier) ForEach(fn func(key, val string) error) error {
 // InjectMetaInto is used to serialize the given span metadata into the given
 // Carrier. This, alongside ExtractMetaFrom, can be used to carry span metadata
 // across process boundaries. See serializationFormat for more details.
-func (t *Tracer) InjectMetaInto(sm SpanMeta, carrier Carrier) error {
+func (t *Tracer) InjectMetaInto(sm SpanMeta, carrier Carrier) {
 	if sm.Empty() {
 		// Fast path when tracing is disabled. ExtractMetaFrom will accept an
 		// empty map as a noop context.
-		return nil
+		return
 	}
 	// If the span has been marked as not wanting children, we don't propagate any
 	// information about it through the carrier (the point of propagating span
 	// info is to create a child from it).
 	if sm.sterile {
-		return nil
+		return
 	}
 
 	carrier.Set(fieldNameTraceID, strconv.FormatUint(uint64(sm.traceID), 16))
@@ -811,8 +811,6 @@ func (t *Tracer) InjectMetaInto(sm SpanMeta, carrier Carrier) error {
 		carrier.Set(fieldNameOtelTraceID, sm.otelCtx.TraceID().String())
 		carrier.Set(fieldNameOtelSpanID, sm.otelCtx.SpanID().String())
 	}
-
-	return nil
 }
 
 var noopSpanMeta = SpanMeta{}

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -253,7 +253,7 @@ func TestSterileSpan(t *testing.T) {
 
 	// Check that the meta of a sterile span doesn't get injected into carriers.
 	carrier := metadataCarrier{metadata.MD{}}
-	require.NoError(t, tr.InjectMetaInto(sp1.Meta(), carrier))
+	tr.InjectMetaInto(sp1.Meta(), carrier)
 	require.Len(t, carrier.MD, 0)
 }
 
@@ -268,9 +268,7 @@ func TestTracerInjectExtract(t *testing.T) {
 		t.Fatalf("expected noop Span: %+v", noop1)
 	}
 	carrier := metadataCarrier{metadata.MD{}}
-	if err := tr.InjectMetaInto(noop1.Meta(), carrier); err != nil {
-		t.Fatal(err)
-	}
+	tr.InjectMetaInto(noop1.Meta(), carrier)
 	if len(carrier.MD) != 0 {
 		t.Errorf("noop Span has carrier: %+v", carrier)
 	}
@@ -296,9 +294,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	s1.SetVerbose(true)
 
 	carrier = metadataCarrier{metadata.MD{}}
-	if err := tr.InjectMetaInto(s1.Meta(), carrier); err != nil {
-		t.Fatal(err)
-	}
+	tr.InjectMetaInto(s1.Meta(), carrier)
 
 	wireSpanMeta, err = tr2.ExtractMetaFrom(carrier)
 	if err != nil {
@@ -355,7 +351,7 @@ func TestTracer_PropagateNonRecordingRealSpanAcrossRPCBoundaries(t *testing.T) {
 	defer sp1.Finish()
 	carrier := metadataCarrier{MD: metadata.MD{}}
 	require.True(t, spanInclusionFuncForClient(sp1))
-	require.NoError(t, tr1.InjectMetaInto(sp1.Meta(), carrier))
+	tr1.InjectMetaInto(sp1.Meta(), carrier)
 	require.Equal(t, 2, carrier.Len(), "%+v", carrier) // trace id and span id
 
 	tr2 := NewTracer()
@@ -390,9 +386,7 @@ func TestOtelTracer(t *testing.T) {
 	s.SetBaggageItem(testBaggageKey, testBaggageVal)
 
 	carrier := metadataCarrier{metadata.MD{}}
-	if err := tr.InjectMetaInto(s.Meta(), carrier); err != nil {
-		t.Fatal(err)
-	}
+	tr.InjectMetaInto(s.Meta(), carrier)
 
 	// ExtractMetaFrom also extracts the embedded OpenTelemetry context.
 	wireSpanMeta, err := tr.ExtractMetaFrom(carrier)


### PR DESCRIPTION
InjectMetaInto can no longer return an error (and I don't forsee it ever
returning an error again), so this patch cleans up the unused retval.

Release note: None