### PR TITLE
release-21.1: tabledesc: fix incomplete post-deserialization changes

### DIFF
--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -74,8 +74,12 @@ type PostDeserializationTableDescriptorChanges struct {
 	// UpgradedFormatVersion indicates that the FormatVersion was upgraded.
 	UpgradedFormatVersion bool
 
+	// FixedIndexEncodingType indicates that the encoding type of a public index
+	// was fixed.
+	FixedIndexEncodingType bool
+
 	// UpgradedIndexFormatVersion indicates that the format version of at least
-	// one index descriptor was upgraded
+	// one index descriptor was upgraded.
 	UpgradedIndexFormatVersion bool
 
 	// FixedPrivileges indicates that the privileges were fixed.

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -187,11 +187,13 @@ func maybeFillInDescriptor(
 
 	changes.UpgradedIndexFormatVersion = maybeUpgradeIndexFormatVersion(&desc.PrimaryIndex)
 	for i := range desc.Indexes {
-		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || maybeUpgradeIndexFormatVersion(&desc.Indexes[i])
+		isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(&desc.Indexes[i])
+		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 	}
 	for i := range desc.Mutations {
 		if idx := desc.Mutations[i].GetIndex(); idx != nil {
-			changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || maybeUpgradeIndexFormatVersion(idx)
+			isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(idx)
+			changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 		}
 	}
 


### PR DESCRIPTION
Backport 2/2 commits from #72541.

/cc @cockroachdb/release

---

After being deserialized from their protobuf representations, table
descriptors, like all descriptors, go through a round of
post-deserialization changes, in order to bring them up to date with
respect to the current codebase.

A canonical example of why this is useful is restoring a backup with
a table using the deprecated foreign-key representation. Instead of
having to support deprecated foreign keys throughout the codebase, we
migrate these to the current representation in this post-deserialization
step.

Another class of post-deserialization changes pertain to index
descriptors and their versions. A bug in how these changes were applied
meant that the changes could sometimes be skipped. This commit fixes
this.

The impact of this bug is limited by the fact that index descriptor
versions are backward-compatible.

Release justification: correctness bug fix

Release note: None
