### PR TITLE
kvserver: load descriptor from disk in StateLoader.Load

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -992,7 +992,9 @@ func (r *Replica) tick(ctx context.Context, livenessMap liveness.IsLiveMap) (boo
 		return false, nil
 	}
 
-	r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx)
+	if r.descRLocked().IsInitialized() {
+		r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx)
+	}
 
 	// For followers, we update lastUpdateTimes when we step a message from them
 	// into the local Raft group. The leader won't hit that path, so we update

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -65,8 +65,12 @@ func (rsl StateLoader) Load(
 		if err != nil {
 			return kvserverpb.ReplicaState{}, err
 		}
+		if loadDesc == nil {
+			panic("no descriptor")
+		}
 		s.Desc = loadDesc
 	} else {
+		panic("should not load state for uninitialized replica")
 		// This is awkward - for an uninitialized replica, the start key is not
 		// known and so we cannot load a descriptor (and even if we could it would
 		// not be there). The incoming descriptor in this case is a complete stub


### PR DESCRIPTION
This is clean-up related to [#72222]. The range descriptor handling in the
replica state is somewhat awkward - callers loading the state are expected to
pass it in. This seems backwards; the descriptor is part of the state and so
the caller should pass in enough information to load it, but no more.

[#72222]: https://github.com/cockroachdb/cockroach/issues/72222. 

Release note: None
