### PR TITLE
dev: override bazel timeout when run under stress

### DIFF
--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -84,7 +84,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' --test_timeout=86400 '--test_filter=TestStartChild*' --test_output streamed
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -31,7 +31,7 @@ bazel test //pkg/util/tracing:tracing_test --nocache_test_results '--test_filter
 dev test --stress pkg/util/tracing --filter TestStartChild*
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress ' --test_timeout=86400 '--test_filter=TestStartChild*' --test_output streamed
 
 dev test --stress pkg/util/tracing --filter TestStartChild* --timeout=10s -v
 ----


### PR DESCRIPTION
When running under stress and no timeout is specified, we want
to respect the timeout passed down to stress[^1]. Not doing so has bazel
default to a timeout based on the test target's size[^2], which is not
what we want.

[^1]: Through --stress-arg=-maxtime or if nothing is specified, a
     -maxtime of 0 that's taken as "run forever")
[^2]: https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner

Release note: None