### PR TITLE
sql: add dependency for `explain` unit test

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -46,7 +46,9 @@ go_test(
         "output_test.go",
         "plan_gist_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//pkg/sql/opt/testutils/opttester:testfixtures",
+    ],
     embed = [":explain"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
The test fails without it.

Release note: None