### PR TITLE
opt: alias `@primary` to PRIMARY KEY

### DIFF
--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1862,3 +1862,49 @@ vectorized: true
       estimated row count: 11,110,000 (100% of the table; stats collected <hidden> ago)
       table: nulls@nulls_pkey
       spans: FULL SCAN
+
+# Test resolution of @primary index hint.
+statement ok
+CREATE TABLE tbl_with_no_primary_constraint (
+  id INT PRIMARY KEY,
+  b INT
+)
+
+statement ok
+CREATE TABLE tbl_with_primary_named_index (
+  id INT PRIMARY KEY,
+  b INT,
+  INDEX "primary" (b)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM tbl_with_no_primary_constraint@primary ORDER BY id
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (id, b)
+  ordering: +id
+  estimated row count: 1,000 (missing stats)
+  table: tbl_with_no_primary_constraint@tbl_with_no_primary_constraint_pkey
+  spans: FULL SCAN
+
+statement ok
+SHOW PARTITIONS FROM INDEX tbl_with_no_primary_constraint@primary
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM tbl_with_primary_named_index@primary ORDER BY b
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (b)
+  ordering: +b
+  estimated row count: 1,000 (missing stats)
+  table: tbl_with_primary_named_index@primary
+  spans: FULL SCAN
+
+statement ok
+SELECT index_name FROM [SHOW PARTITIONS FROM INDEX tbl_with_primary_named_index@primary]

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/seqexpr",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/delegate",
         "//pkg/sql/lex",

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -92,6 +93,11 @@ func (b *Builder) findIndexByName(table cat.Table, name tree.UnrestrictedName) (
 		if tree.Name(name) == idx.Name() {
 			return idx, nil
 		}
+	}
+	// Fallback to referencing @primary as the PRIMARY KEY.
+	// Note that indexes with "primary" as their name takes precedence above.
+	if name == tabledesc.LegacyPrimaryKeyIndexName {
+		return table.Index(0), nil
 	}
 
 	return nil, pgerror.Newf(pgcode.UndefinedObject,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -13,6 +13,7 @@ package optbuilder
 import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -520,6 +521,11 @@ func (b *Builder) buildScan(
 					idx = i
 					break
 				}
+			}
+			// Fallback to referencing @primary as the PRIMARY KEY.
+			// Note that indexes with "primary" as their name takes precedence above.
+			if idx == -1 && indexFlags.Index == tabledesc.LegacyPrimaryKeyIndexName {
+				idx = 0
 			}
 			if idx == -1 {
 				var err error


### PR DESCRIPTION
Release note (sql change): PRIMARY KEYs have been renamed to conform
to postgres (e.g. `@tbl_col1_col2_pkey`) in this release. To protect
certain use cases of backwards compatability, we also allow `@primary`
index hints to alias to the PRIMARY KEY, but only if no other index is
named `primary`.