### PR TITLE
bazel: allow using `cross` configs without opting into CI-specific logic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,6 @@ query --ui_event_filters=-DEBUG
 
 # CI should always run with `--config=ci`.
 build:ci --experimental_convenience_symlinks=ignore
-build:ci --stamp
-build:ci --host_crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
 # Set `-test.v` in Go tests.
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
 test:ci --test_env=GO_TEST_WRAP_TESTV=1
@@ -20,26 +18,29 @@ test:ci --test_output=errors
 # Put all tmp artifacts in /artifacts/tmp.
 test:ci --test_tmpdir=/artifacts/tmp
 
+build:cross --stamp
+build:cross --host_crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
+build:cross --define cockroach_cross=y
+
 # cross-compilation configurations. Add e.g. --config=crosslinux to turn these on
 # TODO(ricky): Having to specify both the `platform` and the `crosstool_top` is
 # weird, but I think `rules_foreign_cc` doesn't play too nicely with `--platforms`?
 build:crosslinux --platforms=//build/toolchains:cross_linux
 build:crosslinux --crosstool_top=@toolchain_cross_x86_64-unknown-linux-gnu//:suite
 build:crosslinux '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-pc-linux-gnu'
-build:crosslinux --config=ci --config=cross
+build:crosslinux --config=cross
 build:crosswindows --platforms=//build/toolchains:cross_windows
 build:crosswindows --crosstool_top=@toolchain_cross_x86_64-w64-mingw32//:suite
 build:crosswindows '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-w64-mingw32'
-build:crosswindows --config=ci --config=cross
+build:crosswindows --config=cross
 build:crossmacos --platforms=//build/toolchains:cross_macos
 build:crossmacos --crosstool_top=@toolchain_cross_x86_64-apple-darwin19//:suite
 build:crossmacos '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-apple-darwin19'
-build:crossmacos --config=ci --config=cross
+build:crossmacos --config=cross
 build:crosslinuxarm --platforms=//build/toolchains:cross_linux_arm
 build:crosslinuxarm --crosstool_top=@toolchain_cross_aarch64-unknown-linux-gnu//:suite
 build:crosslinuxarm '--workspace_status_command=./build/bazelutil/stamp.sh aarch64-unknown-linux-gnu'
-build:crosslinuxarm --config=ci --config=cross
-build:cross --define cockroach_cross=y
+build:crosslinuxarm --config=cross
 
 # developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
 build:devdarwinx86_64 --crosstool_top=@toolchain_dev_darwin_x86-64//:suite

--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -21,6 +21,6 @@ fi
 
 bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
-		       --config "$CONFIG" --config with_ui \
+		       --config "$CONFIG" --config ci --config with_ui \
 		       build //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
 		       //pkg/cmd/cockroach-oss //c-deps:libgeos $GENFILES_TARGETS

--- a/build/teamcity/cockroach/ci/tests/bench_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/bench_impl.sh
@@ -21,7 +21,7 @@ do
     tc_start_block "Bench $target"
     # We need the `test_sharding_strategy` flag or else the benchmarks will
     # fail to run sharded tests like //pkg/ccl/importccl:importccl_test.
-    bazel run --config=test --config=crosslinux --test_sharding_strategy=disabled $target -- \
+    bazel run --config=test --config=crosslinux --config=ci --test_sharding_strategy=disabled $target -- \
           -test.bench=. -test.benchtime=1ns -test.short -test.run=-
     tc_end_block "Bench $target"
 done

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-bazel build --config=crosslinux //pkg/cmd/cockroach-short \
+bazel build --config=crosslinux --config=ci //pkg/cmd/cockroach-short \
       //pkg/cmd/roachprod \
       //pkg/cmd/roachtest \
       //pkg/cmd/workload
 
-BAZEL_BIN=$(bazel info bazel-bin --config=crosslinux)
+BAZEL_BIN=$(bazel info bazel-bin --config=crosslinux --config=ci)
 $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
   --local \
   --parallelism=1 \

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -117,7 +117,7 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	}
 	cross = "cross" + cross
 	volume := mustGetFlagString(cmd, volumeFlag)
-	args = append(args, fmt.Sprintf("--config=%s", cross))
+	args = append(args, fmt.Sprintf("--config=%s", cross), "--config=ci")
 	dockerArgs, err := d.getDockerRunArgs(ctx, volume, false)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	// TODO(ricky): Actually, we need to shell-quote the arguments,
 	// but that's hard and I don't think it's necessary for now.
 	script.WriteString(fmt.Sprintf("bazel %s\n", strings.Join(args, " ")))
-	script.WriteString(fmt.Sprintf("BAZELBIN=`bazel info bazel-bin --color=no --config=%s`\n", cross))
+	script.WriteString(fmt.Sprintf("BAZELBIN=`bazel info bazel-bin --color=no --config=%s --config=ci`\n", cross))
 	for _, target := range buildTargets {
 		script.WriteString(fmt.Sprintf("cp $BAZELBIN/%s /artifacts\n", bazelutil.OutputOfBinaryRule(target.fullName)))
 	}


### PR DESCRIPTION
`dev` recommends using `--config=crosslinux`, which up to this point
implied `--config=ci`. One of the configurations set by `--config=ci` is
setting `/artifacts/tmp` as the `$TMPDIR` location for tests; this works
in the Bazel builder image, which does mount the `/artifacts` directory,
but will not exist on arbitrary dev machines. So we refactor the
configurations slightly: now `--config=crosslinux` implies
`--config=cross`, which is general-use, but CI jobs also have to opt
into `--config=ci` separately.

Closes #72324.

Release note: None