### PR TITLE
bazel: add `pkg/cmd/mirror`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,7 @@
 /pkg/cmd/gossipsim/          @cockroachdb/kv-prs
 /pkg/cmd/import-tools/       @cockroachdb/dev-inf
 /pkg/cmd/internal/issues/    @cockroachdb/test-eng
+/pkg/cmd/mirror/             @cockroachdb/dev-inf
 /pkg/cmd/prereqs/            @cockroachdb/dev-inf
 /pkg/cmd/protoc-gen-gogoroach/ @cockroachdb/server-prs
 /pkg/cmd/publish-artifacts/  @cockroachdb/dev-inf

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,8 @@
+exports_files([
+    "go.mod",
+    "go.sum",
+])
+
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # The following directives inform gazelle how to auto-generate BUILD.bazel

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -43,7 +43,6 @@ def go_deps():
         sum = "h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=",
         version = "v0.0.0-20180502004556-fa1af6a1f4f5",
     )
-
     go_repository(
         name = "com_github_agnivade_levenshtein",
         build_file_proto_mode = "disable_global",
@@ -51,7 +50,6 @@ def go_deps():
         sum = "h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+sxIXdQ=",
         version = "v1.0.1",
     )
-
     go_repository(
         name = "com_github_ajg_form",
         build_file_proto_mode = "disable_global",
@@ -66,7 +64,6 @@ def go_deps():
         sum = "h1:wVe6/Ea46ZMeNkQjjBW6xcqyQA/j5e0D6GytH95g0gQ=",
         version = "v0.0.0-20180226025133-644b8db467af",
     )
-
     go_repository(
         name = "com_github_akavel_rsrc",
         build_file_proto_mode = "disable_global",
@@ -74,7 +71,6 @@ def go_deps():
         sum = "h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=",
         version = "v0.8.0",
     )
-
     go_repository(
         name = "com_github_alecthomas_template",
         build_file_proto_mode = "disable_global",
@@ -96,7 +92,6 @@ def go_deps():
         sum = "h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=",
         version = "v1.4.1",
     )
-
     go_repository(
         name = "com_github_alexbrainman_sspi",
         build_file_proto_mode = "disable_global",
@@ -111,7 +106,6 @@ def go_deps():
         sum = "h1:AMzIhMUqU3jMrZiTuW0zkYeKlKDAFD+DG20IoO421/Y=",
         version = "v0.0.0-20171022225611-72bdc8eae2ae",
     )
-
     go_repository(
         name = "com_github_andreasbriese_bbloom",
         build_file_proto_mode = "disable_global",
@@ -126,7 +120,6 @@ def go_deps():
         sum = "h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=",
         version = "v0.0.0-20170406064948-c7f18ee00883",
     )
-
     go_repository(
         name = "com_github_andy_kimball_arenaskl",
         build_file_proto_mode = "disable_global",
@@ -211,7 +204,6 @@ def go_deps():
         sum = "h1:pv34s756C4pEXnjgPfGYgdhg/ZdajGhyOvzx8k+23nw=",
         version = "v0.0.0-20170710044230-e206f873d14a",
     )
-
     go_repository(
         name = "com_github_asaskevich_govalidator",
         build_file_proto_mode = "disable_global",
@@ -226,7 +218,6 @@ def go_deps():
         sum = "h1:SuCy7H3NLyp+1Mrfp+m80jcbi9KYWAs9/BXwppwRDzY=",
         version = "v1.13.3",
     )
-
     go_repository(
         name = "com_github_aws_aws_sdk_go",
         build_file_proto_mode = "disable_global",
@@ -241,7 +232,6 @@ def go_deps():
         sum = "h1:ZbovGV/qo40nrOJ4q8G33AGICzaPI45FHQWJ9650pF4=",
         version = "v1.9.1",
     )
-
     go_repository(
         name = "com_github_aws_aws_sdk_go_v2_config",
         build_file_proto_mode = "disable_global",
@@ -312,7 +302,6 @@ def go_deps():
         sum = "h1:AEwwwXQZtUwP5Mz506FeXXrKBe0jA8gVM+1gEcSRooc=",
         version = "v1.8.0",
     )
-
     go_repository(
         name = "com_github_axiomhq_hyperloglog",
         build_file_proto_mode = "disable_global",
@@ -362,7 +351,6 @@ def go_deps():
         sum = "h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=",
         version = "v14.2.0+incompatible",
     )
-
     go_repository(
         name = "com_github_azure_go_autorest_autorest",
         build_file_proto_mode = "disable_global",
@@ -454,7 +442,6 @@ def go_deps():
         sum = "h1:T5QPGJD0W6JJxyEEAlVnX3co/IkUrfHen1/42nlgAHo=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_beorn7_perks",
         build_file_proto_mode = "disable_global",
@@ -469,7 +456,6 @@ def go_deps():
         sum = "h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=",
         version = "v0.0.0-20140422174119-9fd32a8b3d3d",
     )
-
     go_repository(
         name = "com_github_bgentry_speakeasy",
         build_file_proto_mode = "disable_global",
@@ -477,7 +463,6 @@ def go_deps():
         sum = "h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=",
         version = "v0.1.0",
     )
-
     go_repository(
         name = "com_github_biogo_store",
         build_file_proto_mode = "disable_global",
@@ -499,7 +484,6 @@ def go_deps():
         sum = "h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=",
         version = "v0.5.0",
     )
-
     go_repository(
         name = "com_github_bketelsen_crypt",
         build_file_proto_mode = "disable_global",
@@ -507,7 +491,6 @@ def go_deps():
         sum = "h1:+0HFd5KSZ/mm3JmhmrDukiId5iR6w4+BdFtfSy4yWIc=",
         version = "v0.0.3-0.20200106085610-5cbc8cc4026c",
     )
-
     go_repository(
         name = "com_github_blang_semver",
         build_file_proto_mode = "disable_global",
@@ -529,7 +512,6 @@ def go_deps():
         sum = "h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=",
         version = "v0.0.0-20170815010413-6226ea591a40",
     )
-
     go_repository(
         name = "com_github_bmizerany_perks",
         build_file_proto_mode = "disable_global",
@@ -551,7 +533,6 @@ def go_deps():
         sum = "h1:MaVh0h9+KaMnJcoDvvIGp+O3fefdWm+8MBUX6ELTJTM=",
         version = "v0.3.4-1.4.0",
     )
-
     go_repository(
         name = "com_github_broady_gogeohash",
         build_file_proto_mode = "disable_global",
@@ -566,7 +547,6 @@ def go_deps():
         sum = "h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=",
         version = "v0.4.1",
     )
-
     go_repository(
         name = "com_github_bsm_sarama_cluster",
         build_file_proto_mode = "disable_global",
@@ -582,7 +562,6 @@ def go_deps():
         sum = "h1:3JIzmmhIDkyRcQhnjWAEiEzdLbVtt/WKLU8erjE8T34=",
         version = "v0.42.2-0.20210706083726-883d34031660",
     )
-
     go_repository(
         name = "com_github_buger_jsonparser",
         build_file_proto_mode = "disable_global",
@@ -611,7 +590,6 @@ def go_deps():
         sum = "h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=",
         version = "v0.0.0-20151223152923-e2c28503fcd0",
     )
-
     go_repository(
         name = "com_github_burntsushi_toml",
         build_file_proto_mode = "disable_global",
@@ -654,7 +632,6 @@ def go_deps():
         sum = "h1:bTwon/ECRx9dwBy2ewRVr5OiqjeXSGiTUY74sDPQi/g=",
         version = "v2.1.2",
     )
-
     go_repository(
         name = "com_github_cenkalti_backoff",
         build_file_proto_mode = "disable_global",
@@ -676,7 +653,6 @@ def go_deps():
         sum = "h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=",
         version = "v4.1.1",
     )
-
     go_repository(
         name = "com_github_census_instrumentation_opencensus_proto",
         build_file_proto_mode = "disable_global",
@@ -698,10 +674,9 @@ def go_deps():
         sum = "h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_cespare_xxhash_v2",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "github.com/cespare/xxhash/v2",
         sum = "h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=",
         version = "v2.1.2",
@@ -713,7 +688,6 @@ def go_deps():
         sum = "h1:WW2B2uxx9KWF6bGlHqhm8Okiafwwx7Y2kcpn8lCpjgo=",
         version = "v4.1.0",
     )
-
     go_repository(
         name = "com_github_chzyer_logex",
         build_file_proto_mode = "disable_global",
@@ -742,7 +716,6 @@ def go_deps():
         sum = "h1:QlHdikaxALkqWasW8hAC1mfR0jdmvbfaBdBPFmRSglA=",
         version = "v0.4.0",
     )
-
     go_repository(
         name = "com_github_circonus_labs_circonus_gometrics",
         build_file_proto_mode = "disable_global",
@@ -764,7 +737,6 @@ def go_deps():
         sum = "h1:EdRZT3IeKQmfCSrgo8SZ8V3MEnskuJP0wCYNpe+aiXo=",
         version = "v0.0.0-20191024224557-825249438eec",
     )
-
     go_repository(
         name = "com_github_client9_misspell",
         build_file_proto_mode = "disable_global",
@@ -800,7 +772,6 @@ def go_deps():
         sum = "h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=",
         version = "v0.0.0-20210312221358-fbca930ec8ed",
     )
-
     go_repository(
         name = "com_github_cockroachdb_apd",
         build_file_proto_mode = "disable_global",
@@ -836,7 +807,6 @@ def go_deps():
         sum = "h1:3XzfSMuUT0wBe1a3o5C0eOTcArhmmFAg2Jzh/7hhKqo=",
         version = "v2.1.1",
     )
-
     go_repository(
         name = "com_github_cockroachdb_crlfmt",
         build_file_proto_mode = "disable_global",
@@ -890,7 +860,6 @@ def go_deps():
         sum = "h1:NY+UDVTyU+Y2wKr0ocnBSbXGYTHEGwnQ9ukP+qg7xfY=",
         version = "v0.0.0-20211019184201-7fec828fc1af",
     )
-
     go_repository(
         name = "com_github_cockroachdb_redact",
         build_file_proto_mode = "disable_global",
@@ -947,7 +916,6 @@ def go_deps():
         sum = "h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNTw=",
         version = "v1.20.0",
     )
-
     go_repository(
         name = "com_github_codegangsta_inject",
         build_file_proto_mode = "disable_global",
@@ -983,7 +951,6 @@ def go_deps():
         sum = "h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=",
         version = "v1.0.2",
     )
-
     go_repository(
         name = "com_github_containerd_containerd",
         build_file_proto_mode = "disable_global",
@@ -991,7 +958,6 @@ def go_deps():
         sum = "h1:uPF0og3ByFzDnaStfiQj3fVGTEtaSNyU+bW7GR/nqGA=",
         version = "v1.5.4",
     )
