### PR TITLE
server,cli: fix improperly wrapped errors

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -94,7 +94,7 @@ func NewSizeSpec(
 		size.Percent, err = strconv.ParseFloat(factorValue, 64)
 		size.Percent *= percentFactor
 		if err != nil {
-			return SizeSpec{}, errors.Newf("could not parse %s size (%s) %s", field, value, err)
+			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
 		}
 		if percentRange != nil {
 			if (percentRange.min != nil && size.Percent < *percentRange.min) ||
@@ -112,7 +112,7 @@ func NewSizeSpec(
 		var err error
 		size.InBytes, err = humanizeutil.ParseBytes(value)
 		if err != nil {
-			return SizeSpec{}, errors.Newf("could not parse %s size (%s) %s", field, value, err)
+			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
 		}
 		if bytesRange != nil {
 			if bytesRange.min != nil && size.InBytes < *bytesRange.min {

--- a/pkg/base/store_spec_test.go
+++ b/pkg/base/store_spec_test.go
@@ -123,7 +123,7 @@ target_file_size=2097152`
 		{"path=/mnt/hda1,size=.009999", "store size (.009999) must be between 1.000000% and 100.000000%", StoreSpec{}},
 		// errors
 		{"path=/mnt/hda1,size=0", "store size (0) must be larger than 640 MiB", StoreSpec{}},
-		{"path=/mnt/hda1,size=abc", "could not parse store size (abc) strconv.ParseFloat: parsing \"\": invalid syntax", StoreSpec{}},
+		{"path=/mnt/hda1,size=abc", "could not parse store size (abc): strconv.ParseFloat: parsing \"\": invalid syntax", StoreSpec{}},
 		{"path=/mnt/hda1,size=", "no value specified for size", StoreSpec{}},
 		{"size=20GiB,path=/mnt/hda1,size=20GiB", "size field was used twice in store definition", StoreSpec{}},
 		{"size=123TB", "no path specified", StoreSpec{}},

--- a/pkg/cli/clisqlclient/conn_test.go
+++ b/pkg/cli/clisqlclient/conn_test.go
@@ -64,12 +64,12 @@ func TestConnRecover(t *testing.T) {
 	// and starts delivering ErrBadConn. We don't know the timing of
 	// this however.
 	testutils.SucceedsSoon(t, func() error {
-		if sqlRows, err := conn.Query(`SELECT 1`, nil); !errors.Is(err, driver.ErrBadConn) {
-			return errors.Newf("expected ErrBadConn, got %v", err)
-		} else if err == nil {
+		if sqlRows, err := conn.Query(`SELECT 1`, nil); err == nil {
 			if closeErr := sqlRows.Close(); closeErr != nil {
 				t.Fatal(closeErr)
 			}
+		} else if !errors.Is(err, driver.ErrBadConn) {
+			return errors.Newf("expected ErrBadConn, got %v", err)
 		}
 		return nil
 	})

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -682,7 +682,7 @@ func (c *cliState) execSyscmd(command string) (string, error) {
 	cmd.Stderr = c.iCtx.stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("error in external command: %s", err)
+		return "", errors.Wrap(err, "error in external command")
 	}
 
 	return out.String(), nil

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -449,7 +449,7 @@ func (n *Node) start(
 	// gossip can bootstrap using the most recently persisted set of
 	// node addresses.
 	if err := n.storeCfg.Gossip.SetStorage(n.stores); err != nil {
-		return fmt.Errorf("failed to initialize the gossip interface: %s", err)
+		return errors.Wrap(err, "failed to initialize the gossip interface")
 	}
 
 	// Initialize remaining stores/engines, if any.


### PR DESCRIPTION
refs #42510

I'm working on a linter that detects errors that are not wrapped
correctly, and it discovered these.

Release note: None