### PR TITLE
bazel: bump size of `changefeedccl` test

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -114,7 +114,7 @@ go_library(
 
 go_test(
     name = "changefeedccl_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "avro_test.go",
         "bench_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None