### PR TITLE
prometheus: fix RunE not actually terminating an instance

### DIFF
--- a/pkg/cmd/roachtest/prometheus/prometheus.go
+++ b/pkg/cmd/roachtest/prometheus/prometheus.go
@@ -69,7 +69,6 @@ func Init(
 	if err := c.RunE(
 		ctx,
 		cfg.PrometheusNode,
-		"terminate existing prometheus instance, if exists",
 		"sudo systemctl stop prometheus || echo 'no prometheus is running'",
 	); err != nil {
 		return nil, err


### PR DESCRIPTION
Copied repeatRunE and noticed there's no description field - woops. I'm
at a loss to explain why this does not error as the `terminate` command
does not exist.

Resolves #71808

Release note: None