### PR TITLE
colexecargs: unify creation of memory monitoring components

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/log",
-        "//pkg/util/log/logcrash",
         "//pkg/util/mon",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -97,12 +97,15 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
 	args := &colexecargs.NewColOperatorArgs{
 		Spec: &execinfrapb.ProcessorSpec{
 			Core:        execinfrapb.ProcessorCoreUnion{TableReader: &tr},
 			ResultTypes: []*types.T{types.Int4},
 		},
 		StreamingMemAccount: &streamingMemAcc,
+		MonitorRegistry:     &monitorRegistry,
 	}
 	r1, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
@@ -117,6 +120,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		},
 		Inputs:              []colexecargs.OpWithMetaInfo{{Root: r1.Root}},
 		StreamingMemAccount: &streamingMemAcc,
+		MonitorRegistry:     &monitorRegistry,
 	}
 	r, err := NewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)

--- a/pkg/sql/colexec/colexecargs/BUILD.bazel
+++ b/pkg/sql/colexec/colexecargs/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "colexecargs",
     srcs = [
         "expr.go",
+        "monitor_registry.go",
         "op_creation.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs",

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -1,0 +1,193 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexecargs
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// MonitorRegistry instantiates and keeps track of the memory monitoring
+// infrastructure in the vectorized engine.
+type MonitorRegistry struct {
+	accounts []*mon.BoundAccount
+	monitors []*mon.BytesMonitor
+}
+
+// GetMonitors returns all the monitors from the registry.
+func (r MonitorRegistry) GetMonitors() []*mon.BytesMonitor {
+	return r.monitors
+}
+
+// NewStreamingMemAccount creates a new memory account bound to the monitor in
+// flowCtx.
+func (r *MonitorRegistry) NewStreamingMemAccount(flowCtx *execinfra.FlowCtx) *mon.BoundAccount {
+	streamingMemAccount := flowCtx.EvalCtx.Mon.MakeBoundAccount()
+	r.accounts = append(r.accounts, &streamingMemAccount)
+	return &streamingMemAccount
+}
+
+// getMemMonitorName returns a unique (for this MonitorRegistry) memory monitor
+// name.
+func (r MonitorRegistry) getMemMonitorName(opName string, processorID int32, suffix string) string {
+	// This way of constructing a string is more efficient than using
+	// fmt.Sprintf.
+	return opName + "-" + strconv.Itoa(int(processorID)) + "-" + suffix + "-" + strconv.Itoa(len(r.monitors))
+}
+
+// CreateMemAccountForSpillStrategy instantiates a memory monitor and a memory
+// account to be used with a buffering colexecop.Operator that can fall back to
+// disk. The default memory limit is used, if flowCtx.Cfg.ForceDiskSpill is
+// used, this will be 1. The receiver is updated to have references to both
+// objects. Memory monitor name is also returned.
+func (r *MonitorRegistry) CreateMemAccountForSpillStrategy(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName string, processorID int32,
+) (*mon.BoundAccount, string) {
+	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
+	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
+		ctx, flowCtx.EvalCtx.Mon, flowCtx, monitorName,
+	)
+	r.monitors = append(r.monitors, bufferingOpMemMonitor)
+	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
+	r.accounts = append(r.accounts, &bufferingMemAccount)
+	return &bufferingMemAccount, monitorName
+}
+
+// CreateMemAccountForSpillStrategyWithLimit is the same as
+// CreateMemAccountForSpillStrategy except that it takes in a custom limit
+// instead of using the number obtained via execinfra.GetWorkMemLimit. Memory
+// monitor name is also returned.
+func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, limit int64, opName string, processorID int32,
+) (*mon.BoundAccount, string) {
+	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
+		limit = 1
+	}
+	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
+	bufferingOpMemMonitor := mon.NewMonitorInheritWithLimit(monitorName, limit, flowCtx.EvalCtx.Mon)
+	bufferingOpMemMonitor.Start(ctx, flowCtx.EvalCtx.Mon, mon.BoundAccount{})
+	r.monitors = append(r.monitors, bufferingOpMemMonitor)
+	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
+	r.accounts = append(r.accounts, &bufferingMemAccount)
+	return &bufferingMemAccount, monitorName
+}
+
+// CreateUnlimitedMemAccount instantiates an unlimited memory monitor and a
+// memory account to be used with a buffering disk-backed colexecop.Operator (or
+// in special circumstances in place of a streaming account when the precise
+// memory usage is needed by an operator). The receiver is updated to have
+// references to both objects. Note that the returned account is only
+// "unlimited" in that it does not have a hard limit that it enforces, but a
+// limit might be enforced by a root monitor.
+//
+// Note that the memory monitor name is not returned (unlike above) because no
+// caller actually needs it.
+func (r *MonitorRegistry) CreateUnlimitedMemAccount(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName string, processorID int32,
+) *mon.BoundAccount {
+	monitorName := r.getMemMonitorName(opName, processorID, "unlimited" /* suffix */)
+	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
+		ctx, flowCtx.EvalCtx.Mon, monitorName,
+	)
+	r.monitors = append(r.monitors, bufferingOpUnlimitedMemMonitor)
+	bufferingMemAccount := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
+	r.accounts = append(r.accounts, &bufferingMemAccount)
+	return &bufferingMemAccount
+}
+
+// CreateUnlimitedMemAccounts instantiates an unlimited memory monitor and
+// numAccounts memory accounts. It should only be used when the component
+// supports spilling to disk and is made aware of a memory usage limit
+// separately. The receiver is updated to have a reference to all created
+// components.
+func (r *MonitorRegistry) CreateUnlimitedMemAccounts(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string, numAccounts int,
+) (*mon.BytesMonitor, []*mon.BoundAccount) {
+	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
+		ctx, flowCtx.EvalCtx.Mon, name+"-unlimited",
+	)
+	r.monitors = append(r.monitors, bufferingOpUnlimitedMemMonitor)
+	oldLen := len(r.accounts)
+	for i := 0; i < numAccounts; i++ {
+		acc := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
+		r.accounts = append(r.accounts, &acc)
+	}
+	return bufferingOpUnlimitedMemMonitor, r.accounts[oldLen:len(r.accounts)]
+}
+
+// CreateDiskAccount instantiates an unlimited disk monitor and a disk account
+// to be used for disk spilling infrastructure in vectorized engine.
+//
+// Note that the memory monitor name is not returned (unlike above) because no
+// caller actually needs it.
+func (r *MonitorRegistry) CreateDiskAccount(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName string, processorID int32,
+) *mon.BoundAccount {
+	monitorName := r.getMemMonitorName(opName, processorID, "disk" /* suffix */)
+	opDiskMonitor := execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, monitorName)
+	r.monitors = append(r.monitors, opDiskMonitor)
+	opDiskAccount := opDiskMonitor.MakeBoundAccount()
+	r.accounts = append(r.accounts, &opDiskAccount)
+	return &opDiskAccount
+}
+
+// CreateDiskAccounts instantiates an unlimited disk monitor and disk accounts
+// to be used for disk spilling infrastructure in vectorized engine.
+func (r *MonitorRegistry) CreateDiskAccounts(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name string, numAccounts int,
+) (*mon.BytesMonitor, []*mon.BoundAccount) {
+	diskMonitor := execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, name)
+	r.monitors = append(r.monitors, diskMonitor)
+	oldLen := len(r.accounts)
+	for i := 0; i < numAccounts; i++ {
+		diskAcc := diskMonitor.MakeBoundAccount()
+		r.accounts = append(r.accounts, &diskAcc)
+	}
+	return diskMonitor, r.accounts[oldLen:len(r.accounts)]
+}
+
+// AssertInvariants confirms that all invariants are maintained by
+// MonitorRegistry.
+func (r *MonitorRegistry) AssertInvariants() {
+	// Check that all memory monitor names are unique (colexec.diskSpillerBase
+	// relies on this in order to catch "memory budget exceeded" errors only
+	// from "its own" component).
+	names := make(map[string]struct{}, len(r.monitors))
+	for _, m := range r.monitors {
+		if _, seen := names[m.Name()]; seen {
+			colexecerror.InternalError(errors.AssertionFailedf("monitor named %q encountered twice", m.Name()))
+		}
+		names[m.Name()] = struct{}{}
+	}
+}
+
+// Close closes all components in the registry.
+func (r *MonitorRegistry) Close(ctx context.Context) {
+	for i := range r.accounts {
+		r.accounts[i].Close(ctx)
+	}
+	for i := range r.monitors {
+		r.monitors[i].Stop(ctx)
+	}
+}
+
+// Reset prepares the registry for reuse.
+func (r *MonitorRegistry) Reset() {
+	// There is no need to deeply reset the memory monitoring infra slices
+	// because these objects are very tiny in the grand scheme of things.
+	r.accounts = r.accounts[:0]
+	r.monitors = r.monitors[:0]
+}

