### PR TITLE
ccl/server/sql: Fix failing reset index usage unit test

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -762,6 +762,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	)
 
 	distSQLServer.ServerConfig.SQLStatsController = pgServer.SQLServer.GetSQLStatsController()
+	distSQLServer.ServerConfig.IndexUsageStatsController = pgServer.SQLServer.GetIndexUsageStatsController()
 
 	// Now that we have a pgwire.Server (which has a sql.Server), we can close a
 	// circular dependency between the rowexec.Server and sql.Server and set

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -741,6 +741,9 @@ func (t *tenantStatusServer) IndexUsageStatistics(
 		return nil, err
 	}
 
+	// Append last reset time.
+	resp.LastReset = t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics().GetLastReset()
+
 	return resp, nil
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -461,6 +461,12 @@ func (s *Server) GetSQLStatsController() *persistedsqlstats.Controller {
 	return s.sqlStatsController
 }
 
+// GetIndexUsageStatsController returns the idxusage.Controller for current
+// sql.Server's index usage stats.
+func (s *Server) GetIndexUsageStatsController() *idxusage.Controller {
+	return s.indexUsageStatsController
+}
+
 // GetSQLStatsProvider returns the provider for the sqlstats subsystem.
 func (s *Server) GetSQLStatsProvider() sqlstats.Provider {
 	return s.sqlStats

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -469,6 +469,35 @@ func TestExtractTimeSpanFromTimeTZ(t *testing.T) {
 	}
 }
 
+// TestResetIndexUsageStatsOnRemoteSQLNode asserts that the built-in for
+// resetting index usage statistics works when it's being set up on a remote
+// node via DistSQL.
+func TestResetIndexUsageStatsOnRemoteSQLNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	testCluster := serverutils.StartNewTestCluster(t, 3 /* numNodes */, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{},
+	})
+	defer testCluster.Stopper().Stop(ctx)
+	testConn := testCluster.ServerConn(2 /* idx */)
+	sqlDB := sqlutils.MakeSQLRunner(testConn)
+
+	query := `
+CREATE TABLE t (k INT PRIMARY KEY);
+INSERT INTO t SELECT generate_series(1, 30);
+
+ALTER TABLE t SPLIT AT VALUES (10), (20);
+ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;
+ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 2, 15;
+ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 3, 25;
+
+SELECT count(*) FROM t WHERE crdb_internal.reset_index_usage_stats();
+`
+
+	sqlDB.Exec(t, query)
+}
+
 func TestExtractTimeSpanFromInterval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Resolves #72254

Previously, the unit test for resetting index usage statistics was
failing. This was happening because of two reasons:
1. The IndexUsageStatsController was not being set properly for DistSQL
server configs.
2. Noise from other tests was sometimes populating the index usage
statistics table right after it was reset, causing the check for a newly
reset table to sometimes randomly fail.

To fix these issues, we have implemented the following:
1. Created a test case to reproduce the first error, and correctly
populated IndexUsageStatsController for DistSQL server configs.
2. Updated the unit test to query for the specific test table id, to
avoid other tables polluting the test space. The test has also been
updated to check for a correct LastReset time.

Release note: none