### PR TITLE
roachtest: fix up `mockgen` usage w/ Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,6 +50,8 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # tell gazelle to resolve to this second target instead. See
 # pkg/kv/kvclient/rangefeed/BUILD.bazel for an annotated example.
 #
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus //pkg/cmd/roachtest/prometheus:with-mocks
+# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests //pkg/cmd/roachtest/tests:with-mocks
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/roachpb //pkg/roachpb:with-mocks
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord //pkg/kv/kvclient/kvcoord:with-mocks
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed //pkg/kv/kvclient/rangefeed:with-mocks
@@ -57,7 +59,6 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # See pkg/roachpb/gen/BUILD.bazel for more details.
 #
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/roachpb //pkg/roachpb:with-mocks
 # gazelle:resolve proto go roachpb/api.proto //pkg/roachpb:with-mocks
 # gazelle:resolve proto go roachpb/app_stats.proto //pkg/roachpb:with-mocks
 # gazelle:resolve proto go roachpb/data.proto //pkg/roachpb:with-mocks
@@ -117,6 +118,8 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/testutils/**/testdata/**
 # gazelle:exclude pkg/security/securitytest/embedded.go
 # gazelle:exclude pkg/cmd/roachprod/vm/aws/embedded.go
+# gazelle:exclude pkg/cmd/roachtest/prometheus/mock_generated.go
+# gazelle:exclude pkg/cmd/roachtest/tests/drt_generated.go
 # gazelle:exclude pkg/**/*_string.go
 # gazelle:exclude pkg/geo/wkt/wkt_generated.go
 # gazelle:exclude pkg/sql/schemachanger/scop/backfill_visitor_generated.go

--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -3,24 +3,20 @@
 set -euo pipefail
 
 EXISTING_GO_GENERATE_COMMENTS="
-pkg/ccl/sqlproxyccl/throttler/service.go://go:generate mockgen -package=throttler -destination=mocks_generated.go -source=service.go . Service
-pkg/ccl/sqlproxyccl/denylist/service.go://go:generate mockgen -package=denylist -destination=mocks_generated.go -source=service.go . Service
-pkg/ccl/sqlproxyccl/tenant/directory.go://go:generate mockgen -package=tenant -destination=mocks_generated.go . DirectoryClient,Directory_WatchEndpointsClient
 pkg/cmd/roachprod/vm/aws/config.go://go:generate go-bindata -mode 0600 -modtime 1400000000 -pkg aws -o embedded.go config.json old.json
 pkg/cmd/roachprod/vm/aws/config.go://go:generate gofmt -s -w embedded.go
 pkg/cmd/roachprod/vm/aws/config.go://go:generate goimports -w embedded.go
 pkg/cmd/roachprod/vm/aws/config.go://go:generate terraformgen -o terraform/main.tf
-pkg/geo/wkt/wkt.go://go:generate sh generate.sh
-pkg/kv/kvserver/concurrency/lock_table.go://go:generate ../../../util/interval/generic/gen.sh *lockState concurrency
-pkg/kv/kvserver/spanlatch/manager.go://go:generate ../../../util/interval/generic/gen.sh *latch spanlatch
-pkg/roachpb/batch.go://go:generate go run -tags gen-batch gen/main.go
-pkg/security/certmgr/cert.go://go:generate mockgen -package=certmgr -destination=mocks_generated.go -source=cert.go . Cert
-pkg/cmd/roachtest/prometheus/prometheus.go://go:generate mockgen -package=prometheus -destination=mock_generated.go -source=prometheus.go . cluster
+pkg/cmd/roachtest/prometheus/prometheus.go://go:generate mockgen -package=prometheus -destination=mock_generated.go -source=prometheus.go . Cluster
+pkg/cmd/roachtest/tests/drt.go://go:generate mockgen -source drt.go -package tests -destination drt_generated.go
+pkg/kv/kvclient/kvcoord/transport.go://go:generate mockgen -package=kvcoord -destination=mocks_generated.go . Transport
 pkg/kv/kvclient/rangecache/range_cache.go://go:generate mockgen -package=rangecache -destination=mocks_generated.go . RangeDescriptorDB
 pkg/kv/kvclient/rangefeed/rangefeed.go://go:generate mockgen -package=rangefeed -source rangefeed.go -destination=mocks_generated.go .
