### PR TITLE
ci: avoid running tests that are broken in bazel in `testrace`

### DIFF
--- a/build/teamcity/cockroach/ci/tests/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
-source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-support.sh"  # For $root, changed_go_pkgs
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Determine changed packages"

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -19,6 +19,11 @@ do
     # Run affected tests.
     for test in $tests
     do
+        if [[ ! -z $(bazel query "attr(tags, \"broken_in_bazel\", $test)") ]]
+        then
+            echo "Skipping test $test as it is broken in bazel"
+            continue
+        fi
         $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --config=ci --config=race test "$test" -- \
                                --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                --test_env=GOMAXPROCS=8


### PR DESCRIPTION
Closes #72531.

Release note: None