### PR TITLE
importccl: introduce DDL via internal executor for IMPORT PGDUMP

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "exportcsv.go",
         "import_job.go",
+        "import_pgdump.go",
         "import_planning.go",
         "import_processor.go",
         "import_processor_planning.go",
@@ -110,6 +111,7 @@ go_test(
         "exportcsv_test.go",
         "import_csv_mark_redaction_test.go",
         "import_into_test.go",
+        "import_pgdump_test.go",
         "import_processor_test.go",
         "import_stmt_test.go",
         "main_test.go",

--- a/pkg/ccl/importccl/import_pgdump.go
+++ b/pkg/ccl/importccl/import_pgdump.go
@@ -1,0 +1,503 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package importccl
+
+import (
+	"context"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	importTempPgdumpDB = "crdb_temp_pgdump_import"
+)
+
+// createTempImportDatabase creates a temporary database where we will create
+// all the PGDUMP objects during the import.
+func createTempImportDatabase(ctx context.Context, p sql.JobExecContext) (descpb.ID, error) {
+	id, err := catalogkv.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
+	if err != nil {
+		return 0, err
+	}
+	// TODO(adityamaru): Figure out how to create the database descriptor with
+	// privileges for only the node user. Currently, root and admin have ALL
+	// privileges on the database descriptor. This is enforced by
+	// `ValidateSuperuserPrivileges` when writing the descriptor to store.
+	// I tried moving the database descriptor to OFFLINE instead of mucking with
+	// privileges, but this prevents us from running any DDL statements on this
+	// database.
+	tempDBDesc := dbdesc.NewInitial(id, importTempPgdumpDB, security.NodeUserName())
+	return tempDBDesc.GetID(), sql.DescsTxn(ctx, p.ExecCfg(), func(ctx context.Context, txn *kv.Txn,
+		col *descs.Collection) error {
+		b := txn.NewBatch()
+		if err := col.WriteDescToBatch(
+			ctx, false /* kvTrace */, tempDBDesc, b,
+		); err != nil {
+			return err
+		}
+		b.CPut(catalogkeys.MakeDatabaseNameKey(p.ExecCfg().Codec, importTempPgdumpDB), tempDBDesc.GetID(), nil)
+		return txn.Run(ctx, b)
+	})
+}
+
+type postgresDDLHandler struct {
+	dumpDatabaseName string
+	// TODO(adityamaru): Maybe memory monitor?
+	bufferedDDLStmts []string
+}
+
+func formatPostgresStatement(n tree.NodeFormatter) string {
+	f := tree.NewFmtCtx(
+		// TODO(adityamaru): should this be serializable?
+		tree.FmtParsable,
+	)
+	f.FormatNode(n)
+	return f.CloseAndGetString()
+}
+
+func rewritePostgresStatementTableName(
+	n tree.NodeFormatter, dumpDatabaseName string,
+) (string, error) {
+	var err error
+	f := tree.NewFmtCtx(
+		// TODO(adityamaru): should this be serializable?
+		tree.FmtParsable,
+		tree.FmtReformatTableNames(func(ctx *tree.FmtCtx, tn *tree.TableName) {
+			// If the node has an explicit catalog name then we must replace it with
+			// the temporary database we are importing into.
+			if tn.CatalogName != "" {
+				if tn.CatalogName != tree.Name(dumpDatabaseName) {
+					err = errors.AssertionFailedf("catalog name %s does not match dump target database name %s",
+						tn.CatalogName, dumpDatabaseName)
+					return
+				}
+				tn.CatalogName = importTempPgdumpDB
+			}
+			// TODO (adityamaru): Is it possible for dump files to have db.object names?
+			// In that case, if the node has an explicit schema name, then this could
+			// be a schema name or catalog name. If the SchemaName matches the target
+			// database the dump file specified via a CREATE DATABASE statement, then
+			// we replace it with the temporary database we are importing into.
+			// Otherwise we leave it as is since it is a schema name. What if we have a
+			// schema with the same name as the target database?
+			// I'm not sure this is an issue so leaving it as a TODO for now.
+			ctx.WithReformatTableNames(nil, func() {
+				ctx.FormatNode(tn)
+			})
+		}),
+	)
+	if err != nil {
+		return "", err
+	}
+	f.FormatNode(n)
+	return f.CloseAndGetString(), nil
+}
+
+func bufferDDLPostgresStatement(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	postgresStmt interface{},
+	p sql.JobExecContext,
+	parentID descpb.ID,
+	handler *postgresDDLHandler,
+) error {
+	switch stmt := postgresStmt.(type) {
+	case *tree.CreateDatabase:
+		// If we have previously seen a `CREATE DATABASE` statement then we error
+		// out.
+		if handler.dumpDatabaseName != "" {
+			return errors.Newf("encountered more than one `CREATE DATABASE` statement when importing PGDUMP file")
+		}
+		handler.dumpDatabaseName = string(stmt.Name)
+	case *tree.CreateSchema:
+		// If the schema specifies an explicit database name, replace it with the
+		// temporary pgdump database being imported into.
+		if stmt.Schema.ExplicitCatalog {
+			if stmt.Schema.CatalogName != tree.Name(handler.dumpDatabaseName) {
+				return errors.AssertionFailedf("catalog name %s does not match dump target database name %s",
+					stmt.Schema.CatalogName, handler.dumpDatabaseName)
+			}
+			stmt.Schema.CatalogName = importTempPgdumpDB
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, formatPostgresStatement(stmt))
+	case *tree.CreateTable:
+		// If the `CREATE TABLE` specifies an explicit database name, replace it
+		// with the temporary pgdump database being imported into.
+		s, err := rewritePostgresStatementTableName(stmt, handler.dumpDatabaseName)
+		if err != nil {
+			return err
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, s)
+	case *tree.AlterTable:
+		// If the `ALTER TABLE` statement has an explicit database name, replace it
+		// with the temporary pgdump database being imported into.
+		if stmt.Table.HasExplicitCatalog() {
+			if stmt.Table.Parts[2] != handler.dumpDatabaseName {
+				return errors.AssertionFailedf("catalog name %s does not match dump target database name %s",
+					stmt.Table.Parts[2], handler.dumpDatabaseName)
+			}
+			stmt.Table.Parts[2] = importTempPgdumpDB
+		}
+		for _, cmd := range stmt.Cmds {
+			switch cmd := cmd.(type) {
+			case *tree.AlterTableAddConstraint:
+				switch con := cmd.ConstraintDef.(type) {
+				case *tree.ForeignKeyConstraintTableDef:
+					// TODO(adityamaru): handle FKs and fk skip option.
+					if con.Table.ExplicitCatalog {
+						con.Table.CatalogName = importTempPgdumpDB
+					}
+				default:
+					// TODO(adityamaru): confirm that not other constraint can have a
+					// qualified table name.
+				}
+			case *tree.AlterTableSetDefault:
+			case *tree.AlterTableSetVisible:
+			case *tree.AlterTableAddColumn:
+				if cmd.IfNotExists {
+					return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported statement: %s", stmt))
+				}
+			case *tree.AlterTableSetNotNull:
+			default:
+				return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported statement: %s", stmt))
+			}
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, formatPostgresStatement(stmt))
+	case *tree.CreateIndex:
+		// If the `CREATE INDEX` specifies an explicit database name, replace it
+		// with the temporary pgdump database being imported into.
+		s, err := rewritePostgresStatementTableName(stmt, handler.dumpDatabaseName)
+		if err != nil {
+			return err
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, s)
+	case *tree.AlterSchema:
+		// If the schema specifies an explicit database name, replace it with the
+		// temporary pgdump database being imported into.
+		if stmt.Schema.ExplicitCatalog {
+			if stmt.Schema.CatalogName != tree.Name(handler.dumpDatabaseName) {
+				return errors.AssertionFailedf("catalog name %s does not match dump target database name %s",
+					stmt.Schema.CatalogName, handler.dumpDatabaseName)
+			}
+			stmt.Schema.CatalogName = importTempPgdumpDB
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, formatPostgresStatement(stmt))
+	case *tree.CreateSequence:
+		s, err := rewritePostgresStatementTableName(stmt, handler.dumpDatabaseName)
+		if err != nil {
+			return err
+		}
+		handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, s)
+	case *tree.AlterTableOwner:
+		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported statement: %s", stmt))
+	case *tree.AlterSequence:
+		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported %T statement: %s", stmt, stmt))
+	// Some SELECT statements mutate schema. Search for those here.
+	case *tree.Select:
+		switch sel := stmt.Select.(type) {
+		case *tree.SelectClause:
+			for _, selExpr := range sel.Exprs {
+				switch expr := selExpr.Expr.(type) {
+				case *tree.FuncExpr:
+					// Look for function calls that mutate schema (this is actually a thing).
+					semaCtx := tree.MakeSemaContext()
+					if _, err := expr.TypeCheck(ctx, &semaCtx, nil /* desired */); err != nil {
+						// If the expression does not type check, it may be a case of using
+						// a column that does not exist yet in a setval call (as is the case
+						// of PGDUMP output from ogr2ogr). We're not interested in setval
+						// calls during schema reading so it is safe to ignore this for now.
+						if f := expr.Func.String(); pgerror.GetPGCode(err) == pgcode.UndefinedColumn && f == "setval" {
+							continue
+						}
+						return err
+					}
+					ov := expr.ResolvedOverload()
+					// Search for a SQLFn, which returns a SQL string to execute.
+					fn := ov.SQLFn
+					if fn == nil {
+						err := errors.Errorf("unsupported function call: %s in stmt: %s",
+							expr.Func.String(), stmt.String())
+						return wrapErrorWithUnsupportedHint(err)
+					}
+					// Attempt to convert all func exprs to datums.
+					datums := make(tree.Datums, len(expr.Exprs))
+					for i, ex := range expr.Exprs {
+						d, ok := ex.(tree.Datum)
+						if !ok {
+							// We got something that wasn't a datum so we can't call the
+							// overload. Since this is a SQLFn and the user would have
+							// expected us to execute it, we have to error.
+							return errors.Errorf("unsupported statement: %s", stmt)
+						}
+						datums[i] = d
+					}
+					// Now that we have all of the datums, we can execute the overload.
+					fnSQL, err := fn(evalCtx, datums)
+					if err != nil {
+						return err
+					}
+					// We have some sql. Parse and process it.
+					fnStmts, err := parser.Parse(fnSQL)
+					if err != nil {
+						return err
+					}
+					for _, fnStmt := range fnStmts {
+						switch ast := fnStmt.AST.(type) {
+						case *tree.AlterTable:
+							alterTableHandler := &postgresDDLHandler{}
+							err := bufferDDLPostgresStatement(ctx, evalCtx, ast, p, parentID, alterTableHandler)
+							if err != nil {
+								return err
+							}
+							handler.bufferedDDLStmts = append(handler.bufferedDDLStmts, alterTableHandler.bufferedDDLStmts[0])
+						default:
+							// We only support ALTER statements returned from a SQLFn.
+							return errors.Errorf("unsupported statement: %s", stmt)
+						}
+					}
+				default:
+					err := errors.Errorf("unsupported %T SELECT expr: %s", expr, expr)
+					return wrapErrorWithUnsupportedHint(err)
+				}
+			}
+		default:
+			err := errors.Errorf("unsupported %T SELECT %s", sel, sel)
+			return wrapErrorWithUnsupportedHint(err)
+		}
+	case *tree.DropTable:
+		names := stmt.Names
+
+		// If we find a table with the same name in the target DB we are importing
+		// into and same public schema, then we throw an error telling the user to
+		// drop the conflicting existing table to proceed.
+		// Otherwise, we silently ignore the drop statement and continue with the import.
+		for _, name := range names {
+			tableName := name.ToUnresolvedObjectName().String()
+			if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				err := catalogkv.CheckObjectCollision(
+					ctx,
+					txn,
+					p.ExecCfg().Codec,
+					parentID,
+					keys.PublicSchemaID,
+					tree.NewUnqualifiedTableName(tree.Name(tableName)),
+				)
+				if err != nil {
+					return errors.Wrapf(err, `drop table "%s" and then retry the import`, tableName)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	case *tree.BeginTransaction, *tree.CommitTransaction:
+	case *tree.Insert, *tree.CopyFrom, *tree.Delete, copyData:
+		// handled during the data ingestion pass.
+	case *tree.CreateExtension, *tree.CommentOnDatabase, *tree.CommentOnTable,
+		*tree.CommentOnIndex, *tree.CommentOnConstraint, *tree.CommentOnColumn, *tree.SetVar, *tree.Analyze,
+		*tree.CommentOnSchema:
+		// These are the statements that can be parsed by CRDB but are not
+		// supported, or are not required to be processed, during an IMPORT.
+		// - ignore txns.
+		// - ignore SETs and DMLs.
+		// - ANALYZE is syntactic sugar for CreateStatistics. It can be ignored
+		// because the auto stats stuff will pick up the changes and run if needed.
+		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported %T statement: %s", stmt, stmt))
+	case *tree.CreateType:
+		return errors.New("IMPORT PGDUMP does not support user defined types; please" +
+			" remove all CREATE TYPE statements and their usages from the dump file")
+	case error:
+		if !errors.Is(stmt, errCopyDone) {
+			return stmt
+		}
+	default:
+		return wrapErrorWithUnsupportedHint(errors.Errorf("unsupported %T statement: %s", stmt, stmt))
+	}
+	return nil
+}
+
+// parseDDLStatementsFromDumpFile parses the DDL statements from the dump file,
+// and replaces all qualified object names to point to the temporary database
+// being imported into.
+// This method returns a postgresDDLHandler that contains the buffered DDL
+// statements along with other relevant metadata.
+func parseDDLStatementsFromDumpFile(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	p sql.JobExecContext,
+	dumpFile string,
+	format roachpb.IOFileFormat,
+	maxRowSize int,
+	parentID descpb.ID,
+) (postgresDDLHandler, error) {
+	handler := postgresDDLHandler{bufferedDDLStmts: make([]string, 0)}
+	// Open the dump file.
+	store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, dumpFile, p.User())
+	if err != nil {
+		return handler, err
+	}
+	defer store.Close()
+
+	raw, err := store.ReadFile(ctx, "")
+	if err != nil {
+		return handler, err
+	}
+	defer raw.Close()
+	reader, err := decompressingReader(raw, dumpFile, format.Compression)
+	if err != nil {
+		return handler, err
+	}
+	defer reader.Close()
+
+	// Start reading postgres statements.
+	ps := newPostgreStream(ctx, reader, maxRowSize, &unsupportedStmtLogger{} /* unsupportedStmtLogger */)
+	for {
+		stmt, err := ps.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return handler, errors.Wrap(err, "postgres parse error")
+		}
+		if err := bufferDDLPostgresStatement(ctx, evalCtx, stmt, p, parentID, &handler); err != nil {
+			return handler, err
+		}
+	}
+	return handler, nil
+}
+
+func runDDLStatementsFromDumpFile(
+	ctx context.Context, p sql.JobExecContext, h postgresDDLHandler,
+) error {
+	for _, stmt := range h.bufferedDDLStmts {
+		_, err := p.ExecCfg().InternalExecutor.ExecEx(ctx, "import-pgdump-ddl", nil, /* txn */
+			sessiondata.InternalExecutorOverride{User: security.RootUserName(), Database: importTempPgdumpDB}, stmt)
+		if err != nil {
+			return errors.Wrapf(err, "executing %s", stmt)
+		}
+	}
+	return nil
+}
+
+func moveObjectsInTempDatabaseToState(
+	ctx context.Context, p sql.JobExecContext, tempDatabaseID descpb.ID, state descpb.DescriptorState,
+) ([]*tabledesc.Mutable, []*schemadesc.Mutable, error) {
+	importedTables := make([]*tabledesc.Mutable, 0)
+	importedSchemas := make([]*schemadesc.Mutable, 0)
+	err := sql.DescsTxn(ctx, p.ExecCfg(), func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
+		b := txn.NewBatch()
+		tableDescs, err := descsCol.GetAllTableDescriptorsInDatabase(ctx, txn, tempDatabaseID,
+			tree.CommonLookupFlags{
+				AvoidCached:    false,
+				IncludeOffline: true,
+			})
+		if err != nil {
+			return err
+		}
+
+		for _, desc := range tableDescs {
+			mutTableDesc := tabledesc.NewBuilder(desc.TableDesc()).BuildExistingMutableTable()
+			mutTableDesc.State = state
+			if state == descpb.DescriptorState_OFFLINE {
+				mutTableDesc.OfflineReason = "importing"
+			}
+			importedTables = append(importedTables, mutTableDesc)
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, mutTableDesc, b); err != nil {
+				return err
+			}
+		}
+
+		schemaDescs, err := descsCol.GetAllSchemaDescriptorsInDatabase(ctx, txn, tempDatabaseID, tree.CommonLookupFlags{
+			AvoidCached:    false,
+			IncludeOffline: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, desc := range schemaDescs {
+			mutSchemaDesc := schemadesc.NewBuilder(desc.SchemaDesc()).BuildCreatedMutableSchema()
+			mutSchemaDesc.State = state
+			if state == descpb.DescriptorState_OFFLINE {
+				mutSchemaDesc.OfflineReason = "importing"
+			}
+			importedSchemas = append(importedSchemas, mutSchemaDesc)
+			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, mutSchemaDesc, b); err != nil {
+				return err
+			}
+		}
+
+		// TODO(adityamaru): When we add UDT support to IMPORT PGDUMP we should
+		// probably set those to offline too.
+		return txn.Run(ctx, b)
+	})
+	return importedTables, importedSchemas, err
+}
+
+// TODO(adityamaru): Figure out job resumption semantics.
+// TODO(adityamaru): Update job status to reflect stage.
+func processDDLStatements(
+	ctx context.Context,
+	evalCtx *tree.EvalContext,
+	p sql.JobExecContext,
+	dumpFile string,
+	format roachpb.IOFileFormat,
+	maxRowSize int,
+	parentID descpb.ID,
+) ([]*tabledesc.Mutable, []*schemadesc.Mutable, error) {
+	// Create a temporary database that we will run DDL statements against.
+	// This database will be in an OFFLINE state thereby remaining invisible to
+	// the user for the duration of the IMPORT.
+	tempDescDBID, err := createTempImportDatabase(ctx, p)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating temporary import database")
+	}
+
+	// Parse DDL statements in the dump file, and replace all qualified object
+	// names to point to the temporary database we created above.
+	h, err := parseDDLStatementsFromDumpFile(ctx, evalCtx, p, dumpFile, format, maxRowSize, parentID)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "parsing DDL statements from dump file")
+	}
+
+	// Run the buffered DDL statements.
+	if err := runDDLStatementsFromDumpFile(ctx, p, h); err != nil {
+		return nil, nil, errors.Wrap(err, "running DDL statements from dump file")
+	}
+
+	// Moved all tables, schemas, sequences in the temporary database to an
+	// OFFLINE state.
+	tableDescs, schemaDescs, err := moveObjectsInTempDatabaseToState(ctx, p, tempDescDBID, descpb.DescriptorState_OFFLINE)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "moving objects in temp database to offline state")
+	}
+
+	// TODO(adityamaru): Now it is safe to run the grants since the objects are
+	// all offline.
+
+	return tableDescs, schemaDescs, nil
+}

