### PR TITLE
bazel: bump size of `pkg/bench/rttanalysis:rttanalysis_test`

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 
 go_test(
     name = "rttanalysis_test",
+    size = "large",
     srcs = [
         "alter_table_bench_test.go",
         "bench_test.go",


### PR DESCRIPTION
Release note: none