### PR TITLE
release-21.1: goschedstats: extend compat to go 1.17

### DIFF
--- a/pkg/util/goschedstats/runtime_go1.15.go
+++ b/pkg/util/goschedstats/runtime_go1.15.go
@@ -9,9 +9,10 @@
 // licenses/APL.txt.
 //
 // The structure definitions in this file have been cross-checked against
-// go1.15.5 and go1.16. Before allowing newer versions, please check that the
+// go1.15-go1.17. Before allowing newer versions, please check that the
 // structures still match with those in go/src/runtime.
-// +build gc,go1.15,!go1.17
+//go:build gc && go1.15 && !go1.18
+// +build gc,go1.15,!go1.18
 
 package goschedstats
 


### PR DESCRIPTION
On master this file's tags have been extended to go 1.17, with no other
change in its content, so this backports those build tags to allow local
development using go 1.17 (which may be more important soon, as 1.17
has better darwin arm64 support).

Release justification: no risk (does not change what we actually build with), high impact (allows additional local builds).
Release note: none.