-
     go_repository(
         name = "com_github_containerd_continuity",
         build_file_proto_mode = "disable_global",
@@ -1076,7 +1042,6 @@ def go_deps():
         sum = "h1:prL8l9w3ntVqXvNH1CiNn5ENjcCnr38JqpSyvKKB4GI=",
         version = "v1.1.1",
     )
-
     go_repository(
         name = "com_github_coreos_bbolt",
         build_file_proto_mode = "disable_global",
@@ -1084,7 +1049,6 @@ def go_deps():
         sum = "h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=",
         version = "v1.3.2",
     )
-
     go_repository(
         name = "com_github_coreos_etcd",
         build_file_proto_mode = "disable_global",
@@ -1106,7 +1070,6 @@ def go_deps():
         sum = "h1:mw6SAibtHKZcNzAsOxjoHIG0gy5YFHhypWSSNc6EjbQ=",
         version = "v0.5.0",
     )
-
     go_repository(
         name = "com_github_coreos_go_oidc",
         build_file_proto_mode = "disable_global",
@@ -1130,7 +1093,7 @@ def go_deps():
     )
     go_repository(
         name = "com_github_coreos_go_systemd_v22",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "github.com/coreos/go-systemd/v22",
         sum = "h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4PxnR5lg=",
         version = "v22.1.0",
@@ -1149,7 +1112,6 @@ def go_deps():
         sum = "h1:RMr1TWc9F4n5jiPDzFHtmaUXLKLNUFK0SgCLo4BhX/U=",
         version = "v0.1.1",
     )
-
     go_repository(
         name = "com_github_cpuguy83_go_md2man",
         build_file_proto_mode = "disable_global",
@@ -1164,7 +1126,6 @@ def go_deps():
         sum = "h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=",
         version = "v2.0.0",
     )
-
     go_repository(
         name = "com_github_creack_pty",
         build_file_proto_mode = "disable_global",
@@ -1179,7 +1140,6 @@ def go_deps():
         sum = "h1:WR1qVJzbvrVywhAk4kMQKRPx09AZVI0NdEdYs59iHcA=",
         version = "v0.0.0-20160816171116-049aabb0122b",
     )
-
     go_repository(
         name = "com_github_cyberdelia_go_metrics_graphite",
         build_file_proto_mode = "disable_global",
@@ -1229,7 +1189,6 @@ def go_deps():
         sum = "h1:itqmmf1PFpC4n5JW+j4BU7X4MTfVurhYRTjODoPb2Y8=",
         version = "v0.0.0-20190221164911-e7d9fbe030e4",
     )
-
     go_repository(
         name = "com_github_daaku_go_zipexe",
         build_file_proto_mode = "disable_global",
@@ -1237,7 +1196,6 @@ def go_deps():
         sum = "h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_data_dog_go_sqlmock",
         build_file_proto_mode = "disable_global",
@@ -1252,7 +1210,6 @@ def go_deps():
         sum = "h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=",
         version = "v3.2.0+incompatible",
     )
-
     go_repository(
         name = "com_github_datadog_zstd",
         build_file_proto_mode = "disable_global",
@@ -1260,7 +1217,6 @@ def go_deps():
         sum = "h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=",
         version = "v1.4.8",
     )
-
     go_repository(
         name = "com_github_dave_dst",
         build_file_proto_mode = "disable_global",
@@ -1331,7 +1287,6 @@ def go_deps():
         sum = "h1:p6poVbjHDkKa+wtC8frBMwQtT3BmqGYBjzMwJ63tuR4=",
         version = "v0.0.0-20190125010748-a747050bb1ba",
     )
-
     go_repository(
         name = "com_github_dgraph_io_badger",
         build_file_proto_mode = "disable_global",
@@ -1360,7 +1315,6 @@ def go_deps():
         sum = "h1:akOQj8IVgoeFfBTzGOEQakCYshWD6RNo1M5pivFXt70=",
         version = "v0.0.0-20180413035011-3522498ce2c8",
     )
-
     go_repository(
         name = "com_github_dgryski_go_farm",
         build_file_proto_mode = "disable_global",
@@ -1389,7 +1343,6 @@ def go_deps():
         sum = "h1:3SywGJBC18HaYtPQF+T36jYzXBi+a6eIMonSjDll7TA=",
         version = "v1.65.0",
     )
-
     go_repository(
         name = "com_github_dimchansky_utfbom",
         build_file_proto_mode = "disable_global",
@@ -1404,7 +1357,6 @@ def go_deps():
         sum = "h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=",
         version = "v1.0.1",
     )
-
     go_repository(
         name = "com_github_docker_distribution",
         build_file_proto_mode = "disable_global",
@@ -1441,7 +1393,6 @@ def go_deps():
         sum = "h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=",
         version = "v0.0.1",
     )
-
     go_repository(
         name = "com_github_docker_go_units",
         build_file_proto_mode = "disable_global",
@@ -1456,7 +1407,6 @@ def go_deps():
         sum = "h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=",
         version = "v0.0.0-20150114040149-fa567046d9b1",
     )
-
     go_repository(
         name = "com_github_docker_spdystream",
         build_file_proto_mode = "disable_global",
@@ -1471,7 +1421,6 @@ def go_deps():
         sum = "h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=",
         version = "v0.0.0-20180111231733-ee0de3bc6815",
     )
-
     go_repository(
         name = "com_github_dustin_go_humanize",
         build_file_proto_mode = "disable_global",
@@ -1507,7 +1456,6 @@ def go_deps():
         sum = "h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=",
         version = "v1.2.0",
     )
-
     go_repository(
         name = "com_github_edsrzf_mmap_go",
         build_file_proto_mode = "disable_global",
@@ -1529,7 +1477,6 @@ def go_deps():
         sum = "h1:T0aQ7n/n2ZA9W7DmAnj60v+qzqKERdBgJBO1CG2W6rc=",
         version = "v0.14.1",
     )
-
     go_repository(
         name = "com_github_elazarl_goproxy",
         build_file_proto_mode = "disable_global",
@@ -1537,7 +1484,6 @@ def go_deps():
         sum = "h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=",
         version = "v0.0.0-20180725130230-947c36da3153",
     )
-
     go_repository(
         name = "com_github_emicklei_dot",
         build_file_proto_mode = "disable_global",
@@ -1552,7 +1498,6 @@ def go_deps():
         sum = "h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=",
         version = "v2.9.5+incompatible",
     )
-
     go_repository(
         name = "com_github_envoyproxy_go_control_plane",
         build_file_proto_mode = "disable_global",
@@ -1582,7 +1527,6 @@ def go_deps():
         sum = "h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=",
         version = "v4.11.0+incompatible",
     )
-
     go_repository(
         name = "com_github_facebookgo_clock",
         build_file_proto_mode = "disable_global",
@@ -1611,7 +1555,6 @@ def go_deps():
         sum = "h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=",
         version = "v1.9.0",
     )
-
     go_repository(
         name = "com_github_fatih_structs",
         build_file_proto_mode = "disable_global",
@@ -1626,7 +1569,6 @@ def go_deps():
         sum = "h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=",
         version = "v1.0.1",
     )
-
     go_repository(
         name = "com_github_flosch_pongo2",
         build_file_proto_mode = "disable_global",
@@ -1641,7 +1583,6 @@ def go_deps():
         sum = "h1:WXb3TSNmHp2vHoCroCIB1foO/yQ36swABL8aOVeDpgg=",
         version = "v1.2.1-0.20190220221249-0403632d5b90",
     )
-
     go_repository(
         name = "com_github_form3tech_oss_jwt_go",
         build_file_proto_mode = "disable_global",
@@ -1649,7 +1590,6 @@ def go_deps():
         sum = "h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=",
         version = "v3.2.3+incompatible",
     )
-
     go_repository(
         name = "com_github_fortytw2_leaktest",
         build_file_proto_mode = "disable_global",
@@ -1678,7 +1618,6 @@ def go_deps():
         sum = "h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=",
         version = "v0.0.0-20171204163338-bcd34c9993f8",
     )
-
     go_repository(
         name = "com_github_frankban_quicktest",
         build_file_proto_mode = "disable_global",
@@ -1693,7 +1632,6 @@ def go_deps():
         sum = "h1:1VjhmRJTlHR2vM3qXiPjsYbTYEtwIxmQZZ7AvVKAcQQ=",
         version = "v0.4.0",
     )
-
     go_repository(
         name = "com_github_fsnotify_fsnotify",
         build_file_proto_mode = "disable_global",
@@ -1715,7 +1653,6 @@ def go_deps():
         sum = "h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=",
         version = "v0.0.0-20150301180006-535138d7bcd7",
     )
-
     go_repository(
         name = "com_github_gavv_httpexpect",
         build_file_proto_mode = "disable_global",
@@ -1744,7 +1681,6 @@ def go_deps():
         sum = "h1:7WzP+MZRRe7YQz2Kc74Ley3dukJmXDvifVbElGmQfoA=",
         version = "v0.53.0",
     )
-
     go_repository(
         name = "com_github_getsentry_raven_go",
         build_file_proto_mode = "disable_global",
@@ -1801,7 +1737,6 @@ def go_deps():
         sum = "h1:gclg6gY70GLy3PbkQ1AERPfmLMMagS60DKF78eWwLn8=",
         version = "v0.0.0-20190410193231-58a59202ab31",
     )
-
     go_repository(
         name = "com_github_go_check_check",
         build_file_proto_mode = "disable_global",
@@ -1823,7 +1758,6 @@ def go_deps():
         sum = "h1:DBPx88FjZJH3FsICfDAfIfnb7XxKIYVGG6lOPlhENAg=",
         version = "v5.0.0",
     )
-
     go_repository(
         name = "com_github_go_errors_errors",
         build_file_proto_mode = "disable_global",
@@ -1838,7 +1772,6 @@ def go_deps():
         sum = "h1:QbL/5oDUmRBzO9/Z7Seo6zf912W/a6Sr4Eu0G/3Jho0=",
         version = "v0.0.0-20190409004039-e6da0acd62b1",
     )
-
     go_repository(
         name = "com_github_go_gl_glfw_v3_3_glfw",
         build_file_proto_mode = "disable_global",
@@ -1853,7 +1786,6 @@ def go_deps():
         sum = "h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=",
         version = "v1.25.4",
     )
-
     go_repository(
         name = "com_github_go_kit_kit",
         build_file_proto_mode = "disable_global",
@@ -1868,7 +1800,6 @@ def go_deps():
         sum = "h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=",
         version = "v0.1.0",
     )
-
     go_repository(
         name = "com_github_go_logfmt_logfmt",
         build_file_proto_mode = "disable_global",
@@ -1883,7 +1814,6 @@ def go_deps():
         sum = "h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=",
         version = "v0.4.0",
     )
