### PR TITLE
bazel: glob-exclude all *_generated.go files from Gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,7 +69,6 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:resolve proto go roachpb/io-formats.proto //pkg/roachpb:with-mocks
 # gazelle:resolve proto go roachpb/metadata.proto //pkg/roachpb:with-mocks
 # gazelle:resolve proto go roachpb/span_config.proto //pkg/roachpb:with-mocks
-# gazelle:exclude pkg/roachpb/batch_generated.go
 # gazelle:exclude pkg/roachpb/batch_generated-gen.go
 
 # See pkg/sql/opt/optgen/cmd/langgen/BUILD.bazel for more details.
@@ -107,7 +106,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude **/*.pb.gw.go
 # gazelle:exclude **/*_interval_btree.go
 # gazelle:exclude **/*_interval_btree_test.go
-# gazelle:exclude **/mocks_generated.go
+# gazelle:exclude **/*_generated.go
 # gazelle:exclude pkg/sql/parser/sql.go
 # gazelle:exclude pkg/sql/parser/helpmap_test.go
 # gazelle:exclude pkg/sql/parser/help_messages.go
@@ -118,25 +117,9 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/testutils/**/testdata/**
 # gazelle:exclude pkg/security/securitytest/embedded.go
 # gazelle:exclude pkg/cmd/roachprod/vm/aws/embedded.go
-# gazelle:exclude pkg/cmd/roachtest/prometheus/mock_generated.go
-# gazelle:exclude pkg/cmd/roachtest/tests/drt_generated.go
 # gazelle:exclude pkg/**/*_string.go
-# gazelle:exclude pkg/geo/wkt/wkt_generated.go
-# gazelle:exclude pkg/sql/schemachanger/scop/backfill_visitor_generated.go
-# gazelle:exclude pkg/sql/schemachanger/scop/mutation_visitor_generated.go
-# gazelle:exclude pkg/sql/schemachanger/scop/validation_visitor_generated.go
-# gazelle:exclude pkg/sql/schemachanger/scpb/elements_generated.go
 # gazelle:exclude pkg/ui/distccl/distccl_no_bazel.go
 # gazelle:exclude pkg/ui/distoss/distoss_no_bazel.go
-# gazelle:exclude pkg/util/log/channel/channel_generated.go
-# gazelle:exclude pkg/util/log/eventpb/eventlog_channels_generated.go
-# gazelle:exclude pkg/util/log/eventpb/json_encode_generated.go
-# gazelle:exclude pkg/util/log/log_channels_generated.go
-# gazelle:exclude pkg/util/log/severity/severity_generated.go
-# gazelle:exclude pkg/util/timeutil/lowercase_timezones_generated.go
-#
-# TODO(irfansharif): Hand excluding these _generated.go/_stringer.go files is
-# silly, we should glob exclude everything once we have full coverage.
 #
 # Generally useful references:
 #

--- a/pkg/col/colserde/arrowserde/BUILD.bazel
+++ b/pkg/col/colserde/arrowserde/BUILD.bazel
@@ -4,12 +4,14 @@ go_library(
     name = "arrowserde",
     srcs = [
         "doc.go",
-        "file_generated.go",
-        "message_generated.go",
-        "schema_generated.go",
-        "tensor_generated.go",
+        "file_generated.go",  # keep
+        "message_generated.go",  # keep
+        "schema_generated.go",  # keep
+        "tensor_generated.go",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/col/colserde/arrowserde",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_google_flatbuffers//go"],
+    deps = [
+        "@com_github_google_flatbuffers//go",  # keep
+    ],
 )


### PR DESCRIPTION
This review is only for the second commit in the stack; the other is from #72098.

This will help ensure that Gazelle doesn't accidentally reference
checked-in generated code.

The generated code in `pkg/col/colserde/arrowserde` is made by `flatc`,
the FlatBuffers compiler -- I tried to make a `genrule` to generate this
code but the code that `flatc` generates now doesn't match up to what's
checked in (maybe we used a different version of `flatc` for the
original version of the code?)

Closes #72096.

Release note: None