### PR TITLE
tabledesc: remove sec. idx. encoding type post-deserialization change

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -323,8 +323,8 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 	}{
 		{ // 1
 			// In this simple case, we exercise most of the post-deserialization
-			// upgrades, in particular the primary index will have its encoding type
-			// and version properly set.
+			// upgrades, in particular the primary index will have its format version
+			// properly set.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -460,8 +460,7 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 		},
 		{ // 4
 			// This test case is much like the first but more complex and with more
-			// indexes. All three should be upgraded to the latest version and have
-			// their encoding types fixed.
+			// indexes. All three should be upgraded to the latest format version.
 			desc: descpb.TableDescriptor{
 				FormatVersion: descpb.BaseFormatVersion,
 				ID:            51,
@@ -496,7 +495,6 @@ func TestMaybeUpgradeIndexFormatVersion(t *testing.T) {
 						KeyColumnIDs:        []descpb.ColumnID{2},
 						KeyColumnNames:      []string{"bar"},
 						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
-						EncodingType:        descpb.PrimaryIndexEncoding,
 						Version:             descpb.EmptyArraysInInvertedIndexesVersion,
 					},
 				},

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -194,8 +194,6 @@ func maybeFillInDescriptor(
 	changes.UpgradedIndexFormatVersion = maybeUpgradePrimaryIndexFormatVersion(desc)
 	for i := range desc.Indexes {
 		idx := &desc.Indexes[i]
-		isFixed := maybeFixSecondaryIndexEncoding(idx)
-		changes.FixedIndexEncodingType = changes.FixedIndexEncodingType || isFixed
 		isUpgraded := maybeUpgradeSecondaryIndexFormatVersion(idx)
 		changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || isUpgraded
 	}
@@ -574,15 +572,5 @@ func maybeFixPrimaryIndexEncoding(idx *descpb.IndexDescriptor) (hasChanged bool)
 		return false
 	}
 	idx.EncodingType = descpb.PrimaryIndexEncoding
-	return true
-}
-
-// maybeFixPrimaryIndexEncoding ensures that the index descriptor for a
-// secondary index has the correct encoding type set.
-func maybeFixSecondaryIndexEncoding(idx *descpb.IndexDescriptor) (hasChanged bool) {
-	if idx.EncodingType == descpb.SecondaryIndexEncoding {
-		return false
-	}
-	idx.EncodingType = descpb.SecondaryIndexEncoding
 	return true
 }


### PR DESCRIPTION
A few hours ago I merged a PR which adds table descriptor
post-deserialization changes that overwrite its primary and secondary
indexes' encoding type. This was motivated by the recent discovery in
issue #71552 that certain secondary indexes could have their encoding
type set to descpb.PrimaryIndexEncoding due to a bug.

The problem is that overwriting of a secondary index's encoding type
is quite possibly wrong, with severe potential consequences. Until we
can test this case properly, we should remove this particular
post-deserialization change.

Release note: None