### PR TITLE
server: Return permission error if one occurs for Events endpoint

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1219,7 +1219,7 @@ func (s *adminServer) Events(
 	// to not use serverError* methods in the body of the function, so we can
 	// just do it here.
 	defer func() {
-		if retErr != nil {
+		if retErr != nil && !errors.Is(retErr, errRequiresAdmin) {
 			retErr = s.serverError(retErr)
 		}
 	}()


### PR DESCRIPTION
Events in DB Console (`/#/events`) would show an internal server error
to the user if they did not have admin permissions to view events. The
error logged in the server is indeed a permissions error, but this is
confusing to the user. To accurately show a permission error on the
FrontEnd, I added an AND statement to the Events endpoint to only return
a server error if an error exists and is not a permission error.

Release note (ui change): Node events will now display a permission
error rather than an internal server error when user does not have admin
privileges to view events.