### PR TITLE
release-21.1: sql: add internal tables cross db refs and interleaved indexes/tables

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -66,9 +66,11 @@ table_name NOT IN (
 	-- allowlisted tables that don't need to be in debug zip
 	'backward_dependencies',
 	'builtin_functions',
+	'cross_db_references',
 	'databases',
 	'forward_dependencies',
 	'index_columns',
+	'interleaved',
 	'lost_descriptors_with_data',
 	'table_columns',
 	'table_indexes',

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -82,6 +82,8 @@ const (
 	CrdbInternalZonesTableID
 	CrdbInternalInvalidDescriptorsTableID
 	CrdbInternalClusterDatabasePrivilegesTableID
+	CrdbInternalInterleaved
+	CrdbInternalCrossDbRefrences
 	CrdbInternalLostTableDescriptors
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -137,6 +137,8 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalZonesTableID:                     crdbInternalZonesTable,
 		catconstants.CrdbInternalInvalidDescriptorsTableID:        crdbInternalInvalidDescriptorsTable,
 		catconstants.CrdbInternalClusterDatabasePrivilegesTableID: crdbInternalClusterDatabasePrivilegesTable,
+		catconstants.CrdbInternalInterleaved:                      crdbInternalInterleaved,
+		catconstants.CrdbInternalCrossDbRefrences:                 crdbInternalCrossDbReferences,
 		catconstants.CrdbInternalLostTableDescriptors:             crdbLostTableDescriptors,
 	},
 	validWithNoDatabaseContext: true,
@@ -4457,5 +4459,206 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 			return err
 		}
 		return nil
