### PR TITLE
roachtest: fix import roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -217,6 +217,9 @@ func registerImportTPCH(r registry.Registry) {
 				if _, err := conn.Exec(`CREATE DATABASE csv;`); err != nil {
 					t.Fatal(err)
 				}
+				if _, err := conn.Exec(`USE csv;`); err != nil {
+					t.Fatal(err)
+				}
 				if _, err := conn.Exec(
 					`SET CLUSTER SETTING kv.bulk_ingest.max_index_buffer_size = '2gb'`,
 				); err != nil && !strings.Contains(err.Error(), "unknown cluster setting") {


### PR DESCRIPTION
This change fixes the import roachtest to switch to the
`csv` database before creating the table and importing into
it. This broke when we switched the roachtest to use
IMPORT INTO from IMPORT CREATE USING in https://github.com/cockroachdb/cockroach/pull/72097.

Fixes: #68037

Release note: None