### PR TITLE
logictest: improve progress output

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1325,11 +1325,13 @@ func (t *logicTest) close() {
 // out emits a message both on stdout and the log files if
 // verbose is set.
 func (t *logicTest) outf(format string, args ...interface{}) {
-	if t.verbose {
-		fmt.Printf(format, args...)
-		fmt.Println()
-		log.Infof(context.Background(), format, args...)
+	if !t.verbose {
+		return
 	}
+	log.Infof(context.Background(), format, args...)
+	msg := fmt.Sprintf(format, args...)
+	now := timeutil.Now().Format("15:04:05")
+	fmt.Printf("[%s] %s\n", now, msg)
 }
 
 // setUser sets the DB client to the specified user.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1217,7 +1217,7 @@ type logicTest struct {
 	// new one, but keep some shared resources across the entire test. An example
 	// would be an IO directory used throughout the test.
 	testCleanupFuncs []func()
-	// progress holds the number of tests executed so far.
+	// progress holds the number of statements executed so far.
 	progress int
 	// failures holds the number of tests failed so far, when
 	// -try-harder is set.
@@ -3220,7 +3220,7 @@ func (t *logicTest) success(file string) {
 	now := timeutil.Now()
 	if now.Sub(t.lastProgress) >= 2*time.Second {
 		t.lastProgress = now
-		t.outf("--- progress: %s: %d statements/queries", file, t.progress)
+		t.outf("--- progress: %s: %d statements", file, t.progress)
 	}
 }
 
@@ -3593,7 +3593,7 @@ func RunLogicTestWithDefaultConfig(
 					now := timeutil.Now()
 					if now.Sub(progress.lastProgress) >= 2*time.Second {
 						progress.lastProgress = now
-						lt.outf("--- total progress: %d statements/queries", progress.total)
+						lt.outf("--- total progress: %d statements", progress.total)
 					}
 				})
 			}


### PR DESCRIPTION
Logictests would print some progress messages to stdout as they run.
Each file prints when it ends and, while it's running, it prints
messages when statements finish successfully (but only up to once per
2s). This patch adds a second-level timestamp to those messages, in
order to provide more clues in the output of timed out logictest
packages. Otherwise, I'm always left guessing if the package had been
making constant progress until the timeout, or if it got stuck at some
point.

Release note: None