### PR TITLE
kvserver: fix span for receiving snapshot

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3229,7 +3229,9 @@ func (h *slowSnapRaftHandler) unblock() {
 }
 
 func (h *slowSnapRaftHandler) HandleSnapshot(
-	header *kvserver.SnapshotRequest_Header, respStream kvserver.SnapshotResponseStream,
+	ctx context.Context,
+	header *kvserver.SnapshotRequest_Header,
+	respStream kvserver.SnapshotResponseStream,
 ) error {
 	if header.RaftMessageRequest.RangeID == h.rangeID {
 		h.Lock()
@@ -3239,7 +3241,7 @@ func (h *slowSnapRaftHandler) HandleSnapshot(
 			<-waitCh
 		}
 	}
-	return h.RaftMessageHandler.HandleSnapshot(header, respStream)
+	return h.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 // TestStoreRangeMergeUninitializedLHSFollower reproduces a rare bug in which a

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -121,14 +121,16 @@ func (h *unreliableRaftHandler) HandleRaftResponse(
 }
 
 func (h *unreliableRaftHandler) HandleSnapshot(
-	header *kvserver.SnapshotRequest_Header, respStream kvserver.SnapshotResponseStream,
+	ctx context.Context,
+	header *kvserver.SnapshotRequest_Header,
+	respStream kvserver.SnapshotResponseStream,
 ) error {
 	if header.RaftMessageRequest.RangeID == h.rangeID && h.snapErr != nil {
 		if err := h.snapErr(header); err != nil {
 			return err
 		}
 	}
-	return h.RaftMessageHandler.HandleSnapshot(header, respStream)
+	return h.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 // testClusterStoreRaftMessageHandler exists to allows a store to be stopped and
@@ -166,13 +168,15 @@ func (h *testClusterStoreRaftMessageHandler) HandleRaftResponse(
 }
 
 func (h *testClusterStoreRaftMessageHandler) HandleSnapshot(
-	header *kvserver.SnapshotRequest_Header, respStream kvserver.SnapshotResponseStream,
+	ctx context.Context,
+	header *kvserver.SnapshotRequest_Header,
+	respStream kvserver.SnapshotResponseStream,
 ) error {
 	store, err := h.getStore()
 	if err != nil {
 		return err
 	}
-	return store.HandleSnapshot(header, respStream)
+	return store.HandleSnapshot(ctx, header, respStream)
 }
 
 // testClusterPartitionedRange is a convenient abstraction to create a range on a node

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1295,11 +1295,6 @@ func (c fakeSnapshotStream) Send(request *kvserver.SnapshotResponse) error {
 	return nil
 }
 
-// Context implements the SnapshotResponseStream interface.
-func (c fakeSnapshotStream) Context() context.Context {
-	return context.Background()
-}
-
 // TestFailedSnapshotFillsReservation tests that failing to finish applying an
 // incoming snapshot still cleans up the outstanding reservation that was made.
 func TestFailedSnapshotFillsReservation(t *testing.T) {
@@ -1340,7 +1335,7 @@ func TestFailedSnapshotFillsReservation(t *testing.T) {
 	// "snapshot accepted" message.
 	expectedErr := errors.Errorf("")
 	stream := fakeSnapshotStream{nil, expectedErr}
-	if err := store1.HandleSnapshot(&header, stream); !errors.Is(err, expectedErr) {
+	if err := store1.HandleSnapshot(ctx, &header, stream); !errors.Is(err, expectedErr) {
 		t.Fatalf("expected error %s, but found %v", expectedErr, err)
 	}
 	if n := store1.ReservationCount(); n != 0 {
@@ -3424,7 +3419,7 @@ func (d errorChannelTestHandler) HandleRaftResponse(
 }
 
 func (errorChannelTestHandler) HandleSnapshot(
-	_ *kvserver.SnapshotRequest_Header, _ kvserver.SnapshotResponseStream,
+	_ context.Context, _ *kvserver.SnapshotRequest_Header, _ kvserver.SnapshotResponseStream,
 ) error {
 	panic("unimplemented")
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5430,10 +5430,6 @@ func TestReplicaRemovalClosesProposalQuota(t *testing.T) {
 
 type noopRaftMessageResponseSteam struct{}
 
-func (n noopRaftMessageResponseSteam) Context() context.Context {
-	return context.Background()
-}
-
 func (n noopRaftMessageResponseSteam) Send(*kvserver.RaftMessageResponse) error {
 	return nil
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5415,7 +5415,7 @@ func TestReplicaRemovalClosesProposalQuota(t *testing.T) {
 		FromReplica:   fromReplDesc,
 		ToReplica:     newReplDesc,
 		Message:       raftpb.Message{Type: raftpb.MsgVote, Term: 2},
-	}, noopRaftMessageResponseSteam{}))
+	}, noopRaftMessageResponseStream{}))
 	ts := waitForTombstone(t, store.Engine(), desc.RangeID)
 	require.Equal(t, ts.NextReplicaID, desc.NextReplicaID)
 	wg.Wait()
@@ -5423,13 +5423,13 @@ func TestReplicaRemovalClosesProposalQuota(t *testing.T) {
 	require.Regexp(t, "closed.*destroyed", err)
 }
 
-type noopRaftMessageResponseSteam struct{}
+type noopRaftMessageResponseStream struct{}
 
-func (n noopRaftMessageResponseSteam) Send(*kvserver.RaftMessageResponse) error {
+func (n noopRaftMessageResponseStream) Send(*kvserver.RaftMessageResponse) error {
 	return nil
 }
 
-var _ kvserver.RaftMessageResponseStream = noopRaftMessageResponseSteam{}
+var _ kvserver.RaftMessageResponseStream = noopRaftMessageResponseStream{}
 
 // TestElectionAfterRestart is an end-to-end test for shouldCampaignOnWakeLocked
 // (see TestReplicaShouldCampaignOnWake for the corresponding unit test). It sets

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -798,10 +798,12 @@ type RaftMessageHandlerInterceptor struct {
 }
 
 func (mh RaftMessageHandlerInterceptor) HandleSnapshot(
-	header *kvserver.SnapshotRequest_Header, respStream kvserver.SnapshotResponseStream,
+	ctx context.Context,
+	header *kvserver.SnapshotRequest_Header,
+	respStream kvserver.SnapshotResponseStream,
 ) error {
 	mh.handleSnapshotFilter(header)
-	return mh.RaftMessageHandler.HandleSnapshot(header, respStream)
+	return mh.RaftMessageHandler.HandleSnapshot(ctx, header, respStream)
 }
 
 // TestStoreEmptyRangeSnapshotSize tests that the snapshot request header for a

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -72,7 +72,6 @@ var targetRaftOutgoingBatchSize = settings.RegisterByteSizeSetting(
 // RaftMessageResponseStream is the subset of the
 // MultiRaft_RaftMessageServer interface that is needed for sending responses.
 type RaftMessageResponseStream interface {
-	Context() context.Context
 	Send(*RaftMessageResponse) error
 }
 
@@ -83,10 +82,6 @@ type RaftMessageResponseStream interface {
 type lockedRaftMessageResponseStream struct {
 	wrapped MultiRaft_RaftMessageBatchServer
 	sendMu  syncutil.Mutex
-}
-
-func (s *lockedRaftMessageResponseStream) Context() context.Context {
-	return s.wrapped.Context()
 }
 
 func (s *lockedRaftMessageResponseStream) Send(resp *RaftMessageResponse) error {

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -98,7 +98,6 @@ func (s *lockedRaftMessageResponseStream) Recv() (*RaftMessageRequestBatch, erro
 // SnapshotResponseStream is the subset of the
 // MultiRaft_RaftSnapshotServer interface that is needed for sending responses.
 type SnapshotResponseStream interface {
-	Context() context.Context
 	Send(*SnapshotResponse) error
 	Recv() (*SnapshotRequest, error)
 }
@@ -120,7 +119,7 @@ type RaftMessageHandler interface {
 
 	// HandleSnapshot is called for each new incoming snapshot stream, after
 	// parsing the initial SnapshotRequest_Header on the stream.
-	HandleSnapshot(header *SnapshotRequest_Header, respStream SnapshotResponseStream) error
+	HandleSnapshot(ctx context.Context, header *SnapshotRequest_Header, respStream SnapshotResponseStream) error
 }
 
 type raftTransportStats struct {
@@ -342,8 +341,10 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 	errCh := make(chan error, 1)
 
 	// Node stopping error is caught below in the select.
+	taskCtx, cancel := t.stopper.WithCancelOnQuiesce(stream.Context())
+	defer cancel()
 	if err := t.stopper.RunAsyncTaskEx(
-		stream.Context(),
+		taskCtx,
 		stop.TaskOpts{
 			TaskName: "storage.RaftTransport: processing batch",
 			SpanOpt:  stop.ChildSpan,
@@ -404,8 +405,10 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 // RaftSnapshot handles incoming streaming snapshot requests.
 func (t *RaftTransport) RaftSnapshot(stream MultiRaft_RaftSnapshotServer) error {
 	errCh := make(chan error, 1)
+	taskCtx, cancel := t.stopper.WithCancelOnQuiesce(stream.Context())
+	defer cancel()
 	if err := t.stopper.RunAsyncTaskEx(
-		stream.Context(),
+		taskCtx,
 		stop.TaskOpts{
 			TaskName: "storage.RaftTransport: processing snapshot",
 			SpanOpt:  stop.ChildSpan,
@@ -427,7 +430,7 @@ func (t *RaftTransport) RaftSnapshot(stream MultiRaft_RaftSnapshotServer) error 
 						rmr.FromReplica, rmr.ToReplica)
 					return roachpb.NewStoreNotFoundError(rmr.ToReplica.StoreID)
 				}
-				return handler.HandleSnapshot(req.Header, stream)
+				return handler.HandleSnapshot(ctx, req.Header, stream)
 			}()
 		}); err != nil {
 		return err

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -342,9 +342,12 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 	errCh := make(chan error, 1)
 
 	// Node stopping error is caught below in the select.
-	if err := t.stopper.RunAsyncTask(
-		stream.Context(), "storage.RaftTransport: processing batch",
-		func(ctx context.Context) {
+	if err := t.stopper.RunAsyncTaskEx(
+		stream.Context(),
+		stop.TaskOpts{
+			TaskName: "storage.RaftTransport: processing batch",
+			SpanOpt:  stop.ChildSpan,
+		}, func(ctx context.Context) {
 			errCh <- func() error {
 				var stats *raftTransportStats
 				stream := &lockedRaftMessageResponseStream{wrapped: stream}
@@ -401,9 +404,12 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 // RaftSnapshot handles incoming streaming snapshot requests.
 func (t *RaftTransport) RaftSnapshot(stream MultiRaft_RaftSnapshotServer) error {
 	errCh := make(chan error, 1)
-	if err := t.stopper.RunAsyncTask(
-		stream.Context(), "storage.RaftTransport: processing snapshot",
-		func(ctx context.Context) {
+	if err := t.stopper.RunAsyncTaskEx(
+		stream.Context(),
+		stop.TaskOpts{
+			TaskName: "storage.RaftTransport: processing snapshot",
+			SpanOpt:  stop.ChildSpan,
+		}, func(ctx context.Context) {
 			errCh <- func() error {
 				req, err := stream.Recv()
 				if err != nil {

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -88,7 +88,9 @@ func (s channelServer) HandleRaftResponse(
 }
 
 func (s channelServer) HandleSnapshot(
-	header *kvserver.SnapshotRequest_Header, stream kvserver.SnapshotResponseStream,
+	_ context.Context,
+	header *kvserver.SnapshotRequest_Header,
+	stream kvserver.SnapshotResponseStream,
 ) error {
 	panic("unexpected HandleSnapshot")
 }

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -65,9 +65,9 @@ func (q *raftRequestQueue) recycle(processed []raftRequestInfo) {
 // HandleSnapshot reads an incoming streaming snapshot and applies it if
 // possible.
 func (s *Store) HandleSnapshot(
-	header *SnapshotRequest_Header, stream SnapshotResponseStream,
+	ctx context.Context, header *SnapshotRequest_Header, stream SnapshotResponseStream,
 ) error {
-	ctx := s.AnnotateCtx(stream.Context())
+	ctx = s.AnnotateCtx(ctx)
 	const name = "storage.Store: handle snapshot"
 	return s.stopper.RunTaskWithErr(ctx, name, func(ctx context.Context) error {
 		s.metrics.RaftRcvdMessages[raftpb.MsgSnap].Inc(1)

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -386,7 +386,7 @@ const (
 	//
 	// ChildSpan has consequences on memory usage: the memory lifetime of
 	// the task's span becomes tied to the lifetime of the parent. Generally
-	// ChildSpan should be used when the parent waits for the task to
+	// ChildSpan should be used when the parent usually waits for the task to
 	// complete, and the parent is not a long-running process.
 	ChildSpan
 


### PR DESCRIPTION
This patch fixes a span use-after-Finish(). Such uses are currently
reluctantly tollerated, but they won't be in the future. The function
processing an incoming snapshot was using the RPCs context, even though
it was running in an async task and the RPC handler could finish before
it. The async task has its own span (for this very purpose), but the
handler in question was using the wrong ctx and hence the wrong span.

This patch also makes it explicit on a couple of code paths that async
functions spawned by some RPC handlers are canceled on quiescence. I
believe this was already the case: the RPC handlers were spawning async
tasks with no explicit cancelation, but then they were returning from
the handler on quiescence without waiting for the tasks. I think the
returning from the handler cancels the RPC's ctx (which ctx was used for
the operations in question). This patch makes this explicit.

Release note: None