### PR TITLE
tree: allow string->tuple cast

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -149,7 +149,7 @@ CREATE VIEW v AS SELECT (1,'a')::b
 statement error cannot modify table record type
 CREATE VIEW v AS SELECT ((1,'a')::b).a
 
-# Test parsing of record types from string literals.
+# Test parsing/casting of record types from string literals.
 
 query T
 SELECT COALESCE(ARRAY[ROW(1, 2)], '{}')
@@ -170,3 +170,13 @@ query T
 SELECT COALESCE(NULL::a[], '{"(1, 3)", "(1, 2)"}');
 ----
 {"(1,\" 3\")","(1,\" 2\")"}
+
+statement ok
+CREATE TABLE strings(s TEXT);
+INSERT INTO strings VALUES('(1,2)'), ('(5,6)')
+
+query TT
+SELECT s, s::a FROM strings ORDER BY 1
+----
+(1,2)  (1,2)
+(5,6)  (5,6)

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1216,6 +1216,7 @@ var validCasts = []castInfo{
 	// Casts to TupleFamily.
 	{from: types.UnknownFamily, to: types.TupleFamily, volatility: VolatilityImmutable},
 	{from: types.TupleFamily, to: types.TupleFamily, volatility: VolatilityStable},
+	{from: types.StringFamily, to: types.TupleFamily, volatility: VolatilityStable},
 }
 
 type castsMapKey struct {
@@ -2366,6 +2367,9 @@ func performCastWithoutPrecisionTruncation(
 				}
 			}
 			return ret, nil
+		case *DString:
+			res, _, err := ParseDTupleFromString(ctx, string(*v), t)
+			return res, err
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up / forgotten case from
b37603815a36a60059afc244ec431ab1398ce9cd

No release note, since the note on the other commit covers it.

Release note: None