### PR TITLE
bazel: allow setting `--action_env` in `rules_foreign_cc` rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -337,10 +337,10 @@ c_deps()
 # aforementioned PRs.
 http_archive(
     name = "rules_foreign_cc",
-    sha256 = "66ab1d53be0a7292e3838b3042ec51a228dbe901972ae57b4a8a7c4336b39ed7",
-    strip_prefix = "rules_foreign_cc-67211f9083234f51ef1d9c21a791ee93bc538143",
+    sha256 = "45d48c71f1b1eadc33a5ad15bbeca8ce42f9ef5ab5d7ee519fc4991e6a9e93d2",
+    strip_prefix = "cockroachdb-rules_foreign_cc-f1cff45",
     urls = [
-        "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_foreign_cc-67211f9083234f51ef1d9c21a791ee93bc538143.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_foreign_cc-master20210730-1-gf1cff45.zip",
     ],
 )
 


### PR DESCRIPTION
Pull in commit `f1cff4544cd7a86f9de44cd79f50d151eb7cc781` of
`rules_foreign_cc` (https://github.com/cockroachdb/rules_foreign_cc/commit/f1cff4544cd7a86f9de44cd79f50d151eb7cc781)
to allow setting `--action_env` for `rules_foreign_cc` rules. This is
necessary for M1 Macs.

Closes #72398.

Release note: None