### PR TITLE
clusterversion: supply new cluster version on OnChange called

### DIFF
--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -30,11 +30,16 @@ go_library(
 go_test(
     name = "clusterversion_test",
     size = "small",
-    srcs = ["cockroach_versions_test.go"],
+    srcs = [
+        "clusterversion_test.go",
+        "cockroach_versions_test.go",
+    ],
     embed = [":clusterversion"],
     deps = [
         "//pkg/roachpb:with-mocks",
+        "//pkg/settings",
         "//pkg/util/leaktest",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -136,13 +136,15 @@ type Handle interface {
 	// version changes. The callback should avoid doing long-running or blocking
 	// work; it's called on the same goroutine handling all cluster setting
 	// updates.
-	SetOnChange(fn func(context.Context))
+	SetOnChange(fn func(ctx context.Context, newVersion ClusterVersion))
 }
 
 // handleImpl is a concrete implementation of Handle. It mostly relegates to the
 // underlying cluster version setting, though provides a way for callers to
 // override the binary and minimum supported versions (for tests usually).
 type handleImpl struct {
+	// setting is the version that this handle operates on.
+	setting *clusterVersionSetting
 	// sv captures the mutable state associated with usage of the otherwise
 	// immutable cluster version setting.
 	sv *settings.Values
@@ -173,9 +175,17 @@ func MakeVersionHandle(sv *settings.Values) Handle {
 func MakeVersionHandleWithOverride(
 	sv *settings.Values, binaryVersion, binaryMinSupportedVersion roachpb.Version,
 ) Handle {
-	return &handleImpl{
-		sv: sv,
+	return newHandleImpl(version, sv, binaryVersion, binaryMinSupportedVersion)
+}
 
+func newHandleImpl(
+	setting *clusterVersionSetting,
+	sv *settings.Values,
+	binaryVersion, binaryMinSupportedVersion roachpb.Version,
+) Handle {
+	return &handleImpl{
+		setting:                   setting,
+		sv:                        sv,
 		binaryVersion:             binaryVersion,
 		binaryMinSupportedVersion: binaryMinSupportedVersion,
 	}
@@ -183,12 +193,12 @@ func MakeVersionHandleWithOverride(
 
 // ActiveVersion implements the Handle interface.
 func (v *handleImpl) ActiveVersion(ctx context.Context) ClusterVersion {
-	return version.activeVersion(ctx, v.sv)
+	return v.setting.activeVersion(ctx, v.sv)
 }
 
 // ActiveVersionOrEmpty implements the Handle interface.
 func (v *handleImpl) ActiveVersionOrEmpty(ctx context.Context) ClusterVersion {
-	return version.activeVersionOrEmpty(ctx, v.sv)
+	return v.setting.activeVersionOrEmpty(ctx, v.sv)
 }
 
 // SetActiveVersion implements the Handle interface.
@@ -198,7 +208,7 @@ func (v *handleImpl) SetActiveVersion(ctx context.Context, cv ClusterVersion) er
 	// SETTING version` was originally called). The stricter form of validation
 	// happens there. SetActiveVersion is simply the cluster version bump that
 	// follows from it.
-	if err := version.validateBinaryVersions(cv.Version, v.sv); err != nil {
+	if err := v.setting.validateBinaryVersions(cv.Version, v.sv); err != nil {
 		return err
 	}
 
@@ -207,18 +217,20 @@ func (v *handleImpl) SetActiveVersion(ctx context.Context, cv ClusterVersion) er
 		return err
 	}
 
-	version.SetInternal(ctx, v.sv, encoded)
+	v.setting.SetInternal(ctx, v.sv, encoded)
 	return nil
 }
 
 // SetOnChange implements the Handle interface.
-func (v *handleImpl) SetOnChange(fn func(ctx context.Context)) {
-	version.SetOnChange(v.sv, fn)
+func (v *handleImpl) SetOnChange(fn func(ctx context.Context, newVersion ClusterVersion)) {
+	v.setting.SetOnChange(v.sv, func(ctx context.Context) {
+		fn(ctx, v.ActiveVersion(ctx))
+	})
 }
 
 // IsActive implements the Handle interface.
 func (v *handleImpl) IsActive(ctx context.Context, key Key) bool {
-	return version.isActive(ctx, v.sv, key)
+	return v.setting.isActive(ctx, v.sv, key)
 }
 
 // BinaryVersion implements the Handle interface.

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -1,0 +1,54 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clusterversion
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that the OnChange callback is called for the cluster version with the
+// right argument.
+func TestClusterVersionOnChange(t *testing.T) {
+	ctx := context.Background()
+	var sv settings.Values
+
+	cvs := &clusterVersionSetting{}
+	cvs.VersionSetting = settings.MakeVersionSetting(cvs)
+	settings.RegisterVersionSetting(
+		"dummy version key",
+		"test description",
+		&cvs.VersionSetting)
+
+	handle := newHandleImpl(cvs, &sv, binaryVersion, binaryMinSupportedVersion)
+	newCV := ClusterVersion{
+		Version: roachpb.Version{
+			Major:    1,
+			Minor:    2,
+			Patch:    3,
+			Internal: 4,
+		},
+	}
+	encoded, err := protoutil.Marshal(&newCV)
+	require.NoError(t, err)
+
+	var capturedV ClusterVersion
+	handle.SetOnChange(func(ctx context.Context, newVersion ClusterVersion) {
+		capturedV = newVersion
+	})
+	cvs.SetInternal(ctx, &sv, encoded)
+	require.Equal(t, newCV, capturedV)
+}

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -124,7 +124,7 @@ func (m *Manager) run(ctx context.Context) {
 	checkReconciliationJobInterval.SetOnChange(&m.settings.SV, func(ctx context.Context) {
 		triggerJobCheck()
 	})
-	m.settings.Version.SetOnChange(func(ctx context.Context) {
+	m.settings.Version.SetOnChange(func(_ context.Context, _ clusterversion.ClusterVersion) {
 		triggerJobCheck()
 	})
 


### PR DESCRIPTION
It's very natural for the OnChange callback to want access to the new
value, and I also need it in a future patch.
This patch also makes the clusterversion.Handle type more testable by
untangling it from a global setting.

Release note: None