### PR TITLE
release-21.2: sql/pgwire: handle broken connection better in processing loop

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -367,6 +367,7 @@ ALL_TESTS = [
     "//pkg/util/metric:metric_test",
     "//pkg/util/mon:mon_test",
     "//pkg/util/netutil/addr:addr_test",
+    "//pkg/util/netutil:netutil_test",
     "//pkg/util/optional:optional_test",
     "//pkg/util/pretty:pretty_test",
     "//pkg/util/protoutil:protoutil_test",

--- a/pkg/util/netutil/BUILD.bazel
+++ b/pkg/util/netutil/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "netutil",
@@ -14,5 +14,17 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//http2",
+    ],
+)
+
+go_test(
+    name = "netutil_test",
+    srcs = ["net_test.go"],
+    embed = [":netutil"],
+    deps = [
+        "//pkg/util/contextutil",
+        "@com_github_cockroachdb_cmux//:cmux",
+        "@com_github_stretchr_testify//assert",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/pkg/util/netutil/net_test.go
+++ b/pkg/util/netutil/net_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package netutil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestIsClosedConnection(t *testing.T) {
+	for _, tc := range []struct {
+		err           error
+		isClosedError bool
+	}{
+		{
+			fmt.Errorf("an error"),
+			false,
+		},
+		{
+			net.ErrClosed,
+			true,
+		},
+		{
+			cmux.ErrListenerClosed,
+			true,
+		},
+		{
+			grpc.ErrServerStopped,
+			true,
+		},
+		{
+			io.EOF,
+			true,
+		},
+		{
+			// TODO(rafi): should this be treated the same as EOF?
+			io.ErrUnexpectedEOF,
+			false,
+		},
+		{
+			&net.AddrError{Err: "addr", Addr: "err"},
+			true,
+		},
+		{
+			syscall.ECONNRESET,
+			true,
+		},
+		{
+			syscall.EADDRINUSE,
+			true,
+		},
+		{
+			syscall.ECONNABORTED,
+			true,
+		},
+		{
+			syscall.ECONNREFUSED,
+			true,
+		},
+		{
+			syscall.EBADMSG,
+			true,
+		},
+		{
+			syscall.EINTR,
+			false,
+		},
+		{
+			&contextutil.TimeoutError{},
+			false,
+		},
+	} {
+		assert.Equalf(t, tc.isClosedError, IsClosedConnection(tc.err),
+			"expected %q to be evaluated as %v", tc.err, tc.isClosedError,
+		)
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #71940.

/cc @cockroachdb/release

---

Broken connections were not being detected correctly. Now, netutil
checks for all net.Errors more broadly. There's also a defensive check
in the pgwire loop so that if an error is mis-classified, we bail out
after a large number of repeated errors.

Release note (bug fix): Previously, some instances of a broken client
connection could cause an infinite loop while processing commands from
the client. This is fixed now.
