### PR TITLE
release-21.2: server: avoid range local scan for status/{ranges,raft} endpoint

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1111,7 +1111,7 @@ func removeDeadReplicas(
 
 	var newDescs []roachpb.RangeDescriptor
 
-	err = kvserver.IterateRangeDescriptors(ctx, db, func(desc roachpb.RangeDescriptor) error {
+	err = kvserver.IterateRangeDescriptorsFromDisk(ctx, db, func(desc roachpb.RangeDescriptor) error {
 		hasSelf := false
 		numDeadPeers := 0
 		allReplicas := desc.Replicas().Descriptors()

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -166,7 +166,7 @@ func checkStoreRangeStats(
 	}
 
 	go func() {
-		if err := kvserver.IterateRangeDescriptors(ctx, eng,
+		if err := kvserver.IterateRangeDescriptorsFromDisk(ctx, eng,
 			func(desc roachpb.RangeDescriptor) error {
 				inCh <- checkInput{eng: eng, desc: &desc, sl: stateloader.Make(desc.RangeID)}
 				return nil

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1898,7 +1898,7 @@ func TestSystemZoneConfigs(t *testing.T) {
 	waitForReplicas := func() error {
 		replicas := make(map[roachpb.RangeID]roachpb.RangeDescriptor)
 		for _, s := range tc.Servers {
-			if err := kvserver.IterateRangeDescriptors(ctx, s.Engines()[0], func(desc roachpb.RangeDescriptor) error {
+			if err := kvserver.IterateRangeDescriptorsFromDisk(ctx, s.Engines()[0], func(desc roachpb.RangeDescriptor) error {
 				if len(desc.Replicas().LearnerDescriptors()) > 0 {
 					return fmt.Errorf("descriptor contains learners: %v", desc)
 				}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2076,10 +2076,24 @@ func (s *Store) recordNewPerSecondStats(newQPS, newWPS float64) {
 	s.asyncGossipStore(context.TODO(), message, false /* useCached */)
 }
 
+// VisitReplicasOption optionally modifies store.VisitReplicas.
+type VisitReplicasOption func(*storeReplicaVisitor)
+
+// WithReplicasInOrder is a VisitReplicasOption that ensures replicas are
+// visited in increasing RangeID order.
+func WithReplicasInOrder() VisitReplicasOption {
+	return func(visitor *storeReplicaVisitor) {
+		visitor.InOrder()
+	}
+}
+
 // VisitReplicas invokes the visitor on the Store's Replicas until the visitor returns false.
 // Replicas which are added to the Store after iteration begins may or may not be observed.
-func (s *Store) VisitReplicas(visitor func(*Replica) (wantMore bool)) {
+func (s *Store) VisitReplicas(visitor func(*Replica) (wantMore bool), opts ...VisitReplicasOption) {
 	v := newStoreReplicaVisitor(s)
+	for _, opt := range opts {
+		opt(v)
+	}
 	v.Visit(visitor)
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1350,10 +1350,10 @@ func IterateIDPrefixKeys(
 	}
 }
 
-// IterateRangeDescriptors calls the provided function with each descriptor
-// from the provided Engine. The return values of this method and fn have
-// semantics similar to engine.MVCCIterate.
-func IterateRangeDescriptors(
+// IterateRangeDescriptorsFromDisk calls the provided function with each
+// descriptor from the provided Engine. The return values of this method and fn
+// have semantics similar to engine.MVCCIterate.
+func IterateRangeDescriptorsFromDisk(
 	ctx context.Context, reader storage.Reader, fn func(desc roachpb.RangeDescriptor) error,
 ) error {
 	log.Event(ctx, "beginning range descriptor iteration")
@@ -1505,7 +1505,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// concurrently. Note that while we can perform this initialization
 	// concurrently, all of the initialization must be performed before we start
 	// listening for Raft messages and starting the process Raft loop.
-	err = IterateRangeDescriptors(ctx, s.engine,
+	err = IterateRangeDescriptorsFromDisk(ctx, s.engine,
 		func(desc roachpb.RangeDescriptor) error {
 			if !desc.IsInitialized() {
 				return errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1859,12 +1859,13 @@ func (s *statusServer) rangesHelper(
 	}
 
 	constructRangeInfo := func(
-		desc roachpb.RangeDescriptor, rep *kvserver.Replica, storeID roachpb.StoreID, metrics kvserver.ReplicaMetrics,
+		rep *kvserver.Replica, storeID roachpb.StoreID, metrics kvserver.ReplicaMetrics,
 	) serverpb.RangeInfo {
 		raftStatus := rep.RaftStatus()
 		raftState := convertRaftStatus(raftStatus)
 		leaseHistory := rep.GetLeaseHistory()
 		var span serverpb.PrettySpan
+		desc := rep.Desc()
 		span.StartKey = desc.StartKey.String()
 		span.EndKey = desc.EndKey.String()
 		state := rep.State(ctx)
@@ -1921,10 +1922,10 @@ func (s *statusServer) rangesHelper(
 
 	// There are two possibilities for ordering of ranges in the results:
 	// it could either be determined by the RangeIDs in the request (if specified),
-	// or be in RangeID order if not (as that's the ordering that
-	// IterateRangeDescriptors works on). The latter is already sorted in a
-	// stable fashion, as far as pagination is concerned. The former case requires
-	// sorting.
+	// or be in RangeID order if not (as we pass in the
+	// VisitReplicasInSortedOrder option to store.VisitReplicas below). The latter
+	// is already sorted in a stable fashion, as far as pagination is concerned.
+	// The former case requires sorting.
 	if len(req.RangeIDs) > 0 {
 		sort.Slice(req.RangeIDs, func(i, j int) bool {
 			return req.RangeIDs[i] < req.RangeIDs[j]
@@ -1935,25 +1936,19 @@ func (s *statusServer) rangesHelper(
 		now := store.Clock().NowAsClockTimestamp()
 		if len(req.RangeIDs) == 0 {
 			// All ranges requested.
-
-			// Use IterateRangeDescriptors to read from the engine only
-			// because it's already exported.
-			err := kvserver.IterateRangeDescriptors(ctx, store.Engine(),
-				func(desc roachpb.RangeDescriptor) error {
-					rep := store.GetReplicaIfExists(desc.RangeID)
-					if rep == nil {
-						return nil // continue
-					}
+			store.VisitReplicas(
+				func(rep *kvserver.Replica) bool {
 					output.Ranges = append(output.Ranges,
 						constructRangeInfo(
-							desc,
 							rep,
 							store.Ident.StoreID,
 							rep.Metrics(ctx, now, isLiveMap, clusterNodes),
 						))
-					return nil
-				})
-			return err
+					return true // continue.
+				},
+				kvserver.WithReplicasInOrder(),
+			)
+			return nil
 		}
 
 		// Specific ranges requested:
@@ -1963,10 +1958,8 @@ func (s *statusServer) rangesHelper(
 				// Not found: continue.
 				continue
 			}
-			desc := rep.Desc()
 			output.Ranges = append(output.Ranges,
 				constructRangeInfo(
-					*desc,
 					rep,
 					store.Ident.StoreID,
 					rep.Metrics(ctx, now, isLiveMap, clusterNodes),

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -65,6 +65,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -610,27 +611,25 @@ func (s *statusServer) Allocator(
 	err = s.stores.VisitStores(func(store *kvserver.Store) error {
 		// All ranges requested:
 		if len(req.RangeIDs) == 0 {
-			// Use IterateRangeDescriptors to read from the engine only
-			// because it's already exported.
-			err := kvserver.IterateRangeDescriptors(ctx, store.Engine(),
-				func(desc roachpb.RangeDescriptor) error {
-					rep := store.GetReplicaIfExists(desc.RangeID)
-					if rep == nil {
-						return nil // continue
-					}
+			var err error
+			store.VisitReplicas(
+				func(rep *kvserver.Replica) bool {
 					if !rep.OwnsValidLease(ctx, store.Clock().NowAsClockTimestamp()) {
-						return nil
+						return true // continue.
 					}
-					allocatorSpans, err := store.AllocatorDryRun(ctx, rep)
+					var allocatorSpans tracing.Recording
+					allocatorSpans, err = store.AllocatorDryRun(ctx, rep)
 					if err != nil {
-						return err
+						return false // break and bubble up the error.
 					}
 					output.DryRuns = append(output.DryRuns, &serverpb.AllocatorDryRun{
-						RangeID: desc.RangeID,
+						RangeID: rep.RangeID,
 						Events:  recordedSpansToTraceEvents(allocatorSpans),
 					})
-					return nil
-				})
+					return true // continue.
+				},
+				kvserver.WithReplicasInOrder(),
+			)
 			return err
 		}
 


### PR DESCRIPTION
Backport 3/3 commits from #71832.

/cc @cockroachdb/release

Release Justification: Low risk, high impact change. 

---

See individual commits for details.
