### PR TITLE
sql/*: fix improperly wrapped errors

### DIFF
--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -194,10 +194,10 @@ func initGEOS(dirs []string) (*C.CR_GEOS, string, error) {
 		}
 		err = errors.CombineErrors(
 			err,
-			errors.Newf(
-				"geos: cannot load GEOS from dir %q: %s",
-				dir,
+			errors.Wrapf(
 				newErr,
+				"geos: cannot load GEOS from dir %q",
+				dir,
 			),
 		)
 	}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -12,7 +12,6 @@ package colrpc
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math"
 	"sync/atomic"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -208,7 +208,7 @@ func (i *Inbox) RunWithStream(
 	case readerCtx = <-i.contextCh:
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
 	case <-streamCtx.Done():
-		return fmt.Errorf("%s: streamCtx while waiting for reader (remote client canceled)", streamCtx.Err())
+		return errors.Wrap(streamCtx.Err(), "streamCtx error while waiting for reader (remote client canceled)")
 	case <-flowCtxDone:
 		// The flow context of the inbox host has been canceled. This can occur
 		// e.g. when the query is canceled, or when another stream encountered
@@ -233,7 +233,7 @@ func (i *Inbox) RunWithStream(
 		return nil
 	case <-streamCtx.Done():
 		// The client canceled the stream.
-		return fmt.Errorf("%s: streamCtx in Inbox stream handler (remote client canceled)", streamCtx.Err())
+		return errors.Wrap(streamCtx.Err(), "streamCtx error in Inbox stream handler (remote client canceled)")
 	}
 }
 
@@ -258,7 +258,7 @@ func (i *Inbox) Init(ctx context.Context) {
 		select {
 		case i.stream = <-i.streamCh:
 		case err := <-i.timeoutCh:
-			i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
+			i.errCh <- errors.Wrap(err, "remote stream arrived too late")
 			return err
 		case <-i.Ctx.Done():
 			// Our reader canceled the context meaning that it no longer needs
@@ -325,7 +325,7 @@ func (i *Inbox) Next() coldata.Batch {
 			// Regardless of the cause we want to propagate such an error as
 			// expected one in all cases so that the caller could decide on how
 			// to handle it.
-			err = pgerror.Newf(pgcode.InternalConnectionFailure, "inbox communication error: %s", err)
+			err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "inbox communication error")
 			i.errCh <- err
 			colexecerror.ExpectedError(err)
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1798,7 +1798,7 @@ type registrySession interface {
 func (r *SessionRegistry) CancelQuery(queryIDStr string) (bool, error) {
 	queryID, err := StringToClusterWideID(queryIDStr)
 	if err != nil {
-		return false, fmt.Errorf("query ID %s malformed: %s", queryID, err)
+		return false, errors.Wrapf(err, "query ID %s malformed", queryID)
 	}
 
 	r.Lock()

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -137,7 +137,7 @@ func processInboundStreamHelper(
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
-					err = pgerror.Newf(pgcode.InternalConnectionFailure, "inbox communication error: %s", err)
+					err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "inbox communication error")
 					sendErrToConsumer(err)
 					errChan <- err
 					return

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -327,7 +327,7 @@ DROP INDEX t_secondary CASCADE;
 ALTER TABLE t DROP COLUMN b;
 INSERT INTO t SELECT a + 1 FROM t;
 
-statement error pgcode 23505 duplicate key value: decoding err=column-id "2" does not exist
+statement error pgcode 23505 duplicate key value got decoding error: column-id "2" does not exist
 UPSERT INTO t SELECT a + 1 FROM t;
 
 statement ok

--- a/pkg/sql/opt/optgen/cmd/langgen/main.go
+++ b/pkg/sql/opt/optgen/cmd/langgen/main.go
@@ -130,7 +130,7 @@ func generate(compiled *lang.CompiledExpr, out string, genFunc genFunc) error {
 		if err != nil {
 			// Write out incorrect source for easier debugging.
 			b = buf.Bytes()
-			err = fmt.Errorf("code formatting failed with Go parse error\n%s:%s", out, err)
+			err = errors.Wrapf(err, "code formatting failed with Go parse error\n%s", out)
 		}
 	} else {
 		b = buf.Bytes()

--- a/pkg/sql/opt/optgen/cmd/optgen/main.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/main.go
@@ -218,7 +218,7 @@ func (g *optgen) generate(compiled *lang.CompiledExpr, genFunc genFunc) error {
 			// Write out incorrect source for easier debugging.
 			b = buf.Bytes()
 			out := g.cmdLine.Lookup("out").Value.String()
-			err = fmt.Errorf("code formatting failed with Go parse error\n%s:%s", out, err)
+			err = errors.Wrapf(err, "code formatting failed with Go parse error\n%s", out)
 		}
 	} else {
 		b = buf.Bytes()

--- a/pkg/sql/opt/optgen/lang/compiler.go
+++ b/pkg/sql/opt/optgen/lang/compiler.go
@@ -200,7 +200,7 @@ func (c *Compiler) compileRules(rules RuleSetExpr) bool {
 
 func (c *Compiler) addErr(src *SourceLoc, err error) {
 	if src != nil {
-		err = fmt.Errorf("%s: %s", src, err.Error())
+		err = errors.Wrapf(err, "%s", src)
 	}
 	c.errors = append(c.errors, err)
 }

--- a/pkg/sql/opt/props/func_dep_rand_test.go
+++ b/pkg/sql/opt/props/func_dep_rand_test.go
@@ -432,7 +432,7 @@ func (tc *testConfig) checkAPIs(fd *FuncDepSet, tr testRelation) error {
 			to:     closure,
 			strict: true,
 		}); err != nil {
-			return fmt.Errorf("ComputeClosure%s incorrectly returns %s: %s", cols, closure, err)
+			return errors.Wrapf(err, "ComputeClosure%s incorrectly returns %s", cols, closure)
 		}
 
 		reduced := fd.ReduceCols(cols)
@@ -441,7 +441,7 @@ func (tc *testConfig) checkAPIs(fd *FuncDepSet, tr testRelation) error {
 			to:     cols,
 			strict: true,
 		}); err != nil {
-			return fmt.Errorf("ReduceCols%s incorrectly returns %s: %s", cols, reduced, err)
+			return errors.Wrapf(err, "ReduceCols%s incorrectly returns %s", cols, reduced)
 		}
 
 		var proj FuncDepSet
@@ -449,7 +449,7 @@ func (tc *testConfig) checkAPIs(fd *FuncDepSet, tr testRelation) error {
 		proj.ProjectCols(cols)
 		// The FDs after projection should still hold on the table.
 		if err := tr.checkFDs(&proj); err != nil {
-			return fmt.Errorf("ProjectCols%s incorrectly returns %s: %s", cols, proj.String(), err)
+			return errors.Wrapf(err, "ProjectCols%s incorrectly returns %s", cols, proj.String())
 		}
 	}
 

--- a/pkg/sql/pg_metadata_test.go
+++ b/pkg/sql/pg_metadata_test.go
@@ -123,6 +123,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/lib/pq/oid"
 )
@@ -678,7 +679,7 @@ type outputFile struct {
 // appendString calls WriteString and panics on error.
 func (o outputFile) appendString(s string) {
 	if _, err := o.f.WriteString(s); err != nil {
-		panic(fmt.Errorf("error while writing string: %s: %v", s, err))
+		panic(errors.Wrapf(err, "error while writing string: %s", s))
 	}
 }
 
@@ -703,7 +704,7 @@ func rewriteFile(fileName string, f func(*os.File, outputFile)) {
 
 	updateFile(tmpName, fileName, func(input *os.File, output outputFile) {
 		if _, err := io.Copy(output.f, input); err != nil {
-			panic(fmt.Errorf("problem at rewriting file %s into %s: %v", tmpName, fileName, err))
+			panic(errors.Wrapf(err, "problem at rewriting file %s into %s", tmpName, fileName))
 		}
 	})
 }
@@ -711,13 +712,13 @@ func rewriteFile(fileName string, f func(*os.File, outputFile)) {
 func updateFile(inputFileName, outputFileName string, f func(input *os.File, output outputFile)) {
 	input, err := os.Open(inputFileName)
 	if err != nil {
-		panic(fmt.Errorf("error opening file %s: %v", inputFileName, err))
+		panic(errors.Wrapf(err, "error opening file %s", inputFileName))
 	}
 	defer dClose(input)
 
 	output, err := os.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		panic(fmt.Errorf("error opening file %s: %v", outputFileName, err))
+		panic(errors.Wrapf(err, "error opening file %s", outputFileName))
 	}
 	defer dClose(output)
 
@@ -895,7 +896,7 @@ func (scf schemaCodeFixer) getTableDefinitionsText(unimplementedTables PGMetadat
 	maxLength := 0
 	f, err := os.Open(fileName)
 	if err != nil {
-		panic(fmt.Errorf("could not open file %s: %v", fileName, err))
+		panic(errors.Wrapf(err, "could not open file %s", fileName))
 	}
 	defer dClose(f)
 	reader := bufio.NewScanner(f)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -739,8 +739,10 @@ func parseClientProvidedSessionParameters(
 		// Read a key-value pair from the client.
 		key, err := buf.GetString()
 		if err != nil {
-			return sql.SessionArgs{}, pgerror.Newf(pgcode.ProtocolViolation,
-				"error reading option key: %s", err)
+			return sql.SessionArgs{}, pgerror.Wrap(
+				err, pgcode.ProtocolViolation,
+				"error reading option key",
+			)
 		}
 		if len(key) == 0 {
 			// End of parameter list.
@@ -748,8 +750,10 @@ func parseClientProvidedSessionParameters(
 		}
 		value, err := buf.GetString()
 		if err != nil {
-			return sql.SessionArgs{}, pgerror.Newf(pgcode.ProtocolViolation,
-				"error reading option value: %s", err)
+			return sql.SessionArgs{}, pgerror.Wrapf(
+				err, pgcode.ProtocolViolation,
+				"error reading option value for key %q", key,
+			)
 		}
 
 		// Case-fold for the key for easier comparison.
@@ -788,13 +792,17 @@ func parseClientProvidedSessionParameters(
 
 			hostS, portS, err := net.SplitHostPort(value)
 			if err != nil {
-				return sql.SessionArgs{}, pgerror.Newf(pgcode.ProtocolViolation,
-					"invalid address format: %v", err)
+				return sql.SessionArgs{}, pgerror.Wrap(
+					err, pgcode.ProtocolViolation,
+					"invalid address format",
+				)
 			}
 			port, err := strconv.Atoi(portS)
 			if err != nil {
-				return sql.SessionArgs{}, pgerror.Newf(pgcode.ProtocolViolation,
-					"remote port is not numeric: %v", err)
+				return sql.SessionArgs{}, pgerror.Wrap(
+					err, pgcode.ProtocolViolation,
+					"remote port is not numeric",
+				)
 			}
 			ip := net.ParseIP(hostS)
 			if ip == nil {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -663,17 +663,17 @@ func prepareZoneConfigForMultiRegionTable(
 		return nil, nil
 	}
 	if err := newZoneConfig.Validate(); err != nil {
-		return nil, pgerror.Newf(
-			pgcode.CheckViolation,
-			"could not validate zone config: %v",
+		return nil, pgerror.Wrap(
 			err,
+			pgcode.CheckViolation,
+			"could not validate zone config",
 		)
 	}
 	if err := newZoneConfig.ValidateTandemFields(); err != nil {
-		return nil, pgerror.Newf(
-			pgcode.CheckViolation,
-			"could not validate zone config: %v",
+		return nil, pgerror.Wrap(
 			err,
+			pgcode.CheckViolation,
+			"could not validate zone config",
 		)
 	}
 	return prepareZoneConfigWrites(

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -115,8 +115,8 @@ func NewUniquenessConstraintViolationError(
 ) error {
 	index, names, values, err := DecodeRowInfo(ctx, tableDesc, key, value, false)
 	if err != nil {
-		return pgerror.Newf(pgcode.UniqueViolation,
-			"duplicate key value: decoding err=%s", err)
+		return pgerror.Wrap(err, pgcode.UniqueViolation,
+			"duplicate key value got decoding error")
 	}
 
 	// Exclude implicit partitioning columns and hash sharded index columns from
@@ -156,8 +156,8 @@ func NewLockNotAvailableError(
 
 	index, colNames, values, err := DecodeRowInfo(ctx, tableDesc, key, nil, false)
 	if err != nil {
-		return pgerror.Newf(pgcode.LockNotAvailable,
-			"%s: decoding err=%s", baseMsg, err)
+		return pgerror.Wrapf(err, pgcode.LockNotAvailable,
+			"%s: got decoding error", baseMsg)
 	}
 
 	return pgerror.Newf(pgcode.LockNotAvailable,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4895,7 +4895,7 @@ value if you rely on the HLC for accuracy.`,
 					},
 				})
 				if err := ctx.Txn.Run(ctx.Context, b); err != nil {
-					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "message: %s", err)
+					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching leaseholder")
 				}
 				resp := b.RawResponse().Responses[0].GetInner().(*roachpb.LeaseInfoResponse)
 
@@ -4990,7 +4990,7 @@ value if you rely on the HLC for accuracy.`,
 					},
 				})
 				if err := ctx.Txn.Run(ctx.Context, b); err != nil {
-					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "message: %s", err)
+					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching range stats")
 				}
 				resp := b.RawResponse().Responses[0].GetInner().(*roachpb.RangeStatsResponse).MVCCStats
 				jsonStr, err := gojson.Marshal(&resp)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2983,8 +2983,8 @@ func MatchLikeEscape(
 
 	like, err := optimizedLikeFunc(pattern, caseInsensitive, escapeRune)
 	if err != nil {
-		return DBoolFalse, pgerror.Newf(
-			pgcode.InvalidRegularExpression, "LIKE regexp compilation failed: %v", err)
+		return DBoolFalse, pgerror.Wrap(
+			err, pgcode.InvalidRegularExpression, "LIKE regexp compilation failed")
 	}
 
 	if like == nil {
@@ -3008,8 +3008,8 @@ func ConvertLikeToRegexp(
 	key := likeKey{s: pattern, caseInsensitive: caseInsensitive, escape: escape}
 	re, err := ctx.ReCache.GetRegexp(key)
 	if err != nil {
-		return nil, pgerror.Newf(
-			pgcode.InvalidRegularExpression, "LIKE regexp compilation failed: %v", err)
+		return nil, pgerror.Wrap(
+			err, pgcode.InvalidRegularExpression, "LIKE regexp compilation failed")
 	}
 	return re, nil
 }
@@ -3033,8 +3033,8 @@ func matchLike(ctx *EvalContext, left, right Datum, caseInsensitive bool) (Datum
 
 	like, err := optimizedLikeFunc(pattern, caseInsensitive, '\\')
 	if err != nil {
-		return DBoolFalse, pgerror.Newf(
-			pgcode.InvalidRegularExpression, "LIKE regexp compilation failed: %v", err)
+		return DBoolFalse, pgerror.Wrap(
+			err, pgcode.InvalidRegularExpression, "LIKE regexp compilation failed")
 	}
 
 	if like == nil {

--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -67,8 +67,8 @@ func (l *intervalLexer) consumeNum() (int64, bool, float64) {
 		// Try to convert.
 		value, err := strconv.ParseFloat(l.str[start:l.offset], 64)
 		if err != nil {
-			l.err = pgerror.Newf(
-				pgcode.InvalidDatetimeFormat, "interval: %v", err)
+			l.err = pgerror.Wrap(
+				err, pgcode.InvalidDatetimeFormat, "interval")
 			return 0, false, 0
 		}
 		decPart = value
@@ -108,8 +108,8 @@ func (l *intervalLexer) consumeInt() int64 {
 
 	x, err := strconv.ParseInt(l.str[start:l.offset], 10, 64)
 	if err != nil {
-		l.err = pgerror.Newf(
-			pgcode.InvalidDatetimeFormat, "interval: %v", err)
+		l.err = pgerror.Wrap(
+			err, pgcode.InvalidDatetimeFormat, "interval")
 		return 0
 	}
 	if start == l.offset {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -641,14 +641,12 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 			// empty, in which case the unmarshaling will be a no-op. This is
 			// innocuous.
 			if err := yaml.UnmarshalStrict([]byte(yamlConfig), &newZone); err != nil {
-				return pgerror.Newf(pgcode.CheckViolation,
-					"could not parse zone config: %v", err)
+				return pgerror.Wrap(err, pgcode.CheckViolation, "could not parse zone config")
 			}
 
 			// Load settings from YAML into the partial zone as well.
 			if err := yaml.UnmarshalStrict([]byte(yamlConfig), &finalZone); err != nil {
-				return pgerror.Newf(pgcode.CheckViolation,
-					"could not parse zone config: %v", err)
+				return pgerror.Wrap(err, pgcode.CheckViolation, "could not parse zone config")
 			}
 
 			// Load settings from var = val assignments. If there were no such
@@ -739,8 +737,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 
 			// Finally revalidate everything. Validate only the completeZone config.
 			if err := completeZone.Validate(); err != nil {
-				return pgerror.Newf(pgcode.CheckViolation,
-					"could not validate zone config: %v", err)
+				return pgerror.Wrap(err, pgcode.CheckViolation, "could not validate zone config")
 			}
 
 			// Finally check for the extra protection partial zone configs would
@@ -1064,8 +1061,7 @@ func prepareZoneConfigWrites(
 	}
 	buf, err := protoutil.Marshal(zone)
 	if err != nil {
-		return nil, pgerror.Newf(pgcode.CheckViolation,
-			"could not marshal zone config: %v", err)
+		return nil, pgerror.Wrap(err, pgcode.CheckViolation, "could not marshal zone config")
 	}
 	return &zoneConfigUpdate{id: targetID, value: buf}, nil
 }

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -217,11 +217,7 @@ func NewDependentObjectErrorf(format string, args ...interface{}) error {
 
 // NewRangeUnavailableError creates an unavailable range error.
 func NewRangeUnavailableError(rangeID roachpb.RangeID, origErr error) error {
-	// TODO(knz): This could should really use errors.Wrap or
-	// errors.WithSecondaryError.
-	return pgerror.Newf(pgcode.RangeUnavailable,
-		"key range id:%d is unavailable. Original error: %v",
-		rangeID, origErr)
+	return pgerror.Wrapf(origErr, pgcode.RangeUnavailable, "key range id:%d is unavailable", rangeID)
 }
 
 // NewWindowInAggError creates an error for the case when a window function is

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -12,7 +12,6 @@ package sslocal
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // New returns an instance of SQLStats.
@@ -185,7 +185,7 @@ func (s *SQLStats) IterateAggregatedTransactionStats(
 
 		err := statsContainer.IterateAggregatedTransactionStats(ctx, options, visitor)
 		if err != nil {
-			return fmt.Errorf("sql stats iteration abort: %s", err)
+			return errors.Wrap(err, "sql stats iteration abort")
 		}
 	}
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -167,7 +167,7 @@ func (s *Container) IterateAggregatedTransactionStats(
 
 	err := visitor(s.appName, &txnStat)
 	if err != nil {
-		return fmt.Errorf("sql stats iteration abort: %s", err)
+		return errors.Wrap(err, "sql stats iteration abort")
 	}
 
 	return nil

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -582,7 +582,7 @@ WHERE
 						return errors.New("expected error, found none")
 					}
 					if !testutils.IsError(err, "invalid input value for enum") {
-						return errors.Newf("expected invalid input for enum error, found %v", err)
+						return errors.NewAssertionErrorWithWrappedErrf(err, "expected invalid input for enum error")
 					}
 					return nil
 				})


### PR DESCRIPTION
refs #42510

I'm working on a linter that detects errors that are not wrapped
correctly, and it discovered these.

Release note: None