### PR TITLE
*: fix improperly wrapped errors

### DIFF
--- a/pkg/cmd/cmpconn/conn.go
+++ b/pkg/cmd/cmpconn/conn.go
@@ -249,7 +249,7 @@ ReadRows:
 				first = vals
 			} else {
 				if err := CompareVals(first, vals); err != nil {
-					return false, fmt.Errorf("compare %s to %s:\n%v", firstName, name, err)
+					return false, errors.Wrapf(err, "compare %s to %s", firstName, name)
 				}
 			}
 		}

--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -58,7 +58,7 @@ func GenerateRRJar(jar string, bnf []byte) ([]byte, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("%s: %s", err, out)
+		return nil, fmt.Errorf("%w: %s", err, out)
 	}
 	return out, nil
 }

--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -79,7 +79,7 @@ func run() error {
 	{
 		fi, err := os.Stat(pkg)
 		if err != nil {
-			return fmt.Errorf("the pkg flag %q is not a directory relative to the current working directory: %v", pkg, err)
+			return errors.Wrapf(err, "the pkg flag %q is not a directory relative to the current working directory", pkg)
 		}
 		if !fi.Mode().IsDir() {
 			return fmt.Errorf("the pkg flag %q is not a directory relative to the current working directory", pkg)
@@ -88,7 +88,7 @@ func run() error {
 		// Verify that the test binary exists.
 		fi, err = os.Stat(localTestBin)
 		if err != nil {
-			return fmt.Errorf("test binary %q does not exist: %v", localTestBin, err)
+			return errors.Wrapf(err, "test binary %q does not exist", localTestBin)
 		}
 		if !fi.Mode().IsRegular() {
 			return fmt.Errorf("test binary %q is not a file", localTestBin)
@@ -113,19 +113,19 @@ func run() error {
 	}
 	if *flagFailure != "" {
 		if _, err := regexp.Compile(*flagFailure); err != nil {
-			return fmt.Errorf("bad failure regexp: %s", err)
+			return errors.Wrap(err, "bad failure regexp")
 		}
 	}
 	if *flagIgnore != "" {
 		if _, err := regexp.Compile(*flagIgnore); err != nil {
-			return fmt.Errorf("bad ignore regexp: %s", err)
+			return errors.Wrap(err, "bad ignore regexp")
 		}
 	}
 
 	cmd := exec.Command("roachprod", "status", cluster)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v\n%s", err, out)
+		return errors.Wrapf(err, "%s", out)
 	}
 	nodes := strings.Count(string(out), "\n") - 1
 
@@ -160,15 +160,15 @@ func run() error {
 		tmpPath := "testdata" + strconv.Itoa(rand.Int())
 		cmd = exec.Command("roachprod", "run", cluster, "--", "rm", "-rf", testdataPath)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("failed to remove old testdata: %v:\n%s", err, output)
+			return errors.Wrapf(err, "failed to remove old testdata:\n%s", output)
 		}
 		cmd = exec.Command("roachprod", "put", cluster, testdataPath, tmpPath)
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to copy testdata: %v", err)
+			return errors.Wrap(err, "failed to copy testdata")
 		}
 		cmd = exec.Command("roachprod", "run", cluster, "mv", tmpPath, testdataPath)
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to move testdata: %v", err)
+			return errors.Wrap(err, "failed to move testdata")
 		}
 	}
 	testBin := filepath.Join(pkg, localTestBin)
@@ -310,7 +310,7 @@ func run() error {
 				}
 				return err
 			default:
-				return fmt.Errorf("unexpected context error: %v", err)
+				return errors.Wrap(err, "unexpected context error")
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
 )
 
 // This file contains common elements for all 3rd party test suite roachtests.
@@ -131,7 +132,7 @@ func repeatRunE(
 		}
 		return nil
 	}
-	return fmt.Errorf("all attempts failed for %s due to error: %s", operation, lastError)
+	return errors.Wrapf(lastError, "all attempts failed for %s", operation)
 }
 
 // repeatRunWithBuffer is the same function as c.RunWithBuffer but with an
@@ -164,7 +165,7 @@ func repeatRunWithBuffer(
 		}
 		return lastResult, nil
 	}
-	return nil, fmt.Errorf("all attempts failed for %s, with error: %s\n%s", operation, lastError, lastResult)
+	return nil, errors.Wrapf(lastError, "all attempts failed for %s\n%s", operation, lastResult)
 }
 
 // repeatGitCloneE is the same function as c.GitCloneE but with an automatic
@@ -193,7 +194,7 @@ func repeatGitCloneE(
 		}
 		return nil
 	}
-	return fmt.Errorf("could not clone %s due to error: %s", src, lastError)
+	return errors.Wrapf(lastError, "could not clone %s", src)
 }
 
 // repeatGetLatestTag fetches the latest (sorted) tag from a github repo.
@@ -290,7 +291,7 @@ func repeatGetLatestTag(
 
 		return releaseTags[len(releaseTags)-1].tag, nil
 	}