--- a/pkg/ccl/importccl/import_pgdump_test.go
+++ b/pkg/ccl/importccl/import_pgdump_test.go
@@ -1,0 +1,268 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package importccl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseDDLStatementsFromDumpFile tests that DDL statements in a dump file
+// are correctly parsed, and the database name for fully-qualified objects is
+// replaced with the temporary database being imported into.
+func TestParseDDLStatementsFromDumpFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	baseDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	tc := testcluster.StartTestCluster(
+		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})
+	defer tc.Stopper().Stop(ctx)
+
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	execCtx, cleanup := sql.MakeJobExecContext("TestParseDDLStatementsFromDumpFile", security.RootUserName(), &sql.MemoryMetrics{}, &execCfg)
+	defer cleanup()
+
+	var data string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			_, _ = w.Write([]byte(data))
+		}
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name          string
+		data          string
+		error         string
+		expectedStmts []string
+	}{
+		{
+			name: "multiple CREATE DATABASE",
+			data: `
+CREATE DATABASE db;
+CREATE TABLE db.schema.table (id INT);
+CREATE DATABASE db2;
+`,
+			error: "encountered more than one `CREATE DATABASE` statement when importing PGDUMP file",
+		},
+		{
+			name: "unqualified create statements",
+			data: `
+		CREATE DATABASE db;
+		CREATE SCHEMA s;
+		CREATE TABLE t (id INT);
+		CREATE SEQUENCE seq;
+		CREATE INDEX idx ON t (id);
+		`,
+			expectedStmts: []string{"CREATE SCHEMA s",
+				"CREATE TABLE t (id INT8)",
+				"CREATE SEQUENCE seq",
+				"CREATE INDEX idx ON t (id)"},
+		},
+		{
+			name: "qualified create statement",
+			data: `
+		CREATE DATABASE db;
+		CREATE SCHEMA db.s;
+		CREATE TABLE db.s.t (id INT);
+		CREATE TABLE s.t2 (id INT);
+		CREATE SEQUENCE db.public.seq;
+		CREATE INDEX idx ON db.s.t (id);
+		`,
+			expectedStmts: []string{"CREATE SCHEMA crdb_temp_pgdump_import.s",
+				"CREATE TABLE crdb_temp_pgdump_import.s.t (id INT8)",
+				"CREATE TABLE s.t2 (id INT8)",
+				"CREATE SEQUENCE crdb_temp_pgdump_import.public.seq",
+				"CREATE INDEX idx ON crdb_temp_pgdump_import.s.t (id)"},
+		},
+		{
+			name: "mismatched catalog name",
+			data: `
+		CREATE DATABASE db;
+		CREATE SCHEMA db2.s;
+		`,
+			error: "catalog name db2 does not match dump target database name db",
+		},
+		{
+			name: "unqualified alter statements",
+			data: `
+CREATE DATABASE db;
+ALTER TABLE t ADD COLUMN col STRING;
+ALTER SCHEMA s RENAME TO s2;
+		`,
+			expectedStmts: []string{"ALTER TABLE t ADD COLUMN col STRING",
+				"ALTER SCHEMA s RENAME TO s2"},
+		},
+		{
+			name: "qualified alter statements",
+			data: `
+CREATE DATABASE db;
+ALTER TABLE db.s.t ADD COLUMN col STRING;
+ALTER SCHEMA db.s RENAME TO s2;
+ALTER TABLE db.s.t ADD CONSTRAINT users_fk FOREIGN KEY (id) REFERENCES db.s.t2 (id) ON DELETE CASCADE;
+		`,
+			expectedStmts: []string{"ALTER TABLE crdb_temp_pgdump_import.s.t ADD COLUMN col STRING",
+				"ALTER SCHEMA crdb_temp_pgdump_import.s RENAME TO s2",
+				"ALTER TABLE crdb_temp_pgdump_import.s.t ADD CONSTRAINT users_fk FOREIGN KEY (id) REFERENCES crdb_temp_pgdump_import.s.t2 (id) ON DELETE CASCADE"},
+		},
+		{
+			name: "shp2pg.sql select statement",
+			data: `
+CREATE DATABASE db;
+CREATE TABLE "nyc_census_blocks" (gid serial,
+"blkid" varchar(15),
+"popn_total" float8,
+"popn_white" float8,
+"popn_black" float8,
+"popn_nativ" float8,
+"popn_asian" float8,
+"popn_other" float8,
+"boroname" varchar(32)) WITH (fillfactor = 2, autovacuum_enabled = false);
+ALTER TABLE "nyc_census_blocks" ADD PRIMARY KEY (gid);
+SELECT AddGeometryColumn('', 'nyc_census_blocks','geom','26918','MULTIPOLYGON',2);
+`,
+			expectedStmts: []string{"CREATE TABLE nyc_census_blocks (gid SERIAL8, blkid VARCHAR(15), popn_total FLOAT8, popn_white FLOAT8, popn_black FLOAT8, popn_nativ FLOAT8, popn_asian FLOAT8, popn_other FLOAT8, boroname VARCHAR(32))",
+				"ALTER TABLE nyc_census_blocks ADD PRIMARY KEY (gid)",
+				"ALTER TABLE nyc_census_blocks ADD COLUMN geom GEOMETRY(MULTIPOLYGON,26918)"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data = test.data
+			h, err := parseDDLStatementsFromDumpFile(ctx, &evalCtx, execCtx, srv.URL,
+				roachpb.IOFileFormat{PgDump: roachpb.PgDumpOptions{
+					MaxRowSize: defaultScanBuffer,
+				}}, defaultScanBuffer, 0)
+			if test.error != "" {
+				require.True(t, testutils.IsError(err, test.error))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedStmts, h.bufferedDDLStmts)
+			}
+		})
+	}
+}
+
+func TestProcessDDLStatements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	baseDir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	tc := testcluster.StartTestCluster(
+		t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: baseDir}})
+	defer tc.Stopper().Stop(ctx)
+
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	execCtx, cleanup := sql.MakeJobExecContext("TestParseDDLStatementsFromDumpFile", security.NodeUserName(), &sql.MemoryMetrics{}, &execCfg)
+	defer cleanup()
+
+	conn := tc.ServerConn(0)
+	tdb := sqlutils.MakeSQLRunner(conn)
+
+	var data string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			_, _ = w.Write([]byte(data))
+		}
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name            string
+		data            string
+		error           string
+		expectedTables  []string
+		expectedSchemas []string
+	}{
+		{
+			name: "simple object creation",
+			data: `
+CREATE DATABASE db;
+CREATE SCHEMA s;
+CREATE TABLE db.s.t (id INT);
+CREATE SCHEMA s2;
+CREATE SEQUENCE s2.seq;
+CREATE INDEX foo ON db.s.t (id);
+`,
+			expectedTables:  []string{"t", "seq"},
+			expectedSchemas: []string{"s", "s2"},
+		},
+		{
+			name: "simple alter statements",
+			data: `
+CREATE DATABASE db;
+CREATE SCHEMA s;
+CREATE TABLE db.s.t (id INT, INDEX foo(id));
+CREATE TABLE db.s.z (id INT PRIMARY KEY, id2 INT);
+
+ALTER TABLE db.s.t ADD COLUMN id2 INT;
+ALTER TABLE db.s.t ALTER COLUMN id2 SET NOT NULL;
+ALTER TABLE db.s.z ALTER COLUMN id2 SET DEFAULT 0;
+`,
+			expectedTables:  []string{"t", "z"},
+			expectedSchemas: []string{"s"},
+		},
+	}
+
+	for _, test := range tests {
+		data = test.data
+		tables, schemas, err := processDDLStatements(ctx, &evalCtx, execCtx, srv.URL,
+			roachpb.IOFileFormat{PgDump: roachpb.PgDumpOptions{
+				MaxRowSize: defaultScanBuffer,
+			}}, defaultScanBuffer, 0)
+		require.NoError(t, err)
+
+		require.Equal(t, len(test.expectedTables), len(tables))
+		require.Equal(t, len(test.expectedSchemas), len(schemas))
+
+		var tempImportDBID descpb.ID
+		tdb.QueryRow(t, fmt.Sprintf(`SELECT id FROM system.namespace WHERE name='%s'`, importTempPgdumpDB)).Scan(&tempImportDBID)
+
+		for i, table := range tables {
+			require.Equal(t, table.GetName(), test.expectedTables[i])
+			require.True(t, table.Offline())
+			require.Equal(t, tempImportDBID, table.GetParentID())
+		}
+
+		for i, schema := range schemas {
+			require.Equal(t, schema.GetName(), test.expectedSchemas[i])
+			require.True(t, schema.Offline())
+			require.Equal(t, tempImportDBID, schema.GetParentID())
+		}
+
+		// For test purposes move all objects to PUBLIC so that we can drop the
+		// database.
+		_, _, err = moveObjectsInTempDatabaseToState(ctx, execCtx, tempImportDBID, descpb.DescriptorState_PUBLIC)
+		require.NoError(t, err)
+		tdb.Exec(t, fmt.Sprintf(`DROP DATABASE %s CASCADE`, importTempPgdumpDB))
+	}
+}

