### PR TITLE
codeowners: transfer ownership of jobs package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -208,7 +208,7 @@
 /pkg/internal/rsg/           @cockroachdb/sql-queries
 /pkg/internal/sqlsmith/      @cockroachdb/sql-queries
 /pkg/internal/team/          @cockroachdb/test-eng
-/pkg/jobs/                   @cockroachdb/sql-schema
+/pkg/jobs/                   @cockroachdb/cdc-prs
 /pkg/keys/                   @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 /pkg/keys/constants.go       @cockroachdb/kv-prs-noreview


### PR DESCRIPTION
Previously, until the 22.1 release cycle, the jobs package was owned by
the SQL Schema team. This ownership has now been transferred to the CDC
team. This patch to the CODEOWNERS file reflects this change of
ownership.

Release note: None