### PR TITLE
kvserver: collect accurate timings for request execution

### DIFF
--- a/pkg/util/metric/timing.go
+++ b/pkg/util/metric/timing.go
@@ -1,0 +1,100 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metric
+
+import (
+	"context"
+	"time"
+)
+
+// A Timing is a container that stores Events resulting from a single-threaded
+// execution of an operation, which it thus breaks up into contiguous (i.e.
+// non-overlapping and without gaps) time intervals. The use of a Timing
+// integrates easily into existing code paths and interacts well with both
+// metrics and tracing.
+//
+// With each event added, the caller learns the duration elapsed since the last
+// event (or another previous event of choice), which facilitates recording the
+// durations of sub-operations to metrics. A "middleware" OnEvent can be set up
+// to tie into tracing, so that existing calls to `log.Event` can be lifted to
+// calls to `Timing.Event`.
+type Timing struct {
+	Now func() time.Time
+	// OnEvent is called every time Event is called. It will be invoked directly
+	// from Event, i.e. logging in OnEvent needs to skip two stack frames to get
+	// to the caller of Event.
+	OnEvent func(context.Context, interface{}, time.Time)
+
+	ents []entry
+}
+
+type entry struct {
+	ts time.Time
+	tr interface{}
+}
+
+// Reset resets the Timing. This prepares it for recording a new
+// operation while allowing re-use of underlying memory and configuration.
+func (tm *Timing) Reset() {
+	tm.ents = append(tm.ents[:0], entry{
+		ts: tm.Now(),
+	})
+}
+
+func (tm *Timing) lastIdx() int {
+	return len(tm.ents) - 1
+}
+
+// Event records an event to the timing. It returns the duration
+// elapsed since the last Event, and the internal index assigned
+// to the new event (for use in Between). The same event may be
+// recorded multiple times, which is useful in case of retry
+// loops.
+//
+// Note that the returned duration is only meaningful if the preceding
+// event is stable. In the following code, the likelyhood of a third event
+// being present (or slipping in down the road) is high and would lead to
+// under-reporting of the duration attributed to 'pouncing':
+//
+//   dur, _ := tm.Event(ctx, "pouncing ends")
+//   doSomethingIncludingMaybeAddAnotherEvent(tm)
+//   fmt.Printf("pouncing took %s!", dur)
+//
+// The use of Between is generally preferable to avoid this problem in all but
+// trivially correct code.
+func (tm *Timing) Event(ctx context.Context, tr interface{}) (time.Duration, int) {
+	tm.Event(ctx, "pouncing starts")
+
+	prev := tm.ents[tm.lastIdx()]
+	ts := tm.Now()
+	tm.ents = append(tm.ents, entry{
+		ts: ts,
+		tr: tr,
+	})
+	idx := tm.lastIdx()
+	tm.OnEvent(ctx, tr, ts)
+	return tm.ents[idx].ts.Sub(prev.ts), idx
+}
+
+// Between returns the duration elapsed between two calls to Event as identified
+// by their respective indexes.
+func (tm *Timing) Between(from, to int) time.Duration {
+	return tm.ents[to].ts.Sub(tm.ents[from].ts)
+}
+
+// TODO(tbg): provide a method to summarize the timings.
+// This could power a granular per-range breakdown of execution
+// timings via a map[struct{A, B interface{}}ewma.MovingAverage.
+// where there is an entry for any events A and B that were ever
+// observed in succession. We should only do this if we know that
+// the set of possible events is small, for example if they are
+// guaranteed to come from a small set of singletons (as is the
+// envisioned reality).