-
     go_repository(
         name = "com_github_go_martini_martini",
         build_file_proto_mode = "disable_global",
@@ -1919,7 +1849,6 @@ def go_deps():
         sum = "h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=",
         version = "v0.19.0",
     )
-
     go_repository(
         name = "com_github_go_openapi_jsonpointer",
         build_file_proto_mode = "disable_global",
@@ -1997,7 +1926,6 @@ def go_deps():
         sum = "h1:JVrqSeQfdhYRFk24TvhTZWU0q8lfCojxZQFi3Ou7+uY=",
         version = "v2.1.1-0.20191201195748-d7b97669fe48",
     )
-
     go_repository(
         name = "com_github_go_sql_driver_mysql",
         build_file_proto_mode = "disable_global",
@@ -2033,7 +1961,6 @@ def go_deps():
         sum = "h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=",
         version = "v1.0.2",
     )
-
     go_repository(
         name = "com_github_gobuffalo_attrs",
         build_file_proto_mode = "disable_global",
@@ -2118,7 +2045,6 @@ def go_deps():
         sum = "h1:tpom+2CJmpzAWj5/VEHync2rJGi+epHNIeRSWjzGA+4=",
         version = "v0.0.0-20190224160051-33c29581e754",
     )
-
     go_repository(
         name = "com_github_gobwas_httphead",
         build_file_proto_mode = "disable_global",
@@ -2154,10 +2080,9 @@ def go_deps():
         sum = "h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=",
         version = "v0.0.0-20190422162347-ade71ed3457e",
     )
-
     go_repository(
         name = "com_github_godbus_dbus_v5",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "github.com/godbus/dbus/v5",
         sum = "h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=",
         version = "v5.0.3",
@@ -2169,7 +2094,6 @@ def go_deps():
         sum = "h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=",
         version = "v0.8.0",
     )
-
     go_repository(
         name = "com_github_gofrs_uuid",
         build_file_proto_mode = "disable_global",
@@ -2244,7 +2168,6 @@ def go_deps():
         sum = "h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=",
         version = "v0.0.0-20170609003504-e2365dfdc4a0",
     )
-
     go_repository(
         name = "com_github_golang_geo",
         build_file_proto_mode = "disable_global",
@@ -2273,7 +2196,6 @@ def go_deps():
         sum = "h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=",
         version = "v4.0.0",
     )
-
     go_repository(
         name = "com_github_golang_mock",
         build_file_proto_mode = "disable_global",
@@ -2313,7 +2235,6 @@ def go_deps():
         sum = "h1:utua3L2IbQJmauC5IXdEA547bcoU5dozgQAfc8Onsg4=",
         version = "v0.0.0-20181222135242-d2cdd8c08219",
     )
-
     go_repository(
         name = "com_github_gomodule_redigo",
         build_file_proto_mode = "disable_global",
@@ -2356,7 +2277,6 @@ def go_deps():
         sum = "h1:N/EEqsvJLgqTbepTiMBz+12KhwLovv6YvwpRezd+4Fg=",
         version = "v27.0.4",
     )
-
     go_repository(
         name = "com_github_google_go_querystring",
         build_file_proto_mode = "disable_global",
@@ -2385,7 +2305,6 @@ def go_deps():
         sum = "h1:d8MncMlErDFTwQGBK1xhv026j9kqhvw1Qv9IbWT1VLQ=",
         version = "v3.2.1",
     )
-
     go_repository(
         name = "com_github_google_pprof",
         build_file_proto_mode = "disable_global",
@@ -2395,7 +2314,7 @@ def go_deps():
     )
     go_repository(
         name = "com_github_google_renameio",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "github.com/google/renameio",
         sum = "h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=",
         version = "v0.1.0",
@@ -2407,7 +2326,6 @@ def go_deps():
         sum = "h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=",
         version = "v0.0.0-20191202100458-e7afc7fbc510",
     )
-
     go_repository(
         name = "com_github_google_uuid",
         build_file_proto_mode = "disable_global",
@@ -2436,7 +2354,6 @@ def go_deps():
         sum = "h1:1+4jrsjVhdX5omlAo4jkmFc6ftLbuXLzgFo4i6lH+Gk=",
         version = "v0.20.0",
     )
-
     go_repository(
         name = "com_github_gopherjs_gopherjs",
         build_file_proto_mode = "disable_global",
@@ -2451,7 +2368,6 @@ def go_deps():
         sum = "h1:vc7Dmrk4JwS0ZPS6WZvWlwDflgDTA26jItmbSj83nug=",
         version = "v0.0.0-20200309095847-7953dde2c7bf",
     )
-
     go_repository(
         name = "com_github_gorhill_cronexpr",
         build_file_proto_mode = "disable_global",
@@ -2466,7 +2382,6 @@ def go_deps():
         sum = "h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=",
         version = "v1.1.1",
     )
-
     go_repository(
         name = "com_github_gorilla_handlers",
         build_file_proto_mode = "disable_global",
@@ -2474,7 +2389,6 @@ def go_deps():
         sum = "h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=",
         version = "v1.5.1",
     )
-
     go_repository(
         name = "com_github_gorilla_mux",
         build_file_proto_mode = "disable_global",
@@ -2531,7 +2445,6 @@ def go_deps():
         sum = "h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=",
         version = "v1.2.0",
     )
-
     go_repository(
         name = "com_github_grpc_ecosystem_grpc_gateway",
         build_file_proto_mode = "disable_global",
@@ -2544,7 +2457,6 @@ def go_deps():
         sum = "h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=",
         version = "v1.16.0",
     )
-
     go_repository(
         name = "com_github_hailocab_go_hostpool",
         build_file_proto_mode = "disable_global",
@@ -2552,7 +2464,6 @@ def go_deps():
         sum = "h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=",
         version = "v0.0.0-20160125115350-e80d13ce29ed",
     )
-
     go_repository(
         name = "com_github_hashicorp_consul_api",
         build_file_proto_mode = "disable_global",
@@ -2623,7 +2534,6 @@ def go_deps():
         sum = "h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8fXS8=",
         version = "v1.3.0",
     )
-
     go_repository(
         name = "com_github_hashicorp_go_retryablehttp",
         build_file_proto_mode = "disable_global",
@@ -2652,7 +2562,6 @@ def go_deps():
         sum = "h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_hashicorp_go_uuid",
         build_file_proto_mode = "disable_global",
@@ -2674,7 +2583,6 @@ def go_deps():
         sum = "h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=",
         version = "v0.5.4",
     )
-
     go_repository(
         name = "com_github_hashicorp_hcl",
         build_file_proto_mode = "disable_global",
@@ -2731,7 +2639,6 @@ def go_deps():
         sum = "h1:7zyN2V7hMlhm3HZdxOarmOtvzKvkcYKjM0hcwYMQZz0=",
         version = "v1.32.0",
     )
-
     go_repository(
         name = "com_github_howeyc_gopass",
         build_file_proto_mode = "disable_global",
@@ -2739,7 +2646,6 @@ def go_deps():
         sum = "h1:aY2hhxLhjEAbfXOx2nRJxCXezC6CO2V/yN+OCr1srtk=",
         version = "v0.0.0-20190910152052-7cb4b85ec19c",
     )
-
     go_repository(
         name = "com_github_hpcloud_tail",
         build_file_proto_mode = "disable_global",
@@ -2761,7 +2667,6 @@ def go_deps():
         sum = "h1:0U6+BtN6LhaYuTnIJq4Wyq5cpn6O2kWrxAtcqBmYY6w=",
         version = "v1.3.0",
     )
-
     go_repository(
         name = "com_github_hydrogen18_memlistener",
         build_file_proto_mode = "disable_global",
@@ -2776,7 +2681,6 @@ def go_deps():
         sum = "h1:ux/56T2xqZO/3cP1I2F86qpeoYPCOzk+KF/UH/Ar+lk=",
         version = "v0.0.0-20180726023541-3605ed457bf7",
     )
-
     go_repository(
         name = "com_github_ianlancetaylor_demangle",
         build_file_proto_mode = "disable_global",
@@ -2791,7 +2695,6 @@ def go_deps():
         sum = "h1:Mo9W14pwbO9VfRe+ygqZ8dFbPpoIK1HFrG/zjTuQ+nc=",
         version = "v0.0.0-20180203215853-4178557ae428",
     )
-
     go_repository(
         name = "com_github_imdario_mergo",
         build_file_proto_mode = "disable_global",
@@ -2897,7 +2800,6 @@ def go_deps():
         sum = "h1:+TUUmaFa4YD1Q+7bH9o5NCHQGPMqZCYJiNW6lIIS9z4=",
         version = "v0.0.0-20160829180054-6d3895376368",
     )
-
     go_repository(
         name = "com_github_iris_contrib_blackfriday",
         build_file_proto_mode = "disable_global",
@@ -2933,7 +2835,6 @@ def go_deps():
         sum = "h1:742eGXur0715JMq73aD95/FU0XpVKXqNuTnEfXsLOYQ=",
         version = "v0.0.0-20160618110441-2cf9dc699c56",
     )
-
     go_repository(
         name = "com_github_jackc_chunkreader",
         build_file_proto_mode = "disable_global",
@@ -2948,7 +2849,6 @@ def go_deps():
         sum = "h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=",
         version = "v2.0.1",
     )
-
     go_repository(
         name = "com_github_jackc_pgconn",
         build_file_proto_mode = "disable_global",
@@ -3005,7 +2905,6 @@ def go_deps():
         sum = "h1:9k0IXtdJXHJbyAWQgbWr1lU+MEhPXZz6RIXxfR5oxXs=",
         version = "v1.8.1",
     )
-
     go_repository(
         name = "com_github_jackc_pgx_v4",
         build_file_proto_mode = "disable_global",
@@ -3097,7 +2996,6 @@ def go_deps():
         sum = "h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=",
         version = "v1.1.1",
     )
-
     go_repository(
         name = "com_github_jmespath_go_jmespath",
         build_file_proto_mode = "disable_global",
@@ -3119,7 +3017,6 @@ def go_deps():
         sum = "h1:aLN7YINNZ7cYOPK3QC83dbM6KT0NMqVMw961TqrejlE=",
         version = "v1.3.1",
     )
-
     go_repository(
         name = "com_github_joho_godotenv",
         build_file_proto_mode = "disable_global",
@@ -3127,7 +3024,6 @@ def go_deps():
         sum = "h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=",
         version = "v1.3.0",
     )
-
     go_repository(
         name = "com_github_joker_hpp",
         build_file_proto_mode = "disable_global",
@@ -3149,7 +3045,6 @@ def go_deps():
         sum = "h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=",
         version = "v0.1.0",
     )
