### PR TITLE
kvserver: improve panic handling

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -766,6 +766,10 @@ func (r *Replica) applySnapshot(
 
 	isInitialSnap := !r.IsInitialized()
 	defer func() {
+		if e := recover(); e != nil {
+			// Re-panic to avoid the log.Fatal() below.
+			panic(e)
+		}
 		if err == nil {
 			desc, err := r.GetReplicaDescriptor()
 			if err != nil {


### PR DESCRIPTION
This deferred function is unusual in that it contains a log.Fatal. In
case the deferred function was called through a panic unwind, the
log.Fatal() would kick in and hide the real panic. This patch avoids
that by re-panicking.

Release note: None