### PR TITLE
ui: Added informative warning for insufficient privileges

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -63,6 +63,9 @@ type NodeStatusState = Pick<AdminUIState, "cachedData", "nodes">;
 export const nodeStatusesSelector = (state: NodeStatusState) =>
   state.cachedData.nodes.data;
 
+export const selectNodesLastError = (state: AdminUIState) =>
+  state.cachedData.nodes.lastError;
+
 /*
  * clusterSelector returns information about cluster.
  */
@@ -381,6 +384,7 @@ export const nodesSummarySelector = createSelector(
   livenessStatusByNodeIDSelector,
   livenessByNodeIDSelector,
   selectStoreIDsByNodeID,
+  selectNodesLastError,
   (
     nodeStatuses,
     nodeIDs,
@@ -390,6 +394,7 @@ export const nodesSummarySelector = createSelector(
     livenessStatusByNodeID,
     livenessByNodeID,
     storeIDsByNodeID,
+    nodeLastError,
   ) => {
     return {
       nodeStatuses,
@@ -400,6 +405,7 @@ export const nodesSummarySelector = createSelector(
       livenessStatusByNodeID,
       livenessByNodeID,
       storeIDsByNodeID,
+      nodeLastError,
     };
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { withRouter, RouteComponentProps } from "react-router-dom";
+import { InlineAlert } from "src/components";
 
 import * as protos from "src/js/protos";
 import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
@@ -325,9 +326,24 @@ export class Nodes extends React.Component<NodesProps, {}> {
     );
   }
 
+  requiresAdmin() {
+    const {
+      nodesSummary: { nodeLastError },
+    } = this.props;
+
+    return nodeLastError?.message === "this operation requires admin privilege";
+  }
+
   render() {
     const { nodesSummary } = this.props;
     const { nodeStatusByID } = nodesSummary;
+
+    if (this.requiresAdmin()) {
+      return (
+        <InlineAlert title="" message="This page requires admin privileges." />
+      );
+    }
+
     if (_.isEmpty(nodesSummary.nodeIDs)) {
       return loading;
     }


### PR DESCRIPTION
<img width="972" alt="Screen Shot 2021-10-25 at 17 17 49" src="https://user-images.githubusercontent.com/397448/138772352-117456e1-10a8-475b-9b1c-79b0e2327558.png">

Previously, `/#/reports/nodes` would seem to hang in a loading state
indefinitely when a DB Console user wouldn't have admin privileges for
that endpoint. This was due to nodes data being empty from a 403
response.

An error is captured in the application state for this response, so
mapping this error as a prop to the component, the UI can distinguish
between the nodes data simply being empty and being empty due to a
restriction error.

<img width="827" alt="Screen Shot 2021-10-25 at 17 16 07" src="https://user-images.githubusercontent.com/397448/138772135-33321d34-9728-489b-8549-1c8bd55cf650.png">

Detecting this error, we render an `<InlineAlert />` to notify the user
of their lack of privileges.

Release note (ui change): All Nodes report notifies user is they need
more privileges to view information.