### PR TITLE
dev: pad internal timeouts when under --stress --timeout

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -180,9 +180,9 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 			args = append(args, "--run_under",
 				fmt.Sprintf("%s -maxtime=%s %s", stressTarget, timeout, stressArgs))
 
-			// The bazel timeout needs to be higher than the stress duration to
-			// pass reliably.
-			args = append(args, fmt.Sprintf("--test_timeout=%.0f", (timeout+time.Second).Seconds()))
+			// The timeout should be higher than the stress duration, lets
+			// generously give it an extra minute.
+			args = append(args, fmt.Sprintf("--test_timeout=%d", int((timeout+time.Minute).Seconds())))
 		} else {
 			// We're running under stress and no timeout is specified. We want
 			// to respect the timeout passed down to stress[1]. Similar to above

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -97,7 +97,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=11 '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=70 '--test_filter=TestStartChild*' --test_output streamed
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -36,7 +36,7 @@ bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --r
 dev test --stress pkg/util/tracing --filter TestStartChild* --timeout=10s -v
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=11 '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' --test_timeout=70 '--test_filter=TestStartChild*' --test_output streamed
 
 dev test //pkg/testutils --timeout=10s
 ----


### PR DESCRIPTION
I was seeing the earlier one second buffer being insufficient.

Release note: None