### PR TITLE
opt: clean up FK ON UPDATE CASCADE code and opt trees

### DIFF
--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -677,10 +677,6 @@ func (cb *onUpdateCascadeBuilder) Build(
 			updateExprs[i] = &tree.UpdateExpr{}
 			switch cb.action {
 			case tree.Cascade:
-				// TODO(radu): This requires special code in addUpdateCols to
-				// prevent this scopeColumn from being duplicated in mb.outScope
-				// (see the addCol anonymous function in addUpdateCols). Find a
-				// cleaner way to handle this.
 				updateExprs[i].Expr = &newValScopeCols[i]
 			case tree.SetNull:
 				updateExprs[i].Expr = tree.DNull
@@ -871,12 +867,17 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 		outScope.expr, mutationInput, on, memo.EmptyJoinPrivate,
 	)
 	// Append the columns from the right-hand side to the scope.
-	for i, col := range outCols {
+	//
+	// These columns can only be referenced if they are update columns. In that
+	// case, they are given distinct names in mutationBuilder.addUpdateCol, so
+	// we make them anonymous here. This prevents column name ambiguity in
+	// outScope. There is no need to attach a metadata name here because these
+	// columns have already been added to the metadata with a name in the calls
+	// to md.AddColumn above.
+	for _, col := range outCols {
 		colMeta := md.ColumnMeta(col)
-		ord := fk.OriginColumnOrdinal(childTable, i%numFKCols)
-		c := childTable.Column(ord)
 		outScope.cols = append(outScope.cols, scopeColumn{
-			name: scopeColName(c.ColName()),
+			name: scopeColName(""),
 			id:   col,
 			typ:  colMeta.Type,
 		})

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -36,20 +36,20 @@ root
            │    └── p_new:17 => child.p:9
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:12!null child.p:13!null p:16!null p_new:17!null
+           │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    ├── scan child
            │    │    └── columns: c:12!null child.p:13!null
            │    ├── select
-           │    │    ├── columns: p:16!null p_new:17!null
+           │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:16!null p_new:17!null
+           │    │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    │    └── mapping:
-           │    │    │         ├──  parent.p:4 => p:16
+           │    │    │         ├──  parent.p:4 => p_old:16
            │    │    │         └──  p_new:7 => p_new:17
            │    │    └── filters
-           │    │         └── p:16 IS DISTINCT FROM p_new:17
+           │    │         └── p_old:16 IS DISTINCT FROM p_new:17
            │    └── filters
-           │         └── child.p:13 = p:16
+           │         └── child.p:13 = p_old:16
            └── f-k-checks
                 └── f-k-checks-item: child(p) -> parent(p)
                      └── anti-join (hash)
@@ -112,27 +112,27 @@ root
            ├── columns: <none>
            ├── fetch columns: c:18 child_multi.p:19 child_multi.q:20
            ├── update-mapping:
-           │    ├── p_new:25 => child_multi.p:14
+           │    ├── p_new:24 => child_multi.p:14
            │    └── q_new:26 => child_multi.q:15
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:23!null q:24!null p_new:25 q_new:26
+           │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    ├── scan child_multi
            │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
            │    ├── select
-           │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+           │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+           │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:7 => p:23
-           │    │    │         ├──  parent_multi.q:8 => q:24
-           │    │    │         ├──  p_new:11 => p_new:25
+           │    │    │         ├──  parent_multi.p:7 => p_old:23
+           │    │    │         ├──  parent_multi.q:8 => q_old:25
+           │    │    │         ├──  p_new:11 => p_new:24
            │    │    │         └──  q_new:12 => q_new:26
            │    │    └── filters
-           │    │         └── (p:23 IS DISTINCT FROM p_new:25) OR (q:24 IS DISTINCT FROM q_new:26)
+           │    │         └── (p_old:23 IS DISTINCT FROM p_new:24) OR (q_old:25 IS DISTINCT FROM q_new:26)
            │    └── filters
-           │         ├── child_multi.p:19 = p:23
-           │         └── child_multi.q:20 = q:24
+           │         ├── child_multi.p:19 = p_old:23
+           │         └── child_multi.q:20 = q_old:25
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -142,7 +142,7 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:27 q:28
                           │    │    └── mapping:
-                          │    │         ├──  p_new:25 => p:27
+                          │    │         ├──  p_new:24 => p:27
                           │    │         └──  q_new:26 => q:28
                           │    └── filters
                           │         ├── p:27 IS NOT NULL
@@ -182,27 +182,27 @@ root
            ├── columns: <none>
            ├── fetch columns: c:17 child_multi.p:18 child_multi.q:19
            ├── update-mapping:
-           │    ├── p_new:24 => child_multi.p:13
-           │    └── q:25 => child_multi.q:14
+           │    ├── p_new:23 => child_multi.p:13
+           │    └── q_new:25 => child_multi.q:14
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p_new:24!null q:25
+           │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    ├── scan child_multi
            │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
            │    ├── select
-           │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+           │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+           │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:7 => p:22
-           │    │    │         ├──  parent_multi.q:8 => q:23
-           │    │    │         ├──  p_new:11 => p_new:24
-           │    │    │         └──  parent_multi.q:8 => q:25
+           │    │    │         ├──  parent_multi.p:7 => p_old:22
+           │    │    │         ├──  parent_multi.q:8 => q_old:24
+           │    │    │         ├──  p_new:11 => p_new:23
+           │    │    │         └──  parent_multi.q:8 => q_new:25
            │    │    └── filters
-           │    │         └── (p:22 IS DISTINCT FROM p_new:24) OR (q:23 IS DISTINCT FROM q:25)
+           │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
            │    └── filters
-           │         ├── child_multi.p:18 = p:22
-           │         └── child_multi.q:19 = q:23
+           │         ├── child_multi.p:18 = p_old:22
+           │         └── child_multi.q:19 = q_old:24
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -212,8 +212,8 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:26!null q:27
                           │    │    └── mapping:
-                          │    │         ├──  p_new:24 => p:26
-                          │    │         └──  q:25 => q:27
+                          │    │         ├──  p_new:23 => p:26
+                          │    │         └──  q_new:25 => q:27
                           │    └── filters
                           │         └── q:27 IS NOT NULL
                           ├── scan parent_multi
@@ -268,27 +268,27 @@ root
            ├── columns: <none>
            ├── fetch columns: c:20 child_multi.p:21 child_multi.q:22
            ├── update-mapping:
-           │    ├── column2:27 => child_multi.p:16
-           │    └── column3:28 => child_multi.q:17
+           │    ├── p_new:26 => child_multi.p:16
+           │    └── q_new:28 => child_multi.q:17
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+           │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
            │    ├── scan child_multi
            │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
            │    ├── select
-           │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+           │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+           │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p:25
-           │    │    │         ├──  parent_multi.q:11 => q:26
-           │    │    │         ├──  column2:7 => column2:27
-           │    │    │         └──  column3:8 => column3:28
+           │    │    │         ├──  parent_multi.p:10 => p_old:25
+           │    │    │         ├──  parent_multi.q:11 => q_old:27
+           │    │    │         ├──  column2:7 => p_new:26
+           │    │    │         └──  column3:8 => q_new:28
            │    │    └── filters
-           │    │         └── (p:25 IS DISTINCT FROM column2:27) OR (q:26 IS DISTINCT FROM column3:28)
+           │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
            │    └── filters
-           │         ├── child_multi.p:21 = p:25
-           │         └── child_multi.q:22 = q:26
+           │         ├── child_multi.p:21 = p_old:25
+           │         └── child_multi.q:22 = q_old:27
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -296,8 +296,8 @@ root
                           ├── with-scan &2
                           │    ├── columns: p:29!null q:30!null
                           │    └── mapping:
-                          │         ├──  column2:27 => p:29
-                          │         └──  column3:28 => q:30
+                          │         ├──  p_new:26 => p:29
+                          │         └──  q_new:28 => q:30
                           ├── scan parent_multi
                           │    └── columns: parent_multi.p:32 parent_multi.q:33
                           └── filters
@@ -355,27 +355,27 @@ root
            ├── columns: <none>
            ├── fetch columns: c:21 child_multi.p:22 child_multi.q:23
            ├── update-mapping:
-           │    ├── column2:28 => child_multi.p:17
-           │    └── q:29 => child_multi.q:18
+           │    ├── p_new:27 => child_multi.p:17
+           │    └── q_new:29 => child_multi.q:18
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p:26!null q:27!null column2:28!null q:29
+           │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
            │    ├── scan child_multi
            │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
            │    ├── select
-           │    │    ├── columns: p:26 q:27 column2:28!null q:29
+           │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:26 q:27 column2:28!null q:29
+           │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p:26
-           │    │    │         ├──  parent_multi.q:11 => q:27
-           │    │    │         ├──  column2:7 => column2:28
-           │    │    │         └──  parent_multi.q:11 => q:29
+           │    │    │         ├──  parent_multi.p:10 => p_old:26
+           │    │    │         ├──  parent_multi.q:11 => q_old:28
+           │    │    │         ├──  column2:7 => p_new:27
+           │    │    │         └──  parent_multi.q:11 => q_new:29
            │    │    └── filters
-           │    │         └── (p:26 IS DISTINCT FROM column2:28) OR (q:27 IS DISTINCT FROM q:29)
+           │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
            │    └── filters
-           │         ├── child_multi.p:22 = p:26
-           │         └── child_multi.q:23 = q:27
+           │         ├── child_multi.p:22 = p_old:26
+           │         └── child_multi.q:23 = q_old:28
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -385,8 +385,8 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:30!null q:31
                           │    │    └── mapping:
-                          │    │         ├──  column2:28 => p:30
-                          │    │         └──  q:29 => q:31
+                          │    │         ├──  p_new:27 => p:30
+                          │    │         └──  q_new:29 => q:31
                           │    └── filters
                           │         └── q:31 IS NOT NULL
                           ├── scan parent_multi
@@ -445,27 +445,27 @@ root
            ├── columns: <none>
            ├── fetch columns: c:23 child_multi.p:24 child_multi.q:25
            ├── update-mapping:
-           │    ├── upsert_p:30 => child_multi.p:19
-           │    └── q:31 => child_multi.q:20
+           │    ├── p_new:29 => child_multi.p:19
+           │    └── q_new:31 => child_multi.q:20
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p:28!null q:29!null upsert_p:30!null q:31
+           │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
            │    ├── scan child_multi
            │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
            │    ├── select
-           │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+           │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+           │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_multi.p:10 => p:28
-           │    │    │         ├──  parent_multi.q:11 => q:29
-           │    │    │         ├──  upsert_p:16 => upsert_p:30
-           │    │    │         └──  parent_multi.q:11 => q:31
+           │    │    │         ├──  parent_multi.p:10 => p_old:28
+           │    │    │         ├──  parent_multi.q:11 => q_old:30
+           │    │    │         ├──  upsert_p:16 => p_new:29
+           │    │    │         └──  parent_multi.q:11 => q_new:31
            │    │    └── filters
-           │    │         └── (p:28 IS DISTINCT FROM upsert_p:30) OR (q:29 IS DISTINCT FROM q:31)
+           │    │         └── (p_old:28 IS DISTINCT FROM p_new:29) OR (q_old:30 IS DISTINCT FROM q_new:31)
            │    └── filters
-           │         ├── child_multi.p:24 = p:28
-           │         └── child_multi.q:25 = q:29
+           │         ├── child_multi.p:24 = p_old:28
+           │         └── child_multi.q:25 = q_old:30
            └── f-k-checks
                 └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
                      └── anti-join (hash)
@@ -475,8 +475,8 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:32!null q:33
                           │    │    └── mapping:
-                          │    │         ├──  upsert_p:30 => p:32
-                          │    │         └──  q:31 => q:33
+                          │    │         ├──  p_new:29 => p:32
+                          │    │         └──  q_new:31 => q:33
                           │    └── filters
                           │         └── q:33 IS NOT NULL
                           ├── scan parent_multi
@@ -521,29 +521,29 @@ root
       │    ├── columns: <none>
       │    ├── fetch columns: c:17 child_multi.p:18 child_multi.q:19
       │    ├── update-mapping:
-      │    │    ├── p:24 => child_multi.p:13
+      │    │    ├── p_new:23 => child_multi.p:13
       │    │    └── q_new:25 => child_multi.q:14
       │    ├── input binding: &2
       │    ├── cascades
       │    │    └── fk2
       │    ├── inner-join (hash)
-      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p:24!null q_new:25
+      │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    ├── scan child_multi
       │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │    │    ├── select
-      │    │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    ├── with-scan &1
-      │    │    │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    │    └── mapping:
-      │    │    │    │         ├──  parent_multi.p:7 => p:22
-      │    │    │    │         ├──  parent_multi.q:8 => q:23
-      │    │    │    │         ├──  parent_multi.p:7 => p:24
+      │    │    │    │         ├──  parent_multi.p:7 => p_old:22
+      │    │    │    │         ├──  parent_multi.q:8 => q_old:24
+      │    │    │    │         ├──  parent_multi.p:7 => p_new:23
       │    │    │    │         └──  q_new:11 => q_new:25
       │    │    │    └── filters
-      │    │    │         └── (p:22 IS DISTINCT FROM p:24) OR (q:23 IS DISTINCT FROM q_new:25)
+      │    │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
       │    │    └── filters
-      │    │         ├── child_multi.p:18 = p:22
-      │    │         └── child_multi.q:19 = q:23
+      │    │         ├── child_multi.p:18 = p_old:22
+      │    │         └── child_multi.q:19 = q_old:24
       │    └── f-k-checks
       │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
       │              └── anti-join (hash)
@@ -553,7 +553,7 @@ root
       │                   │    ├── with-scan &2
       │                   │    │    ├── columns: p:26!null q:27
       │                   │    │    └── mapping:
-      │                   │    │         ├──  p:24 => p:26
+      │                   │    │         ├──  p_new:23 => p:26
       │                   │    │         └──  q_new:25 => q:27
       │                   │    └── filters
       │                   │         └── q:27 IS NOT NULL
@@ -567,27 +567,27 @@ root
                 ├── columns: <none>
                 ├── fetch columns: g:38 grandchild.c:39 grandchild.q:40
                 ├── update-mapping:
-                │    ├── c:45 => grandchild.c:34
+                │    ├── c_new:44 => grandchild.c:34
                 │    └── q_new:46 => grandchild.q:35
                 ├── input binding: &3
                 ├── inner-join (hash)
-                │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c:43!null q:44!null c:45!null q_new:46
+                │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    ├── scan grandchild
                 │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40
                 │    ├── select
-                │    │    ├── columns: c:43!null q:44!null c:45!null q_new:46
+                │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    │    ├── with-scan &2
-                │    │    │    ├── columns: c:43!null q:44!null c:45!null q_new:46
+                │    │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    │    │    └── mapping:
-                │    │    │         ├──  child_multi.c:17 => c:43
-                │    │    │         ├──  child_multi.q:19 => q:44
-                │    │    │         ├──  child_multi.c:17 => c:45
+                │    │    │         ├──  child_multi.c:17 => c_old:43
+                │    │    │         ├──  child_multi.q:19 => q_old:45
+                │    │    │         ├──  child_multi.c:17 => c_new:44
                 │    │    │         └──  q_new:25 => q_new:46
                 │    │    └── filters
-                │    │         └── (c:43 IS DISTINCT FROM c:45) OR (q:44 IS DISTINCT FROM q_new:46)
+                │    │         └── (c_old:43 IS DISTINCT FROM c_new:44) OR (q_old:45 IS DISTINCT FROM q_new:46)
                 │    └── filters
-                │         ├── grandchild.c:39 = c:43
-                │         └── grandchild.q:40 = q:44
+                │         ├── grandchild.c:39 = c_old:43
+                │         └── grandchild.q:40 = q_old:45
                 └── f-k-checks
                      └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
                           └── anti-join (hash)
@@ -597,7 +597,7 @@ root
                                │    ├── with-scan &3
                                │    │    ├── columns: c:47!null q:48
                                │    │    └── mapping:
-                               │    │         ├──  c:45 => c:47
+                               │    │         ├──  c_new:44 => c:47
                                │    │         └──  q_new:46 => q:48
                                │    └── filters
                                │         └── q:48 IS NOT NULL
@@ -653,29 +653,29 @@ root
       │    ├── columns: <none>
       │    ├── fetch columns: c:20 child_multi.p:21 child_multi.q:22
       │    ├── update-mapping:
-      │    │    ├── column2:27 => child_multi.p:16
-      │    │    └── column3:28 => child_multi.q:17
+      │    │    ├── p_new:26 => child_multi.p:16
+      │    │    └── q_new:28 => child_multi.q:17
       │    ├── input binding: &2
       │    ├── cascades
       │    │    └── fk2
       │    ├── inner-join (hash)
-      │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+      │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    ├── scan child_multi
       │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
       │    │    ├── select
-      │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    ├── with-scan &1
-      │    │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    │    └── mapping:
-      │    │    │    │         ├──  parent_multi.p:10 => p:25
-      │    │    │    │         ├──  parent_multi.q:11 => q:26
-      │    │    │    │         ├──  column2:7 => column2:27
-      │    │    │    │         └──  column3:8 => column3:28
+      │    │    │    │         ├──  parent_multi.p:10 => p_old:25
+      │    │    │    │         ├──  parent_multi.q:11 => q_old:27
+      │    │    │    │         ├──  column2:7 => p_new:26
+      │    │    │    │         └──  column3:8 => q_new:28
       │    │    │    └── filters
-      │    │    │         └── (p:25 IS DISTINCT FROM column2:27) OR (q:26 IS DISTINCT FROM column3:28)
+      │    │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
       │    │    └── filters
-      │    │         ├── child_multi.p:21 = p:25
-      │    │         └── child_multi.q:22 = q:26
+      │    │         ├── child_multi.p:21 = p_old:25
+      │    │         └── child_multi.q:22 = q_old:27
       │    └── f-k-checks
       │         └── f-k-checks-item: child_multi(p,q) -> parent_multi(p,q)
       │              └── anti-join (hash)
@@ -683,8 +683,8 @@ root
       │                   ├── with-scan &2
       │                   │    ├── columns: p:29!null q:30!null
       │                   │    └── mapping:
-      │                   │         ├──  column2:27 => p:29
-      │                   │         └──  column3:28 => q:30
+      │                   │         ├──  p_new:26 => p:29
+      │                   │         └──  q_new:28 => q:30
       │                   ├── scan parent_multi
       │                   │    └── columns: parent_multi.p:32 parent_multi.q:33
       │                   └── filters
@@ -695,27 +695,27 @@ root
                 ├── columns: <none>
                 ├── fetch columns: g:41 grandchild.c:42 grandchild.q:43
                 ├── update-mapping:
-                │    ├── c:48 => grandchild.c:37
-                │    └── column3:49 => grandchild.q:38
+                │    ├── c_new:47 => grandchild.c:37
+                │    └── q_new:49 => grandchild.q:38
                 ├── input binding: &3
                 ├── inner-join (hash)
-                │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c:46!null q:47!null c:48!null column3:49!null
+                │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    ├── scan grandchild
                 │    │    └── columns: g:41!null grandchild.c:42 grandchild.q:43
                 │    ├── select
-                │    │    ├── columns: c:46!null q:47!null c:48!null column3:49!null
+                │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    │    ├── with-scan &2
-                │    │    │    ├── columns: c:46!null q:47!null c:48!null column3:49!null
+                │    │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    │    │    └── mapping:
-                │    │    │         ├──  child_multi.c:20 => c:46
-                │    │    │         ├──  child_multi.q:22 => q:47
-                │    │    │         ├──  child_multi.c:20 => c:48
-                │    │    │         └──  column3:28 => column3:49
+                │    │    │         ├──  child_multi.c:20 => c_old:46
+                │    │    │         ├──  child_multi.q:22 => q_old:48
+                │    │    │         ├──  child_multi.c:20 => c_new:47
+                │    │    │         └──  q_new:28 => q_new:49
                 │    │    └── filters
-                │    │         └── (c:46 IS DISTINCT FROM c:48) OR (q:47 IS DISTINCT FROM column3:49)
+                │    │         └── (c_old:46 IS DISTINCT FROM c_new:47) OR (q_old:48 IS DISTINCT FROM q_new:49)
                 │    └── filters
-                │         ├── grandchild.c:42 = c:46
-                │         └── grandchild.q:43 = q:47
+                │         ├── grandchild.c:42 = c_old:46
+                │         └── grandchild.q:43 = q_old:48
                 └── f-k-checks
                      └── f-k-checks-item: grandchild(c,q) -> child_multi(c,q)
                           └── anti-join (hash)
@@ -723,8 +723,8 @@ root
                                ├── with-scan &3
                                │    ├── columns: c:50!null q:51!null
                                │    └── mapping:
-                               │         ├──  c:48 => c:50
-                               │         └──  column3:49 => q:51
+                               │         ├──  c_new:47 => c:50
+                               │         └──  q_new:49 => q:51
                                ├── scan child_multi
                                │    └── columns: child_multi.c:52!null child_multi.q:54
                                └── filters
@@ -778,9 +778,9 @@ root
            ├── partial index del columns: partial_index_put1:20 partial_index_del2:22
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:20 partial_index_put2:21!null partial_index_del2:22!null c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+           │    ├── columns: partial_index_put1:20 partial_index_put2:21!null partial_index_del2:22!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+           │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    ├── scan child_partial
            │    │    │    ├── columns: c:13!null child_partial.p:14 i:15
            │    │    │    └── partial index predicates
@@ -789,16 +789,16 @@ root
            │    │    │         └── child_partial_i_idx: filters
            │    │    │              └── child_partial.p:14 > 0
            │    │    ├── select
-           │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_partial.p:4 => p:18
+           │    │    │    │         ├──  parent_partial.p:4 => p_old:18
            │    │    │    │         └──  p_new:7 => p_new:19
            │    │    │    └── filters
-           │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
            │    │    └── filters
-           │    │         └── child_partial.p:14 = p:18
+           │    │         └── child_partial.p:14 = p_old:18
            │    └── projections
            │         ├── i:15 > 0 [as=partial_index_put1:20]
            │         ├── p_new:19 > 0 [as=partial_index_put2:21]
@@ -857,32 +857,32 @@ root
            ├── columns: <none>
            ├── fetch columns: c:13 child_partial_ambig.p_new:14 i:15
            ├── update-mapping:
-           │    └── p_new:19 => child_partial_ambig.p_new:9
+           │    └── p_new_new:19 => child_partial_ambig.p_new:9
            ├── partial index put columns: partial_index_put1:20
            ├── partial index del columns: partial_index_del1:21
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:20!null partial_index_del1:21!null c:13!null child_partial_ambig.p_new:14!null i:15 p:18!null p_new:19!null
+           │    ├── columns: partial_index_put1:20!null partial_index_del1:21!null c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p:18!null p_new:19!null
+           │    │    ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    │    ├── scan child_partial_ambig
            │    │    │    ├── columns: c:13!null child_partial_ambig.p_new:14 i:15
            │    │    │    └── partial index predicates
            │    │    │         └── child_partial_ambig_i_idx: filters
            │    │    │              └── child_partial_ambig.p_new:14 > 0
            │    │    ├── select
-           │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_partial_ambig.p:4 => p:18
-           │    │    │    │         └──  p_new:7 => p_new:19
+           │    │    │    │         ├──  p:4 => p_new_old:18
+           │    │    │    │         └──  p_new:7 => p_new_new:19
            │    │    │    └── filters
-           │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │    │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
            │    │    └── filters
-           │    │         └── child_partial_ambig.p_new:14 = p:18
+           │    │         └── child_partial_ambig.p_new:14 = p_new_old:18
            │    └── projections
-           │         ├── p_new:19 > 0 [as=partial_index_put1:20]
+           │         ├── p_new_new:19 > 0 [as=partial_index_put1:20]
            │         └── child_partial_ambig.p_new:14 > 0 [as=partial_index_del1:21]
            └── f-k-checks
                 └── f-k-checks-item: child_partial_ambig(p_new) -> parent_partial_ambig(p)
@@ -891,11 +891,11 @@ root
                           ├── with-scan &2
                           │    ├── columns: p_new:22!null
                           │    └── mapping:
-                          │         └──  p_new:19 => p_new:22
+                          │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_partial_ambig
-                          │    └── columns: parent_partial_ambig.p:23!null
+                          │    └── columns: p:23!null
                           └── filters
-                               └── p_new:22 = parent_partial_ambig.p:23
+                               └── p_new:22 = p:23
 
 # Test an UPSERT that cascades to a child with a partial index.
 exec-ddl
@@ -969,15 +969,15 @@ root
            ├── columns: <none>
            ├── fetch columns: c:20 child_multi_partial.p:21 child_multi_partial.q:22 i:23
            ├── update-mapping:
-           │    ├── p_default:28 => child_multi_partial.p:15
-           │    └── p_default:29 => child_multi_partial.q:16
+           │    ├── p_new:27 => child_multi_partial.p:15
+           │    └── q_new:29 => child_multi_partial.q:16
            ├── partial index put columns: partial_index_put1:30 partial_index_put2:31
            ├── partial index del columns: partial_index_put1:30 partial_index_del2:32
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:30 partial_index_put2:31 partial_index_del2:32!null c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p:26!null q:27!null p_default:28 p_default:29
+           │    ├── columns: partial_index_put1:30 partial_index_put2:31 partial_index_del2:32!null c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p:26!null q:27!null p_default:28 p_default:29
+           │    │    ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
            │    │    ├── scan child_multi_partial
            │    │    │    ├── columns: c:20!null child_multi_partial.p:21 child_multi_partial.q:22 i:23
            │    │    │    └── partial index predicates
@@ -986,22 +986,22 @@ root
            │    │    │         └── child_multi_partial_i_idx: filters
            │    │    │              └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
            │    │    ├── select
-           │    │    │    ├── columns: p:26 q:27 p_default:28 p_default:29
+           │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:26 q:27 p_default:28 p_default:29
+           │    │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_multi_partial.p:9 => p:26
-           │    │    │    │         ├──  parent_multi_partial.q:10 => q:27
-           │    │    │    │         ├──  p_default:7 => p_default:28
-           │    │    │    │         └──  p_default:7 => p_default:29
+           │    │    │    │         ├──  parent_multi_partial.p:9 => p_old:26
+           │    │    │    │         ├──  parent_multi_partial.q:10 => q_old:28
+           │    │    │    │         ├──  p_default:7 => p_new:27
+           │    │    │    │         └──  p_default:7 => q_new:29
            │    │    │    └── filters
-           │    │    │         └── (p:26 IS DISTINCT FROM p_default:28) OR (q:27 IS DISTINCT FROM p_default:29)
+           │    │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
            │    │    └── filters
-           │    │         ├── child_multi_partial.p:21 = p:26
-           │    │         └── child_multi_partial.q:22 = q:27
+           │    │         ├── child_multi_partial.p:21 = p_old:26
+           │    │         └── child_multi_partial.q:22 = q_old:28
            │    └── projections
            │         ├── i:23 > 0 [as=partial_index_put1:30]
-           │         ├── (p_default:28 > 0) AND (p_default:29 > 0) [as=partial_index_put2:31]
+           │         ├── (p_new:27 > 0) AND (q_new:29 > 0) [as=partial_index_put2:31]
            │         └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0) [as=partial_index_del2:32]
            └── f-k-checks
                 └── f-k-checks-item: child_multi_partial(p,q) -> parent_multi_partial(p,q)
@@ -1012,8 +1012,8 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:33 q:34
                           │    │    └── mapping:
-                          │    │         ├──  p_default:28 => p:33
-                          │    │         └──  p_default:29 => q:34
+                          │    │         ├──  p_new:27 => p:33
+                          │    │         └──  q_new:29 => q:34
                           │    └── filters
                           │         ├── p:33 IS NOT NULL
                           │         └── q:34 IS NOT NULL
@@ -1068,36 +1068,36 @@ root
            ├── columns: <none>
            ├── fetch columns: c:13 child_check_ambig.p_new:14 i:15
            ├── update-mapping:
-           │    ├── p_new:19 => child_check_ambig.p_new:9
+           │    ├── p_new_new:19 => child_check_ambig.p_new:9
            │    └── i_comp:20 => i:10
            ├── check columns: check1:21
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:21!null c:13!null child_check_ambig.p_new:14!null i:15 p:18!null p_new:19!null i_comp:20!null
+           │    ├── columns: check1:21!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null i_comp:20!null
            │    ├── project
-           │    │    ├── columns: i_comp:20!null c:13!null child_check_ambig.p_new:14!null i:15 p:18!null p_new:19!null
+           │    │    ├── columns: i_comp:20!null c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    │    ├── inner-join (hash)
-           │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p:18!null p_new:19!null
+           │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    │    │    ├── scan child_check_ambig
            │    │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14 i:15
            │    │    │    │    └── computed column expressions
            │    │    │    │         └── i:15
            │    │    │    │              └── child_check_ambig.p_new:14 * 2
            │    │    │    ├── select
-           │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    │    ├── with-scan &1
-           │    │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    │    │    └── mapping:
-           │    │    │    │    │         ├──  parent_check_ambig.p:4 => p:18
-           │    │    │    │    │         └──  p_new:7 => p_new:19
+           │    │    │    │    │         ├──  p:4 => p_new_old:18
+           │    │    │    │    │         └──  p_new:7 => p_new_new:19
            │    │    │    │    └── filters
-           │    │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │    │    │         └── p_new_old:18 IS DISTINCT FROM p_new_new:19
            │    │    │    └── filters
-           │    │    │         └── child_check_ambig.p_new:14 = p:18
+           │    │    │         └── child_check_ambig.p_new:14 = p_new_old:18
            │    │    └── projections
-           │    │         └── p_new:19 * 2 [as=i_comp:20]
+           │    │         └── p_new_new:19 * 2 [as=i_comp:20]
            │    └── projections
-           │         └── p_new:19 > 0 [as=check1:21]
+           │         └── p_new_new:19 > 0 [as=check1:21]
            └── f-k-checks
                 └── f-k-checks-item: child_check_ambig(p_new) -> parent_check_ambig(p)
                      └── anti-join (hash)
@@ -1105,11 +1105,11 @@ root
                           ├── with-scan &2
                           │    ├── columns: p_new:22!null
                           │    └── mapping:
-                          │         └──  p_new:19 => p_new:22
+                          │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_check_ambig
-                          │    └── columns: parent_check_ambig.p:23!null
+                          │    └── columns: p:23!null
                           └── filters
-                               └── p_new:22 = parent_check_ambig.p:23
+                               └── p_new:22 = p:23
 
 # Test cascade to a child with a virtual column that references the FK.
 exec-ddl
@@ -1155,7 +1155,7 @@ root
            │    └── p_new:19 => v:10
            ├── input binding: &2
            ├── inner-join (hash)
-           │    ├── columns: c:13!null child_virt.p:14!null v:15 p:18!null p_new:19!null
+           │    ├── columns: c:13!null child_virt.p:14!null v:15 p_old:18!null p_new:19!null
            │    ├── project
            │    │    ├── columns: v:15 c:13!null child_virt.p:14
            │    │    ├── scan child_virt
@@ -1166,16 +1166,16 @@ root
            │    │    └── projections
            │    │         └── child_virt.p:14 [as=v:15]
            │    ├── select
-           │    │    ├── columns: p:18!null p_new:19!null
+           │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    ├── with-scan &1
-           │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    └── mapping:
-           │    │    │         ├──  parent_virt.p:4 => p:18
+           │    │    │         ├──  parent_virt.p:4 => p_old:18
            │    │    │         └──  p_new:7 => p_new:19
            │    │    └── filters
-           │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │         └── p_old:18 IS DISTINCT FROM p_new:19
            │    └── filters
-           │         └── child_virt.p:14 = p:18
+           │         └── child_virt.p:14 = p_old:18
            └── f-k-checks
                 └── f-k-checks-item: child_virt(p) -> parent_virt(p)
                      └── anti-join (hash)

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -36,22 +36,22 @@ root
            │    └── p_new:18 => child.p:9
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:18!null c:12!null child.p:13!null p:16!null p_new:17!null
+           │    ├── columns: p_new:18!null c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:12!null child.p:13!null p:16!null p_new:17!null
+           │    │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    │    ├── scan child
            │    │    │    └── columns: c:12!null child.p:13!null
            │    │    ├── select
-           │    │    │    ├── columns: p:16!null p_new:17!null
+           │    │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:16!null p_new:17!null
+           │    │    │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent.p:4 => p:16
+           │    │    │    │         ├──  parent.p:4 => p_old:16
            │    │    │    │         └──  p_new:7 => p_new:17
            │    │    │    └── filters
-           │    │    │         └── p:16 IS DISTINCT FROM p_new:17
+           │    │    │         └── p_old:16 IS DISTINCT FROM p_new:17
            │    │    └── filters
-           │    │         └── child.p:13 = p:16
+           │    │         └── child.p:13 = p_old:16
            │    └── projections
            │         └── 0 [as=p_new:18]
            └── f-k-checks
@@ -121,25 +121,25 @@ root
            │    └── q_new:28 => child_multi.q:15
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:27!null q_new:28!null c:18!null child_multi.p:19!null child_multi.q:20!null p:23!null q:24!null p_new:25 q_new:26
+           │    ├── columns: p_new:27!null q_new:28!null c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:23!null q:24!null p_new:25 q_new:26
+           │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    │    ├── scan child_multi
            │    │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
            │    │    ├── select
-           │    │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+           │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+           │    │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_multi.p:7 => p:23
-           │    │    │    │         ├──  parent_multi.q:8 => q:24
-           │    │    │    │         ├──  p_new:11 => p_new:25
+           │    │    │    │         ├──  parent_multi.p:7 => p_old:23
+           │    │    │    │         ├──  parent_multi.q:8 => q_old:25
+           │    │    │    │         ├──  p_new:11 => p_new:24
            │    │    │    │         └──  q_new:12 => q_new:26
            │    │    │    └── filters
-           │    │    │         └── (p:23 IS DISTINCT FROM p_new:25) OR (q:24 IS DISTINCT FROM q_new:26)
+           │    │    │         └── (p_old:23 IS DISTINCT FROM p_new:24) OR (q_old:25 IS DISTINCT FROM q_new:26)
            │    │    └── filters
-           │    │         ├── child_multi.p:19 = p:23
-           │    │         └── child_multi.q:20 = q:24
+           │    │         ├── child_multi.p:19 = p_old:23
+           │    │         └── child_multi.q:20 = q_old:25
            │    └── projections
            │         ├── 0 [as=p_new:27]
            │         └── 1 [as=q_new:28]
@@ -191,25 +191,25 @@ root
            │    └── q_new:27 => child_multi.q:14
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p_new:24!null q:25
+           │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p_new:24!null q:25
+           │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    │    ├── scan child_multi
            │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
            │    │    ├── select
-           │    │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+           │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+           │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_multi.p:7 => p:22
-           │    │    │    │         ├──  parent_multi.q:8 => q:23
-           │    │    │    │         ├──  p_new:11 => p_new:24
-           │    │    │    │         └──  parent_multi.q:8 => q:25
+           │    │    │    │         ├──  parent_multi.p:7 => p_old:22
+           │    │    │    │         ├──  parent_multi.q:8 => q_old:24
+           │    │    │    │         ├──  p_new:11 => p_new:23
+           │    │    │    │         └──  parent_multi.q:8 => q_new:25
            │    │    │    └── filters
-           │    │    │         └── (p:22 IS DISTINCT FROM p_new:24) OR (q:23 IS DISTINCT FROM q:25)
+           │    │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
            │    │    └── filters
-           │    │         ├── child_multi.p:18 = p:22
-           │    │         └── child_multi.q:19 = q:23
+           │    │         ├── child_multi.p:18 = p_old:22
+           │    │         └── child_multi.q:19 = q_old:24
            │    └── projections
            │         ├── 0 [as=p_new:26]
            │         └── 1 [as=q_new:27]
@@ -270,25 +270,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p:24!null q_new:25
+      │    │    ├── columns: p_new:26!null q_new:27!null c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p:24!null q_new:25
+      │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    │    ├── scan child_multi
       │    │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │    │    │    ├── select
-      │    │    │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    │    ├── with-scan &1
-      │    │    │    │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │    │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    │    │    └── mapping:
-      │    │    │    │    │         ├──  parent_multi.p:7 => p:22
-      │    │    │    │    │         ├──  parent_multi.q:8 => q:23
-      │    │    │    │    │         ├──  parent_multi.p:7 => p:24
+      │    │    │    │    │         ├──  parent_multi.p:7 => p_old:22
+      │    │    │    │    │         ├──  parent_multi.q:8 => q_old:24
+      │    │    │    │    │         ├──  parent_multi.p:7 => p_new:23
       │    │    │    │    │         └──  q_new:11 => q_new:25
       │    │    │    │    └── filters
-      │    │    │    │         └── (p:22 IS DISTINCT FROM p:24) OR (q:23 IS DISTINCT FROM q_new:25)
+      │    │    │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
       │    │    │    └── filters
-      │    │    │         ├── child_multi.p:18 = p:22
-      │    │    │         └── child_multi.q:19 = q:23
+      │    │    │         ├── child_multi.p:18 = p_old:22
+      │    │    │         └── child_multi.q:19 = q_old:24
       │    │    └── projections
       │    │         ├── 0 [as=p_new:26]
       │    │         └── 1 [as=q_new:27]
@@ -315,25 +315,25 @@ root
                 │    └── q_new:50 => grandchild.q:37
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:49!null q_new:50!null g:40!null grandchild.c:41!null grandchild.q:42!null c:45!null q:46!null c:47!null q_new:48!null
+                │    ├── columns: c_new:49!null q_new:50!null g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c:45!null q:46!null c:47!null q_new:48!null
+                │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    ├── scan grandchild
                 │    │    │    └── columns: g:40!null grandchild.c:41 grandchild.q:42
                 │    │    ├── select
-                │    │    │    ├── columns: c:45!null q:46!null c:47!null q_new:48!null
+                │    │    │    ├── columns: c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    │    ├── with-scan &2
-                │    │    │    │    ├── columns: c:45!null q:46!null c:47!null q_new:48!null
+                │    │    │    │    ├── columns: c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    │    │    └── mapping:
-                │    │    │    │         ├──  child_multi.c:17 => c:45
-                │    │    │    │         ├──  child_multi.q:19 => q:46
-                │    │    │    │         ├──  child_multi.c:17 => c:47
+                │    │    │    │         ├──  child_multi.c:17 => c_old:45
+                │    │    │    │         ├──  child_multi.q:19 => q_old:47
+                │    │    │    │         ├──  child_multi.c:17 => c_new:46
                 │    │    │    │         └──  q_new:27 => q_new:48
                 │    │    │    └── filters
-                │    │    │         └── (c:45 IS DISTINCT FROM c:47) OR (q:46 IS DISTINCT FROM q_new:48)
+                │    │    │         └── (c_old:45 IS DISTINCT FROM c_new:46) OR (q_old:47 IS DISTINCT FROM q_new:48)
                 │    │    └── filters
-                │    │         ├── grandchild.c:41 = c:45
-                │    │         └── grandchild.q:42 = q:46
+                │    │         ├── grandchild.c:41 = c_old:45
+                │    │         └── grandchild.q:42 = q_old:47
                 │    └── projections
                 │         ├── 10 [as=c_new:49]
                 │         └── 11 [as=q_new:50]
@@ -404,25 +404,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:29!null q_new:30!null c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+      │    │    ├── columns: p_new:29!null q_new:30!null c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+      │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    │    ├── scan child_multi
       │    │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
       │    │    │    ├── select
-      │    │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    │    ├── with-scan &1
-      │    │    │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │    │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    │    │    └── mapping:
-      │    │    │    │    │         ├──  parent_multi.p:10 => p:25
-      │    │    │    │    │         ├──  parent_multi.q:11 => q:26
-      │    │    │    │    │         ├──  column2:7 => column2:27
-      │    │    │    │    │         └──  column3:8 => column3:28
+      │    │    │    │    │         ├──  parent_multi.p:10 => p_old:25
+      │    │    │    │    │         ├──  parent_multi.q:11 => q_old:27
+      │    │    │    │    │         ├──  column2:7 => p_new:26
+      │    │    │    │    │         └──  column3:8 => q_new:28
       │    │    │    │    └── filters
-      │    │    │    │         └── (p:25 IS DISTINCT FROM column2:27) OR (q:26 IS DISTINCT FROM column3:28)
+      │    │    │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
       │    │    │    └── filters
-      │    │    │         ├── child_multi.p:21 = p:25
-      │    │    │         └── child_multi.q:22 = q:26
+      │    │    │         ├── child_multi.p:21 = p_old:25
+      │    │    │         └── child_multi.q:22 = q_old:27
       │    │    └── projections
       │    │         ├── 0 [as=p_new:29]
       │    │         └── 1 [as=q_new:30]
@@ -449,25 +449,25 @@ root
                 │    └── q_new:53 => grandchild.q:40
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:52!null q_new:53!null g:43!null grandchild.c:44!null grandchild.q:45!null c:48!null q:49!null c:50!null q_new:51!null
+                │    ├── columns: c_new:52!null q_new:53!null g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:43!null grandchild.c:44!null grandchild.q:45!null c:48!null q:49!null c:50!null q_new:51!null
+                │    │    ├── columns: g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    ├── scan grandchild
                 │    │    │    └── columns: g:43!null grandchild.c:44 grandchild.q:45
                 │    │    ├── select
-                │    │    │    ├── columns: c:48!null q:49!null c:50!null q_new:51!null
+                │    │    │    ├── columns: c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    │    ├── with-scan &2
-                │    │    │    │    ├── columns: c:48!null q:49!null c:50!null q_new:51!null
+                │    │    │    │    ├── columns: c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    │    │    └── mapping:
-                │    │    │    │         ├──  child_multi.c:20 => c:48
-                │    │    │    │         ├──  child_multi.q:22 => q:49
-                │    │    │    │         ├──  child_multi.c:20 => c:50
+                │    │    │    │         ├──  child_multi.c:20 => c_old:48
+                │    │    │    │         ├──  child_multi.q:22 => q_old:50
+                │    │    │    │         ├──  child_multi.c:20 => c_new:49
                 │    │    │    │         └──  q_new:30 => q_new:51
                 │    │    │    └── filters
-                │    │    │         └── (c:48 IS DISTINCT FROM c:50) OR (q:49 IS DISTINCT FROM q_new:51)
+                │    │    │         └── (c_old:48 IS DISTINCT FROM c_new:49) OR (q_old:50 IS DISTINCT FROM q_new:51)
                 │    │    └── filters
-                │    │         ├── grandchild.c:44 = c:48
-                │    │         └── grandchild.q:45 = q:49
+                │    │         ├── grandchild.c:44 = c_old:48
+                │    │         └── grandchild.q:45 = q_old:50
                 │    └── projections
                 │         ├── 10 [as=c_new:52]
                 │         └── 11 [as=q_new:53]
@@ -543,25 +543,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:30!null q_new:31!null c:21!null child_multi.p:22!null child_multi.q:23!null p:26!null q:27!null column2:28!null q:29
+      │    │    ├── columns: p_new:30!null q_new:31!null c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p:26!null q:27!null column2:28!null q:29
+      │    │    │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │    │    │    ├── scan child_multi
       │    │    │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
       │    │    │    ├── select
-      │    │    │    │    ├── columns: p:26 q:27 column2:28!null q:29
+      │    │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │    │    │    │    ├── with-scan &1
-      │    │    │    │    │    ├── columns: p:26 q:27 column2:28!null q:29
+      │    │    │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │    │    │    │    │    └── mapping:
-      │    │    │    │    │         ├──  parent_multi.p:10 => p:26
-      │    │    │    │    │         ├──  parent_multi.q:11 => q:27
-      │    │    │    │    │         ├──  column2:7 => column2:28
-      │    │    │    │    │         └──  parent_multi.q:11 => q:29
+      │    │    │    │    │         ├──  parent_multi.p:10 => p_old:26
+      │    │    │    │    │         ├──  parent_multi.q:11 => q_old:28
+      │    │    │    │    │         ├──  column2:7 => p_new:27
+      │    │    │    │    │         └──  parent_multi.q:11 => q_new:29
       │    │    │    │    └── filters
-      │    │    │    │         └── (p:26 IS DISTINCT FROM column2:28) OR (q:27 IS DISTINCT FROM q:29)
+      │    │    │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
       │    │    │    └── filters
-      │    │    │         ├── child_multi.p:22 = p:26
-      │    │    │         └── child_multi.q:23 = q:27
+      │    │    │         ├── child_multi.p:22 = p_old:26
+      │    │    │         └── child_multi.q:23 = q_old:28
       │    │    └── projections
       │    │         ├── 0 [as=p_new:30]
       │    │         └── 1 [as=q_new:31]
@@ -588,25 +588,25 @@ root
                 │    └── q_new:54 => grandchild.q:41
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:53!null q_new:54!null g:44!null grandchild.c:45!null grandchild.q:46!null c:49!null q:50!null c:51!null q_new:52!null
+                │    ├── columns: c_new:53!null q_new:54!null g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:44!null grandchild.c:45!null grandchild.q:46!null c:49!null q:50!null c:51!null q_new:52!null
+                │    │    ├── columns: g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    ├── scan grandchild
                 │    │    │    └── columns: g:44!null grandchild.c:45 grandchild.q:46
                 │    │    ├── select
-                │    │    │    ├── columns: c:49!null q:50!null c:51!null q_new:52!null
+                │    │    │    ├── columns: c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    │    ├── with-scan &2
-                │    │    │    │    ├── columns: c:49!null q:50!null c:51!null q_new:52!null
+                │    │    │    │    ├── columns: c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    │    │    └── mapping:
-                │    │    │    │         ├──  child_multi.c:21 => c:49
-                │    │    │    │         ├──  child_multi.q:23 => q:50
-                │    │    │    │         ├──  child_multi.c:21 => c:51
+                │    │    │    │         ├──  child_multi.c:21 => c_old:49
+                │    │    │    │         ├──  child_multi.q:23 => q_old:51
+                │    │    │    │         ├──  child_multi.c:21 => c_new:50
                 │    │    │    │         └──  q_new:31 => q_new:52
                 │    │    │    └── filters
-                │    │    │         └── (c:49 IS DISTINCT FROM c:51) OR (q:50 IS DISTINCT FROM q_new:52)
+                │    │    │         └── (c_old:49 IS DISTINCT FROM c_new:50) OR (q_old:51 IS DISTINCT FROM q_new:52)
                 │    │    └── filters
-                │    │         ├── grandchild.c:45 = c:49
-                │    │         └── grandchild.q:46 = q:50
+                │    │         ├── grandchild.c:45 = c_old:49
+                │    │         └── grandchild.q:46 = q_old:51
                 │    └── projections
                 │         ├── 10 [as=c_new:53]
                 │         └── 11 [as=q_new:54]
@@ -681,25 +681,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    ├── project
-      │    │    ├── columns: p_new:32!null q_new:33!null c:23!null child_multi.p:24!null child_multi.q:25!null p:28!null q:29!null upsert_p:30!null q:31
+      │    │    ├── columns: p_new:32!null q_new:33!null c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p:28!null q:29!null upsert_p:30!null q:31
+      │    │    │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │    │    │    ├── scan child_multi
       │    │    │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
       │    │    │    ├── select
-      │    │    │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+      │    │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │    │    │    │    ├── with-scan &1
-      │    │    │    │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+      │    │    │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │    │    │    │    │    └── mapping:
-      │    │    │    │    │         ├──  parent_multi.p:10 => p:28
-      │    │    │    │    │         ├──  parent_multi.q:11 => q:29
-      │    │    │    │    │         ├──  upsert_p:16 => upsert_p:30
-      │    │    │    │    │         └──  parent_multi.q:11 => q:31
+      │    │    │    │    │         ├──  parent_multi.p:10 => p_old:28
+      │    │    │    │    │         ├──  parent_multi.q:11 => q_old:30
+      │    │    │    │    │         ├──  upsert_p:16 => p_new:29
+      │    │    │    │    │         └──  parent_multi.q:11 => q_new:31
       │    │    │    │    └── filters
-      │    │    │    │         └── (p:28 IS DISTINCT FROM upsert_p:30) OR (q:29 IS DISTINCT FROM q:31)
+      │    │    │    │         └── (p_old:28 IS DISTINCT FROM p_new:29) OR (q_old:30 IS DISTINCT FROM q_new:31)
       │    │    │    └── filters
-      │    │    │         ├── child_multi.p:24 = p:28
-      │    │    │         └── child_multi.q:25 = q:29
+      │    │    │         ├── child_multi.p:24 = p_old:28
+      │    │    │         └── child_multi.q:25 = q_old:30
       │    │    └── projections
       │    │         ├── 0 [as=p_new:32]
       │    │         └── 1 [as=q_new:33]
@@ -726,25 +726,25 @@ root
                 │    └── q_new:56 => grandchild.q:43
                 ├── input binding: &3
                 ├── project
-                │    ├── columns: c_new:55!null q_new:56!null g:46!null grandchild.c:47!null grandchild.q:48!null c:51!null q:52!null c:53!null q_new:54!null
+                │    ├── columns: c_new:55!null q_new:56!null g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: g:46!null grandchild.c:47!null grandchild.q:48!null c:51!null q:52!null c:53!null q_new:54!null
+                │    │    ├── columns: g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    ├── scan grandchild
                 │    │    │    └── columns: g:46!null grandchild.c:47 grandchild.q:48
                 │    │    ├── select
-                │    │    │    ├── columns: c:51!null q:52!null c:53!null q_new:54!null
+                │    │    │    ├── columns: c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    │    ├── with-scan &2
-                │    │    │    │    ├── columns: c:51!null q:52!null c:53!null q_new:54!null
+                │    │    │    │    ├── columns: c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    │    │    └── mapping:
-                │    │    │    │         ├──  child_multi.c:23 => c:51
-                │    │    │    │         ├──  child_multi.q:25 => q:52
-                │    │    │    │         ├──  child_multi.c:23 => c:53
+                │    │    │    │         ├──  child_multi.c:23 => c_old:51
+                │    │    │    │         ├──  child_multi.q:25 => q_old:53
+                │    │    │    │         ├──  child_multi.c:23 => c_new:52
                 │    │    │    │         └──  q_new:33 => q_new:54
                 │    │    │    └── filters
-                │    │    │         └── (c:51 IS DISTINCT FROM c:53) OR (q:52 IS DISTINCT FROM q_new:54)
+                │    │    │         └── (c_old:51 IS DISTINCT FROM c_new:52) OR (q_old:53 IS DISTINCT FROM q_new:54)
                 │    │    └── filters
-                │    │         ├── grandchild.c:47 = c:51
-                │    │         └── grandchild.q:48 = q:52
+                │    │         ├── grandchild.c:47 = c_old:51
+                │    │         └── grandchild.q:48 = q_old:53
                 │    └── projections
                 │         ├── 10 [as=c_new:55]
                 │         └── 11 [as=q_new:56]
@@ -810,11 +810,11 @@ root
            ├── partial index del columns: partial_index_put1:21 partial_index_del2:23
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:21 partial_index_put2:22!null partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null p_new:20!null
+           │    ├── columns: partial_index_put1:21 partial_index_put2:22!null partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null p_new:20!null
            │    ├── project
-           │    │    ├── columns: p_new:20!null c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+           │    │    ├── columns: p_new:20!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    ├── inner-join (hash)
-           │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+           │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    │    ├── scan child_partial
            │    │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15
            │    │    │    │    └── partial index predicates
@@ -823,16 +823,16 @@ root
            │    │    │    │         └── child_partial_i_idx: filters
            │    │    │    │              └── child_partial.p:14 > 0
            │    │    │    ├── select
-           │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    ├── with-scan &1
-           │    │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    │    └── mapping:
-           │    │    │    │    │         ├──  parent_partial.p:4 => p:18
+           │    │    │    │    │         ├──  parent_partial.p:4 => p_old:18
            │    │    │    │    │         └──  p_new:7 => p_new:19
            │    │    │    │    └── filters
-           │    │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
            │    │    │    └── filters
-           │    │    │         └── child_partial.p:14 = p:18
+           │    │    │         └── child_partial.p:14 = p_old:18
            │    │    └── projections
            │    │         └── 0 [as=p_new:20]
            │    └── projections
@@ -896,9 +896,9 @@ root
            │    └── p_new:20 => v:10
            ├── input binding: &2
            ├── project
-           │    ├── columns: p_new:20!null c:13!null child_virt.p:14!null v:15!null p:18!null p_new:19!null
+           │    ├── columns: p_new:20!null c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:13!null child_virt.p:14!null v:15!null p:18!null p_new:19!null
+           │    │    ├── columns: c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
            │    │    ├── project
            │    │    │    ├── columns: v:15!null c:13!null child_virt.p:14!null
            │    │    │    ├── scan child_virt
@@ -909,16 +909,16 @@ root
            │    │    │    └── projections
            │    │    │         └── child_virt.p:14 [as=v:15]
            │    │    ├── select
-           │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:18!null p_new:19!null
+           │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    └── mapping:
-           │    │    │    │         ├──  parent_virt.p:4 => p:18
+           │    │    │    │         ├──  parent_virt.p:4 => p_old:18
            │    │    │    │         └──  p_new:7 => p_new:19
            │    │    │    └── filters
-           │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+           │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
            │    │    └── filters
-           │    │         └── child_virt.p:14 = p:18
+           │    │         └── child_virt.p:14 = p_old:18
            │    └── projections
            │         └── 0 [as=p_new:20]
            └── f-k-checks

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -35,22 +35,22 @@ root
            ├── update-mapping:
            │    └── p_new:18 => child.p:9
            └── project
-                ├── columns: p_new:18 c:12!null child.p:13!null p:16!null p_new:17!null
+                ├── columns: p_new:18 c:12!null child.p:13!null p_old:16!null p_new:17!null
                 ├── inner-join (hash)
-                │    ├── columns: c:12!null child.p:13!null p:16!null p_new:17!null
+                │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
                 │    ├── scan child
                 │    │    └── columns: c:12!null child.p:13!null
                 │    ├── select
-                │    │    ├── columns: p:16!null p_new:17!null
+                │    │    ├── columns: p_old:16!null p_new:17!null
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: p:16!null p_new:17!null
+                │    │    │    ├── columns: p_old:16!null p_new:17!null
                 │    │    │    └── mapping:
-                │    │    │         ├──  parent.p:4 => p:16
+                │    │    │         ├──  parent.p:4 => p_old:16
                 │    │    │         └──  p_new:7 => p_new:17
                 │    │    └── filters
-                │    │         └── p:16 IS DISTINCT FROM p_new:17
+                │    │         └── p_old:16 IS DISTINCT FROM p_new:17
                 │    └── filters
-                │         └── child.p:13 = p:16
+                │         └── child.p:13 = p_old:16
                 └── projections
                      └── NULL::INT8 [as=p_new:18]
 
@@ -106,25 +106,25 @@ root
            │    ├── p_new:27 => child_multi.p:14
            │    └── p_new:27 => child_multi.q:15
            └── project
-                ├── columns: p_new:27 c:18!null child_multi.p:19!null child_multi.q:20!null p:23!null q:24!null p_new:25 q_new:26
+                ├── columns: p_new:27 c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
                 ├── inner-join (hash)
-                │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p:23!null q:24!null p_new:25 q_new:26
+                │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
                 │    ├── scan child_multi
                 │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
                 │    ├── select
-                │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+                │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: p:23 q:24 p_new:25 q_new:26
+                │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
                 │    │    │    └── mapping:
-                │    │    │         ├──  parent_multi.p:7 => p:23
-                │    │    │         ├──  parent_multi.q:8 => q:24
-                │    │    │         ├──  p_new:11 => p_new:25
+                │    │    │         ├──  parent_multi.p:7 => p_old:23
+                │    │    │         ├──  parent_multi.q:8 => q_old:25
+                │    │    │         ├──  p_new:11 => p_new:24
                 │    │    │         └──  q_new:12 => q_new:26
                 │    │    └── filters
-                │    │         └── (p:23 IS DISTINCT FROM p_new:25) OR (q:24 IS DISTINCT FROM q_new:26)
+                │    │         └── (p_old:23 IS DISTINCT FROM p_new:24) OR (q_old:25 IS DISTINCT FROM q_new:26)
                 │    └── filters
-                │         ├── child_multi.p:19 = p:23
-                │         └── child_multi.q:20 = q:24
+                │         ├── child_multi.p:19 = p_old:23
+                │         └── child_multi.q:20 = q_old:25
                 └── projections
                      └── NULL::INT8 [as=p_new:27]
 
@@ -159,25 +159,25 @@ root
            │    ├── p_new:26 => child_multi.p:13
            │    └── p_new:26 => child_multi.q:14
            └── project
-                ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p_new:24!null q:25
+                ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
                 ├── inner-join (hash)
-                │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p_new:24!null q:25
+                │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
                 │    ├── scan child_multi
                 │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
                 │    ├── select
-                │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+                │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: p:22!null q:23 p_new:24!null q:25
+                │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
                 │    │    │    └── mapping:
-                │    │    │         ├──  parent_multi.p:7 => p:22
-                │    │    │         ├──  parent_multi.q:8 => q:23
-                │    │    │         ├──  p_new:11 => p_new:24
-                │    │    │         └──  parent_multi.q:8 => q:25
+                │    │    │         ├──  parent_multi.p:7 => p_old:22
+                │    │    │         ├──  parent_multi.q:8 => q_old:24
+                │    │    │         ├──  p_new:11 => p_new:23
+                │    │    │         └──  parent_multi.q:8 => q_new:25
                 │    │    └── filters
-                │    │         └── (p:22 IS DISTINCT FROM p_new:24) OR (q:23 IS DISTINCT FROM q:25)
+                │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
                 │    └── filters
-                │         ├── child_multi.p:18 = p:22
-                │         └── child_multi.q:19 = q:23
+                │         ├── child_multi.p:18 = p_old:22
+                │         └── child_multi.q:19 = q_old:24
                 └── projections
                      └── NULL::INT8 [as=p_new:26]
 
@@ -223,25 +223,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p:24!null q_new:25
+      │         ├── columns: p_new:26 c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p:22!null q:23!null p:24!null q_new:25
+      │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │         │    ├── scan child_multi
       │         │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
       │         │    ├── select
-      │         │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │         │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │         │    │    ├── with-scan &1
-      │         │    │    │    ├── columns: p:22!null q:23 p:24!null q_new:25
+      │         │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │         │    │    │    └── mapping:
-      │         │    │    │         ├──  parent_multi.p:7 => p:22
-      │         │    │    │         ├──  parent_multi.q:8 => q:23
-      │         │    │    │         ├──  parent_multi.p:7 => p:24
+      │         │    │    │         ├──  parent_multi.p:7 => p_old:22
+      │         │    │    │         ├──  parent_multi.q:8 => q_old:24
+      │         │    │    │         ├──  parent_multi.p:7 => p_new:23
       │         │    │    │         └──  q_new:11 => q_new:25
       │         │    │    └── filters
-      │         │    │         └── (p:22 IS DISTINCT FROM p:24) OR (q:23 IS DISTINCT FROM q_new:25)
+      │         │    │         └── (p_old:22 IS DISTINCT FROM p_new:23) OR (q_old:24 IS DISTINCT FROM q_new:25)
       │         │    └── filters
-      │         │         ├── child_multi.p:18 = p:22
-      │         │         └── child_multi.q:19 = q:23
+      │         │         ├── child_multi.p:18 = p_old:22
+      │         │         └── child_multi.q:19 = q_old:24
       │         └── projections
       │              └── NULL::INT8 [as=p_new:26]
       └── cascade
@@ -252,25 +252,25 @@ root
                 │    ├── c_new:41 => grandchild.c:28
                 │    └── c_new:41 => grandchild.q:29
                 └── project
-                     ├── columns: c_new:41 g:32!null grandchild.c:33!null grandchild.q:34!null c:37!null q:38!null c:39!null p_new:40
+                     ├── columns: c_new:41 g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
                      ├── inner-join (hash)
-                     │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c:37!null q:38!null c:39!null p_new:40
+                     │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    ├── scan grandchild
                      │    │    └── columns: g:32!null grandchild.c:33 grandchild.q:34
                      │    ├── select
-                     │    │    ├── columns: c:37!null q:38!null c:39!null p_new:40
+                     │    │    ├── columns: c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    │    ├── with-scan &2
-                     │    │    │    ├── columns: c:37!null q:38!null c:39!null p_new:40
+                     │    │    │    ├── columns: c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    │    │    └── mapping:
-                     │    │    │         ├──  child_multi.c:17 => c:37
-                     │    │    │         ├──  child_multi.q:19 => q:38
-                     │    │    │         ├──  child_multi.c:17 => c:39
-                     │    │    │         └──  p_new:26 => p_new:40
+                     │    │    │         ├──  child_multi.c:17 => c_old:37
+                     │    │    │         ├──  child_multi.q:19 => q_old:39
+                     │    │    │         ├──  child_multi.c:17 => c_new:38
+                     │    │    │         └──  p_new:26 => q_new:40
                      │    │    └── filters
-                     │    │         └── (c:37 IS DISTINCT FROM c:39) OR (q:38 IS DISTINCT FROM p_new:40)
+                     │    │         └── (c_old:37 IS DISTINCT FROM c_new:38) OR (q_old:39 IS DISTINCT FROM q_new:40)
                      │    └── filters
-                     │         ├── grandchild.c:33 = c:37
-                     │         └── grandchild.q:34 = q:38
+                     │         ├── grandchild.c:33 = c_old:37
+                     │         └── grandchild.q:34 = q_old:39
                      └── projections
                           └── NULL::INT8 [as=c_new:41]
 
@@ -326,25 +326,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:29 c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+      │         ├── columns: p_new:29 c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p:25!null q:26!null column2:27!null column3:28!null
+      │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │         │    ├── scan child_multi
       │         │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
       │         │    ├── select
-      │         │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │         │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │         │    │    ├── with-scan &1
-      │         │    │    │    ├── columns: p:25 q:26 column2:27!null column3:28!null
+      │         │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │         │    │    │    └── mapping:
-      │         │    │    │         ├──  parent_multi.p:10 => p:25
-      │         │    │    │         ├──  parent_multi.q:11 => q:26
-      │         │    │    │         ├──  column2:7 => column2:27
-      │         │    │    │         └──  column3:8 => column3:28
+      │         │    │    │         ├──  parent_multi.p:10 => p_old:25
+      │         │    │    │         ├──  parent_multi.q:11 => q_old:27
+      │         │    │    │         ├──  column2:7 => p_new:26
+      │         │    │    │         └──  column3:8 => q_new:28
       │         │    │    └── filters
-      │         │    │         └── (p:25 IS DISTINCT FROM column2:27) OR (q:26 IS DISTINCT FROM column3:28)
+      │         │    │         └── (p_old:25 IS DISTINCT FROM p_new:26) OR (q_old:27 IS DISTINCT FROM q_new:28)
       │         │    └── filters
-      │         │         ├── child_multi.p:21 = p:25
-      │         │         └── child_multi.q:22 = q:26
+      │         │         ├── child_multi.p:21 = p_old:25
+      │         │         └── child_multi.q:22 = q_old:27
       │         └── projections
       │              └── NULL::INT8 [as=p_new:29]
       └── cascade
@@ -355,25 +355,25 @@ root
                 │    ├── c_new:44 => grandchild.c:31
                 │    └── c_new:44 => grandchild.q:32
                 └── project
-                     ├── columns: c_new:44 g:35!null grandchild.c:36!null grandchild.q:37!null c:40!null q:41!null c:42!null p_new:43
+                     ├── columns: c_new:44 g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
                      ├── inner-join (hash)
-                     │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c:40!null q:41!null c:42!null p_new:43
+                     │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    ├── scan grandchild
                      │    │    └── columns: g:35!null grandchild.c:36 grandchild.q:37
                      │    ├── select
-                     │    │    ├── columns: c:40!null q:41!null c:42!null p_new:43
+                     │    │    ├── columns: c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    │    ├── with-scan &2
-                     │    │    │    ├── columns: c:40!null q:41!null c:42!null p_new:43
+                     │    │    │    ├── columns: c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    │    │    └── mapping:
-                     │    │    │         ├──  child_multi.c:20 => c:40
-                     │    │    │         ├──  child_multi.q:22 => q:41
-                     │    │    │         ├──  child_multi.c:20 => c:42
-                     │    │    │         └──  p_new:29 => p_new:43
+                     │    │    │         ├──  child_multi.c:20 => c_old:40
+                     │    │    │         ├──  child_multi.q:22 => q_old:42
+                     │    │    │         ├──  child_multi.c:20 => c_new:41
+                     │    │    │         └──  p_new:29 => q_new:43
                      │    │    └── filters
-                     │    │         └── (c:40 IS DISTINCT FROM c:42) OR (q:41 IS DISTINCT FROM p_new:43)
+                     │    │         └── (c_old:40 IS DISTINCT FROM c_new:41) OR (q_old:42 IS DISTINCT FROM q_new:43)
                      │    └── filters
-                     │         ├── grandchild.c:36 = c:40
-                     │         └── grandchild.q:37 = q:41
+                     │         ├── grandchild.c:36 = c_old:40
+                     │         └── grandchild.q:37 = q_old:42
                      └── projections
                           └── NULL::INT8 [as=c_new:44]
 
@@ -434,25 +434,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:30 c:21!null child_multi.p:22!null child_multi.q:23!null p:26!null q:27!null column2:28!null q:29
+      │         ├── columns: p_new:30 c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p:26!null q:27!null column2:28!null q:29
+      │         │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │         │    ├── scan child_multi
       │         │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
       │         │    ├── select
-      │         │    │    ├── columns: p:26 q:27 column2:28!null q:29
+      │         │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │         │    │    ├── with-scan &1
-      │         │    │    │    ├── columns: p:26 q:27 column2:28!null q:29
+      │         │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │         │    │    │    └── mapping:
-      │         │    │    │         ├──  parent_multi.p:10 => p:26
-      │         │    │    │         ├──  parent_multi.q:11 => q:27
-      │         │    │    │         ├──  column2:7 => column2:28
-      │         │    │    │         └──  parent_multi.q:11 => q:29
+      │         │    │    │         ├──  parent_multi.p:10 => p_old:26
+      │         │    │    │         ├──  parent_multi.q:11 => q_old:28
+      │         │    │    │         ├──  column2:7 => p_new:27
+      │         │    │    │         └──  parent_multi.q:11 => q_new:29
       │         │    │    └── filters
-      │         │    │         └── (p:26 IS DISTINCT FROM column2:28) OR (q:27 IS DISTINCT FROM q:29)
+      │         │    │         └── (p_old:26 IS DISTINCT FROM p_new:27) OR (q_old:28 IS DISTINCT FROM q_new:29)
       │         │    └── filters
-      │         │         ├── child_multi.p:22 = p:26
-      │         │         └── child_multi.q:23 = q:27
+      │         │         ├── child_multi.p:22 = p_old:26
+      │         │         └── child_multi.q:23 = q_old:28
       │         └── projections
       │              └── NULL::INT8 [as=p_new:30]
       └── cascade
@@ -463,25 +463,25 @@ root
                 │    ├── c_new:45 => grandchild.c:32
                 │    └── c_new:45 => grandchild.q:33
                 └── project
-                     ├── columns: c_new:45 g:36!null grandchild.c:37!null grandchild.q:38!null c:41!null q:42!null c:43!null p_new:44
+                     ├── columns: c_new:45 g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
                      ├── inner-join (hash)
-                     │    ├── columns: g:36!null grandchild.c:37!null grandchild.q:38!null c:41!null q:42!null c:43!null p_new:44
+                     │    ├── columns: g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    ├── scan grandchild
                      │    │    └── columns: g:36!null grandchild.c:37 grandchild.q:38
                      │    ├── select
-                     │    │    ├── columns: c:41!null q:42!null c:43!null p_new:44
+                     │    │    ├── columns: c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    │    ├── with-scan &2
-                     │    │    │    ├── columns: c:41!null q:42!null c:43!null p_new:44
+                     │    │    │    ├── columns: c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    │    │    └── mapping:
-                     │    │    │         ├──  child_multi.c:21 => c:41
-                     │    │    │         ├──  child_multi.q:23 => q:42
-                     │    │    │         ├──  child_multi.c:21 => c:43
-                     │    │    │         └──  p_new:30 => p_new:44
+                     │    │    │         ├──  child_multi.c:21 => c_old:41
+                     │    │    │         ├──  child_multi.q:23 => q_old:43
+                     │    │    │         ├──  child_multi.c:21 => c_new:42
+                     │    │    │         └──  p_new:30 => q_new:44
                      │    │    └── filters
-                     │    │         └── (c:41 IS DISTINCT FROM c:43) OR (q:42 IS DISTINCT FROM p_new:44)
+                     │    │         └── (c_old:41 IS DISTINCT FROM c_new:42) OR (q_old:43 IS DISTINCT FROM q_new:44)
                      │    └── filters
-                     │         ├── grandchild.c:37 = c:41
-                     │         └── grandchild.q:38 = q:42
+                     │         ├── grandchild.c:37 = c_old:41
+                     │         └── grandchild.q:38 = q_old:43
                      └── projections
                           └── NULL::INT8 [as=c_new:45]
 
@@ -541,25 +541,25 @@ root
       │    ├── cascades
       │    │    └── fk2
       │    └── project
-      │         ├── columns: p_new:32 c:23!null child_multi.p:24!null child_multi.q:25!null p:28!null q:29!null upsert_p:30!null q:31
+      │         ├── columns: p_new:32 c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │         ├── inner-join (hash)
-      │         │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p:28!null q:29!null upsert_p:30!null q:31
+      │         │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │         │    ├── scan child_multi
       │         │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
       │         │    ├── select
-      │         │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+      │         │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │         │    │    ├── with-scan &1
-      │         │    │    │    ├── columns: p:28 q:29 upsert_p:30!null q:31
+      │         │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │         │    │    │    └── mapping:
-      │         │    │    │         ├──  parent_multi.p:10 => p:28
-      │         │    │    │         ├──  parent_multi.q:11 => q:29
-      │         │    │    │         ├──  upsert_p:16 => upsert_p:30
-      │         │    │    │         └──  parent_multi.q:11 => q:31
+      │         │    │    │         ├──  parent_multi.p:10 => p_old:28
+      │         │    │    │         ├──  parent_multi.q:11 => q_old:30
+      │         │    │    │         ├──  upsert_p:16 => p_new:29
+      │         │    │    │         └──  parent_multi.q:11 => q_new:31
       │         │    │    └── filters
-      │         │    │         └── (p:28 IS DISTINCT FROM upsert_p:30) OR (q:29 IS DISTINCT FROM q:31)
+      │         │    │         └── (p_old:28 IS DISTINCT FROM p_new:29) OR (q_old:30 IS DISTINCT FROM q_new:31)
       │         │    └── filters
-      │         │         ├── child_multi.p:24 = p:28
-      │         │         └── child_multi.q:25 = q:29
+      │         │         ├── child_multi.p:24 = p_old:28
+      │         │         └── child_multi.q:25 = q_old:30
       │         └── projections
       │              └── NULL::INT8 [as=p_new:32]
       └── cascade
@@ -570,25 +570,25 @@ root
                 │    ├── c_new:47 => grandchild.c:34
                 │    └── c_new:47 => grandchild.q:35
                 └── project
-                     ├── columns: c_new:47 g:38!null grandchild.c:39!null grandchild.q:40!null c:43!null q:44!null c:45!null p_new:46
+                     ├── columns: c_new:47 g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                      ├── inner-join (hash)
-                     │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c:43!null q:44!null c:45!null p_new:46
+                     │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    ├── scan grandchild
                      │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40
                      │    ├── select
-                     │    │    ├── columns: c:43!null q:44!null c:45!null p_new:46
+                     │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    │    ├── with-scan &2
-                     │    │    │    ├── columns: c:43!null q:44!null c:45!null p_new:46
+                     │    │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    │    │    └── mapping:
-                     │    │    │         ├──  child_multi.c:23 => c:43
-                     │    │    │         ├──  child_multi.q:25 => q:44
-                     │    │    │         ├──  child_multi.c:23 => c:45
-                     │    │    │         └──  p_new:32 => p_new:46
+                     │    │    │         ├──  child_multi.c:23 => c_old:43
+                     │    │    │         ├──  child_multi.q:25 => q_old:45
+                     │    │    │         ├──  child_multi.c:23 => c_new:44
+                     │    │    │         └──  p_new:32 => q_new:46
                      │    │    └── filters
-                     │    │         └── (c:43 IS DISTINCT FROM c:45) OR (q:44 IS DISTINCT FROM p_new:46)
+                     │    │         └── (c_old:43 IS DISTINCT FROM c_new:44) OR (q_old:45 IS DISTINCT FROM q_new:46)
                      │    └── filters
-                     │         ├── grandchild.c:39 = c:43
-                     │         └── grandchild.q:40 = q:44
+                     │         ├── grandchild.c:39 = c_old:43
+                     │         └── grandchild.q:40 = q_old:45
                      └── projections
                           └── NULL::INT8 [as=c_new:47]
 
@@ -638,11 +638,11 @@ root
            ├── partial index put columns: partial_index_put1:21 partial_index_put2:22
            ├── partial index del columns: partial_index_put1:21 partial_index_del2:23
            └── project
-                ├── columns: partial_index_put1:21 partial_index_put2:22 partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null p_new:20
+                ├── columns: partial_index_put1:21 partial_index_put2:22 partial_index_del2:23!null c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null p_new:20
                 ├── project
-                │    ├── columns: p_new:20 c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+                │    ├── columns: p_new:20 c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
                 │    ├── inner-join (hash)
-                │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p:18!null p_new:19!null
+                │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
                 │    │    ├── scan child_partial
                 │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15
                 │    │    │    └── partial index predicates
@@ -651,16 +651,16 @@ root
                 │    │    │         └── child_partial_i_idx: filters
                 │    │    │              └── child_partial.p:14 > 0
                 │    │    ├── select
-                │    │    │    ├── columns: p:18!null p_new:19!null
+                │    │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    │    ├── with-scan &1
-                │    │    │    │    ├── columns: p:18!null p_new:19!null
+                │    │    │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    │    │    └── mapping:
-                │    │    │    │         ├──  parent_partial.p:4 => p:18
+                │    │    │    │         ├──  parent_partial.p:4 => p_old:18
                 │    │    │    │         └──  p_new:7 => p_new:19
                 │    │    │    └── filters
-                │    │    │         └── p:18 IS DISTINCT FROM p_new:19
+                │    │    │         └── p_old:18 IS DISTINCT FROM p_new:19
                 │    │    └── filters
-                │    │         └── child_partial.p:14 = p:18
+                │    │         └── child_partial.p:14 = p_old:18
                 │    └── projections
                 │         └── NULL::INT8 [as=p_new:20]
                 └── projections
@@ -711,9 +711,9 @@ root
            │    ├── p_new:20 => child_virt.p:9
            │    └── p_new:20 => v:10
            └── project
-                ├── columns: p_new:20 c:13!null child_virt.p:14!null v:15!null p:18!null p_new:19!null
+                ├── columns: p_new:20 c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
                 ├── inner-join (hash)
-                │    ├── columns: c:13!null child_virt.p:14!null v:15!null p:18!null p_new:19!null
+                │    ├── columns: c:13!null child_virt.p:14!null v:15!null p_old:18!null p_new:19!null
                 │    ├── project
                 │    │    ├── columns: v:15!null c:13!null child_virt.p:14!null
                 │    │    ├── scan child_virt
@@ -724,15 +724,15 @@ root
                 │    │    └── projections
                 │    │         └── child_virt.p:14 [as=v:15]
                 │    ├── select
-                │    │    ├── columns: p:18!null p_new:19!null
+                │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: p:18!null p_new:19!null
+                │    │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    │    └── mapping:
-                │    │    │         ├──  parent_virt.p:4 => p:18
+                │    │    │         ├──  parent_virt.p:4 => p_old:18
                 │    │    │         └──  p_new:7 => p_new:19
                 │    │    └── filters
-                │    │         └── p:18 IS DISTINCT FROM p_new:19
+                │    │         └── p_old:18 IS DISTINCT FROM p_new:19
                 │    └── filters
-                │         └── child_virt.p:14 = p:18
+                │         └── child_virt.p:14 = p_old:18
                 └── projections
                      └── NULL::INT8 [as=p_new:20]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -212,21 +212,6 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 	}
 
 	addCol := func(expr tree.Expr, targetColID opt.ColumnID) {
-		// If the expression is already a scopeColumn, we can skip creating a
-		// new scopeColumn and proceed with type checking and adding the column
-		// to the list of source columns to update. The expression can be a
-		// scopeColumn when addUpdateCols is called from the
-		// onUpdateCascadeBuilder while building foreign key cascading updates.
-		//
-		// The input scopeColumn is a pointer to a column in mb.outScope. It was
-		// copied by value to projectionsScope. The checkCol function mutates
-		// the name of projected columns, so we must lookup the column in
-		// projectionsScope so that the correct scopeColumn is renamed.
-		if scopeCol, ok := expr.(*scopeColumn); ok {
-			checkCol(projectionsScope.getColumn(scopeCol.id), targetColID)
-			return
-		}
-
 		// Allow right side of SET to be DEFAULT.
 		if _, ok := expr.(tree.DefaultVal); ok {
 			expr = mb.parseDefaultExpr(targetColID)


### PR DESCRIPTION
#### opt: make FK ON UPDATE CASCADE input columns anonymous

This commit anonymizes the columns in the input of a foreign key
ON UPDATE CASCADE expression. This is safe because these columns can
only be referenced by other expressions if they are update columns, and
in that case, `mutationBuilder.addUpdateCascade` will give them a
distinct name in the scope it produces. This change allows a special
case added in #57153 to be removed, without failing the regression test.

Release note: None

#### opt: use more accurate FK ON UPDATE column metadata names

Columns produced by the WithScan expression in a foreign key ON UPDATE
CASCADE now have metadata names based on the column names of the child
table, rather than the parent table. This more accurately describes the
columns in the cascade plan because the plan is concerned with the child
table, not the parent. Metadata names are only used in opt expression
trees, so this is purely an aesthetic change, not a semantic one.

Release note: None
