### PR TITLE
sql: fix indkey column in pg_catalog.pg_index for expression indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1033,7 +1033,20 @@ WHERE indnkeyatts = 2
 indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
 450499961   55        true       false           3 4     0 0           0 0       2 2        NULL      NULL
 3660126516  59        true       false           1 2 3   0 0           0 0       2 1        NULL      NULL
-2574785777  63        true       false           6 7     3403232968 0  0 0       2 2        NULL      NULL
+2574785777  63        true       false           0 0     3403232968 0  0 0       2 2        NULL      NULL
+
+# indkey should be 0 for expression elements an index.
+# TODO: In Postgres indexprs are values that represent the expression. Matching
+# this representation may be difficult and unnecessary.
+query TTT colnames
+SELECT c.relname, i.indkey, i.indexprs
+FROM pg_catalog.pg_index i
+JOIN pg_catalog.pg_class c ON i.indexrelid = c.oid
+WHERE c.relname IN ('t6_expr_idx', 't6_expr_expr1_idx')
+----
+relname            indkey  indexprs
+t6_expr_idx        0       NULL
+t6_expr_expr1_idx  0 0     NULL
 
 statement ok
 SET DATABASE = system

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1698,10 +1698,16 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 					colIDs := make([]descpb.ColumnID, 0, index.NumKeyColumns())
 					for i := index.IndexDesc().ExplicitColumnStartIdx(); i < index.NumKeyColumns(); i++ {
 						columnID := index.GetKeyColumnID(i)
-						colIDs = append(colIDs, columnID)
 						col, err := table.FindColumnWithID(columnID)
 						if err != nil {
 							return err
+						}
+						// The indkey for an expression element in an index
+						// should be 0.
+						if col.IsExpressionIndexColumn() {
+							colIDs = append(colIDs, 0)
+						} else {
+							colIDs = append(colIDs, columnID)
 						}
 						if err := collationOids.Append(typColl(col.GetType(), h)); err != nil {
 							return err


### PR DESCRIPTION
Fixes #72041

Release note (bug fix): A bug has been fixed that incorrectly populated
the `indkey` column of `pg_catalog.pg_index` for expression indexes.
This bug was present since the introduction of expression indexes in
version 21.2.0.