### PR TITLE
server,ui: transactionDetail page now shows statement stats scoped by transaction fingerprint ID

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -113,6 +113,7 @@ func collectCombinedStatements(
 	query := fmt.Sprintf(
 		`SELECT
 				fingerprint_id,
+				transaction_fingerprint_id,
 				app_name,
 				aggregated_ts,
 				metadata,
@@ -122,7 +123,7 @@ func collectCombinedStatements(
 			FROM crdb_internal.statement_statistics
 			%s`, whereClause)
 
-	const expectedNumDatums = 7
+	const expectedNumDatums = 8
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-by-interval", nil,
 		sessiondata.InternalExecutorOverride{
@@ -157,30 +158,37 @@ func collectCombinedStatements(
 			return nil, err
 		}
 
-		app := string(tree.MustBeDString(row[1]))
-		aggregatedTs := tree.MustBeDTimestampTZ(row[2]).Time
+		var transactionFingerprintID uint64
+		if transactionFingerprintID, err = sqlstatsutil.DatumToUint64(row[1]); err != nil {
+			return nil, err
+		}
+
+		app := string(tree.MustBeDString(row[2]))
+		aggregatedTs := tree.MustBeDTimestampTZ(row[3]).Time
 
 		var metadata roachpb.CollectedStatementStatistics
-		metadataJSON := tree.MustBeDJSON(row[3]).JSON
+		metadataJSON := tree.MustBeDJSON(row[4]).JSON
 		if err = sqlstatsutil.DecodeStmtStatsMetadataJSON(metadataJSON, &metadata); err != nil {
 			return nil, err
 		}
 
 		metadata.Key.App = app
+		metadata.Key.TransactionFingerprintID =
+			roachpb.TransactionFingerprintID(transactionFingerprintID)
 
-		statsJSON := tree.MustBeDJSON(row[4]).JSON
+		statsJSON := tree.MustBeDJSON(row[5]).JSON
 		if err = sqlstatsutil.DecodeStmtStatsStatisticsJSON(statsJSON, &metadata.Stats); err != nil {
 			return nil, err
 		}
 
-		planJSON := tree.MustBeDJSON(row[5]).JSON
+		planJSON := tree.MustBeDJSON(row[6]).JSON
 		plan, err := sqlstatsutil.JSONToExplainTreePlanNode(planJSON)
 		if err != nil {
 			return nil, err
 		}
 		metadata.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
 
-		aggInterval := tree.MustBeDInterval(row[6]).Duration
+		aggInterval := tree.MustBeDInterval(row[7]).Duration
 
 		stmt := serverpb.StatementsResponse_CollectedStatementStatistics{
 			Key: serverpb.StatementsResponse_ExtendedStatementStatisticsKey{

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -76,6 +76,7 @@ interface TState {
   statementFingerprintIds: Long[] | null;
   aggregatedTs: Timestamp | null;
   transactionStats: TransactionStats | null;
+  transactionFingerprintId: Long | null;
 }
 
 export interface TransactionsPageStateProps {
@@ -136,6 +137,7 @@ export class TransactionsPage extends React.Component<
     aggregatedTs: null,
     statementFingerprintIds: null,
     transactionStats: null,
+    transactionFingerprintId: null,
   };
 
   refreshData = (): void => {
@@ -245,6 +247,8 @@ export class TransactionsPage extends React.Component<
         transaction?.stats_data?.statement_fingerprint_ids,
       transactionStats: transaction?.stats_data?.stats,
       aggregatedTs: transaction?.stats_data?.aggregated_ts,
+      transactionFingerprintId:
+        transaction?.stats_data?.transaction_fingerprint_id,
     });
   };
 
@@ -466,6 +470,7 @@ export class TransactionsPage extends React.Component<
       aggregatedTs,
       statementFingerprintIds,
       transactionStats,
+      transactionFingerprintId,
     } = this.state;
     const transactionDetails =
       statementFingerprintIds &&
@@ -489,6 +494,7 @@ export class TransactionsPage extends React.Component<
         error={this.props.error}
         resetSQLStats={this.props.resetSQLStats}
         isTenant={this.props.isTenant}
+        transactionFingerprintId={transactionFingerprintId}
       />
     );
   }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -22,12 +22,12 @@ import {
   aggregateNumericStats,
   FixLong,
   longToInt,
-  statementKey,
   TimestampToNumber,
   addStatementStats,
   flattenStatementStats,
   DurationToNumber,
   computeOrUseStmtSummary,
+  transactionScopedStatementKey,
 } from "../util";
 
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -97,7 +97,7 @@ export const aggregateStatements = (
   const statsKey: { [key: string]: AggregateStatistics } = {};
 
   flattenStatementStats(statements).forEach(s => {
-    const key = statementKey(s);
+    const key = transactionScopedStatementKey(s);
     if (!(key in statsKey)) {
       statsKey[key] = {
         label: s.statement,

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -214,6 +214,7 @@ export interface ExecutionStatistics {
   full_scan: boolean;
   failed: boolean;
   node_id: number;
+  transaction_fingerprint_id: Long;
   stats: StatementStatistics;
 }
 
@@ -233,6 +234,7 @@ export function flattenStatementStats(
     full_scan: stmt.key.key_data.full_scan,
     failed: stmt.key.key_data.failed,
     node_id: stmt.key.node_id,
+    transaction_fingerprint_id: stmt.key.key_data.transaction_fingerprint_id,
     stats: stmt.stats,
   }));
 }
@@ -261,4 +263,12 @@ export function statementKey(stmt: ExecutionStatistics): string {
     stmt.aggregated_ts +
     stmt.aggregation_interval
   );
+}
+
+// transactionScopedStatementKey is similar to statementKey, except that
+// it appends the transactionFingerprintID to the string key it generated.
+export function transactionScopedStatementKey(
+  stmt: ExecutionStatistics,
+): string {
+  return statementKey(stmt) + stmt.transaction_fingerprint_id.toString();
 }


### PR DESCRIPTION
Previously, transactionDetail page shows statement statistics aggregated
across **all** executions of that statement fingerprint. This led to
confusing UX and the statement statistics were subsequently removed
from transactionDetail page.
This commit reintroduces statement statistics on transactionDetail
page. The statistics now are only aggregated across the statement
fingerprints that are part of the selected transaction fingerprint.

Resolves #59205 #65106

Release note (ui change): transactionDetail page now shows statement
statistics scoped by the transaction fingeprint.



https://user-images.githubusercontent.com/9267198/138916095-c91895d5-6f34-49b7-87dd-81f375b3f582.mov

