### PR TITLE
pkg/sql: send notice when fk col type differs from referenced col

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -923,6 +923,14 @@ func ResolveFK(
 				"type of %q (%s) does not match foreign key %q.%q (%s)",
 				s.GetName(), s.GetType().String(), target.Name, t.GetName(), t.GetType().String())
 		}
+		// Send a notice to client if origin col type is not identical to the
+		// referenced col.
+		if s, t := originCols[i], referencedCols[i]; !s.GetType().Identical(t.GetType()) {
+			notice := pgnotice.Newf(
+				"type of foreign key column %q (%s) is not identical to referenced column %q.%q (%s)",
+				s.ColName(), s.GetType().String(), target.Name, t.GetName(), t.GetType().String())
+			evalCtx.ClientNoticeSender.BufferClientNotice(ctx, notice)
+		}
 	}
 
 	// Verify we are not writing a constraint over the same name.

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3810,3 +3810,29 @@ INSERT INTO t3 VALUES (1, 1, 1), (2, NULL, 2)
 
 statement ok
 DROP TABLE t3, t1, t2
+
+# Test notice is sent when foreign key col type is not identical to referenced
+# col when either creating a new table or adding FK to an existing table
+subtest notice_on_fk_ref_col_type_mismatch
+
+statement ok
+CREATE DATABASE db_type_test
+
+statement ok
+CREATE TABLE db_type_test.public.parent (id INT8 PRIMARY KEY, name STRING NULL)
+
+query T noticetrace
+CREATE TABLE db_type_test.public.child_1 (id INT8 PRIMARY KEY, parent_id INT4 NULL REFERENCES db_type_test.public.parent(id), name STRING NULL)
+----
+NOTICE: type of foreign key column "parent_id" (int4) is not identical to referenced column "parent"."id" (int)
+
+statement ok
+CREATE TABLE db_type_test.public.child_2 (id INT8 PRIMARY KEY, parent_id INT4 NULL, name STRING NULL)
+
+query T noticetrace
+ALTER TABLE db_type_test.public.child_2 ADD CONSTRAINT child_2_fk_parent_id FOREIGN KEY (parent_id) REFERENCES db_type_test.public.parent(id)
+----
+NOTICE: type of foreign key column "parent_id" (int4) is not identical to referenced column "parent"."id" (int)
+
+statement ok
+DROP DATABASE db_type_test


### PR DESCRIPTION
Fixes #68649
An extra check is added to notify user when the fk column
type is not identical to the referenced col type.

Here is a sample output:
```
demo@127.0.0.1:56661/defaultdb> CREATE TABLE public.parent (
  id INT8 NOT NULL PRIMARY KEY, --bigger data type
  name STRING NULL
);
CREATE TABLE

Time: 6ms total (execution 6ms / network 0ms)

demo@127.0.0.1:56661/defaultdb> CREATE TABLE public.child (
  child_id INT8 NOT NULL PRIMARY KEY,
  parent_id INT4 NULL, --smaller data type than the PK column it references
  value INT8 NULL,
  CONSTRAINT fk_parent_id_ref_parent3 FOREIGN KEY (parent_id) REFERENCES public.parent(id)
);
NOTICE: type of foreign key column "parent_id" (int4) is not identical to referenced column "parent"."id" (int)
CREATE TABLE

Time: 47ms total (execution 47ms / network 0ms)
```

Release note: None