### PR TITLE
colexec: allow for some sort functions to be inlined

### DIFF
--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -423,7 +423,6 @@ func newSingleSorter(
 }
 
 type sortBoolAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
@@ -433,7 +432,6 @@ type sortBoolAscWithNullsOp struct {
 func (s *sortBoolAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -444,7 +442,6 @@ func (s *sortBoolAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBoolAscWithNullsOp) sort() {
@@ -482,13 +479,10 @@ func (s *sortBoolAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -517,8 +511,8 @@ func (s *sortBoolAscWithNullsOp) Len() int {
 }
 
 type sortBytesAscWithNullsOp struct {
-	allocator          *colmem.Allocator
 	sortCol            *coldata.Bytes
+	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
 	order              []int
@@ -528,8 +522,8 @@ type sortBytesAscWithNullsOp struct {
 func (s *sortBytesAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator = allocator
 	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
 	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
@@ -539,11 +533,11 @@ func (s *sortBytesAscWithNullsOp) init(
 
 func (s *sortBytesAscWithNullsOp) reset() {
 	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.allocator = nil
 	s.abbreviatedSortCol = nil
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBytesAscWithNullsOp) sort() {
@@ -581,22 +575,19 @@ func (s *sortBytesAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	// If the type can be abbreviated as a uint64, compare the abbreviated
 	// values first. If they are not equal, we are done with the comparison. If
 	// they are equal, we must fallback to a full comparison of the datums.
-	abbr1 := s.abbreviatedSortCol[order1]
-	abbr2 := s.abbreviatedSortCol[order2]
+	abbr1 := s.abbreviatedSortCol[s.order[i]]
+	abbr2 := s.abbreviatedSortCol[s.order[j]]
 	if abbr1 != abbr2 {
 		return abbr1 < abbr2
 	}
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -617,7 +608,6 @@ func (s *sortBytesAscWithNullsOp) Len() int {
 }
 
 type sortDecimalAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
@@ -627,7 +617,6 @@ type sortDecimalAscWithNullsOp struct {
 func (s *sortDecimalAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -638,7 +627,6 @@ func (s *sortDecimalAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDecimalAscWithNullsOp) sort() {
@@ -676,13 +664,10 @@ func (s *sortDecimalAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -703,7 +688,6 @@ func (s *sortDecimalAscWithNullsOp) Len() int {
 }
 
 type sortInt16AscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
@@ -713,7 +697,6 @@ type sortInt16AscWithNullsOp struct {
 func (s *sortInt16AscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -724,7 +707,6 @@ func (s *sortInt16AscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt16AscWithNullsOp) sort() {
@@ -762,13 +744,10 @@ func (s *sortInt16AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -800,7 +779,6 @@ func (s *sortInt16AscWithNullsOp) Len() int {
 }
 
 type sortInt32AscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
@@ -810,7 +788,6 @@ type sortInt32AscWithNullsOp struct {
 func (s *sortInt32AscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -821,7 +798,6 @@ func (s *sortInt32AscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt32AscWithNullsOp) sort() {
@@ -859,13 +835,10 @@ func (s *sortInt32AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -897,7 +870,6 @@ func (s *sortInt32AscWithNullsOp) Len() int {
 }
 
 type sortInt64AscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -907,7 +879,6 @@ type sortInt64AscWithNullsOp struct {
 func (s *sortInt64AscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -918,7 +889,6 @@ func (s *sortInt64AscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt64AscWithNullsOp) sort() {
@@ -956,13 +926,10 @@ func (s *sortInt64AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -994,7 +961,6 @@ func (s *sortInt64AscWithNullsOp) Len() int {
 }
 
 type sortFloat64AscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -1004,7 +970,6 @@ type sortFloat64AscWithNullsOp struct {
 func (s *sortFloat64AscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1015,7 +980,6 @@ func (s *sortFloat64AscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortFloat64AscWithNullsOp) sort() {
@@ -1053,13 +1017,10 @@ func (s *sortFloat64AscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1099,7 +1060,6 @@ func (s *sortFloat64AscWithNullsOp) Len() int {
 }
 
 type sortTimestampAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
@@ -1109,7 +1069,6 @@ type sortTimestampAscWithNullsOp struct {
 func (s *sortTimestampAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1120,7 +1079,6 @@ func (s *sortTimestampAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortTimestampAscWithNullsOp) sort() {
@@ -1158,13 +1116,10 @@ func (s *sortTimestampAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1192,7 +1147,6 @@ func (s *sortTimestampAscWithNullsOp) Len() int {
 }
 
 type sortIntervalAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
@@ -1202,7 +1156,6 @@ type sortIntervalAscWithNullsOp struct {
 func (s *sortIntervalAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1213,7 +1166,6 @@ func (s *sortIntervalAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortIntervalAscWithNullsOp) sort() {
@@ -1251,13 +1203,10 @@ func (s *sortIntervalAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1278,7 +1227,6 @@ func (s *sortIntervalAscWithNullsOp) Len() int {
 }
 
 type sortJSONAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
@@ -1288,7 +1236,6 @@ type sortJSONAscWithNullsOp struct {
 func (s *sortJSONAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1299,7 +1246,6 @@ func (s *sortJSONAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortJSONAscWithNullsOp) sort() {
@@ -1337,13 +1283,10 @@ func (s *sortJSONAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1370,7 +1313,6 @@ func (s *sortJSONAscWithNullsOp) Len() int {
 }
 
 type sortDatumAscWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
@@ -1380,7 +1322,6 @@ type sortDatumAscWithNullsOp struct {
 func (s *sortDatumAscWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1391,7 +1332,6 @@ func (s *sortDatumAscWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDatumAscWithNullsOp) sort() {
@@ -1429,13 +1369,10 @@ func (s *sortDatumAscWithNullsOp) Less(i, j int) bool {
 		return false
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1458,7 +1395,6 @@ func (s *sortDatumAscWithNullsOp) Len() int {
 }
 
 type sortBoolDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
@@ -1468,7 +1404,6 @@ type sortBoolDescWithNullsOp struct {
 func (s *sortBoolDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1479,7 +1414,6 @@ func (s *sortBoolDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBoolDescWithNullsOp) sort() {
@@ -1517,13 +1451,10 @@ func (s *sortBoolDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1552,8 +1483,8 @@ func (s *sortBoolDescWithNullsOp) Len() int {
 }
 
 type sortBytesDescWithNullsOp struct {
-	allocator          *colmem.Allocator
 	sortCol            *coldata.Bytes
+	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
 	order              []int
@@ -1563,8 +1494,8 @@ type sortBytesDescWithNullsOp struct {
 func (s *sortBytesDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator = allocator
 	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
 	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
@@ -1574,11 +1505,11 @@ func (s *sortBytesDescWithNullsOp) init(
 
 func (s *sortBytesDescWithNullsOp) reset() {
 	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.allocator = nil
 	s.abbreviatedSortCol = nil
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBytesDescWithNullsOp) sort() {
@@ -1616,22 +1547,19 @@ func (s *sortBytesDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	// If the type can be abbreviated as a uint64, compare the abbreviated
 	// values first. If they are not equal, we are done with the comparison. If
 	// they are equal, we must fallback to a full comparison of the datums.
-	abbr1 := s.abbreviatedSortCol[order1]
-	abbr2 := s.abbreviatedSortCol[order2]
+	abbr1 := s.abbreviatedSortCol[s.order[i]]
+	abbr2 := s.abbreviatedSortCol[s.order[j]]
 	if abbr1 != abbr2 {
 		return abbr1 > abbr2
 	}
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1652,7 +1580,6 @@ func (s *sortBytesDescWithNullsOp) Len() int {
 }
 
 type sortDecimalDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
@@ -1662,7 +1589,6 @@ type sortDecimalDescWithNullsOp struct {
 func (s *sortDecimalDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1673,7 +1599,6 @@ func (s *sortDecimalDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDecimalDescWithNullsOp) sort() {
@@ -1711,13 +1636,10 @@ func (s *sortDecimalDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1738,7 +1660,6 @@ func (s *sortDecimalDescWithNullsOp) Len() int {
 }
 
 type sortInt16DescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
@@ -1748,7 +1669,6 @@ type sortInt16DescWithNullsOp struct {
 func (s *sortInt16DescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1759,7 +1679,6 @@ func (s *sortInt16DescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt16DescWithNullsOp) sort() {
@@ -1797,13 +1716,10 @@ func (s *sortInt16DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1835,7 +1751,6 @@ func (s *sortInt16DescWithNullsOp) Len() int {
 }
 
 type sortInt32DescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
@@ -1845,7 +1760,6 @@ type sortInt32DescWithNullsOp struct {
 func (s *sortInt32DescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1856,7 +1770,6 @@ func (s *sortInt32DescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt32DescWithNullsOp) sort() {
@@ -1894,13 +1807,10 @@ func (s *sortInt32DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -1932,7 +1842,6 @@ func (s *sortInt32DescWithNullsOp) Len() int {
 }
 
 type sortInt64DescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -1942,7 +1851,6 @@ type sortInt64DescWithNullsOp struct {
 func (s *sortInt64DescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -1953,7 +1861,6 @@ func (s *sortInt64DescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt64DescWithNullsOp) sort() {
@@ -1991,13 +1898,10 @@ func (s *sortInt64DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2029,7 +1933,6 @@ func (s *sortInt64DescWithNullsOp) Len() int {
 }
 
 type sortFloat64DescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -2039,7 +1942,6 @@ type sortFloat64DescWithNullsOp struct {
 func (s *sortFloat64DescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2050,7 +1952,6 @@ func (s *sortFloat64DescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortFloat64DescWithNullsOp) sort() {
@@ -2088,13 +1989,10 @@ func (s *sortFloat64DescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2134,7 +2032,6 @@ func (s *sortFloat64DescWithNullsOp) Len() int {
 }
 
 type sortTimestampDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
@@ -2144,7 +2041,6 @@ type sortTimestampDescWithNullsOp struct {
 func (s *sortTimestampDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2155,7 +2051,6 @@ func (s *sortTimestampDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortTimestampDescWithNullsOp) sort() {
@@ -2193,13 +2088,10 @@ func (s *sortTimestampDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2227,7 +2119,6 @@ func (s *sortTimestampDescWithNullsOp) Len() int {
 }
 
 type sortIntervalDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
@@ -2237,7 +2128,6 @@ type sortIntervalDescWithNullsOp struct {
 func (s *sortIntervalDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2248,7 +2138,6 @@ func (s *sortIntervalDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortIntervalDescWithNullsOp) sort() {
@@ -2286,13 +2175,10 @@ func (s *sortIntervalDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2313,7 +2199,6 @@ func (s *sortIntervalDescWithNullsOp) Len() int {
 }
 
 type sortJSONDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
@@ -2323,7 +2208,6 @@ type sortJSONDescWithNullsOp struct {
 func (s *sortJSONDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2334,7 +2218,6 @@ func (s *sortJSONDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortJSONDescWithNullsOp) sort() {
@@ -2372,13 +2255,10 @@ func (s *sortJSONDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2405,7 +2285,6 @@ func (s *sortJSONDescWithNullsOp) Len() int {
 }
 
 type sortDatumDescWithNullsOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
@@ -2415,7 +2294,6 @@ type sortDatumDescWithNullsOp struct {
 func (s *sortDatumDescWithNullsOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2426,7 +2304,6 @@ func (s *sortDatumDescWithNullsOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDatumDescWithNullsOp) sort() {
@@ -2464,13 +2341,10 @@ func (s *sortDatumDescWithNullsOp) Less(i, j int) bool {
 		return true
 	}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2493,7 +2367,6 @@ func (s *sortDatumDescWithNullsOp) Len() int {
 }
 
 type sortBoolAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
@@ -2503,7 +2376,6 @@ type sortBoolAscOp struct {
 func (s *sortBoolAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2514,7 +2386,6 @@ func (s *sortBoolAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBoolAscOp) sort() {
@@ -2542,13 +2413,10 @@ func (s *sortBoolAscOp) sortPartitions(partitions []int) {
 
 func (s *sortBoolAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2577,8 +2445,8 @@ func (s *sortBoolAscOp) Len() int {
 }
 
 type sortBytesAscOp struct {
-	allocator          *colmem.Allocator
 	sortCol            *coldata.Bytes
+	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
 	order              []int
@@ -2588,8 +2456,8 @@ type sortBytesAscOp struct {
 func (s *sortBytesAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator = allocator
 	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
 	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
@@ -2599,11 +2467,11 @@ func (s *sortBytesAscOp) init(
 
 func (s *sortBytesAscOp) reset() {
 	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.allocator = nil
 	s.abbreviatedSortCol = nil
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBytesAscOp) sort() {
@@ -2631,22 +2499,19 @@ func (s *sortBytesAscOp) sortPartitions(partitions []int) {
 
 func (s *sortBytesAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	// If the type can be abbreviated as a uint64, compare the abbreviated
 	// values first. If they are not equal, we are done with the comparison. If
 	// they are equal, we must fallback to a full comparison of the datums.
-	abbr1 := s.abbreviatedSortCol[order1]
-	abbr2 := s.abbreviatedSortCol[order2]
+	abbr1 := s.abbreviatedSortCol[s.order[i]]
+	abbr2 := s.abbreviatedSortCol[s.order[j]]
 	if abbr1 != abbr2 {
 		return abbr1 < abbr2
 	}
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2667,7 +2532,6 @@ func (s *sortBytesAscOp) Len() int {
 }
 
 type sortDecimalAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
@@ -2677,7 +2541,6 @@ type sortDecimalAscOp struct {
 func (s *sortDecimalAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2688,7 +2551,6 @@ func (s *sortDecimalAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDecimalAscOp) sort() {
@@ -2716,13 +2578,10 @@ func (s *sortDecimalAscOp) sortPartitions(partitions []int) {
 
 func (s *sortDecimalAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2743,7 +2602,6 @@ func (s *sortDecimalAscOp) Len() int {
 }
 
 type sortInt16AscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
@@ -2753,7 +2611,6 @@ type sortInt16AscOp struct {
 func (s *sortInt16AscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2764,7 +2621,6 @@ func (s *sortInt16AscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt16AscOp) sort() {
@@ -2790,15 +2646,13 @@ func (s *sortInt16AscOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt16AscOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2830,7 +2684,6 @@ func (s *sortInt16AscOp) Len() int {
 }
 
 type sortInt32AscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
@@ -2840,7 +2693,6 @@ type sortInt32AscOp struct {
 func (s *sortInt32AscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2851,7 +2703,6 @@ func (s *sortInt32AscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt32AscOp) sort() {
@@ -2877,15 +2728,13 @@ func (s *sortInt32AscOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt32AscOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -2917,7 +2766,6 @@ func (s *sortInt32AscOp) Len() int {
 }
 
 type sortInt64AscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -2927,7 +2775,6 @@ type sortInt64AscOp struct {
 func (s *sortInt64AscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -2938,7 +2785,6 @@ func (s *sortInt64AscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt64AscOp) sort() {
@@ -2964,15 +2810,13 @@ func (s *sortInt64AscOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt64AscOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3004,7 +2848,6 @@ func (s *sortInt64AscOp) Len() int {
 }
 
 type sortFloat64AscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -3014,7 +2857,6 @@ type sortFloat64AscOp struct {
 func (s *sortFloat64AscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3025,7 +2867,6 @@ func (s *sortFloat64AscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortFloat64AscOp) sort() {
@@ -3053,13 +2894,10 @@ func (s *sortFloat64AscOp) sortPartitions(partitions []int) {
 
 func (s *sortFloat64AscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3099,7 +2937,6 @@ func (s *sortFloat64AscOp) Len() int {
 }
 
 type sortTimestampAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
@@ -3109,7 +2946,6 @@ type sortTimestampAscOp struct {
 func (s *sortTimestampAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3120,7 +2956,6 @@ func (s *sortTimestampAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortTimestampAscOp) sort() {
@@ -3148,13 +2983,10 @@ func (s *sortTimestampAscOp) sortPartitions(partitions []int) {
 
 func (s *sortTimestampAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3182,7 +3014,6 @@ func (s *sortTimestampAscOp) Len() int {
 }
 
 type sortIntervalAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
@@ -3192,7 +3023,6 @@ type sortIntervalAscOp struct {
 func (s *sortIntervalAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3203,7 +3033,6 @@ func (s *sortIntervalAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortIntervalAscOp) sort() {
@@ -3231,13 +3060,10 @@ func (s *sortIntervalAscOp) sortPartitions(partitions []int) {
 
 func (s *sortIntervalAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3258,7 +3084,6 @@ func (s *sortIntervalAscOp) Len() int {
 }
 
 type sortJSONAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
@@ -3268,7 +3093,6 @@ type sortJSONAscOp struct {
 func (s *sortJSONAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3279,7 +3103,6 @@ func (s *sortJSONAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortJSONAscOp) sort() {
@@ -3307,13 +3130,10 @@ func (s *sortJSONAscOp) sortPartitions(partitions []int) {
 
 func (s *sortJSONAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3340,7 +3160,6 @@ func (s *sortJSONAscOp) Len() int {
 }
 
 type sortDatumAscOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
@@ -3350,7 +3169,6 @@ type sortDatumAscOp struct {
 func (s *sortDatumAscOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3361,7 +3179,6 @@ func (s *sortDatumAscOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDatumAscOp) sort() {
@@ -3389,13 +3206,10 @@ func (s *sortDatumAscOp) sortPartitions(partitions []int) {
 
 func (s *sortDatumAscOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3418,7 +3232,6 @@ func (s *sortDatumAscOp) Len() int {
 }
 
 type sortBoolDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
 	order         []int
@@ -3428,7 +3241,6 @@ type sortBoolDescOp struct {
 func (s *sortBoolDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3439,7 +3251,6 @@ func (s *sortBoolDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBoolDescOp) sort() {
@@ -3467,13 +3278,10 @@ func (s *sortBoolDescOp) sortPartitions(partitions []int) {
 
 func (s *sortBoolDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3502,8 +3310,8 @@ func (s *sortBoolDescOp) Len() int {
 }
 
 type sortBytesDescOp struct {
-	allocator          *colmem.Allocator
 	sortCol            *coldata.Bytes
+	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
 	order              []int
@@ -3513,8 +3321,8 @@ type sortBytesDescOp struct {
 func (s *sortBytesDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Bytes()
+	s.allocator = allocator
 	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
 	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	s.nulls = col.Nulls()
@@ -3524,11 +3332,11 @@ func (s *sortBytesDescOp) init(
 
 func (s *sortBytesDescOp) reset() {
 	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.allocator = nil
 	s.abbreviatedSortCol = nil
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortBytesDescOp) sort() {
@@ -3556,22 +3364,19 @@ func (s *sortBytesDescOp) sortPartitions(partitions []int) {
 
 func (s *sortBytesDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	// If the type can be abbreviated as a uint64, compare the abbreviated
 	// values first. If they are not equal, we are done with the comparison. If
 	// they are equal, we must fallback to a full comparison of the datums.
-	abbr1 := s.abbreviatedSortCol[order1]
-	abbr2 := s.abbreviatedSortCol[order2]
+	abbr1 := s.abbreviatedSortCol[s.order[i]]
+	abbr2 := s.abbreviatedSortCol[s.order[j]]
 	if abbr1 != abbr2 {
 		return abbr1 > abbr2
 	}
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3592,7 +3397,6 @@ func (s *sortBytesDescOp) Len() int {
 }
 
 type sortDecimalDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
 	order         []int
@@ -3602,7 +3406,6 @@ type sortDecimalDescOp struct {
 func (s *sortDecimalDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3613,7 +3416,6 @@ func (s *sortDecimalDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDecimalDescOp) sort() {
@@ -3641,13 +3443,10 @@ func (s *sortDecimalDescOp) sortPartitions(partitions []int) {
 
 func (s *sortDecimalDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3668,7 +3467,6 @@ func (s *sortDecimalDescOp) Len() int {
 }
 
 type sortInt16DescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
 	order         []int
@@ -3678,7 +3476,6 @@ type sortInt16DescOp struct {
 func (s *sortInt16DescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3689,7 +3486,6 @@ func (s *sortInt16DescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt16DescOp) sort() {
@@ -3715,15 +3511,13 @@ func (s *sortInt16DescOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt16DescOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3755,7 +3549,6 @@ func (s *sortInt16DescOp) Len() int {
 }
 
 type sortInt32DescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
 	order         []int
@@ -3765,7 +3558,6 @@ type sortInt32DescOp struct {
 func (s *sortInt32DescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3776,7 +3568,6 @@ func (s *sortInt32DescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt32DescOp) sort() {
@@ -3802,15 +3593,13 @@ func (s *sortInt32DescOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt32DescOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3842,7 +3631,6 @@ func (s *sortInt32DescOp) Len() int {
 }
 
 type sortInt64DescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -3852,7 +3640,6 @@ type sortInt64DescOp struct {
 func (s *sortInt64DescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3863,7 +3650,6 @@ func (s *sortInt64DescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortInt64DescOp) sort() {
@@ -3889,15 +3675,13 @@ func (s *sortInt64DescOp) sortPartitions(partitions []int) {
 	}
 }
 
+//gcassert:inline
 func (s *sortInt64DescOp) Less(i, j int) bool {
-
-	order1 := s.order[i]
-	order2 := s.order[j]
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -3929,7 +3713,6 @@ func (s *sortInt64DescOp) Len() int {
 }
 
 type sortFloat64DescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
 	order         []int
@@ -3939,7 +3722,6 @@ type sortFloat64DescOp struct {
 func (s *sortFloat64DescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -3950,7 +3732,6 @@ func (s *sortFloat64DescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortFloat64DescOp) sort() {
@@ -3978,13 +3759,10 @@ func (s *sortFloat64DescOp) sortPartitions(partitions []int) {
 
 func (s *sortFloat64DescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -4024,7 +3802,6 @@ func (s *sortFloat64DescOp) Len() int {
 }
 
 type sortTimestampDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Times
 	nulls         *coldata.Nulls
 	order         []int
@@ -4034,7 +3811,6 @@ type sortTimestampDescOp struct {
 func (s *sortTimestampDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -4045,7 +3821,6 @@ func (s *sortTimestampDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortTimestampDescOp) sort() {
@@ -4073,13 +3848,10 @@ func (s *sortTimestampDescOp) sortPartitions(partitions []int) {
 
 func (s *sortTimestampDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -4107,7 +3879,6 @@ func (s *sortTimestampDescOp) Len() int {
 }
 
 type sortIntervalDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
 	order         []int
@@ -4117,7 +3888,6 @@ type sortIntervalDescOp struct {
 func (s *sortIntervalDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -4128,7 +3898,6 @@ func (s *sortIntervalDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortIntervalDescOp) sort() {
@@ -4156,13 +3925,10 @@ func (s *sortIntervalDescOp) sortPartitions(partitions []int) {
 
 func (s *sortIntervalDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -4183,7 +3949,6 @@ func (s *sortIntervalDescOp) Len() int {
 }
 
 type sortJSONDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
 	order         []int
@@ -4193,7 +3958,6 @@ type sortJSONDescOp struct {
 func (s *sortJSONDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -4204,7 +3968,6 @@ func (s *sortJSONDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortJSONDescOp) sort() {
@@ -4232,13 +3995,10 @@ func (s *sortJSONDescOp) sortPartitions(partitions []int) {
 
 func (s *sortJSONDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int
@@ -4265,7 +4025,6 @@ func (s *sortJSONDescOp) Len() int {
 }
 
 type sortDatumDescOp struct {
-	allocator     *colmem.Allocator
 	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
 	order         []int
@@ -4275,7 +4034,6 @@ type sortDatumDescOp struct {
 func (s *sortDatumDescOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
@@ -4286,7 +4044,6 @@ func (s *sortDatumDescOp) reset() {
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sortDatumDescOp) sort() {
@@ -4314,13 +4071,10 @@ func (s *sortDatumDescOp) sortPartitions(partitions []int) {
 
 func (s *sortDatumDescOp) Less(i, j int) bool {
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 
 	{
 		var cmpResult int

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -135,9 +135,9 @@ func newSingleSorter(
 // {{range .WidthOverloads}}
 
 type sort_TYPE_DIR_HANDLES_NULLSOp struct {
-	allocator *colmem.Allocator
-	sortCol   _GOTYPESLICE
+	sortCol _GOTYPESLICE
 	// {{if .CanAbbreviate}}
+	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	// {{end}}
 	nulls         *coldata.Nulls
@@ -148,9 +148,9 @@ type sort_TYPE_DIR_HANDLES_NULLSOp struct {
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(
 	ctx context.Context, allocator *colmem.Allocator, col coldata.Vec, order []int,
 ) {
-	s.allocator = allocator
 	s.sortCol = col.TemplateType()
 	// {{if .CanAbbreviate}}
+	s.allocator = allocator
 	s.allocator.AdjustMemoryUsage(memsize.Uint64 * int64(s.sortCol.Len()))
 	s.abbreviatedSortCol = s.sortCol.Abbreviated()
 	// {{end}}
@@ -162,12 +162,12 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) reset() {
 	// {{if .CanAbbreviate}}
 	s.allocator.AdjustMemoryUsage(0 - memsize.Uint64*int64(s.sortCol.Len()))
+	s.allocator = nil
 	s.abbreviatedSortCol = nil
 	// {{end}}
 	s.sortCol = nil
 	s.nulls = nil
 	s.order = nil
-	s.allocator = nil
 }
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sort() {
@@ -193,6 +193,15 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(partitions []int) {
 	}
 }
 
+// {{/*
+// TODO(yuzefovich): think through how we can inline more implementations of
+// Less method - this has non-trivial performance improvements.
+// */}}
+// {{$isInt := or (eq .VecMethod "Int16") (eq .VecMethod "Int32")}}
+// {{$isInt = or ($isInt) (eq .VecMethod "Int64")}}
+// {{if and ($isInt) (not $nulls)}}
+//gcassert:inline
+// {{end}}
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// {{if $nulls}}
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
@@ -218,15 +227,12 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// {{end}}
 	// {{end}}
 
-	order1 := s.order[i]
-	order2 := s.order[j]
-
 	// {{if .CanAbbreviate}}
 	// If the type can be abbreviated as a uint64, compare the abbreviated
 	// values first. If they are not equal, we are done with the comparison. If
 	// they are equal, we must fallback to a full comparison of the datums.
-	abbr1 := s.abbreviatedSortCol[order1]
-	abbr2 := s.abbreviatedSortCol[order2]
+	abbr1 := s.abbreviatedSortCol[s.order[i]]
+	abbr2 := s.abbreviatedSortCol[s.order[j]]
 	if abbr1 != abbr2 {
 		// {{if eq $dir "Asc"}}
 		return abbr1 < abbr2
@@ -238,8 +244,8 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 
 	var lt bool
 	// We always indirect via the order vector.
-	arg1 := s.sortCol.Get(order1)
-	arg2 := s.sortCol.Get(order2)
+	arg1 := s.sortCol.Get(s.order[i])
+	arg2 := s.sortCol.Get(s.order[j])
 	_ASSIGN_LT(lt, arg1, arg2, _, s.sortCol, s.sortCol)
 	return lt
 }


### PR DESCRIPTION
This commit partially reverts the changes in
1bfa1a6 so that in some cases `Less`
implementations by the sorters could be inlined. It additionally
enforces those inlines by a linter and keeps the allocator field only
when it is actually used.

Addresses: #71820.

Release note: None