### PR TITLE
ccl/changefeedccl: skip TestChangefeedColumnFamily

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1315,6 +1315,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 
 func TestChangefeedColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 71796, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {


### PR DESCRIPTION
Refs: #71796

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None