### PR TITLE
kv: reject requests from merge txn to RHS of merge after subsumption

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1471,6 +1471,8 @@ func (r *Replica) shouldWaitForPendingMergeRLocked(
 				return nil
 			}
 		}
+		return errors.Errorf("merge transaction attempting to issue "+
+			"batch on right-hand side range after subsumption: %s", ba.Summary())
 	}
 
 	// Otherwise, the request must wait. We can't wait for the merge to complete


### PR DESCRIPTION
Closes #71901.

This commit causes batch requests from the transaction coordinating a
range merge and sent to the right-hand side of the merge after the RHS
has been subsumed to be rejected instead of waiting for the merge to
complete and causing a deadlock. We don't expect this situation in
almost any real case, but we do see a rare situation in #71901 where
this can happen. It's better to throw an error up the stack and cause
the merge to roll back than to stall the merge.

This doesn't completely fix #71901 in that some range merges issued to
the range on the left of the `system.descriptors` range may still see
errors (but no longer deadlocks), but it does seem to deflake
`TestApplier`. I don't quite understand why, but it's pretty clear that
before this change, it was failing roughly every 200k iterations and
after it, I haven't seen a failure in over 2M iterations. Because of
that, I'm going to close the issue.

Release note (bug fix): fixed a rare condition that could cause a range
merge to get stuck waiting on itself. The symptom of this deadlock was a
goroutine stuck in `handleMergeInProgressError` for tens of minutes.