### PR TITLE
server: fix span use after Finish() 

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2380,7 +2380,7 @@ func (s *SQLServer) startServeSQL(
 	_ = stopper.RunAsyncTaskEx(pgCtx,
 		stop.TaskOpts{TaskName: "pgwire-listener", SpanOpt: stop.SterileRootSpan},
 		func(ctx context.Context) {
-			err := connManager.ServeWith(ctx, stopper, pgL, func(conn net.Conn) {
+			err := connManager.ServeWith(ctx, stopper, pgL, func(ctx context.Context, conn net.Conn) {
 				connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
 				tcpKeepAlive.configure(connCtx, conn)
 
@@ -2423,7 +2423,7 @@ func (s *SQLServer) startServeSQL(
 		if err := stopper.RunAsyncTaskEx(pgCtx,
 			stop.TaskOpts{TaskName: "unix-listener", SpanOpt: stop.SterileRootSpan},
 			func(ctx context.Context) {
-				err := connManager.ServeWith(ctx, stopper, unixLn, func(conn net.Conn) {
+				err := connManager.ServeWith(ctx, stopper, unixLn, func(ctx context.Context, conn net.Conn) {
 					connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
 					if err := s.pgServer.ServeConn(connCtx, conn, pgwire.SocketUnix); err != nil {
 						log.Ops.Errorf(connCtx, "%v", err)

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -127,7 +127,10 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 
 // ServeWith accepts connections on ln and serves them using serveConn.
 func (s *Server) ServeWith(
-	ctx context.Context, stopper *stop.Stopper, l net.Listener, serveConn func(net.Conn),
+	ctx context.Context,
+	stopper *stop.Stopper,
+	l net.Listener,
+	serveConn func(context.Context, net.Conn),
 ) error {
 	// Inspired by net/http.(*Server).Serve
 	var tempDelay time.Duration // how long to sleep on accept failure
@@ -150,12 +153,15 @@ func (s *Server) ServeWith(
 			return e
 		}
 		tempDelay = 0
-		go func() {
+		err := stopper.RunAsyncTask(ctx, "pgwire-serve", func(ctx context.Context) {
 			defer stopper.Recover(ctx)
 			s.Server.ConnState(rw, http.StateNew) // before Serve can return
-			serveConn(rw)
+			serveConn(ctx, rw)
 			s.Server.ConnState(rw, http.StateClosed)
-		}()
+		})
+		if err != nil {
+			return err
+		}
 	}
 }
 
@@ -169,10 +175,11 @@ func IsClosedConnection(err error) bool {
 		strings.Contains(err.Error(), "use of closed network connection")
 }
 
-// FatalIfUnexpected calls Log.Fatal(err) unless err is nil,
-// cmux.ErrListenerClosed, or the net package's errClosed.
+// FatalIfUnexpected calls Log.Fatal(err) unless err is nil, or an error that
+// comes from the net package indicating that the listener was closed or from
+// the Stopper indicating quiescence.
 func FatalIfUnexpected(err error) {
-	if err != nil && !IsClosedConnection(err) {
+	if err != nil && !IsClosedConnection(err) && !errors.Is(err, stop.ErrUnavailable) {
 		log.Fatalf(context.TODO(), "%+v", err)
 	}
 }


### PR DESCRIPTION
The closure serving a pgwire connection was capturing a context with a
long-lived span, and so all connections were logging to that span.
That was bad, but what was even worse is that the long-lived span can
end before the closures, on server shutdown. That was
use-after-Finish(), which is currently reluctantly tolerated, but won't
be tolerated much longer.

This patch fixes it by giving each connection its own span.

Touches #58164

Release note: None