### PR TITLE
roachprod: clean up use of SyncedCluster

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/roachprod",
-        "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/install",
@@ -22,6 +21,7 @@ go_library(
         "//pkg/util/flagutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_term//:term",
     ],
 )
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var rootCmd = &cobra.Command{
@@ -150,7 +151,7 @@ func clusterOpts(clusterName string) install.SyncedCluster {
 		Tag:            tag,
 		CertsDir:       certsDir,
 		Secure:         secure,
-		Quiet:          quiet,
+		Quiet:          quiet || !term.IsTerminal(int(os.Stdout.Fd())),
 		UseTreeDist:    useTreeDist,
 		Args:           nodeArgs,
 		Env:            nodeEnv,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -136,18 +135,9 @@ func wrap(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Comma
 	}
 }
 
-// clusterOpts returns an install.SyncedCluster partially initialized according
-// to the command-line flags.
-//
-// The clusterName can contain node designators.
-//
-// TODO(radu,ahmad): we should use a different type and reserve SyncedCluster
-// for existing clusters (and we should stop overloading the cluster name).
-func clusterOpts(clusterName string) install.SyncedCluster {
-	return install.SyncedCluster{
-		Cluster: cloud.Cluster{
-			Name: clusterName,
-		},
+// clusterOpts returns the ClusterSettings according to the command-line flags.
+func clusterOpts() install.ClusterSettings {
+	return install.ClusterSettings{
 		Tag:            tag,
 		CertsDir:       certsDir,
 		Secure:         secure,
@@ -205,7 +195,7 @@ Local Clusters
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.Create(numNodes, username, createVMOpts, clusterOpts(args[0]))
+		return roachprod.Create(numNodes, username, createVMOpts, args[0], clusterOpts())
 	}),
 }
 
@@ -224,7 +214,7 @@ if the user would like to update the keys on the remote hosts.
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.SetupSSH(clusterOpts(args[0]), username)
+		return roachprod.SetupSSH(args[0], clusterOpts(), username)
 	}),
 }
 
@@ -245,11 +235,7 @@ directories inside ${HOME}/local directory are removed.
 `,
 	Args: cobra.ArbitraryArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		var clusters []install.SyncedCluster
-		for _, clusterName := range args {
-			clusters = append(clusters, clusterOpts(clusterName))
-		}
-		return roachprod.Destroy(clusters, destroyAllMine, destroyAllLocal, username)
+		return roachprod.Destroy(args, clusterOpts(), destroyAllMine, destroyAllLocal, username)
 	}),
 }
 
@@ -424,7 +410,7 @@ destroyed:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Extend(clusterOpts(args[0]), extendLifetime)
+		return roachprod.Extend(args[0], clusterOpts(), extendLifetime)
 	}),
 }
 
@@ -468,7 +454,7 @@ cluster setting will be set to its value.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Start(clusterOpts(args[0]), startOpts)
+		return roachprod.Start(args[0], clusterOpts(), startOpts)
 	}),
 }
 
@@ -497,7 +483,7 @@ signals.
 		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
 			wait = true
 		}
-		return roachprod.Stop(clusterOpts(args[0]), sig, wait)
+		return roachprod.Stop(args[0], clusterOpts(), sig, wait)
 	}),
 }
 
@@ -512,7 +498,7 @@ default cluster settings. It's intended to be used in conjunction with
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Init(clusterOpts(args[0]), username)
+		return roachprod.Init(args[0], clusterOpts(), username)
 	}),
 }
 
@@ -532,7 +518,7 @@ The "status" command outputs the binary and PID for the specified nodes:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Status(clusterOpts(args[0]))
+		return roachprod.Status(args[0], clusterOpts())
 	}),
 }
 
@@ -557,7 +543,7 @@ into a single stream.
 		} else {
 			dest = args[0] + ".logs"
 		}
-		return roachprod.Logs(logsOpts, clusterOpts(args[0]), dest, username)
+		return roachprod.Logs(logsOpts, args[0], clusterOpts(), dest, username)
 	}),
 }
 
@@ -580,7 +566,7 @@ of nodes, outputting a line whenever a change is detected:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Monitor(clusterOpts(args[0]), monitorIgnoreEmptyNodes, monitorOneShot)
+		return roachprod.Monitor(args[0], clusterOpts(), monitorIgnoreEmptyNodes, monitorOneShot)
 	}),
 }
 
@@ -595,7 +581,7 @@ nodes.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Wipe(clusterOpts(args[0]), wipePreserveCerts)
+		return roachprod.Wipe(args[0], clusterOpts(), wipePreserveCerts)
 	}),
 }
 
@@ -625,7 +611,7 @@ the 'zfs rollback' command:
 
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Reformat(clusterOpts(args[0]), args[1])
+		return roachprod.Reformat(args[0], clusterOpts(), args[1])
 	}),
 }
 
@@ -637,7 +623,7 @@ var runCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
-		return roachprod.Run(clusterOpts(args[0]), extraSSHOptions, args[1:])
+		return roachprod.Run(args[0], clusterOpts(), extraSSHOptions, args[1:])
 	}),
 }
 
@@ -648,7 +634,7 @@ var resetCmd = &cobra.Command{
 environments and will fall back to a no-op.`,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.Reset(clusterOpts(args[0]), numNodes, username)
