### PR TITLE
cdc: add detail to buffer closed error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -444,17 +444,22 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 			return ca.ProcessRowHelper(ca.resolvedSpanBuf.Pop()), nil
 		}
 		if err := ca.tick(); err != nil {
-			if errors.Is(err, kvevent.ErrBufferClosed) {
+			var e kvevent.ErrBufferClosed
+			if errors.As(err, &e) {
 				// ErrBufferClosed is a signal that
 				// our kvfeed has exited expectedly.
-				err = nil
-			}
+				err = e.Unwrap()
+				if errors.Is(err, kvevent.ErrNormalRestartReason) {
+					err = nil
+				}
+			} else {
 
-			select {
-			// If the poller errored first, that's the
-			// interesting one, so overwrite `err`.
-			case err = <-ca.errCh:
-			default:
+				select {
+				// If the poller errored first, that's the
+				// interesting one, so overwrite `err`.
+				case err = <-ca.errCh:
+				default:
+				}
 			}
 			// Shut down the poller if it wasn't already.
 			ca.cancel()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1315,7 +1315,6 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 
 func TestChangefeedColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 71796, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
@@ -1464,7 +1463,6 @@ func requireErrorSoon(
 func TestChangefeedFailOnTableOffline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDeadlock(t, "timeout")
 
 	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -80,7 +80,7 @@ func TestBlockingBuffer(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics, quotapool.OnWaitStart(notifyWait))
 	defer func() {
-		require.NoError(t, buf.Close(context.Background()))
+		require.NoError(t, buf.CloseWithReason(context.Background(), nil))
 	}()
 
 	producerCtx, stopProducers := context.WithCancel(context.Background())
@@ -123,7 +123,7 @@ func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)
 	defer func() {
-		require.NoError(t, buf.Close(context.Background()))
+		require.NoError(t, buf.CloseWithReason(context.Background(), nil))
 	}()
 
 	producerCtx, stopProducer := context.WithCancel(context.Background())

--- a/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/chan_buffer.go
@@ -17,7 +17,8 @@ import (
 // chanBuffer mediates between the changed data KVFeed and the rest of the
 // changefeed pipeline (which is backpressured all the way to the sink).
 type chanBuffer struct {
-	entriesCh chan Event
+	entriesCh    chan Event
+	closedReason error
 }
 
 // MakeChanBuffer returns an Buffer backed by an unbuffered channel.
@@ -45,7 +46,9 @@ func (b *chanBuffer) Drain(ctx context.Context) error {
 	return nil
 }
 
-func (b *chanBuffer) Close(_ context.Context) error {
+// CloseWithReason implements Writer interface.
+func (b *chanBuffer) CloseWithReason(_ context.Context, reason error) error {
+	b.closedReason = reason
 	close(b.entriesCh)
 	return nil
 }
@@ -60,7 +63,7 @@ func (b *chanBuffer) Get(ctx context.Context) (Event, error) {
 		if !ok {
 			// Our channel has been closed by the
 			// Writer. No more events will be returned.
-			return e, ErrBufferClosed
+			return e, ErrBufferClosed{reason: b.closedReason}
 		}
 		e.bufferGetTimestamp = timeutil.Now()
 		return e, nil

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -114,7 +114,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if !errors.As(err, &scErr) {
 		// Regardless of whether we exited KV feed with or without an error, that error
 		// is not a schema change; so, close the writer and return.
-		return errors.CombineErrors(err, f.writer.Close(ctx))
+		return errors.CombineErrors(err, f.writer.CloseWithReason(ctx, err))
 	}
 
 	log.Infof(ctx, "stopping kv feed due to schema change at %v", scErr.ts)
@@ -124,7 +124,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// Regardless of whether drain succeeds, we must also close the buffer to release
 	// any resources, and to let the consumer (changeAggregator) know that no more writes
 	// are expected so that it can transition to a draining state.
-	err = errors.CombineErrors(f.writer.Drain(ctx), f.writer.Close(ctx))
+	err = errors.CombineErrors(f.writer.Drain(ctx), f.writer.CloseWithReason(ctx, kvevent.ErrNormalRestartReason))
 
 	if err == nil {
 		// This context is canceled by the change aggregator when it receives
@@ -352,7 +352,7 @@ func (f *kvFeed) runUntilTableEvent(
 
 	memBuf := f.bufferFactory()
 	defer func() {
-		err = errors.CombineErrors(err, memBuf.Close(ctx))
+		err = errors.CombineErrors(err, memBuf.CloseWithReason(ctx, err))
 	}()
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
@@ -42,7 +42,7 @@ func (r *recordResolvedWriter) Drain(ctx context.Context) error {
 	return nil
 }
 
-func (r *recordResolvedWriter) Close(ctx context.Context) error {
+func (r *recordResolvedWriter) CloseWithReason(ctx context.Context, reason error) error {
 	return nil
 }
 


### PR DESCRIPTION
When a kvfeed closes the buffer it's writing to due to an expected error,
such as a schema change, the reader may return ErrBufferClosed before the
error has propagated to be available to the caller of Get(), leading to a
race condition. Rather than force the caller to wait for an error it knows
is coming, we can decorate the ErrBufferClosed with the reason.

Fixes #71796
Fixes #71797 
Fixes #72019

Release note (bug fix): Fixed a race condition that could have caused core changefeeds whose targeted table became invalid to not explain why when shutting down.