### PR TITLE
rpc/nodedialer: fix race condition in `TestConnHealthTryDial`

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -184,9 +184,11 @@ func TestConnHealthTryDial(t *testing.T) {
 	defer stopper.Stop(ctx)
 	nd := New(rpcCtx, newSingleNodeResolver(staticNodeID, ln.Addr()))
 
+	// Make sure no connection exists yet, via ConnHealth().
+	require.Equal(t, rpc.ErrNoConnection, nd.ConnHealth(staticNodeID, rpc.DefaultClass))
+
 	// When no connection exists, we expect ConnHealthTryDial to dial the node,
 	// which will return ErrNoHeartbeat at first but eventually succeed.
-	require.Equal(t, rpc.ErrNotHeartbeated, nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass))
 	require.Eventually(t, func() bool {
 		return nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass) == nil
 	}, time.Second, 10*time.Millisecond)


### PR DESCRIPTION
Fixes #71506.

There existed a race condition in `TestConnHealthTryDial` that resulted in
a call to `ConnHealthTryDial` occasionally not returning `ErrNoHeartbeat`,
causing an assertion failure. This patch fixes this by checking connection status
using `ConnHealth`. 

Release note: None