### PR TITLE
pkg/storage: enable read compactions on cockroach

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -351,13 +351,6 @@ func DefaultPebbleOptions() *pebble.Options {
 	// SSDs, that kick off an expensive GC if a lot of files are deleted at
 	// once.
 	opts.Experimental.MinDeletionRate = 128 << 20 // 128 MB
-	// Disable read sampling and by extension read-triggered compactions. Read-
-	// triggered compactions are known to cause excessively high write
-	// amplification on some read heavy workloads. See:
-	// https://github.com/cockroachdb/pebble/issues/1143
-	//
-	// TODO(bilal): Remove this line when the above issue is addressed.
-	opts.Experimental.ReadSamplingMultiplier = -1
 	// Validate min/max keys in each SSTable when performing a compaction. This
 	// serves as a simple protection against corruption or programmer-error in
 	// Pebble.


### PR DESCRIPTION
We disabled these, because they were causing high w-amp.
With the fixes in https://github.com/cockroachdb/pebble/pull/1200,
it is okay to reenable read compactions on cockroach.

Release note: None