### PR TITLE
tests: multiply acceptable failures by number of workers for MR DRT

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -617,7 +617,7 @@ func registerTPCC(r registry.Registry) {
 								// * ERROR: inbox communication error: rpc error: code = Canceled
 								//   desc = context canceled (SQLSTATE 58C01)
 								// Setting this allows some errors to occur.
-								maxErrorsDuringUptime: warehousesPerRegion * 5,
+								maxErrorsDuringUptime: warehousesPerRegion * tpcc.NumWorkersPerWarehouse,
 								// "delivery" does not trigger often.
 								allowZeroSuccessDuringUptime: true,
 							}, nil

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -192,7 +192,7 @@ var tpccMeta = workload.Meta{
 		g.flags.StringVar(&g.dbOverride, `db`, ``,
 			`Override for the SQL database to use. If empty, defaults to the generator name`)
 		g.flags.IntVar(&g.workers, `workers`, 0, fmt.Sprintf(
-			`Number of concurrent workers. Defaults to --warehouses * %d`, numWorkersPerWarehouse,
+			`Number of concurrent workers. Defaults to --warehouses * %d`, NumWorkersPerWarehouse,
 		))
 		g.flags.IntVar(&g.numConns, `conns`, 0, fmt.Sprintf(
 			`Number of connections. Defaults to --warehouses * %d (except in nowait mode, where it defaults to --workers`,
@@ -319,7 +319,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 			w.initNonUniformRandomConstants()
 
 			if w.workers == 0 {
-				w.workers = w.activeWarehouses * numWorkersPerWarehouse
+				w.workers = w.activeWarehouses * NumWorkersPerWarehouse
 			}
 
 			if w.numConns == 0 {
@@ -334,9 +334,9 @@ func (w *tpcc) Hooks() workload.Hooks {
 				}
 			}
 
-			if w.waitFraction > 0 && w.workers != w.activeWarehouses*numWorkersPerWarehouse {
+			if w.waitFraction > 0 && w.workers != w.activeWarehouses*NumWorkersPerWarehouse {
 				return errors.Errorf(`--wait > 0 and --warehouses=%d requires --workers=%d`,
-					w.activeWarehouses, w.warehouses*numWorkersPerWarehouse)
+					w.activeWarehouses, w.warehouses*NumWorkersPerWarehouse)
 			}
 
 			if w.serializable {

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	numWorkersPerWarehouse = 10
+	// NumWorkersPerWarehouse is the default number of workers per warehouse.
+	NumWorkersPerWarehouse = 10
 	numConnsPerWarehouse   = 2
 )
 


### PR DESCRIPTION
TPC-C has 10 workers, and we're allowing each worker to die once during
a chaos test as the query gets cancelled by DistSQL. As such, tweak the
acceptable failure rate.

Resolves #72235 
Resolves #72234

Release note: None