### PR TITLE
sql: destroy_tenant queues gc job

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7127,11 +7127,9 @@ func TestBackupRestoreTenant(t *testing.T) {
 			[][]string{{`10`, `false`, `{"id": "10", "state": "DROP"}`}},
 		)
 
-		// Make GC jobs run in 1 second.
+		// Make GC job scheduled by destroy_tenant run in 1 second.
 		restoreDB.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue_enabled = false")
 		restoreDB.Exec(t, "ALTER RANGE tenants CONFIGURE ZONE USING gc.ttlseconds = 1;")
-		// Now run the GC job to delete the tenant and its data.
-		restoreDB.Exec(t, `SELECT crdb_internal.gc_tenant(10)`)
 		// Wait for tenant GC job to complete.
 		restoreDB.CheckQueryResultsRetry(
 			t,
@@ -7163,7 +7161,6 @@ func TestBackupRestoreTenant(t *testing.T) {
 		restoreTenant10.CheckQueryResults(t, `select * from foo.bar2`, tenant10.QueryStr(t, `select * from foo.bar2`))
 
 		restoreDB.Exec(t, `SELECT crdb_internal.destroy_tenant(10)`)
-		restoreDB.Exec(t, `SELECT crdb_internal.gc_tenant(10)`)
 		// Wait for tenant GC job to complete.
 		restoreDB.CheckQueryResultsRetry(
 			t,

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
@@ -15,7 +15,8 @@ SELECT crdb_internal.update_tenant_resource_limits(5, 1000, 100, 0, now(), 0)
 
 # TODO(radu): inspect internal tenant_usage state.
 
-# Note this just marks the tenant as dropped but does not call GC.
+# Note this marks the tenant as dropped. The GC will not delete the tenant
+# until after the ttl expires.
 query I
 SELECT crdb_internal.destroy_tenant(5)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -46,18 +46,9 @@ id  active  crdb_internal.pb_to_json
 5   false   {"id": "5", "state": "DROP"}
 10  true    {"id": "10", "state": "ACTIVE"}
 
+
 # Try to recreate an existing tenant.
-
-query error pgcode 42710 tenant "5" already exists
-SELECT crdb_internal.create_tenant(5)
-
-query I
-SELECT crdb_internal.gc_tenant(5)
-----
-5
-
-# GC job has not run yet.
-
+# GC job for tenant 5 has not run yet.
 query error pgcode 42710 tenant "5" already exists
 SELECT crdb_internal.create_tenant(5)
 
@@ -142,7 +133,7 @@ SELECT status FROM [
 succeeded
 
 query error pgcode 42704 tenant "5" does not exist
-SELECT crdb_internal.gc_tenant(5)
+SELECT crdb_internal.destroy_tenant(5)
 
 query IBT colnames
 SELECT id, active, crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4566,12 +4566,6 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return args[0], nil
 			},
-			// TODO(spaskob): this built-in currently does not actually delete the
-			// data but just marks it as DROP. This is for done for safety in case we
-			// would like to restore the tenant later. If data in needs to be removed
-			// use gc_tenant built-in.
-			// We should just add a new built-in called `drop_tenant` instead and use
-			// this one to really destroy the tenant.
 			Info:       "Destroys a tenant with the provided ID. Must be run by the System tenant.",
 			Volatility: tree.VolatilityVolatile,
 		},
@@ -5663,6 +5657,8 @@ value if you rely on the HLC for accuracy.`,
 	),
 
 	"crdb_internal.gc_tenant": makeBuiltin(
+		// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
+		// changes are deployed to all Cockroach Cloud serverless hosts.
 		tree.FunctionProperties{
 			Category:     categoryMultiTenancy,
 			Undocumented: true,

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -330,11 +330,6 @@ func clearTenant(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Tena
 }
 
 // DestroyTenant implements the tree.TenantOperator interface.
-// TODO(spaskob): this function currently does not actually delete the data but
-// just marks it as DROP. This is for done for safety in case we would like to
-// restore the tenant later.
-// We should just add a new function DropTenant to the interface and convert
-// this one to really remove the tenant and its data.
 func (p *planner) DestroyTenant(ctx context.Context, tenID uint64) error {
 	const op = "destroy"
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
@@ -356,7 +351,11 @@ func (p *planner) DestroyTenant(ctx context.Context, tenID uint64) error {
 
 	// Mark the tenant as dropping.
 	info.State = descpb.TenantInfo_DROP
-	return errors.Wrap(updateTenantRecord(ctx, p.execCfg, p.txn, info), "destroying tenant")
+	if err := updateTenantRecord(ctx, p.execCfg, p.txn, info); err != nil {
+		return errors.Wrap(err, "destroying tenant")
+	}
+
+	return errors.Wrap(gcTenantJob(ctx, p.execCfg, p.txn, p.User(), tenID), "scheduling gc job")
 }
 
 // GCTenantSync clears the tenant's data and removes its record.
@@ -394,8 +393,8 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Ten
 	return errors.Wrapf(err, "deleting tenant %d record", info.ID)
 }
 
-// GCTenantJob clears the tenant's data and removes its record using a GC job.
-func GCTenantJob(
+// gcTenantJob clears the tenant's data and removes its record using a GC job.
+func gcTenantJob(
 	ctx context.Context,
 	execCfg *ExecutorConfig,
 	txn *kv.Txn,
@@ -425,6 +424,8 @@ func GCTenantJob(
 
 // GCTenant implements the tree.TenantOperator interface.
 func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
+	// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
+	// changes are deployed to all Cockroach Cloud serverless hosts.
 	if !p.ExtendedEvalContext().TxnImplicit {
 		return errors.Errorf("gc_tenant cannot be used inside a transaction")
 	}
@@ -442,7 +443,7 @@ func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
 		return errors.Errorf("tenant %d is not in state DROP", info.ID)
 	}
 
-	return GCTenantJob(ctx, p.ExecCfg(), p.Txn(), p.User(), tenID)
+	return gcTenantJob(ctx, p.ExecCfg(), p.Txn(), p.User(), tenID)
 }
 
 // UpdateTenantResourceLimits implements the tree.TenantOperator interface.


### PR DESCRIPTION
Previously, destory_tenant marked the tenant as inactive. A seperate
call to gc_tenant was required to trigger the deletion. Now, the
gc is scheduled by the destroy_tenant command. The gc_tenant command
will be deleted once this change is live in the Cockroach Cloud
Serverless clusters and all inactive tenants are deleted.

Release note: None