### PR TITLE
colrpc: disable some warnings when gRPC stream is interrupted

### DIFF
--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -228,12 +228,10 @@ func handleStreamErr(
 	flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) {
 	if err == io.EOF {
-		if log.V(1) {
-			log.Infof(ctx, "Outbox calling outboxCtxCancel after %s EOF", opName)
-		}
+		log.VEventf(ctx, 2, "Outbox calling outboxCtxCancel after %s EOF", opName)
 		outboxCtxCancel()
 	} else {
-		log.Warningf(ctx, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
+		log.VEventf(ctx, 1, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
 		flowCtxCancel()
 	}
 }


### PR DESCRIPTION
Previously, whenever a gRPC stream between the outbox and the inbox is
interrupted for any reason, we would log a scary-looking warning. The
warning has been quite confusing for users and CRDB employees alike, and
it is quite hard to make the warning more useful because the stream can
be interrupted for several reasons (e.g. a user canceling a query which
is a graceful shutdown, so nothing should be logged; or a node in the
cluster crashes which is an ungraceful shutdown, so logging something is
probably warranted), and it is not easy - if possible - to distinguish
between these different scenarios.

I believe originally (about half a year ago) we were too concerned with
the problem of proper cancellation of the DistSQL flows, so we wanted as
much logging that could help us during the investigations as possible,
and now those logs seem less useful to our team while being confusing to
everybody else. This commit makes it so that we log these events only if
the verbose tracing is enabled on `outbox` file.

Fixes: #71769.

Release note: None