### PR TITLE
kvserver: apply gossip side-effects under Raft

### DIFF
--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -103,6 +103,15 @@ func (lResult *LocalResult) String() string {
 		lResult.MaybeGossipNodeLiveness)
 }
 
+// RequiresRaft returns true if the local result needs to go via Raft, e.g. in
+// order to apply side effects under Raft.
+func (lResult *LocalResult) RequiresRaft() bool {
+	// Gossip triggers require raftMu to be held.
+	return lResult.MaybeGossipNodeLiveness != nil ||
+		lResult.MaybeGossipSystemConfig ||
+		lResult.MaybeGossipSystemConfigIfHaveFailure
+}
+
 // DetachEncounteredIntents returns (and removes) those encountered
 // intents from the LocalEvalResult which are supposed to be handled.
 func (lResult *LocalResult) DetachEncounteredIntents() []roachpb.Intent {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -1202,7 +1202,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 	if cmd.IsLocal() {
 		// Handle the LocalResult.
 		if cmd.localResult != nil {
-			sm.r.handleReadWriteLocalEvalResult(ctx, *cmd.localResult, true /* raftMuHeld */)
+			sm.r.handleReadWriteLocalEvalResult(ctx, *cmd.localResult)
 		}
 
 		rejected := cmd.Rejected()

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -634,9 +634,7 @@ func addSSTablePreApply(
 	return copied
 }
 
-func (r *Replica) handleReadWriteLocalEvalResult(
-	ctx context.Context, lResult result.LocalResult, raftMuHeld bool,
-) {
+func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult result.LocalResult) {
 	// Fields for which no action is taken in this method are zeroed so that
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
@@ -702,19 +700,13 @@ func (r *Replica) handleReadWriteLocalEvalResult(
 		lResult.MaybeAddToSplitQueue = false
 	}
 
-	// The following three triggers require the raftMu to be held. If a
-	// trigger is present, acquire the mutex if it is not held already.
-	maybeAcquireRaftMu := func() func() {
-		if raftMuHeld {
-			return func() {}
-		}
-		raftMuHeld = true
-		r.raftMu.Lock()
-		return r.raftMu.Unlock
-	}
-
+	// The gossip triggers below require raftMu to be held, but
+	// handleReadWriteLocalEvalResult() may be called from non-Raft code paths (in
+	// particular for noop proposals). LocalResult.RequiresRaft() will force
+	// results that set these gossip triggers to always go via Raft such that
+	// raftMu is held. The triggers assert that callers hold the mutex during race
+	// tests via raftMu.AssertHeld().
 	if lResult.MaybeGossipSystemConfig {
-		defer maybeAcquireRaftMu()()
 		if err := r.MaybeGossipSystemConfigRaftMuLocked(ctx); err != nil {
 			log.Errorf(ctx, "%v", err)
 		}
@@ -722,7 +714,6 @@ func (r *Replica) handleReadWriteLocalEvalResult(
 	}
 
 	if lResult.MaybeGossipSystemConfigIfHaveFailure {
-		defer maybeAcquireRaftMu()()
 		if err := r.MaybeGossipSystemConfigIfHaveFailureRaftMuLocked(ctx); err != nil {
 			log.Errorf(ctx, "%v", err)
 		}
@@ -730,7 +721,6 @@ func (r *Replica) handleReadWriteLocalEvalResult(
 	}
 
 	if lResult.MaybeGossipNodeLiveness != nil {
-		defer maybeAcquireRaftMu()()
 		if err := r.MaybeGossipNodeLivenessRaftMuLocked(ctx, *lResult.MaybeGossipNodeLiveness); err != nil {
 			log.Errorf(ctx, "%v", err)
 		}
@@ -833,10 +823,12 @@ func (r *Replica) evaluateProposal(
 	//    even with an empty write batch when stats are recomputed.
 	// 3. the request has replicated side-effects.
 	// 4. the request is of a type that requires consensus (eg. Barrier).
+	// 5. the request has side-effects that must be applied under Raft.
 	needConsensus := !batch.Empty() ||
 		ms != (enginepb.MVCCStats{}) ||
 		!res.Replicated.IsZero() ||
-		ba.RequiresConsensus()
+		ba.RequiresConsensus() ||
+		res.Local.RequiresRaft()
 
 	if needConsensus {
 		log.VEventf(ctx, 2, "need consensus on write batch with op count=%d", batch.Count())

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -113,9 +113,13 @@ func (r *Replica) evalAndPropose(
 	// 2. pErr != nil corresponds to a failed proposal - the command resulted
 	//    in an error.
 	if proposal.command == nil {
+		if proposal.Local.RequiresRaft() {
+			return nil, nil, "", roachpb.NewError(errors.AssertionFailedf(
+				"proposal resulting from batch %s erroneously bypassed Raft", ba))
+		}
 		intents := proposal.Local.DetachEncounteredIntents()
 		endTxns := proposal.Local.DetachEndTxns(pErr != nil /* alwaysOnly */)
-		r.handleReadWriteLocalEvalResult(ctx, *proposal.Local, false /* raftMuHeld */)
+		r.handleReadWriteLocalEvalResult(ctx, *proposal.Local)
 
 		pr := proposalResult{
 			Reply:              proposal.Local.Reply,


### PR DESCRIPTION
Following 584fb97, `Replica.handleReadWriteLocalEvalResult()` may take
out `raftMu` when applying gossip triggers. However, this was called
from `Replica.evalAndPropose()` via `Replica.executeWriteBatch()` which
already held `readOnlyCmdMu`.  This violates the `Store.mu` locking
protocol since `raftMu` must be taken out before `readOnlyCmdMu`, which
may lead to deadlocks.

The motivation for that change was to avoid sending noop `EndTxn`
requests via Raft, even when they result in gossip triggers that require
`raftMu`. However, taking out `raftMu` above Raft complicates the
locking model, which can result in bugs like this one, and the commit
message outlines an alternative solution: do not omit Raft when a local
result has a gossip trigger.

Since noop `EndTxn` requests with gossip triggers are fairly rare, and
are not significantly impacted by the additional Raft latency, this
patch reverts 584fb97 and instead sends these results through Raft.

Resolves #71646.

Release note: None