-
     go_repository(
         name = "com_github_jordanlewis_gcassert",
         build_file_proto_mode = "disable_global",
@@ -3171,7 +3066,6 @@ def go_deps():
         sum = "h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_json_iterator_go",
         build_file_proto_mode = "disable_global",
@@ -3193,7 +3087,6 @@ def go_deps():
         sum = "h1:1v+PK4/B48cy8cfQbxL4FmmNZrjnIMr2BsnyEmXqv2o=",
         version = "v1.2.0",
     )
-
     go_repository(
         name = "com_github_jtolds_gls",
         build_file_proto_mode = "disable_global",
@@ -3243,7 +3136,6 @@ def go_deps():
         sum = "h1:2jNeR4YUziVtswNP9sEFAI913cVrzH85T+8Q6LpYbT0=",
         version = "v0.0.0-20170811194829-b4e1701a28ef",
     )
-
     go_repository(
         name = "com_github_k0kubun_colorstring",
         build_file_proto_mode = "disable_global",
@@ -3258,7 +3150,6 @@ def go_deps():
         sum = "h1:lOpSw2vJP0y5eLBW906QwKsUK/fe/QDyoqM5rnnuPDY=",
         version = "v1.10.3",
     )
-
     go_repository(
         name = "com_github_kataras_golog",
         build_file_proto_mode = "disable_global",
@@ -3329,7 +3220,6 @@ def go_deps():
         sum = "h1:KAZ1BW2TCmT6PRihDPpocIy1QTtsAsrx6TneU/4+CMg=",
         version = "v0.0.0-20161016154125-cb6bfca970f6",
     )
-
     go_repository(
         name = "com_github_klauspost_pgzip",
         build_file_proto_mode = "disable_global",
@@ -3344,7 +3234,6 @@ def go_deps():
         sum = "h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=",
         version = "v3.0.1-0.20171022003610-9aa49832a739+incompatible",
     )
-
     go_repository(
         name = "com_github_knz_go_libedit",
         build_file_proto_mode = "disable_global",
@@ -3378,7 +3267,6 @@ def go_deps():
         sum = "h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=",
         version = "v0.1.0",
     )
-
     go_repository(
         name = "com_github_kr_logfmt",
         build_file_proto_mode = "disable_global",
@@ -3421,7 +3309,6 @@ def go_deps():
         sum = "h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_labstack_echo_v4",
         build_file_proto_mode = "disable_global",
@@ -3450,7 +3337,6 @@ def go_deps():
         sum = "h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_lib_pq",
         build_file_proto_mode = "disable_global",
@@ -3479,7 +3365,6 @@ def go_deps():
         sum = "h1:vi1F1IQ8N7hNWytK9DpJsUfQhGuNSc19z330K6vl4zk=",
         version = "v0.18.1",
     )
-
     go_repository(
         name = "com_github_linkedin_goavro_v2",
         build_file_proto_mode = "disable_global",
@@ -3494,7 +3379,6 @@ def go_deps():
         sum = "h1:IK04cx2b/IwAAd6XLruf1Dl/n3dRXj87Uw/5qo6afVU=",
         version = "v0.32.0",
     )
-
     go_repository(
         name = "com_github_lufia_iostat",
         build_file_proto_mode = "disable_global",
@@ -3502,7 +3386,6 @@ def go_deps():
         sum = "h1:umdPgllno4d03WCBsA0UIwzGIJYV8FfV4325kOYIhBU=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_lusis_slack_test",
         build_file_proto_mode = "disable_global",
@@ -3524,7 +3407,6 @@ def go_deps():
         sum = "h1:KNt/RhmQTOLr7Aj8PsJ7mTronaFyx80mRTT9qF261dA=",
         version = "v0.0.13",
     )
-
     go_repository(
         name = "com_github_magiconair_properties",
         build_file_proto_mode = "disable_global",
@@ -3560,7 +3442,6 @@ def go_deps():
         sum = "h1:/M4H/1G4avsieL6BbUwCOBzulmoeKVP5ux/3mQNnbyI=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_martini_contrib_auth",
         build_file_proto_mode = "disable_global",
@@ -3589,7 +3470,6 @@ def go_deps():
         sum = "h1:4/Pd1VuUKlxD7+Dwx9sm49vgAr/tTMexKSh6uPnZQkw=",
         version = "v2.2.0",
     )
-
     go_repository(
         name = "com_github_marusama_semaphore",
         build_file_proto_mode = "disable_global",
@@ -3604,7 +3484,6 @@ def go_deps():
         sum = "h1:M5MOH04TyRiMBVeWHbifqTpnauxWINIubTCOkhXh+2g=",
         version = "v0.13.2",
     )
-
     go_repository(
         name = "com_github_masterminds_goutils",
         build_file_proto_mode = "disable_global",
@@ -3626,7 +3505,6 @@ def go_deps():
         sum = "h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=",
         version = "v3.1.1",
     )
-
     go_repository(
         name = "com_github_masterminds_sprig",
         build_file_proto_mode = "disable_global",
@@ -3648,7 +3526,6 @@ def go_deps():
         sum = "h1:HvFwW+cm9bCbZ/+vuGNq7CRWXql8c0y8nGeYpqmpvmk=",
         version = "v0.0.0-20190312154309-6cfb0558e1bd",
     )
-
     go_repository(
         name = "com_github_mattn_go_colorable",
         build_file_proto_mode = "disable_global",
@@ -3663,7 +3540,6 @@ def go_deps():
         sum = "h1:qiyop7gCflfhwCzGyeT0gro3sF9AIg9HU98JORTkqfI=",
         version = "v0.0.1",
     )
-
     go_repository(
         name = "com_github_mattn_go_isatty",
         build_file_proto_mode = "disable_global",
@@ -3685,7 +3561,6 @@ def go_deps():
         sum = "h1:K/VxK7SZ+cvuPgFSLKi5QPI9Vr/ipOf4C1gN+ntueUk=",
         version = "v1.0.3",
     )
-
     go_repository(
         name = "com_github_mattn_go_sqlite3",
         build_file_proto_mode = "disable_global",
@@ -3700,7 +3575,6 @@ def go_deps():
         sum = "h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=",
         version = "v0.0.0-20180907095812-13ff1204f104",
     )
-
     go_repository(
         name = "com_github_mattn_go_zglob",
         build_file_proto_mode = "disable_global",
@@ -3743,7 +3617,6 @@ def go_deps():
         sum = "h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=",
         version = "v0.0.0-20200706080929-d51e80ef957d",
     )
-
     go_repository(
         name = "com_github_mibk_dupl",
         build_file_proto_mode = "disable_global",
@@ -3786,7 +3659,6 @@ def go_deps():
         sum = "h1:4FA+QBaydEHlwxg0lMN3rhwoDaQy6LKhVWR4qvq4BuA=",
         version = "v0.0.0-20210227013316-43a75bb4edd3",
     )
-
     go_repository(
         name = "com_github_miekg_dns",
         build_file_proto_mode = "disable_global",
@@ -3808,7 +3680,6 @@ def go_deps():
         sum = "h1:pXqZHmHOz6LN+zbbUgqyGgAWRnnZEI40IzG3tMsXcSI=",
         version = "v0.0.0-20190129205925-3e331f0949a5",
     )
-
     go_repository(
         name = "com_github_minio_minio_go",
         build_file_proto_mode = "disable_global",
@@ -3823,7 +3694,6 @@ def go_deps():
         sum = "h1:aKW/4cBs+yK6gpqU3K/oIwk9Q/XICqd3zOX/UFuvqmk=",
         version = "v2.1.2-0.20190413222219-f784269be439+incompatible",
     )
-
     go_repository(
         name = "com_github_mitchellh_cli",
         build_file_proto_mode = "disable_global",
@@ -3831,7 +3701,6 @@ def go_deps():
         sum = "h1:tEElEatulEHDeedTxwckzyYMA5c86fbmNIUL1hBIiTg=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_mitchellh_copystructure",
         build_file_proto_mode = "disable_global",
@@ -3881,7 +3750,6 @@ def go_deps():
         sum = "h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_mitchellh_mapstructure",
         build_file_proto_mode = "disable_global",
@@ -3896,7 +3764,6 @@ def go_deps():
         sum = "h1:2+myh5ml7lgEU/51gbeLHfKGNfgEQQIWrlbdaOsidbQ=",
         version = "v0.0.0-20151018003038-5e2d6d41470f",
     )
-
     go_repository(
         name = "com_github_mitchellh_reflectwalk",
         build_file_proto_mode = "disable_global",
@@ -3911,7 +3778,6 @@ def go_deps():
         sum = "h1:k96hdaR9Z+nMcnDwNrOvhdBqtjyMrbVyxLpsRCdP2mA=",
         version = "v0.2.0",
     )
-
     go_repository(
         name = "com_github_mmatczuk_go_generics",
         build_file_proto_mode = "disable_global",
@@ -3954,7 +3820,6 @@ def go_deps():
         sum = "h1:MTFZ74KtNI6qQQpuBxU+uKCim4WtOMokr03hCfJcazE=",
         version = "v0.1.0",
     )
-
     go_repository(
         name = "com_github_moby_term",
         build_file_proto_mode = "disable_global",
@@ -3962,7 +3827,6 @@ def go_deps():
         sum = "h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=",
         version = "v0.0.0-20201216013528-df9cb8a40635",
     )
-
     go_repository(
         name = "com_github_modern_go_concurrent",
         build_file_proto_mode = "disable_global",
@@ -3991,7 +3855,6 @@ def go_deps():
         sum = "h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_moul_http2curl",
         build_file_proto_mode = "disable_global",
@@ -4020,7 +3883,6 @@ def go_deps():
         sum = "h1:VeRdUYdCw49yizlSbMEn2SZ+gT+3IUKx8BqxyQdz+BY=",
         version = "v0.0.0-20160514031455-90eadee771ae",
     )
-
     go_repository(
         name = "com_github_munnerz_goautoneg",
         build_file_proto_mode = "disable_global",
@@ -4028,7 +3890,6 @@ def go_deps():
         sum = "h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=",
         version = "v0.0.0-20191010083416-a7dc8b61c822",
     )
-
     go_repository(
         name = "com_github_mwitkow_go_conntrack",
         build_file_proto_mode = "disable_global",
@@ -4057,7 +3918,6 @@ def go_deps():
         sum = "h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=",
         version = "v0.3.2",
     )
-
     go_repository(
         name = "com_github_nats_io_nats_go",
         build_file_proto_mode = "disable_global",
@@ -4072,7 +3932,6 @@ def go_deps():
         sum = "h1:i2Ly0B+1+rzNZHHWtD4ZwKi+OU5l+uQo1iDHZ2PmiIc=",
         version = "v2.1.2",
     )
-
     go_repository(
         name = "com_github_nats_io_nkeys",
         build_file_proto_mode = "disable_global",
@@ -4101,7 +3960,6 @@ def go_deps():
         sum = "h1:4DQRPj35Y41WogBxyhOXlrI37nzGlyEcsforeudyYPQ=",
         version = "v1.0.47",
     )
