### PR TITLE
kvserver: simplify testContext

### DIFF
--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -857,20 +856,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	dir, cleanup := testutils.TempDir(t)
-	defer cleanup()
-
-	eng, err := storage.Open(ctx,
-		storage.Filesystem(dir),
-		storage.CacheSize(1<<20 /* 1 MiB */))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer eng.Close()
-
-	tc := testContext{
-		engine: eng,
-	}
+	tc := testContext{}
 	cfg := TestStoreConfig(nil)
 	cfg.TestingKnobs.DisableRaftLogQueue = true
 	stopper := stop.NewStopper()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -191,13 +191,12 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 		Settings:   cfg.Settings,
 	})
 	grpcServer := rpc.NewServer(rpcContext) // never started
-	if tc.gossip == nil {
-		tc.gossip = gossip.NewTest(1, rpcContext, grpcServer, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
-	}
-	if tc.transport == nil {
-		dialer := nodedialer.New(rpcContext, gossip.AddressResolver(tc.gossip))
-		tc.transport = NewRaftTransport(cfg.AmbientCtx, cfg.Settings, dialer, grpcServer, stopper)
-	}
+	require.Nil(t, tc.gossip)
+	tc.gossip = gossip.NewTest(1, rpcContext, grpcServer, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	require.Nil(t, tc.transport)
+	dialer := nodedialer.New(rpcContext, gossip.AddressResolver(tc.gossip))
+	tc.transport = NewRaftTransport(cfg.AmbientCtx, cfg.Settings, dialer, grpcServer, stopper)
+
 	if tc.engine == nil {
 		disableSeparatedIntents :=
 			!cfg.Settings.Version.ActiveVersionOrEmpty(context.Background()).IsActive(

--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -20,33 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/kr/pretty"
 )
-
-// initialStats are the stats for a Replica which has been created through
-// bootstrapRangeOnly. These stats are not empty because we call
-// writeInitialState().
-func initialStats() enginepb.MVCCStats {
-	return enginepb.MVCCStats{
-		SysBytes: 66,
-		SysCount: 2,
-	}
-}
-func TestRangeStatsEmpty(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	tc := testContext{
-		bootstrapMode: bootstrapRangeOnly,
-	}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
-	tc.Start(t, stopper)
-
-	ms := tc.repl.GetMVCCStats()
-	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
-		t.Errorf("unexpected stats diff(exp, actual):\n%s", pretty.Diff(exp, ms))
-	}
-}
 
 func TestRangeStatsInit(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
See individual commits for details. I just spent some time cleaning up
`createTestStore` (#72383) and I noticed that `testContext` is much more
heavily used and has accumulated quite a bit of detritus.

I hope to ultimately make it use `createTestStore` but that will be for
another day.

----

- kvserver: remove two uses of bootstrapRangeOnly
- kvserver: remove TestReplicaLaziness
- kvserver: remove testContext.bootstrapMode
- kvserver: drop useless on-disk engine in a test
- kvserver: simplify testContext
- kvserver: fix up TestRaftSSTableSideloading
- kvserver: prevent pre-populating `testContext.eng`

Release note: None
