### PR TITLE
Makefile: add proto & log dependencies to roachvet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1764,7 +1764,7 @@ logictest-bins := bin/logictest bin/logictestopt bin/logictestccl
 # Additional dependencies for binaries that depend on generated code.
 #
 # TODO(benesch): Derive this automatically. This is getting out of hand.
-bin/workload bin/docgen bin/execgen bin/roachtest $(logictest-bins): $(SQLPARSER_TARGETS) $(LOG_TARGETS) $(PROTOBUF_TARGETS)
+bin/workload bin/docgen bin/execgen bin/roachtest bin/roachvet $(logictest-bins): $(SQLPARSER_TARGETS) $(LOG_TARGETS) $(PROTOBUF_TARGETS)
 bin/workload bin/docgen bin/roachtest $(logictest-bins): $(LIBPROJ) $(CGO_FLAGS_FILES)
 bin/roachtest $(logictest-bins): $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(OPTGEN_TARGETS) | $(C_LIBS_DYNAMIC)
 


### PR DESCRIPTION
`bin/roachvet` depends on `pkg/testutils/lint/passes/fmtsafe` which
depends on `pkg/util/log/logpb` which requires that the protobufs are
compiled.

This could result in the following failure if you happened to run
`make lint` after pulling in a protobuf update (but before any other
target that would recompile the protos):

```
pkg/util/log/logpb/severity.go:19:10: undefined: Severity
pkg/util/log/logpb/severity.go:20:16: undefined: Severity
pkg/util/log/logpb/severity.go:29:15: undefined: Severity
pkg/util/log/logpb/severity.go:36:9: undefined: Severity
pkg/util/log/logpb/severity.go:36:46: undefined: Severity_UNKNOWN
pkg/util/log/logpb/severity.go:39:9: undefined: Severity
pkg/util/log/logpb/severity.go:42:10: undefined: Severity
pkg/util/log/logpb/severity.go:48:32: undefined: Severity
pkg/util/log/logpb/severity.go:63:10: undefined: Severity
pkg/util/log/logpb/severity.go:72:9: undefined: Severity
pkg/util/log/logpb/severity.go:36:46: too many errors
make: *** [Makefile:1788: bin/roachvet] Error 2
make: *** Waiting for unfinished jobs....
```

Release note: None