### PR TITLE
backupccl: allow using LATEST shorthand in RESTORE and SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -246,26 +246,11 @@ func resolveBackupCollection(
 	var chosenSuffix string
 	collectionURI := defaultURI
 	if appendToLatest {
-		collection, err := makeCloudStorage(ctx, collectionURI, user)
+		latest, err := readLatestFile(ctx, collectionURI, makeCloudStorage, user)
 		if err != nil {
 			return "", "", err
 		}
-		defer collection.Close()
-		latestFile, err := collection.ReadFile(ctx, latestFileName)
-		if err != nil {
-			if errors.Is(err, cloud.ErrFileDoesNotExist) {
-				return "", "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
-			}
-			return "", "", pgerror.WithCandidateCode(err, pgcode.Io)
-		}
-		latest, err := ioutil.ReadAll(latestFile)
-		if err != nil {
-			return "", "", err
-		}
-		if len(latest) == 0 {
-			return "", "", errors.Errorf("malformed LATEST file")
-		}
-		chosenSuffix = string(latest)
+		chosenSuffix = latest
 	} else if subdir != "" {
 		// User has specified a subdir via `BACKUP INTO 'subdir' IN...`.
 		chosenSuffix = strings.TrimPrefix(subdir, "/")
@@ -274,4 +259,32 @@ func resolveBackupCollection(
 		chosenSuffix = endTime.GoTime().Format(DateBasedIntoFolderName)
 	}
 	return collectionURI, chosenSuffix, nil
+}
+
+func readLatestFile(
+	ctx context.Context,
+	collectionURI string,
+	makeCloudStorage cloud.ExternalStorageFromURIFactory,
+	user security.SQLUsername,
+) (string, error) {
+	collection, err := makeCloudStorage(ctx, collectionURI, user)
+	if err != nil {
+		return "", err
+	}
+	defer collection.Close()
+	latestFile, err := collection.ReadFile(ctx, latestFileName)
+	if err != nil {
+		if errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
+		}
+		return "", pgerror.WithCandidateCode(err, pgcode.Io)
+	}
+	latest, err := ioutil.ReadAll(latestFile)
+	if err != nil {
+		return "", err
+	}
+	if len(latest) == 0 {
+		return "", errors.Errorf("malformed LATEST file")
+	}
+	return string(latest), nil
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -914,6 +914,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
+	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
+
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
 	// to the job description.
@@ -940,6 +943,10 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedCollectionURIs[0], resolvedCollectionURIs[1],
 				resolvedCollectionURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
+				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
+				resolvedSubdirURIs[2])},
+			// and again from LATEST IN...
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
 				resolvedSubdirURIs[2])},

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1524,19 +1524,6 @@ func restorePlanHook(
 				return err
 			}
 		}
-		if subdir != "" {
-			if len(from) != 1 {
-				return errors.Errorf("RESTORE FROM ... IN can only by used against a single collection path (per-locality)")
-			}
-			for i := range from[0] {
-				parsed, err := url.Parse(from[0][i])
-				if err != nil {
-					return err
-				}
-				parsed.Path = path.Join(parsed.Path, subdir)
-				from[0][i] = parsed.String()
-			}
-		}
 
 		if err := checkPrivilegesForRestore(ctx, restoreStmt, p, from); err != nil {
 			return err
@@ -1582,6 +1569,29 @@ func restorePlanHook(
 				return err
 			}
 		}
+
+		if subdir != "" {
+			if strings.EqualFold(subdir, "LATEST") {
+				// set subdir to content of latest file
+				latest, err := readLatestFile(ctx, from[0][0], p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, p.User())
+				if err != nil {
+					return err
+				}
+				subdir = latest
+			}
+			if len(from) != 1 {
+				return errors.Errorf("RESTORE FROM ... IN can only by used against a single collection path (per-locality)")
+			}
+			for i := range from[0] {
+				parsed, err := url.Parse(from[0][i])
+				if err != nil {
+					return err
+				}
+				parsed.Path = path.Join(parsed.Path, subdir)
+				from[0][i] = parsed.String()
+			}
+		}
+
 		return doRestorePlan(ctx, restoreStmt, p, from, passphrase, kms, intoDB, newDBName, endTime,
 			resultsCh)
 	}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -217,29 +217,41 @@ func showBackupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		str, err := toFn()
+		dest, err := toFn()
 		if err != nil {
 			return err
 		}
 
+		var subdir string
+
 		if inColFn != nil {
-			collection, err := inColFn()
+			subdir = dest
+			dest, err = inColFn()
 			if err != nil {
 				return err
 			}
-			parsed, err := url.Parse(collection)
-			if err != nil {
-				return err
-			}
-			parsed.Path = path.Join(parsed.Path, str)
-			str = parsed.String()
 		}
 
-		if err := checkShowBackupURIPrivileges(ctx, p, str); err != nil {
+		if err := checkShowBackupURIPrivileges(ctx, p, dest); err != nil {
 			return err
 		}
 
-		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, str, p.User())
+		if subdir != "" {
+			parsed, err := url.Parse(dest)
+			if err != nil {
+				return err
+			}
+			if strings.EqualFold(subdir, "LATEST") {
+				subdir, err = readLatestFile(ctx, dest, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, p.User())
+				if err != nil {
+					return errors.Wrap(err, "read LATEST path")
+				}
+			}
+			parsed.Path = path.Join(parsed.Path, subdir)
+			dest = parsed.String()
+		}
+
+		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, dest, p.User())
 		if err != nil {
 			return errors.Wrapf(err, "make storage")
 		}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -433,6 +433,11 @@ func TestShowBackups(t *testing.T) {
 	require.Equal(t, 4, len(b1))
 	b2 := sqlDBRestore.QueryStr(t, `SELECT * FROM [SHOW BACKUP $1 IN $2] WHERE object_type='table'`, rows[1][0], full)
 	require.Equal(t, 3, len(b2))
+
+	require.Equal(t,
+		sqlDBRestore.QueryStr(t, `SHOW BACKUP $1 IN $2`, rows[2][0], full),
+		sqlDBRestore.QueryStr(t, `SHOW BACKUP LATEST IN $1`, full),
+	)
 }
 
 func TestShowBackupTenants(t *testing.T) {


### PR DESCRIPTION
We allow the alias 'LATEST' when backing up into a collection, e.g. by running
BACKUP INTO LATEST IN x, which automatically replaces 'LATEST' with the path to
most recent backup added to the collection. However for RESTORE and SHOW BACKUP
using the same alias would previously return an error, saying that the literal
'latest' path did not contain a backup. This change fixes that, doing the same
automatic expansion of the alias during RESTORE and SHOW that is done by BACKUP.

Release note (bug fix): 'RESTORE ... FROM LATEST IN' now works to restore the latest backup from a collection without needing to first inspect the collection to supply its actual path.