### PR TITLE
util/tracing: separate recording from span existence 

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -166,4 +166,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-8	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-10	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -171,6 +171,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-8</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-10</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -277,6 +277,10 @@ const (
 	// descriptors have draining names.
 	DrainingNamesMigration
 
+	// TraceIDDoesntImplyStructuredRecording changes the contract about the kind
+	// of span that RPCs get on the server depending on the tracing context.
+	TraceIDDoesntImplyStructuredRecording
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -472,6 +476,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     DrainingNamesMigration,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 8},
+	},
+	{
+		Key:     TraceIDDoesntImplyStructuredRecording,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 10},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -47,11 +47,12 @@ func _() {
 	_ = x[TargetBytesAvoidExcess-36]
 	_ = x[AvoidDrainingNames-37]
 	_ = x[DrainingNamesMigration-38]
+	_ = x[TraceIDDoesntImplyStructuredRecording-39]
 }
 
-const _Key_name = "V21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDeleteTenantUsageSingleConsumptionColumnSQLStatsTablesSQLStatsCompactionScheduledJobV21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigration"
+const _Key_name = "V21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDeleteTenantUsageSingleConsumptionColumnSQLStatsTablesSQLStatsCompactionScheduledJobV21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecording"
 
-var _Key_index = [...]uint16{0, 5, 18, 27, 42, 71, 88, 105, 154, 168, 188, 204, 221, 248, 283, 308, 337, 368, 388, 419, 436, 465, 498, 521, 540, 559, 582, 598, 618, 639, 661, 680, 714, 728, 758, 763, 772, 794, 812, 834}
+var _Key_index = [...]uint16{0, 5, 18, 27, 42, 71, 88, 105, 154, 168, 188, 204, 221, 248, 283, 308, 337, 368, 388, 419, 436, 465, 498, 521, 540, 559, 582, 598, 618, 639, 661, 680, 714, 728, 758, 763, 772, 794, 812, 834, 871}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -390,7 +390,7 @@ func (r *Registry) runJob(
 	// A new root span will be created on every resumption of the job.
 	var spanOptions []tracing.SpanOption
 	if tj, ok := resumer.(TraceableJob); ok && tj.ForceRealSpan() {
-		spanOptions = append(spanOptions, tracing.WithForceRealSpan())
+		spanOptions = append(spanOptions, tracing.WithRecording(tracing.RecordingStructured))
 	}
 	// TODO(ajwerner): Move this writing up the trace ID down into
 	// stepThroughStateMachine where we're already often (and soon with

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -151,9 +151,8 @@ func (*mockInternalClient) ResetQuorum(
 func (m *mockInternalClient) Batch(
 	ctx context.Context, in *roachpb.BatchRequest, opts ...grpc.CallOption,
 ) (*roachpb.BatchResponse, error) {
-	sp := m.tr.StartSpan("mock", tracing.WithForceRealSpan())
+	sp := m.tr.StartSpan("mock", tracing.WithRecording(tracing.RecordingVerbose))
 	defer sp.Finish()
-	sp.SetVerbose(true)
 	ctx = tracing.ContextWithSpan(ctx, sp)
 
 	log.Eventf(ctx, "mockInternalClient processing batch")

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -159,7 +159,7 @@ func (m *mockInternalClient) Batch(
 	log.Eventf(ctx, "mockInternalClient processing batch")
 	br := &roachpb.BatchResponse{}
 	br.Error = m.pErr
-	if rec := sp.GetRecording(); rec != nil {
+	if rec := sp.GetRecording(tracing.RecordingVerbose); rec != nil {
 		br.CollectedSpans = append(br.CollectedSpans, rec...)
 	}
 	return br, nil

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -151,8 +151,7 @@ func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 	key := roachpb.Key("a")
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("test", tracing.WithForceRealSpan())
-	sp.SetVerbose(true)
+	sp := tracer.StartSpan("test", tracing.WithRecording(tracing.RecordingVerbose))
 	txnCtx := tracing.ContextWithSpan(context.Background(), sp)
 
 	push := func(ctx context.Context, key roachpb.Key) error {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -179,7 +179,7 @@ func TestNoDuplicateHeartbeatLoops(t *testing.T) {
 		t.Fatalf("expected 2 attempts, got: %d", attempts)
 	}
 	sp.Finish()
-	recording := sp.GetRecording()
+	recording := sp.GetRecording(tracing.RecordingVerbose)
 	var foundHeartbeatLoop bool
 	for _, sp := range recording {
 		if tracing.LogsContainMsg(sp, kvbase.SpawningHeartbeatLoopMsg) {

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -56,7 +56,7 @@ func TestTxnVerboseTrace(t *testing.T) {
 	}
 	log.Event(ctx, "txn complete")
 	sp.Finish()
-	collectedSpans := sp.GetRecording()
+	collectedSpans := sp.GetRecording(tracing.RecordingVerbose)
 	dump := collectedSpans.String()
 	// dump:
 	//    0.105ms      0.000ms    event:inside txn

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -404,6 +405,11 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 
 	sqlCfg := MakeSQLConfig(roachpb.SystemTenantID, tempStorageCfg)
 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+	// NB: The OnChange callback will be called on server startup when the version
+	// is initialized.
+	st.Version.SetOnChange(func(ctx context.Context, newVersion clusterversion.ClusterVersion) {
+		tr.SetBackwardsCompatibilityWith211(!newVersion.IsActive(clusterversion.TraceIDDoesntImplyStructuredRecording))
+	})
 	baseCfg := MakeBaseConfig(st, tr)
 	kvCfg := MakeKVConfig(storeSpec)
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1039,7 +1039,7 @@ func (n *Node) setupSpanForIncomingRPC(
 			// Tenants get a redacted recording, i.e. with anything
 			// sensitive stripped out of the verbose messages. However,
 			// structured payloads stay untouched.
-			if rec := grpcSpan.GetRecording(); rec != nil {
+			if rec := grpcSpan.GetRecording(grpcSpan.RecordingType()); rec != nil {
 				err := redactRecordingForTenant(tenID, rec)
 				if err == nil {
 					br.CollectedSpans = append(br.CollectedSpans, rec...)

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -45,8 +45,7 @@ func TestRedactRecordingForTenant(t *testing.T) {
 			Add("tag_sensitive", tagSensitive).
 			Add("tag_not_sensitive", log.Safe(tagNotSensitive))
 		ctx := logtags.WithTags(context.Background(), tags)
-		ctx, sp := tracing.NewTracer().StartSpanCtx(ctx, "foo", tracing.WithForceRealSpan())
-		sp.SetVerbose(true)
+		ctx, sp := tracing.NewTracer().StartSpanCtx(ctx, "foo", tracing.WithRecording(tracing.RecordingVerbose))
 
 		log.Eventf(ctx, "%s %s", msgSensitive, log.Safe(msgNotSensitive))
 		sp.SetTag("all_span_tags_are_stripped", attribute.StringValue("because_no_redactability"))

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -51,7 +51,7 @@ func TestRedactRecordingForTenant(t *testing.T) {
 		log.Eventf(ctx, "%s %s", msgSensitive, log.Safe(msgNotSensitive))
 		sp.SetTag("all_span_tags_are_stripped", attribute.StringValue("because_no_redactability"))
 		sp.Finish()
-		rec := sp.GetRecording()
+		rec := sp.GetRecording(tracing.RecordingVerbose)
 		require.Len(t, rec, 1)
 		return rec
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -707,7 +707,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmtThresholdSpan.Finish()
 		logTraceAboveThreshold(
 			ctx,
-			stmtThresholdSpan.GetRecording(),
+			stmtThresholdSpan.GetRecording(tracing.RecordingVerbose),
 			fmt.Sprintf("SQL stmt %s", stmt.AST.String()),
 			stmtTraceThreshold,
 			timeutil.Since(ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived)),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -694,8 +694,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()
 	stmtTraceThreshold := traceStmtThreshold.Get(&ex.planner.execCfg.Settings.SV)
 	if !alreadyRecording && stmtTraceThreshold > 0 {
-		ctx, stmtThresholdSpan = createRootOrChildSpan(ctx, "trace-stmt-threshold", ex.transitionCtx.tracer, tracing.WithForceRealSpan())
-		stmtThresholdSpan.SetVerbose(true)
+		ctx, stmtThresholdSpan = createRootOrChildSpan(ctx, "trace-stmt-threshold", ex.transitionCtx.tracer, tracing.WithRecording(tracing.RecordingVerbose))
 	}
 
 	if err := ex.dispatchToExecutionEngine(ctx, p, res); err != nil {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1348,7 +1348,7 @@ CREATE TABLE crdb_internal.node_inflight_trace_spans (
 				"only users with the admin role are allowed to read crdb_internal.node_inflight_trace_spans")
 		}
 		return p.ExecCfg().AmbientCtx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
-			for _, rec := range span.GetRecording() {
+			for _, rec := range span.GetRecording(tracing.RecordingVerbose) {
 				traceID := rec.TraceID
 				parentSpanID := rec.ParentSpanID
 				spanID := rec.SpanID

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -735,7 +735,7 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, func()) {
 	// Start another remote child span on "node 2" that we finish.
 	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithParentAndManualCollection(child.Meta()))
 	childRemoteChildFinished.Finish()
-	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording())
+	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording(tracing.RecordingVerbose))
 
 	// Start another remote child span on "node 2" that we finish. This will have
 	// a different trace_id from the spans created above.

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -712,8 +712,7 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 // 		root2.child								<-- traceID2
 func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, func()) {
 	// Start a root span on "node 1".
-	root := t1.StartSpan("root", tracing.WithForceRealSpan())
-	root.SetVerbose(true)
+	root := t1.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -739,8 +738,7 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, func()) {
 
 	// Start another remote child span on "node 2" that we finish. This will have
 	// a different trace_id from the spans created above.
-	root2 := t2.StartSpan("root2", tracing.WithForceRealSpan())
-	root2.SetVerbose(true)
+	root2 := t2.StartSpan("root2", tracing.WithRecording(tracing.RecordingVerbose))
 
 	// Start a child span on "node 2".
 	child2 := t2.StartSpan("root2.child", tracing.WithParentAndAutoCollection(root2))

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1966,7 +1966,7 @@ func (st *SessionTracing) getSessionTrace() ([]traceRow, error) {
 		return st.lastRecording, nil
 	}
 
-	return generateSessionTraceVTable(st.connSpan.GetRecording())
+	return generateSessionTraceVTable(st.connSpan.GetRecording(tracing.RecordingVerbose))
 }
 
 // StartTracing starts "session tracing". From this moment on, everything
@@ -2070,7 +2070,7 @@ func (st *SessionTracing) StopTracing() error {
 	st.recordingType = tracing.RecordingOff
 
 	// Accumulate all recordings and finish the tracing spans.
-	rec := st.connSpan.GetRecording()
+	rec := st.connSpan.GetRecording(tracing.RecordingVerbose)
 	// We're about to finish this span, but there might be a child that remains
 	// open - the child corresponding to the current transaction. We don't want
 	// that span to be recording any more.

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -252,7 +252,7 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 // GetTraceData returns the trace data.
 func GetTraceData(ctx context.Context) []tracingpb.RecordedSpan {
 	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		return sp.GetRecording()
+		return sp.GetRecording(tracing.RecordingVerbose)
 	}
 	return nil
 }
@@ -260,7 +260,7 @@ func GetTraceData(ctx context.Context) []tracingpb.RecordedSpan {
 // GetTraceDataAsMetadata returns the trace data as execinfrapb.ProducerMetadata
 // object.
 func GetTraceDataAsMetadata(span *tracing.Span) *execinfrapb.ProducerMetadata {
-	if trace := span.GetRecording(); len(trace) > 0 {
+	if trace := span.GetRecording(tracing.RecordingVerbose); len(trace) > 0 {
 		meta := execinfrapb.GetProducerMeta()
 		meta.TraceData = trace
 		return meta

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -665,7 +665,7 @@ func (pb *ProcessorBaseNoHelper) moveToTrailingMeta() {
 				pb.span.RecordStructured(stats)
 			}
 		}
-		if trace := pb.span.GetRecording(); trace != nil {
+		if trace := pb.span.GetRecording(pb.span.RecordingType()); trace != nil {
 			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 		}
 	}

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -128,7 +128,7 @@ func TestTraceAnalyzer(t *testing.T) {
 		)
 		sp.Finish()
 		require.NoError(t, err)
-		trace := sp.GetRecording()
+		trace := sp.GetRecording(tracing.RecordingVerbose)
 		analyzer := <-analyzerChan
 		require.NoError(t, analyzer.AddTrace(trace, true /* makeDeterministic */))
 		require.NoError(t, analyzer.ProcessStats())

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 // EngineMetrics groups a set of SQL metrics.
@@ -273,7 +274,7 @@ func getNodesFromPlanner(planner *planner) []int64 {
 	// Retrieve the list of all nodes which the statement was executed on.
 	var nodes []int64
 	if planner.instrumentation.sp != nil {
-		trace := planner.instrumentation.sp.GetRecording()
+		trace := planner.instrumentation.sp.GetRecording(tracing.RecordingStructured)
 		// ForEach returns nodes in order.
 		execinfrapb.ExtractNodesFromSpans(planner.EvalContext().Context, trace).ForEach(func(i int) {
 			nodes = append(nodes, int64(i))

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -249,7 +249,7 @@ func (ih *instrumentationHelper) Finish(
 
 	// Record the statement information that we've collected.
 	// Note that in case of implicit transactions, the trace contains the auto-commit too.
-	trace := ih.sp.GetRecording()
+	trace := ih.sp.GetRecording(ih.sp.RecordingType())
 
 	if ih.withStatementTrace != nil {
 		ih.withStatementTrace(trace, stmtRawSQL)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -211,9 +211,11 @@ func (ih *instrumentationHelper) Setup(
 
 	if !ih.collectBundle && ih.withStatementTrace == nil && ih.outputMode == unmodifiedOutput {
 		if ih.collectExecStats {
-			// If we need to collect stats, create a non-verbose child span. Stats
-			// will be added as structured metadata and processed in Finish.
-			newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithForceRealSpan())
+			// If we need to collect stats, create a child span with structured
+			// recording. Stats will be added as structured metadata and processed in
+			// Finish.
+			newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement",
+				tracing.WithRecording(tracing.RecordingStructured))
 			ih.shouldFinishSpan = true
 			return newCtx, true
 		}

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -401,8 +401,7 @@ func TestLimitScans(t *testing.T) {
 
 	// Now we're going to run the tableReader and trace it.
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp.SetVerbose(true)
+	sp := tracer.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 	ctx = tracing.ContextWithSpan(ctx, sp)
 	flowCtx.EvalCtx.Context = ctx
 	flowCtx.CollectStats = true

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -441,7 +441,7 @@ func TestLimitScans(t *testing.T) {
 	// scans from the same key as the DistSender retries scans when it detects
 	// splits.
 	re := regexp.MustCompile(fmt.Sprintf(`querying next range at /Table/%d/1(\S.*)?`, tableDesc.GetID()))
-	spans := sp.GetRecording()
+	spans := sp.GetRecording(tracing.RecordingVerbose)
 	ranges := make(map[string]struct{})
 	for _, span := range spans {
 		if span.Operation == tableReaderProcName {

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -754,8 +754,7 @@ func TestRouterDiskSpill(t *testing.T) {
 
 	// Enable stats recording.
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp.SetVerbose(true)
+	sp := tracer.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 	ctx := tracing.ContextWithSpan(context.Background(), sp)
 
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4311,7 +4311,7 @@ value if you rely on the HLC for accuracy.`,
 					return tree.DBoolFalse, nil
 				}
 
-				rootSpan.SetVerboseRecursively(verbosity)
+				rootSpan.SetVerbose(verbosity)
 				return tree.DBoolTrue, nil
 			},
 			Info:       "Returns true if root span was found and verbosity was set, false otherwise.",

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1846,10 +1846,10 @@ func (p *payloadsForSpanGenerator) Next(_ context.Context) (bool, error) {
 	for p.payloads == nil {
 		p.recordingIndex++
 		// If there are no more recordings, then we cannot continue.
-		if !(p.recordingIndex < p.span.GetRecording().Len()) {
+		if !(p.recordingIndex < p.span.GetRecording(tracing.RecordingVerbose).Len()) {
 			return false, nil
 		}
-		currRecording := p.span.GetRecording()[p.recordingIndex]
+		currRecording := p.span.GetRecording(tracing.RecordingVerbose)[p.recordingIndex]
 		currRecording.Structured(func(item *pbtypes.Any, _ time.Time) {
 			payload, err := protoreflect.MessageToJSON(item, protoreflect.FmtFlags{EmitDefaults: true})
 			if err != nil {

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -171,10 +171,10 @@ func (ts *txnState) resetForNewSQLTxn(
 	var txnCtx context.Context
 	var sp *tracing.Span
 	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
-	if alreadyRecording || ts.testingForceRealTracingSpans || duration > 0 {
-		// WithForceRealSpan is used to support the use of session tracing,
-		// which will start recording on this span. Similarly, it enables the
-		// tracing of the txns that exceed the duration threshold.
+	if alreadyRecording || duration > 0 {
+		txnCtx, sp = createRootOrChildSpan(connCtx, opName, tranCtx.tracer,
+			tracing.WithRecording(tracing.RecordingVerbose))
+	} else if ts.testingForceRealTracingSpans {
 		txnCtx, sp = createRootOrChildSpan(connCtx, opName, tranCtx.tracer, tracing.WithForceRealSpan())
 	} else {
 		txnCtx, sp = createRootOrChildSpan(connCtx, opName, tranCtx.tracer)
@@ -184,7 +184,6 @@ func (ts *txnState) resetForNewSQLTxn(
 	}
 
 	if !alreadyRecording && (duration > 0) {
-		sp.SetVerbose(true)
 		ts.recordingThreshold = duration
 		ts.recordingStart = timeutil.Now()
 	}

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -232,7 +232,7 @@ func (ts *txnState) finishSQLTxn() {
 	}
 
 	if ts.recordingThreshold > 0 {
-		logTraceAboveThreshold(ts.Ctx, sp.GetRecording(), "SQL txn", ts.recordingThreshold, timeutil.Since(ts.recordingStart))
+		logTraceAboveThreshold(ts.Ctx, sp.GetRecording(sp.RecordingType()), "SQL txn", ts.recordingThreshold, timeutil.Since(ts.recordingStart))
 	}
 
 	sp.Finish()

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -149,7 +149,7 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 			var buf strings.Builder
 			fmt.Fprintf(&buf, "unexpectedly found %d active spans:\n", len(sps))
 			for _, sp := range sps {
-				fmt.Fprintln(&buf, sp.GetRecording())
+				fmt.Fprintln(&buf, sp.GetRecording(tracing.RecordingVerbose))
 				fmt.Fprintln(&buf)
 			}
 			return errors.Newf("%s", buf.String())

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -59,7 +59,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 	sp2.Finish()
 	sp1.Finish()
 
-	if err := tracing.CheckRecordedSpans(sp1.GetRecording(), `
+	if err := tracing.CheckRecordedSpans(sp1.GetRecording(tracing.RecordingVerbose), `
 		span: root
 			tags: _verbose=1
 			event: a

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -47,8 +47,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 
 	// Annotate a context that has an open span.
 
-	sp1 := tracer.StartSpan("root", tracing.WithForceRealSpan())
-	sp1.SetVerbose(true)
+	sp1 := tracer.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 	ctx1 := tracing.ContextWithSpan(context.Background(), sp1)
 	Event(ctx1, "a")
 

--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -31,8 +31,7 @@ func TestTrace(t *testing.T) {
 			name: "verbose",
 			init: func(ctx context.Context) (context.Context, *tracing.Span) {
 				tracer := tracing.NewTracer()
-				sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-				sp.SetVerbose(true)
+				sp := tracer.StartSpan("s", tracing.WithRecording(tracing.RecordingVerbose))
 				ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 				return ctxWithSpan, sp
 			},
@@ -95,9 +94,8 @@ func TestTraceWithTags(t *testing.T) {
 	ctx = logtags.AddTag(ctx, "tag", 1)
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
+	sp := tracer.StartSpan("s", tracing.WithRecording(tracing.RecordingVerbose))
 	ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
-	sp.SetVerbose(true)
 
 	log.Event(ctxWithSpan, "test1")
 	log.VEvent(ctxWithSpan, log.NoLogV(), "test2")

--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -37,7 +37,7 @@ func TestTrace(t *testing.T) {
 				return ctxWithSpan, sp
 			},
 			check: func(t *testing.T, _ context.Context, sp *tracing.Span) {
-				if err := tracing.CheckRecordedSpans(sp.GetRecording(), `
+				if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
 		span: s
 			tags: _verbose=1
 			event: test1
@@ -105,7 +105,7 @@ func TestTraceWithTags(t *testing.T) {
 	log.Info(ctxWithSpan, "log")
 
 	sp.Finish()
-	if err := tracing.CheckRecordedSpans(sp.GetRecording(), `
+	if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
 		span: s
 			tags: _verbose=1
 			event: [tag=1] test1

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -130,7 +130,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	sp.Finish()
 	el.Finish()
 
-	if err := tracing.CheckRecordedSpans(sp.GetRecording(), `
+	if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
 		span: s
 			tags: _verbose=1
 			event: test3

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -116,8 +116,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	VErrEvent(ctxWithEventLog, NoLogV(), "testerr")
 
 	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("s", tracing.WithForceRealSpan())
-	sp.SetVerbose(true)
+	sp := tracer.StartSpan("s", tracing.WithRecording(tracing.RecordingVerbose))
 	ctxWithBoth := tracing.ContextWithSpan(ctxWithEventLog, sp)
 	// Events should only go to the trace.
 	Event(ctxWithBoth, "test3")

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -82,7 +82,7 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 	run := func(b *testing.B, sp *Span) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = sp.GetRecording()
+			_ = sp.GetRecording(RecordingStructured)
 		}
 	}
 
@@ -113,7 +113,7 @@ func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
 		child := tr.StartSpan("bar", WithParentAndAutoCollection(root))
 		child.RecordStructured(ev)
 		child.Finish()
-		_ = root.GetRecording()
+		_ = root.GetRecording(RecordingStructured)
 	}
 }
 

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -66,8 +66,7 @@ func newTestStructured(i string) *testStructuredImpl {
 // 		root2.child								<-- traceID2
 func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, func()) {
 	// Start a root span on "node 1".
-	root := t1.StartSpan("root", tracing.WithForceRealSpan())
-	root.SetVerbose(true)
+	root := t1.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 	root.RecordStructured(newTestStructured("root"))
 
 	time.Sleep(10 * time.Millisecond)
@@ -91,8 +90,7 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording(tracing.RecordingVerbose))
 
 	// Start a root span on "node 2".
-	root2 := t2.StartSpan("root2", tracing.WithForceRealSpan())
-	root2.SetVerbose(true)
+	root2 := t2.StartSpan("root2", tracing.WithRecording(tracing.RecordingVerbose))
 	root2.RecordStructured(newTestStructured("root2"))
 
 	// Start a child span on "node 2".

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -88,7 +88,7 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	// Start another remote child span on "node 2" that we finish.
 	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithParentAndManualCollection(child.Meta()))
 	childRemoteChildFinished.Finish()
-	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording())
+	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording(tracing.RecordingVerbose))
 
 	// Start a root span on "node 2".
 	root2 := t2.StartSpan("root2", tracing.WithForceRealSpan())

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -665,8 +665,8 @@ func (s *crdbSpan) parentFinished() {
 	s.mu.parent = nil
 }
 
-// SetVerboseRecursively is part of the RegistrySpan interface.
-func (s *crdbSpan) SetVerboseRecursively(to bool) {
+// SetVerbose is part of the RegistrySpan interface.
+func (s *crdbSpan) SetVerbose(to bool) {
 	if to {
 		s.enableRecording(RecordingVerbose)
 	} else {
@@ -676,7 +676,7 @@ func (s *crdbSpan) SetVerboseRecursively(to bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, child := range s.mu.recording.openChildren {
-		child.SetVerboseRecursively(to)
+		child.SetVerbose(to)
 	}
 
 	// TODO(andrei): The children that have started while this span was not

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -55,7 +55,15 @@ type crdbSpan struct {
 
 type crdbSpanMu struct {
 	syncutil.Mutex
-	parent   *crdbSpan
+
+	// parent is the span's local parent; nil if the span is a root or the parent
+	// is remote.
+	//
+	// Note that parent is mutable; a span can start by having a parent but then,
+	// if the parent finishes before the child does (which is uncommon), the
+	// child's parent is set to nil.
+	parent *crdbSpan
+
 	finished bool
 	// duration is initialized to -1 and set on Finish().
 	duration  time.Duration

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -63,9 +63,7 @@ func TestGRPCInterceptors(t *testing.T) {
 			return nil, errors.New("no span in ctx")
 		}
 		sp.RecordStructured(newTestStructured(magicValue))
-		sp.SetVerbose(true) // want the tags
-		recs := sp.GetRecording()
-		sp.SetVerbose(false)
+		recs := sp.GetRecording(tracing.RecordingVerbose)
 		if len(recs) != 1 {
 			return nil, errors.Newf("expected exactly one recorded span, not %+v", recs)
 		}
@@ -199,7 +197,7 @@ func TestGRPCInterceptors(t *testing.T) {
 			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
 			sp.Finish()
 			var n int
-			finalRecs := sp.GetRecording()
+			finalRecs := sp.GetRecording(tracing.RecordingVerbose)
 			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
 				n += len(rec.StructuredRecords)
@@ -231,7 +229,8 @@ func TestGRPCInterceptors(t *testing.T) {
 	runtime.GC()
 	testutils.SucceedsSoon(t, func() error {
 		return tr.VisitSpans(func(sp tracing.RegistrySpan) error {
-			return errors.Newf("leaked span: %s %s", sp.GetRecording()[0].Operation, sp.GetRecording()[0].Tags)
+			rec := sp.GetRecording(tracing.RecordingVerbose)[0]
+			return errors.Newf("leaked span: %s %s", rec.Operation, rec.Tags)
 		})
 	})
 }

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -187,8 +187,7 @@ func TestGRPCInterceptors(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, sp := tr.StartSpanCtx(context.Background(), "root", tracing.WithForceRealSpan())
-			sp.SetVerbose(true) // to set the tags
+			ctx, sp := tr.StartSpanCtx(context.Background(), "root", tracing.WithRecording(tracing.RecordingVerbose))
 			recAny, err := tc.do(ctx)
 			require.NoError(t, err)
 			var rec tracingpb.RecordedSpan

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -29,24 +29,47 @@ import (
 type RecordingType int32
 
 const (
-	// RecordingOff means that the Span discards events passed in through
-	// Recordf(). Events passed in through RecordStructured() are still collected
-	// in the span's recording (so the name RecordingOff is a misnomer). Child
-	// spans will behave the same.
+	// RecordingOff means that the Span discards events passed in.
 	RecordingOff RecordingType = iota
 
-	// RecordingStructured is the same as RecordingOff.
-	//
-	// TODO(andrei): RecordingStructured is WIP. For now, it is never set on a
-	// span; it is only used with GetRecording(RecordingStructured) to ask for the
-	// structured recording. In the future, a span with RecordingOff will not
-	// collect structured events.
+	// RecordingStructured means that the Span discards events passed in through
+	// Recordf(), but collects events passed in through RecordStructured(), as
+	// well as information about child spans (their name, start and stop time).
 	RecordingStructured
 
 	// RecordingVerbose means that the Span collects events passed in through
-	// Recordf() in its recording and that derived spans will do so as well.
+	// Recordf() in its recording.
 	RecordingVerbose
 )
+
+// ToCarrierValue encodes the RecordingType to be propagated through a carrier.
+func (t RecordingType) ToCarrierValue() string {
+	switch t {
+	case RecordingOff:
+		return "n"
+	case RecordingStructured:
+		return "s"
+	case RecordingVerbose:
+		return "v"
+	default:
+		panic(fmt.Sprintf("invalid RecordingType: %d", t))
+	}
+}
+
+// RecordingTypeFromCarrierValue decodes a recording type carried by a carrier.
+func RecordingTypeFromCarrierValue(val string) RecordingType {
+	switch val {
+	case "v":
+		return RecordingVerbose
+	case "s":
+		return RecordingStructured
+	case "n":
+		return RecordingOff
+	default:
+		// Unrecognized.
+		return RecordingOff
+	}
+}
 
 type traceLogData struct {
 	logRecord

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -34,6 +34,15 @@ const (
 	// in the span's recording (so the name RecordingOff is a misnomer). Child
 	// spans will behave the same.
 	RecordingOff RecordingType = iota
+
+	// RecordingStructured is the same as RecordingOff.
+	//
+	// TODO(andrei): RecordingStructured is WIP. For now, it is never set on a
+	// span; it is only used with GetRecording(RecordingStructured) to ask for the
+	// structured recording. In the future, a span with RecordingOff will not
+	// collect structured events.
+	RecordingStructured
+
 	// RecordingVerbose means that the Span collects events passed in through
 	// Recordf() in its recording and that derived spans will do so as well.
 	RecordingVerbose

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -29,14 +29,14 @@ import (
 type RecordingType int32
 
 const (
-	// RecordingOff means that the Span discards all events handed to it.
-	// Child spans created from it similarly won't be recording by default.
+	// RecordingOff means that the Span discards events passed in through
+	// Recordf(). Events passed in through RecordStructured() are still collected
+	// in the span's recording (so the name RecordingOff is a misnomer). Child
+	// spans will behave the same.
 	RecordingOff RecordingType = iota
-	// RecordingVerbose means that the Span is adding events passed in via LogKV
-	// and LogData to its recording and that derived spans will do so as well.
+	// RecordingVerbose means that the Span collects events passed in through
+	// Recordf() in its recording and that derived spans will do so as well.
 	RecordingVerbose
-
-	// TODO(tbg): add RecordingBackground for always-on tracing.
 )
 
 type traceLogData struct {

--- a/pkg/util/tracing/service/service.go
+++ b/pkg/util/tracing/service/service.go
@@ -53,7 +53,7 @@ func (s *Service) GetSpanRecordings(
 		if span.TraceID() != request.TraceID {
 			return nil
 		}
-		recording := span.GetRecording()
+		recording := span.GetRecording(tracing.RecordingVerbose)
 		if recording != nil {
 			resp.Recordings = append(resp.Recordings,
 				tracingservicepb.GetSpanRecordingsResponse_Recording{RecordedSpans: recording})

--- a/pkg/util/tracing/service/service_test.go
+++ b/pkg/util/tracing/service/service_test.go
@@ -29,8 +29,7 @@ func TestTracingServiceGetSpanRecordings(t *testing.T) {
 	tracer1 := tracing.NewTracer()
 	setupTraces := func() (tracingpb.TraceID, func()) {
 		// Start a root span.
-		root1 := tracer1.StartSpan("root1", tracing.WithForceRealSpan())
-		root1.SetVerbose(true)
+		root1 := tracer1.StartSpan("root1", tracing.WithRecording(tracing.RecordingVerbose))
 
 		child1 := tracer1.StartSpan("root1.child", tracing.WithParentAndAutoCollection(root1))
 
@@ -41,8 +40,7 @@ func TestTracingServiceGetSpanRecordings(t *testing.T) {
 		fork1 := tracer1.StartSpan("fork1", tracing.WithParentAndManualCollection(root1.Meta()))
 
 		// Start span with different trace ID.
-		root2 := tracer1.StartSpan("root2", tracing.WithForceRealSpan())
-		root2.SetVerbose(true)
+		root2 := tracer1.StartSpan("root2", tracing.WithRecording(tracing.RecordingVerbose))
 		root2.Record("root2")
 
 		return root1.TraceID(), func() {

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -95,8 +95,14 @@ func (sp *Span) Finish() {
 // enabled. This can be called while spans that are part of the recording are
 // still open; it can run concurrently with operations on those spans.
 //
-// As a performance optimization, GetRecording does not return tags when the
-// underlying Span is not verbose. Returning tags requires expensive
+// recType indicates the type of information to be returned: structured info or
+// structured + verbose info. The caller can ask for either regardless of the
+// current recording mode (and also regardless of past recording modes) but, of
+// course, GetRecording(RecordingVerbose) will not return verbose info if it was
+// never collected.
+//
+// As a performance optimization, GetRecording does not return tags when
+// recType == RecordingStructured. Returning tags requires expensive
 // stringification.
 //
 // A few internal tags are added to denote span properties:
@@ -104,9 +110,12 @@ func (sp *Span) Finish() {
 //    "_unfinished"	The span was never Finish()ed
 //    "_verbose"	The span is a verbose one
 //    "_dropped"	The span dropped recordings due to sizing constraints
-func (sp *Span) GetRecording() Recording {
+//
+// If recType is RecordingStructured, the return value will be nil if the span
+// doesn't have any structured events.
+func (sp *Span) GetRecording(recType RecordingType) Recording {
 	// It's always valid to get the recording, even for a finished span.
-	return sp.i.GetRecording()
+	return sp.i.GetRecording(recType)
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;
@@ -155,9 +164,14 @@ func (sp *Span) ResetRecording() {
 	sp.i.ResetRecording()
 }
 
+// RecordingType returns the range's current recording mode.
+func (sp *Span) RecordingType() RecordingType {
+	return sp.i.RecordingType()
+}
+
 // IsVerbose returns true if the Span is verbose. See SetVerbose for details.
 func (sp *Span) IsVerbose() bool {
-	return sp.i.IsVerbose()
+	return sp.RecordingType() == RecordingVerbose
 }
 
 // Record provides a way to record free-form text into verbose spans. Recordings

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -57,8 +57,8 @@ func (s *spanInner) isSterile() bool {
 	return s.sterile
 }
 
-func (s *spanInner) IsVerbose() bool {
-	return s.crdb.recordingType() == RecordingVerbose
+func (s *spanInner) RecordingType() RecordingType {
+	return s.crdb.recordingType()
 }
 
 func (s *spanInner) SetVerbose(to bool) {
@@ -86,11 +86,11 @@ func (s *spanInner) ResetRecording() {
 	s.crdb.resetRecording()
 }
 
-func (s *spanInner) GetRecording() Recording {
+func (s *spanInner) GetRecording(recType RecordingType) Recording {
 	if s.isNoop() {
 		return nil
 	}
-	return s.crdb.GetRecording()
+	return s.crdb.GetRecording(recType)
 }
 
 func (s *spanInner) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
@@ -229,7 +229,7 @@ func (s *spanInner) Recordf(format string, args ...interface{}) {
 // hasVerboseSink returns false if there is no reason to even evaluate Record
 // because the result wouldn't be used for anything.
 func (s *spanInner) hasVerboseSink() bool {
-	if s.netTr == nil && s.otelSpan == nil && !s.IsVerbose() {
+	if s.netTr == nil && s.otelSpan == nil && s.RecordingType() != RecordingVerbose {
 		return false
 	}
 	return true

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -62,24 +62,10 @@ func (s *spanInner) RecordingType() RecordingType {
 }
 
 func (s *spanInner) SetVerbose(to bool) {
-	// TODO(tbg): when always-on tracing is firmly established, we can remove the ugly
-	// caveat that SetVerbose(true) is a panic on a noop span because there will be no
-	// noop span.
 	if s.isNoop() {
 		panic(errors.AssertionFailedf("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
 	}
-	if to {
-		s.crdb.enableRecording(RecordingVerbose)
-	} else {
-		s.crdb.disableRecording()
-	}
-}
-
-func (s *spanInner) SetVerboseRecursively(to bool) {
-	if s.isNoop() {
-		panic(errors.AssertionFailedf("SetVerboseRecursively called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
-	}
-	s.crdb.SetVerboseRecursively(to)
+	s.crdb.SetVerbose(to)
 }
 
 func (s *spanInner) ResetRecording() {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -188,7 +188,7 @@ func TestImportRemoteSpans(t *testing.T) {
 	for _, verbose := range []bool{false, true} {
 		t.Run(fmt.Sprintf("%s=%t", "verbose-child=", verbose), func(t *testing.T) {
 			tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
-			sp := tr.StartSpan("root")
+			sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 			ch := tr.StartSpan("child", WithParentAndManualCollection(sp.Meta()))
 			ch.RecordStructured(&types.Int32Value{Value: 4})
 			if verbose {
@@ -220,7 +220,7 @@ func TestImportRemoteSpans(t *testing.T) {
 
 func TestSpanRecordStructured(t *testing.T) {
 	tr := NewTracer()
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 	defer sp.Finish()
 
 	sp.RecordStructured(&types.Int32Value{Value: 4})
@@ -248,7 +248,7 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 	clock := timeutil.NewManualTime(now)
 	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{Clock: clock}))
 
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 	defer sp.Finish()
 
 	pad := func(i int) string { return fmt.Sprintf("%06d", i) }
@@ -421,9 +421,9 @@ func TestSpanReset(t *testing.T) {
 	require.False(t, found)
 }
 
-func TestNonVerboseChildSpanRegisteredWithParent(t *testing.T) {
+func TestChildSpanRegisteredWithRecordingParent(t *testing.T) {
 	tr := NewTracer()
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 	defer sp.Finish()
 	ch := tr.StartSpan("child", WithParentAndAutoCollection(sp))
 	defer ch.Finish()
@@ -441,10 +441,10 @@ func TestNonVerboseChildSpanRegisteredWithParent(t *testing.T) {
 // track at most maxChildrenPerSpan direct children.
 func TestSpanMaxChildren(t *testing.T) {
 	tr := NewTracer()
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 	defer sp.Finish()
 	for i := 0; i < maxChildrenPerSpan+123; i++ {
-		tr.StartSpan(fmt.Sprintf("child %d", i), WithParentAndAutoCollection(sp), WithForceRealSpan())
+		tr.StartSpan(fmt.Sprintf("child %d", i), WithParentAndAutoCollection(sp))
 		exp := i + 1
 		if exp > maxChildrenPerSpan {
 			exp = maxChildrenPerSpan
@@ -567,7 +567,7 @@ func TestStructureRecording(t *testing.T) {
 			for _, finishCh2 := range []bool{true, false} {
 				t.Run(fmt.Sprintf("finish2=%t", finishCh2), func(t *testing.T) {
 					tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
-					sp := tr.StartSpan("root")
+					sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 					ch1 := tr.StartSpan("child", WithParentAndAutoCollection(sp))
 					ch2 := tr.StartSpan("grandchild", WithParentAndAutoCollection(ch1))
 					for i := int32(0); i < 5; i++ {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -34,8 +34,7 @@ func TestRecordingString(t *testing.T) {
 	tr := NewTracer()
 	tr2 := NewTracer()
 
-	root := tr.StartSpan("root", WithForceRealSpan())
-	root.SetVerbose(true)
+	root := tr.StartSpan("root", WithRecording(RecordingVerbose))
 	root.Record("root 1")
 	{
 		// Hackily fix the timing on the first log message, so that we can check it later.
@@ -145,10 +144,8 @@ func parseLine(s string) (traceLine, error) {
 func TestRecordingInRecording(t *testing.T) {
 	tr := NewTracer()
 
-	root := tr.StartSpan("root", WithForceRealSpan())
-	root.SetVerbose(true)
-	child := tr.StartSpan("child", WithParentAndAutoCollection(root), WithForceRealSpan())
-	child.SetVerbose(true)
+	root := tr.StartSpan("root", WithRecording(RecordingVerbose))
+	child := tr.StartSpan("child", WithParentAndAutoCollection(root), WithRecording(RecordingVerbose))
 	// The remote grandchild is also recording, however since it's remote the spans
 	// have to be imported into the parent manually (this would usually happen via
 	// code at the RPC boundaries).
@@ -187,7 +184,7 @@ func TestRecordingInRecording(t *testing.T) {
 func TestImportRemoteSpans(t *testing.T) {
 	for _, verbose := range []bool{false, true} {
 		t.Run(fmt.Sprintf("%s=%t", "verbose-child=", verbose), func(t *testing.T) {
-			tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
+			tr := NewTracerWithOpt(context.Background())
 			sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 			ch := tr.StartSpan("child", WithParentAndManualCollection(sp.Meta()))
 			ch.RecordStructured(&types.Int32Value{Value: 4})
@@ -297,9 +294,8 @@ func TestSpanRecordLimit(t *testing.T) {
 	clock := &timeutil.ManualTime{}
 	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{Clock: clock}))
 
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingVerbose))
 	defer sp.Finish()
-	sp.SetVerbose(true)
 
 	msg := func(i int) string { return fmt.Sprintf("msg: %10d", i) }
 
@@ -350,9 +346,8 @@ func TestSpanReset(t *testing.T) {
 	clock := &timeutil.ManualTime{}
 	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{Clock: clock}))
 
-	sp := tr.StartSpan("root", WithForceRealSpan())
+	sp := tr.StartSpan("root", WithRecording(RecordingVerbose))
 	defer sp.Finish()
-	sp.SetVerbose(true)
 
 	for i := 1; i <= 10; i++ {
 		if i%2 == 0 {

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -31,7 +31,7 @@ func TestLogTags(t *testing.T) {
 	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
 	sp1.SetVerbose(true)
 	sp1.Finish()
-	require.NoError(t, CheckRecordedSpans(sp1.GetRecording(), `
+	require.NoError(t, CheckRecordedSpans(sp1.GetRecording(RecordingVerbose), `
 		span: foo
 			tags: _verbose=1 tag1=val1 tag2=val2
 	`))
@@ -51,7 +51,7 @@ func TestLogTags(t *testing.T) {
 	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
 	sp2.SetVerbose(true)
 	sp2.Finish()
-	require.NoError(t, CheckRecordedSpans(sp2.GetRecording(), `
+	require.NoError(t, CheckRecordedSpans(sp2.GetRecording(RecordingVerbose), `
 		span: bar
 			tags: _verbose=1 one=val1 two=val2
 	`))
@@ -69,7 +69,7 @@ func TestLogTags(t *testing.T) {
 	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
 	sp3.SetVerbose(true)
 	sp3.Finish()
-	require.NoError(t, CheckRecordedSpans(sp3.GetRecording(), `
+	require.NoError(t, CheckRecordedSpans(sp3.GetRecording(RecordingVerbose), `
 		span: baz
 			tags: _verbose=1 one=val1 two=val2
 	`))

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -65,17 +65,22 @@ const (
 
 	fieldNameTraceID = prefixTracerState + "traceid"
 	fieldNameSpanID  = prefixTracerState + "spanid"
+	// fieldNameRecordingType will contain the desired type of trace recording.
+	fieldNameRecordingType = "rec"
+
 	// fieldNameOtel{TraceID,SpanID} will contain the OpenTelemetry span info, hex
 	// encoded.
 	fieldNameOtelTraceID = prefixTracerState + "otel_traceid"
 	fieldNameOtelSpanID  = prefixTracerState + "otel_spanid"
 
-	// verboseTracingKey is the carrier key indicating that the trace has verbose
-	// recording enabled. It means that a) spans derived from this one will not be
-	// no-op spans and b) they will start recording.
+	// fieldNameDeprecatedVerboseTracing is the carrier key indicating that the trace
+	// has verbose recording enabled. It means that a) spans derived from this one
+	// will not be no-op spans and b) they will start recording.
 	//
 	// The key is named the way it is for backwards compatibility reasons.
-	verboseTracingKey = "crdb-baggage-sb"
+	// TODO(andrei): remove in 22.2, once we no longer need to set this key for
+	// compatibility with 21.2.
+	fieldNameDeprecatedVerboseTracing = "crdb-baggage-sb"
 
 	spanKindTagKey = "span.kind"
 )
@@ -152,6 +157,12 @@ type Tracer struct {
 	// Preallocated noopSpan, used to avoid creating spans when we are not using
 	// x/net/trace or lightstep and we are not recording.
 	noopSpan *Span
+
+	// backardsCompatibilityWith211, if set, makes the Tracer
+	// work with 21.1 remote nodes.
+	//
+	// Accessed atomically.
+	backwardsCompatibilityWith211 int64
 
 	// True if tracing to the debug/requests endpoint. Accessed via t.useNetTrace().
 	_useNetTrace int32 // updated atomically
@@ -604,9 +615,10 @@ func (t *Tracer) startSpanGeneric(
 		}
 	}
 
-	// Are we tracing everything, or have a parent, or want a real span? Then
-	// we create a real trace span. In all other cases, a noop span will do.
-	if !(t.AlwaysTrace() || opts.parentTraceID() != 0 || opts.ForceRealSpan) {
+	// Are we tracing everything, or have a parent, or want a real span, or were
+	// asked for a recording? Then we create a real trace span. In all other
+	// cases, a noop span will do.
+	if !(t.AlwaysTrace() || opts.parentTraceID() != 0 || opts.ForceRealSpan || opts.recordingType() != RecordingOff) {
 		return maybeWrapCtx(ctx, nil /* octx */, t.noopSpan)
 	}
 
@@ -711,14 +723,14 @@ func (t *Tracer) startSpanGeneric(
 	s := &helper.span
 
 	{
-		// If a parent is specified, link the newly created Span to the parent. This
-		// is done even when not recording because recording could be started later.
-		//
-		// We inherit the recording type of the local parent, if any, over the
-		// remote parent, if any. If neither are specified, we're not recording.
+		// If a parent is specified and the parent is recording, link the newly
+		// created Span to the parent so that the parent will later be able to
+		// collect the child's recording.
 		if opts.Parent != nil && opts.Parent.i.crdb != nil {
-			s.i.crdb.mu.parent = opts.Parent.i.crdb
-			opts.Parent.i.crdb.addChild(s.i.crdb)
+			if opts.Parent.i.crdb.recordingType() != RecordingOff {
+				s.i.crdb.mu.parent = opts.Parent.i.crdb
+				opts.Parent.i.crdb.addChild(s.i.crdb)
+			}
 		}
 		s.i.crdb.enableRecording(opts.recordingType())
 	}
@@ -728,6 +740,13 @@ func (t *Tracer) startSpanGeneric(
 	//
 	// NB: (opts.Parent != nil && opts.Parent.i.crdb == nil) is not possible at
 	// the moment, but let's not rely on that.
+	//
+	// TODO(andrei): We should be adding to the registry also if the span has a
+	// local parent but the parent is not recording, since in that case we haven't
+	// linked the span to the parent above. But I don't want to do that before
+	// optimizing the registry code. For now, not adding the span to the registry
+	// in this case doesn't really matter, since the only cases where we're
+	// creating spans is when the parent is recording.
 	if opts.Parent == nil || opts.Parent.i.crdb == nil {
 		t.activeSpansRegistry.addSpan(s.i.crdb)
 	}
@@ -780,16 +799,27 @@ func (t *Tracer) InjectMetaInto(sm SpanMeta, carrier Carrier) {
 		return
 	}
 
-	carrier.Set(fieldNameTraceID, strconv.FormatUint(uint64(sm.traceID), 16))
-	carrier.Set(fieldNameSpanID, strconv.FormatUint(uint64(sm.spanID), 16))
-
-	if sm.recordingType == RecordingVerbose {
-		// This key is dictated by backwards compatibility.
-		carrier.Set(verboseTracingKey, "1")
-	}
 	if sm.otelCtx.TraceID().IsValid() {
 		carrier.Set(fieldNameOtelTraceID, sm.otelCtx.TraceID().String())
 		carrier.Set(fieldNameOtelSpanID, sm.otelCtx.SpanID().String())
+	}
+
+	compatMode := atomic.LoadInt64(&t.backwardsCompatibilityWith211) == 1
+
+	// For compatibility with 21.1, we don't want to propagate the traceID when
+	// we're not recording. A 21.1 node interprets a traceID as wanting structured
+	// recording (or verbose recording if fieldNameDeprecatedVerboseTracing is also
+	// set).
+	if compatMode && sm.recordingType == RecordingOff {
+		return
+	}
+
+	carrier.Set(fieldNameTraceID, strconv.FormatUint(uint64(sm.traceID), 16))
+	carrier.Set(fieldNameSpanID, strconv.FormatUint(uint64(sm.spanID), 16))
+	carrier.Set(fieldNameRecordingType, sm.recordingType.ToCarrierValue())
+
+	if compatMode && sm.recordingType == RecordingVerbose {
+		carrier.Set(fieldNameDeprecatedVerboseTracing, "1")
 	}
 }
 
@@ -803,6 +833,7 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (SpanMeta, error) {
 	var spanID tracingpb.SpanID
 	var otelTraceID oteltrace.TraceID
 	var otelSpanID oteltrace.SpanID
+	var recordingTypeExplicit bool
 	var recordingType RecordingType
 
 	iterFn := func(k, v string) error {
@@ -833,8 +864,14 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (SpanMeta, error) {
 			if err != nil {
 				return err
 			}
-		case verboseTracingKey:
-			recordingType = RecordingVerbose
+		case fieldNameRecordingType:
+			recordingTypeExplicit = true
+			recordingType = RecordingTypeFromCarrierValue(v)
+		case fieldNameDeprecatedVerboseTracing:
+			// Compatibility with 21.2.
+			if !recordingTypeExplicit {
+				recordingType = RecordingVerbose
+			}
 		}
 		return nil
 	}
@@ -856,6 +893,13 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (SpanMeta, error) {
 
 	if traceID == 0 && spanID == 0 {
 		return noopSpanMeta, nil
+	}
+
+	if !recordingTypeExplicit && recordingType == RecordingOff {
+		// A 21.1 node (or a 21.2 mode running in backwards-compatibility mode)
+		// that passed a TraceID but not fieldNameDeprecatedVerboseTracing wants the
+		// structured events.
+		recordingType = RecordingStructured
 	}
 
 	var otelCtx oteltrace.SpanContext
@@ -919,6 +963,15 @@ func (t *Tracer) ShouldRecordAsyncSpans() bool {
 	defer t.testingMu.Unlock()
 
 	return t.testingRecordAsyncSpans
+}
+
+// SetBackwardsCompatibilityWith211 toggles the compatibility mode.
+func (t *Tracer) SetBackwardsCompatibilityWith211(to bool) {
+	if to {
+		atomic.StoreInt64(&t.backwardsCompatibilityWith211, 1)
+	} else {
+		atomic.StoreInt64(&t.backwardsCompatibilityWith211, 0)
+	}
 }
 
 // ForkSpan forks the current span, if any[1]. Forked spans "follow from" the
@@ -1035,8 +1088,7 @@ var optsPool = sync.Pool{
 //
 // TODO(tbg): remove this method. It adds very little over EnsureChildSpan.
 func StartVerboseTrace(ctx context.Context, tr *Tracer, opName string) (context.Context, *Span) {
-	ctx, sp := EnsureChildSpan(ctx, tr, opName, WithForceRealSpan())
-	sp.SetVerbose(true)
+	ctx, sp := EnsureChildSpan(ctx, tr, opName, WithRecording(RecordingVerbose))
 	return ctx, sp
 }
 
@@ -1050,8 +1102,7 @@ func StartVerboseTrace(ctx context.Context, tr *Tracer, opName string) (context.
 func ContextWithRecordingSpan(
 	ctx context.Context, tr *Tracer, opName string,
 ) (_ context.Context, getRecording func() Recording, cancel func()) {
-	ctx, sp := tr.StartSpanCtx(ctx, opName, WithForceRealSpan())
-	sp.SetVerbose(true)
+	ctx, sp := tr.StartSpanCtx(ctx, opName, WithRecording(RecordingVerbose))
 	ctx, cancelCtx := context.WithCancel(ctx)
 
 	cancel = func() {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -881,7 +881,7 @@ type RegistrySpan interface {
 	TraceID() tracingpb.TraceID
 
 	// GetRecording returns the recording of the trace rooted at this span.
-	GetRecording() Recording
+	GetRecording(recType RecordingType) Recording
 
 	// SetVerboseRecursively sets the verbosity of the span appropriately and
 	// recurses on its children.
@@ -1058,7 +1058,11 @@ func ContextWithRecordingSpan(
 		cancelCtx()
 		sp.Finish()
 	}
-	return ctx, sp.GetRecording, cancel
+	return ctx,
+		func() Recording {
+			return sp.GetRecording(RecordingVerbose)
+		},
+		cancel
 }
 
 // makeOtelSpan creates an OpenTelemetry span. If either of localParent or

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -927,9 +927,9 @@ type RegistrySpan interface {
 	// GetRecording returns the recording of the trace rooted at this span.
 	GetRecording(recType RecordingType) Recording
 
-	// SetVerboseRecursively sets the verbosity of the span appropriately and
+	// SetVerbose sets the verbosity of the span appropriately and
 	// recurses on its children.
-	SetVerboseRecursively(to bool)
+	SetVerbose(to bool)
 }
 
 var _ RegistrySpan = &crdbSpan{}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -718,7 +718,7 @@ func (t *Tracer) startSpanGeneric(
 		// remote parent, if any. If neither are specified, we're not recording.
 		if opts.Parent != nil && opts.Parent.i.crdb != nil {
 			s.i.crdb.mu.parent = opts.Parent.i.crdb
-			defer opts.Parent.i.crdb.addChild(s.i.crdb)
+			opts.Parent.i.crdb.addChild(s.i.crdb)
 		}
 		s.i.crdb.enableRecording(opts.recordingType())
 	}

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -179,8 +179,7 @@ func TestTracerRecording(t *testing.T) {
 
 func TestStartChildSpan(t *testing.T) {
 	tr := NewTracer()
-	sp1 := tr.StartSpan("parent", WithForceRealSpan())
-	sp1.SetVerbose(true)
+	sp1 := tr.StartSpan("parent", WithRecording(RecordingVerbose))
 	sp2 := tr.StartSpan("child", WithParentAndAutoCollection(sp1))
 	sp2.Finish()
 	sp1.Finish()
@@ -194,8 +193,7 @@ func TestStartChildSpan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sp1 = tr.StartSpan("parent", WithForceRealSpan())
-	sp1.SetVerbose(true)
+	sp1 = tr.StartSpan("parent", WithRecording(RecordingVerbose))
 	sp2 = tr.StartSpan("child", WithParentAndManualCollection(sp1.Meta()))
 	sp2.Finish()
 	sp1.Finish()
@@ -212,8 +210,7 @@ func TestStartChildSpan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sp1 = tr.StartSpan("parent", WithForceRealSpan())
-	sp1.SetVerbose(true)
+	sp1 = tr.StartSpan("parent", WithRecording(RecordingVerbose))
 	sp2 = tr.StartSpan("child", WithParentAndAutoCollection(sp1),
 		WithLogTags(logtags.SingleTagBuffer("key", "val")))
 	sp2.Finish()
@@ -232,10 +229,9 @@ func TestSterileSpan(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
 
 	// Check that a children of sterile spans are roots.
-	sp1 := tr.StartSpan("parent", WithSterile())
 	// Make the span verbose so that we can use its recording below to assert that
 	// there were no children.
-	sp1.SetVerbose(true)
+	sp1 := tr.StartSpan("parent", WithSterile(), WithRecording(RecordingVerbose))
 	sp2 := tr.StartSpan("child", WithParentAndAutoCollection(sp1))
 	require.Zero(t, sp2.i.crdb.parentSpanID)
 
@@ -290,8 +286,7 @@ func TestTracerInjectExtract(t *testing.T) {
 	// Verify that verbose tracing is propagated and triggers verbosity on the
 	// remote side.
 
-	s1 := tr.StartSpan("a", WithForceRealSpan())
-	s1.SetVerbose(true)
+	s1 := tr.StartSpan("a", WithRecording(RecordingVerbose))
 
 	carrier = metadataCarrier{metadata.MD{}}
 	tr.InjectMetaInto(s1.Meta(), carrier)
@@ -479,8 +474,7 @@ func TestTracer_VisitSpans(t *testing.T) {
 	tr1 := NewTracer()
 	tr2 := NewTracer()
 
-	root := tr1.StartSpan("root", WithForceRealSpan())
-	root.SetVerbose(true)
+	root := tr1.StartSpan("root", WithRecording(RecordingVerbose))
 	child := tr1.StartSpan("root.child", WithParentAndAutoCollection(root))
 	require.Len(t, tr1.activeSpansRegistry.mu.m, 1)
 
@@ -514,8 +508,7 @@ func TestTracer_VisitSpans(t *testing.T) {
 // in-flight trace have recordings indicating that they have, in fact, finished.
 func TestSpanRecordingFinished(t *testing.T) {
 	tr1 := NewTracer()
-	root := tr1.StartSpan("root", WithForceRealSpan())
-	root.SetVerbose(true)
+	root := tr1.StartSpan("root", WithRecording(RecordingVerbose))
 
 	child := tr1.StartSpan("root.child", WithParentAndAutoCollection(root))
 	childChild := tr1.StartSpan("root.child.child", WithParentAndAutoCollection(child))
@@ -599,8 +592,7 @@ func TestSpanWithNoopParentIsInActiveSpans(t *testing.T) {
 
 func TestConcurrentChildAndRecording(t *testing.T) {
 	tr := NewTracer()
-	rootSp := tr.StartSpan("root", WithForceRealSpan())
-	rootSp.SetVerbose(true)
+	rootSp := tr.StartSpan("root", WithRecording(RecordingVerbose))
 	var wg sync.WaitGroup
 	const n = 1000
 	wg.Add(2 * n)
@@ -623,8 +615,7 @@ func TestConcurrentChildAndRecording(t *testing.T) {
 
 func TestFinishedSpanInRecording(t *testing.T) {
 	tr := NewTracer()
-	s1 := tr.StartSpan("a", WithForceRealSpan())
-	s1.SetVerbose(true)
+	s1 := tr.StartSpan("a", WithRecording(RecordingVerbose))
 	s2 := tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	s3 := tr.StartSpan("c", WithParentAndAutoCollection(s2))
 
@@ -658,8 +649,7 @@ span: a
 `))
 
 	// Now the same thing, but finish s2 first.
-	s1 = tr.StartSpan("a", WithForceRealSpan())
-	s1.SetVerbose(true)
+	s1 = tr.StartSpan("a", WithRecording(RecordingVerbose))
 	s2 = tr.StartSpan("b", WithParentAndAutoCollection(s1))
 	tr.StartSpan("c", WithParentAndAutoCollection(s2))
 


### PR DESCRIPTION
Before this patch, a span either didn't exist (it was "created" as the
singleton no-op span) or, if it existed, it was recording. By default,
it was only recording structured events and, if you put it in verbose
mode, it would also record verbose events (i.e. logs). The fact that a
span was always recording the structured events was confusing, because
the code definitely pretends that there recording can be "off". The
default recording mode was called RecordingOff, which is an egregious
misnomer. The concepts of span existence and recording were
unfortunately mixed because, for the most part, the only reason for a
span existing is because we want it to do some sort of recording. But
that's not exactly true, since we have this registry of open spans. A
span might exist because it needs to be present in the registry, not
because it's recording anything.

This patch separates the concepts by making RecordingOff actually mean
no recording, and introducing a new recording mode -
RecordingStructured. So, now, a span that exists (for example because it
was created with the WithForceRealSpan() option) does not necessarily
record anything.

The patch does not do anything about creating spans that were not
created before. But this will come - the culmination of this work will
be spans always existing, and being registered with the registry,
without recording anything.

As an immediate benefit of this patch, structured recording is no longer
enabled when OpenTelemetry tracing is enabled. Before this patch it was,
since otel forces spans to exist, which in turn implied the structured
recording (for no good reason).

Release note: None