### PR TITLE
release-21.2: kvserver: scan only intents during rts scan

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -87,6 +87,7 @@ func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	db.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = true")
+	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.separated_intent_scan.enabled = true")
 }
 
 const randomSettingPercent = 0.50

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/roachpb:with-mocks",
         "//pkg/storage",
         "//pkg/storage/enginepb",

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -154,15 +154,15 @@ func newTestProcessorWithTxnPusher(
 		EventChanCap:         testProcessorEventCCap,
 		CheckStreamsInterval: 10 * time.Millisecond,
 	})
-	p.Start(stopper, makeIteratorConstructor(rtsIter))
+	p.Start(stopper, makeIntentScannerConstructor(rtsIter))
 	return p, stopper
 }
 
-func makeIteratorConstructor(rtsIter storage.SimpleMVCCIterator) IteratorConstructor {
+func makeIntentScannerConstructor(rtsIter storage.SimpleMVCCIterator) IntentScannerConstructor {
 	if rtsIter == nil {
 		return nil
 	}
-	return func() storage.SimpleMVCCIterator { return rtsIter }
+	return func() IntentScanner { return NewLegacyIntentScanner(rtsIter) }
 }
 
 func newTestProcessor(rtsIter storage.SimpleMVCCIterator) (*Processor, *stop.Stopper) {

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,66 +192,160 @@ func (s *testIterator) curKV() storage.MVCCKeyValue {
 
 func TestInitResolvedTSScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	startKey := roachpb.RKey("d")
+	endKey := roachpb.RKey("w")
 
-	// Mock processor. We just needs its eventC.
-	p := Processor{
-		Config: Config{
-			Span: roachpb.RSpan{
-				Key:    roachpb.RKey("d"),
-				EndKey: roachpb.RKey("w"),
-			},
-		},
-		eventC: make(chan *event, 100),
+	makeTxn := func(key string, id uuid.UUID, ts hlc.Timestamp) roachpb.Transaction {
+		txnMeta := enginepb.TxnMeta{
+			Key:            []byte(key),
+			ID:             id,
+			Epoch:          1,
+			WriteTimestamp: ts,
+			MinTimestamp:   ts,
+		}
+		return roachpb.Transaction{
+			TxnMeta:       txnMeta,
+			ReadTimestamp: ts,
+		}
 	}
 
-	// Run an init rts scan over a test iterator with the following keys.
-	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-	iter := newTestIterator([]storage.MVCCKeyValue{
-		makeKV("a", "val1", 10),
-		makeInline("b", "val2"),
-		makeIntent("c", txn1, "txnKey1", 15),
-		makeProvisionalKV("c", "txnKey1", 15),
-		makeKV("c", "val3", 11),
-		makeKV("c", "val4", 9),
-		makeIntent("d", txn2, "txnKey2", 21),
-		makeProvisionalKV("d", "txnKey2", 21),
-		makeKV("d", "val5", 20),
-		makeKV("d", "val6", 19),
-		makeInline("g", "val7"),
-		makeKV("m", "val8", 1),
-		makeIntent("n", txn1, "txnKey1", 12),
-		makeProvisionalKV("n", "txnKey1", 12),
-		makeIntent("r", txn1, "txnKey1", 19),
-		makeProvisionalKV("r", "txnKey1", 19),
-		makeKV("r", "val9", 4),
-		makeIntent("w", txn1, "txnKey1", 3),
-		makeProvisionalKV("w", "txnKey1", 3),
-		makeInline("x", "val10"),
-		makeIntent("z", txn2, "txnKey2", 21),
-		makeProvisionalKV("z", "txnKey2", 21),
-		makeKV("z", "val11", 4),
-	}, nil)
+	txn1ID := uuid.MakeV4()
+	txn1TS := hlc.Timestamp{WallTime: 15}
+	txn1Key := "txnKey1"
+	txn1 := makeTxn(txn1Key, txn1ID, txn1TS)
 
-	initScan := newInitResolvedTSScan(&p, iter)
-	initScan.Run(context.Background())
-	require.True(t, iter.closed)
+	txn2ID := uuid.MakeV4()
+	txn2TS := hlc.Timestamp{WallTime: 21}
+	txn2Key := "txnKey2"
+	txn2 := makeTxn(txn2Key, txn2ID, txn2TS)
 
-	// Compare the event channel to the expected events.
+	type op struct {
+		kv  storage.MVCCKeyValue
+		txn *roachpb.Transaction
+	}
+
+	makeEngine := func(enableSeparatedIntents bool) storage.Engine {
+		ctx := context.Background()
+		engine, err := storage.Open(context.Background(), storage.InMemory(),
+			storage.SetSeparatedIntents(!enableSeparatedIntents), storage.MaxSize(1<<20))
+		require.NoError(t, err)
+		testData := []op{
+			{kv: makeKV("a", "val1", 10)},
+			{kv: makeInline("b", "val2")},
+			{kv: makeKV("c", "val4", 9)},
+			{kv: makeKV("c", "val3", 11)},
+			{
+				txn: &txn1,
+				kv:  makeProvisionalKV("c", "txnKey1", 15),
+			},
+			{kv: makeKV("d", "val6", 19)},
+			{kv: makeKV("d", "val5", 20)},
+			{
+				txn: &txn2,
+				kv:  makeProvisionalKV("d", "txnKey2", 21),
+			},
+			{kv: makeInline("g", "val7")},
+			{kv: makeKV("m", "val8", 1)},
+			{
+				txn: &txn1,
+				kv:  makeProvisionalKV("n", "txnKey1", 15),
+			},
+			{kv: makeKV("r", "val9", 4)},
+			{
+				txn: &txn1,
+				kv:  makeProvisionalKV("r", "txnKey1", 15),
+			},
+			{
+				txn: &txn1,
+				kv:  makeProvisionalKV("w", "txnKey1", 15),
+			},
+			{kv: makeInline("x", "val10")},
+			{kv: makeKV("z", "val11", 4)},
+			{
+				txn: &txn2,
+				kv:  makeProvisionalKV("z", "txnKey2", 21),
+			},
+		}
+		for _, op := range testData {
+			kv := op.kv
+			err := storage.MVCCPut(ctx, engine, nil, kv.Key.Key, kv.Key.Timestamp, roachpb.Value{RawBytes: kv.Value}, op.txn)
+			require.NoError(t, err)
+		}
+		return engine
+	}
+
 	expEvents := []*event{
 		{ops: []enginepb.MVCCLogicalOp{
-			writeIntentOpWithKey(txn2, []byte("txnKey2"), hlc.Timestamp{WallTime: 21}),
+			writeIntentOpWithKey(txn2ID, []byte("txnKey2"), hlc.Timestamp{WallTime: 21}),
 		}},
 		{ops: []enginepb.MVCCLogicalOp{
-			writeIntentOpWithKey(txn1, []byte("txnKey1"), hlc.Timestamp{WallTime: 12}),
+			writeIntentOpWithKey(txn1ID, []byte("txnKey1"), hlc.Timestamp{WallTime: 15}),
 		}},
 		{ops: []enginepb.MVCCLogicalOp{
-			writeIntentOpWithKey(txn1, []byte("txnKey1"), hlc.Timestamp{WallTime: 19}),
+			writeIntentOpWithKey(txn1ID, []byte("txnKey1"), hlc.Timestamp{WallTime: 15}),
 		}},
 		{initRTS: true},
 	}
-	require.Equal(t, len(expEvents), len(p.eventC))
-	for _, expEvent := range expEvents {
-		require.Equal(t, expEvent, <-p.eventC)
+
+	testCases := map[string]struct {
+		intentScanner func() (IntentScanner, func())
+	}{
+		"legacy intent scanner": {
+			intentScanner: func() (IntentScanner, func()) {
+				engine := makeEngine(true)
+				iter := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+					UpperBound: endKey.AsRawKey(),
+				})
+				return NewLegacyIntentScanner(iter), func() { engine.Close() }
+			},
+		},
+		"legacy intent scanner with interleaved intents": {
+			intentScanner: func() (IntentScanner, func()) {
+				engine := makeEngine(false)
+				iter := engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+					UpperBound: endKey.AsRawKey(),
+				})
+				return NewLegacyIntentScanner(iter), func() { engine.Close() }
+			},
+		},
+		"separated intent scanner": {
+			intentScanner: func() (IntentScanner, func()) {
+				engine := makeEngine(true)
+				require.True(t, engine.IsSeparatedIntentsEnabledForTesting(context.Background()))
+				lowerBound, _ := keys.LockTableSingleKey(startKey.AsRawKey(), nil)
+				upperBound, _ := keys.LockTableSingleKey(endKey.AsRawKey(), nil)
+				iter := engine.NewEngineIterator(storage.IterOptions{
+					LowerBound: lowerBound,
+					UpperBound: upperBound,
+				})
+				return NewSeparatedIntentScanner(iter), func() { engine.Close() }
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Mock processor. We just needs its eventC.
+			p := Processor{
+				Config: Config{
+					Span: roachpb.RSpan{
+						Key:    startKey,
+						EndKey: endKey,
+					},
+				},
+				eventC: make(chan *event, 100),
+			}
+			isc, cleanup := tc.intentScanner()
+			defer cleanup()
+			initScan := newInitResolvedTSScan(&p, isc)
+			initScan.Run(context.Background())
+			// Compare the event channel to the expected events.
+			assert.Equal(t, len(expEvents), len(p.eventC))
+			for _, expEvent := range expEvents {
+				assert.Equal(t, expEvent, <-p.eventC)
+			}
+
+		})
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #71295 and an additional commit
to gate the new behaviour behind a cluster setting, per our
backport policy.

/cc @cockroachdb/release

---

In 21.2, separated intents are the default. Once migrated, we can then
use this to iterate over substantially less data to find all intents
for a given keyspan. The hope is that this will make rangefeed
start-up substantially cheaper.

Informs #70920
Fixes #69697 

Release note: None

Release justification: Performance improvement to help address the impact
of CHANGEFEED restarts.