+		return roachprod.Reset(args[0], clusterOpts(), numNodes, username)
 	}),
 }
 
@@ -661,7 +647,7 @@ var installCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Install(clusterOpts(args[0]), args[1:])
+		return roachprod.Install(args[0], clusterOpts(), args[1:])
 	}),
 }
 
@@ -676,7 +662,7 @@ var downloadCmd = &cobra.Command{
 		if len(args) == 4 {
 			dest = args[3]
 		}
-		return roachprod.Download(clusterOpts(args[0]), src, sha, dest)
+		return roachprod.Download(args[0], clusterOpts(), src, sha, dest)
 	}),
 }
 
@@ -737,7 +723,7 @@ Some examples of usage:
 		if len(args) == 3 {
 			versionArg = args[2]
 		}
-		return roachprod.Stage(clusterOpts(args[0]), stageOS, stageDir, args[1], versionArg)
+		return roachprod.Stage(args[0], clusterOpts(), stageOS, stageDir, args[1], versionArg)
 	}),
 }
 
@@ -751,7 +737,7 @@ start."
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.DistributeCerts(clusterOpts(args[0]))
+		return roachprod.DistributeCerts(args[0], clusterOpts())
 	}),
 }
 
@@ -767,7 +753,7 @@ var putCmd = &cobra.Command{
 		if len(args) == 3 {
 			dest = args[2]
 		}
-		return roachprod.Put(clusterOpts(args[0]), src, dest)
+		return roachprod.Put(args[0], clusterOpts(), src, dest)
 	}),
 }
 
@@ -784,7 +770,7 @@ multiple nodes the destination file name will be prefixed with the node number.
 		if len(args) == 3 {
 			dest = args[2]
 		}
-		return roachprod.Get(clusterOpts(args[0]), src, dest)
+		return roachprod.Get(args[0], clusterOpts(), src, dest)
 	}),
 }
 
@@ -794,7 +780,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(clusterOpts(args[0]), args[1:])
+		return roachprod.SQL(args[0], clusterOpts(), args[1:])
 	}),
 }
 
@@ -805,7 +791,7 @@ var pgurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.PgURL(clusterOpts(args[0]), external)
+		return roachprod.PgURL(args[0], clusterOpts(), external)
 	}),
 }
 
@@ -838,7 +824,7 @@ Examples:
 		if cmd.CalledAs() == "pprof-heap" {
 			pprofOptions.heap = true
 		}
-		return roachprod.Pprof(clusterOpts(args[0]), pprofOptions.duration, pprofOptions.heap, pprofOptions.open, pprofOptions.startingPort)
+		return roachprod.Pprof(args[0], clusterOpts(), pprofOptions.duration, pprofOptions.heap, pprofOptions.open, pprofOptions.startingPort)
 	}),
 }
 
