### PR TITLE
workload/tpcc: check the 90th percentile instead of the .9th

### DIFF
--- a/pkg/workload/tpcc/result.go
+++ b/pkg/workload/tpcc/result.go
@@ -192,7 +192,7 @@ func (r *Result) FailureError() error {
 		if !exists {
 			return errors.Errorf("no %v data exists", query)
 		}
-		if v := time.Duration(h.ValueAtQuantile(.9)); v > max90th {
+		if v := time.Duration(h.ValueAtQuantile(90)); v > max90th {
 			err = errors.CombineErrors(err,
 				errors.Errorf("90th percentile latency for %v at %v exceeds passing threshold of %v",
 					query, v, max90th))


### PR DESCRIPTION
The hdrhistogram API was misleading. It expected a percentile for a quantile
calculation. All-in-all it appears the author of that library had percentile
and quantile confused. At some point in the last year, somebody did add a
`ValueAtPercentile` method which has the identical behavior as
`ValueAtQuantile`.

See https://github.com/cockroachdb/vendored/blob/5b815c7d468d59337db2c742373183af5525e729/github.com/codahale/hdrhistogram/hdr.go#L241-L259

Fixes #72282.

Release note: None