--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -381,10 +380,8 @@ func TestCrossJoiner(t *testing.T) {
 	}
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-	var (
-		accounts []*mon.BoundAccount
-		monitors []*mon.BytesMonitor
-	)
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
 
 	for _, spillForced := range []bool{false, true} {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
@@ -399,24 +396,16 @@ func TestCrossJoiner(t *testing.T) {
 						StreamingMemAccount: testMemAcc,
 						DiskQueueCfg:        queueCfg,
 						FDSemaphore:         colexecop.NewTestingSemaphore(externalHJMinPartitions),
+						MonitorRegistry:     &monitorRegistry,
 					}
 					result, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
 					if err != nil {
 						return nil, err
 					}
-					accounts = append(accounts, result.OpAccounts...)
-					monitors = append(monitors, result.OpMonitors...)
 					return result.Root, nil
 				})
 			}
 		}
-	}
-
-	for _, acc := range accounts {
-		acc.Close(ctx)
-	}
-	for _, mon := range monitors {
-		mon.Stop(ctx)
 	}
 }
 
@@ -439,12 +428,11 @@ func BenchmarkCrossJoiner(b *testing.B) {
 		sourceTypes[colIdx] = types.Int
 	}
 
-	var (
-		accounts []*mon.BoundAccount
-		monitors []*mon.BytesMonitor
-	)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
+
 	for _, spillForced := range []bool{false, true} {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
 		for _, joinType := range []descpb.JoinType{descpb.InnerJoin, descpb.LeftSemiJoin} {
@@ -470,6 +458,7 @@ func BenchmarkCrossJoiner(b *testing.B) {
 					StreamingMemAccount: testMemAcc,
 					DiskQueueCfg:        queueCfg,
 					FDSemaphore:         colexecop.NewTestingSemaphore(VecMaxOpenFDsLimit),
+					MonitorRegistry:     &monitorRegistry,
 				}
 				b.Run(fmt.Sprintf("spillForced=%t/type=%s/rows=%d", spillForced, joinType, nRows), func(b *testing.B) {
 					var nOutputRows int
@@ -485,9 +474,6 @@ func BenchmarkCrossJoiner(b *testing.B) {
 						args.Inputs[1].Root = colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
 						result, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
 						require.NoError(b, err)
-						accounts = append(accounts, result.OpAccounts...)
-						monitors = append(monitors, result.OpMonitors...)
-						require.NoError(b, err)
 						cj := result.Root
 						cj.Init(ctx)
 						for b := cj.Next(); b.Length() > 0; b = cj.Next() {
@@ -496,11 +482,5 @@ func BenchmarkCrossJoiner(b *testing.B) {
 				})
 			}
 		}
-	}
-	for _, acc := range accounts {
-		acc.Close(ctx)
-	}
-	for _, mon := range monitors {
-		mon.Stop(ctx)
 	}
 }

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/marusama/semaphore"
 	"github.com/stretchr/testify/require"
@@ -53,11 +52,9 @@ func TestExternalHashJoiner(t *testing.T) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
 
-	var (
-		accounts []*mon.BoundAccount
-		monitors []*mon.BytesMonitor
-	)
 	rng, _ := randutil.NewTestRand()
 	numForcedRepartitions := rng.Intn(5)
 	// Test the case in which the default memory is used as well as the case in
@@ -88,17 +85,16 @@ func TestExternalHashJoiner(t *testing.T) {
 					//  conditionally explicitly call Close() on the hash joiner
 					//  (through result.ToClose) in cases where it is known the sorter
 					//  will not be drained.
-					hjOp, newAccounts, newMonitors, closers, err := createDiskBackedHashJoiner(
+					hjOp, closers, err := createDiskBackedHashJoiner(
 						ctx, flowCtx, spec, sources, func() {}, queueCfg,
 						numForcedRepartitions, delegateFDAcquisitions, sem,
+						&monitorRegistry,
 					)
 					// Expect three closers. These are the external hash joiner, and
 					// one external sorter for each input.
 					// TODO(asubiotto): Explicitly Close when testing.T is passed into
 					//  this constructor and we do a substring match.
 					require.Equal(t, 3, len(closers))
-					accounts = append(accounts, newAccounts...)
-					monitors = append(monitors, newMonitors...)
 					return hjOp, err
 				})
 				for i, sem := range semsToCheck {
@@ -107,12 +103,6 @@ func TestExternalHashJoiner(t *testing.T) {
 				tc.skipAllNullsInjection = oldSkipAllNullsInjection
 			}
 		}
-	}
-	for _, acc := range accounts {
-		acc.Close(ctx)
-	}
-	for _, mon := range monitors {
-		mon.Stop(ctx)
 	}
 }
 
