### PR TITLE
sql: add test fixtures dependency to BUILD.bazel

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -46,7 +46,9 @@ go_test(
         "output_test.go",
         "plan_gist_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "//pkg/sql/opt/testutils/opttester:testfixtures",
+    ],
     embed = [":explain"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
This fixes recent TestPlanGistBuilder failures when using bazel.

Release note: None