### PR TITLE
bulkio: fix rollback when cleaning up user defined schemas in database

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7518,6 +7518,7 @@ func TestRestoreTypeDescriptorsRollBack(t *testing.T) {
 
 	sqlDB.Exec(t, `
 CREATE DATABASE db;
+CREATE SCHEMA db.s;
 CREATE TYPE db.typ AS ENUM();
 CREATE TABLE db.table (k INT PRIMARY KEY, v db.typ);
 `)


### PR DESCRIPTION
Release note (bug fix): Previously if a restore failed involving a
database with a user defined schema, the descriptor would not be
cleaned up properly possibly causing an error if repeating the same
restore.