### PR TITLE
opt: fix regression in many-columns-and-indexes microbenchmark

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1181,8 +1181,7 @@ select
  │    ├── cost: 1064.42
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    ├── prune: (1,2)
- │    └── interesting orderings: (+1)
+ │    └── prune: (1,2)
  └── filters
       └── (k:1 % 2) = 1 [outer=(1), immutable]
 

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -27,6 +27,10 @@ func selectBuildChildReqOrdering(
 	if childIdx != 0 {
 		return props.OrderingChoice{}
 	}
+	if required.Any() {
+		return *required
+	}
+
 	child := parent.(*memo.SelectExpr).Input
 
 	// Use interesting orderings from the child to "guide" the required ordering


### PR DESCRIPTION
This commit fixes a regression that was due to unnecessary computation
of interesting orderings. We now only compute interesting orderings
when it may be beneficial for planning purposes.

Fixes #72001

Release note (performance improvement): Fixed a performance regression
in planning that could occur for simple queries on schemas with a large
number of indexes.