@@ -850,7 +836,7 @@ var adminurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.AdminURL(clusterOpts(args[0]), adminurlIPs, adminurlOpen, adminurlPath)
+		return roachprod.AdminURL(args[0], clusterOpts(), adminurlIPs, adminurlOpen, adminurlPath)
 	}),
 }
 
@@ -861,7 +847,7 @@ var ipCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		ips, err := roachprod.IP(clusterOpts(args[0]), external)
+		ips, err := roachprod.IP(args[0], clusterOpts(), external)
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -27,6 +27,5 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@org_golang_x_sys//unix",
-        "@org_golang_x_term//:term",
     ],
 )

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/local",
+        "//pkg/util",
         "//pkg/util/envutil",
         "//pkg/util/httputil",
         "//pkg/util/log",

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"golang.org/x/sys/unix"
-	"golang.org/x/term"
 )
 
 // verifyClusterName ensures that the given name conforms to
@@ -211,7 +210,7 @@ Available clusters:
 	c.Args = opts.Args
 	c.Tag = opts.Tag
 	c.UseTreeDist = opts.UseTreeDist
-	c.Quiet = opts.Quiet || !term.IsTerminal(int(os.Stdout.Fd()))
+	c.Quiet = opts.Quiet
 	c.MaxConcurrency = opts.MaxConcurrency
 	return c, nil
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -121,29 +121,6 @@ func verifyClusterName(clusterName, username string) error {
 		clusterName, suggestions)
 }
 
