### PR TITLE
sql: fix excess privileges being created from default privileges.

### DIFF
--- a/pkg/sql/catalog/catprivilege/default_privilege.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege.go
@@ -145,12 +145,21 @@ func (d *immutable) CreatePrivilegesFromDefaultPrivileges(
 	}
 
 	newPrivs := descpb.NewDefaultPrivilegeDescriptor(user)
-	// If default privileges are not defined for the creator role, we handle
-	// it as the default case where the user has all privileges.
 	role := descpb.DefaultPrivilegesRole{Role: user}
-	if _, found := d.GetDefaultPrivilegesForRole(role); !found {
+	if defaultPrivilegesForRole, found := d.GetDefaultPrivilegesForRole(role); !found {
+		// If default privileges are not defined for the creator role, we handle
+		// it as the case where the user has all privileges.
 		defaultPrivilegesForCreatorRole := descpb.InitDefaultPrivilegesForRole(role)
 		for _, user := range GetUserPrivilegesForObject(defaultPrivilegesForCreatorRole, targetObject) {
+			newPrivs.Grant(
+				user.UserProto.Decode(),
+				privilege.ListFromBitField(user.Privileges, targetObject.ToPrivilegeObjectType()),
+			)
+		}
+	} else {
+		// If default privileges were defined for the role, we create privileges
+		// using the default privileges.
+		for _, user := range GetUserPrivilegesForObject(*defaultPrivilegesForRole, targetObject) {
 			newPrivs.Grant(
 				user.UserProto.Decode(),
 				privilege.ListFromBitField(user.Privileges, targetObject.ToPrivilegeObjectType()),
@@ -161,15 +170,15 @@ func (d *immutable) CreatePrivilegesFromDefaultPrivileges(
 	// The privileges for the object are the union of the default privileges
 	// defined for the object for the object creator and the default privileges
 	// defined for all roles.
-	_ = d.ForEachDefaultPrivilegeForRole(func(defaultPrivilegesForRole descpb.DefaultPrivilegesForRole) error {
-		for _, user := range GetUserPrivilegesForObject(defaultPrivilegesForRole, targetObject) {
+	defaultPrivilegesForAllRoles, found := d.GetDefaultPrivilegesForRole(descpb.DefaultPrivilegesRole{ForAllRoles: true})
+	if found {
+		for _, user := range GetUserPrivilegesForObject(*defaultPrivilegesForAllRoles, targetObject) {
 			newPrivs.Grant(
 				user.UserProto.Decode(),
 				privilege.ListFromBitField(user.Privileges, targetObject.ToPrivilegeObjectType()),
 			)
 		}
-		return nil
-	})
+	}
 	newPrivs.SetOwner(user)
 	newPrivs.Version = descpb.Version21_2
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -137,3 +137,20 @@ database_name  schema_name  grantee   privilege_type
 d              s5           admin     ALL
 d              s5           root      ALL
 d              s5           testuser  CREATE
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO testuser, testuser2
+
+user root
+
+statement ok
+CREATE SCHEMA s_72322
+
+# When root creates the table, testuser and testuser2 should not get privileges.
+query TTTT colnames
+SHOW GRANTS ON SCHEMA s_72322
+----
+database_name  schema_name  grantee   privilege_type
+d              s_72322      admin     ALL
+d              s_72322      root      ALL
+d              s_72322      testuser  CREATE


### PR DESCRIPTION
Release note (bug fix): Previously, when creating an object
default privileges from users that were not the user creating
the object would be added to the privileges of the object.
This fix ensures only the relevant default privileges are applied.

Resolves https://github.com/cockroachdb/cockroach/issues/72322