### PR TITLE
dev: fix bad output if `bazel query` fails

### DIFF
--- a/pkg/cmd/dev/io/exec/exec.go
+++ b/pkg/cmd/dev/io/exec/exec.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -169,7 +168,7 @@ func (e *Exec) commandContextImpl(
 		cmd := exec.CommandContext(ctx, name, args...)
 		if silent {
 			cmd.Stdout = &buffer
-			cmd.Stderr = ioutil.Discard
+			cmd.Stderr = nil
 		} else {
 			cmd.Stdout = io.MultiWriter(e.stdout, &buffer)
 			cmd.Stderr = e.stderr

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -11,11 +11,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/spf13/cobra"
 )
 
@@ -126,7 +130,8 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 			// where we define `Stringer` separately for the `RemoteOffset`
 			// type.
 			{
-				out, err := d.exec.CommandContextSilent(ctx, "bazel", "query", fmt.Sprintf("kind(go_test,  //%s)", pkg))
+				queryArgs := []string{fmt.Sprintf("kind(go_test,  //%s)", pkg)}
+				out, err := d.getQueryOutput(ctx, queryArgs...)
 				if err != nil {
 					return err
 				}
@@ -136,7 +141,8 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		} else if strings.Contains(pkg, ":") {
 			testTargets = append(testTargets, pkg)
 		} else {
-			out, err := d.exec.CommandContextSilent(ctx, "bazel", "query", fmt.Sprintf("kind(go_test, //%s:all)", pkg))
+			queryArgs := []string{fmt.Sprintf("kind(go_test, //%s:all)", pkg)}
+			out, err := d.getQueryOutput(ctx, queryArgs...)
 			if err != nil {
 				return err
 			}
@@ -212,4 +218,26 @@ func getDirectoryFromTarget(target string) string {
 		return target
 	}
 	return target[:colon]
+}
+
+// getQueryOutput runs `bazel query` w/ the given arguments, but returns
+// a more informative error if the query fails.
+func (d *dev) getQueryOutput(ctx context.Context, args ...string) ([]byte, error) {
+	queryArgs := []string{"query"}
+	queryArgs = append(queryArgs, args...)
+	stdoutBytes, err := d.exec.CommandContextSilent(ctx, "bazel", queryArgs...)
+	if err == nil {
+		return stdoutBytes, err
+	}
+	var cmderr *exec.ExitError
+	var stdout, stderr string
+	if len(stdoutBytes) > 0 {
+		stdout = fmt.Sprintf("stdout: \"%s\" ", string(stdoutBytes))
+	}
+	if errors.As(err, &cmderr) && len(cmderr.Stderr) > 0 {
+		stderr = fmt.Sprintf("stderr: \"%s\" ", strings.TrimSpace(string(cmderr.Stderr)))
+	}
+	return nil, fmt.Errorf("failed to run `bazel %s` %s%s(%w)",
+		shellescape.QuoteCommand(queryArgs), stdout, stderr, err)
+
 }


### PR DESCRIPTION
You could see this by passing a non-existent path to `bazel test`, like
`dev test pkg/cmd/foo`. This would print out an unhelpful message like
`Exit status 7`. This makes the message a little more comprehensible.

Release note: None