### PR TITLE
roachprod: fix `roachprod start` ignoring --binary flag

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -63,22 +63,21 @@ destroy the cluster.
 }
 
 var (
-	numNodes           int
-	numRacks           int
-	username           string
-	dryrun             bool
-	destroyAllMine     bool
-	destroyAllLocal    bool
-	extendLifetime     time.Duration
-	wipePreserveCerts  bool
-	listDetails        bool
-	listJSON           bool
-	listMine           bool
-	listPattern        string
-	sqlCockroachBinary = "cockroach"
-	secure             = false
-	extraSSHOptions    = ""
-	nodeEnv            = []string{
+	numNodes          int
+	numRacks          int
+	username          string
+	dryrun            bool
+	destroyAllMine    bool
+	destroyAllLocal   bool
+	extendLifetime    time.Duration
+	wipePreserveCerts bool
+	listDetails       bool
+	listJSON          bool
+	listMine          bool
+	listPattern       string
+	secure            = false
+	extraSSHOptions   = ""
+	nodeEnv           = []string{
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
 	}
@@ -795,7 +794,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(clusterOpts(args[0]), sqlCockroachBinary, args[1:])
+		return roachprod.SQL(clusterOpts(args[0]), args[1:])
 	}),
 }
 
@@ -1134,7 +1133,7 @@ func main() {
 			fallthrough
 		case sqlCmd:
 			cmd.Flags().StringVarP(
-				&sqlCockroachBinary, "binary", "b", "cockroach",
+				&config.Binary, "binary", "b", config.Binary,
 				"the remote cockroach binary to use")
 			fallthrough
 		case pgurlCmd, adminurlCmd:

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -423,8 +423,7 @@ func Run(clusterOpts install.SyncedCluster, SSHOptions string, cmdArray []string
 }
 
 // SQL runs `cockroach sql` on a remote cluster.
-func SQL(clusterOpts install.SyncedCluster, remoteCockroachBinary string, cmdArray []string) error {
-	config.Binary = remoteCockroachBinary
+func SQL(clusterOpts install.SyncedCluster, cmdArray []string) error {
 	c, err := newCluster(clusterOpts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Merging #71660 introduced a bug where roachprod ignores --binary
flag when running `roachprod start`.

This patch reverts to the old way of setting config.Binary as a quick solution to the bug.

Release note: None

Fixes #72425 #72420 #72373 #72372