### PR TITLE
ui: default filter on Transaction and Statement pages now exclude internals

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -169,6 +169,11 @@ export const selectStatements = createSelector(
           (showInternal && isInternal(statement)) ||
           criteria.includes(statement.app),
       );
+    } else {
+      // We don't want to show internal statements by default.
+      statements = statements.filter(
+        (statement: ExecutionStatistics) => !isInternal(statement),
+      );
     }
 
     const statsByStatementKey: {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -44,7 +44,7 @@ describe("getStatementsByFingerprintIdAndTime", () => {
 const txData = (data.transactions as any) as Transaction[];
 
 describe("Filter transactions", () => {
-  it("show all if no filters applied", () => {
+  it("show non internal if no filters applied", () => {
     const filter: Filters = {
       app: "",
       timeNumber: "0",
@@ -61,7 +61,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      11,
+      4,
     );
   });
 
@@ -151,7 +151,7 @@ describe("Filter transactions", () => {
 
   it("filters by time", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "40",
       timeUnit: "miliseconds",
       nodes: "",
@@ -172,7 +172,7 @@ describe("Filter transactions", () => {
 
   it("filters by one node", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n1",
@@ -193,7 +193,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple nodes", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST,$ TEST EXACT",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n2,n4",
@@ -214,7 +214,7 @@ describe("Filter transactions", () => {
 
   it("filters by one region", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",
@@ -235,7 +235,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple regions", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST,$ TEST EXACT",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -157,26 +157,32 @@ export const filterTransactions = (
 
   // Return transactions filtered by the values selected on the filter. A
   // transaction must match all selected filters.
+  // We don't want to show statements that are internal or with unset App names by default.
   // Current filters: app, service latency, nodes and regions.
   const filteredTransactions = data
     .filter((t: Transaction) => {
       const isInternal = (t: Transaction) =>
         t.stats_data.app.startsWith(internalAppNamePrefix);
-      const apps = filters.app.split(",");
-      let showInternal = false;
-      if (apps.includes(internalAppNamePrefix)) {
-        showInternal = true;
-      }
-      if (apps.includes("(unset)")) {
-        apps.push("");
-      }
 
-      return (
-        filters.app === "" ||
-        (showInternal && isInternal(t)) ||
-        t.stats_data.app === filters.app ||
-        apps.includes(t.stats_data.app)
-      );
+      if (filters.app && filters.app != "All") {
+        const apps = filters.app.split(",");
+        let showInternal = false;
+        if (apps.includes(internalAppNamePrefix)) {
+          showInternal = true;
+        }
+        if (apps.includes("(unset)")) {
+          apps.push("");
+        }
+
+        return (
+          (showInternal && isInternal(t)) ||
+          t.stats_data.app === filters.app ||
+          apps.includes(t.stats_data.app)
+        );
+      } else {
+        // We don't want to show internal transactions by default.
+        return !isInternal(t);
+      }
     })
     .filter(
       (t: Transaction) =>

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -65,7 +65,7 @@ describe("selectStatements", () => {
     assert.deepEqual(actualFingerprints, expectedFingerprints);
   });
 
-  it("returns the statements with Internal for default ALL filter", () => {
+  it("returns the statements without Internal for default ALL filter", () => {
     const stmtA = makeFingerprint(1);
     const stmtB = makeFingerprint(2, INTERNAL_STATEMENT_PREFIX);
     const stmtC = makeFingerprint(3, INTERNAL_STATEMENT_PREFIX);
@@ -75,7 +75,7 @@ describe("selectStatements", () => {
 
     const result = selectStatements(state, props);
 
-    assert.equal(result.length, 3);
+    assert.equal(result.length, 2);
   });
 
   it("coalesces statements from different apps", () => {

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -100,6 +100,11 @@ export const selectStatements = createSelector(
           (showInternal && isInternal(statement)) ||
           criteria.includes(statement.app),
       );
+    } else {
+      // We don't want to show internal statements by default.
+      statements = statements.filter(
+        (statement: ExecutionStatistics) => !isInternal(statement),
+      );
     }
 
     const statsByStatementKey: {


### PR DESCRIPTION
Previously, the default value when no App filter was
selected on Transactions and Statements page, we were showing
all data, now we're excluding internal transaction/statements.

Fixes #70544

Release note (ui change): The default value when no App is selected
on Transactions and Statements filter is now excluding internal
Transactions and Statements.