### PR TITLE
catalog/descs: hydrate types for tuples

### DIFF
--- a/pkg/sql/catalog/descs/dist_sql_type_resolver.go
+++ b/pkg/sql/catalog/descs/dist_sql_type_resolver.go
@@ -131,18 +131,8 @@ func (dt DistSQLTypeResolver) GetTypeDescriptor(
 // HydrateTypeSlice installs metadata into a slice of types.T's.
 func (dt DistSQLTypeResolver) HydrateTypeSlice(ctx context.Context, typs []*types.T) error {
 	for _, t := range typs {
-		if t.UserDefined() {
-			id, err := typedesc.GetUserDefinedTypeDescID(t)
-			if err != nil {
-				return err
-			}
-			name, desc, err := dt.GetTypeDescriptor(ctx, id)
-			if err != nil {
-				return err
-			}
-			if err := desc.HydrateTypeInfoWithName(ctx, t, &name, dt); err != nil {
-				return err
-			}
+		if err := typedesc.EnsureTypeIsHydrated(ctx, t, dt); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -41,6 +41,8 @@ type TableImplicitRecordType struct {
 	privs *descpb.PrivilegeDescriptor
 }
 
+var _ catalog.TypeDescriptor = (*TableImplicitRecordType)(nil)
+
 // CreateImplicitRecordTypeFromTableDesc creates a TypeDescriptor that represents
 // the implicit record type for a table, which has 1 field for every visible
 // column in the table.
@@ -231,14 +233,7 @@ func (v TableImplicitRecordType) HydrateTypeInfoWithName(
 		Name:           name.Object(),
 	}
 	typ.TypeMeta.Version = uint32(v.desc.GetVersion())
-	for _, t := range typ.TupleContents() {
-		if t.UserDefined() {
-			if err := hydrateElementType(ctx, t, res); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return EnsureTypeIsHydrated(ctx, typ, res)
 }
 
 // MakeTypesT implements the TypeDescriptor interface.

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1600,3 +1600,19 @@ SELECT * FROM enum_table
 ----
 a
 c
+
+# Regression test for not hydrating an enum when it is used in a tuple.
+statement ok
+DROP TYPE IF EXISTS greeting;
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE seed AS SELECT g::INT8 AS _int8 FROM generate_series(1, 5) AS g;
+WITH
+  cte1 (col1)
+    AS (
+      SELECT * FROM (VALUES (COALESCE((NULL, 'hello':::greeting), (1, 'howdy':::greeting))), ((2, 'hi':::greeting)))
+    ),
+  cte2 (col2) AS (SELECT _int8 FROM seed)
+SELECT
+  col1, col2
+FROM
+  cte1, cte2;


### PR DESCRIPTION
Before we can use the user-defined types, we have to hydrate them. We do
so for enums as well as arrays of enums, but we forgot to do so for
tuples containing enums in some cases. This is now fixed.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error or crash when some queries involving tuples with ENUMs
were executed in a distributed manner. This is now fixed.