### PR TITLE
roachtest: add ctx timeout in multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -126,6 +126,8 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 			return err
 		}
 		defer db.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
 		_, err = db.ExecContext(ctx, `SELECT 1`)
 		return err
 	}); err != nil {


### PR DESCRIPTION
This would have turned the timeout in #72420 into a faster failure.

Release note: None