--- a/pkg/spanconfig/spanconfigsqltranslator/sql_translator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sql_translator.go
@@ -326,7 +326,8 @@ func (s *SQLTranslator) findDescendantLeafIDsForDescriptor(
 
 	// Expand the database descriptor to all the tables inside it and return their
 	// IDs.
-	tables, err := descsCol.GetAllTableDescriptorsInDatabase(ctx, txn, desc.GetID())
+	tables, err := descsCol.GetAllTableDescriptorsInDatabase(ctx, txn, desc.GetID(),
+		tree.DatabaseLookupFlags{AvoidCached: false})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -284,12 +284,10 @@ func (tc *Collection) GetAllDatabaseDescriptors(
 // collection's cached descriptors before defaulting to a key-value scan, if
 // necessary.
 func (tc *Collection) GetAllTableDescriptorsInDatabase(
-	ctx context.Context, txn *kv.Txn, dbID descpb.ID,
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
 ) ([]catalog.TableDescriptor, error) {
 	// Ensure the given ID does indeed belong to a database.
-	found, _, err := tc.getDatabaseByID(ctx, txn, dbID, tree.DatabaseLookupFlags{
-		AvoidCached: false,
-	})
+	found, _, err := tc.getDatabaseByID(ctx, txn, dbID, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -305,6 +303,36 @@ func (tc *Collection) GetAllTableDescriptorsInDatabase(
 		if desc.GetParentID() == dbID {
 			if table, ok := desc.(catalog.TableDescriptor); ok {
 				ret = append(ret, table)
+			}
+		}
+	}
+	return ret, nil
+}
+
+// GetAllSchemaDescriptorsInDatabase returns all the schema descriptors visible
+// to the transaction under the database with the given ID. It first checks the
+// collection's cached descriptors before defaulting to a key-value scan, if
+// necessary.
+func (tc *Collection) GetAllSchemaDescriptorsInDatabase(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, flags tree.DatabaseLookupFlags,
+) ([]catalog.SchemaDescriptor, error) {
+	// Ensure the given ID does indeed belong to a database.
+	found, _, err := tc.getDatabaseByID(ctx, txn, dbID, flags)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, sqlerrors.NewUndefinedDatabaseError(fmt.Sprintf("[%d]", dbID))
+	}
+	descs, err := tc.GetAllDescriptors(ctx, txn)
+	if err != nil {
+		return nil, err
+	}
+	var ret []catalog.SchemaDescriptor
+	for _, desc := range descs {
+		if desc.GetParentID() == dbID {
+			if schema, ok := desc.(catalog.SchemaDescriptor); ok {
+				ret = append(ret, schema)
 			}
 		}
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -299,8 +299,8 @@ func FmtPlaceholderFormat(placeholderFn func(_ *FmtCtx, _ *Placeholder)) FmtCtxO
 	}
 }
 
-// FmtReformatTableNames modifies FmtCtx to to substitute the printing of table
-// naFmtParsable using the provided function.
+// FmtReformatTableNames modifies FmtCtx to to substitute the printing of
+// tableNameFmtParsable using the provided function.
 func FmtReformatTableNames(tableNameFmt func(*FmtCtx, *TableName)) FmtCtxOption {
 	return func(ctx *FmtCtx) {
 		ctx.tableNameFormatter = tableNameFmt


### PR DESCRIPTION
This change is the first of many in the endeavour to run all
DDL statement during IMPORT PGDUMP via an internal executor.
This is not hooked up to IMPORT PGDUMP and will be introduced
as a standalone codepath, only to be swapped once we have parity
with the existing implementation.

During an IMPORT PGDUMP, in the future, our schema parsing phase will:

- Create a database in which we will create the schema objects and import
data into them. This database will be invisible to every user except `node`
via priviliges.

- Parse the dump file, pointing all DDL statements to the new
import database.

- Run all the buffered DDL statements using an internal executor.

- Mark all created schema objects in the importing database as OFFLINE.

Note, this change does not add or remove DDL support from PGDUMP but aims
to achieve parity with the existing implementation in `read_import_pgdump.go`.

Follow up work will include:

- [ ] Hooking the schema parsing into the data ingestion.
- [ ] Supporting `GRANT` statements and running them
once the schema objects have been marked OFFLINE.
- [ ] Remapping schema objects to the target database from the importing
database before we flip the objects to PUBLIC.
- [ ] Cleanup on import job failure.
- [ ] Resumption semantics during the schema parsing phase.
- [ ] Support for ignore_unsupported_statements.

Informs: #67076

Release note: None