-pkg/kv/kvclient/kvcoord/transport.go://go:generate mockgen -package=kvcoord -destination=mocks_generated.go . Transport
+pkg/kv/kvserver/concurrency/lock_table.go://go:generate ../../../util/interval/generic/gen.sh *lockState concurrency
+pkg/kv/kvserver/spanlatch/manager.go://go:generate ../../../util/interval/generic/gen.sh *latch spanlatch
 pkg/roachpb/api.go://go:generate mockgen -package=roachpb -destination=mocks_generated.go . InternalClient,Internal_RangeFeedClient
-pkg/cmd/roachtest/tests/drt.go://go:generate mockgen -source drt.go -package tests -destination drt_generated.go
+pkg/roachpb/batch.go://go:generate go run -tags gen-batch gen/main.go
+pkg/security/certmgr/cert.go://go:generate mockgen -package=certmgr -destination=mocks_generated.go -source=cert.go . Cert
 pkg/security/securitytest/securitytest.go://go:generate go-bindata -mode 0600 -modtime 1400000000 -pkg securitytest -o embedded.go -ignore README.md -ignore regenerate.sh test_certs
 pkg/security/securitytest/securitytest.go://go:generate gofmt -s -w embedded.go
 pkg/security/securitytest/securitytest.go://go:generate goimports -w embedded.go

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
-        "//pkg/cmd/roachtest/tests",
+        "//pkg/cmd/roachtest/tests:with-mocks",
         "//pkg/internal/team",
         "//pkg/testutils/skip",
         "//pkg/util/contextutil",

