### PR TITLE
release-21.1: kvserver: batch intents in `MVCCIterator.CheckForKeyCollisions`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -499,6 +500,9 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 			e := engineImpl.create()
 			defer e.Close()
 
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext()
+
 			for _, kv := range mvccKVsFromStrs([]strKv{
 				{"a", 2, "aa"},
 				{"b", 1, "bb"},
@@ -554,6 +558,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				sstBytes := getSSTBytes(sstKVs)
 				stats := getStats(roachpb.Key("a"), roachpb.Key("b"), sstBytes)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -581,6 +586,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -610,6 +616,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -637,6 +644,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				sstBytes := getSSTBytes(sstKVs)
 				stats := getStats(roachpb.Key("c"), roachpb.Key("i"), sstBytes)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -669,6 +677,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -697,6 +706,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -726,6 +736,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -743,16 +754,16 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				}
 			}
 
-			// Test key collision when ingesting a key which has a write intent in the
+			// Test key collision when ingesting keys which have write intents in the
 			// existing data.
 			{
 				sstKVs := mvccKVsFromStrs([]strKv{
 					{"f", 2, "ff"},
-					{"q", 4, "qq"},
-					{"t", 3, "ttt"}, // has a write intent in the existing data.
+					{"q", 4, "qq"},  // has a write intent in the existing data
+					{"t", 3, "ttt"}, // has a write intent in the existing data
 				})
 
-				// Add in a write intent.
+				// Add in two write intents.
 				ts := hlc.Timestamp{WallTime: 7}
 				txn := roachpb.MakeTransaction(
 					"test",
@@ -762,17 +773,23 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 					base.DefaultMaxClockOffset.Nanoseconds(),
 				)
 				if err := storage.MVCCPut(
+					ctx, e, nil, []byte("q"), ts,
+					roachpb.MakeValueFromBytes([]byte("q")),
+					&txn,
+				); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := storage.MVCCPut(
 					ctx, e, nil, []byte("t"), ts,
 					roachpb.MakeValueFromBytes([]byte("tt")),
 					&txn,
 				); err != nil {
-					if !errors.HasType(err, (*roachpb.WriteIntentError)(nil)) {
-						t.Fatalf("%+v", err)
-					}
+					t.Fatalf("%+v", err)
 				}
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -785,7 +802,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				}
 
 				_, err := batcheval.EvalAddSSTable(ctx, e, cArgs, nil)
-				if !testutils.IsError(err, "conflicting intents on \"t") {
+				if !testutils.IsError(err, "conflicting intents on \"q\", \"t\"") {
 					t.Fatalf("%+v", err)
 				}
 			}
@@ -811,6 +828,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -840,6 +858,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				sstBytes := getSSTBytes(sstKVs)
 				stats := getStats(roachpb.Key("e"), roachpb.Key("zz"), sstBytes)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -869,6 +888,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -897,6 +917,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -925,6 +946,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 
 				sstBytes := getSSTBytes(sstKVs)
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},
@@ -964,6 +986,7 @@ func TestAddSSTableDisallowShadowing(t *testing.T) {
 				commandStats := enginepb.MVCCStats{}
 
 				cArgs := batcheval.CommandArgs{
+					EvalCtx: evalCtx,
 					Header: roachpb.Header{
 						Timestamp: hlc.Timestamp{WallTime: 7},
 					},

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -215,9 +215,9 @@ func (i *MVCCIterator) FindSplitKey(
 
 // CheckForKeyCollisions is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) CheckForKeyCollisions(
-	sstData []byte, start, end roachpb.Key,
+	sstData []byte, start, end roachpb.Key, maxIntents int64,
 ) (enginepb.MVCCStats, error) {
-	return i.i.CheckForKeyCollisions(sstData, start, end)
+	return i.i.CheckForKeyCollisions(sstData, start, end, maxIntents)
 }
 
 // SetUpperBound is part of the storage.MVCCIterator interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -154,9 +154,13 @@ type MVCCIterator interface {
 	// must set the upper bound on the iterator before calling this method.
 	FindSplitKey(start, end, minSplitKey roachpb.Key, targetSize int64) (MVCCKey, error)
 	// CheckForKeyCollisions checks whether any keys collide between the iterator
-	// and the encoded SST data specified, within the provided key range. Returns
-	// stats on skipped KVs, or an error if a collision is found.
-	CheckForKeyCollisions(sstData []byte, start, end roachpb.Key) (enginepb.MVCCStats, error)
+	// and the encoded SST data specified, within the provided key range.
+	// maxIntents specifies the number of intents to collect and return in a
+	// WriteIntentError (0 disables batching, pass math.MaxInt64 to collect all).
+	// Returns stats on skipped KVs, or an error if a collision is found.
+	CheckForKeyCollisions(
+		sstData []byte, start, end roachpb.Key, maxIntents int64,
+	) (enginepb.MVCCStats, error)
 	// SetUpperBound installs a new upper bound for this iterator. The caller
 	// can modify the parameter after this function returns. This must not be a
 	// nil key. When Reader.ConsistentIterators is true, prefer creating a new

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -990,6 +990,86 @@ func TestEngineDeleteIterRange(t *testing.T) {
 	})
 }
 
