### PR TITLE
kvserver: improve an assertion about closed timestamps

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -165,6 +165,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -139,6 +140,7 @@ type proposer interface {
 	leaseAppliedIndex() uint64
 	enqueueUpdateCheck()
 	closedTimestampTarget() hlc.Timestamp
+
 	// The following require the proposer to hold an exclusive lock.
 	withGroupLocked(func(proposerRaft) error) error
 	registerProposalLocked(*ProposalData)
@@ -156,6 +158,9 @@ type proposer interface {
 		prop *ProposalData,
 		redirectTo roachpb.ReplicaID,
 	)
+
+	// leaseDebugRLocked returns info on the current lease.
+	leaseDebugRLocked() string
 }
 
 // proposerRaft abstracts the propBuf's dependency on *raft.RawNode, to help
@@ -468,7 +473,21 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 
 		// Raft processing bookkeeping.
 		b.p.registerProposalLocked(p)
+
 		// Exit the tracker.
+		if !reproposal && p.Request.IsIntentWrite() {
+			// Sanity check that the request is tracked by the evaluation tracker at
+			// this point. It's supposed to be tracked until the
+			// doneIfNotMovedLocked() call below.
+			wts := p.Request.WriteTimestamp()
+			lb := b.evalTracker.LowerBound(ctx)
+			if wts.Less(lb) {
+				wts, lb := wts, lb // copies escape to heap
+				log.Fatalf(ctx, "%v", errorutil.UnexpectedWithIssueErrorf(72428,
+					"request writing below tracked lower bound: wts: %s < lb: %s; ba: %s; lease: %s.",
+					wts, lb, p.Request, b.p.leaseDebugRLocked()))
+			}
+		}
 		p.tok.doneIfNotMovedLocked(ctx)
 
 		// If we don't have a raft group or if the raft group has rejected one
@@ -655,9 +674,10 @@ func (b *propBuf) allocateLAIAndClosedTimestampLocked(
 	// the write timestamp of any request the began evaluating after it was
 	// set).
 	if p.Request.WriteTimestamp().Less(b.assignedClosedTimestamp) && p.Request.IsIntentWrite() {
-		return 0, hlc.Timestamp{}, errors.AssertionFailedf("attempting to propose command writing below closed timestamp. "+
-			"wts: %s < assigned closed: %s; ba: %s",
-			p.Request.WriteTimestamp(), b.assignedClosedTimestamp, p.Request)
+		log.Fatalf(ctx, "%v", errorutil.UnexpectedWithIssueErrorf(72428,
+			"attempting to propose command writing below closed timestamp. "+
+				"wts: %s < assigned closed: %s; ba: %s; lease: %s.",
+			p.Request.WriteTimestamp(), b.assignedClosedTimestamp, p.Request, b.p.leaseDebugRLocked()))
 	}
 
 	lb := b.evalTracker.LowerBound(ctx)
@@ -995,6 +1015,10 @@ func (rp *replicaProposer) withGroupLocked(fn func(raftGroup proposerRaft) error
 		(*Replica)(rp).unquiesceLocked()
 		return false /* unquiesceLocked */, fn(raftGroup)
 	})
+}
+
+func (rp *replicaProposer) leaseDebugRLocked() string {
+	return rp.mu.state.Lease.String()
 }
 
 func (rp *replicaProposer) registerProposalLocked(p *ProposalData) {

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -152,6 +152,10 @@ func (t *testProposer) withGroupLocked(fn func(proposerRaft) error) error {
 	return fn(t.raftGroup)
 }
 
+func (t *testProposer) leaseDebugRLocked() string {
+	return ""
+}
+
 func (t *testProposer) registerProposalLocked(p *ProposalData) {
 	t.registered++
 }


### PR DESCRIPTION
We have a sanity check on the proposer side asserting that a proposal's
write timestamp is not below the closedts that the propBuf has
previously communicated to followers. Unfortunately, this seems to have
failed in the wild for unknown reasons.

This patch adds lease information to the assertion, and also adds a
second assertion that tries to isolate the failure to properly track
in-flight evaluations. This new assertion checks that a request that's
exiting the evaluation tracker has a higher timestamp than the tracker's
lower bound. This way, if one of these assertions fires again, we'll
know whether the bug is a Tracker problem, or whether the bug is about
the propBuf's assignedClosedTimestamp maintenance.

Release note: None

Touches #72428