### PR TITLE
cli: Enable multi-tenant demo by default

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -585,6 +585,7 @@ func setDemoContextDefaults() {
 	demoCtx.SQLPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
+	demoCtx.Multitenant = true
 }
 
 // stmtDiagCtx captures the command-line parameters of the 'statement-diag'

--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -25,10 +25,11 @@ func Example_demo_locality() {
 
 	defer democluster.TestingForceRandomizeDemoPorts()()
 
+	// Disable multi-tenant for this test due to the unsupported gossip commands.
 	testData := [][]string{
-		{`demo`, `--nodes`, `3`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `9`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
-		{`demo`, `--nodes`, `3`, `--demo-locality=region=us-east1:region=us-east2:region=us-east3`,
+		{`demo`, `--nodes`, `3`, `--multitenant=false`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
+		{`demo`, `--nodes`, `9`, `--multitenant=false`, `-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
+		{`demo`, `--nodes`, `3`, `--multitenant=false`, `--demo-locality=region=us-east1:region=us-east2:region=us-east3`,
 			`-e`, `select node_id, locality from crdb_internal.gossip_nodes order by node_id`},
 	}
 	setCLIDefaultsForTests()
@@ -45,12 +46,12 @@ func Example_demo_locality() {
 	}
 
 	// Output:
-	// demo --nodes 3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// demo --nodes 3 --multitenant=false -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
 	// node_id	locality
 	// 1	region=us-east1,az=b
 	// 2	region=us-east1,az=c
 	// 3	region=us-east1,az=d
-	// demo --nodes 9 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// demo --nodes 9 --multitenant=false -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
 	// node_id	locality
 	// 1	region=us-east1,az=b
 	// 2	region=us-east1,az=c
@@ -61,7 +62,7 @@ func Example_demo_locality() {
 	// 7	region=europe-west1,az=b
 	// 8	region=europe-west1,az=c
 	// 9	region=europe-west1,az=d
-	// demo --nodes 3 --demo-locality=region=us-east1:region=us-east2:region=us-east3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
+	// demo --nodes 3 --multitenant=false --demo-locality=region=us-east1:region=us-east2:region=us-east3 -e select node_id, locality from crdb_internal.gossip_nodes order by node_id
 	// node_id	locality
 	// 1	region=us-east1
 	// 2	region=us-east2

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -22,21 +22,22 @@ func Example_demo() {
 
 	defer democluster.TestingForceRandomizeDemoPorts()()
 
+	// Disable multi-tenant, as it requires a CCL binary
 	testData := [][]string{
-		{`demo`, `-e`, `show database`},
-		{`demo`, `-e`, `show database`, `--no-example-database`},
-		{`demo`, `-e`, `show application_name`},
-		{`demo`, `--format=table`, `-e`, `show database`},
-		{`demo`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
-		{`demo`, `--echo-sql`, `-e`, `select 1 as "1"`},
-		{`demo`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
-		{`demo`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`},
-		{`demo`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`, `--format=table`},
+		{`demo`, `--multitenant=false`, `-e`, `show database`},
+		{`demo`, `--multitenant=false`, `-e`, `show database`, `--no-example-database`},
+		{`demo`, `--multitenant=false`, `-e`, `show application_name`},
+		{`demo`, `--multitenant=false`, `--format=table`, `-e`, `show database`},
+		{`demo`, `--multitenant=false`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
+		{`demo`, `--multitenant=false`, `--echo-sql`, `-e`, `select 1 as "1"`},
+		{`demo`, `--multitenant=false`, `--set=errexit=0`, `-e`, `select nonexistent`, `-e`, `select 123 as "123"`},
+		{`demo`, `--multitenant=false`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`},
+		{`demo`, `--multitenant=false`, `startrek`, `-e`, `SELECT database_name, owner FROM [show databases]`, `--format=table`},
 		// Test that if we start with --insecure we cannot perform
 		// commands that require a secure cluster.
-		{`demo`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
-		{`demo`, `--insecure`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
-		{`demo`, `--geo-partitioned-replicas`, `--disable-demo-license`},
+		{`demo`, `--multitenant=false`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
+		{`demo`, `--multitenant=false`, `--insecure`, `-e`, `CREATE USER test WITH PASSWORD 'testpass'`},
+		{`demo`, `--multitenant=false`, `--geo-partitioned-replicas`, `--disable-demo-license`},
 	}
 	setCLIDefaultsForTests()
 	// We must reset the security asset loader here, otherwise the dummy
@@ -52,41 +53,41 @@ func Example_demo() {
 	}
 
 	// Output:
-	// demo -e show database
+	// demo --multitenant=false -e show database
 	// database
 	// movr
-	// demo -e show database --no-example-database
+	// demo --multitenant=false -e show database --no-example-database
 	// database
 	// defaultdb
-	// demo -e show application_name
+	// demo --multitenant=false -e show application_name
 	// application_name
 	// $ cockroach demo
-	// demo --format=table -e show database
+	// demo --multitenant=false --format=table -e show database
 	//   database
 	// ------------
 	//   movr
 	// (1 row)
-	// demo -e select 1 as "1" -e select 3 as "3"
+	// demo --multitenant=false -e select 1 as "1" -e select 3 as "3"
 	// 1
 	// 1
 	// 3
 	// 3
-	// demo --echo-sql -e select 1 as "1"
+	// demo --multitenant=false --echo-sql -e select 1 as "1"
 	// > select 1 as "1"
 	// 1
 	// 1
-	// demo --set=errexit=0 -e select nonexistent -e select 123 as "123"
+	// demo --multitenant=false --set=errexit=0 -e select nonexistent -e select 123 as "123"
 	// ERROR: column "nonexistent" does not exist
 	// SQLSTATE: 42703
 	// 123
 	// 123
-	// demo startrek -e SELECT database_name, owner FROM [show databases]
+	// demo --multitenant=false startrek -e SELECT database_name, owner FROM [show databases]
 	// database_name	owner
 	// defaultdb	root
 	// postgres	root
 	// startrek	demo
 	// system	node
-	// demo startrek -e SELECT database_name, owner FROM [show databases] --format=table
+	// demo --multitenant=false startrek -e SELECT database_name, owner FROM [show databases] --format=table
 	//   database_name | owner
 	// ----------------+--------
 	//   defaultdb     | root
@@ -94,11 +95,11 @@ func Example_demo() {
 	//   startrek      | demo
 	//   system        | node
 	// (4 rows)
-	// demo -e CREATE USER test WITH PASSWORD 'testpass'
+	// demo --multitenant=false -e CREATE USER test WITH PASSWORD 'testpass'
 	// CREATE ROLE
-	// demo --insecure -e CREATE USER test WITH PASSWORD 'testpass'
+	// demo --multitenant=false --insecure -e CREATE USER test WITH PASSWORD 'testpass'
 	// ERROR: setting or updating a password is not supported in insecure mode
 	// SQLSTATE: 28P01
-	// demo --geo-partitioned-replicas --disable-demo-license
+	// demo --multitenant=false --geo-partitioned-replicas --disable-demo-license
 	// ERROR: enterprise features are needed for this demo (--geo-partitioned-replicas)
 }

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1151,7 +1151,7 @@ func (c *transientCluster) SetupWorkload(ctx context.Context, licenseDone <-chan
 		if c.demoCtx.RunWorkload {
 			var sqlURLs []string
 			for i := range c.servers {
-				sqlURL, err := c.getNetworkURLForServer(ctx, i, true /* includeAppName */, false /* isTenant */)
+				sqlURL, err := c.getNetworkURLForServer(ctx, i, true /* includeAppName */, c.demoCtx.Multitenant)
 				if err != nil {
 					return err
 				}

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -3,8 +3,9 @@
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check \\demo commands work as expected"
-# Start a demo with 5 nodes.
-spawn $argv demo movr --nodes=5
+# Start a demo with 5 nodes. Set multitenant=false due to unsupported
+# gossip commands below.
+spawn $argv demo movr --nodes=5 --multitenant=false
 
 # Ensure db is movr.
 eexpect "movr>"

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -39,7 +39,9 @@ end_test
 start_test "Check that controlling ranges of the movr dataset works"
 # Reset the timeout.
 set timeout 30
-spawn $argv demo movr --num-ranges=6
+# Need to disable multi-tenant mode here, as splitting is not supported.
+# See 54254 for more details.
+spawn $argv demo movr --num-ranges=6 --multitenant=false
 
 eexpect "movr>"
 

--- a/pkg/cli/interactive_tests/test_disable_replication.tcl
+++ b/pkg/cli/interactive_tests/test_disable_replication.tcl
@@ -7,7 +7,9 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that demo disables replication properly"
-send "$argv demo -e 'show zone configuration for range default'\r"
+# Disable multitenant until zone configs are properly enabled in tenants.
+# See 67679 for more details.
+send "$argv demo --multitenant=false -e 'show zone configuration for range default'\r"
 eexpect "num_replicas = 1"
 eexpect ":/# "
 end_test

--- a/pkg/workload/workloadsql/workloadsql.go
+++ b/pkg/workload/workloadsql/workloadsql.go
@@ -106,8 +106,9 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 	// we can't perform splits.
 	_, err := db.Exec("SHOW RANGES FROM TABLE system.descriptor")
 	if err != nil {
-		if strings.Contains(err.Error(), "not fully contained in tenant") {
-			log.Infof(ctx, `not perform workload splits; can't split on tenants'`)
+		if strings.Contains(err.Error(), "not fully contained in tenant") ||
+			strings.Contains(err.Error(), "operation is unsupported in multi-tenancy mode") {
+			log.Infof(ctx, `skipping workload splits; can't split on tenants'`)
 			//nolint:returnerrcheck
 			return nil
 		}


### PR DESCRIPTION
#71026 added support for cockroach demo to run in multi-tenant mode. In an
effort to get broader testing around multi-tenancy, this PR enables
multi-tenant mode by default.

This is currently a WIP as we first need to see what breaks in CI with this
enabled.

Release note (cli change): cockroach demo now runs by default in multi-tenant
mode. See #71026 for more details.