### PR TITLE
sql: textual explain analyze now shows max mem/disk stats

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -587,6 +587,8 @@ func (m execNodeTraceMetadata) annotateExplain(
 				nodeStats.SeekCount.MaybeAdd(stats.KV.NumInterfaceSeeks)
 				nodeStats.InternalSeekCount.MaybeAdd(stats.KV.NumInternalSeeks)
 				nodeStats.VectorizedBatchCount.MaybeAdd(stats.Output.NumBatches)
+				nodeStats.MaxAllocatedMem.MaybeAdd(stats.Exec.MaxAllocatedMem)
+				nodeStats.MaxAllocatedDisk.MaybeAdd(stats.Exec.MaxAllocatedDisk)
 			}
 			// If we didn't get statistics for all processors, we don't show the
 			// incomplete results. In the future, we may consider an incomplete flag

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -73,6 +73,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
+      estimated max memory allocated: 0 B
       missing stats
       table: kv@kv_pkey
       spans: FULL SCAN
@@ -95,6 +96,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ equality: (k) = (k)
 │ left cols are key
 │ right cols are key
@@ -107,6 +110,7 @@ regions: <hidden>
 │     KV contention time: 0µs
 │     KV rows read: 5
 │     KV bytes read: 40 B
+│     estimated max memory allocated: 0 B
 │     missing stats
 │     table: kv@kv_pkey
 │     spans: FULL SCAN
@@ -119,6 +123,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
+      estimated max memory allocated: 0 B
       missing stats
       table: kw@kw_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -22,6 +22,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
+  estimated max memory allocated: 0 B
   missing stats
   table: kv@kv_pkey
   spans: [/2 - ]
@@ -49,6 +50,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 3
   KV bytes read: 24 B
+  estimated max memory allocated: 0 B
   missing stats
   table: kv@kv_pkey
   spans: [/2 - ]
@@ -75,6 +77,8 @@ regions: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ estimated row count: 990 (missing stats)
 │ equality: (v) = (a)
 │ right cols are key
@@ -89,6 +93,7 @@ regions: <hidden>
 │     KV contention time: 0µs
 │     KV rows read: 4
 │     KV bytes read: 32 B
+│     estimated max memory allocated: 0 B
 │     MVCC step count (ext/int): 0/0
 │     MVCC seek count (ext/int): 0/0
 │     estimated row count: 1,000 (missing stats)
@@ -105,6 +110,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 3
       KV bytes read: 24 B
+      estimated max memory allocated: 0 B
       MVCC step count (ext/int): 0/0
       MVCC seek count (ext/int): 0/0
       estimated row count: 1,000 (missing stats)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -80,6 +80,8 @@ regions: <hidden>
     │ nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
     │ equality: (k) = (k)
     │ left cols are key
     │ right cols are key
@@ -92,6 +94,7 @@ regions: <hidden>
     │     KV contention time: 0µs
     │     KV rows read: 5
     │     KV bytes read: 40 B
+    │     estimated max memory allocated: 0 B
     │     missing stats
     │     table: kv@kv_pkey
     │     spans: FULL SCAN
@@ -104,6 +107,7 @@ regions: <hidden>
           KV contention time: 0µs
           KV rows read: 5
           KV bytes read: 40 B
+          estimated max memory allocated: 0 B
           missing stats
           table: kw@kw_pkey
           spans: FULL SCAN
@@ -127,18 +131,24 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ order: +w
 │
 └── • distinct
     │ nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
     │ distinct on: w
     │
     └── • hash join
         │ nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 5
+        │ estimated max memory allocated: 0 B
+        │ estimated max sql temp disk usage: 0 B
         │ equality: (k) = (w)
         │ left cols are key
         │
@@ -150,6 +160,7 @@ regions: <hidden>
         │     KV contention time: 0µs
         │     KV rows read: 5
         │     KV bytes read: 40 B
+        │     estimated max memory allocated: 0 B
         │     missing stats
         │     table: kv@kv_pkey
         │     spans: FULL SCAN
