### PR TITLE
Makefile: remove extra go build from lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1161,10 +1161,6 @@ lint: override TAGS += lint
 lint: ## Run all style checkers and linters.
 lint: bin/returncheck bin/roachvet bin/optfmt
 	@if [ -t 1 ]; then echo '$(yellow)NOTE: `make lint` is very slow! Perhaps `make lintshort`?$(term-reset)'; fi
-	@# Run 'go build -i' to ensure we have compiled object files available for all
-	@# packages. In Go 1.10, only 'go vet' recompiles on demand. For details:
-	@# https://groups.google.com/forum/#!msg/golang-dev/qfa3mHN4ZPA/X2UzjNV1BAAJ.
-	$(xgo) build -i -v $(GOFLAGS) $(GOMODVENDORFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
 	$(xgo) test $(GOTESTFLAGS) ./pkg/testutils/lint -v $(GOFLAGS) $(GOMODVENDORFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -timeout $(TESTTIMEOUT) -run 'Lint/$(TESTS)'
 
 .PHONY: lintshort


### PR DESCRIPTION
Removing this works locally, and there are a few other reasons to
believe it works better now:

- We no longer use `go tool vet` and use `go vet` instead: 804d03281
- https://github.com/golang/go/issues/16086 was fixed in Go 1.10
- golang/go@804d03281c04096fca7f73dc33d1d62e09a86892 landed in Go 1.11

Note that we've tried to remove this before and had to revert it: #24350

Release note: None