### PR TITLE
bazel: increase test size of `rttanalysisccl` test

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -19,7 +19,7 @@ go_library(
 
 go_test(
     name = "rttanalysisccl_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "bench_test.go",
         "multi_region_bench_test.go",


### PR DESCRIPTION
Prevent timeouts in CI.

Release note: None