### PR TITLE
sql: fix bug where validate constraint checked inaccessible columns

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -48,7 +48,7 @@ func validateCheckExpr(
 	if err != nil {
 		return err
 	}
-	colSelectors := tabledesc.ColumnsSelectors(tableDesc.PublicColumns())
+	colSelectors := tabledesc.ColumnsSelectors(tableDesc.AccessibleColumns())
 	columns := tree.AsStringWithFlags(&colSelectors, tree.FmtSerializable)
 	queryStr := fmt.Sprintf(`SELECT %s FROM [%d AS t] WHERE NOT (%s) LIMIT 1`, columns, tableDesc.GetID(), exprStr)
 	log.Infof(ctx, "validating check constraint %q with query %q", expr, queryStr)
@@ -60,7 +60,7 @@ func validateCheckExpr(
 	if rows.Len() > 0 {
 		return pgerror.Newf(pgcode.CheckViolation,
 			"validation of CHECK %q failed on row: %s",
-			expr, labeledRowValues(tableDesc.PublicColumns(), rows))
+			expr, labeledRowValues(tableDesc.AccessibleColumns(), rows))
 	}
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -883,3 +883,28 @@ INSERT INTO uniq VALUES (3, 1, 109) ON CONFLICT ((a + b)) DO NOTHING
 # See https://github.com/cockroachdb/cockroach/issues/67893.
 statement error syntax error
 INSERT INTO uniq VALUES (4, 1, 219) ON CONFLICT ((a + b)) DO UPDATE SET b = 90
+
+# Regression test for #72012. CHECK CONSTRAINT should not check inaccessible columns.
+
+statement ok
+CREATE TABLE t72012 (col integer);
+CREATE INDEX t72012_idx ON t72012 ((abs(col)));
+ALTER TABLE t72012 ALTER COLUMN col SET NOT NULL
+
+query TT
+SHOW CREATE TABLE t72012
+----
+t72012  CREATE TABLE public.t72012 (
+        col INT8 NOT NULL,
+        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+        CONSTRAINT t72012_pkey PRIMARY KEY (rowid ASC),
+        INDEX t72012_idx (abs(col) ASC),
+        FAMILY "primary" (col, rowid)
+)
+
+statement ok
+ALTER TABLE t72012 ALTER COLUMN col DROP NOT NULL;
+INSERT INTO t72012 VALUES (NULL)
+
+statement error validation of NOT NULL constraint failed: validation of CHECK "col IS NOT NULL" failed on row: col=NULL, rowid=\d+
+ALTER TABLE t72012 ALTER COLUMN col SET NOT NULL


### PR DESCRIPTION
Resolves #72012

Release note (bug fix): Fixed a bug where certain schema changes (e.g.
SET NULL) did not work if there was a expression-based index on the
table.