### PR TITLE
release-21.1: backupccl: fix bug when restoring a table with existing UDT

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8268,3 +8268,26 @@ DROP INDEX foo@bar;
 
 	sqlRunner.Exec(t, `BACKUP INTO LATEST IN 'nodelocal://0/foo' WITH revision_history`)
 }
+
+// TestRestoreRemappingOfExistingUDTInColExpr is a regression test for a nil
+// pointer exception when restoring tables that point to existing types. When
+// updating the back references of the existing types we would index into a map
+// keyed on pre-rewrite IDs using a post rewrite ID.
+func TestRestoreRemappingOfExistingUDTInColExpr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+CREATE TABLE foo (id INT PRIMARY KEY, what status default 'open');
+BACKUP DATABASE data to 'nodelocal://0/foo';
+DROP TABLE foo CASCADE;
+DROP TYPE status;
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+RESTORE TABLE foo FROM 'nodelocal://0/foo';
+`)
+}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1148,8 +1148,21 @@ func createImportingDescriptors(
 		}
 	}
 
-	// Assign new IDs to all of the type descriptors that need to be written.
-	if err := rewriteTypeDescs(typesToWrite, details.DescriptorRewrites); err != nil {
+	// Perform rewrites on ALL type descriptors that are present in the rewrite
+	// mapping.
+	//
+	// `types` contains a mix of existing type descriptors in the restoring
+	// cluster, and new type descriptors we will write from the backup.
+	//
+	// New type descriptors need to be rewritten with their generated IDs before
+	// they are written out to disk.
+	//
+	// Existing type descriptors need to be rewritten to the type ID of the type
+	// they are referring to in the restoring cluster. This ID is different from
+	// the ID the descriptor had when it was backed up. Changes to existing type
+	// descriptors will not be written to disk, and is only for accurate,
+	// in-memory resolution hereon out.
+	if err := rewriteTypeDescs(types, details.DescriptorRewrites); err != nil {
 		return nil, nil, err
 	}
 
@@ -1323,7 +1336,11 @@ func createImportingDescriptors(
 						return err
 					}
 					typeIDs, err := table.GetAllReferencedTypeIDs(dbDesc, func(id descpb.ID) (catalog.TypeDescriptor, error) {
-						return typesByID[id], nil
+						t, ok := typesByID[id]
+						if !ok {
+							return nil, errors.AssertionFailedf("type with id %d was not found in rewritten type mapping", id)
+						}
+						return t, nil
 					})
 					if err != nil {
 						return err


### PR DESCRIPTION
Backport 1/1 commits from #71421.

/cc @cockroachdb/release

---

Backport 1/1 commits from #71161.

/cc @cockroachdb/release

---

This change fixes a nil pointer exception, when restoring tables that
point to existing types. Particularly tables that have column expressions
(computed, default etc) that reference the UDT.

When updating the backreferences of the existing types in
the restoring cluster, we would index into a map keyed on pre-rewrite
IDs using a post rewrite ID. This change fixes the map to be
keyed on post rewrite IDs.

Informs: #71145

Release note (bug fix): bug fix when restoring a table that references a UDT that is already present in the restoring cluster

