### PR TITLE
ui: update sessions table tooltip

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTableContent.tsx
@@ -21,7 +21,7 @@ export const SessionTableTitle = {
     <Tooltip
       style="tableTitle"
       placement="bottom"
-      content={"Most recent or currently active statement."}
+      content={"Currently active statement."}
     >
       Statement
     </Tooltip>


### PR DESCRIPTION
The tooltip for statement on Sessions table was indicating
that the we were displaying most recent or currently active
statement. This commits changes to text to the accurate
message that we only show currently active statements.

Fixes #72047

Before
![139118536-8f2c0b53-8a54-40c3-995d-8fcf4ae352a4](https://user-images.githubusercontent.com/1017486/139147225-e8d0d33e-c292-4ee2-b550-5ab1ef812eff.png)

After
<img width="276" alt="Screen Shot 2021-10-27 at 5 05 22 PM" src="https://user-images.githubusercontent.com/1017486/139147259-7de41824-4986-44f4-8292-ece74a57f1a1.png">

Release note (ui change): Update tooltip text on Statement
column on Session table to the accurate information that we show
only currently active statements.