### PR TITLE
release-21.1: catalog/descs: hydrate types for tuples

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -2061,14 +2061,8 @@ func (dt DistSQLTypeResolver) GetTypeDescriptor(
 // HydrateTypeSlice installs metadata into a slice of types.T's.
 func (dt DistSQLTypeResolver) HydrateTypeSlice(ctx context.Context, typs []*types.T) error {
 	for _, t := range typs {
-		if t.UserDefined() {
-			name, desc, err := dt.GetTypeDescriptor(ctx, typedesc.GetTypeDescID(t))
-			if err != nil {
-				return err
-			}
-			if err := desc.HydrateTypeInfoWithName(ctx, t, &name, dt); err != nil {
-				return err
-			}
+		if err := typedesc.EnsureTypeIsHydrated(ctx, t, dt); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -715,35 +715,52 @@ func (desc *Immutable) MakeTypesT(
 	}
 }
 
-// HydrateTypesInTableDescriptor uses typeLookup to install metadata in the
-// types present in a table descriptor. typeLookup retrieves the fully
-// qualified name and descriptor for a particular ID.
-func HydrateTypesInTableDescriptor(
-	ctx context.Context, desc *descpb.TableDescriptor, res catalog.TypeDescriptorResolver,
+// EnsureTypeIsHydrated makes sure that t is a fully-hydrated type.
+func EnsureTypeIsHydrated(
+	ctx context.Context, t *types.T, res catalog.TypeDescriptorResolver,
 ) error {
-	hydrateCol := func(col *descpb.ColumnDescriptor) error {
-		if col.Type.UserDefined() {
-			// Look up its type descriptor.
-			name, typDesc, err := res.GetTypeDescriptor(ctx, GetTypeDescID(col.Type))
-			if err != nil {
-				return err
-			}
-			// Note that this will no-op if the type is already hydrated.
-			if err := typDesc.HydrateTypeInfoWithName(ctx, col.Type, &name, res); err != nil {
+	// maybeHydrateType checks if t is a user-defined type that hasn't been
+	// hydrated yet, and installs the metadata if so.
+	maybeHydrateType := func(ctx context.Context, t *types.T, res catalog.TypeDescriptorResolver) error {
+		if !t.UserDefined() || t.IsHydrated() {
+			return nil
+		}
+		// Look up its type descriptor.
+		name, typDesc, err := res.GetTypeDescriptor(ctx, GetTypeDescID(t))
+		if err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		return typDesc.HydrateTypeInfoWithName(ctx, t, &name, res)
+	}
+	if t.Family() == types.TupleFamily {
+		for _, typ := range t.TupleContents() {
+			if err := maybeHydrateType(ctx, typ, res); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
+	return maybeHydrateType(ctx, t, res)
+}
+
+// HydrateTypesInTableDescriptor uses res to install metadata in the types
+// present in a table descriptor. res retrieves the fully qualified name and
+// descriptor for a particular ID.
+func HydrateTypesInTableDescriptor(
+	ctx context.Context, desc *descpb.TableDescriptor, res catalog.TypeDescriptorResolver,
+) error {
 	for i := range desc.Columns {
-		if err := hydrateCol(&desc.Columns[i]); err != nil {
+		if err := EnsureTypeIsHydrated(ctx, desc.Columns[i].Type, res); err != nil {
 			return err
 		}
 	}
 	for i := range desc.Mutations {
 		mut := &desc.Mutations[i]
 		if col := mut.GetColumn(); col != nil {
-			if err := hydrateCol(col); err != nil {
+			if err := EnsureTypeIsHydrated(ctx, col.Type, res); err != nil {
 				return err
 			}
 		}
@@ -787,14 +804,7 @@ func (desc *Immutable) HydrateTypeInfoWithName(
 			case types.ArrayFamily:
 				// Hydrate the element type.
 				elemType := typ.ArrayContents()
-				elemTypName, elemTypDesc, err := res.GetTypeDescriptor(ctx, GetTypeDescID(elemType))
-				if err != nil {
-					return err
-				}
-				if err := elemTypDesc.HydrateTypeInfoWithName(ctx, elemType, &elemTypName, res); err != nil {
-					return err
-				}
-				return nil
+				return EnsureTypeIsHydrated(ctx, elemType, res)
 			default:
 				return errors.AssertionFailedf("only array types aliases can be user defined")
 			}

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1385,3 +1385,19 @@ query T
 SELECT * from arr_t5
 ----
 {a,b}
+
+# Regression test for not hydrating an enum when it is used in a tuple.
+statement ok
+DROP TYPE IF EXISTS greeting;
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
+CREATE TABLE seed AS SELECT g::INT8 AS _int8 FROM generate_series(1, 5) AS g;
+WITH
+  cte1 (col1)
+    AS (
+      SELECT * FROM (VALUES (COALESCE((NULL, 'hello':::greeting), (1, 'howdy':::greeting))), ((2, 'hi':::greeting)))
+    ),
+  cte2 (col2) AS (SELECT _int8 FROM seed)
+SELECT
+  col1, col2
+FROM
+  cte1, cte2;


### PR DESCRIPTION
Backport 1/1 commits from #72406.

/cc @cockroachdb/release

---

Before we can use the user-defined types, we have to hydrate them. We do
so for enums as well as arrays of enums, but we forgot to do so for
tuples containing enums in some cases. This is now fixed.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error or crash when some queries involving tuples with ENUMs
were executed in a distributed manner. This is now fixed.