-
     go_repository(
         name = "com_github_ngdinhtoan_glide_cleanup",
         build_file_proto_mode = "disable_global",
@@ -4109,7 +3967,6 @@ def go_deps():
         sum = "h1:kN4sV+0tp2F1BvwU+5SfNRMDndRmvIfnI3kZ7B8Yv4Y=",
         version = "v0.2.0",
     )
-
     go_repository(
         name = "com_github_niemeyer_pretty",
         build_file_proto_mode = "disable_global",
@@ -4124,7 +3981,6 @@ def go_deps():
         sum = "h1:3f0nxAmdj/VoCGN/ijdMy7bj6SBagaqYg1B0hu8clMA=",
         version = "v0.0.0-20200524104333-86fad755b4d3",
     )
-
     go_repository(
         name = "com_github_nkovacs_streamquote",
         build_file_proto_mode = "disable_global",
@@ -4132,7 +3988,6 @@ def go_deps():
         sum = "h1:E2B8qYyeSgv5MXpmzZXRNp8IAQ4vjxIjhpAf5hv/tAg=",
         version = "v0.0.0-20170412213628-49af9bddb229",
     )
-
     go_repository(
         name = "com_github_nlopes_slack",
         build_file_proto_mode = "disable_global",
@@ -4168,7 +4023,6 @@ def go_deps():
         sum = "h1:wVfs8F+in6nTBMkA7CbRw+zZMIB7nNM825cM1wuzoTk=",
         version = "v0.3.2",
     )
-
     go_repository(
         name = "com_github_oklog_run",
         build_file_proto_mode = "disable_global",
@@ -4176,7 +4030,6 @@ def go_deps():
         sum = "h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_oklog_ulid",
         build_file_proto_mode = "disable_global",
@@ -4184,7 +4037,6 @@ def go_deps():
         sum = "h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=",
         version = "v1.3.1",
     )
-
     go_repository(
         name = "com_github_olekukonko_tablewriter",
         build_file_proto_mode = "disable_global",
@@ -4200,7 +4052,6 @@ def go_deps():
         sum = "h1:c57kY8PF/J6Iz2ATxHQkWFNkYyKDlEZr6hl/O5ZFNvQ=",
         version = "v6.2.27+incompatible",
     )
-
     go_repository(
         name = "com_github_oneofone_xxhash",
         build_file_proto_mode = "disable_global",
@@ -4208,7 +4059,6 @@ def go_deps():
         sum = "h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=",
         version = "v1.2.2",
     )
-
     go_repository(
         name = "com_github_onsi_ginkgo",
         build_file_proto_mode = "disable_global",
@@ -4230,7 +4080,6 @@ def go_deps():
         sum = "h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=",
         version = "v0.0.0-20160315200505-970db520ece7",
     )
-
     go_repository(
         name = "com_github_opencontainers_go_digest",
         build_file_proto_mode = "disable_global",
@@ -4273,7 +4122,6 @@ def go_deps():
         sum = "h1:+77ba4ar4jsCbL1GLbFL8fFM57w6suPfSS9PDLDY7KM=",
         version = "v1.8.0",
     )
-
     go_repository(
         name = "com_github_opennota_wd",
         build_file_proto_mode = "disable_global",
@@ -4288,7 +4136,6 @@ def go_deps():
         sum = "h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_opentracing_contrib_go_grpc",
         build_file_proto_mode = "disable_global",
@@ -4303,7 +4150,6 @@ def go_deps():
         sum = "h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=",
         version = "v0.0.0-20170622124052-a52f23424492",
     )
-
     go_repository(
         name = "com_github_opentracing_contrib_go_stdlib",
         build_file_proto_mode = "disable_global",
@@ -4311,7 +4157,6 @@ def go_deps():
         sum = "h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_opentracing_opentracing_go",
         build_file_proto_mode = "disable_global",
@@ -4326,7 +4171,6 @@ def go_deps():
         sum = "h1:ZCnq+JUrvXcDVhX/xRolRBZifmabN1HcS1wrPSvxhrU=",
         version = "v0.4.5",
     )
-
     go_repository(
         name = "com_github_openzipkin_zipkin_go",
         build_file_proto_mode = "disable_global",
@@ -4334,7 +4178,6 @@ def go_deps():
         sum = "h1:UwtQQx2pyPIgWYHRg+epgdx1/HnBQTgN3/oIYEJTQzU=",
         version = "v0.2.5",
     )
-
     go_repository(
         name = "com_github_ory_dockertest_v3",
         build_file_proto_mode = "disable_global",
@@ -4356,7 +4199,6 @@ def go_deps():
         sum = "h1:OYkFijGHoZAYbOIb1LWXrwKQbMMRUv1oQ89blD2Mh2Q=",
         version = "v1.0.4",
     )
-
     go_repository(
         name = "com_github_pascaldekloe_goe",
         build_file_proto_mode = "disable_global",
@@ -4378,7 +4220,6 @@ def go_deps():
         sum = "h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=",
         version = "v0.2.0",
     )
-
     go_repository(
         name = "com_github_pborman_uuid",
         build_file_proto_mode = "disable_global",
@@ -4400,7 +4241,6 @@ def go_deps():
         sum = "h1:2WnRzIquHa5QxaJKShDkLM+sc0JPuwhXzK8OYOyt3Vg=",
         version = "v3.0.0+incompatible",
     )
-
     go_repository(
         name = "com_github_peterbourgon_diskv",
         build_file_proto_mode = "disable_global",
@@ -4408,7 +4248,6 @@ def go_deps():
         sum = "h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=",
         version = "v2.0.1+incompatible",
     )
-
     go_repository(
         name = "com_github_peterbourgon_g2s",
         build_file_proto_mode = "disable_global",
@@ -4423,7 +4262,6 @@ def go_deps():
         sum = "h1:O62NGAXV0cNzBI6e7vI3zTHSTgPHsWIcS3Q4XC1/pAU=",
         version = "v1.0.1-0.20180619022028-8c1271fcf47f",
     )
-
     go_repository(
         name = "com_github_petermattis_goid",
         build_file_proto_mode = "disable_global",
@@ -4438,7 +4276,6 @@ def go_deps():
         sum = "h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_pierrec_lz4",
         build_file_proto_mode = "disable_global",
@@ -4474,7 +4311,6 @@ def go_deps():
         sum = "h1:JPLdtNmpXbWytipbGwYz7zXZzlQNASEiFw5aGAM75us=",
         version = "v0.0.0-20191211124218-517ecdf5bb2b",
     )
-
     go_repository(
         name = "com_github_pkg_browser",
         build_file_proto_mode = "disable_global",
@@ -4496,7 +4332,6 @@ def go_deps():
         sum = "h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=",
         version = "v1.6.0",
     )
-
     go_repository(
         name = "com_github_pkg_sftp",
         build_file_proto_mode = "disable_global",
@@ -4511,7 +4346,6 @@ def go_deps():
         sum = "h1:tFwafIEMf0B7NlcxV/zJ6leBIa81D3hgGSgsE5hCkOQ=",
         version = "v0.0.0-20180730021639-bffc007b7fd5",
     )
-
     go_repository(
         name = "com_github_pmezard_go_difflib",
         build_file_proto_mode = "disable_global",
@@ -4526,7 +4360,6 @@ def go_deps():
         sum = "h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=",
         version = "v1.2.3",
     )
-
     go_repository(
         name = "com_github_pquerna_cachecontrol",
         build_file_proto_mode = "disable_global",
@@ -4548,7 +4381,6 @@ def go_deps():
         sum = "h1:KIb9IChC3kg+1CC388qfr7bsT+tARpQqdsCMoatdObA=",
         version = "v0.23.0",
     )
-
     go_repository(
         name = "com_github_prometheus_client_golang",
         build_file_proto_mode = "disable_global",
@@ -4588,7 +4420,6 @@ def go_deps():
         sum = "h1:Aqk75wQD92N9CqmTlZwjKwq6272nOGrWIbc8Z7+xQO0=",
         version = "v0.6.1",
     )
-
     go_repository(
         name = "com_github_prometheus_procfs",
         build_file_proto_mode = "disable_global",
@@ -4603,7 +4434,6 @@ def go_deps():
         sum = "h1:U8ZpFGP11pZi0ZavWWGeAqck3dVT9AY6zbr4fbBftjA=",
         version = "v1.8.2-0.20210914090109-37468d88dce8",
     )
-
     go_repository(
         name = "com_github_prometheus_tsdb",
         build_file_proto_mode = "disable_global",
@@ -4611,7 +4441,6 @@ def go_deps():
         sum = "h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=",
         version = "v0.7.1",
     )
-
     go_repository(
         name = "com_github_pseudomuto_protoc_gen_doc",
         build_file_proto_mode = "disable_global",
@@ -4651,7 +4480,6 @@ def go_deps():
         sum = "h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=",
         version = "v0.0.0-20170810143723-de5bf2ad4578",
     )
-
     go_repository(
         name = "com_github_rcrowley_go_metrics",
         build_file_proto_mode = "disable_global",
@@ -4673,7 +4501,6 @@ def go_deps():
         sum = "h1:RnWNS9Hlm8BIkjr6wx8li5abe0fr73jljLycdfemTp0=",
         version = "v1.0.1-0.20180308014038-101a6d2f8b52",
     )
-
     go_repository(
         name = "com_github_rogpeppe_fastuuid",
         build_file_proto_mode = "disable_global",
@@ -4683,7 +4510,7 @@ def go_deps():
     )
     go_repository(
         name = "com_github_rogpeppe_go_internal",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "github.com/rogpeppe/go-internal",
         sum = "h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=",
         version = "v1.3.0",
@@ -4695,7 +4522,6 @@ def go_deps():
         sum = "h1:P2KMzcFwrPoSjkF1WLRPsp3UMLyql8L4v9hQpVeK5so=",
         version = "v1.8.0",
     )
-
     go_repository(
         name = "com_github_rs_xid",
         build_file_proto_mode = "disable_global",
@@ -4724,7 +4550,6 @@ def go_deps():
         sum = "h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=",
         version = "v2.0.1",
     )
-
     go_repository(
         name = "com_github_ryanuber_columnize",
         build_file_proto_mode = "disable_global",
@@ -4739,7 +4564,6 @@ def go_deps():
         sum = "h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=",
         version = "v0.0.0-20190326074333-42ed695e3de8",
     )
-
     go_repository(
         name = "com_github_samuel_go_zookeeper",
         build_file_proto_mode = "disable_global",
@@ -4754,7 +4578,6 @@ def go_deps():
         sum = "h1:hkw4ozGZ/i4eak7ZuGkY5e0hxiXFdNUBNhr4AvZVNFE=",
         version = "v0.14.1",
     )