--- a/pkg/cmd/roachtest/prometheus/BUILD.bazel
+++ b/pkg/cmd/roachtest/prometheus/BUILD.bazel
@@ -1,17 +1,25 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "prometheus",
-    srcs = [
-        "mock_generated.go",
-        "prometheus.go",
-    ],
+    name = "with-mocks",
+    srcs = [":prometheus_mocks"],
+    embed = [":prometheus"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_golang_mock//gomock",
+    ],
+)
+
+go_library(
+    name = "prometheus",
+    srcs = ["prometheus.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus",
+    visibility = ["//visibility:private"],
+    deps = [
         "//pkg/cmd/roachtest/logger",
         "//pkg/cmd/roachtest/option",
-        "@com_github_golang_mock//gomock",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )
@@ -19,10 +27,18 @@ go_library(
 go_test(
     name = "prometheus_test",
     srcs = ["prometheus_test.go"],
-    embed = [":prometheus"],
+    embed = [":with-mocks"],  # keep
     deps = [
         "//pkg/cmd/roachtest/option",
         "@com_github_golang_mock//gomock",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+gomock(
+    name = "prometheus_mocks",
+    out = "mock_generated.go",
+    interfaces = ["Cluster"],
+    library = ":prometheus",
+    package = "prometheus",
 )

--- a/pkg/cmd/roachtest/prometheus/mock_generated.go
+++ b/pkg/cmd/roachtest/prometheus/mock_generated.go
@@ -14,31 +14,31 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// Mockcluster is a mock of cluster interface.
-type Mockcluster struct {
+// MockCluster is a mock of Cluster interface.
+type MockCluster struct {
 	ctrl     *gomock.Controller
-	recorder *MockclusterMockRecorder
+	recorder *MockClusterMockRecorder
 }
 
-// MockclusterMockRecorder is the mock recorder for Mockcluster.
-type MockclusterMockRecorder struct {
-	mock *Mockcluster
+// MockClusterMockRecorder is the mock recorder for MockCluster.
+type MockClusterMockRecorder struct {
+	mock *MockCluster
 }
 
-// NewMockcluster creates a new mock instance.
-func NewMockcluster(ctrl *gomock.Controller) *Mockcluster {
-	mock := &Mockcluster{ctrl: ctrl}
-	mock.recorder = &MockclusterMockRecorder{mock}
+// NewMockCluster creates a new mock instance.
+func NewMockCluster(ctrl *gomock.Controller) *MockCluster {
+	mock := &MockCluster{ctrl: ctrl}
+	mock.recorder = &MockClusterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *Mockcluster) EXPECT() *MockclusterMockRecorder {
+func (m *MockCluster) EXPECT() *MockClusterMockRecorder {
 	return m.recorder
 }
 
 // ExternalIP mocks base method.
-func (m *Mockcluster) ExternalIP(arg0 context.Context, arg1 option.NodeListOption) ([]string, error) {
+func (m *MockCluster) ExternalIP(arg0 context.Context, arg1 option.NodeListOption) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalIP", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -47,13 +47,13 @@ func (m *Mockcluster) ExternalIP(arg0 context.Context, arg1 option.NodeListOptio
 }
 
 // ExternalIP indicates an expected call of ExternalIP.
-func (mr *MockclusterMockRecorder) ExternalIP(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) ExternalIP(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalIP", reflect.TypeOf((*Mockcluster)(nil).ExternalIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalIP", reflect.TypeOf((*MockCluster)(nil).ExternalIP), arg0, arg1)
 }
 
 // Get mocks base method.
-func (m *Mockcluster) Get(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error {
+func (m *MockCluster) Get(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, l, src, dest}
 	for _, a := range opts {
@@ -65,14 +65,14 @@ func (m *Mockcluster) Get(ctx context.Context, l *logger.Logger, src, dest strin
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockclusterMockRecorder) Get(ctx, l, src, dest interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) Get(ctx, l, src, dest interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, l, src, dest}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockcluster)(nil).Get), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCluster)(nil).Get), varargs...)
 }
 
 // PutString mocks base method.
-func (m *Mockcluster) PutString(ctx context.Context, content, dest string, mode os.FileMode, opts ...option.Option) error {
+func (m *MockCluster) PutString(ctx context.Context, content, dest string, mode os.FileMode, opts ...option.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, content, dest, mode}
 	for _, a := range opts {
@@ -84,14 +84,14 @@ func (m *Mockcluster) PutString(ctx context.Context, content, dest string, mode 
 }
 
 // PutString indicates an expected call of PutString.
-func (mr *MockclusterMockRecorder) PutString(ctx, content, dest, mode interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) PutString(ctx, content, dest, mode interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, content, dest, mode}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutString", reflect.TypeOf((*Mockcluster)(nil).PutString), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutString", reflect.TypeOf((*MockCluster)(nil).PutString), varargs...)
 }
 
 // RunE mocks base method.
-func (m *Mockcluster) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
+func (m *MockCluster) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, node}
 	for _, a := range args {
@@ -103,8 +103,8 @@ func (m *Mockcluster) RunE(ctx context.Context, node option.NodeListOption, args
 }
 
 // RunE indicates an expected call of RunE.
-func (mr *MockclusterMockRecorder) RunE(ctx, node interface{}, args ...interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) RunE(ctx, node interface{}, args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, node}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunE", reflect.TypeOf((*Mockcluster)(nil).RunE), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunE", reflect.TypeOf((*MockCluster)(nil).RunE), varargs...)
 }

--- a/pkg/cmd/roachtest/prometheus/prometheus.go
+++ b/pkg/cmd/roachtest/prometheus/prometheus.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:generate mockgen -package=prometheus -destination=mock_generated.go -source=prometheus.go . cluster
+//go:generate mockgen -package=prometheus -destination=mock_generated.go -source=prometheus.go . Cluster
 
 package prometheus
 
@@ -42,10 +42,10 @@ type Config struct {
 	ScrapeConfigs  []ScrapeConfig
 }
 
-// cluster is a subset of roachtest.Cluster.
+// Cluster is a subset of roachtest.Cluster.
 // It is abstracted to prevent a circular dependency on roachtest, as Cluster
 // requires the test interface.
-type cluster interface {
+type Cluster interface {
 	ExternalIP(context.Context, option.NodeListOption) ([]string, error)
 	Get(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
@@ -63,7 +63,7 @@ type Prometheus struct {
 func Init(
 	ctx context.Context,
 	cfg Config,
-	c cluster,
+	c Cluster,
 	repeatFunc func(context.Context, option.NodeListOption, string, ...string) error,
 ) (*Prometheus, error) {
 	if err := c.RunE(
@@ -118,7 +118,7 @@ sudo systemd-run --unit prometheus --same-dir \
 
 // Snapshot takes a snapshot of prometheus and stores the snapshot in the given localPath
 func (pm *Prometheus) Snapshot(
-	ctx context.Context, c cluster, l *logger.Logger, localPath string,
+	ctx context.Context, c Cluster, l *logger.Logger, localPath string,
 ) error {
 	if err := c.RunE(
 		ctx,
@@ -148,7 +148,7 @@ const (
 )
 
 // makeYAMLConfig creates a prometheus YAML config for the server to use.
-func makeYAMLConfig(ctx context.Context, c cluster, scrapeConfigs []ScrapeConfig) (string, error) {
+func makeYAMLConfig(ctx context.Context, c Cluster, scrapeConfigs []ScrapeConfig) (string, error) {
 	type yamlStaticConfig struct {
 		Targets []string
 	}

--- a/pkg/cmd/roachtest/prometheus/prometheus_test.go
+++ b/pkg/cmd/roachtest/prometheus/prometheus_test.go
@@ -24,15 +24,15 @@ func TestMakeYAMLConfig(t *testing.T) {
 	testCases := []struct {
 		desc string
 
-		mockCluster   func(ctrl *gomock.Controller) cluster
+		mockCluster   func(ctrl *gomock.Controller) Cluster
 		scrapeConfigs []ScrapeConfig
 
 		expected string
 	}{
 		{
 			desc: "multiple scrape nodes",
-			mockCluster: func(ctrl *gomock.Controller) cluster {
-				c := NewMockcluster(ctrl)
+			mockCluster: func(ctrl *gomock.Controller) Cluster {
+				c := NewMockCluster(ctrl)
 				c.EXPECT().
 					ExternalIP(ctx, []int{1}).
 					Return([]string{"127.0.0.1"}, nil)
@@ -91,8 +91,8 @@ scrape_configs:
 		},
 		{
 			desc: "using make commands",
-			mockCluster: func(ctrl *gomock.Controller) cluster {
-				c := NewMockcluster(ctrl)
+			mockCluster: func(ctrl *gomock.Controller) Cluster {
+				c := NewMockCluster(ctrl)
 				c.EXPECT().
 					ExternalIP(ctx, []int{3, 4, 5}).
 					Return([]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"}, nil)

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -1,4 +1,16 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "with-mocks",
+    srcs = [":mocks_drt"],
+    embed = [":tests"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_mock//gomock",
+    ],
+)
 
 go_library(
     name = "tests",
@@ -32,7 +44,6 @@ go_library(
         "django_blocklist.go",
         "drop.go",
         "drt.go",
-        "drt_generated.go",
         "encryption.go",
         "engine_switch.go",
         "event_log.go",
@@ -131,7 +142,7 @@ go_library(
         "ycsb.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/changefeedccl/cdctest",
@@ -143,7 +154,7 @@ go_library(
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/logger",
         "//pkg/cmd/roachtest/option",
-        "//pkg/cmd/roachtest/prometheus",
+        "//pkg/cmd/roachtest/prometheus:with-mocks",
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
@@ -185,7 +196,6 @@ go_library(
         "@com_github_cockroachdb_ttycolor//:ttycolor",
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
         "@com_github_dustin_go_humanize//:go-humanize",
-        "@com_github_golang_mock//gomock",
         "@com_github_google_go_cmp//cmp",
         "@com_github_jackc_pgtype//:pgtype",
         "@com_github_kr_pretty//:pretty",
@@ -209,11 +219,11 @@ go_test(
         "tpcc_test.go",
         "util_load_group_test.go",
     ],
-    embed = [":tests"],
+    embed = [":with-mocks"],  # keep
     deps = [
         "//pkg/cmd/roachtest/logger",
         "//pkg/cmd/roachtest/option",
-        "//pkg/cmd/roachtest/prometheus",
+        "//pkg/cmd/roachtest/prometheus:with-mocks",
         "//pkg/cmd/roachtest/spec",
         "//pkg/testutils/skip",
         "//pkg/util/version",
@@ -223,4 +233,12 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_x_oauth2//:oauth2",
     ],
+)
+
+gomock(
+    name = "mocks_drt",
+    out = "drt_generated.go",
+    interfaces = ["PromClient"],
+    library = ":tests",
+    package = "tests",
 )

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -24,7 +24,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-type promClient interface {
+// PromClient is an interface allowing queries against Prometheus.
+type PromClient interface {
 	Query(ctx context.Context, query string, ts time.Time) (model.Value, promv1.Warnings, error)
 }
 
@@ -33,7 +34,7 @@ type tpccChaosEventProcessor struct {
 	workloadNodeIP    string
 	ops               []string
 	ch                chan ChaosEvent
-	promClient        promClient
+	promClient        PromClient
 	errs              []error
 
 	// allowZeroSuccessDuringUptime allows 0 successes during an uptime event.

--- a/pkg/cmd/roachtest/tests/drt_generated.go
+++ b/pkg/cmd/roachtest/tests/drt_generated.go
@@ -14,31 +14,31 @@ import (
 	model "github.com/prometheus/common/model"
 )
 
-// MockpromClient is a mock of promClient interface.
-type MockpromClient struct {
+// MockPromClient is a mock of PromClient interface.
+type MockPromClient struct {
 	ctrl     *gomock.Controller
-	recorder *MockpromClientMockRecorder
+	recorder *MockPromClientMockRecorder
 }
 
-// MockpromClientMockRecorder is the mock recorder for MockpromClient.
-type MockpromClientMockRecorder struct {
-	mock *MockpromClient
+// MockPromClientMockRecorder is the mock recorder for MockPromClient.
+type MockPromClientMockRecorder struct {
+	mock *MockPromClient
 }
 
-// NewMockpromClient creates a new mock instance.
-func NewMockpromClient(ctrl *gomock.Controller) *MockpromClient {
-	mock := &MockpromClient{ctrl: ctrl}
-	mock.recorder = &MockpromClientMockRecorder{mock}
+// NewMockPromClient creates a new mock instance.
+func NewMockPromClient(ctrl *gomock.Controller) *MockPromClient {
+	mock := &MockPromClient{ctrl: ctrl}
+	mock.recorder = &MockPromClientMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockpromClient) EXPECT() *MockpromClientMockRecorder {
+func (m *MockPromClient) EXPECT() *MockPromClientMockRecorder {
 	return m.recorder
 }
 
 // Query mocks base method.
-func (m *MockpromClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+func (m *MockPromClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Query", ctx, query, ts)
 	ret0, _ := ret[0].(model.Value)
@@ -48,7 +48,7 @@ func (m *MockpromClient) Query(ctx context.Context, query string, ts time.Time) 
 }
 
 // Query indicates an expected call of Query.
-func (mr *MockpromClientMockRecorder) Query(ctx, query, ts interface{}) *gomock.Call {
+func (mr *MockPromClientMockRecorder) Query(ctx, query, ts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockpromClient)(nil).Query), ctx, query, ts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockPromClient)(nil).Query), ctx, query, ts)
 }

--- a/pkg/cmd/roachtest/tests/drt_test.go
+++ b/pkg/cmd/roachtest/tests/drt_test.go
@@ -518,8 +518,8 @@ func TestTPCCChaosEventProcessor(t *testing.T) {
 				allowZeroSuccessDuringUptime: tc.allowZeroSuccessDuringUptime,
 				maxErrorsDuringUptime:        tc.maxErrorsDuringUptime,
 
-				promClient: func(ctrl *gomock.Controller) promClient {
-					c := NewMockpromClient(ctrl)
+				promClient: func(ctrl *gomock.Controller) PromClient {
+					c := NewMockPromClient(ctrl)
 					e := c.EXPECT()
 					for _, m := range tc.mockPromQueries {
 						e.Query(ctx, m.q, m.t).Return(


### PR DESCRIPTION
We were pointing to the checked-in generated files in the Bazel build
here; instead, use `gomock`.

Also clean up the `EXISTING_GO_GENERATE_COMMENTS` in
`build/bazelutil/check.sh`.

Release note: None