--- a/pkg/util/metric/timing.go
+++ b/pkg/util/metric/timing.go
@@ -71,8 +71,6 @@ func (tm *Timing) lastIdx() int {
 // The use of Between is generally preferable to avoid this problem in all but
 // trivially correct code.
 func (tm *Timing) Event(ctx context.Context, tr interface{}) (time.Duration, int) {
-	tm.Event(ctx, "pouncing starts")
-
 	prev := tm.ents[tm.lastIdx()]
 	ts := tm.Now()
 	tm.ents = append(tm.ents, entry{
@@ -88,6 +86,14 @@ func (tm *Timing) Event(ctx context.Context, tr interface{}) (time.Duration, int
 // by their respective indexes.
 func (tm *Timing) Between(from, to int) time.Duration {
 	return tm.ents[to].ts.Sub(tm.ents[from].ts)
+}
+
+func (tm *Timing) Duration() time.Duration {
+	last := tm.lastIdx()
+	if last == 0 {
+		return 0
+	}
+	return tm.Between(0, last)
 }
 
 // TODO(tbg): provide a method to summarize the timings.

--- a/pkg/util/metric/timing_test.go
+++ b/pkg/util/metric/timing_test.go
@@ -26,23 +26,19 @@ func TestTiming(t *testing.T) {
 	const (
 		evStart = iota
 		evLeaseStart
-		evLeaseEnd
 		evContentionStart
-		evContentionEnd
-		evSequenceBegin
-		evSequenceEnd
+		evSequenceStart
 		evEvalStart
-		evEvalEnd
 		evReplStart
-		evReplEnd
 	)
-	mc := hlc.NewManualClock(0)
+	mc := hlc.NewManualClock(1)
 	tm := &Timing{Now: func() time.Time {
 		return time.Unix(0, mc.UnixNano())
 	}}
 	r := rand.New(rand.NewSource(123))
+	_ = r
 	tick := func() {
-		nanos := r.Int63n(5000)
+		nanos := r.Int63n(100)
 		mc.Increment(nanos)
 	}
 
@@ -50,27 +46,28 @@ func TestTiming(t *testing.T) {
 	tick()
 	tm.Event(ctx, evLeaseStart)
 	tick()
-	tm.Event(ctx, evLeaseEnd)
+	tm.Event(ctx, &End{evLeaseStart})
 	tick()
-	tm.Event(ctx, evSequenceBegin)
+	tm.Event(ctx, evSequenceStart)
 	tick()
-	tm.Event(ctx, evSequenceEnd)
+	tm.Event(ctx, &End{evSequenceStart})
 	tick()
 	tm.Event(ctx, evContentionStart)
 	tick()
-	tm.Event(ctx, evContentionEnd)
+	tm.Event(ctx, &End{evContentionStart})
 	tick()
-	tm.Event(ctx, evSequenceBegin)
+	tm.Event(ctx, evSequenceStart)
 	tick()
-	tm.Event(ctx, evSequenceEnd)
+	tm.Event(ctx, &End{evSequenceStart})
 	tick()
 	tm.Event(ctx, evEvalStart)
 	tick()
-	tm.Event(ctx, evEvalEnd)
+	tm.Event(ctx, &End{evEvalStart})
 	tick()
 	tm.Event(ctx, evReplStart)
 	tick()
-	tm.Event(ctx, evReplEnd)
+	tm.Event(ctx, &End{evReplStart})
 
-	require.EqualValues(t, mc.UnixNano(), tm.Duration())
+	require.EqualValues(t, mc.UnixNano(), 1+tm.Duration())
+	t.Error(tm.Summary())
 }

--- a/pkg/util/metric/timing_test.go
+++ b/pkg/util/metric/timing_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metric
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTiming(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		evStart = iota
+		evLeaseStart
+		evLeaseEnd
+		evContentionStart
+		evContentionEnd
+		evSequenceBegin
+		evSequenceEnd
+		evEvalStart
+		evEvalEnd
+		evReplStart
+		evReplEnd
+	)
+	mc := hlc.NewManualClock(0)
+	tm := &Timing{Now: func() time.Time {
+		return time.Unix(0, mc.UnixNano())
+	}}
+	r := rand.New(rand.NewSource(123))
+	tick := func() {
+		nanos := r.Int63n(5000)
+		mc.Increment(nanos)
+	}
+
+	tm.Event(ctx, evStart)
+	tick()
+	tm.Event(ctx, evLeaseStart)
+	tick()
+	tm.Event(ctx, evLeaseEnd)
+	tick()
+	tm.Event(ctx, evSequenceBegin)
+	tick()
+	tm.Event(ctx, evSequenceEnd)
+	tick()
+	tm.Event(ctx, evContentionStart)
+	tick()
+	tm.Event(ctx, evContentionEnd)
+	tick()
+	tm.Event(ctx, evSequenceBegin)
+	tick()
+	tm.Event(ctx, evSequenceEnd)
+	tick()
+	tm.Event(ctx, evEvalStart)
+	tick()
+	tm.Event(ctx, evEvalEnd)
+	tick()
+	tm.Event(ctx, evReplStart)
+	tick()
+	tm.Event(ctx, evReplEnd)
+
+	require.EqualValues(t, mc.UnixNano(), tm.Duration())
+}

--- a/pkg/util/metric/timing_test.go
+++ b/pkg/util/metric/timing_test.go
@@ -14,10 +14,8 @@ import (
 	"context"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTiming(t *testing.T) {
@@ -32,42 +30,57 @@ func TestTiming(t *testing.T) {
 		evReplStart
 	)
 	mc := hlc.NewManualClock(1)
-	tm := &Timing{Now: func() time.Time {
-		return time.Unix(0, mc.UnixNano())
+	tm := &Timing{Now: func() int64 {
+		return mc.UnixNano()
 	}}
 	r := rand.New(rand.NewSource(123))
 	_ = r
 	tick := func() {
-		nanos := r.Int63n(100)
+		//nanos := r.Int63n(100)
+		const nanos = 1000
 		mc.Increment(nanos)
 	}
 
 	tm.Event(ctx, evStart)
 	tick()
-	tm.Event(ctx, evLeaseStart)
+	tm.Event(ctx, &End{evStart})
 	tick()
-	tm.Event(ctx, &End{evLeaseStart})
 	tick()
-	tm.Event(ctx, evSequenceStart)
 	tick()
-	tm.Event(ctx, &End{evSequenceStart})
+	tm.Event(ctx, evStart)
 	tick()
-	tm.Event(ctx, evContentionStart)
-	tick()
-	tm.Event(ctx, &End{evContentionStart})
-	tick()
-	tm.Event(ctx, evSequenceStart)
-	tick()
-	tm.Event(ctx, &End{evSequenceStart})
-	tick()
-	tm.Event(ctx, evEvalStart)
-	tick()
-	tm.Event(ctx, &End{evEvalStart})
-	tick()
-	tm.Event(ctx, evReplStart)
-	tick()
-	tm.Event(ctx, &End{evReplStart})
+	tm.Event(ctx, &End{evStart})
 
-	require.EqualValues(t, mc.UnixNano(), 1+tm.Duration())
+	if false {
+		tm.Event(ctx, evStart)
+		tick()
+		tm.Event(ctx, &End{evLeaseStart})
+		tick() // where is this accounted for? Can return "gaps" from summary?
+		tm.Event(ctx, evLeaseStart)
+		tick()
+		tm.Event(ctx, &End{evLeaseStart})
+		tick()
+		tm.Event(ctx, evSequenceStart)
+		tick()
+		tm.Event(ctx, &End{evSequenceStart})
+		tick()
+		tm.Event(ctx, evContentionStart)
+		tick()
+		tm.Event(ctx, &End{evContentionStart})
+		tick()
+		tm.Event(ctx, evSequenceStart)
+		tick()
+		tm.Event(ctx, &End{evSequenceStart})
+		tick()
+		tm.Event(ctx, evEvalStart)
+		tick()
+		tm.Event(ctx, &End{evEvalStart})
+		tick()
+		tm.Event(ctx, evReplStart)
+		tick()
+		tm.Event(ctx, &End{evReplStart})
+	}
+
+	//require.EqualValues(t, mc.UnixNano(), 1+tm.Duration())
 	t.Error(tm.Summary())
 }


### PR DESCRIPTION
This prototype is an exploration of [this comment]. Our server-side RPC
timing metrics are not great and in particular they don't allow us to
see which fraction of the end-to-end latency is spent in contention
(which is generally not something indicative of the health of the
KV layer, as users can easily generate as much contention as they
like).

[this comment]: https://github.com/cockroachdb/cockroach/issues/71169#issuecomment-942136438
