### PR TITLE
sql: type VALUES smarter to handle tuple arrays

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -248,12 +248,12 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 		}
 	case *tree.DArray:
 		// We need to check for arrays of untyped tuples here since constant-folding
-		// on builtin functions sometimes produces this.
+		// on builtin functions sometimes produces this. DecodeUntaggedDatum
+		// requires that all the types of the tuple contents are known.
 		if t.ResolvedType().ArrayContents() == types.AnyTuple {
 			v.err = newQueryNotSupportedErrorf("array %s cannot be executed with distsql", t)
 			return false, expr
 		}
-
 	}
 	return true, expr
 }

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -979,3 +979,108 @@ UNION
 SELECT (1::INT, NULL)
 ----
 (1,)
+
+# Regression test for #70767. Make sure we avoid encoding arrays where the
+# array content type is AnyTuple.
+subtest regression_70767
+
+query T
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])), ((ARRAY[()])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+{}
+{()}
+
+query T
+SELECT
+  col
+FROM
+  (VALUES (NULL), ((ARRAY[]::RECORD[])), ((ARRAY[()])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+NULL
+{}
+{()}
+
+# ARRAY[(1)] is type-checked as an int[] -- this also matches Postgres.
+statement error VALUES types int\[\] and tuple\[\] cannot be matched
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])), ((ARRAY[(1)])))
+    AS t(col)
+ORDER BY
+  col ASC
+
+statement error VALUES types tuple{int, string}\[\] and tuple{int, int}\[\] cannot be matched
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])), ((ARRAY[(1,2)])), ((ARRAY[(1,'cat')])))
+    AS t(col)
+ORDER BY
+  col ASC
+
+query T
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])), ((ARRAY[(1,2)])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+{}
+{"(1,2)"}
+
+query T
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[(1,2)])), ((ARRAY[]::RECORD[])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+{}
+{"(1,2)"}
+
+query T
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])),  ((ARRAY[(1,2), (3,4)])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+{}
+{"(1,2)","(3,4)"}
+
+statement error expected tuple \(3, 4, 5\) to have a length of 2
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])),  ((ARRAY[(1,2), (3,4), (3,4,5)])))
+    AS t(col)
+ORDER BY
+  col ASC
+
+query T
+SELECT
+  col
+FROM
+  (VALUES ((ARRAY[]::RECORD[])), ((ARRAY[(1,'cat')])))
+    AS t(col)
+ORDER BY
+  col ASC
+----
+{}
+{"(1,cat)"}

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -78,6 +78,15 @@ func (b *Builder) buildValuesClause(
 			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
 				if colTypes[colIdx].Family() == types.UnknownFamily {
 					colTypes[colIdx] = typ
+				} else if colTypes[colIdx].Family() == types.ArrayFamily &&
+					colTypes[colIdx].ArrayContents() == types.AnyTuple &&
+					typ.Family() == types.ArrayFamily &&
+					typ.ArrayContents().Family() == types.TupleFamily &&
+					typ.ArrayContents() != types.AnyTuple {
+					// This more complicated condition handles the case when an earlier
+					// expression in the VALUES clause is an array of AnyTuple, but a
+					// later expression is an array of a more specific tuple type.
+					colTypes[colIdx] = typ
 				} else if !typ.Equivalent(colTypes[colIdx]) {
 					panic(pgerror.Newf(pgcode.DatatypeMismatch,
 						"VALUES types %s and %s cannot be matched", typ, colTypes[colIdx]))

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -36,15 +36,3 @@ func (node *ValuesClause) Format(ctx *FmtCtx) {
 		comma = ", "
 	}
 }
-
-// ValuesClauseWithNames is a VALUES clause that has been annotated with column
-// names. This is only produced at plan time, never by the parser. It's used to
-// pass column names to the VALUES planNode, so it can produce intelligible
-// error messages during value type checking.
-type ValuesClauseWithNames struct {
-	ValuesClause
-
-	// Names is a list of the column names that each tuple in the ValuesClause
-	// corresponds to.
-	Names NameList
-}

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -11,180 +11,19 @@
 package sql
 
 import (
-	"context"
-	"fmt"
-	"go/constant"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/apd/v2"
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
-
-func makeTestPlanner() *planner {
-	// Initialize an Executorconfig sufficiently for the purposes of creating a
-	// planner.
-	settings := cluster.MakeTestingClusterSettings()
-	execCfg := ExecutorConfig{
-		Settings: settings,
-		NodeInfo: NodeInfo{
-			NodeID: base.TestingIDContainer,
-			ClusterID: func() uuid.UUID {
-				return uuid.MakeV4()
-			},
-		},
-		RootMemoryMonitor: mon.NewUnlimitedMonitor(context.Background(), "test", mon.MemoryResource, nil, nil, 0, nil),
-		CollectionFactory: descs.NewCollectionFactory(settings, nil, nil, nil),
-	}
-
-	// TODO(andrei): pass the cleanup along to the caller.
-	p, _ /* cleanup */ := NewInternalPlanner(
-		"test",
-		nil, /* txn */
-		security.RootUserName(),
-		&MemoryMetrics{},
-		&execCfg,
-		sessiondatapb.SessionData{},
-	)
-	return p.(*planner)
-}
-
-func TestValues(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	p := makeTestPlanner()
-
-	vInt := int64(5)
-	vNum := 3.14159
-	vStr := "two furs one cub"
-	vBool := true
-
-	unsupp := &tree.RangeCond{}
-
-	intVal := func(v int64) *tree.NumVal {
-		return tree.NewNumVal(
-			constant.MakeInt64(v),
-			"", /* origString */
-			false /* negative */)
-	}
-	floatVal := func(f float64) *tree.CastExpr {
-		return &tree.CastExpr{
-			Expr: tree.NewNumVal(
-				constant.MakeFloat64(f),
-				"", /* origString */
-				false /* negative */),
-			Type: types.Float,
-		}
-	}
-	asRow := func(datums ...tree.Datum) []tree.Datums {
-		return []tree.Datums{datums}
-	}
-
-	makeValues := func(tuples ...tree.Exprs) *tree.ValuesClause {
-		return &tree.ValuesClause{Rows: tuples}
-	}
-	makeTuple := func(exprs ...tree.Expr) tree.Exprs {
-		return tree.Exprs(exprs)
-	}
-
-	testCases := []struct {
-		stmt *tree.ValuesClause
-		rows []tree.Datums
-		ok   bool
-	}{
-		{
-			makeValues(makeTuple(intVal(vInt))),
-			asRow(tree.NewDInt(tree.DInt(vInt))),
-			true,
-		},
-		{
-			makeValues(makeTuple(intVal(vInt), intVal(vInt))),
-			asRow(tree.NewDInt(tree.DInt(vInt)), tree.NewDInt(tree.DInt(vInt))),
-			true,
-		},
-		{
-			makeValues(makeTuple(floatVal(vNum))),
-			asRow(tree.NewDFloat(tree.DFloat(vNum))),
-			true,
-		},
-		{
-			makeValues(makeTuple(tree.NewDString(vStr))),
-			asRow(tree.NewDString(vStr)),
-			true,
-		},
-		{
-			makeValues(makeTuple(tree.NewDBytes(tree.DBytes(vStr)))),
-			asRow(tree.NewDBytes(tree.DBytes(vStr))),
-			true,
-		},
-		{
-			makeValues(makeTuple(tree.MakeDBool(tree.DBool(vBool)))),
-			asRow(tree.MakeDBool(tree.DBool(vBool))),
-			true,
-		},
-		{
-			makeValues(makeTuple(unsupp)),
-			nil,
-			false,
-		},
-	}
-
-	ctx := context.Background()
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			plan, err := func() (_ planNode, err error) {
-				defer func() {
-					if r := recover(); r != nil {
-						err = errors.Errorf("%v", r)
-					}
-				}()
-				return p.Values(context.Background(), tc.stmt, nil)
-			}()
-			if plan != nil {
-				defer plan.Close(ctx)
-			}
-			if err == nil != tc.ok {
-				t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
-			}
-			if plan == nil {
-				return
-			}
-			params := runParams{ctx: ctx, p: p, extendedEvalCtx: &p.extendedEvalCtx}
-			if err := startExec(params, plan); err != nil {
-				t.Fatalf("%d: unexpected error in Start: %v", i, err)
-			}
-			var rows []tree.Datums
-			next, err := plan.Next(params)
-			for ; next; next, err = plan.Next(params) {
-				rows = append(rows, plan.Values())
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(rows, tc.rows) {
-				t.Errorf("%d: expected rows:\n%+v\nactual rows:\n%+v", i, tc.rows, rows)
-			}
-		})
-	}
-}
 
 type floatAlias float32
 type boolAlias bool


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/70767

The VALUES clause previously would take the type of the first non-null element. Now it also searches for the first type that is not an array containing AnyTuple typed elements. This fixes a bug that was causing internal errors with some queries.

Release note: None