### PR TITLE
dev: allow linting a single package

### DIFF
--- a/pkg/cmd/dev/io/exec/exec.go
+++ b/pkg/cmd/dev/io/exec/exec.go
@@ -97,10 +97,24 @@ func (e *Exec) CommandContextWithInput(
 	return e.commandContextImpl(ctx, r, false, name, args...)
 }
 
+// CommandContextWithEnv is like CommandContextInheritingStdStreams, but
+// accepting an additional argument for environment variables.
+func (e *Exec) CommandContextWithEnv(
+	ctx context.Context, env []string, name string, args ...string,
+) error {
+	return e.commandContextInheritingStdStreamsImpl(ctx, env, name, args...)
+}
+
 // CommandContextInheritingStdStreams is like CommandContext, but stdin,
 // stdout, and stderr are passed directly to the terminal.
 func (e *Exec) CommandContextInheritingStdStreams(
 	ctx context.Context, name string, args ...string,
+) error {
+	return e.commandContextInheritingStdStreamsImpl(ctx, nil, name, args...)
+}
+
+func (e *Exec) commandContextInheritingStdStreamsImpl(
+	ctx context.Context, env []string, name string, args ...string,
 ) error {
 	var command string
 	if len(args) > 0 {
@@ -117,6 +131,7 @@ func (e *Exec) CommandContextInheritingStdStreams(
 		cmd.Stdout = e.stdout
 		cmd.Stderr = e.stderr
 		cmd.Dir = e.dir
+		cmd.Env = env
 
 		if err := cmd.Start(); err != nil {
 			return err


### PR DESCRIPTION
Tie into the `lint` test's support for specifiying `PKG` in the
environment.

Closes #72093.

Release note: None