### PR TITLE
server: allow toleration of panics in HTTP handlers

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -164,7 +164,7 @@ func (a *apiV2Server) registerRoutes(innerMux *mux.Router, authMux http.Handler)
 		var handler http.Handler
 		handler = &callCountDecorator{
 			counter: telemetry.GetCounter(fmt.Sprintf("api.v2.%s", route.url)),
-			inner:   http.Handler(route.handler),
+			inner:   route.handler,
 		}
 		if route.requiresAuth {
 			a.mux.Handle(apiV2Path+route.url, authMux)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,6 +92,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -2722,9 +2723,6 @@ func (s *Server) Stop() {
 
 // ServeHTTP is necessary to implement the http.Handler interface.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// This is our base handler, so catch all panics and make sure they stick.
-	defer log.FatalOnPanic()
-
 	// Disable caching of responses.
 	w.Header().Set("Cache-control", "no-cache")
 
@@ -2750,6 +2748,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}()
 		w = gzw
 	}
+
+	// This is our base handler.
+	// Intercept all panics, log them, and return an internal server error as a response.
+	defer func() {
+		if p := recover(); p != nil {
+			// Note: use of a background context here so we can log even with the absence of a client.
+			// Assumes appropriate timeouts are used.
+			logcrash.ReportPanic(context.Background(), &s.st.SV, p, 1 /* depth */)
+			http.Error(w, errAPIInternalErrorString, http.StatusInternalServerError)
+		}
+	}()
+
 	s.mux.ServeHTTP(w, r)
 }
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -25,16 +25,6 @@ func init() {
 // Severity aliases a type.
 type Severity = logpb.Severity
 
-// FatalOnPanic recovers from a panic and exits the process with a
-// Fatal log. This is useful for avoiding a panic being caught through
-// a CGo exported function or preventing HTTP handlers from recovering
-// panics and ignoring them.
-func FatalOnPanic() {
-	if r := recover(); r != nil {
-		Fatalf(context.Background(), "unexpected panic: %s", r)
-	}
-}
-
 // V returns true if the logging verbosity is set to the specified level or
 // higher.
 //


### PR DESCRIPTION
Fixes #68638.

A panic in an HTTP request handler can cause a node to crash. Nodes should
be tolerant to such panics. This patch handles these panics by intercepting
them at the base HTTP handler. When they occur, they are logged and a 500
error response will be returned.

Release note (bug fix): servers no longer crash due to panics in HTTP handlers.