### PR TITLE
sql: add new BACKFILLING mutation state

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -673,6 +673,19 @@ message DescriptorMutation {
     // (column default or index data) can only be backfilled once
     // all nodes have transitioned into the DELETE_AND_WRITE_ONLY state.
     DELETE_AND_WRITE_ONLY = 2;
+
+    // Operations other than non-transactional backfilling must not
+    // use this descriptor.
+    //
+    // Column: Columns do not use this state. A column descriptor in
+    // this state is a programming error.
+    //
+    // Index: A descriptor in this state is invisible to an INSERT,
+    // UPDATE, and DELETE.
+    //
+    // TODO(ssd): This is currently unused and is being added to
+    // facilitate the new temporary-index-based backfilling process.
+    BACKFILLING = 3;
   }
   optional State state = 3 [(gogoproto.nullable) = false];
 

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -385,9 +385,17 @@ type TableDescriptor interface {
 
 	// DeletableNonPrimaryIndexes returns a slice of all non-primary indexes
 	// which allow being deleted from: public + delete-and-write-only +
-	// delete-only, in  their canonical order. This is equivalent to taking
-	// the slice produced by AllIndexes and removing the primary index.
+	// delete-only, in their canonical order. This is equivalent to taking
+	// the slice produced by AllIndexes and removing the primary index and
+	// backfilling indexes.
 	DeletableNonPrimaryIndexes() []Index
+
+	// NonPrimaryIndexes returns a slice of all the indexes that
+	// are not yet public: backfilling, delete, and
+	// delete-and-write-only, in their canonical order. This is
+	// equivalent to taking the slice produced by AllIndexes and
+	// removing the primary index.
+	NonPrimaryIndexes() []Index
 
 	// DeleteOnlyNonPrimaryIndexes returns a slice of all non-primary indexes
 	// which allow only being deleted from, in their canonical order. This is

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -41,6 +41,10 @@ type TableElementMaybeMutation interface {
 	// delete-only state.
 	DeleteOnly() bool
 
+	// Backfilling returns true iff the table element is in a
+	// mutation in the backfilling state.
+	Backfilling() bool
+
 	// Adding returns true iff the table element is in an add mutation.
 	Adding() bool
 
@@ -529,6 +533,12 @@ func ForEachPartialIndex(desc TableDescriptor, f func(idx Index) error) error {
 	return forEachIndex(desc.PartialIndexes(), f)
 }
 
+// ForEachNonPrimaryIndex is like ForEachIndex over
+// NonPrimaryIndexes().
+func ForEachNonPrimaryIndex(desc TableDescriptor, f func(idx Index) error) error {
+	return forEachIndex(desc.NonPrimaryIndexes(), f)
+}
+
 // ForEachPublicNonPrimaryIndex is like ForEachIndex over
 // PublicNonPrimaryIndexes().
 func ForEachPublicNonPrimaryIndex(desc TableDescriptor, f func(idx Index) error) error {
@@ -611,6 +621,12 @@ func FindWritableNonPrimaryIndex(desc TableDescriptor, test func(idx Index) bool
 // DeletableNonPrimaryIndex() for which test returns true.
 func FindDeletableNonPrimaryIndex(desc TableDescriptor, test func(idx Index) bool) Index {
 	return findIndex(desc.DeletableNonPrimaryIndexes(), test)
+}
+
+// FindNonPrimaryIndex returns the first index in
+// NonPrimaryIndex() for which test returns true.
+func FindNonPrimaryIndex(desc TableDescriptor, test func(idx Index) bool) Index {
+	return findIndex(desc.NonPrimaryIndexes(), test)
 }
 
 // FindDeleteOnlyNonPrimaryIndex returns the first index in

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -195,6 +195,13 @@ func TestIndexInterface(t *testing.T) {
 			catalog.FindDeletableNonPrimaryIndex,
 		},
 		{
+			"NonPrimaryIndex",
+			indexNames[1:],
+			catalog.TableDescriptor.NonPrimaryIndexes,
+			catalog.ForEachNonPrimaryIndex,
+			catalog.FindNonPrimaryIndex,
+		},
+		{
 			"DeleteOnlyNonPrimaryIndex",
 			[]string{},
 			catalog.TableDescriptor.DeleteOnlyNonPrimaryIndexes,

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -62,6 +62,12 @@ func (mm maybeMutation) DeleteOnly() bool {
 	return mm.mutationState == descpb.DescriptorMutation_DELETE_ONLY
 }
 
+// Backfilling returns true iff the table element is a mutation in the
+// backfilling state.
+func (mm maybeMutation) Backfilling() bool {
+	return mm.mutationState == descpb.DescriptorMutation_BACKFILLING
+}
+
 // Adding returns true iff the table element is in an add mutation.
 func (mm maybeMutation) Adding() bool {
 	return mm.mutationDirection == descpb.DescriptorMutation_ADD

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -708,7 +708,7 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 	}
 
 	// Assign names to unnamed indexes.
-	err := catalog.ForEachDeletableNonPrimaryIndex(desc, func(idx catalog.Index) error {
+	err := catalog.ForEachNonPrimaryIndex(desc, func(idx catalog.Index) error {
 		if len(idx.GetName()) == 0 {
 			name, err := BuildIndexName(desc, idx.IndexDesc())
 			if err != nil {

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -288,6 +288,13 @@ func (desc *wrapper) PartialIndexes() []catalog.Index {
 	return desc.getExistingOrNewIndexCache().partial
 }
 
+// NonPrimaryIndexes returns a slice of all non-primary indexes, in
+// their canonical order. This is equivalent to taking the slice
+// produced by AllIndexes and removing the primary index.
+func (desc *wrapper) NonPrimaryIndexes() []catalog.Index {
+	return desc.getExistingOrNewIndexCache().nonPrimary
+}
+
 // PublicNonPrimaryIndexes returns a slice of all active secondary indexes,
 // in their canonical order. This is equivalent to the Indexes array in the
 // proto.
@@ -304,10 +311,11 @@ func (desc *wrapper) WritableNonPrimaryIndexes() []catalog.Index {
 	return desc.getExistingOrNewIndexCache().writableNonPrimary
 }
 
-// DeletableNonPrimaryIndexes returns a slice of all non-primary indexes
-// which allow being deleted from: public + delete-and-write-only +
-// delete-only, in  their canonical order. This is equivalent to taking
-// the slice produced by AllIndexes and removing the primary index.
+// DeletableNonPrimaryIndexes returns a slice of all non-primary
+// indexes which allow being deleted from: public +
+// delete-and-write-only + delete-only, in their canonical order. This
+// is equivalent to taking the slice produced by AllIndexes and
+// removing the primary index and backfilling indexes.
 func (desc *wrapper) DeletableNonPrimaryIndexes() []catalog.Index {
 	return desc.getExistingOrNewIndexCache().deletableNonPrimary
 }

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1067,7 +1067,7 @@ func (ot *optTable) WritableIndexCount() int {
 // DeletableIndexCount is part of the cat.Table interface.
 func (ot *optTable) DeletableIndexCount() int {
 	// Primary index is always present, so count is always >= 1.
-	return len(ot.desc.AllIndexes())
+	return len(ot.desc.DeletableNonPrimaryIndexes()) + 1
 }
 
 // Index is part of the cat.Table interface.


### PR DESCRIPTION
This adds a BACKFILLING mutation state. When an index is in this
state, it is ignored for the purposes of INSERT, UPDATE, and
DELETE. Currently, this state is unused in the actual code.

This new state will eventually be used in the new index backfiller. In
the new backfiller, the bulk-backfill using AddSSTable will occur when
the index is in this state, with concurrent updates being captured by
a temporary index. See
docs/RFCS/20211004_incremental_index_backfiller.md for more details.

Indexes in this state are returned by `(TableDescriptor).AllIndexes`, 
`(TableDescriptor).NonDropIndexes`, and `(TableDescriptor).Partial`.

Release note: None