+func TestMVCCIteratorCheckForKeyCollisionsMaxIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	keys := []string{"aa", "bb", "cc", "dd"}
+	intents := []string{"a", "b", "c"}
+
+	testcases := []struct {
+		maxIntents    int64
+		expectIntents []string
+	}{
+		{maxIntents: -1, expectIntents: []string{"a"}},
+		{maxIntents: 0, expectIntents: []string{"a"}},
+		{maxIntents: 1, expectIntents: []string{"a"}},
+		{maxIntents: 2, expectIntents: []string{"a", "b"}},
+		{maxIntents: 3, expectIntents: []string{"a", "b", "c"}},
+		{maxIntents: 4, expectIntents: []string{"a", "b", "c"}},
+	}
+
+	// Create SST with keys equal to intents at txn2TS.
+	sstFile := &MemFile{}
+	sstWriter := MakeBackupSSTWriter(sstFile)
+	defer sstWriter.Close()
+	for _, k := range intents {
+		key := MVCCKey{Key: roachpb.Key(k), Timestamp: txn2TS}
+		value := roachpb.Value{}
+		value.SetString("sst")
+		value.InitChecksum(key.Key)
+		require.NoError(t, sstWriter.Put(key, value.RawBytes))
+	}
+	require.NoError(t, sstWriter.Finish())
+	sstWriter.Close()
+
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			ctx := context.Background()
+			engine := engineImpl.create()
+			defer engine.Close()
+
+			// Write some committed keys and intents at txn1TS.
+			batch := engine.NewBatch()
+			for _, key := range keys {
+				require.NoError(t, batch.PutMVCC(
+					MVCCKey{Key: roachpb.Key(key), Timestamp: txn1TS}, []byte("value")))
+			}
+			for _, key := range intents {
+				require.NoError(t, MVCCPut(
+					ctx, batch, nil, roachpb.Key(key), txn1TS, roachpb.MakeValueFromString("intent"), txn1))
+			}
+			require.NoError(t, batch.Commit(true))
+			batch.Close()
+			require.NoError(t, engine.Flush())
+
+			for _, tc := range testcases {
+				t.Run(fmt.Sprintf("maxIntents=%d", tc.maxIntents), func(t *testing.T) {
+					// Provoke and check WriteIntentErrors.
+					iter := engine.NewMVCCIterator(
+						MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.Key("z")})
+					defer iter.Close()
+					iter.SeekGE(MVCCKey{Key: roachpb.Key("a")})
+
+					_, err := iter.CheckForKeyCollisions(
+						sstFile.Bytes(), roachpb.Key("a"), roachpb.Key("z"), tc.maxIntents)
+					require.Error(t, err)
+					writeIntentErr := &roachpb.WriteIntentError{}
+					if !errors.As(err, &writeIntentErr) {
+						t.Fatalf("expected WriteIntentError, got %T", err)
+					}
+
+					actual := []string{}
+					for _, i := range writeIntentErr.Intents {
+						actual = append(actual, string(i.Key))
+					}
+					require.Equal(t, tc.expectIntents, actual)
+				})
+			}
+		})
+	}
+}
+
 func TestSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -843,9 +843,9 @@ func (i *intentInterleavingIter) FindSplitKey(
 }
 
 func (i *intentInterleavingIter) CheckForKeyCollisions(
-	sstData []byte, start, end roachpb.Key,
+	sstData []byte, start, end roachpb.Key, maxIntents int64,
 ) (enginepb.MVCCStats, error) {
-	return checkForKeyCollisionsGo(i, sstData, start, end)
+	return checkForKeyCollisionsGo(i, sstData, start, end, maxIntents)
 }
 
 func (i *intentInterleavingIter) SetUpperBound(key roachpb.Key) {

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -704,9 +704,9 @@ func (p *pebbleIterator) SupportsPrev() bool {
 // CheckForKeyCollisions indicates if the provided SST data collides with this
 // iterator in the specified range.
 func (p *pebbleIterator) CheckForKeyCollisions(
-	sstData []byte, start, end roachpb.Key,
+	sstData []byte, start, end roachpb.Key, maxIntents int64,
 ) (enginepb.MVCCStats, error) {
-	return checkForKeyCollisionsGo(p, sstData, start, end)
+	return checkForKeyCollisionsGo(p, sstData, start, end, maxIntents)
 }
 
 // GetRawIter is part of the EngineIterator interface.


### PR DESCRIPTION
Backport 1/2 commits from #72042.

/cc @cockroachdb/release

---

`MVCCIterator.CheckForKeyCollisions()` is used by `AddSSTable` to check
for key collisions when `DisallowShadowing` is set. If it encounters any
intents, it returns `WriteIntentError` to resolve these before retrying.

However, this returned an error for each individual intent, which has
quadratic performance. This patch changes it to instead collect and
return a batch of intents, for more efficient intent resolution.

The batch size is controlled by the existing setting
`storage.mvcc.max_intents_per_error`, which defaults to 5000.

Resolves #71697.

Release note (performance improvement): Improved `IMPORT INTO`
performance in cases where it encounters large numbers of unresolved
write intents.