-
     go_repository(
         name = "com_github_sasha_s_go_deadlock",
         build_file_proto_mode = "disable_global",
@@ -4776,7 +4599,6 @@ def go_deps():
         sum = "h1:3egqo0Vut6daANFm7tOXdNAa8v5/uLU+sgCJrc88Meo=",
         version = "v1.0.0-beta.7.0.20210223165440-c65ae3540d44",
     )
-
     go_repository(
         name = "com_github_sclevine_agouti",
         build_file_proto_mode = "disable_global",
@@ -4798,7 +4620,6 @@ def go_deps():
         sum = "h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=",
         version = "v0.9.1",
     )
-
     go_repository(
         name = "com_github_sectioneight_md_to_godoc",
         build_file_proto_mode = "disable_global",
@@ -4820,7 +4641,6 @@ def go_deps():
         sum = "h1:HtCSf6B4gN/87yc5qTl7WsxPKQIIGXLPPM1bMCPOsoY=",
         version = "v0.2.0",
     )
-
     go_repository(
         name = "com_github_sergi_go_diff",
         build_file_proto_mode = "disable_global",
@@ -4849,7 +4669,6 @@ def go_deps():
         sum = "h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=",
         version = "v0.0.0-20171204204709-577dee27f20d",
     )
-
     go_repository(
         name = "com_github_shopify_sarama",
         build_file_proto_mode = "disable_global",
@@ -4878,7 +4697,6 @@ def go_deps():
         sum = "h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=",
         version = "v0.0.0-20190707220628-8d4bc4ba7749",
     )
-
     go_repository(
         name = "com_github_shurcool_sanitized_anchor_name",
         build_file_proto_mode = "disable_global",
@@ -4893,7 +4711,6 @@ def go_deps():
         sum = "h1:pXY9qYc/MP5zdvqWEUH6SjNiu7VhSjuVFTFiTcphaLU=",
         version = "v0.0.0-20200824052919-0d455de96546",
     )
-
     go_repository(
         name = "com_github_sirupsen_logrus",
         build_file_proto_mode = "disable_global",
@@ -4908,7 +4725,6 @@ def go_deps():
         sum = "h1:acClJNSOjUrAUKW+ZneCZymCFDWtSaJG5YQl8FoOlyI=",
         version = "v0.0.0-20170613150411-f380bf8a9be1",
     )
-
     go_repository(
         name = "com_github_smartystreets_assertions",
         build_file_proto_mode = "disable_global",
@@ -4930,7 +4746,6 @@ def go_deps():
         sum = "h1:Gyoi6g4lMHsilEwW9+KV+bgYkJTgf5pVfvL7Utus920=",
         version = "v1.3.4",
     )
-
     go_repository(
         name = "com_github_soheilhy_cmux",
         build_file_proto_mode = "disable_global",
@@ -4945,7 +4760,6 @@ def go_deps():
         sum = "h1:oMnRNZXX5j85zso6xCPRNPtmAycat+WcoKbklScLDgQ=",
         version = "v0.4.1",
     )
-
     go_repository(
         name = "com_github_spaolacci_murmur3",
         build_file_proto_mode = "disable_global",
@@ -4953,7 +4767,6 @@ def go_deps():
         sum = "h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=",
         version = "v0.0.0-20180118202830-f09979ecbc72",
     )
-
     go_repository(
         name = "com_github_spf13_afero",
         build_file_proto_mode = "disable_global",
@@ -5017,7 +4830,6 @@ def go_deps():
         sum = "h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=",
         version = "v1.2.0",
     )
-
     go_repository(
         name = "com_github_streadway_amqp",
         build_file_proto_mode = "disable_global",
@@ -5032,7 +4844,6 @@ def go_deps():
         sum = "h1:AhmOdSHeswKHBjhsLs/7+1voOxT+LLrSk/Nxvk35fug=",
         version = "v0.0.0-20190108123426-d5acb3125c2a",
     )
-
     go_repository(
         name = "com_github_streadway_quantile",
         build_file_proto_mode = "disable_global",
@@ -5040,7 +4851,6 @@ def go_deps():
         sum = "h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=",
         version = "v0.0.0-20150917103942-b0c588724d25",
     )
-
     go_repository(
         name = "com_github_stretchr_objx",
         build_file_proto_mode = "disable_global",
@@ -5069,7 +4879,6 @@ def go_deps():
         sum = "h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=",
         version = "v0.0.0-20200815063812-42c35b437635",
     )
-
     go_repository(
         name = "com_github_tchap_go_patricia",
         build_file_proto_mode = "disable_global",
@@ -5084,7 +4893,6 @@ def go_deps():
         sum = "h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=",
         version = "v0.9.9",
     )
-
     go_repository(
         name = "com_github_the42_cartconvert",
         build_file_proto_mode = "disable_global",
@@ -5113,7 +4921,6 @@ def go_deps():
         sum = "h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=",
         version = "v0.0.0-20190109142713-0ad062ec5ee5",
     )
-
     go_repository(
         name = "com_github_tomihiltunen_geohash_golang",
         build_file_proto_mode = "disable_global",
@@ -5128,7 +4935,6 @@ def go_deps():
         sum = "h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=",
         version = "v1.2.0",
     )
-
     go_repository(
         name = "com_github_tv42_httpunix",
         build_file_proto_mode = "disable_global",
@@ -5143,7 +4949,6 @@ def go_deps():
         sum = "h1:VgwjwtPtKRwVt80FRXNCSkm30+n4YhqroQMkjLEbtik=",
         version = "v7.1.1+incompatible",
     )
-
     go_repository(
         name = "com_github_twpayne_go_geom",
         build_file_proto_mode = "disable_global",
@@ -5179,7 +4984,6 @@ def go_deps():
         sum = "h1:k6k0RBeXjR7oZ8NO557MsRw3eX1cc/9B0GNx+W9eHiQ=",
         version = "v1.1.4",
     )
-
     go_repository(
         name = "com_github_uber_go_atomic",
         build_file_proto_mode = "disable_global",
@@ -5194,7 +4998,6 @@ def go_deps():
         sum = "h1:9hLSgNBP28CjIaDmAuRTq9qV+UZY+9PcvAkXO4nNMwg=",
         version = "v3.3.15+incompatible",
     )
-
     go_repository(
         name = "com_github_uber_jaeger_client_go",
         build_file_proto_mode = "disable_global",
@@ -5216,7 +5019,6 @@ def go_deps():
         sum = "h1:B7dirDs15/vJJYDeoHpv3xaEUjuRZ38Rvt1qq9g7pSo=",
         version = "v1.16.0",
     )
-
     go_repository(
         name = "com_github_ugorji_go",
         build_file_proto_mode = "disable_global",
@@ -5238,7 +5040,6 @@ def go_deps():
         sum = "h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=",
         version = "v1.22.2",
     )
-
     go_repository(
         name = "com_github_urfave_negroni",
         build_file_proto_mode = "disable_global",
@@ -5302,7 +5103,6 @@ def go_deps():
         sum = "h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=",
         version = "v0.0.0-20200728191858-db3c7e526aae",
     )
-
     go_repository(
         name = "com_github_vividcortex_ewma",
         build_file_proto_mode = "disable_global",
@@ -5317,7 +5117,6 @@ def go_deps():
         sum = "h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=",
         version = "v1.0.0",
     )
-
     go_repository(
         name = "com_github_wadey_gocovmerge",
         build_file_proto_mode = "disable_global",
@@ -5353,7 +5152,6 @@ def go_deps():
         sum = "h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyhBc=",
         version = "v1.0.2",
     )
-
     go_repository(
         name = "com_github_xdg_scram",
         build_file_proto_mode = "disable_global",
@@ -5403,7 +5201,6 @@ def go_deps():
         sum = "h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "com_github_xordataexchange_crypt",
         build_file_proto_mode = "disable_global",
@@ -5425,7 +5222,6 @@ def go_deps():
         sum = "h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=",
         version = "v0.0.0-20181117223130-1be2e3e5546d",
     )
-
     go_repository(
         name = "com_github_yudai_gojsondiff",
         build_file_proto_mode = "disable_global",
@@ -5475,7 +5271,6 @@ def go_deps():
         sum = "h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=",
         version = "v0.0.0-20140908184405-b21fdbd4370f",
     )
-
     go_repository(
         name = "com_github_z_division_go_zookeeper",
         build_file_proto_mode = "disable_global",
@@ -5483,7 +5278,6 @@ def go_deps():
         sum = "h1:Itr7GbuXoM1PK/eCeNNia4Qd3ib9IgX9g9SpXgo8BwQ=",
         version = "v0.0.0-20190128072838-6d7457066b9b",
     )
-
     go_repository(
         name = "com_github_zabawaba99_go_gitignore",
         build_file_proto_mode = "disable_global",
@@ -5519,7 +5313,6 @@ def go_deps():
         sum = "h1:PAplkJLXheOLlK5PPyy4/HXtPzHn+1/LaYDWIeGxnio=",
         version = "v1.3.0",
     )
-
     go_repository(
         name = "com_google_cloud_go_datastore",
         build_file_proto_mode = "disable_global",
@@ -5548,7 +5341,6 @@ def go_deps():
         sum = "h1:1UwAux2OZP4310YXg5ohqBEpV16Y93uZG4+qOX7K2Kg=",
         version = "v1.16.0",
     )
-
     go_repository(
         name = "com_shuralyov_dmitri_gpu_mtl",
         build_file_proto_mode = "disable_global",
@@ -5570,7 +5362,6 @@ def go_deps():
         sum = "h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=",
         version = "v2.0.9",
     )
-
     go_repository(
         name = "in_gopkg_alecthomas_kingpin_v2",
         build_file_proto_mode = "disable_global",
@@ -5585,7 +5376,6 @@ def go_deps():
         sum = "h1:TxyelI5cVkbREznMhfzycHdkp5cLA7DpE+GKjSslYhM=",
         version = "v1.0.0-20181015200546-f715ec2f112d",
     )
-
     go_repository(
         name = "in_gopkg_check_v1",
         build_file_proto_mode = "disable_global",
@@ -5607,10 +5397,9 @@ def go_deps():
         sum = "h1:j9vAp9Re9bbtA/QFehkJpNba/6W2IbJtNuXZophCa54=",
         version = "v1.17.0",
     )
-
     go_repository(
         name = "in_gopkg_errgo_v2",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "gopkg.in/errgo.v2",
         sum = "h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=",
         version = "v2.1.0",
@@ -5622,7 +5411,6 @@ def go_deps():
         sum = "h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBlQbo=",
         version = "v1.4.7",
     )
-
     go_repository(
         name = "in_gopkg_fsnotify_v1",
         build_file_proto_mode = "disable_global",
@@ -5644,7 +5432,6 @@ def go_deps():
         sum = "h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=",
         version = "v2.1.2",
     )
