### PR TITLE
release-20.2: server: fix data distribution page for upgraded cluster

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -41,7 +42,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -1830,6 +1833,26 @@ func TestAdminAPIDataDistribution(t *testing.T) {
 	if err := getAdminJSONProto(firstServer, "data_distribution", &resp); err != nil {
 		t.Fatal(err)
 	}
+
+	// Clusters which were upgraded rather than bootstrapped are missing a
+	// namespace entry for namespace2. Remarkably this causes very few problems
+	// because very little refers to namespace2, however, it can cause problems
+	// in the data distribution page which uses the names in descriptors to
+	// then look up zone configurations by name. This tests that even when
+	// that namespace entry does not exist, no issues arise
+	t.Run("missing namespace entry for namespace2", func(t *testing.T) {
+		ctx := context.Background()
+		require.NoError(t, testCluster.Server(0).DB().Txn(ctx, func(
+			ctx context.Context, txn *kv.Txn,
+		) (err error) {
+			err = catalogkv.RemoveObjectNamespaceEntry(
+				ctx, txn, keys.SystemSQLCodec, keys.SystemDatabaseID, descpb.InvalidID,
+				systemschema.NamespaceTable.Name, // namespace2
+				false /* kvTrace */)
+			return err
+		}))
+		require.NoError(t, getAdminJSONProto(firstServer, "data_distribution", &resp))
+	})
 }
 
 func BenchmarkAdminAPIDataDistribution(b *testing.B) {


### PR DESCRIPTION
For whatever reason, cluster upgraded from 19.2->20.1->20.2 do not have a
namespace entry for the `system.namespace2` table. This ends up causing
problems for the data distribution page. In practice, we don't really care.
What's bad is that results in the page not working. This patch detects the
error indicating the missing entry (which can also occur organically) and,
in doing so, fixes the bad behavior.

Touches https://github.com/cockroachdb/cockroach/issues/49882. 

Release note (bug fix): Fixed a bug which prevented the Data Distribution page
from working on clusters which were upgraded from 19.2 or earlier.