-	return "", fmt.Errorf("could not get tags from %s, due to error: %s", url, lastError)
+	return "", errors.Wrapf(lastError, "could not get tags from %s", url)
 }
 
 // gitCloneWithRecurseSubmodules clones a git repo from src into dest and checks out origin's

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -151,7 +151,7 @@ func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) er
 		}
 		log.Printf("%s %s", cmd.Env, cmd.Args)
 		if out, err := params.execFn(cmd); err != nil {
-			return errors.Newf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
+			return errors.Wrapf(err, "%s %s:\n\n%s", cmd.Env, cmd.Args, out)
 		}
 	}
 	if strings.Contains(b.BuildType, "linux") {
@@ -163,7 +163,7 @@ func MakeRelease(b SupportedTarget, pkgDir string, opts ...MakeReleaseOption) er
 		cmd.Stderr = os.Stderr
 		log.Printf("%s %s", cmd.Env, cmd.Args)
 		if out, err := params.execFn(cmd); err != nil {
-			return errors.Newf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
+			return errors.Wrapf(err, "%s %s:\n\n%s", cmd.Env, cmd.Args, out)
 		}
 
 		cmd = exec.Command("ldd", binaryName)

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1301,8 +1301,7 @@ func (c *SyncedCluster) Logs(
 		var errBuf bytes.Buffer
 		cmd.Stderr = &errBuf
 		if err := cmd.Run(); err != nil && ctx.Err() == nil {
-			return fmt.Errorf("failed to run cockroach debug merge-logs:%v\n%v",
-				err, errBuf.String())
+			return errors.Wrapf(err, "failed to run cockroach debug merge-logs:\n%v", errBuf.String())
 		}
 		return nil
 	}

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -375,7 +375,7 @@ func ExpandZonesFlag(zoneFlag []string) (zones []string, err error) {
 		}
 		n, err := strconv.Atoi(zone[colonIdx+1:])
 		if err != nil {
-			return zones, fmt.Errorf("failed to parse %q: %v", zone, err)
+			return zones, errors.Wrapf(err, "failed to parse %q", zone)
 		}
 		for i := 0; i < n; i++ {
 			zones = append(zones, zone[:colonIdx])

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1307,13 +1307,13 @@ func grpcRunKeepaliveTestCase(testCtx context.Context, c grpcKeepaliveTestCase) 
 	}
 	if c.expClose {
 		if sendErr == nil || !grpcutil.IsClosedConnection(sendErr) {
-			newErr := fmt.Errorf("expected closed connection, found %v", sendErr)
+			newErr := errors.Newf("expected closed connection, found %v", sendErr)
 			log.Infof(ctx, "%+v", newErr)
 			return newErr
 		}
 	} else {
 		if sendErr != nil {
-			newErr := fmt.Errorf("expected unclosed connection, found %v", sendErr)
+			newErr := errors.Newf("expected unclosed connection, found %v", sendErr)
 			log.Infof(ctx, "%+v", newErr)
 			return newErr
 		}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -588,6 +588,7 @@ go_test(
         "//pkg/sql/opt/exec/explain",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/sql/physicalplan",
         "//pkg/sql/querycache",

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -582,7 +583,7 @@ WHERE
 						return errors.New("expected error, found none")
 					}
 					if !testutils.IsError(err, "invalid input value for enum") {
-						return errors.NewAssertionErrorWithWrappedErrf(err, "expected invalid input for enum error")
+						return errors.Newf("expected invalid input for enum error, found %s", pgerror.FullError(err))
 					}
 					return nil
 				})

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/lexbase",
         "//pkg/sql/parser",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/util/fileutil",

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -105,7 +106,7 @@ func (sr *SQLRunner) ExpectErr(t testutils.TB, errRE string, query string, args 
 	t.Helper()
 	_, err := sr.DB.ExecContext(context.Background(), query, args...)
 	if !testutils.IsError(err, errRE) {
-		t.Fatalf("expected error '%s', got: %v", errRE, err)
+		t.Fatalf("expected error '%s', got: %s", errRE, pgerror.FullError(err))
 	}
 }
 
@@ -117,7 +118,7 @@ func (sr *SQLRunner) ExpectErrSucceedsSoon(
 	sr.succeedsWithin(t, func() error {
 		_, err := sr.DB.ExecContext(context.Background(), query, args...)
 		if !testutils.IsError(err, errRE) {
-			return errors.Newf("expected error '%s', got: %v", errRE, err)
+			return errors.Newf("expected error '%s', got: %s", errRE, pgerror.FullError(err))
 		}
 		return nil
 	})

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -98,7 +98,7 @@ func (w *tpccChecks) Ops(
 ) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.flags.Lookup("db").Value.String(), urls)
 	if err != nil {
-		return workload.QueryLoad{}, fmt.Errorf("%v", err)
+		return workload.QueryLoad{}, errors.Wrapf(err, "could not sanitize urls %v", urls)
 	}
 	dbs := make([]*gosql.DB, len(urls))
 	for i, url := range urls {


### PR DESCRIPTION
refs #42510

I'm working on a linter that detects errors that are not wrapped
correctly, and it discovered these.

Release note: None