### PR TITLE
tabledesc: fix incomplete post-deserialization changes

### DIFF
--- a/pkg/sql/catalog/catprivilege/fix.go
+++ b/pkg/sql/catalog/catprivilege/fix.go
@@ -90,13 +90,14 @@ func MaybeFixPrivileges(
 
 	fixSuperUser := func(user security.SQLUsername) {
 		privs := p.FindOrCreateUser(user)
-		if privs.Privileges != allowedPrivilegesBits {
+		oldPrivilegeBits := privs.Privileges
+		if oldPrivilegeBits != allowedPrivilegesBits {
 			if privilege.ALL.IsSetIn(allowedPrivilegesBits) {
 				privs.Privileges = privilege.ALL.Mask()
 			} else {
 				privs.Privileges = allowedPrivilegesBits
 			}
-			changed = true
+			changed = (privs.Privileges != oldPrivilegeBits) || changed
 		}
 	}
 

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//proto",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -76,8 +76,12 @@ type PostDeserializationTableDescriptorChanges struct {
 	// UpgradedFormatVersion indicates that the FormatVersion was upgraded.
 	UpgradedFormatVersion bool
 
+	// FixedIndexEncodingType indicates that the encoding type of a public index
+	// was fixed.
+	FixedIndexEncodingType bool
+
 	// UpgradedIndexFormatVersion indicates that the format version of at least
-	// one index descriptor was upgraded
+	// one index descriptor was upgraded.
 	UpgradedIndexFormatVersion bool
 
 	// UpgradedForeignKeyRepresentation indicates that the foreign key

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -322,6 +322,9 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 		expValidErr string
 	}{
 		{ // 1
+			// In this simple case, we exercise most of the post-deserialization
+			// upgrades, in particular the primary index will have its encoding type
+			// and version properly set.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -374,6 +377,7 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 			},
 		},
 		{ // 2
+			// This test case is defined to be a no-op.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.InterleavedFormatVersion,
 				ID:            51,
@@ -400,6 +404,7 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 					KeyColumnIDs:        []descpb.ColumnID{1, 2},
 					KeyColumnNames:      []string{"foo", "bar"},
 					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
+					EncodingType:        descpb.PrimaryIndexEncoding,
 					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
 				},
 				Indexes: []descpb.IndexDescriptor{
@@ -418,6 +423,8 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 			upgraded: nil,
 		},
 		{ // 3
+			// In this case we expect validation to fail owing to a violation of
+			// assumptions for this secondary index's descriptor format version.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -452,6 +459,9 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 			expValidErr: "relation \"tbl\" (51): index \"other\" has column ID 1 present in: [KeyColumnIDs KeySuffixColumnIDs]",
 		},
 		{ // 4
+			// This test case is much like the first but more complex and with more
+			// indexes. All three should be upgraded to the latest version and have
+			// their encoding types fixed.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -486,6 +496,7 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 						KeyColumnIDs:        []descpb.ColumnID{2},
 						KeyColumnNames:      []string{"bar"},
 						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						EncodingType:        descpb.PrimaryIndexEncoding,
 						Version:             descpb.EmptyArraysInInvertedIndexesVersion,
 					},
 				},

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
@@ -317,10 +318,10 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 	tests := []struct {
 		desc        descpb.TableDescriptor
-		expUpgrade  bool
+		upgraded    *descpb.TableDescriptor
 		expValidErr string
 	}{
-		{
+		{ // 1
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -340,19 +341,58 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
 				},
 			},
-			expUpgrade: true,
-		},
-		{
-			desc: descpb.TableDescriptor{
-				FormatVersion: descpb.BaseFormatVersion,
+			upgraded: &descpb.TableDescriptor{
+				FormatVersion: descpb.InterleavedFormatVersion,
 				ID:            51,
 				Name:          "tbl",
 				ParentID:      52,
 				NextColumnID:  3,
+				NextFamilyID:  1,
+				NextIndexID:   2,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "foo"},
+					{ID: 2, Name: "bar"},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{
+						ID:          0,
+						Name:        "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"foo", "bar"},
+					},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  descpb.IndexID(1),
+					Name:                "primary",
+					KeyColumnIDs:        []descpb.ColumnID{1, 2},
+					KeyColumnNames:      []string{"foo", "bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
+					EncodingType:        descpb.PrimaryIndexEncoding,
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+				},
+				Privileges: descpb.NewDefaultPrivilegeDescriptor(security.RootUserName()),
+			},
+		},
+		{ // 2
+			desc: descpb.TableDescriptor{
+				FormatVersion: descpb.InterleavedFormatVersion,
+				ID:            51,
+				Name:          "tbl",
+				ParentID:      52,
+				NextColumnID:  3,
+				NextFamilyID:  1,
 				NextIndexID:   3,
 				Columns: []descpb.ColumnDescriptor{
 					{ID: 1, Name: "foo"},
 					{ID: 2, Name: "bar"},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{
+						ID:          0,
+						Name:        "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"foo", "bar"},
+					},
 				},
 				PrimaryIndex: descpb.IndexDescriptor{
 					ID:                  descpb.IndexID(1),
@@ -369,14 +409,15 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 						KeyColumnIDs:        []descpb.ColumnID{1},
 						KeyColumnNames:      []string{"foo"},
 						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
-						KeySuffixColumnIDs:  []descpb.ColumnID{1},
+						KeySuffixColumnIDs:  []descpb.ColumnID{1}, // This corruption is benign but prevents bumping Version.
 						Version:             descpb.SecondaryIndexFamilyFormatVersion,
 					},
 				},
+				Privileges: descpb.NewDefaultPrivilegeDescriptor(security.RootUserName()),
 			},
-			expUpgrade: false,
+			upgraded: nil,
 		},
