### PR TITLE
storage/metamorphic: skip TestPebbleEquivalence

### DIFF
--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -162,6 +162,7 @@ func runMetaTest(run testRun) {
 // for matching outputs by the test suite between different options of Pebble.
 func TestPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 72077, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #72077

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None