### PR TITLE
roachprod: avoid flaky test due to unused functions

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
-	// cld "github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -94,6 +93,7 @@ var (
 	quiet             = false
 	sig               = 9
 	waitFlag          = false
+	createVMOpts      = vm.DefaultCreateOpts()
 	startOpts         = install.StartOptsType{}
 	stageOS           string
 	stageDir          string
@@ -133,8 +133,6 @@ func wrap(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Comma
 		}
 	}
 }
-
-var createVMOpts vm.CreateOpts
 
 var createCmd = &cobra.Command{
 	Use:   "create <cluster>",

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -124,7 +124,6 @@ func verifyClusterName(clusterName, username string) (string, error) {
 }
 
 // DefaultSyncedCluster returns install.SyncedCluster with default values.
-//lint:ignore U1001 unused
 func DefaultSyncedCluster() install.SyncedCluster {
 	return install.SyncedCluster{
 		Name:        "",
@@ -142,6 +141,8 @@ func DefaultSyncedCluster() install.SyncedCluster {
 		MaxConcurrency: 32,
 	}
 }
+
+var _ = DefaultSyncedCluster()
 
 func sortedClusters() []string {
 	var r []string

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -154,7 +154,6 @@ type CreateOpts struct {
 }
 
 // DefaultCreateOpts returns a new vm.CreateOpts with default values set.
-//lint:ignore U1001 unused
 func DefaultCreateOpts() CreateOpts {
 	defaultCreateOpts := CreateOpts{
 		ClusterName:    "",


### PR DESCRIPTION
Merging #71660 trigerred a flaky test due to unused functions.

This patch avoids that test by making use of / commenting out unused functions.

Release note: None