### PR TITLE
protectedts/ptstorage: deflake test

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -571,7 +571,7 @@ func TestCorruptData(t *testing.T) {
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
+		require.GreaterOrEqual(t, 1, len(entries), "entries: %v", entries)
 		for _, e := range entries {
 			require.Equal(t, severity.ERROR, e.Severity)
 		}
@@ -623,7 +623,7 @@ func TestCorruptData(t *testing.T) {
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
+		require.GreaterOrEqual(t, 1, len(entries), "entries: %v", entries)
 		for _, e := range entries {
 			require.Equal(t, severity.ERROR, e.Severity)
 		}


### PR DESCRIPTION
The test asserted that the error message appeared just once. If there's a retry
the error can appear in the trace more than once. This commit cleans up that
condition.

Fixes #67972

Release note: None