### PR TITLE
util/admission: avoid write to tenantInfo after releasing it

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -442,8 +442,7 @@ func (q *WorkQueue) gcTenantsAndResetTokens() {
 		if info.used == 0 && len(info.waitingWorkHeap) == 0 {
 			delete(q.mu.tenants, id)
 			releaseTenantInfo(info)
-		}
-		if q.usesTokens {
+		} else if q.usesTokens {
 			info.used = 0
 			// All the heap members will reset used=0, so no need to change heap
 			// ordering.


### PR DESCRIPTION
Previously, `releaseTenantInfo(info)` put the *tenantInfo back into
the pool, but we then wrote to `info.used` directly after. This is a data 
race leading to multiple test failures.

Since releaseTenantInfo resets the tenantInfo, we don't care about
resetting the used field in that case anyway.

Fixes #72219
Fixes #72216
Fixes #72215
Fixes #72214
Fixes #72213
Fixes #72212
Fixes #72208
Fixes #72207
Fixes #72206
Fixes #72205
Fixes #72204
Fixes #72203
Fixes #72202
Fixes #72201
Fixes #72199
Fixes #72198
Fixes #72197
Fixes #72196
Fixes #72195
Fixes #72194
Fixes #72193
Fixes #72192
Fixes #72191
Fixes #72190
Fixes #72189
Fixes #72187
Fixes #72186
Fixes #72185
Fixes #72184
Fixes #72183
Fixes #72182
Fixes #72181
Fixes #72180
Fixes #72179
Fixes #72178
Fixes #72177
Fixes #72176
Fixes #72175
Fixes #72174
Fixes #72173
Fixes #72172
Fixes #72171
Fixes #72170
Fixes #72167
Fixes #72165
Fixes #72164
Fixes #72163
Fixes #72162
Fixes #72157
Fixes #72156
Fixes #72155
Fixes #72154
Fixes #72153
Fixes #72152
Fixes #72151
Fixes #72150
Fixes #72149
Fixes #72148
Fixes #72147
Fixes #72146
Fixes #72145
Fixes #72144
Fixes #72143
Fixes #72142
Fixes #72141
Fixes #72140

Release note: None