+	},
+}
+
+var crdbInternalInterleaved = virtualSchemaTable{
+	comment: `virtual table with interleaved table information`,
+	schema: `
+CREATE TABLE crdb_internal.interleaved (
+	database_name
+		STRING NOT NULL,
+	schema_name
+		STRING NOT NULL,
+	table_name
+		STRING NOT NULL,
+	index_name
+		STRING NOT NULL,
+	parent_index
+		STRING NOT NULL
+);`,
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return forEachTableDescAllWithTableLookup(ctx, p, dbContext, hideVirtual,
+			func(db *dbdesc.Immutable, schemaName string, table catalog.TableDescriptor, lookupFn tableLookupFn) error {
+				if !table.IsInterleaved() {
+					return nil
+				}
+				indexes := table.NonDropIndexes()
+				for _, index := range indexes {
+					if index.NumInterleaveAncestors() == 0 {
+						continue
+					}
+
+					ancestor := index.GetInterleaveAncestor(index.NumInterleaveAncestors() - 1)
+					parentTable, err := lookupFn.getTableByID(ancestor.TableID)
+					if err != nil {
+						return err
+					}
+					parentIndex, err := parentTable.FindIndexWithID(ancestor.IndexID)
+					if err != nil {
+						return err
+					}
+					parentSchemaName, err := lookupFn.getSchemaNameByID(parentTable.GetParentSchemaID())
+					if err != nil {
+						return err
+					}
+					database, err := lookupFn.getDatabaseByID(parentTable.GetParentID())
+					if err != nil {
+						return err
+					}
+
+					if err := addRow(tree.NewDString(database.GetName()),
+						tree.NewDString(parentSchemaName),
+						tree.NewDString(table.GetName()),
+						tree.NewDString(index.GetName()),
+						tree.NewDString(parentIndex.GetName())); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+var crdbInternalCrossDbReferences = virtualSchemaTable{
+	comment: `virtual table with cross db references`,
+	schema: `
+CREATE TABLE crdb_internal.cross_db_references (
+	object_database
+		STRING NOT NULL,
+	object_schema
+		STRING NOT NULL,
+	object_name
+		STRING NOT NULL,
+	referenced_object_database
+		STRING NOT NULL,
+	referenced_object_schema
+		STRING NOT NULL,
+	referenced_object_name
+		STRING NOT NULL,
+	cross_database_reference_description
+		STRING NOT NULL
+);`,
+	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
+		return forEachTableDescAllWithTableLookup(ctx, p, dbContext, hideVirtual,
+			func(db *dbdesc.Immutable, schemaName string, table catalog.TableDescriptor, lookupFn tableLookupFn) error {
+				// For tables detect if foreign key references point at a different
+				// database. Additionally, check if any of the columns have sequence
+				// references to a different database.
+				if table.IsTable() {
+					objectDatabaseName := lookupFn.getDatabaseName(table)
+					err := table.ForeachOutboundFK(
+						func(fk *descpb.ForeignKeyConstraint) error {
+							referencedTable, err := lookupFn.getTableByID(fk.ReferencedTableID)
+							if err != nil {
+								return err
+							}
+							if referencedTable.GetParentID() != table.GetParentID() {
+								refSchemaName, err := lookupFn.getSchemaNameByID(referencedTable.GetParentSchemaID())
+								if err != nil {
+									return err
+								}
+								refDatabaseName := lookupFn.getDatabaseName(referencedTable)
+
+								if err := addRow(tree.NewDString(objectDatabaseName),
+									tree.NewDString(schemaName),
+									tree.NewDString(table.GetName()),
+									tree.NewDString(refDatabaseName),
+									tree.NewDString(refSchemaName),
+									tree.NewDString(referencedTable.GetName()),
+									tree.NewDString("table foreign key reference")); err != nil {
+									return err
+								}
+							}
+							return nil
+						})
+					if err != nil {
+						return err
+					}
+
+					// Check for sequence dependencies
+					for _, col := range table.PublicColumns() {
+						for i := 0; i < col.NumUsesSequences(); i++ {
+							sequenceID := col.GetUsesSequenceID(i)
+							seqDesc, err := lookupFn.getTableByID(sequenceID)
+							if err != nil {
+								return err
+							}
+							if seqDesc.GetParentID() != table.GetParentID() {
+								seqSchemaName, err := lookupFn.getSchemaNameByID(seqDesc.GetParentSchemaID())
+								if err != nil {
+									return err
+								}
+								refDatabaseName := lookupFn.getDatabaseName(seqDesc)
+								if err := addRow(tree.NewDString(objectDatabaseName),
+									tree.NewDString(schemaName),
+									tree.NewDString(table.GetName()),
+									tree.NewDString(refDatabaseName),
+									tree.NewDString(seqSchemaName),
+									tree.NewDString(seqDesc.GetName()),
+									tree.NewDString("table column refers to sequence")); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				} else if table.IsView() {
+					// For views check if we depend on tables in a different database.
+					dependsOn := table.GetDependsOn()
+					for _, dependency := range dependsOn {
+						dependentTable, err := lookupFn.getTableByID(dependency)
+						if err != nil {
+							return err
+						}
+						if dependentTable.GetParentID() != table.GetParentID() {
+							objectDatabaseName := lookupFn.getDatabaseName(table)
+							refSchemaName, err := lookupFn.getSchemaNameByID(dependentTable.GetParentSchemaID())
+							if err != nil {
+								return err
+							}
+							refDatabaseName := lookupFn.getDatabaseName(dependentTable)
+
+							if err := addRow(tree.NewDString(objectDatabaseName),
+								tree.NewDString(schemaName),
+								tree.NewDString(table.GetName()),
+								tree.NewDString(refDatabaseName),
+								tree.NewDString(refSchemaName),
+								tree.NewDString(dependentTable.GetName()),
+								tree.NewDString("view references table")); err != nil {
+								return err
+							}
+						}
+					}
+				} else if table.IsSequence() {
+					// For sequences check if the sequence is owned by
+					// a different database.
+					sequenceOpts := table.GetSequenceOpts()
+					if sequenceOpts.SequenceOwner.OwnerTableID != descpb.InvalidID {
+						ownerTable, err := lookupFn.getTableByID(sequenceOpts.SequenceOwner.OwnerTableID)
+						if err != nil {
+							return err
+						}
+						if ownerTable.GetParentID() != table.GetParentID() {
+							objectDatabaseName := lookupFn.getDatabaseName(table)
+							refSchemaName, err := lookupFn.getSchemaNameByID(ownerTable.GetParentSchemaID())
+							if err != nil {
+								return err
+							}
+							refDatabaseName := lookupFn.getDatabaseName(ownerTable)
+
+							if err := addRow(tree.NewDString(objectDatabaseName),
+								tree.NewDString(schemaName),
+								tree.NewDString(table.GetName()),
+								tree.NewDString(refDatabaseName),
+								tree.NewDString(refSchemaName),
+								tree.NewDString(ownerTable.GetName()),
+								tree.NewDString("sequences owning table")); err != nil {
+								return err
+							}
+						}
+					}
+				}
+				return nil
+			})
 	},
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -25,6 +25,7 @@ crdb_internal  cluster_settings             table  NULL  NULL  NULL
 crdb_internal  cluster_transactions         table  NULL  NULL  NULL
 crdb_internal  create_statements            table  NULL  NULL  NULL
 crdb_internal  create_type_statements       table  NULL  NULL  NULL
+crdb_internal  cross_db_references          table  NULL  NULL  NULL
 crdb_internal  databases                    table  NULL  NULL  NULL
 crdb_internal  feature_usage                table  NULL  NULL  NULL
 crdb_internal  forward_dependencies         table  NULL  NULL  NULL
@@ -33,6 +34,7 @@ crdb_internal  gossip_liveness              table  NULL  NULL  NULL
 crdb_internal  gossip_network               table  NULL  NULL  NULL
 crdb_internal  gossip_nodes                 table  NULL  NULL  NULL
 crdb_internal  index_columns                table  NULL  NULL  NULL
+crdb_internal  interleaved                  table  NULL  NULL  NULL
 crdb_internal  invalid_objects              table  NULL  NULL  NULL
 crdb_internal  jobs                         table  NULL  NULL  NULL
 crdb_internal  kv_node_liveness             table  NULL  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -37,6 +37,7 @@ crdb_internal  cluster_settings             table  NULL  NULL  NULL
 crdb_internal  cluster_transactions         table  NULL  NULL  NULL
 crdb_internal  create_statements            table  NULL  NULL  NULL
 crdb_internal  create_type_statements       table  NULL  NULL  NULL
+crdb_internal  cross_db_references          table  NULL  NULL  NULL
 crdb_internal  databases                    table  NULL  NULL  NULL
 crdb_internal  feature_usage                table  NULL  NULL  NULL
 crdb_internal  forward_dependencies         table  NULL  NULL  NULL
@@ -45,6 +46,7 @@ crdb_internal  gossip_liveness              table  NULL  NULL  NULL
 crdb_internal  gossip_network               table  NULL  NULL  NULL
 crdb_internal  gossip_nodes                 table  NULL  NULL  NULL
 crdb_internal  index_columns                table  NULL  NULL  NULL
+crdb_internal  interleaved                  table  NULL  NULL  NULL
 crdb_internal  invalid_objects              table  NULL  NULL  NULL
 crdb_internal  jobs                         table  NULL  NULL  NULL
 crdb_internal  kv_node_liveness             table  NULL  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -241,6 +241,23 @@ CREATE TABLE crdb_internal.create_type_statements (
    enum_members STRING[] NULL,
    INDEX create_type_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_name, create_statement, enum_members)
 )  {}  {}
+CREATE TABLE crdb_internal.cross_db_references (
+   object_database STRING NOT NULL,
+   object_schema STRING NOT NULL,
+   object_name STRING NOT NULL,
+   referenced_object_database STRING NOT NULL,
+   referenced_object_schema STRING NOT NULL,
+   referenced_object_name STRING NOT NULL,
+   cross_database_reference_description STRING NOT NULL
+)  CREATE TABLE crdb_internal.cross_db_references (
+   object_database STRING NOT NULL,
+   object_schema STRING NOT NULL,
+   object_name STRING NOT NULL,
+   referenced_object_database STRING NOT NULL,
+   referenced_object_schema STRING NOT NULL,
+   referenced_object_name STRING NOT NULL,
+   cross_database_reference_description STRING NOT NULL
+)  {}  {}
 CREATE TABLE crdb_internal.databases (
    id INT8 NOT NULL,
    name STRING NOT NULL,
@@ -374,6 +391,19 @@ CREATE TABLE crdb_internal.index_columns (
    column_name STRING NULL,
    column_direction STRING NULL,
    implicit BOOL NULL
+)  {}  {}
+CREATE TABLE crdb_internal.interleaved (
+database_name STRING NOT NULL,
+schema_name STRING NOT NULL,
+table_name STRING NOT NULL,
+index_name STRING NOT NULL,
+parent_index STRING NOT NULL
+)  CREATE TABLE crdb_internal.interleaved (
+database_name STRING NOT NULL,
+schema_name STRING NOT NULL,
+table_name STRING NOT NULL,
+index_name STRING NOT NULL,
+parent_index STRING NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.invalid_objects (
    id INT8 NULL,

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3633,6 +3633,15 @@ USE db2
 statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT REFERENCES db1.public.parent(p))
 
+
+# Validate that cross DB foreign keys are detected by internal tables
+query TTTTTTT
+select * from "".crdb_internal.cross_db_references;
+----
+db2  public  child   db1  public  parent  table foreign key reference
+db2  public  child2  db1  public  parent  table foreign key reference
+
+
 # Test that foreign keys cannot reference columns that are indexed by a partial
 # unique index or a partial unique constraint. Partial unique indexes and
 # constraints do not guarantee uniqueness in the entire table.

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -37,6 +37,7 @@ test           crdb_internal       cluster_settings                       public
 test           crdb_internal       cluster_transactions                   public   SELECT
 test           crdb_internal       create_statements                      public   SELECT
 test           crdb_internal       create_type_statements                 public   SELECT
+test           crdb_internal       cross_db_references                    public   SELECT
 test           crdb_internal       databases                              public   SELECT
 test           crdb_internal       feature_usage                          public   SELECT
 test           crdb_internal       forward_dependencies                   public   SELECT
@@ -45,6 +46,7 @@ test           crdb_internal       gossip_liveness                        public
 test           crdb_internal       gossip_network                         public   SELECT
 test           crdb_internal       gossip_nodes                           public   SELECT
 test           crdb_internal       index_columns                          public   SELECT
+test           crdb_internal       interleaved                            public   SELECT
 test           crdb_internal       invalid_objects                        public   SELECT
 test           crdb_internal       jobs                                   public   SELECT
 test           crdb_internal       kv_node_liveness                       public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -289,6 +289,7 @@ crdb_internal       cluster_settings
 crdb_internal       cluster_transactions
 crdb_internal       create_statements
 crdb_internal       create_type_statements
+crdb_internal       cross_db_references
 crdb_internal       databases
 crdb_internal       feature_usage
 crdb_internal       forward_dependencies
@@ -297,6 +298,7 @@ crdb_internal       gossip_liveness
 crdb_internal       gossip_network
 crdb_internal       gossip_nodes
 crdb_internal       index_columns
+crdb_internal       interleaved
 crdb_internal       invalid_objects
 crdb_internal       jobs
 crdb_internal       kv_node_liveness
@@ -486,6 +488,7 @@ cluster_settings
 cluster_transactions
 create_statements
 create_type_statements
+cross_db_references
 databases
 feature_usage
 forward_dependencies
@@ -494,6 +497,7 @@ gossip_liveness
 gossip_network
 gossip_nodes
 index_columns
+interleaved
 invalid_objects
 jobs
 kv_node_liveness
@@ -702,6 +706,7 @@ system         crdb_internal       cluster_settings                       SYSTEM
 system         crdb_internal       cluster_transactions                   SYSTEM VIEW  NO                  1
 system         crdb_internal       create_statements                      SYSTEM VIEW  NO                  1
 system         crdb_internal       create_type_statements                 SYSTEM VIEW  NO                  1
+system         crdb_internal       cross_db_references                    SYSTEM VIEW  NO                  1
 system         crdb_internal       databases                              SYSTEM VIEW  NO                  1
 system         crdb_internal       feature_usage                          SYSTEM VIEW  NO                  1
 system         crdb_internal       forward_dependencies                   SYSTEM VIEW  NO                  1
@@ -710,6 +715,7 @@ system         crdb_internal       gossip_liveness                        SYSTEM
 system         crdb_internal       gossip_network                         SYSTEM VIEW  NO                  1
 system         crdb_internal       gossip_nodes                           SYSTEM VIEW  NO                  1
 system         crdb_internal       index_columns                          SYSTEM VIEW  NO                  1
+system         crdb_internal       interleaved                            SYSTEM VIEW  NO                  1
 system         crdb_internal       invalid_objects                        SYSTEM VIEW  NO                  1
 system         crdb_internal       jobs                                   SYSTEM VIEW  NO                  1
 system         crdb_internal       kv_node_liveness                       SYSTEM VIEW  NO                  1
@@ -2000,6 +2006,7 @@ NULL     public   system         crdb_internal       cluster_settings           
 NULL     public   system         crdb_internal       cluster_transactions                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       create_statements                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       create_type_statements                 SELECT          NULL          YES
+NULL     public   system         crdb_internal       cross_db_references                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       databases                              SELECT          NULL          YES
 NULL     public   system         crdb_internal       feature_usage                          SELECT          NULL          YES
 NULL     public   system         crdb_internal       forward_dependencies                   SELECT          NULL          YES
@@ -2008,6 +2015,7 @@ NULL     public   system         crdb_internal       gossip_liveness            
 NULL     public   system         crdb_internal       gossip_network                         SELECT          NULL          YES
 NULL     public   system         crdb_internal       gossip_nodes                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       index_columns                          SELECT          NULL          YES
+NULL     public   system         crdb_internal       interleaved                            SELECT          NULL          YES
 NULL     public   system         crdb_internal       invalid_objects                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       jobs                                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_node_liveness                       SELECT          NULL          YES
@@ -2432,6 +2440,7 @@ NULL     public   system         crdb_internal       cluster_settings           
 NULL     public   system         crdb_internal       cluster_transactions                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       create_statements                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       create_type_statements                 SELECT          NULL          YES
+NULL     public   system         crdb_internal       cross_db_references                    SELECT          NULL          YES
 NULL     public   system         crdb_internal       databases                              SELECT          NULL          YES
 NULL     public   system         crdb_internal       feature_usage                          SELECT          NULL          YES
 NULL     public   system         crdb_internal       forward_dependencies                   SELECT          NULL          YES
@@ -2440,6 +2449,7 @@ NULL     public   system         crdb_internal       gossip_liveness            
 NULL     public   system         crdb_internal       gossip_network                         SELECT          NULL          YES
 NULL     public   system         crdb_internal       gossip_nodes                           SELECT          NULL          YES
 NULL     public   system         crdb_internal       index_columns                          SELECT          NULL          YES
+NULL     public   system         crdb_internal       interleaved                            SELECT          NULL          YES
 NULL     public   system         crdb_internal       invalid_objects                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       jobs                                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_node_liveness                       SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -453,6 +453,7 @@ CREATE TABLE interleave_parent (x INT PRIMARY KEY);
 statement notice NOTICE: interleaved tables and interleaved indexes are deprecated in 20.2 and will be removed in 21.2\nHINT: .*52009.*
 CREATE TABLE interleave_create_notice (x INT, y INT, s STRING, PRIMARY KEY (x, y)) INTERLEAVE IN PARENT interleave_parent(x);
 
+
 statement notice NOTICE: interleaved tables and interleaved indexes are deprecated in 20.2 and will be removed in 21.2\nHINT: .*52009.*
 CREATE INDEX interleave_index ON interleave_create_notice (x, s) INTERLEAVE IN PARENT interleave_parent(x);
 
@@ -473,3 +474,45 @@ CREATE INDEX willfail ON interleave_create_notice (x, s) INTERLEAVE IN PARENT in
 
 statement error interleaved tables and interleaved indexes are disabled
 ALTER TABLE interleave_pk_notice ALTER PRIMARY KEY USING COLUMNS (x) INTERLEAVE IN PARENT interleave_parent(x);
+
+statement ok
+SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true
+
+# Interleaved index as non-primary one check
+statement ok
+CREATE TABLE parent(x int, y int);
+
+statement ok
+CREATE TABLE child(x int, y int, z int );
+
+statement ok
+CREATE INDEX NIINDX ON PARENT(x,y);
+
+statement ok
+CREATE INDEX NIINDX2 ON CHILD(z);
+
+statement ok
+CREATE INDEX NIINDX3 ON CHILD(z);
+
+statement ok
+CREATE INDEX IINDX ON CHILD(rowid,x,y,z) INTERLEAVE IN PARENT PARENT(rowid);
+
+
+
+query TTTTT
+select * from "".crdb_internal.interleaved;
+----
+test   public  p1_1                      p1_id                    primary
+test   public  all_interleaves           primary                  primary
+test   public  all_interleaves           all_interleaves_c_d_idx  primary
+test   public  all_interleaves           all_interleaves_d_c_key  primary
+test   public  orders                    primary                  primary
+other  public  interdb                   primary                  primary
+test   public  c20067                    primary                  primary
+test   public  documents                 primary                  primary
+test   public  big_interleave_parent     primary                  primary
+test   public  big_interleave_child      primary                  primary
+test   public  interleave_create_notice  primary                  primary
+test   public  interleave_create_notice  interleave_index         primary
+test   public  interleave_pk_notice      primary                  primary
+test   public  child                     iindx                    primary

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1122,14 +1122,14 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967204  58          0         4294967204  55         1            n
-4294967204  58          0         4294967204  55         2            n
-4294967204  58          0         4294967204  55         3            n
-4294967204  58          0         4294967204  55         4            n
-4294967201  2143281868  0         4294967204  450499961  0            n
-4294967201  2355671820  0         4294967204  0          0            n
-4294967201  3911002394  0         4294967204  0          0            n
-4294967201  4089604113  0         4294967204  450499960  0            n
+4294967202  58          0         4294967202  55         1            n
+4294967202  58          0         4294967202  55         2            n
+4294967202  58          0         4294967202  55         3            n
+4294967202  58          0         4294967202  55         4            n
+4294967199  2143281868  0         4294967202  450499961  0            n
+4294967199  2355671820  0         4294967202  0          0            n
+4294967199  3911002394  0         4294967202  0          0            n
+4294967199  4089604113  0         4294967202  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -1142,8 +1142,8 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967204  4294967204  pg_class       pg_class
-4294967201  4294967204  pg_constraint  pg_class
+4294967202  4294967202  pg_class       pg_class
+4294967199  4294967202  pg_constraint  pg_class
 
 # Some entries in pg_depend are foreign key constraints that reference an index
 # in pg_class. Other entries are table-view dependencies
@@ -1859,167 +1859,169 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967204  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967204  0         built-in functions (RAM/static)
-4294967291  4294967204  0         contention information (cluster RPC; expensive!)
-4294967246  4294967204  0         virtual table with database privileges
-4294967290  4294967204  0         DistSQL remote flows information (cluster RPC; expensive!)
-4294967289  4294967204  0         running queries visible by current user (cluster RPC; expensive!)
-4294967287  4294967204  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967286  4294967204  0         cluster settings (RAM)
-4294967288  4294967204  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967285  4294967204  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967284  4294967204  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967283  4294967204  0         databases accessible by the current user (KV scan)
-4294967282  4294967204  0         telemetry counters (RAM; local node only)
-4294967281  4294967204  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967278  4294967204  0         locally known gossiped health alerts (RAM; local node only)
-4294967277  4294967204  0         locally known gossiped node liveness (RAM; local node only)
-4294967276  4294967204  0         locally known edges in the gossip network (RAM; local node only)
-4294967279  4294967204  0         locally known gossiped node details (RAM; local node only)
-4294967275  4294967204  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967247  4294967204  0         virtual table to validate descriptors
-4294967273  4294967204  0         decoded job metadata from system.jobs (KV scan)
-4294967280  4294967204  0         node liveness status, as seen by kv
-4294967272  4294967204  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967271  4294967204  0         store details and status (cluster RPC; expensive!)
-4294967270  4294967204  0         acquired table leases (RAM; local node only)
-4294967245  4294967204  0         virtual table with table descriptors that still have data
-4294967293  4294967204  0         detailed identification strings (RAM, local node only)
-4294967269  4294967204  0         contention information (RAM; local node only)
-4294967268  4294967204  0         DistSQL remote flows information (RAM; local node only)
-4294967274  4294967204  0         in-flight spans (RAM; local node only)
-4294967264  4294967204  0         current values for metrics (RAM; local node only)
-4294967267  4294967204  0         running queries visible by current user (RAM; local node only)
-4294967259  4294967204  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967265  4294967204  0         running sessions visible by current user (RAM; local node only)
-4294967255  4294967204  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967250  4294967204  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967266  4294967204  0         running user transactions visible by the current user (RAM; local node only)
-4294967249  4294967204  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967263  4294967204  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967262  4294967204  0         comments for predefined virtual tables (RAM/static)
-4294967261  4294967204  0         range metadata without leaseholder details (KV join; expensive!)
-4294967258  4294967204  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967257  4294967204  0         session trace accumulated so far (RAM)
-4294967256  4294967204  0         session variables (RAM)
-4294967254  4294967204  0         details for all columns accessible by current user in current database (KV scan)
-4294967253  4294967204  0         indexes accessible by current user in current database (KV scan)
-4294967251  4294967204  0         stats for all tables accessible by current user in current database as of 10s ago
-4294967252  4294967204  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967248  4294967204  0         decoded zone configurations from system.zones (KV scan)
-4294967243  4294967204  0         roles for which the current user has admin option
-4294967242  4294967204  0         roles available to the current user
-4294967241  4294967204  0         character sets available in the current database
-4294967240  4294967204  0         check constraints
-4294967239  4294967204  0         identifies which character set the available collations are
-4294967238  4294967204  0         shows the collations available in the current database
-4294967237  4294967204  0         column privilege grants (incomplete)
-4294967235  4294967204  0         columns with user defined types
-4294967236  4294967204  0         table and view columns (incomplete)
-4294967234  4294967204  0         columns usage by constraints
-4294967233  4294967204  0         roles for the current user
-4294967232  4294967204  0         column usage by indexes and key constraints
-4294967231  4294967204  0         built-in function parameters (empty - introspection not yet supported)
-4294967230  4294967204  0         foreign key constraints
-4294967229  4294967204  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967228  4294967204  0         built-in functions (empty - introspection not yet supported)
-4294967226  4294967204  0         schema privileges (incomplete; may contain excess users or roles)
-4294967227  4294967204  0         database schemas (may contain schemata without permission)
-4294967224  4294967204  0         sequences
-4294967225  4294967204  0         exposes the session variables.
-4294967223  4294967204  0         index metadata and statistics (incomplete)
-4294967222  4294967204  0         table constraints
-4294967221  4294967204  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967220  4294967204  0         tables and views
-4294967219  4294967204  0         type privileges (incomplete; may contain excess users or roles)
-4294967217  4294967204  0         grantable privileges (incomplete)
-4294967218  4294967204  0         views (incomplete)
-4294967215  4294967204  0         aggregated built-in functions (incomplete)
-4294967214  4294967204  0         index access methods (incomplete)
-4294967213  4294967204  0         pg_amop was created for compatibility and is currently unimplemented
-4294967212  4294967204  0         pg_amproc was created for compatibility and is currently unimplemented
-4294967211  4294967204  0         column default values
-4294967210  4294967204  0         table columns (incomplete - see also information_schema.columns)
-4294967208  4294967204  0         role membership
-4294967209  4294967204  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967207  4294967204  0         pg_available_extension_versions was created for compatibility and is currently unimplemented
-4294967206  4294967204  0         available extensions
-4294967205  4294967204  0         casts (empty - needs filling out)
-4294967204  4294967204  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967203  4294967204  0         available collations (incomplete)
-4294967202  4294967204  0         pg_config was created for compatibility and is currently unimplemented
-4294967201  4294967204  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967200  4294967204  0         encoding conversions (empty - unimplemented)
-4294967199  4294967204  0         pg_cursors was created for compatibility and is currently unimplemented
-4294967198  4294967204  0         available databases (incomplete)
-4294967197  4294967204  0         pg_db_role_setting was created for compatibility and is currently unimplemented
-4294967196  4294967204  0         default ACLs (empty - unimplemented)
-4294967195  4294967204  0         dependency relationships (incomplete)
-4294967194  4294967204  0         object comments
-4294967193  4294967204  0         enum types and labels (empty - feature does not exist)
-4294967192  4294967204  0         event triggers (empty - feature does not exist)
-4294967191  4294967204  0         installed extensions (empty - feature does not exist)
-4294967190  4294967204  0         pg_file_settings was created for compatibility and is currently unimplemented
-4294967189  4294967204  0         foreign data wrappers (empty - feature does not exist)
-4294967188  4294967204  0         foreign servers (empty - feature does not exist)
-4294967187  4294967204  0         foreign tables (empty  - feature does not exist)
-4294967186  4294967204  0         pg_group was created for compatibility and is currently unimplemented
-4294967185  4294967204  0         pg_hba_file_rules was created for compatibility and is currently unimplemented
-4294967184  4294967204  0         indexes (incomplete)
-4294967183  4294967204  0         index creation statements
-4294967182  4294967204  0         table inheritance hierarchy (empty - feature does not exist)
-4294967181  4294967204  0         available languages (empty - feature does not exist)
-4294967180  4294967204  0         pg_largeobject was created for compatibility and is currently unimplemented
-4294967179  4294967204  0         locks held by active processes (empty - feature does not exist)
-4294967178  4294967204  0         available materialized views (empty - feature does not exist)
-4294967177  4294967204  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967176  4294967204  0         opclass (empty - Operator classes not supported yet)
-4294967175  4294967204  0         operators (incomplete)
-4294967174  4294967204  0         pg_opfamily was created for compatibility and is currently unimplemented
-4294967173  4294967204  0         pg_policies was created for compatibility and is currently unimplemented
-4294967172  4294967204  0         prepared statements
-4294967171  4294967204  0         prepared transactions (empty - feature does not exist)
-4294967170  4294967204  0         built-in functions (incomplete)
-4294967168  4294967204  0         pg_publication was created for compatibility and is currently unimplemented
-4294967169  4294967204  0         pg_publication_rel was created for compatibility and is currently unimplemented
-4294967167  4294967204  0         pg_publication_tables was created for compatibility and is currently unimplemented
-4294967166  4294967204  0         range types (empty - feature does not exist)
-4294967165  4294967204  0         pg_replication_origin was created for compatibility and is currently unimplemented
-4294967164  4294967204  0         rewrite rules (empty - feature does not exist)
-4294967163  4294967204  0         database roles
-4294967162  4294967204  0         pg_rules was created for compatibility and is currently unimplemented
-4294967160  4294967204  0         security labels (empty - feature does not exist)
-4294967161  4294967204  0         security labels (empty)
-4294967159  4294967204  0         sequences (see also information_schema.sequences)
-4294967158  4294967204  0         session variables (incomplete)
-4294967157  4294967204  0         pg_shadow was created for compatibility and is currently unimplemented
-4294967154  4294967204  0         shared dependencies (empty - not implemented)
-4294967156  4294967204  0         shared object comments
-4294967153  4294967204  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
-4294967155  4294967204  0         shared security labels (empty - feature not supported)
-4294967152  4294967204  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967151  4294967204  0         pg_statistic_ext was created for compatibility and is currently unimplemented
-4294967150  4294967204  0         pg_subscription was created for compatibility and is currently unimplemented
-4294967149  4294967204  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967148  4294967204  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967147  4294967204  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
-4294967146  4294967204  0         pg_timezone_names was created for compatibility and is currently unimplemented
-4294967145  4294967204  0         pg_transform was created for compatibility and is currently unimplemented
-4294967144  4294967204  0         triggers (empty - feature does not exist)
-4294967142  4294967204  0         pg_ts_config was created for compatibility and is currently unimplemented
-4294967143  4294967204  0         pg_ts_config_map was created for compatibility and is currently unimplemented
-4294967141  4294967204  0         pg_ts_dict was created for compatibility and is currently unimplemented
-4294967140  4294967204  0         pg_ts_parser was created for compatibility and is currently unimplemented
-4294967139  4294967204  0         pg_ts_template was created for compatibility and is currently unimplemented
-4294967138  4294967204  0         scalar types (incomplete)
-4294967135  4294967204  0         database users
-4294967137  4294967204  0         local to remote user mapping (empty - feature does not exist)
-4294967136  4294967204  0         pg_user_mappings was created for compatibility and is currently unimplemented
-4294967134  4294967204  0         view definitions (incomplete - see also information_schema.views)
-4294967132  4294967204  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967131  4294967204  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967130  4294967204  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967202  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967202  0         built-in functions (RAM/static)
+4294967291  4294967202  0         contention information (cluster RPC; expensive!)
+4294967246  4294967202  0         virtual table with database privileges
+4294967290  4294967202  0         DistSQL remote flows information (cluster RPC; expensive!)
+4294967289  4294967202  0         running queries visible by current user (cluster RPC; expensive!)
+4294967287  4294967202  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967286  4294967202  0         cluster settings (RAM)
+4294967288  4294967202  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967285  4294967202  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967284  4294967202  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967244  4294967202  0         virtual table with cross db references
+4294967283  4294967202  0         databases accessible by the current user (KV scan)
+4294967282  4294967202  0         telemetry counters (RAM; local node only)
+4294967281  4294967202  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967278  4294967202  0         locally known gossiped health alerts (RAM; local node only)
+4294967277  4294967202  0         locally known gossiped node liveness (RAM; local node only)
+4294967276  4294967202  0         locally known edges in the gossip network (RAM; local node only)
+4294967279  4294967202  0         locally known gossiped node details (RAM; local node only)
+4294967275  4294967202  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967245  4294967202  0         virtual table with interleaved table information
+4294967247  4294967202  0         virtual table to validate descriptors
+4294967273  4294967202  0         decoded job metadata from system.jobs (KV scan)
+4294967280  4294967202  0         node liveness status, as seen by kv
+4294967272  4294967202  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967271  4294967202  0         store details and status (cluster RPC; expensive!)
+4294967270  4294967202  0         acquired table leases (RAM; local node only)
+4294967243  4294967202  0         virtual table with table descriptors that still have data
+4294967293  4294967202  0         detailed identification strings (RAM, local node only)
+4294967269  4294967202  0         contention information (RAM; local node only)
+4294967268  4294967202  0         DistSQL remote flows information (RAM; local node only)
+4294967274  4294967202  0         in-flight spans (RAM; local node only)
+4294967264  4294967202  0         current values for metrics (RAM; local node only)
+4294967267  4294967202  0         running queries visible by current user (RAM; local node only)
+4294967259  4294967202  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967265  4294967202  0         running sessions visible by current user (RAM; local node only)
+4294967255  4294967202  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967250  4294967202  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967266  4294967202  0         running user transactions visible by the current user (RAM; local node only)
+4294967249  4294967202  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967263  4294967202  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967262  4294967202  0         comments for predefined virtual tables (RAM/static)
+4294967261  4294967202  0         range metadata without leaseholder details (KV join; expensive!)
+4294967258  4294967202  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967257  4294967202  0         session trace accumulated so far (RAM)
+4294967256  4294967202  0         session variables (RAM)
+4294967254  4294967202  0         details for all columns accessible by current user in current database (KV scan)
+4294967253  4294967202  0         indexes accessible by current user in current database (KV scan)
+4294967251  4294967202  0         stats for all tables accessible by current user in current database as of 10s ago
+4294967252  4294967202  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967248  4294967202  0         decoded zone configurations from system.zones (KV scan)
+4294967241  4294967202  0         roles for which the current user has admin option
+4294967240  4294967202  0         roles available to the current user
+4294967239  4294967202  0         character sets available in the current database
+4294967238  4294967202  0         check constraints
+4294967237  4294967202  0         identifies which character set the available collations are
+4294967236  4294967202  0         shows the collations available in the current database
+4294967235  4294967202  0         column privilege grants (incomplete)
+4294967233  4294967202  0         columns with user defined types
+4294967234  4294967202  0         table and view columns (incomplete)
+4294967232  4294967202  0         columns usage by constraints
+4294967231  4294967202  0         roles for the current user
+4294967230  4294967202  0         column usage by indexes and key constraints
+4294967229  4294967202  0         built-in function parameters (empty - introspection not yet supported)
+4294967228  4294967202  0         foreign key constraints
+4294967227  4294967202  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967226  4294967202  0         built-in functions (empty - introspection not yet supported)
+4294967224  4294967202  0         schema privileges (incomplete; may contain excess users or roles)
+4294967225  4294967202  0         database schemas (may contain schemata without permission)
+4294967222  4294967202  0         sequences
+4294967223  4294967202  0         exposes the session variables.
+4294967221  4294967202  0         index metadata and statistics (incomplete)
+4294967220  4294967202  0         table constraints
+4294967219  4294967202  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967218  4294967202  0         tables and views
+4294967217  4294967202  0         type privileges (incomplete; may contain excess users or roles)
+4294967215  4294967202  0         grantable privileges (incomplete)
+4294967216  4294967202  0         views (incomplete)
+4294967213  4294967202  0         aggregated built-in functions (incomplete)
+4294967212  4294967202  0         index access methods (incomplete)
+4294967211  4294967202  0         pg_amop was created for compatibility and is currently unimplemented
+4294967210  4294967202  0         pg_amproc was created for compatibility and is currently unimplemented
+4294967209  4294967202  0         column default values
+4294967208  4294967202  0         table columns (incomplete - see also information_schema.columns)
+4294967206  4294967202  0         role membership
+4294967207  4294967202  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967205  4294967202  0         pg_available_extension_versions was created for compatibility and is currently unimplemented
+4294967204  4294967202  0         available extensions
+4294967203  4294967202  0         casts (empty - needs filling out)
+4294967202  4294967202  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967201  4294967202  0         available collations (incomplete)
+4294967200  4294967202  0         pg_config was created for compatibility and is currently unimplemented
+4294967199  4294967202  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967198  4294967202  0         encoding conversions (empty - unimplemented)
+4294967197  4294967202  0         pg_cursors was created for compatibility and is currently unimplemented
+4294967196  4294967202  0         available databases (incomplete)
+4294967195  4294967202  0         pg_db_role_setting was created for compatibility and is currently unimplemented
+4294967194  4294967202  0         default ACLs (empty - unimplemented)
+4294967193  4294967202  0         dependency relationships (incomplete)
+4294967192  4294967202  0         object comments
+4294967191  4294967202  0         enum types and labels (empty - feature does not exist)
+4294967190  4294967202  0         event triggers (empty - feature does not exist)
+4294967189  4294967202  0         installed extensions (empty - feature does not exist)
+4294967188  4294967202  0         pg_file_settings was created for compatibility and is currently unimplemented
+4294967187  4294967202  0         foreign data wrappers (empty - feature does not exist)
+4294967186  4294967202  0         foreign servers (empty - feature does not exist)
+4294967185  4294967202  0         foreign tables (empty  - feature does not exist)
+4294967184  4294967202  0         pg_group was created for compatibility and is currently unimplemented
+4294967183  4294967202  0         pg_hba_file_rules was created for compatibility and is currently unimplemented
+4294967182  4294967202  0         indexes (incomplete)
+4294967181  4294967202  0         index creation statements
+4294967180  4294967202  0         table inheritance hierarchy (empty - feature does not exist)
+4294967179  4294967202  0         available languages (empty - feature does not exist)
+4294967178  4294967202  0         pg_largeobject was created for compatibility and is currently unimplemented
+4294967177  4294967202  0         locks held by active processes (empty - feature does not exist)
+4294967176  4294967202  0         available materialized views (empty - feature does not exist)
+4294967175  4294967202  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967174  4294967202  0         opclass (empty - Operator classes not supported yet)
+4294967173  4294967202  0         operators (incomplete)
+4294967172  4294967202  0         pg_opfamily was created for compatibility and is currently unimplemented
+4294967171  4294967202  0         pg_policies was created for compatibility and is currently unimplemented
+4294967170  4294967202  0         prepared statements
+4294967169  4294967202  0         prepared transactions (empty - feature does not exist)
+4294967168  4294967202  0         built-in functions (incomplete)
+4294967166  4294967202  0         pg_publication was created for compatibility and is currently unimplemented
+4294967167  4294967202  0         pg_publication_rel was created for compatibility and is currently unimplemented
+4294967165  4294967202  0         pg_publication_tables was created for compatibility and is currently unimplemented
+4294967164  4294967202  0         range types (empty - feature does not exist)
+4294967163  4294967202  0         pg_replication_origin was created for compatibility and is currently unimplemented
+4294967162  4294967202  0         rewrite rules (empty - feature does not exist)
+4294967161  4294967202  0         database roles
+4294967160  4294967202  0         pg_rules was created for compatibility and is currently unimplemented
+4294967158  4294967202  0         security labels (empty - feature does not exist)
+4294967159  4294967202  0         security labels (empty)
+4294967157  4294967202  0         sequences (see also information_schema.sequences)
+4294967156  4294967202  0         session variables (incomplete)
+4294967155  4294967202  0         pg_shadow was created for compatibility and is currently unimplemented
+4294967152  4294967202  0         shared dependencies (empty - not implemented)
+4294967154  4294967202  0         shared object comments
+4294967151  4294967202  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
+4294967153  4294967202  0         shared security labels (empty - feature not supported)
+4294967150  4294967202  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967149  4294967202  0         pg_statistic_ext was created for compatibility and is currently unimplemented
+4294967148  4294967202  0         pg_subscription was created for compatibility and is currently unimplemented
+4294967147  4294967202  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967146  4294967202  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967145  4294967202  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
+4294967144  4294967202  0         pg_timezone_names was created for compatibility and is currently unimplemented
+4294967143  4294967202  0         pg_transform was created for compatibility and is currently unimplemented
+4294967142  4294967202  0         triggers (empty - feature does not exist)
+4294967140  4294967202  0         pg_ts_config was created for compatibility and is currently unimplemented
+4294967141  4294967202  0         pg_ts_config_map was created for compatibility and is currently unimplemented
+4294967139  4294967202  0         pg_ts_dict was created for compatibility and is currently unimplemented
+4294967138  4294967202  0         pg_ts_parser was created for compatibility and is currently unimplemented
+4294967137  4294967202  0         pg_ts_template was created for compatibility and is currently unimplemented
+4294967136  4294967202  0         scalar types (incomplete)
+4294967133  4294967202  0         database users
+4294967135  4294967202  0         local to remote user mapping (empty - feature does not exist)
+4294967134  4294967202  0         pg_user_mappings was created for compatibility and is currently unimplemented
+4294967132  4294967202  0         view definitions (incomplete - see also information_schema.views)
+4294967130  4294967202  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967129  4294967202  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967128  4294967202  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 
@@ -3229,7 +3231,7 @@ indoption
 query TTI
 SELECT database_name, descriptor_name, descriptor_id from test.crdb_internal.create_statements where descriptor_name = 'pg_views'
 ----
-test  pg_views  4294967134
+test  pg_views  4294967132
 
 # Verify INCLUDED columns appear in pg_index. See issue #59563
 statement ok
@@ -3286,36 +3288,3 @@ GROUP BY indexname, indisunique, indisprimary, amname, exprdef, attoptions
 indexname            array_agg  indisunique  indisprimary  array_agg      amname  exprdef  attoptions
 indexes_include_idx  {a,c,d}    false        false         {ASC,ASC,ASC}  prefix  NULL     NULL
 primary              {id}       true         true          {ASC}          prefix  NULL     NULL
-
-statement ok
-CREATE TABLE partial_index (
-    a INT,
-    b INT,
-    INDEX (a, b) WHERE (a >= 0)
-)
-
-query OOBBTTTTTT colnames
-SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, indclass, indoption, indexprs, indpred
-FROM pg_catalog.pg_index
-WHERE indpred LIKE 'a >= 0%'
-----
-indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
-2955071326  113       true       false           1 2     0 0           0 0       2 2        NULL      a >= 0:::INT8
-
-statement ok
-DROP TABLE partial_index
-
-statement ok
-SET stub_catalog_tables=false
-
-statement error pq: unimplemented: virtual schema table not implemented: pg_catalog.pg_seclabel
-SELECT * FROM pg_seclabel
-
-statement ok
-SELECT count(*) FROM pg_depend
-
-statement ok
-SET stub_catalog_tables=true
-
-statement ok
-SELECT * FROM pg_seclabel

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1799,3 +1799,20 @@ DROP SEQUENCE s1
 
 statement ok
 DROP TABLE s2
+
+# Validate that cross DB sequences are detected by internal tables
+statement ok
+CREATE DATABASE db3;
+
+statement ok
+CREATE SEQUENCE db3.s;
+
+statement ok
+CREATE TABLE tDb3Ref (i INT PRIMARY KEY DEFAULT (nextval('db3.s')));
+
+query TTTTTTT
+SELECT * FROM "".crdb_internal.cross_db_references;
+----
+db2  public  seq   db1  public  t  sequences owning table
+db2  public  seq2  db1  public  t  sequences owning table
+test  public  tdb3ref  db3  public  s  table column refers to sequence

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -546,6 +546,7 @@ cluster_settings                       NULL
 cluster_transactions                   NULL
 create_statements                      NULL
 create_type_statements                 NULL
+cross_db_references                    NULL
 databases                              NULL
 feature_usage                          NULL
 forward_dependencies                   NULL
@@ -554,6 +555,7 @@ gossip_liveness                        NULL
 gossip_network                         NULL
 gossip_nodes                           NULL
 index_columns                          NULL
+interleaved                            NULL
 invalid_objects                        NULL
 jobs                                   NULL
 kv_node_liveness                       NULL

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -903,29 +903,36 @@ DROP TYPE v4
 statement ok
 DROP TABLE t
 
-subtest view-cascade-nesting
+# Validate that cross DB views are detected by internal tables
 
 statement ok
-CREATE TABLE t1nest (id INT PRIMARY KEY, name varchar(256))
+USE DB1;
 
 statement ok
-CREATE VIEW v1nest AS (SELECT name FROM t1nest)
+CREATE SEQUENCE SQ1;
 
 statement ok
-CREATE VIEW v2nest AS (SELECT name AS n1, name AS n2 FROM v1nest)
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
 
 statement ok
-CREATE VIEW v3nest AS (SELECT name, n1 FROM v1nest, v2nest);
+CREATE TABLE tval (val int primary key);
 
 statement ok
-DROP table t1nest CASCADE
+CREATE VIEW rv as select val from tval;
 
-# Validate the objects being dropped
-query T
-SELECT info::JSONB - 'Timestamp' - 'DescriptorID'
-FROM system.eventlog
-WHERE "eventType" in ('drop_view', 'drop_table')
-ORDER BY "timestamp" DESC, info
-LIMIT 1
+statement ok;
+USE DB2;
+
+statement ok;
+CREATE VIEW vm as (select s.last_value, t.val as a, v.val as b, cast('open' as db1.status) from db1.tval as t, db1.sq1 as s, db1.rv as v)
+
+query TTTTTTT
+select * from "".crdb_internal.cross_db_references order by object_database, object_schema, object_name, referenced_object_database, referenced_object_schema, referenced_object_name desc;
 ----
-{"CascadeDroppedViews": ["db2.public.v3nest", "db2.public.v2nest", "db2.public.v1nest"], "EventType": "drop_table", "Statement": "DROP TABLE db2.public.t1nest CASCADE", "TableName": "db2.public.t1nest", "Tag": "DROP TABLE", "User": "root"}
+db1  public  sys   system  public  descriptor  view references table
+db1  public  sys2  system  public  descriptor  view references table
+db2  public  v1    db1     public  ab          view references table
+db2  public  v2    db1     public  ab          view references table
+db2  public  vm    db1     public  tval        view references table
+db2  public  vm    db1     public  sq1         view references table
+db2  public  vm    db1     public  rv          view references table

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1013,6 +1013,18 @@ func (l *internalLookupCtx) getSchemaByID(id descpb.ID) (*schemadesc.Immutable, 
 	return sc, nil
 }
 
+// getSchemaNameByID returns the schema name given an ID for a schema.
+func (l *internalLookupCtx) getSchemaNameByID(id descpb.ID) (string, error) {
+	if id == keys.PublicSchemaID {
+		return tree.PublicSchema, nil
+	}
+	schema, err := l.getSchemaByID(id)
+	if err != nil {
+		return "", err
+	}
+	return schema.GetName(), nil
+}
+
 func (l *internalLookupCtx) getDatabaseName(table catalog.TableDescriptor) string {
 	parentName := l.dbNames[table.GetParentID()]
 	if parentName == "" {


### PR DESCRIPTION
Backport 1/1 commits from #61629.

/cc @cockroachdb/release

Release Justification: This backport introduces new crdb_internal functions that allow users to detect
if they have interleaved tables or cross-database references. The changes themselves are low
risk and make it easier to migrate away from these features.

---

Fixes: #58867

Previously, users had no way of determining which objects in
their database utilized either deprecated features like
interleaved indexes/tables or cross DB references. This was
inadequate since users need to know which object utilize
this functionality. To address this, this patch introduces
the crdb_internal tables: cross_db_references, interleaved_indexes,
interleaved_tables.

Release justification: Low risk internal tables for detecting
deprecated features.
Release note (sql change): Added crdb_internal tables cross_db_references,
interleaved_indexes, and interleaved_tables for detecting the
deprecated features cross db references and interleaved tables
/ indexes within a given database.
