### PR TITLE
release-21.1: sql: fix OIDs in RowDescription in some cases

### DIFF
--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -120,11 +120,11 @@ func makeScanColumnsConfig(table cat.Table, cols exec.TableColumnOrdinalSet) sca
 }
 
 // getResultColumnsForSimpleProject populates result columns for a simple
-// projection. It supports two configurations:
+// projection. inputCols must be non-nil and contain the result columns before
+// the projection has been applied. It supports two configurations:
 // 1. colNames and resultTypes are non-nil. resultTypes indicates the updated
 //    types (after the projection has been applied)
-// 2. if colNames is nil, then inputCols must be non-nil (which are the result
-//    columns before the projection has been applied).
+// 2. colNames is nil.
 func getResultColumnsForSimpleProject(
 	cols []exec.NodeColumnOrdinal,
 	colNames []string,
@@ -140,8 +140,10 @@ func getResultColumnsForSimpleProject(
 			resultCols[i].Hidden = false
 		} else {
 			resultCols[i] = colinfo.ResultColumn{
-				Name: colNames[i],
-				Typ:  resultTypes[i],
+				Name:           colNames[i],
+				Typ:            resultTypes[i],
+				TableID:        inputCols[col].TableID,
+				PGAttributeNum: inputCols[col].PGAttributeNum,
 			}
 		}
 	}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -239,11 +239,7 @@ func constructSimpleProjectForPlanNode(
 		r.reqOrdering = ReqOrdering(reqOrdering)
 		return r, nil
 	}
-	var inputCols colinfo.ResultColumns
-	if colNames == nil {
-		// We will need the names of the input columns.
-		inputCols = planColumns(n.(planNode))
-	}
+	inputCols := planColumns(n.(planNode))
 
 	var rb renderBuilder
 	rb.init(n, reqOrdering)

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -135,6 +135,29 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Regression test for not setting OIDs in some cases (#71891).
+send
+Query {"String": "SELECT a, tab1_a FROM tab2 INNER MERGE JOIN tab1 ON a = tab1_a WHERE a = 1"}
+----
+
+# With postgres we don't control the table OID.
+until ignore_table_oids noncrdb_only
+RowDescription
+----
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"tab1_a","TableOID":0,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+
+until crdb_only
+RowDescription
+----
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":52,"TableAttributeNumber":1,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0},{"Name":"tab1_a","TableOID":53,"TableAttributeNumber":2,"DataTypeOID":20,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 send
 Query {"String": "CREATE TABLE tab3 (a INT8 PRIMARY KEY, b CHAR(8))"}
 ----


### PR DESCRIPTION
Backport 1/1 commits from #72071.

/cc @cockroachdb/release

---

Fixes: #71891.

Release note (bug fix): Previously, CockroachDB could not set the
`TableOID` and `TableAttributeNumber` attributes of `RowDescription`
message of pgwire protocol in some cases (these values would be left as
0), and this is now fixed.
