### PR TITLE
tabledesc: fix bug involving DEFAULT exprs in MakeColumnDefDescs

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -148,8 +148,11 @@ func avroFieldMetadataToColDesc(metadata string) (*descpb.ColumnDescriptor, erro
 	def := parsed.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
 	ctx := context.Background()
 	semaCtx := makeTestSemaCtx()
-	col, _, _, err := tabledesc.MakeColumnDefDescs(ctx, def, &semaCtx, &tree.EvalContext{})
-	return col, err
+	cdd, err := tabledesc.MakeColumnDefDescs(ctx, def, &semaCtx, &tree.EvalContext{})
+	if err != nil {
+		return nil, err
+	}
+	return cdd.ColumnDescriptor, err
 }
 
 // randTime generates a random time.Time whose .UnixNano result doesn't

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -220,10 +220,11 @@ CREATE TABLE t.test (k INT);
 		t.Fatal(err)
 	}
 	colDef := alterCmd.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	col, _, _, err := tabledesc.MakeColumnDefDescs(ctx, colDef, nil, nil)
+	cdd, err := tabledesc.MakeColumnDefDescs(ctx, colDef, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	col := cdd.ColumnDescriptor
 	col.ID = tableDesc.NextColumnID
 	tableDesc.NextColumnID++
 	tableDesc.Families[0].ColumnNames = append(tableDesc.Families[0].ColumnNames, col.Name)

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -600,11 +600,11 @@ func addResultColumns(
 		columnTableDef.Nullable.Nullability = tree.SilentNull
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := tabledesc.MakeColumnDefDescs(ctx, &columnTableDef, semaCtx, evalCtx)
+		cdd, err := tabledesc.MakeColumnDefDescs(ctx, &columnTableDef, semaCtx, evalCtx)
 		if err != nil {
 			return err
 		}
-		desc.AddColumn(col)
+		desc.AddColumn(cdd.ColumnDescriptor)
 	}
 	if err := desc.AllocateIDs(ctx); err != nil {
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/on_update
+++ b/pkg/sql/logictest/testdata/logic_test/on_update
@@ -279,6 +279,39 @@ pk1  3
 pk2  4
 pk3  2
 
+
+# Regression test for issue #72116.
+statement ok
+CREATE SEQUENCE seq_72116;
+CREATE TABLE table_72116 (a INT);
+ALTER TABLE table_72116 ADD COLUMN b INT DEFAULT nextval('seq_72116') ON UPDATE NULL
+
+# Make sure that our DEFAULT has a dependency on seq_72116
+statement error pq: cannot drop sequence seq_72116 because other objects depend on it
+DROP SEQUENCE seq_72116
+
+statement ok
+DROP TABLE table_72116;
+CREATE TABLE table_72116 (a INT DEFAULT nextval('seq_72116') ON UPDATE NULL)
+
+statement error pq: cannot drop sequence seq_72116 because other objects depend on it
+DROP SEQUENCE seq_72116
+
+statement ok
+DROP TABLE table_72116;
+CREATE TABLE table_72116 (a INT);
+ALTER TABLE table_72116 ADD COLUMN b INT DEFAULT (1) ON UPDATE nextval('seq_72116')
+
+statement error pq: cannot drop sequence seq_72116 because other objects depend on it
+DROP SEQUENCE seq_72116
+
+statement ok
+DROP TABLE table_72116;
+CREATE TABLE table_72116 (a INT DEFAULT (1) ON UPDATE nextval('seq_72116'))
+
+statement error pq: cannot drop sequence seq_72116 because other objects depend on it
+DROP SEQUENCE seq_72116
+
 subtest EnumDependencies
 
 statement ok

--- a/pkg/sql/schemachanger/scbuild/table.go
+++ b/pkg/sql/schemachanger/scbuild/table.go
@@ -108,17 +108,19 @@ func (b *buildContext) alterTableAddColumn(
 	if d.Unique.IsUnique {
 		panic(&notImplementedError{n: t.ColumnDef, detail: "contains unique constraint"})
 	}
-	col, idx, defaultExpr, err := tabledesc.MakeColumnDefDescs(ctx, d, semaCtx(b), evalCtx(ctx, b))
+	cdd, err := tabledesc.MakeColumnDefDescs(ctx, d, semaCtx(b), evalCtx(ctx, b))
 	onErrPanic(err)
 
+	col := cdd.ColumnDescriptor
 	colID := b.nextColumnID(table)
 	col.ID = colID
 
-	// If the new column has a DEFAULT expression that uses a sequence, add
-	// references between its descriptor and this column descriptor.
-	if d.HasDefaultExpr() {
-		b.maybeAddSequenceReferenceDependencies(ctx, table.GetID(), col, defaultExpr)
-	}
+	// If the new column has a DEFAULT or ON UPDATE expression that uses a
+	// sequence, add references between its descriptor and this column descriptor.
+	_ = cdd.ForEachTypedExpr(func(expr tree.TypedExpr) error {
+		b.maybeAddSequenceReferenceDependencies(ctx, table.GetID(), col, expr)
+		return nil
+	})
 
 	b.validateColumnName(table, d, col, t.IfNotExists)
 
@@ -179,7 +181,7 @@ func (b *buildContext) alterTableAddColumn(
 	})
 	newPrimaryIdxID := b.addOrUpdatePrimaryIndexTargetsForAddColumn(table, colID, col.Name)
 
-	if idx != nil {
+	if idx := cdd.PrimaryKeyOrUniqueIndexDescriptor; idx != nil {
 		idxID := b.nextIndexID(table)
 		idx.ID = idxID
 		b.addNode(scpb.Target_ADD, &scpb.SecondaryIndex{


### PR DESCRIPTION
This commit fixes a bug in MakeColumnDefDescs where the typed expression
for DEFAULT would get overwritten by the ON UPDATE expression. This
would cause any sequence dependencies to not properly be tracked.

Fixes #72116.

Release note (bug fix): Fixes potential descriptor corruption bug for
tables with a column with a DEFAULT expression referencing a SEQUENCE
and with an ON UPDATE expression.