### PR TITLE
sql: fix setting DateStyle/IntervalStyle on -c

### DIFF
--- a/pkg/cli/interactive_tests/test_style_enabled.tcl
+++ b/pkg/cli/interactive_tests/test_style_enabled.tcl
@@ -1,0 +1,39 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+# Setup.
+spawn $argv sql
+eexpect root@
+send "SET CLUSTER SETTING sql.defaults.intervalstyle.enabled = true;\r"
+eexpect "SET CLUSTER SETTING"
+eexpect root@
+send "SET CLUSTER SETTING sql.defaults.datestyle.enabled = true;\r"
+eexpect "SET CLUSTER SETTING"
+eexpect root@
+interrupt
+eexpect eof
+
+
+# Try connect and check the session variables match.
+
+spawn $argv sql --url "postgresql://test@localhost:26257?options=-cintervalstyle%3Diso_8601"
+eexpect root@
+send "SHOW intervalstyle;\r"
+eexpect "iso_8601"
+eexpect root@
+interrupt
+eexpect eof
+
+# TODO(#72065): uncomment
+#spawn $argv sql --url "postgresql://test@localhost:26257?options=-cdatestyle%3Dymd"
+#eexpect root@
+#send "SHOW datestyle;\r"
+#eexpect "ISO, YMD"
+#eexpect root@
+#interrupt
+#eexpect eof
+
+stop_server $argv

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -47,14 +47,30 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 }
 
 func resetSessionVars(ctx context.Context, m sessionDataMutator) error {
+	// Always do intervalstyle_enabled and datestyle_enabled first so that
+	// IntervalStyle and DateStyle which depend on these flags are correctly
+	// configured.
+	if err := resetSessionVar(ctx, m, "datestyle_enabled"); err != nil {
+		return err
+	}
+	if err := resetSessionVar(ctx, m, "intervalstyle_enabled"); err != nil {
+		return err
+	}
 	for _, varName := range varNames {
-		v := varGen[varName]
-		if v.Set != nil {
-			hasDefault, defVal := getSessionVarDefaultString(varName, v, m.sessionDataMutatorBase)
-			if hasDefault {
-				if err := v.Set(ctx, m, defVal); err != nil {
-					return err
-				}
+		if err := resetSessionVar(ctx, m, varName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetSessionVar(ctx context.Context, m sessionDataMutator, varName string) error {
+	v := varGen[varName]
+	if v.Set != nil {
+		hasDefault, defVal := getSessionVarDefaultString(varName, v, m.sessionDataMutatorBase)
+		if hasDefault {
+			if err := v.Set(ctx, m, defVal); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -848,6 +848,7 @@ func parseClientProvidedSessionParameters(
 }
 
 func loadParameter(ctx context.Context, key, value string, args *sql.SessionArgs) error {
+	key = strings.ToLower(key)
 	exists, configurable := sql.IsSessionVariableConfigurable(key)
 
 	switch {


### PR DESCRIPTION
Release note (bug fix): Previously, specifying IntervalStyle or
DateStyle on `options=-c...` in a pgurl would fail, even if the
sql.defaults.datestyle.enabled and sql.defaults.intervalstyle.enabled
cluster settings were set. This has now been resolved.