### PR TITLE
release-21.2: sql: provide more helpful error message when creating the wrong type …

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -423,6 +423,17 @@ func replaceExpressionElemsWithVirtualCols(
 			}
 
 			if !isInverted && !colinfo.ColumnTypeIsIndexable(typ) {
+				if colinfo.ColumnTypeIsInvertedIndexable(typ) {
+					return errors.WithHint(
+						pgerror.Newf(
+							pgcode.InvalidTableDefinition,
+							"index element %s of type %s is not indexable in a non-inverted index",
+							elem.Expr.String(),
+							typ.Name(),
+						),
+						"you may want to create an inverted index instead. See the documentation for inverted indexes: "+docs.URL("inverted-indexes.html"),
+					)
+				}
 				return pgerror.Newf(
 					pgcode.InvalidTableDefinition,
 					"index element %s of type %s is not indexable",

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1468,3 +1468,6 @@ SELECT j FROM cb2@i WHERE j <@ '[[1], [2]]' ORDER BY k
 []
 [[2]]
 [[1], [2]]
+
+statement error pq: index element j->'some_key' of type jsonb is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+CREATE TABLE t2 (j JSON, INDEX ((j->'some_key')))


### PR DESCRIPTION
Backport 1/1 commits from #69824.

/cc @cockroachdb/release

---

…of index

Previously, when a user attempts to create a forward index on a datatype that
does not support forward indexes, the error message is not very clear:

```
defaultdb> CREATE TABLE t (j JSON, INDEX ((j->'some_key')));
ERROR: index element j->'some_key' of type jsonb is not indexable
SQLSTATE: 42P16
```

To be more helpful, the error message could mention that an inverted index can
be created instead and include a hint to the docs.

The existing error message was not helpful and caused confusion to users.

This fixes #69589 

Release justification: Low risk fix.

Release note (sql change): The error message when creating the wrong type of index
was not clear and it is now more helpful.