-		{
+		{ // 3
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -408,28 +449,136 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 					},
 				},
 			},
-			expUpgrade:  false,
 			expValidErr: "relation \"tbl\" (51): index \"other\" has column ID 1 present in: [KeyColumnIDs KeySuffixColumnIDs]",
+		},
+		{ // 4
+			desc: descpb.TableDescriptor{
+				FormatVersion: descpb.BaseFormatVersion,
+				ID:            51,
+				Name:          "tbl",
+				ParentID:      52,
+				NextColumnID:  3,
+				NextIndexID:   4,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "foo"},
+					{ID: 2, Name: "bar"},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  descpb.IndexID(1),
+					Name:                "primary",
+					KeyColumnIDs:        []descpb.ColumnID{1, 2},
+					KeyColumnNames:      []string{"foo", "bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{
+						ID:                  descpb.IndexID(2),
+						Name:                "other",
+						KeyColumnIDs:        []descpb.ColumnID{1},
+						KeyColumnNames:      []string{"foo"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						Version:             descpb.EmptyArraysInInvertedIndexesVersion,
+					},
+					{
+						ID:                  descpb.IndexID(3),
+						Name:                "another",
+						KeyColumnIDs:        []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"bar"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						Version:             descpb.EmptyArraysInInvertedIndexesVersion,
+					},
+				},
+			},
+			upgraded: &descpb.TableDescriptor{
+				FormatVersion: descpb.InterleavedFormatVersion,
+				ID:            51,
+				Name:          "tbl",
+				ParentID:      52,
+				NextColumnID:  3,
+				NextFamilyID:  1,
+				NextIndexID:   4,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "foo"},
+					{ID: 2, Name: "bar"},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{
+						ID:          0,
+						Name:        "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"foo", "bar"},
+					},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  descpb.IndexID(1),
+					Name:                "primary",
+					KeyColumnIDs:        []descpb.ColumnID{1, 2},
+					KeyColumnNames:      []string{"foo", "bar"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
+					EncodingType:        descpb.PrimaryIndexEncoding,
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{
+						ID:                  descpb.IndexID(2),
+						Name:                "other",
+						KeyColumnIDs:        []descpb.ColumnID{1},
+						KeyColumnNames:      []string{"foo"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						EncodingType:        descpb.SecondaryIndexEncoding,
+						Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
+					},
+					{
+						ID:                  descpb.IndexID(3),
+						Name:                "another",
+						KeyColumnIDs:        []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"bar"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						EncodingType:        descpb.SecondaryIndexEncoding,
+						Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
+					},
+				},
+				Privileges: descpb.NewDefaultPrivilegeDescriptor(security.RootUserName()),
+			},
 		},
 	}
 	for i, test := range tests {
-		b := NewBuilder(&test.desc)
-		err := b.RunPostDeserializationChanges(context.Background(), nil)
-		desc := b.BuildImmutableTable()
-		require.NoError(t, err)
-		changes, err := GetPostDeserializationChanges(desc)
-		require.NoError(t, err)
-		err = catalog.ValidateSelf(desc)
-		if test.expValidErr == "" {
+		t.Run(fmt.Sprintf("#%d", i+1), func(t *testing.T) {
+			b := NewBuilder(&test.desc)
+			err := b.RunPostDeserializationChanges(context.Background(), nil)
+			desc := b.BuildImmutableTable()
 			require.NoError(t, err)
-		} else {
-			require.EqualError(t, err, test.expValidErr)
-		}
+			changes, err := GetPostDeserializationChanges(desc)
+			require.NoError(t, err)
+			err = catalog.ValidateSelf(desc)
+			if test.expValidErr != "" {
+				require.EqualError(t, err, test.expValidErr)
+				return
+			}
 
-		upgraded := changes.UpgradedIndexFormatVersion
-		if upgraded != test.expUpgrade {
-			t.Fatalf("%d: expected upgraded=%t, but got upgraded=%t", i, test.expUpgrade, upgraded)
-		}
+			require.NoError(t, err)
+			if test.upgraded == nil {
+				require.Equal(t, PostDeserializationTableDescriptorChanges{}, changes)
+				return
+			}
+
+			if e, a := test.upgraded, desc.TableDesc(); !reflect.DeepEqual(e, a) {
+				for _, diff := range pretty.Diff(e, a) {
+					t.Error(diff)
+				}
+			}
+
+			// Run post-deserialization changes again, descriptor should not change.
+			b2 := NewBuilder(desc.TableDesc())
+			err = b2.RunPostDeserializationChanges(context.Background(), nil)
+			require.NoError(t, err)
+			desc2 := b2.BuildImmutableTable()
+			changes2, err := GetPostDeserializationChanges(desc2)
+			require.NoError(t, err)
+			require.Equal(t, PostDeserializationTableDescriptorChanges{}, changes2)
+			require.Equal(t, desc.TableDesc(), desc2.TableDesc())
+		})
 	}
 }
 

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -192,11 +192,13 @@ func maybeFillInDescriptor(
 
 	changes.UpgradedIndexFormatVersion = maybeUpgradePrimaryIndexFormatVersion(desc)
 	for i := range desc.Indexes {
-		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || maybeUpgradeSecondaryIndexFormatVersion(&desc.Indexes[i])
+		isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(&desc.Indexes[i])
+		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 	}
 	for i := range desc.Mutations {
 		if idx := desc.Mutations[i].GetIndex(); idx != nil {
-			changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || maybeUpgradeSecondaryIndexFormatVersion(idx)
+			isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(idx)
+			changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 		}
 	}
 	changes.UpgradedNamespaceName = maybeUpgradeNamespaceName(desc)

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -190,9 +190,13 @@ func maybeFillInDescriptor(
 ) (changes PostDeserializationTableDescriptorChanges, err error) {
 	changes.UpgradedFormatVersion = maybeUpgradeFormatVersion(desc)
 
+	changes.FixedIndexEncodingType = maybeFixPrimaryIndexEncoding(&desc.PrimaryIndex)
 	changes.UpgradedIndexFormatVersion = maybeUpgradePrimaryIndexFormatVersion(desc)
 	for i := range desc.Indexes {
-		isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(&desc.Indexes[i])
+		idx := &desc.Indexes[i]
+		isFixed := maybeFixSecondaryIndexEncoding(idx)
+		changes.FixedIndexEncodingType = changes.FixedIndexEncodingType || isFixed
+		isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(idx)
 		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 	}
 	for i := range desc.Mutations {
@@ -560,5 +564,25 @@ func maybeUpgradeNamespaceName(d *descpb.TableDescriptor) (hasChanged bool) {
 		return false
 	}
 	d.Name = string(catconstants.NamespaceTableName)
+	return true
+}
+
+// maybeFixPrimaryIndexEncoding ensures that the index descriptor for a primary
+// index has the correct encoding type set.
+func maybeFixPrimaryIndexEncoding(idx *descpb.IndexDescriptor) (hasChanged bool) {
+	if idx.EncodingType == descpb.PrimaryIndexEncoding {
+		return false
+	}
+	idx.EncodingType = descpb.PrimaryIndexEncoding
+	return true
+}
+
+// maybeFixPrimaryIndexEncoding ensures that the index descriptor for a
+// secondary index has the correct encoding type set.
+func maybeFixSecondaryIndexEncoding(idx *descpb.IndexDescriptor) (hasChanged bool) {
+	if idx.EncodingType == descpb.SecondaryIndexEncoding {
+		return false
+	}
+	idx.EncodingType = descpb.SecondaryIndexEncoding
 	return true
 }


### PR DESCRIPTION
After being deserialized from their protobuf representations, table
descriptors, like all descriptors, go through a round of
post-deserialization changes, in order to bring them up to date with
respect to the current codebase.

A canonical example of why this is useful is restoring a backup with
a table using the deprecated foreign-key representation. Instead of
having to support deprecated foreign keys throughout the codebase, we
migrate these to the current representation in this post-deserialization
step.

Another class of post-deserialization changes pertain to index
descriptors and their versions. A bug in how these changes were applied
meant that the changes could sometimes be skipped. This commit fixes
this.

The impact of this bug is limited by the fact that index descriptor
versions are backward-compatible.

Release note: None