@@ -162,6 +173,7 @@ regions: <hidden>
               KV contention time: 0µs
               KV rows read: 5
               KV bytes read: 40 B
+              estimated max memory allocated: 0 B
               missing stats
               table: kw@kw_pkey
               spans: FULL SCAN
@@ -185,6 +197,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 25
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │
 ├── • ordinality
 │   │ nodes: <hidden>
@@ -199,6 +213,7 @@ regions: <hidden>
 │         KV contention time: 0µs
 │         KV rows read: 5
 │         KV bytes read: 40 B
+│         estimated max memory allocated: 0 B
 │         missing stats
 │         table: kv@kv_pkey
 │         spans: FULL SCAN
@@ -216,6 +231,7 @@ regions: <hidden>
           KV contention time: 0µs
           KV rows read: 5
           KV bytes read: 40 B
+          estimated max memory allocated: 0 B
           missing stats
           table: kv@kv_pkey
           spans: FULL SCAN
@@ -260,6 +276,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │
 └── • scan
       nodes: <hidden>
@@ -269,6 +287,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 5
       KV bytes read: 40 B
+      estimated max memory allocated: 0 B
       missing stats
       table: kv@kv_pkey
       spans: FULL SCAN
@@ -296,6 +315,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
+  estimated max memory allocated: 0 B
   missing stats
   table: kv@kv_pkey
   spans: [/0 - /0]
@@ -352,6 +372,7 @@ regions: <hidden>
 │             KV contention time: 0µs
 │             KV rows read: 1
 │             KV bytes read: 8 B
+│             estimated max memory allocated: 0 B
 │             missing stats
 │             table: parent@parent_pkey
 │             spans: LIMITED SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -35,6 +35,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ order: +k
 │
 └── • filter
@@ -51,12 +53,15 @@ regions: <hidden>
         │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
+        │ estimated max memory allocated: 0 B
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ estimated max memory allocated: 0 B
+            │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -68,6 +73,7 @@ regions: <hidden>
                   KV contention time: 0µs
                   KV rows read: 4
                   KV bytes read: 32 B
+                  estimated max memory allocated: 0 B
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans
@@ -113,6 +119,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ order: +k
 │
 └── • filter
@@ -129,12 +137,15 @@ regions: <hidden>
         │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
+        │ estimated max memory allocated: 0 B
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ estimated max memory allocated: 0 B
+            │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -146,6 +157,7 @@ regions: <hidden>
                   KV contention time: 0µs
                   KV rows read: 2
                   KV bytes read: 16 B
+                  estimated max memory allocated: 0 B
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans
@@ -175,6 +187,8 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ order: +k
 │
 └── • filter
@@ -191,12 +205,15 @@ regions: <hidden>
         │ KV contention time: 0µs
         │ KV rows read: 2
         │ KV bytes read: 16 B
+        │ estimated max memory allocated: 0 B
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ estimated max memory allocated: 0 B
+            │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -208,6 +225,7 @@ regions: <hidden>
                   KV contention time: 0µs
                   KV rows read: 2
                   KV bytes read: 16 B
+                  estimated max memory allocated: 0 B
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -128,6 +128,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 1
   KV bytes read: 8 B
+  estimated max memory allocated: 0 B
   estimated row count: 0
   table: ab@ab_pkey
   spans: [/1 - /1]
@@ -151,6 +152,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 0
   KV bytes read: 0 B
+  estimated max memory allocated: 0 B
   estimated row count: 0
   table: ab@ab_pkey
   spans: [/2 - /2]

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -55,6 +55,7 @@ regions: <hidden>
   KV contention time: 0µs
   KV rows read: 2,001
   KV bytes read: 16 KiB
+  estimated max memory allocated: 0 B
   missing stats
   table: a@a_pkey
   spans: FULL SCAN
@@ -92,6 +93,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 2
       KV bytes read: 16 B
