### PR TITLE
jobs: don't include job id in span name

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "@com_github_gogo_protobuf//types",
         "@com_github_gorhill_cronexpr//:cronexpr",
         "@com_github_prometheus_client_model//go",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 


### PR DESCRIPTION
Make it a tag instead. Span names are not supposed to have high
cardinality.

Release note: None