### PR TITLE
storage/metamorphic: Don't have two txns write to a key

### DIFF
--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -136,7 +136,7 @@ func (m *metaTestRunner) init() {
 		tsGenerator:    &m.tsGenerator,
 		txnIDMap:       make(map[txnID]*roachpb.Transaction),
 		openBatches:    make(map[txnID]map[readWriterID]struct{}),
-		inUseKeys:      make(map[txnID][]writtenKeySpan),
+		inUseKeys:      make([]writtenKeySpan, 0),
 		openSavepoints: make(map[txnID]int),
 		testRunner:     m,
 	}

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -162,7 +162,6 @@ func runMetaTest(run testRun) {
 // for matching outputs by the test suite between different options of Pebble.
 func TestPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 72077, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -210,7 +209,6 @@ func TestPebbleEquivalence(t *testing.T) {
 // engine sequences with restarts in between.
 func TestPebbleRestarts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 72078, "flaky test")
 	defer log.Scope(t).Close(t)
 	// This test times out with the race detector enabled.
 	skip.UnderRace(t)


### PR DESCRIPTION
Previously, we were letting two txns concurrently
write to a key as long as they were not using the
same writer. At first this seemed to be deterministic enough
for our purposes despite violating MVCC invariants,
but turns out `intentInterleavingIter` makes some
optimizations where it assumes there are never
two intents for the same key, so we need to mimic
KV-style latching here.

Fixes #72077, #72078.

Release note: None.