### PR TITLE
[DNM] pkg/server: add env vars for setting total size defaults for sampling dumps

### DIFF
--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -44,7 +45,10 @@ var (
 		"total size of goroutine dumps to be kept. "+
 			"Dumps are GC'ed in the order of creation time. The latest dump is "+
 			"always kept even if its size exceeds the limit.",
-		500<<20, // 500MiB
+		envutil.EnvOrDefaultInt64(
+			"COCKROACH_SERVER_GOROUTINEDUMP_TOTAL_SIZE_LIMIT",
+			500<<20, // 500MiB
+		),
 	)
 )
 

--- a/pkg/server/heapprofiler/profilestore.go
+++ b/pkg/server/heapprofiler/profilestore.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -37,7 +38,10 @@ var (
 	maxCombinedFileSize = settings.RegisterByteSizeSetting(
 		"server.mem_profile.total_dump_size_limit",
 		"maximum combined disk size of preserved memory profiles",
-		128<<20, // 128MiB
+		envutil.EnvOrDefaultInt64(
+			"COCKROACH_SERVER_MEMPROFILE_TOTAL_SIZE_LIMIT",
+			128<<20, // 128MiB
+		),
 	)
 )
 


### PR DESCRIPTION
Previously, the total dump size limit for both the goroutine dumper as well
as the profile store can only be configured through the following cluster:
settings:
- server.mem_profile.total_dump_size_limit
- server.goroutine_dump.total_dump_size_limit

This commit introduces two new environment variables that can be used to
configure those default limits during process startup without the need of
issuing cluster settings:
- COCKROACH_SERVER_MEMPROFILE_TOTAL_SIZE_LIMIT
- COCKROACH_SERVER_GOROUTINEDUMP_TOTAL_SIZE_LIMIT

For the context of CC Serverless, we want a better storage estimate to know
how much space should we allocate to tenant pods for disk spilling. The
default values for these dumps seem too much for SQL pods which are ephemeral,
and we'd like to lower those values. The defaults can be configured through
cluster settings, but doing so requires us to spin up every single SQL pod
to do that, given CC's infrastructure. For simplicity, we would introduce these
new environment variables to allow us to configure defaults across all SQL
pods without the need of manually setting cluster settings one by one, which
can be extremely slow to rollout, when we have a lot of SQL tenants.

No release notes because this is meant to be used internally only.

NOTE: This PR took a similar approach to https://github.com/cockroachdb/cockroach/pull/70890.

cc: @andy-kimball 

Release note: None