### PR TITLE
tracing: fix tracer closing

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1057,7 +1057,6 @@ func ContextWithRecordingSpan(
 	cancel = func() {
 		cancelCtx()
 		sp.Finish()
-		tr.Close()
 	}
 	return ctx, sp.GetRecording, cancel
 }


### PR DESCRIPTION
ContextWithRecording span was closing the passed-in Tracer, which is
completely wrong. This has been broken since a long time ago; the
function originally was written to create its own Tracer but then
changed to take in a Tracer and the bad close remained.

As a practical consequence, tracing to external tracers stopped whenever
one of the debug pages that uses this utility was used.

Release note (bug fix): Fixed a bug causing tracing to external tracers
to inadvertently stop after the Enqueue Range or the Allocator debug
pages was used.