### PR TITLE
ui: fix links for debugging tracing pages when proxying

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -330,8 +330,8 @@ export default function Debug() {
       </DebugTable>
       <DebugTable heading="Tracing and Profiling Endpoints (local node only)">
         <DebugTableRow title="Tracing">
-          <DebugTableLink name="Requests" url="/debug/requests" />
-          <DebugTableLink name="Events" url="/debug/events" />
+          <DebugTableLink name="Requests" url="debug/requests" />
+          <DebugTableLink name="Events" url="debug/events" />
           <DebugTableLink
             name="Logs (JSON)"
             url="/debug/logspy?count=100&amp;duration=10s&amp;grep=.&flatten=0"

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -207,9 +207,10 @@ module.exports = (env, argv) => {
       contentBase: path.join(__dirname, `dist${env.dist}`),
       index: "",
       proxy: {
-        "/": {
+        "/clusters/12345/": {
           secure: false,
           target: env.target || process.env.TARGET,
+          pathRewrite: { "^/clusters/12345": "" },
         },
       },
     },


### PR DESCRIPTION
A possible solution to fix navigation to tracing debugging pages.

Changes in webpack.app.js is used to simulate case where proxy is used with base path that differs from default one (`/`)