+      estimated max memory allocated: 0 B
       estimated row count: 1 (100% of the table; stats collected <hidden> ago)
       table: c@sec
       spans: FULL SCAN
@@ -155,12 +157,16 @@ regions: <hidden>
 │ nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ estimated max memory allocated: 0 B
+│ estimated max sql temp disk usage: 0 B
 │ equality: (a) = (b)
 │
 ├── • sort
 │   │ nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 2
+│   │ estimated max memory allocated: 0 B
+│   │ estimated max sql temp disk usage: 0 B
 │   │ estimated row count: 1
 │   │ order: +a
 │   │
@@ -172,6 +178,7 @@ regions: <hidden>
 │         KV contention time: 0µs
 │         KV rows read: 2
 │         KV bytes read: 16 B
+│         estimated max memory allocated: 0 B
 │         estimated row count: 1 (100% of the table; stats collected <hidden> ago)
 │         table: c@sec
 │         spans: FULL SCAN
@@ -184,6 +191,7 @@ regions: <hidden>
       KV contention time: 0µs
       KV rows read: 2
       KV bytes read: 16 B
+      estimated max memory allocated: 0 B
       missing stats
       table: d@d_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -376,6 +376,12 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if s.KVBytesRead.HasValue() {
 			e.ob.AddField("KV bytes read", humanize.IBytes(s.KVBytesRead.Value()))
 		}
+		if s.MaxAllocatedMem.HasValue() {
+			e.ob.AddField("estimated max memory allocated", humanize.IBytes(s.MaxAllocatedMem.Value()))
+		}
+		if s.MaxAllocatedDisk.HasValue() {
+			e.ob.AddField("estimated max sql temp disk usage", humanize.IBytes(s.MaxAllocatedDisk.Value()))
+		}
 		if e.ob.flags.Verbose {
 			if s.StepCount.HasValue() {
 				e.ob.AddField("MVCC step count (ext/int)", fmt.Sprintf("%s/%s",

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -331,6 +331,9 @@ type ExecutionStats struct {
 	SeekCount         optional.Uint
 	InternalSeekCount optional.Uint
 
+	MaxAllocatedMem  optional.Uint
+	MaxAllocatedDisk optional.Uint
+
 	// Nodes on which this operator was executed.
 	Nodes []string
 


### PR DESCRIPTION
Resolves #66109

Release note (sql change): explain analyze now shows maximum
allocated memory and maximum sql temp disk usage for a statement.

Example: 



```
EXPLAIN ANALYZE SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b
----
planning time: 10µs
execution time: 100µs
distribution: <hidden>
vectorized: <hidden>
rows read from KV: 4 (32 B)
maximum memory usage: <hidden>
network usage: <hidden>
regions: <hidden>
·
• merge join
│ nodes: <hidden>
│ regions: <hidden>
│ actual row count: 2
│ estimated max memory allocated: 0 B
│ estimated max sql temp disk usage: 0 B
│ equality: (a) = (b)
│
├── • sort
│   │ nodes: <hidden>
│   │ regions: <hidden>
│   │ actual row count: 2
│   │ estimated max memory allocated: 0 B
│   │ estimated max sql temp disk usage: 0 B
│   │ estimated row count: 1
│   │ order: +a
│   │
│   └── • scan
│         nodes: <hidden>
│         regions: <hidden>
│         actual row count: 2
│         KV time: 0µs
│         KV contention time: 0µs
│         KV rows read: 2
│         KV bytes read: 16 B
│         estimated max memory allocated: 0 B
│         estimated row count: 1 (100% of the table; stats collected <hidden> ago)
│         table: c@sec
│         spans: FULL SCAN
│
└── • scan
      nodes: <hidden>
      regions: <hidden>
      actual row count: 2
      KV time: 0µs
      KV contention time: 0µs
      KV rows read: 2
      KV bytes read: 16 B
      estimated max memory allocated: 0 B
      missing stats
      table: d@d_pkey
      spans: FULL SCAN
```