### PR TITLE
storage/metamorphic: skip TestPebbleRestarts

### DIFF
--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -209,6 +209,7 @@ func TestPebbleEquivalence(t *testing.T) {
 // engine sequences with restarts in between.
 func TestPebbleRestarts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 72078, "flaky test")
 	defer log.Scope(t).Close(t)
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)


### PR DESCRIPTION
Refs: #72078

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None