### PR TITLE
ui: update browser tab on tab change

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -127,7 +127,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
   backToSessionsPage = (): void => {
     const { history, onBackButtonClick } = this.props;
     onBackButtonClick && onBackButtonClick();
-    history.push("/sql-activity?tab=sessions");
+    history.push("/sql-activity?tab=Sessions");
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -11,14 +11,13 @@
 import React from "react";
 import { isNil, merge } from "lodash";
 
-import { getMatchParamByName, syncHistory } from "src/util/query";
+import { syncHistory } from "src/util/query";
 import { appAttr } from "src/util/constants";
 import {
   makeSessionsColumns,
   SessionInfo,
   SessionsSortedTable,
 } from "./sessionsTable";
-import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
 import { sessionsTable } from "src/util/docs";
@@ -212,11 +211,9 @@ export class SessionsPage extends React.Component<
   };
 
   render(): React.ReactElement {
-    const { match, cancelSession, cancelQuery } = this.props;
-    const app = getMatchParamByName(match, appAttr);
+    const { cancelSession, cancelQuery } = this.props;
     return (
       <div className={sessionsPageCx("sessions-page")}>
-        <Helmet title={app ? `${app} App | Sessions` : "Sessions"} />
         <Loading
           loading={isNil(this.props.sessions)}
           error={this.props.sessionsError}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -184,7 +184,7 @@ function AppLink(props: { app: string }) {
   return (
     <Link
       className={cx("app-name")}
-      to={`/sql-activity?tab=statements&${searchParams.toString()}`}
+      to={`/sql-activity?tab=Statements&${searchParams.toString()}`}
     >
       {props.app}
     </Link>
@@ -387,7 +387,7 @@ export class StatementDetails extends React.Component<
   };
 
   backToStatementsClick = (): void => {
-    this.props.history.push("/sql-activity?tab=statements");
+    this.props.history.push("/sql-activity?tab=Statements");
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }
@@ -457,7 +457,7 @@ export class StatementDetails extends React.Component<
     if (!stats) {
       const sourceApp = queryByName(this.props.location, appAttr);
       const listUrl =
-        "/sql-activity?tab=statements" +
+        "/sql-activity?tab=Statements" +
         (sourceApp ? "&" + appAttr + "=" + sourceApp : "");
 
       return (

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -11,7 +11,6 @@
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { isNil, merge } from "lodash";
-import Helmet from "react-helmet";
 import moment, { Moment } from "moment";
 import classNames from "classnames/bind";
 import { Loading } from "src/loading";
@@ -568,15 +567,12 @@ export class StatementsPage extends React.Component<
 
   render(): React.ReactElement {
     const {
-      location,
       refreshStatementDiagnosticsRequests,
       onActivateStatementDiagnostics,
       onDiagnosticsModalOpen,
     } = this.props;
-    const app = queryByName(location, appAttr);
     return (
       <div className={cx("root", "table-area")}>
-        <Helmet title={app ? `${app} App | Statements` : "Statements"} />
         <Loading
           loading={isNil(this.props.statements)}
           error={this.props.statementsError}

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -339,12 +339,12 @@ describe("Routing to", () => {
   });
 
   describe("'/statement' path", () => {
-    it("redirected to '/sql-activity?tab=statements'", () => {
+    it("redirected to '/sql-activity?tab=Statements'", () => {
       navigateToPath("/statement");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=statements",
+        "/sql-activity?tab=Statements",
       );
     });
   });
@@ -587,34 +587,34 @@ describe("Routing to", () => {
   });
 
   describe("'/statements' path", () => {
-    it("redirected to '/sql-activity?tab=statements'", () => {
+    it("redirected to '/sql-activity?tab=Statements'", () => {
       navigateToPath("/statements");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=statements",
+        "/sql-activity?tab=Statements",
       );
     });
   });
 
   describe("'/sessions' path", () => {
-    it("redirected to '/sql-activity?tab=sessions'", () => {
+    it("redirected to '/sql-activity?tab=Sessions'", () => {
       navigateToPath("/sessions");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=sessions",
+        "/sql-activity?tab=Sessions",
       );
     });
   });
 
   describe("'/transactions' path", () => {
-    it("redirected to '/sql-activity?tab=transactions'", () => {
+    it("redirected to '/sql-activity?tab=Transactions'", () => {
       navigateToPath("/transactions");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=transactions",
+        "/sql-activity?tab=Transactions",
       );
     });
   });

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -183,7 +183,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/statements`}
-                  to={`/sql-activity?${tabAttr}=statements`}
+                  to={`/sql-activity?${tabAttr}=Statements`}
                 />
                 <Redirect
                   exact
@@ -223,14 +223,14 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/statement`}
-                  to={`/sql-activity?${tabAttr}=statements`}
+                  to={`/sql-activity?${tabAttr}=Statements`}
                 />
 
                 {/* sessions */}
                 <Redirect
                   exact
                   from={`/sessions`}
-                  to={`/sql-activity?${tabAttr}=sessions`}
+                  to={`/sql-activity?${tabAttr}=Sessions`}
                 />
                 <Route
                   exact
@@ -242,7 +242,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/transactions`}
-                  to={`/sql-activity?${tabAttr}=transactions`}
+                  to={`/sql-activity?${tabAttr}=Transactions`}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -12,6 +12,7 @@
 // file on managed-service repo.
 
 import React, { useState, useEffect } from "react";
+import Helmet from "react-helmet";
 import { Tabs } from "antd";
 import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import SessionsPageConnected from "src/views/sessions/sessionsPage";
@@ -22,7 +23,7 @@ import { RouteComponentProps } from "react-router-dom";
 const { TabPane } = Tabs;
 
 const SQLActivityPage = (props: RouteComponentProps) => {
-  const defaultTab = util.queryByName(props.location, "tab") || "sessions";
+  const defaultTab = util.queryByName(props.location, "tab") || "Sessions";
   const [currentTab, setCurrentTab] = useState(defaultTab);
 
   const onTabChange = (tabId: string): void => {
@@ -32,7 +33,7 @@ const SQLActivityPage = (props: RouteComponentProps) => {
   };
 
   useEffect(() => {
-    const queryTab = util.queryByName(props.location, "tab") || "sessions";
+    const queryTab = util.queryByName(props.location, "tab") || "Sessions";
     if (queryTab !== currentTab) {
       setCurrentTab(queryTab);
     }
@@ -40,6 +41,7 @@ const SQLActivityPage = (props: RouteComponentProps) => {
 
   return (
     <div>
+      <Helmet title={defaultTab} />
       <h3 className={commonStyles("base-heading")}>SQL Activity</h3>
       <Tabs
         defaultActiveKey={defaultTab}
@@ -47,13 +49,13 @@ const SQLActivityPage = (props: RouteComponentProps) => {
         onChange={onTabChange}
         activeKey={currentTab}
       >
-        <TabPane tab="Sessions" key="sessions">
+        <TabPane tab="Sessions" key="Sessions">
           <SessionsPageConnected />
         </TabPane>
-        <TabPane tab="Transactions" key="transactions">
+        <TabPane tab="Transactions" key="Transactions">
           <TransactionsPageConnected />
         </TabPane>
-        <TabPane tab="Statements" key="statements">
+        <TabPane tab="Statements" key="Statements">
           <StatementsPageConnected />
         </TabPane>
       </Tabs>


### PR DESCRIPTION
Previously, the browser tab title was not being updated
when a differen tab was selected on SQL Activity tab.
This commits make sure the browser tab is updated.

Fixes #71991

Release note (bug fix): Update browser tab when SQL Activity
tab is changed.