### PR TITLE
sqlproxy: add a hint to the error returned by the connection throttle

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy.go
+++ b/pkg/ccl/sqlproxyccl/proxy.go
@@ -60,7 +60,7 @@ func toPgError(err error) *pgproto3.ErrorResponse {
 			Severity: "FATAL",
 			Code:     pgCode,
 			Message:  msg,
-			Hint:     errors.FlattenHints(codeErr.err),
+			Hint:     errors.FlattenHints(err),
 		}
 	}
 	// Return a generic "internal server error" message.

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1000,7 +1000,7 @@ func newTester() *tester {
 	// Record successful connection and authentication.
 	originalAuthenticate := authenticate
 	te.restoreAuthenticate =
-		testutils.TestingHook(&authenticate, func(clientConn, crdbConn net.Conn, throttleHook func(status throttler.AttemptStatus) *pgproto3.ErrorResponse) error {
+		testutils.TestingHook(&authenticate, func(clientConn, crdbConn net.Conn, throttleHook func(status throttler.AttemptStatus) error) error {
 			err := originalAuthenticate(clientConn, crdbConn, throttleHook)
 			te.setAuthenticated(err == nil)
 			return err


### PR DESCRIPTION
The most common cause of connection throttling is a misconfigured
user or password. Providing a hint should make it clear to a user
what they need to do to fix it.

There was a bug in the toPgError handler that prevented it from handling
hints properly. It was taking hints from the internal code error instead
of the wrapping error.

Release note: None