### PR TITLE
colexec: fix BenchmarkExternalHashAggregator

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1073,10 +1073,11 @@ func benchmarkAggregateFunction(
 		aggCols[i] = uint32(numGroupCol + i)
 	}
 	tc := aggregatorTestCase{
-		typs:      typs,
-		groupCols: groupCols,
-		aggCols:   [][]uint32{aggCols},
-		aggFns:    []execinfrapb.AggregatorSpec_Func{aggFn},
+		typs:           typs,
+		groupCols:      groupCols,
+		aggCols:        [][]uint32{aggCols},
+		aggFns:         []execinfrapb.AggregatorSpec_Func{aggFn},
+		unorderedInput: agg.order == unordered,
 	}
 	if distinctProb > 0 {
 		if !typs[0].Identical(types.Int) {
@@ -1090,7 +1091,6 @@ func benchmarkAggregateFunction(
 		}
 	}
 	if agg.order == partial {
-		tc.unorderedInput = false
 		tc.orderedCols = []uint32{0}
 	}
 	require.NoError(b, tc.init())

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -218,7 +218,8 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 							// purposes of this benchmark.
 							return colexecop.NewNoop(op), err
 						},
-						name: fmt.Sprintf("spilled=%t", spillForced),
+						name:  fmt.Sprintf("spilled=%t", spillForced),
+						order: unordered,
 					},
 					aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
 					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)


### PR DESCRIPTION
Previously, the external hash aggregator benchmark had two flaws:
- it didn't specify explicitly `ordering` property, so the input was
actually ordered
- similarly, it didn't specify `unorderedInput` field, so we planned
a sort on top of the aggregation to preserve the order.

Both of these things are undesirable and are now fixed.

Addresses: #71820.

Release note: None