-// DefaultSyncedCluster returns install.SyncedCluster with default values.
-func DefaultSyncedCluster() install.SyncedCluster {
-	return install.SyncedCluster{
-		Cluster: cloud.Cluster{
-			Name: "",
-		},
-		Tag:         "",
-		CertsDir:    "./certs",
-		Secure:      false,
-		Quiet:       false,
-		UseTreeDist: true,
-		Args:        nil,
-		Env: []string{
-			"COCKROACH_ENABLE_RPC_COMPRESSION=false",
-			"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
-		},
-		NumRacks:       0,
-		MaxConcurrency: 32,
-	}
-}
-
-var _ = DefaultSyncedCluster()
-
 func sortedClusters() []string {
 	var r []string
 	for n := range install.Clusters {
@@ -153,26 +130,29 @@ func sortedClusters() []string {
 	return r
 }
 
-func newCluster(opts install.SyncedCluster) (*install.SyncedCluster, error) {
+// newCluster initializes a SyncedCluster for the given cluster name.
+//
+// The cluster name can include a node selector (e.g. "foo:1-3").
+func newCluster(name string, clusterOpts install.ClusterSettings) (*install.SyncedCluster, error) {
 	nodeNames := "all"
 	{
-		parts := strings.Split(opts.Name, ":")
+		parts := strings.Split(name, ":")
 		switch len(parts) {
 		case 2:
 			nodeNames = parts[1]
 			fallthrough
 		case 1:
-			opts.Name = parts[0]
+			name = parts[0]
 		case 0:
 			return nil, fmt.Errorf("no cluster specified")
 		default:
-			return nil, fmt.Errorf("invalid cluster name: %s", opts.Name)
+			return nil, fmt.Errorf("invalid cluster name: %s", name)
 		}
 	}
 
-	c, ok := install.Clusters[opts.Name]
+	c, ok := install.Clusters[name]
 	if !ok {
-		err := errors.Newf(`unknown cluster: %s`, opts.Name)
+		err := errors.Newf(`unknown cluster: %s`, name)
 		err = errors.WithHintf(err, `
 Available clusters:
   %s
@@ -181,37 +161,13 @@ Available clusters:
 		return nil, err
 	}
 
-	c.Impl = install.Cockroach{}
-	c.NumRacks = opts.NumRacks
-	if c.NumRacks > 0 {
-		for i := range c.Localities {
-			rack := fmt.Sprintf("rack=%d", i%opts.NumRacks)
-			if c.Localities[i] != "" {
-				rack = "," + rack
-			}
-			c.Localities[i] += rack
-		}
-	}
+	c.Prepare(clusterOpts)
 
 	nodes, err := install.ListNodes(nodeNames, len(c.VMs))
 	if err != nil {
 		return nil, err
 	}
-	for _, n := range nodes {
-		if n > len(c.VMs) {
-			return nil, fmt.Errorf("invalid node spec %s, cluster contains %d nodes",
-				nodeNames, len(c.VMs))
-		}
-	}
 	c.Nodes = nodes
-	c.Secure = opts.Secure
-	c.CertsDir = opts.CertsDir
-	c.Env = opts.Env
-	c.Args = opts.Args
-	c.Tag = opts.Tag
-	c.UseTreeDist = opts.UseTreeDist
-	c.Quiet = opts.Quiet
-	c.MaxConcurrency = opts.MaxConcurrency
 	return c, nil
 }
 
@@ -401,8 +357,10 @@ func List(quiet, listMine bool, clusterNamePattern string) (cloud.Cloud, error) 
 }
 
 // Run runs a command on the nodes in a cluster.
-func Run(clusterOpts install.SyncedCluster, SSHOptions string, cmdArray []string) error {
-	c, err := newCluster(clusterOpts)
+func Run(
+	name string, clusterOpts install.ClusterSettings, SSHOptions string, cmdArray []string,
+) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -422,8 +380,8 @@ func Run(clusterOpts install.SyncedCluster, SSHOptions string, cmdArray []string
 }
 
 // SQL runs `cockroach sql` on a remote cluster.
-func SQL(clusterOpts install.SyncedCluster, cmdArray []string) error {
-	c, err := newCluster(clusterOpts)
+func SQL(name string, clusterOpts install.ClusterSettings, cmdArray []string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -435,8 +393,8 @@ func SQL(clusterOpts install.SyncedCluster, cmdArray []string) error {
 }
 
 // IP gets the ip addresses of the nodes in a cluster.
-func IP(clusterOpts install.SyncedCluster, external bool) ([]string, error) {
-	c, err := newCluster(clusterOpts)
+func IP(name string, clusterOpts install.ClusterSettings, external bool) ([]string, error) {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -460,8 +418,8 @@ func IP(clusterOpts install.SyncedCluster, external bool) ([]string, error) {
 }
 
 // Status retrieves the status of nodes in a cluster.
-func Status(clusterOpts install.SyncedCluster) error {
-	c, err := newCluster(clusterOpts)
+func Status(name string, clusterOpts install.ClusterSettings) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -472,9 +430,11 @@ func Status(clusterOpts install.SyncedCluster) error {
 // Stage stages release and edge binaries to the cluster.
 // stageOS, stageDir, version can be "" to use default values
 func Stage(
-	clusterOpts install.SyncedCluster, stageOS, stageDir, applicationName, version string,
+	name string,
+	clusterOpts install.ClusterSettings,
+	stageOS, stageDir, applicationName, version string,
 ) error {
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -495,13 +455,14 @@ func Stage(
 }
 
 // Reset resets all VMs in a cluster.
-func Reset(clusterOpts install.SyncedCluster, numNodes int, username string) error {
+func Reset(
+	clusterName string, clusterOpts install.ClusterSettings, numNodes int, username string,
+) error {
 	if numNodes <= 0 || numNodes >= 1000 {
 		// Upper limit is just for safety.
 		return fmt.Errorf("number of nodes must be in [1..999]")
 	}
 
-	clusterName := clusterOpts.Name
 	if err := verifyClusterName(clusterName, username); err != nil {
 		return err
 	}
@@ -525,8 +486,7 @@ func Reset(clusterOpts install.SyncedCluster, numNodes int, username string) err
 }
 
 // SetupSSH sets up the keys and host keys for the vms in the cluster.
-func SetupSSH(clusterOpts install.SyncedCluster, username string) error {
-	clusterName := clusterOpts.Name
+func SetupSSH(clusterName string, clusterOpts install.ClusterSettings, username string) error {
 	if err := verifyClusterName(clusterName, username); err != nil {
 		return err
 	}
@@ -554,7 +514,7 @@ func SetupSSH(clusterOpts install.SyncedCluster, username string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	installCluster, err := newCluster(clusterOpts)
+	installCluster, err := newCluster(clusterName, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -578,15 +538,15 @@ func SetupSSH(clusterOpts install.SyncedCluster, username string) error {
 }
 
 // Extend extends the lifetime of the specified cluster to prevent it from being destroyed.
-func Extend(clusterOpts install.SyncedCluster, lifetime time.Duration) error {
+func Extend(clusterName string, clusterOpts install.ClusterSettings, lifetime time.Duration) error {
 	cld, err := cloud.ListCloud()
 	if err != nil {
 		return err
 	}
 
-	c, ok := cld.Clusters[clusterOpts.Name]
+	c, ok := cld.Clusters[clusterName]
 	if !ok {
-		return fmt.Errorf("cluster %s does not exist", clusterOpts.Name)
+		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 
 	if err := cloud.ExtendCluster(c, lifetime); err != nil {
@@ -599,9 +559,9 @@ func Extend(clusterOpts install.SyncedCluster, lifetime time.Duration) error {
 		return err
 	}
 
-	c, ok = cld.Clusters[clusterOpts.Name]
+	c, ok = cld.Clusters[clusterName]
 	if !ok {
-		return fmt.Errorf("cluster %s does not exist", clusterOpts.Name)
+		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 
 	c.PrintDetails()
@@ -609,9 +569,11 @@ func Extend(clusterOpts install.SyncedCluster, lifetime time.Duration) error {
 }
 
 // Start starts nodes on a cluster.
-func Start(clusterOpts install.SyncedCluster, startOpts install.StartOptsType) error {
+func Start(
+	name string, clusterOpts install.ClusterSettings, startOpts install.StartOptsType,
+) error {
 	install.StartOpts = startOpts
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -621,9 +583,9 @@ func Start(clusterOpts install.SyncedCluster, startOpts install.StartOptsType) e
 
 // Monitor monitors the status of cockroach nodes in a cluster.
 func Monitor(
-	clusterOpts install.SyncedCluster, monitorIgnoreEmptyNodes, monitorOneShot bool,
+	name string, clusterOpts install.ClusterSettings, monitorIgnoreEmptyNodes, monitorOneShot bool,
 ) error {
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -641,8 +603,8 @@ func Monitor(
 }
 
 // Stop starts nodes on a cluster.
-func Stop(clusterOpts install.SyncedCluster, sig int, wait bool) error {
-	c, err := newCluster(clusterOpts)
+func Stop(name string, clusterOpts install.ClusterSettings, sig int, wait bool) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -651,12 +613,12 @@ func Stop(clusterOpts install.SyncedCluster, sig int, wait bool) error {
 }
 
 // Init initializes the cluster.
-func Init(clusterOpts install.SyncedCluster, username string) error {
-	if err := verifyClusterName(clusterOpts.Name, username); err != nil {
+func Init(clusterName string, clusterOpts install.ClusterSettings, username string) error {
+	if err := verifyClusterName(clusterName, username); err != nil {
 		return err
 	}
 
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(clusterName, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -665,8 +627,8 @@ func Init(clusterOpts install.SyncedCluster, username string) error {
 }
 
 // Wipe wipes the nodes in a cluster.
-func Wipe(clusterOpts install.SyncedCluster, wipePreserveCerts bool) error {
-	c, err := newCluster(clusterOpts)
+func Wipe(name string, clusterOpts install.ClusterSettings, wipePreserveCerts bool) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -675,8 +637,8 @@ func Wipe(clusterOpts install.SyncedCluster, wipePreserveCerts bool) error {
 }
 
 // Reformat reformats disks in a cluster to use the specified filesystem.
-func Reformat(clusterOpts install.SyncedCluster, fs string) error {
-	c, err := newCluster(clusterOpts)
+func Reformat(name string, clusterOpts install.ClusterSettings, fs string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -712,8 +674,8 @@ sudo chmod 777 /mnt/data1
 }
 
 // Install installs third party software.
-func Install(clusterOpts install.SyncedCluster, software []string) error {
-	c, err := newCluster(clusterOpts)
+func Install(name string, clusterOpts install.ClusterSettings, software []string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -721,8 +683,8 @@ func Install(clusterOpts install.SyncedCluster, software []string) error {
 }
 
 // Download downloads 3rd party tools, using a GCS cache if possible.
-func Download(clusterOpts install.SyncedCluster, src, sha, dest string) error {
-	c, err := newCluster(clusterOpts)
+func Download(name string, clusterOpts install.ClusterSettings, src, sha, dest string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -731,8 +693,8 @@ func Download(clusterOpts install.SyncedCluster, src, sha, dest string) error {
 
 // DistributeCerts distributes certificates to the nodes in a cluster.
 // If the certificates already exist, no action is taken.
-func DistributeCerts(clusterOpts install.SyncedCluster) error {
-	c, err := newCluster(clusterOpts)
+func DistributeCerts(name string, clusterOpts install.ClusterSettings) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -741,8 +703,8 @@ func DistributeCerts(clusterOpts install.SyncedCluster) error {
 }
 
 // Put copies a local file to the nodes in a cluster.
-func Put(clusterOpts install.SyncedCluster, src, dest string) error {
-	c, err := newCluster(clusterOpts)
+func Put(name string, clusterOpts install.ClusterSettings, src, dest string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -753,8 +715,8 @@ func Put(clusterOpts install.SyncedCluster, src, dest string) error {
 // Get copies a remote file from the nodes in a cluster.
 // If the file is retrieved from multiple nodes the destination
 // file name will be prefixed with the node number.
-func Get(clusterOpts install.SyncedCluster, src, dest string) error {
-	c, err := newCluster(clusterOpts)
+func Get(name string, clusterOpts install.ClusterSettings, src, dest string) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -763,8 +725,8 @@ func Get(clusterOpts install.SyncedCluster, src, dest string) error {
 }
 
 // PgURL generates pgurls for the nodes in a cluster.
-func PgURL(clusterOpts install.SyncedCluster, external bool) error {
-	c, err := newCluster(clusterOpts)
+func PgURL(name string, clusterOpts install.ClusterSettings, external bool) error {
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -799,9 +761,12 @@ func PgURL(clusterOpts install.SyncedCluster, external bool) error {
 
 // AdminURL generates admin UI URLs for the nodes in a cluster.
 func AdminURL(
-	clusterOpts install.SyncedCluster, adminurlIPs, adminurlOpen bool, adminurlPath string,
+	name string,
+	clusterOpts install.ClusterSettings,
+	adminurlIPs, adminurlOpen bool,
+	adminurlPath string,
 ) error {
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -842,9 +807,13 @@ func AdminURL(
 
 // Pprof TODO
 func Pprof(
-	clusterOpts install.SyncedCluster, duration time.Duration, heap, open bool, startingPort int,
+	name string,
+	clusterOpts install.ClusterSettings,
+	duration time.Duration,
+	heap, open bool,
+	startingPort int,
 ) error {
-	c, err := newCluster(clusterOpts)
+	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
@@ -963,16 +932,19 @@ func Pprof(
 
 // Destroy TODO
 func Destroy(
-	clusters []install.SyncedCluster, destroyAllMine bool, destroyAllLocal bool, username string,
+	clusterNames []string,
+	clusterOpts install.ClusterSettings,
+	destroyAllMine bool,
+	destroyAllLocal bool,
+	username string,
 ) error {
-	var clusterNames []string
 	// We want to avoid running ListCloud() if we are only trying to destroy a
 	// local cluster.
 	var cld *cloud.Cloud
 
 	switch {
 	case destroyAllMine:
-		if len(clusters) != 0 {
+		if len(clusterNames) != 0 {
 			return errors.New("--all-mine cannot be combined with cluster names")
 		}
 		if destroyAllLocal {
@@ -990,22 +962,21 @@ func Destroy(
 		clusterNames = clusters.Names()
 
 	case destroyAllLocal:
-		if len(clusters) != 0 {
+		if len(clusterNames) != 0 {
 			return errors.New("--all-local cannot be combined with cluster names")
 		}
 
 		clusterNames = local.Clusters()
 
 	default:
-		if len(clusters) == 0 {
+		if len(clusterNames) == 0 {
 			return errors.New("no cluster name provided")
 		}
 
-		for _, cluster := range clusters {
-			if err := verifyClusterName(cluster.Name, username); err != nil {
+		for _, n := range clusterNames {
+			if err := verifyClusterName(n, username); err != nil {
 				return err
 			}
-			clusterNames = append(clusterNames, cluster.Name)
 		}
 	}
 
@@ -1046,7 +1017,7 @@ func destroyLocalCluster(clusterName string) error {
 	if !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
-	c, err := newCluster(*cluster)
+	c, err := newCluster(clusterName, cluster.ClusterSettings)
 	if err != nil {
 		return err
 	}
@@ -1082,14 +1053,17 @@ func cleanupFailedCreate(clusterName string) error {
 
 // Create TODO
 func Create(
-	numNodes int, username string, createVMOpts vm.CreateOpts, clusterOpts install.SyncedCluster,
+	numNodes int,
+	username string,
+	createVMOpts vm.CreateOpts,
+	clusterName string,
+	clusterOpts install.ClusterSettings,
 ) (retErr error) {
 	if numNodes <= 0 || numNodes >= 1000 {
 		// Upper limit is just for safety.
 		return fmt.Errorf("number of nodes must be in [1..999]")
 	}
 
-	clusterName := clusterOpts.Name
 	if err := verifyClusterName(clusterName, username); err != nil {
 		return err
 	}
@@ -1146,7 +1120,7 @@ func Create(
 		// No need for ssh for local clusters.
 		return nil
 	}
-	return SetupSSH(clusterOpts, username)
+	return SetupSSH(clusterName, clusterOpts, username)
 }
 
 // GC garbage-collects expired clusters and unused SSH keypairs in AWS.
@@ -1170,12 +1144,17 @@ type LogsOpts struct {
 }
 
 // Logs TODO
-func Logs(logsOpts LogsOpts, clusterOpts install.SyncedCluster, dest, username string) error {
-	c, err := newCluster(clusterOpts)
+func Logs(
+	logsOpts LogsOpts, clusterName string, clusterOpts install.ClusterSettings, dest, username string,
+) error {
+	c, err := newCluster(clusterName, clusterOpts)
 	if err != nil {
 		return err
 	}
-	return c.Logs(logsOpts.Dir, dest, username, logsOpts.Filter, logsOpts.ProgramFilter, logsOpts.Interval, logsOpts.From, logsOpts.To, logsOpts.Out)
+	return c.Logs(
+		logsOpts.Dir, dest, username, logsOpts.Filter, logsOpts.ProgramFilter,
+		logsOpts.Interval, logsOpts.From, logsOpts.To, logsOpts.Out,
+	)
 }
 
 // StageURL TODO


### PR DESCRIPTION
#### roachprod: move quiet determination out of the library

Moving the logic of automatically enabling Quiet in non-terminal
output.

Release note: None

#### roachprod: clean up use of SyncedCluster

`SyncedCluster` is currently used to pass the cluster name (with
optional node selector) and the settings. This is a misuse of the type
and complicates things conceptually.

This change separates out the relevant settings into a new struct
`ClusterSettings`. All commands now pass the cluster name and the
`ClusterSettings` instead of passing a `SyncedCluster`.

Release note: None