@@ -158,26 +148,20 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	var spilled bool
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
 	sem := colexecop.NewTestingSemaphore(externalHJMinPartitions)
 	// Ignore closers since the sorter should close itself when it is drained of
 	// all tuples. We assert this by checking that the semaphore reports a count
 	// of 0.
-	hj, accounts, monitors, _, err := createDiskBackedHashJoiner(
+	hj, _, err := createDiskBackedHashJoiner(
 		ctx, flowCtx, spec, []colexecop.Operator{leftSource, rightSource},
 		func() { spilled = true }, queueCfg,
 		// Force a repartition so that the recursive repartitioning always
 		// occurs.
 		1, /* numForcedRepartitions */
-		true /* delegateFDAcquisitions */, sem,
+		true /* delegateFDAcquisitions */, sem, &monitorRegistry,
 	)
-	defer func() {
-		for _, acc := range accounts {
-			acc.Close(ctx)
-		}
-		for _, mon := range monitors {
-			mon.Stop(ctx)
-		}
-	}()
 	require.NoError(t, err)
 	hj.Init(ctx)
 	// We have a full cross-product, so we should get the number of tuples
@@ -225,12 +209,11 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 		sourceTypes[colIdx] = types.Int
 	}
 
-	var (
-		memAccounts []*mon.BoundAccount
-		memMonitors []*mon.BytesMonitor
-	)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
+
 	for _, spillForced := range []bool{false, true} {
 		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
 		for _, nRows := range []int{1, 1 << 4, 1 << 8, 1 << 12, 1 << 16, 1 << 20} {
@@ -262,13 +245,11 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
 						rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, sourceTypes, cols, nRows)
-						hj, accounts, monitors, _, err := createDiskBackedHashJoiner(
+						hj, _, err := createDiskBackedHashJoiner(
 							ctx, flowCtx, spec, []colexecop.Operator{leftSource, rightSource},
 							func() {}, queueCfg, 0 /* numForcedRepartitions */, false, /* delegateFDAcquisitions */
-							colexecop.NewTestingSemaphore(VecMaxOpenFDsLimit),
+							colexecop.NewTestingSemaphore(VecMaxOpenFDsLimit), &monitorRegistry,
 						)
-						memAccounts = append(memAccounts, accounts...)
-						memMonitors = append(memMonitors, monitors...)
 						require.NoError(b, err)
 						hj.Init(ctx)
 						for b := hj.Next(); b.Length() > 0; b = hj.Next() {
@@ -278,19 +259,11 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 			}
 		}
 	}