-
     go_repository(
         name = "in_gopkg_go_playground_assert_v1",
         build_file_proto_mode = "disable_global",
@@ -5666,7 +5453,6 @@ def go_deps():
         sum = "h1:SvGtYmN60a5CVKTOzMSyfzWDeZRxRuGvRQyEAKbw1xc=",
         version = "v9.29.1",
     )
-
     go_repository(
         name = "in_gopkg_inconshreveable_log15_v2",
         build_file_proto_mode = "disable_global",
@@ -5688,7 +5474,6 @@ def go_deps():
         sum = "h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=",
         version = "v1.62.0",
     )
-
     go_repository(
         name = "in_gopkg_jcmturner_aescts_v1",
         build_file_proto_mode = "disable_global",
@@ -5731,7 +5516,6 @@ def go_deps():
         sum = "h1:1rO3ojzsHUk+gq4ZYhC4Pg+EzWaaKIV8+DJwExS5/QQ=",
         version = "v2.5.0",
     )
-
     go_repository(
         name = "in_gopkg_mgo_v2",
         build_file_proto_mode = "disable_global",
@@ -5753,7 +5537,6 @@ def go_deps():
         sum = "h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=",
         version = "v1.12.0",
     )
-
     go_repository(
         name = "in_gopkg_square_go_jose_v2",
         build_file_proto_mode = "disable_global",
@@ -5811,10 +5594,9 @@ def go_deps():
         sum = "h1:1JFLBqwIgdyHN1ZtgjTBwO+blA6gVOmZurpiMEsETKo=",
         version = "v0.5.0-alpha.5.0.20200910180754-dd1b699fc489",
     )
-
     go_repository(
         name = "io_etcd_go_etcd_pkg_v3",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "go.etcd.io/etcd/pkg/v3",
         replace = "go.etcd.io/etcd/pkg/v3",
         sum = "h1:U/PIBuOTa8JXLPKF81Xh7xhIjA0jbpyqFWUPIiT4Ilc=",
@@ -5845,7 +5627,6 @@ def go_deps():
         sum = "h1:J0xfPJMRfHgpVcYLrEAIqY/apdvTIkrltPQNHQLq9Qc=",
         version = "v1.21.4",
     )
-
     go_repository(
         name = "io_k8s_api",
         build_file_proto_mode = "disable_global",
@@ -5902,7 +5683,6 @@ def go_deps():
         sum = "h1:iXX0K2pRrbR8yXbZtDK/bSnmg/uSqIFiVJK1x4LUOMc=",
         version = "v0.20.6",
     )
-
     go_repository(
         name = "io_k8s_gengo",
         build_file_proto_mode = "disable_global",
@@ -5924,7 +5704,6 @@ def go_deps():
         sum = "h1:R2HDMDJsHVTHA2n4RjwbeYXdOcBymXdX/JRb1v0VGhE=",
         version = "v2.10.0",
     )
-
     go_repository(
         name = "io_k8s_kube_openapi",
         build_file_proto_mode = "disable_global",
@@ -5946,7 +5725,6 @@ def go_deps():
         sum = "h1:4uqm9Mv+w2MmBYD+F4qf/v6tDFUdPOk29C095RbU5mY=",
         version = "v0.0.15",
     )
-
     go_repository(
         name = "io_k8s_sigs_structured_merge_diff",
         build_file_proto_mode = "disable_global",
@@ -5968,7 +5746,6 @@ def go_deps():
         sum = "h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=",
         version = "v4.1.2",
     )
-
     go_repository(
         name = "io_k8s_sigs_yaml",
         build_file_proto_mode = "disable_global",
@@ -5983,7 +5760,6 @@ def go_deps():
         sum = "h1:imL9YgXQ9p7xmPzHFm/vVd/cF78jad+n4wK1ABwYtMM=",
         version = "v0.0.0-20210707171843-4b05e18ac7d9",
     )
-
     go_repository(
         name = "io_opencensus_go",
         build_file_proto_mode = "disable_global",
@@ -6040,7 +5816,6 @@ def go_deps():
         sum = "h1:9F0ayEvlxv8BmNmPbU005WK7hC+7KbOazCPZjNa1yME=",
         version = "v1.0.0-RC3",
     )
-
     go_repository(
         name = "io_opentelemetry_go_proto_otlp",
         build_file_proto_mode = "disable_global",
@@ -6052,7 +5827,6 @@ def go_deps():
         sum = "h1:C0g6TWmQYvjKRnljRULLWUVJGy8Uvu0NEL/5frY2/t4=",
         version = "v0.9.0",
     )
-
     go_repository(
         name = "io_rsc_binaryregexp",
         build_file_proto_mode = "disable_global",
@@ -6067,7 +5841,6 @@ def go_deps():
         sum = "h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=",
         version = "v0.1.1",
     )
-
     go_repository(
         name = "io_rsc_quote_v3",
         build_file_proto_mode = "disable_global",
@@ -6082,7 +5855,6 @@ def go_deps():
         sum = "h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=",
         version = "v1.3.0",
     )
-
     go_repository(
         name = "io_vitess_vitess",
         build_file_proto_mode = "disable_global",
@@ -6105,7 +5877,6 @@ def go_deps():
         sum = "h1:iNBHGw1VvPJxH2B6RiFWFZ+vsjo1lCdRszBeOuwGi00=",
         version = "v0.3.0",
     )
-
     go_repository(
         name = "org_golang_google_api",
         build_file_proto_mode = "disable_global",
@@ -6127,7 +5898,6 @@ def go_deps():
         sum = "h1:Cpp2P6TPjujNoC5M2KHY6g7wfyLYfIWRZaSdIKfDasA=",
         version = "v0.0.0-20151119220103-975617b05ea8",
     )
-
     go_repository(
         name = "org_golang_google_genproto",
         build_file_proto_mode = "disable_global",
@@ -6149,7 +5919,6 @@ def go_deps():
         sum = "h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=",
         version = "v1.1.0",
     )
-
     go_repository(
         name = "org_golang_google_grpc_examples",
         build_file_proto_mode = "disable_global",
@@ -6157,7 +5926,6 @@ def go_deps():
         sum = "h1:CJP00gEaaYNJuaTXEg456rWNC1oUOfiAiUjuwyAhEmM=",
         version = "v0.0.0-20210324172016-702608ffae4d",
     )
-
     go_repository(
         name = "org_golang_google_protobuf",
         build_file_proto_mode = "disable_global",
@@ -6165,7 +5933,6 @@ def go_deps():
         sum = "h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=",
         version = "v1.27.1",
     )
-
     go_repository(
         name = "org_golang_x_arch",
         build_file_proto_mode = "disable_global",
@@ -6306,7 +6073,6 @@ def go_deps():
         sum = "h1:Qh4dB5D/WpoUUp3lSod7qgoyEHbDGPUWjIbnqdqqe1k=",
         version = "v0.0.0-20190515093506-e2840ee46a6b",
     )
-
     go_repository(
         name = "org_modernc_cc",
         build_file_proto_mode = "disable_global",
@@ -6356,7 +6122,6 @@ def go_deps():
         sum = "h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=",
         version = "v0.0.0-20200128120323-432b2356ecb1",
     )
-
     go_repository(
         name = "org_uber_go_atomic",
         build_file_proto_mode = "disable_global",
@@ -6378,7 +6143,6 @@ def go_deps():
         sum = "h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=",
         version = "v1.1.10",
     )
-
     go_repository(
         name = "org_uber_go_multierr",
         build_file_proto_mode = "disable_global",
@@ -6388,12 +6152,11 @@ def go_deps():
     )
     go_repository(
         name = "org_uber_go_tools",
-        build_file_proto_mode = "disable",
+        build_file_proto_mode = "disable_global",
         importpath = "go.uber.org/tools",
         sum = "h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=",
         version = "v0.0.0-20190618225709-2cfd321de3ee",
     )
