### PR TITLE
coldata: fix BenchmarkAppend so that it could be run with multiple count

### DIFF
--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -429,10 +429,10 @@ func BenchmarkAppend(b *testing.B) {
 			for _, bc := range benchCases {
 				bc.args.Src = src
 				bc.args.SrcEndIdx = coldata.BatchSize()
-				dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 				b.Run(fmt.Sprintf("%s/%s/NullProbability=%.1f", typ, bc.name, nullProbability), func(b *testing.B) {
 					b.SetBytes(8 * int64(coldata.BatchSize()))
 					bc.args.DestIdx = 0
+					dest := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)
 					for i := 0; i < b.N; i++ {
 						dest.Append(bc.args)
 						bc.args.DestIdx += coldata.BatchSize()


### PR DESCRIPTION
Previously, we could get an index out of bounds because we'd allocate
larger `Bytes.data` slice than `int32` offset can support.

Release note: None