-	for _, memAccount := range memAccounts {
-		memAccount.Close(ctx)
-	}
-	for _, memMonitor := range memMonitors {
-		memMonitor.Stop(ctx)
-	}
 }
 
 // createDiskBackedHashJoiner is a helper function that instantiates a
 // disk-backed hash join operator. The desired memory limit must have been
-// already set on flowCtx. It returns an operator and an error as well as
-// memory monitors and memory accounts that will need to be closed once the
-// caller is done with the operator.
+// already set on flowCtx.
 func createDiskBackedHashJoiner(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
@@ -301,13 +274,15 @@ func createDiskBackedHashJoiner(
 	numForcedRepartitions int,
 	delegateFDAcquisitions bool,
 	testingSemaphore semaphore.Semaphore,
-) (colexecop.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []colexecop.Closer, error) {
+	monitorRegistry *colexecargs.MonitorRegistry,
+) (colexecop.Operator, []colexecop.Closer, error) {
 	args := &colexecargs.NewColOperatorArgs{
 		Spec:                spec,
 		Inputs:              colexectestutils.MakeInputs(sources),
 		StreamingMemAccount: testMemAcc,
 		DiskQueueCfg:        diskQueueCfg,
 		FDSemaphore:         testingSemaphore,
+		MonitorRegistry:     monitorRegistry,
 	}
 	// We will not use streaming memory account for the external hash join so
 	// that the in-memory hash join operator could hit the memory limit set on
@@ -316,5 +291,5 @@ func createDiskBackedHashJoiner(
 	args.TestingKnobs.NumForcedRepartitions = numForcedRepartitions
 	args.TestingKnobs.DelegateFDAcquisitions = delegateFDAcquisitions
 	result, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
-	return result.Root, result.OpAccounts, result.OpMonitors, result.ToClose, err
+	return result.Root, result.ToClose, err
 }

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -56,6 +56,8 @@ func TestColBatchScanMeta(t *testing.T) {
 	st := s.ClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
+	var monitorRegistry colexecargs.MonitorRegistry
+	defer monitorRegistry.Close(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
 	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
@@ -84,6 +86,7 @@ func TestColBatchScanMeta(t *testing.T) {
 	args := &colexecargs.NewColOperatorArgs{
 		Spec:                &spec,
 		StreamingMemAccount: testMemAcc,
+		MonitorRegistry:     &monitorRegistry,
 	}
 	res, err := colbuilder.NewColOperator(ctx, &flowCtx, args)
 	if err != nil {
@@ -138,6 +141,8 @@ func BenchmarkColBatchScan(b *testing.B) {
 
 			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(ctx)
+			var monitorRegistry colexecargs.MonitorRegistry
+			defer monitorRegistry.Close(ctx)
 
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
@@ -156,6 +161,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 				args := &colexecargs.NewColOperatorArgs{
 					Spec:                &spec,
 					StreamingMemAccount: testMemAcc,
+					MonitorRegistry:     &monitorRegistry,
 				}
 				res, err := colbuilder.NewColOperator(ctx, &flowCtx, args)
 				if err != nil {

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -231,6 +231,8 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					result *colexecargs.NewColOperatorResult
 					err    error
 				)
+				args.MonitorRegistry = &colexecargs.MonitorRegistry{}
+				defer args.MonitorRegistry.Close(ctx)
 				// The memory error can occur either during planning or during
 				// execution, and we want to actually execute the "query" only
 				// if there was no error during planning. That is why we have
@@ -244,14 +246,6 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 						result.Root.Next()
 						result.Root.Next()
 					})
-				}
-				if result != nil {
-					for _, memAccount := range result.OpAccounts {
-						memAccount.Close(ctx)
-					}
-					for _, memMonitor := range result.OpMonitors {
-						memMonitor.Stop(ctx)
-					}
 				}
 				if expectNoMemoryError {
 					require.NoError(t, err, "expected success, found: ", err)


### PR DESCRIPTION
**sql: fix benchmark of TableReaders**

We recently merged a change which made the `txnKVFetcher` take ownership
of the passed-in slice of spans. This broke a couple of benchmarks where
the spec would be invalid after the first iteration. This is now fixed.

Release note: None

**colexecargs: unify creation of memory monitoring components**

This commit introduces a utility struct that keeps track of all memory
monitoring components which allows us to remove some duplicated code and
clean up the tests a bit.

Fixes: #71358.

Release note: None