### PR TITLE
jobs: add mechanism to communicate job completion in-memory locally

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1709,7 +1709,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 			return err
 		}
 
-		p.ExecCfg().JobRegistry.NotifyToAdoptJobs(ctx)
+		p.ExecCfg().JobRegistry.NotifyToAdoptJobs()
 		if fn := r.testingKnobs.afterPublishingDescriptors; fn != nil {
 			if err := fn(); err != nil {
 				return err
@@ -1814,7 +1814,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 	// Reload the details as we may have updated the job.
 	details = r.job.Details().(jobspb.RestoreDetails)
-	p.ExecCfg().JobRegistry.NotifyToAdoptJobs(ctx)
+	p.ExecCfg().JobRegistry.NotifyToAdoptJobs()
 
 	if details.DescriptorCoverage == tree.AllDescriptors {
 		// We restore the system tables from the main data bundle so late because it

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "update.go",
         "utils.go",
         "validate.go",
+        "wait.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/jobs",
     visibility = ["//visibility:public"],

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -11,9 +11,7 @@
 package jobs
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -261,111 +258,6 @@ func (r *Registry) makeCtx() (context.Context, func()) {
 // MakeJobID generates a new job ID.
 func (r *Registry) MakeJobID() jobspb.JobID {
 	return jobspb.JobID(builtins.GenerateUniqueInt(r.nodeID.SQLInstanceID()))
-}
-
-// NotifyToAdoptJobs notifies the job adoption loop to start claimed jobs.
-func (r *Registry) NotifyToAdoptJobs(context.Context) {
-	select {
-	case r.adoptionCh <- resumeClaimedJobs:
-	default:
-	}
-}
-
-// WaitForJobs waits for a given list of jobs to reach some sort
-// of terminal state.
-func (r *Registry) WaitForJobs(
-	ctx context.Context, ex sqlutil.InternalExecutor, jobs []jobspb.JobID,
-) error {
-	if len(jobs) == 0 {
-		return nil
-	}
-	buf := bytes.Buffer{}
-	for i, id := range jobs {
-		if i > 0 {
-			buf.WriteString(",")
-		}
-		buf.WriteString(fmt.Sprintf(" %d", id))
-	}
-	// Manually retry instead of using SHOW JOBS WHEN COMPLETE so we have greater
-	// control over retries. Also, avoiding SHOW JOBS prevents us from having to
-	// populate the crdb_internal.jobs vtable.
-	query := fmt.Sprintf(
-		`SELECT count(*) FROM system.jobs WHERE id IN (%s)
-       AND (status != $1 AND status != $2 AND status != $3 AND status != $4 AND status != $5)`,
-		buf.String())
-	for r := retry.StartWithCtx(ctx, retry.Options{
-		InitialBackoff: 5 * time.Millisecond,
-		MaxBackoff:     1 * time.Second,
-		Multiplier:     1.5,
-	}); r.Next(); {
-		// We poll the number of queued jobs that aren't finished. As with SHOW JOBS
-		// WHEN COMPLETE, if one of the jobs is missing from the jobs table for
-		// whatever reason, we'll fail later when we try to load the job.
-		row, err := ex.QueryRowEx(
-			ctx,
-			"poll-show-jobs",
-			nil, /* txn */
-			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-			query,
-			StatusSucceeded,
-			StatusFailed,
-			StatusCanceled,
-			StatusRevertFailed,
-			StatusPaused,
-		)
-		if err != nil {
-			return errors.Wrap(err, "polling for queued jobs to complete")
-		}
-		if row == nil {
-			return errors.New("polling for queued jobs failed")
-		}
-		count := int64(tree.MustBeDInt(row[0]))
-		if log.V(3) {
-			log.Infof(ctx, "waiting for %d queued jobs to complete", count)
-		}
-		if count == 0 {
-			break
-		}
-	}
-	for i, id := range jobs {
-		j, err := r.LoadJob(ctx, id)
-		if err != nil {
-			return errors.WithHint(
-				errors.Wrapf(err, "job %d could not be loaded", jobs[i]),
-				"The job may not have succeeded.")
-		}
-		if j.Payload().FinalResumeError != nil {
-			decodedErr := errors.DecodeError(ctx, *j.Payload().FinalResumeError)
-			return decodedErr
-		}
-		if j.Payload().Error != "" {
-			return errors.Newf("job %d failed with error: %s", jobs[i], j.Payload().Error)
-		}
-		if j.Status() == StatusPaused {
-			if reason := j.Payload().PauseReason; reason != "" {
-				return errors.Newf("job %d was paused before it completed with reason: %s", jobs[i], reason)
-			}
-			return errors.Newf("job %d was paused before it completed", jobs[i])
-		}
-	}
-	return nil
-}
-
-// Run starts previously unstarted jobs from a list of scheduled
-// jobs. Canceling ctx interrupts the waiting but doesn't cancel the jobs.
-func (r *Registry) Run(
-	ctx context.Context, ex sqlutil.InternalExecutor, jobs []jobspb.JobID,
-) error {
-	if len(jobs) == 0 {
-		return nil
-	}
-	log.Infof(ctx, "scheduled jobs %+v", jobs)
-	r.NotifyToAdoptJobs(ctx)
-	err := r.WaitForJobs(ctx, ex, jobs)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // newJob creates a new Job.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -137,7 +137,18 @@ type Registry struct {
 		// jobs scheduled inside a transaction, they will show in this map but will
 		// only be run when the transaction commits.
 		adoptedJobs map[jobspb.JobID]*adoptedJob
+
+		// waiting is a set of jobs for which we're waiting to complete. In general,
+		// we expect these jobs to have been started with a claim by this instance.
+		// That may not have lasted to completion. Separately a goroutine will be
+		// passively polling for these jobs to complete. If they complete locally,
+		// the waitingSet will be updated appropriately.
+		waiting jobWaitingSets
 	}
+
+	// withSessionEvery ensures that logging when failing to get a live session
+	// is not too loud.
+	withSessionEvery log.EveryN
 
 	TestingResumerCreationKnobs map[jobspb.Type]func(Resumer) Resumer
 }
@@ -195,7 +206,8 @@ func MakeRegistry(
 		// Use a non-zero buffer to allow queueing of notifications.
 		// The writing method will use a default case to avoid blocking
 		// if a notification is already queued.
-		adoptionCh: make(chan adoptionNotice, 1),
+		adoptionCh:       make(chan adoptionNotice, 1),
+		withSessionEvery: log.Every(time.Second),
 	}
 	if knobs != nil {
 		r.knobs = *knobs
@@ -204,6 +216,7 @@ func MakeRegistry(
 		}
 	}
 	r.mu.adoptedJobs = make(map[jobspb.JobID]*adoptedJob)
+	r.mu.waiting = make(map[jobspb.JobID]map[*waitingSet]struct{})
 	r.metrics.init(histogramWindowInterval)
 	return r
 }
@@ -656,26 +669,28 @@ SELECT claim_session_id
  FETCH FIRST $2 ROWS ONLY)
 `
 
+type withSessionFunc func(ctx context.Context, s sqlliveness.Session)
+
+func (r *Registry) withSession(ctx context.Context, f withSessionFunc) {
+	s, err := r.sqlInstance.Session(ctx)
+	if err != nil {
+		if log.ExpensiveLogEnabled(ctx, 2) ||
+			(ctx.Err() == nil && r.withSessionEvery.ShouldLog()) {
+			log.Errorf(ctx, "error getting live session: %s", err)
+		}
+		return
+	}
+
+	log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
+	f(ctx, s)
+}
+
 // Start polls the current node for liveness failures and cancels all registered
 // jobs if it observes a failure. Otherwise it starts all the main daemons of
 // registry that poll the jobs table and start/cancel/gc jobs.
 func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
-	every := log.Every(time.Second)
-	withSession := func(
-		f func(ctx context.Context, s sqlliveness.Session),
-	) func(ctx context.Context) {
-		return func(ctx context.Context) {
-			s, err := r.sqlInstance.Session(ctx)
-			if err != nil {
-				if log.ExpensiveLogEnabled(ctx, 2) || (ctx.Err() == nil && every.ShouldLog()) {
-					log.Errorf(ctx, "error getting live session: %s", err)
-				}
-				return
-			}
-
-			log.VEventf(ctx, 1, "registry live claim (instance_id: %s, sid: %s)", r.ID(), s.ID())
-			f(ctx, s)
-		}
+	wrapWithSession := func(f withSessionFunc) func(ctx context.Context) {
+		return func(ctx context.Context) { r.withSession(ctx, f) }
 	}
 
 	// removeClaimsFromDeadSessions queries the jobs table for non-terminal
@@ -708,14 +723,14 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			log.Errorf(ctx, "failed to serve pause and cancel requests: %v", err)
 		}
 	}
-	cancelLoopTask := withSession(func(ctx context.Context, s sqlliveness.Session) {
+	cancelLoopTask := wrapWithSession(func(ctx context.Context, s sqlliveness.Session) {
 		removeClaimsFromDeadSessions(ctx, s)
 		r.maybeCancelJobs(ctx, s)
 		servePauseAndCancelRequests(ctx, s)
 	})
 	// claimJobs iterates the set of jobs which are not currently claimed and
 	// claims jobs up to maxAdoptionsPerLoop.
-	claimJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+	claimJobs := wrapWithSession(func(ctx context.Context, s sqlliveness.Session) {
 		r.metrics.AdoptIterations.Inc(1)
 		if err := r.claimJobs(ctx, s); err != nil {
 			log.Errorf(ctx, "error claiming jobs: %s", err)
@@ -724,7 +739,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// processClaimedJobs iterates the jobs claimed by the current node that
 	// are in the running or reverting state, and then it starts those jobs if
 	// they are not already running.
-	processClaimedJobs := withSession(func(ctx context.Context, s sqlliveness.Session) {
+	processClaimedJobs := wrapWithSession(func(ctx context.Context, s sqlliveness.Session) {
 		if r.adoptionDisabled(ctx) {
 			log.Warningf(ctx, "canceling all adopted jobs due to liveness failure")
 			r.cancelAllAdoptedJobs()
@@ -1161,6 +1176,7 @@ func (r *Registry) stepThroughStateMachine(
 			)
 		}
 		telemetry.Inc(TelemetryMetrics[jobType].Canceled)
+		r.removeFromWaitingSets(job.ID())
 		return errors.WithSecondaryError(errors.Errorf("job %s", status), jobErr)
 	case StatusSucceeded:
 		if jobErr != nil {
@@ -1171,6 +1187,7 @@ func (r *Registry) stepThroughStateMachine(
 		switch {
 		case err == nil:
 			telemetry.Inc(TelemetryMetrics[jobType].Successful)
+			r.removeFromWaitingSets(job.ID())
 		default:
 			// If we can't transactionally mark the job as succeeded then it will be
 			// restarted during the next adopt loop and it will be retried.
@@ -1223,6 +1240,7 @@ func (r *Registry) stepThroughStateMachine(
 			)
 		}
 		telemetry.Inc(TelemetryMetrics[jobType].Failed)
+		r.removeFromWaitingSets(job.ID())
 		return jobErr
 	case StatusRevertFailed:
 		// TODO(sajjad): Remove StatusRevertFailed and related code in other places in v22.1.

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -20,9 +20,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -34,23 +36,59 @@ func (r *Registry) NotifyToAdoptJobs() {
 	}
 }
 
+// NotifyToResume is used to notify the registry that it should attempt
+// to resume the specified jobs. The assumption is that these jobs were
+// created by this registry and thus are pre-claimed by it. This bypasses
+// the loop to discover jobs already claimed by this registry. If the jobs
+// turn out to not be claimed by this registry, it's not a problem.
+func (r *Registry) NotifyToResume(ctx context.Context, jobs ...jobspb.JobID) {
+	m := newJobIDSet(jobs...)
+	_ = r.stopper.RunAsyncTask(ctx, "resume-jobs", func(ctx context.Context) {
+		r.withSession(ctx, func(ctx context.Context, s sqlliveness.Session) {
+			r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, m)
+			r.resumeClaimedJobs(ctx, s, m)
+		})
+	})
+}
+
 // WaitForJobs waits for a given list of jobs to reach some sort
 // of terminal state.
 func (r *Registry) WaitForJobs(
 	ctx context.Context, ex sqlutil.InternalExecutor, jobs []jobspb.JobID,
 ) error {
+	log.Infof(ctx, "waiting for %d %v queued jobs to complete", len(jobs), jobs)
+	jobFinishedLocally, cleanup := r.installWaitingSet(jobs...)
+	defer cleanup()
+	return r.waitForJobs(ctx, ex, jobs, jobFinishedLocally)
+}
+
+func (r *Registry) waitForJobs(
+	ctx context.Context,
+	ex sqlutil.InternalExecutor,
+	jobs []jobspb.JobID,
+	jobFinishedLocally <-chan struct{},
+) error {
+
 	if len(jobs) == 0 {
 		return nil
 	}
+
 	query := makeWaitForJobsQuery(jobs)
+	start := timeutil.Now()
 	// Manually retry instead of using SHOW JOBS WHEN COMPLETE so we have greater
 	// control over retries. Also, avoiding SHOW JOBS prevents us from having to
 	// populate the crdb_internal.jobs vtable.
-	for r := retry.StartWithCtx(ctx, retry.Options{
-		InitialBackoff: 5 * time.Millisecond,
-		MaxBackoff:     1 * time.Second,
+	ret := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     3 * time.Second,
 		Multiplier:     1.5,
-	}); r.Next(); {
+
+		// Setting the closer here will terminate the loop if the job finishes
+		// before the first InitialBackoff period.
+		Closer: jobFinishedLocally,
+	})
+	ret.Next() // wait at least one InitialBackoff, first Next() doesn't block
+	for ret.Next() {
 		// We poll the number of queued jobs that aren't finished. As with SHOW JOBS
 		// WHEN COMPLETE, if one of the jobs is missing from the jobs table for
 		// whatever reason, we'll fail later when we try to load the job.
@@ -75,6 +113,10 @@ func (r *Registry) WaitForJobs(
 			break
 		}
 	}
+	defer func() {
+		log.Infof(ctx, "waited for %d %v queued jobs to complete %v",
+			len(jobs), jobs, timeutil.Since(start))
+	}()
 	for i, id := range jobs {
 		j, err := r.LoadJob(ctx, id)
 		if err != nil {
@@ -126,11 +168,115 @@ func (r *Registry) Run(
 	if len(jobs) == 0 {
 		return nil
 	}
-	log.Infof(ctx, "scheduled jobs %+v", jobs)
-	r.NotifyToAdoptJobs()
-	err := r.WaitForJobs(ctx, ex, jobs)
-	if err != nil {
-		return err
+	done, cleanup := r.installWaitingSet(jobs...)
+	defer cleanup()
+	r.NotifyToResume(ctx, jobs...)
+	return r.waitForJobs(ctx, ex, jobs, done)
+}
+
+// jobWaitingSets stores the set of waitingSets currently waiting on a job ID.
+type jobWaitingSets map[jobspb.JobID]map[*waitingSet]struct{}
+
+// waitingSet is a set of job IDs that a local client is waiting to complete.
+// It is an optimization for the Registry.Run() method which allows completion
+// when a job is scheduled and run to completion locally to be communicated
+// directly, without requiring the waiting goroutine to poll KV. This allows
+// the jobs package to be responsive to job termination with much less
+// contention on the table itself.
+//
+// The waitingSet is installed in Registry.installWaitingSet(), which returns
+// a cleanup function which will remove the waiter from the relevant
+// jobWaitingSets when the caller is no longer waiting. This cleanup makes any
+// call to notify the waiter purely an optimization. If no calls to
+// Registry.removeFromWaitingSet() were placed anywhere in the package, no
+// resources would be wasted. In order to deal with the fact that the waiting
+// set is an optimization, the caller still polls the job state to wait for it
+// to transition to a terminal status (or paused). This is unavoidable: the job
+// may end up running elsewhere.
+type waitingSet struct {
+	// jobDoneCh is closed when the set becomes empty because all
+	// jobs in the set have entered a terminal state.
+	jobDoneCh chan struct{}
+	// Note that the set itself is only ever mutated under the registry's mu.
+	// This choice is made to remove any concerns regarding lock ordering.
+	// See Registry.removeFromWaitingSet() for the one place where this is
+	// mutated. The code in the cleanup function returned from
+	// Registry.installWaitingSet() uses this set to determine which entries in
+	// the Registry's jobsWaitingSets which still need to be cleaned up.
+	set jobIDSet
+}
+
+// jobIDSet is a set of job IDs.
+type jobIDSet map[jobspb.JobID]struct{}
+
+func newJobIDSet(ids ...jobspb.JobID) jobIDSet {
+	m := make(map[jobspb.JobID]struct{}, len(ids))
+	for _, j := range ids {
+		m[j] = struct{}{}
 	}
-	return nil
+	return m
+}
+
+// installWaitingSet constructs a waiting set and installs it in the registry.
+// If all the jobs execute to a terminal status in this registry, the done
+// channel will be closed. The cleanup function must be called to avoid
+// leaking memory.
+func (r *Registry) installWaitingSet(
+	ids ...jobspb.JobID,
+) (jobDoneCh <-chan struct{}, cleanup func()) {
+	ws := &waitingSet{
+		jobDoneCh: make(chan struct{}),
+		set:       newJobIDSet(ids...),
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, id := range ids {
+		sets, ok := r.mu.waiting[id]
+		if !ok {
+			sets = make(map[*waitingSet]struct{}, 1)
+			r.mu.waiting[id] = sets
+		}
+		sets[ws] = struct{}{}
+	}
+	cleanup = func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for id := range ws.set {
+			set, ok := r.mu.waiting[id]
+			if !ok {
+				// This should never happen and indicates a programming error.
+				log.Errorf(
+					r.ac.AnnotateCtx(context.Background()),
+					"corruption detected in waiting set for id %d", id,
+				)
+				continue
+			}
+			delete(set, ws)
+			delete(ws.set, id)
+			if len(set) == 0 {
+				delete(r.mu.waiting, id)
+			}
+		}
+	}
+	return ws.jobDoneCh, cleanup
+}
+
+func (r *Registry) removeFromWaitingSets(id jobspb.JobID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sets, ok := r.mu.waiting[id]
+	if !ok {
+		return
+	}
+	for ws := range sets {
+
+		// Note that the set is only ever mutated underneath this mutex, so it's
+		// not possible for any other goroutine to have observed the set become
+		// empty.
+		delete(ws.set, id)
+		if len(ws.set) == 0 {
+			close(ws.jobDoneCh)
+		}
+	}
+	delete(r.mu.waiting, id)
 }

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -1,0 +1,136 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
+)
+
+// NotifyToAdoptJobs notifies the job adoption loop to start claimed jobs.
+func (r *Registry) NotifyToAdoptJobs() {
+	select {
+	case r.adoptionCh <- resumeClaimedJobs:
+	default:
+	}
+}
+
+// WaitForJobs waits for a given list of jobs to reach some sort
+// of terminal state.
+func (r *Registry) WaitForJobs(
+	ctx context.Context, ex sqlutil.InternalExecutor, jobs []jobspb.JobID,
+) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+	query := makeWaitForJobsQuery(jobs)
+	// Manually retry instead of using SHOW JOBS WHEN COMPLETE so we have greater
+	// control over retries. Also, avoiding SHOW JOBS prevents us from having to
+	// populate the crdb_internal.jobs vtable.
+	for r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: 5 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     1.5,
+	}); r.Next(); {
+		// We poll the number of queued jobs that aren't finished. As with SHOW JOBS
+		// WHEN COMPLETE, if one of the jobs is missing from the jobs table for
+		// whatever reason, we'll fail later when we try to load the job.
+		row, err := ex.QueryRowEx(
+			ctx,
+			"poll-show-jobs",
+			nil, /* txn */
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			query,
+		)
+		if err != nil {
+			return errors.Wrap(err, "polling for queued jobs to complete")
+		}
+		if row == nil {
+			return errors.New("polling for queued jobs failed")
+		}
+		count := int64(tree.MustBeDInt(row[0]))
+		if log.V(3) {
+			log.Infof(ctx, "waiting for %d queued jobs to complete", count)
+		}
+		if count == 0 {
+			break
+		}
+	}
+	for i, id := range jobs {
+		j, err := r.LoadJob(ctx, id)
+		if err != nil {
+			return errors.WithHint(
+				errors.Wrapf(err, "job %d could not be loaded", jobs[i]),
+				"The job may not have succeeded.")
+		}
+		if j.Payload().FinalResumeError != nil {
+			decodedErr := errors.DecodeError(ctx, *j.Payload().FinalResumeError)
+			return decodedErr
+		}
+		if j.Status() == StatusPaused {
+			if reason := j.Payload().PauseReason; reason != "" {
+				return errors.Newf("job %d was paused before it completed with reason: %s", jobs[i], reason)
+			}
+			return errors.Newf("job %d was paused before it completed", jobs[i])
+		}
+		if j.Payload().Error != "" {
+			return errors.Newf("job %d failed with error: %s", jobs[i], j.Payload().Error)
+		}
+	}
+	return nil
+}
+
+func makeWaitForJobsQuery(jobs []jobspb.JobID) string {
+	var buf strings.Builder
+	buf.WriteString(`SELECT count(*) FROM system.jobs WHERE status NOT IN ( ` +
+		`'` + string(StatusSucceeded) + `', ` +
+		`'` + string(StatusFailed) + `',` +
+		`'` + string(StatusCanceled) + `',` +
+		`'` + string(StatusRevertFailed) + `',` +
+		`'` + string(StatusPaused) + `'` +
+		` ) AND id IN (`)
+	for i, id := range jobs {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+		_, _ = fmt.Fprintf(&buf, " %d", id)
+	}
+	buf.WriteString(")")
+	return buf.String()
+}
+
+// Run starts previously unstarted jobs from a list of scheduled
+// jobs. Canceling ctx interrupts the waiting but doesn't cancel the jobs.
+func (r *Registry) Run(
+	ctx context.Context, ex sqlutil.InternalExecutor, jobs []jobspb.JobID,
+) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+	log.Infof(ctx, "scheduled jobs %+v", jobs)
+	r.NotifyToAdoptJobs()
+	err := r.WaitForJobs(ctx, ex, jobs)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -216,6 +216,6 @@ func (m *Manager) createAndStartJobIfNoneExists(ctx context.Context) (bool, erro
 	if fn := m.knobs.ManagerCreatedJobInterceptor; fn != nil {
 		fn(job)
 	}
-	m.jr.NotifyToAdoptJobs(ctx)
+	m.jr.NotifyToAdoptJobs()
 	return true, nil
 }

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -216,6 +216,6 @@ func (m *Manager) createAndStartJobIfNoneExists(ctx context.Context) (bool, erro
 	if fn := m.knobs.ManagerCreatedJobInterceptor; fn != nil {
 		fn(job)
 	}
-	m.jr.NotifyToAdoptJobs()
+	m.jr.NotifyToResume(ctx, job.ID())
 	return true, nil
 }

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -491,8 +491,8 @@ func startGCJob(
 	}); err != nil {
 		return err
 	}
-	log.Infof(ctx, "starting GC job %d", jobID)
-	jobRegistry.NotifyToAdoptJobs()
+	log.Infof(ctx, "created GC job %d", jobID)
+	jobRegistry.NotifyToResume(ctx, jobID)
 	return nil
 }
 
@@ -886,7 +886,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 		return err
 	}
 	log.Infof(ctx, "starting GC job %d", gcJobID)
-	sc.jobRegistry.NotifyToAdoptJobs()
+	sc.jobRegistry.NotifyToResume(ctx, gcJobID)
 	return nil
 }
 
@@ -1003,6 +1003,7 @@ func (sc *SchemaChanger) createIndexGCJob(
 		return err
 	}
 	log.Infof(ctx, "created index GC job %d", jobID)
+	sc.jobRegistry.NotifyToResume(ctx, jobID)
 	return nil
 }
 
@@ -1018,13 +1019,14 @@ func WaitToUpdateLeases(
 		MaxBackoff:     time.Second,
 		Multiplier:     1.5,
 	}
+	start := timeutil.Now()
 	log.Infof(ctx, "waiting for a single version...")
 	desc, err := leaseMgr.WaitForOneVersion(ctx, descID, retryOpts)
 	var version descpb.DescriptorVersion
 	if desc != nil {
 		version = desc.GetVersion()
 	}
-	log.Infof(ctx, "waiting for a single version... done (at v %d)", version)
+	log.Infof(ctx, "waiting for a single version... done (at v %d), took %v", version, timeutil.Since(start))
 	return desc, err
 }
 
@@ -1040,9 +1042,12 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	// descriptor updates are published.
 	var didUpdate bool
 	var depMutationJobs []jobspb.JobID
+	var otherJobIDs []jobspb.JobID
 	err := sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutor, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
+		depMutationJobs = depMutationJobs[:0]
+		otherJobIDs = otherJobIDs[:0]
 		var err error
 		scTable, err := descsCol.GetMutableTableVersionByID(ctx, sc.descID, txn)
 		if err != nil {
@@ -1222,8 +1227,12 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 				// If we performed MakeMutationComplete on a PrimaryKeySwap mutation, then we need to start
 				// a job for the index deletion mutations that the primary key swap mutation added, if any.
-				if err := sc.queueCleanupJobs(ctx, scTable, txn); err != nil {
+				jobID, err := sc.queueCleanupJob(ctx, scTable, txn)
+				if err != nil {
 					return err
+				}
+				if jobID > 0 {
+					depMutationJobs = append(depMutationJobs, jobID)
 				}
 			}
 
@@ -1235,8 +1244,12 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				// If we performed MakeMutationComplete on a computed column swap, then
 				// we need to start a job for the column deletion that the swap mutation
 				// added if any.
-				if err := sc.queueCleanupJobs(ctx, scTable, txn); err != nil {
+				jobID, err := sc.queueCleanupJob(ctx, scTable, txn)
+				if err != nil {
 					return err
+				}
+				if jobID > 0 {
+					depMutationJobs = append(depMutationJobs, jobID)
 				}
 			}
 			didUpdate = true
@@ -1252,10 +1265,11 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 		// Check any jobs that we need to depend on for the current
 		// job to be successful.
-		depMutationJobs, err = sc.getDependentMutationsJobs(ctx, scTable, committedMutations)
+		existingDepMutationJobs, err := sc.getDependentMutationsJobs(ctx, scTable, committedMutations)
 		if err != nil {
 			return err
 		}
+		depMutationJobs = append(depMutationJobs, existingDepMutationJobs...)
 
 		for i, g := range scTable.MutationJobs {
 			if g.MutationID == sc.mutationID {
@@ -1332,13 +1346,11 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Notify the job registry to start jobs, in case we started any.
-	sc.jobRegistry.NotifyToAdoptJobs()
 
 	// If any operations was skipped because a mutation was made
 	// redundant due to a column getting dropped later on then we should
 	// wait for those jobs to complete before returning our result back.
-	if err := sc.jobRegistry.WaitForJobs(ctx, sc.execCfg.InternalExecutor, depMutationJobs); err != nil {
+	if err := sc.jobRegistry.Run(ctx, sc.execCfg.InternalExecutor, depMutationJobs); err != nil {
 		return errors.Wrap(err, "A dependent transaction failed for this schema change")
 	}
 
@@ -2312,11 +2324,11 @@ func init() {
 	jobs.RegisterConstructor(jobspb.TypeSchemaChange, createResumerFn)
 }
 
-// queueCleanupJobs checks if the completed schema change needs to start a
+// queueCleanupJob checks if the completed schema change needs to start a
 // child job to clean up dropped schema elements.
-func (sc *SchemaChanger) queueCleanupJobs(
+func (sc *SchemaChanger) queueCleanupJob(
 	ctx context.Context, scDesc *tabledesc.Mutable, txn *kv.Txn,
-) error {
+) (jobspb.JobID, error) {
 	// Create jobs for dropped columns / indexes to be deleted.
 	mutationID := scDesc.ClusterVersion.NextMutationID
 	span := scDesc.PrimaryIndexSpan(sc.execCfg.Codec)
@@ -2330,6 +2342,7 @@ func (sc *SchemaChanger) queueCleanupJobs(
 	}
 	// Only start a job if spanList has any spans. If len(spanList) == 0, then
 	// no mutations were enqueued by the primary key change.
+	var jobID jobspb.JobID
 	if len(spanList) > 0 {
 		jobRecord := jobs.Record{
 			Description:   fmt.Sprintf("CLEANUP JOB for '%s'", sc.job.Payload().Description),
@@ -2346,9 +2359,9 @@ func (sc *SchemaChanger) queueCleanupJobs(
 			Progress:      jobspb.SchemaChangeProgress{},
 			NonCancelable: true,
 		}
-		jobID := sc.jobRegistry.MakeJobID()
+		jobID = sc.jobRegistry.MakeJobID()
 		if _, err := sc.jobRegistry.CreateJobWithTxn(ctx, jobRecord, jobID, txn); err != nil {
-			return err
+			return 0, err
 		}
 		log.Infof(ctx, "created job %d to drop previous columns and indexes", jobID)
 		scDesc.MutationJobs = append(scDesc.MutationJobs, descpb.TableDescriptor_MutationJob{
@@ -2356,7 +2369,7 @@ func (sc *SchemaChanger) queueCleanupJobs(
 			JobID:      int64(jobID),
 		})
 	}
-	return nil
+	return jobID, nil
 }
 
 func (sc *SchemaChanger) applyZoneConfigChangeForMutation(

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -492,7 +492,7 @@ func startGCJob(
 		return err
 	}
 	log.Infof(ctx, "starting GC job %d", jobID)
-	jobRegistry.NotifyToAdoptJobs(ctx)
+	jobRegistry.NotifyToAdoptJobs()
 	return nil
 }
 
@@ -886,7 +886,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 		return err
 	}
 	log.Infof(ctx, "starting GC job %d", gcJobID)
-	sc.jobRegistry.NotifyToAdoptJobs(ctx)
+	sc.jobRegistry.NotifyToAdoptJobs()
 	return nil
 }
 
@@ -1333,7 +1333,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		return err
 	}
 	// Notify the job registry to start jobs, in case we started any.
-	sc.jobRegistry.NotifyToAdoptJobs(ctx)
+	sc.jobRegistry.NotifyToAdoptJobs()
 
 	// If any operations was skipped because a mutation was made
 	// redundant due to a column getting dropped later on then we should

--- a/pkg/sql/schemachanger/scdeps/run_deps.go
+++ b/pkg/sql/schemachanger/scdeps/run_deps.go
@@ -118,6 +118,6 @@ func (d *jobExecutionDeps) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc
 	if err != nil {
 		return err
 	}
-	d.jobRegistry.NotifyToAdoptJobs(ctx)
+	d.jobRegistry.NotifyToAdoptJobs()
 	return nil
 }

--- a/pkg/sql/schemachanger/scdeps/run_deps.go
+++ b/pkg/sql/schemachanger/scdeps/run_deps.go
@@ -118,6 +118,8 @@ func (d *jobExecutionDeps) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc
 	if err != nil {
 		return err
 	}
+	// TODO(ajwerner): Rework the job registry dependency to capture the set of
+	// jobs which were created to more efficiently notify and wait for jobs here.
 	d.jobRegistry.NotifyToAdoptJobs()
 	return nil
 }


### PR DESCRIPTION
The first commit just moves some code out into a new file to make the second
commit more obvious.

This change does two things. Firstly, when local transactions create jobs
which are pre-claimed by the current registry, there's no need for the
registry to go search to find these job IDs. Instead, it can just directly
attempt to resume them. This nicely avoids a bunch of contention. Then,
when we wait for the jobs to complete, we can avoid polling the status
of the jobs table in the common case and instead wait for an in-memory
notification. This is beneficial because it reduces contention on the
job record of the running job.


Epic: CRDB-10719
    
Release note (performance improvement): Improved job performance in the
face of concurrent schema changes by reducing contention.

