### PR TITLE
release-21.1: import: add support for non-admin outbound flag

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -352,18 +352,20 @@ func importPlanHook(
 			return err
 		}
 
-		// Certain ExternalStorage URIs require super-user access. Check all the
-		// URIs passed to the IMPORT command.
-		for _, file := range filenamePatterns {
-			hasExplicitAuth, uriScheme, err := cloud.AccessIsWithExplicitAuth(file)
-			if err != nil {
-				return err
-			}
-			if !hasExplicitAuth {
-				err := p.RequireAdminRole(ctx,
-					fmt.Sprintf("IMPORT from the specified %s URI", uriScheme))
+		if !p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
+			// Certain ExternalStorage URIs require super-user access. Check all the
+			// URIs passed to the IMPORT command.
+			for _, file := range filenamePatterns {
+				hasExplicitAuth, uriScheme, err := cloud.AccessIsWithExplicitAuth(file)
 				if err != nil {
 					return err
+				}
+				if !hasExplicitAuth {
+					err := p.RequireAdminRole(ctx,
+						fmt.Sprintf("IMPORT from the specified %s URI", uriScheme))
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This adds support to IMPORT for the outbound/implicit access without
admin role flag that was previously added to BACKUP, SHOW BACKUP, RESTORE,
and EXPORT in #71594.

Release note (ops change): IMPORT now also allows non-admin access to some previously admin-only URIs if --external-io-enable-non-admin-implicit-access is passed, following its prior addition to BACKUP, RESTORE, and EXPORT.

Release justification: bug fix.