### PR TITLE
storage/metamorphic: Increment endTime in ClearTimeRange

### DIFF
--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -930,6 +930,11 @@ var opGenerators = []opGenerator{
 			if endTime.Less(startTime) {
 				startTime, endTime = endTime, startTime
 			}
+			// This is to avoid a panic where startTime == endTime == hlc.Timestamp{}
+			// and where startTime gets next()'d in the time-bound iterator creation
+			// but endTime doesn't, making it seem like a start timestamp is set
+			// but an end timestamp is not.
+			endTime = endTime.Next()
 			return &mvccClearTimeRangeOp{
 				m:         m,
 				writer:    writer,


### PR DESCRIPTION
Eliminates a panic when endTime ends up being the zero
timestamp, and startTime is slightly ahead of endTime
as it gets next()'d in TBI creation but endTime doesn't.

Fixes #72269
Fixes #72261

Release note: None.