-
     go_repository(
         name = "org_uber_go_zap",
         build_file_proto_mode = "disable_global",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,15 +41,13 @@ http_archive(
 )
 
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
-# `DEPS.bzl` file is kept up to date using the `update-repos` Gazelle command
-# (see `build/bazelutil/bazel-generate.sh`).
-#
-# gazelle:repository_macro DEPS.bzl%go_deps
+# `DEPS.bzl` file is kept up to date using `build/bazelutil/bazel-generate.sh`.
 load("//:DEPS.bzl", "go_deps")
 
 # VERY IMPORTANT that we call into this function to prefer our pinned versions
 # of the dependencies to any that might be pulled in via functions like
 # `go_rules_dependencies`, `gazelle_dependencies`, etc.
+# gazelle:repository_macro DEPS.bzl%go_deps
 go_deps()
 
 ####### THIRD-PARTY DEPENDENCIES #######

--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # be blocked by the existence of a file before the bazel command is
 # invoked. For now, this is left as an exercise for the user.
 
-bazel run //:gazelle -- update-repos -from_file=go.mod -build_file_proto_mode=disable_global -to_macro=DEPS.bzl%go_deps -prune=true
+CONTENTS=$(bazel run //pkg/cmd/mirror)
+echo "$CONTENTS" > DEPS.bzl
 bazel run //:gazelle
 CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")
 echo "$CONTENTS" > pkg/BUILD.bazel

--- a/build/patches/BUILD.bazel
+++ b/build/patches/BUILD.bazel
@@ -1,2 +1,7 @@
-# This directory contains patches for third-party vendored code.
-# This file is intentionally empty.
+# This directory contains patches for third-party vendored code in the Bazel build.
+
+filegroup(
+    name = "all_patches",
+    srcs = glob(["*.patch"]),
+    visibility = ["//visibility:public"],
+)

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -77,6 +77,7 @@ ALL_TESTS = [
     "//pkg/cmd/github-pull-request-make:github-pull-request-make_test",
     "//pkg/cmd/internal/issues:issues_test",
     "//pkg/cmd/label-merged-pr:label-merged-pr_test",
+    "//pkg/cmd/mirror:mirror_test",
     "//pkg/cmd/prereqs:prereqs_test",
     "//pkg/cmd/publish-artifacts:publish-artifacts_test",
     "//pkg/cmd/publish-provisional-artifacts:publish-provisional-artifacts_test",

--- a/pkg/build/bazel/bazel.go
+++ b/pkg/build/bazel/bazel.go
@@ -48,6 +48,12 @@ func TestTmpDir() string {
 	return inner.TestTmpDir()
 }
 
+// NewTmpDir is a convenience wrapper around the rules_go variant.
+// The caller is responsible for cleaning the directory up after use.
+func NewTmpDir(prefix string) (string, error) {
+	return inner.NewTmpDir(prefix)
+}
+
 // Updates the current environment to use the Go toolchain that Bazel built this
 // binary/test with (updates the `PATH`/`GOROOT`/`GOCACHE` environment
 // variables).

--- a/pkg/build/bazel/non_bazel.go
+++ b/pkg/build/bazel/non_bazel.go
@@ -36,6 +36,11 @@ func TestTmpDir() string {
 	panic("not built with Bazel")
 }
 
+// NewTmpDir is not implemented.
+func NewTmpDir(prefix string) (string, error) {
+	panic("not built with Bazel")
+}
+
 // RelativeTestTargetPath is not implemented.
 func RelativeTestTargetPath() string {
 	panic("not built with Bazel")

--- a/pkg/cmd/mirror/BUILD.bazel
+++ b/pkg/cmd/mirror/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "mirror_lib",
+    srcs = ["mirror.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/mirror",
+    visibility = ["//visibility:private"],
+    deps = ["//pkg/build/bazel"],
+)
+
+go_binary(
+    name = "mirror",
+    data = [
+        "//:go.mod",
+        "//:go.sum",
+        "//build/patches:all_patches",
+        "@go_sdk//:files",
+    ],
+    embed = [":mirror_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "mirror_test",
+    srcs = ["mirror_test.go"],
+    embed = [":mirror_lib"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/cmd/mirror/mirror.go
+++ b/pkg/cmd/mirror/mirror.go
@@ -1,0 +1,276 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+)
+
+// downloadedModule captures `go mod download -json` output.
+type downloadedModule struct {
+	Path    string `json:"Path"`
+	Sum     string `json:"Sum"`
+	Version string `json:"Version"`
+}
+
+// listedModule captures `go list -m -json` output.
+type listedModule struct {
+	Path    string        `json:"Path"`
+	Version string        `json:"Version"`
+	Replace *listedModule `json:"Replace,omitempty"`
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func createTmpDir() (tmpdir string, err error) {
+	tmpdir, err = bazel.NewTmpDir("gomirror")
+	if err != nil {
+		return
+	}
+	gomod, err := bazel.Runfile("go.mod")
+	if err != nil {
+		return
+	}
+	gosum, err := bazel.Runfile("go.sum")
+	if err != nil {
+		return
+	}
+	err = copyFile(gomod, filepath.Join(tmpdir, "go.mod"))
+	if err != nil {
+		return
+	}
+	err = copyFile(gosum, filepath.Join(tmpdir, "go.sum"))
+	return
+}
+
+func downloadZips(tmpdir string) (map[string]downloadedModule, error) {
+	gobin, err := bazel.Runfile("bin/go")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(gobin, "mod", "download", "-json")
+	cmd.Dir = tmpdir
+	jsonBytes, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var jsonBuilder strings.Builder
+	ret := make(map[string]downloadedModule)
+	for _, line := range strings.Split(string(jsonBytes), "\n") {
+		jsonBuilder.WriteString(line)
+		if strings.HasPrefix(line, "}") {
+			var mod downloadedModule
+			if err := json.Unmarshal([]byte(jsonBuilder.String()), &mod); err != nil {
+				return nil, err
+			}
+			ret[mod.Path] = mod
+			jsonBuilder.Reset()
+		}
+	}
+	return ret, nil
+}
+
+func listAllModules(tmpdir string) (map[string]listedModule, error) {
+	gobin, err := bazel.Runfile("bin/go")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(gobin, "list", "-mod=readonly", "-m", "-json", "all")
+	cmd.Dir = tmpdir
+	jsonBytes, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]listedModule)
+	var jsonBuilder strings.Builder
+	for _, line := range strings.Split(string(jsonBytes), "\n") {
+		jsonBuilder.WriteString(line)
+		if strings.HasPrefix(line, "}") {
+			var mod listedModule
+			if err := json.Unmarshal([]byte(jsonBuilder.String()), &mod); err != nil {
+				return nil, err
+			}
+			jsonBuilder.Reset()
+			// The output will include the `cockroach` module, but we
+			// can just throw it away.
+			if mod.Path == "github.com/cockroachdb/cockroach" {
+				continue
+			}
+			ret[mod.Path] = mod
+		}
+	}
+	return ret, nil
+}
+
+func mungeBazelRepoNameComponent(component string) string {
+	component = strings.Trim(component, ".-")
+	component = strings.ReplaceAll(component, "-", "_")
+	component = strings.ReplaceAll(component, ".", "_")
+	return strings.ToLower(component)
+}
+
+func modulePathToBazelRepoName(mod string) string {
+	components := strings.Split(mod, "/")
+	head := strings.Split(components[0], ".")
+	for i, j := 0, len(head)-1; i < j; i, j = i+1, j-1 {
+		head[i], head[j] = mungeBazelRepoNameComponent(head[j]), mungeBazelRepoNameComponent(head[i])
+	}
+	for index, component := range components {
+		if index == 0 {
+			continue
+		}
+		components[index] = mungeBazelRepoNameComponent(component)
+	}
+	return strings.Join(append(head, components[1:]...), "_")
+}
+
+func dumpPatchArgsForRepo(repoName string) error {
+	runfiles, err := bazel.RunfilesPath()
+	if err != nil {
+		return err
+	}
+	candidate := filepath.Join(runfiles, "build", "patches", repoName+".patch")
+	if _, err := os.Stat(candidate); err == nil {
+		fmt.Printf(`        patch_args = ["-p1"],
+        patches = [
+            "@cockroach//build/patches:%s.patch",
+        ],
+`, repoName)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func buildFileProtoModeForRepo(repoName string) string {
+	if repoName == "com_github_prometheus_client_model" {
+		return "package"
+	}
+	return "disable_global"
+}
+
+func dumpBuildNamingConventionArgsForRepo(repoName string) {
+	if repoName == "com_github_envoyproxy_protoc_gen_validate" || repoName == "com_github_grpc_ecosystem_grpc_gateway" {
+		fmt.Printf("        build_naming_convention = \"go_default_library\",\n")
+	}
+}
+
+func dumpNewDepsBzl(listed map[string]listedModule, downloaded map[string]downloadedModule) error {
+	var sorted []string
+	repoNameToModPath := make(map[string]string)
+	for _, mod := range listed {
+		repoName := modulePathToBazelRepoName(mod.Path)
+		sorted = append(sorted, repoName)
+		repoNameToModPath[repoName] = mod.Path
+	}
+	sort.Strings(sorted)
+
+	fmt.Println(`load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+# PRO-TIP: You can inject temorary changes to any of these dependencies by
+# by pointing to an alternate remote to clone from. Delete the ` + "`sum`" + ` and
+# ` + "`version` " + `parameters, and add ` + "`vcs = \"git\"` as well as a custom `remote` and" + `
+# ` + "`commit`" + `. For example:
+#     go_repository(
+#        name = "com_github_cockroachdb_sentry_go",
+#        build_file_proto_mode = "disable_global",
+#        importpath = "github.com/cockroachdb/sentry-go",
+#        vcs = "git",
+#        remote = "https://github.com/rickystewart/sentry-go",  # Custom fork.
+#        commit = "6c8e10aca9672de108063d4953399bd331b54037",  # Custom commit.
+#    )
+# The ` + "`remote` " + `can be EITHER a URL, or an absolute local path to a clone, such
+# as ` + "`/Users/ricky/go/src/github.com/cockroachdb/sentry-go`" + `. Bazel will clone
+# from the remote and check out the commit you specify.
+
+def go_deps():
+    # NOTE: We ensure that we pin to these specific dependencies by calling
+    # this function FIRST, before calls to pull in dependencies for
+    # third-party libraries (e.g. rules_go, gazelle, etc.)`)
+	for _, repoName := range sorted {
+		path := repoNameToModPath[repoName]
+		mod := listed[path]
+		replaced := &mod
+		if mod.Replace != nil {
+			replaced = mod.Replace
+		}
+		fmt.Printf(`    go_repository(
+        name = "%s",
+        build_file_proto_mode = "%s",
+`, repoName, buildFileProtoModeForRepo(repoName))
+
+		dumpBuildNamingConventionArgsForRepo(repoName)
+		fmt.Printf("        importpath = \"%s\",\n", mod.Path)
+		if err := dumpPatchArgsForRepo(repoName); err != nil {
+			return err
+		}
+		d := downloaded[replaced.Path]
+		if mod.Replace != nil {
+			fmt.Printf("        replace = \"%s\",\n", replaced.Path)
+		}
+		fmt.Printf(`        sum = "%s",
+        version = "%s",
+    )
+`, d.Sum, d.Version)
+	}
+
+	return nil
+}
+
+func mirror() error {
+	tmpdir, err := createTmpDir()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := os.RemoveAll(tmpdir)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	downloaded, err := downloadZips(tmpdir)
+	if err != nil {
+		return err
+	}
+	listed, err := listAllModules(tmpdir)
+	if err != nil {
+		return err
+	}
+	return dumpNewDepsBzl(listed, downloaded)
+}
+
+func main() {
+	if err := mirror(); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/cmd/mirror/mirror_test.go
+++ b/pkg/cmd/mirror/mirror_test.go
@@ -1,0 +1,25 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModulePathToBazelRepoName(t *testing.T) {
+	require.Equal(t, modulePathToBazelRepoName("github.com/alecthomas/template"), "com_github_alecthomas_template")
+	require.Equal(t, modulePathToBazelRepoName("github.com/aws/aws-sdk-go-v2/service/iam"), "com_github_aws_aws_sdk_go_v2_service_iam")
+	require.Equal(t, modulePathToBazelRepoName("github.com/Azure/go-ansiterm"), "com_github_azure_go_ansiterm")
+	require.Equal(t, modulePathToBazelRepoName("gopkg.in/yaml.v3"), "in_gopkg_yaml_v3")
+	require.Equal(t, modulePathToBazelRepoName("collectd.org"), "org_collectd")
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -765,6 +765,7 @@ func TestLint(t *testing.T) {
 			"--",
 			"*.go",
 			":!cmd/dev/**",
+			":!cmd/mirror/**",
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -1681,6 +1682,8 @@ func TestLint(t *testing.T) {
 				// This file is a conditionally-compiled stub implementation that
 				// will produce fake "func is unused" errors.
 				stream.GrepNot(`pkg/build/bazel/non_bazel.go`),
+				// NOTE(ricky): No idea what's wrong with mirror.go. See #72521
+				stream.GrepNot(`pkg/cmd/mirror/mirror.go`),
 				// Skip generated file.
 				stream.GrepNot(`pkg/ui/distoss/bindata.go`),
 				stream.GrepNot(`pkg/ui/distccl/bindata.go`),


### PR DESCRIPTION
This tool will be extended with functionality to mirror Go module ZIP's
to cloud storage. For now, the mirroring functionality is missing, so
we just generate the `DEPS.bzl` content in much the same way as
`gazelle update-repos` does. (This doesn't change the content of
`DEPS.bzl` in any way besides alphabetizing the contents.)

Release note: None