### PR TITLE
types: correct atttypmod for DECIMAL with precision but no width

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -574,3 +574,13 @@ Infinity
 Infinity
 Infinity
 -Infinity
+
+statement ok
+CREATE TABLE t71926(no_typmod decimal, precision decimal(5), precision_and_width decimal(5,3))
+
+query TI
+SELECT attname, atttypmod FROM pg_attribute WHERE attrelid = 't71926'::regclass::oid AND atttypid = 'decimal'::regtype::oid
+----
+no_typmod            -1
+precision            327684
+precision_and_width  327687

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1191,20 +1191,25 @@ func (t *T) TypeModifier() int32 {
 	if t.Oid() == oid.T_char {
 		return int32(-1)
 	}
-	if width := t.Width(); width != 0 {
-		switch t.Family() {
-		case StringFamily, CollatedStringFamily:
+
+	switch t.Family() {
+	case StringFamily, CollatedStringFamily:
+		if width := t.Width(); width != 0 {
 			// Postgres adds 4 to the attypmod for bounded string types, the
 			// var header size.
 			return width + 4
-		case BitFamily:
+		}
+	case BitFamily:
+		if width := t.Width(); width != 0 {
 			return width
-		case DecimalFamily:
-			// attTypMod is calculated by putting the precision in the upper
-			// bits and the scale in the lower bits of a 32-bit int, and adding
-			// 4 (the var header size). We mock this for clients' sake. See
-			// numeric.c.
-			return ((t.Precision() << 16) | width) + 4
+		}
+	case DecimalFamily:
+		// attTypMod is calculated by putting the precision in the upper
+		// bits and the scale in the lower bits of a 32-bit int, and adding
+		// 4 (the var header size). We mock this for clients' sake. See
+		// https://github.com/postgres/postgres/blob/5a2832465fd8984d089e8c44c094e6900d987fcd/src/backend/utils/adt/numeric.c#L1242.
+		if width, precision := t.Width(), t.Precision(); precision != 0 || width != 0 {
+			return ((precision << 16) | width) + 4
 		}
 	}
 	return int32(-1)


### PR DESCRIPTION
Resolves #71926

Release note (bug fix): Previously, atttypmod in
pg_catalog.pg_attributes for DECIMAL types with precision but no
width was incorrectly -1. This is now populated correctly.

