### PR TITLE
bench: add tracing benchmark for net.Trace

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -286,6 +286,9 @@ type TracerTestingKnobs struct {
 	// ForceRealSpans, if set, forces the Tracer to create spans even when tracing
 	// is otherwise disabled.
 	ForceRealSpans bool
+	// UseNetTrace, if set, forces the Traces to always create spans which record
+	// to net.Trace objects.
+	UseNetTrace bool
 }
 
 // NewTracer creates a Tracer. It initially tries to run with minimal overhead
@@ -512,7 +515,7 @@ func (t *Tracer) HasExternalSink() bool {
 }
 
 func (t *Tracer) useNetTrace() bool {
-	return atomic.LoadInt32(&t._useNetTrace) != 0
+	return t.testing.UseNetTrace || atomic.LoadInt32(&t._useNetTrace) != 0
 }
 
 // Close cleans up any resources associated with a Tracer.


### PR DESCRIPTION
Add a sub-bench for the use of net.Trace. Turns out that guy is a major
performance hog - notice how it's much slower than everything else
below.

Tracing/1node/scan/trace=off-32        219µs ± 6%
Tracing/1node/scan/trace=1%-32         226µs ± 4%
Tracing/1node/scan/trace=100%-32       244µs ± 8%
Tracing/1node/scan/trace=on-32         203µs ± 3%
Tracing/1node/scan/trace=netTrace-32   597µs ± 8%

Release note: None