### PR TITLE
pkg/roachprod: allow multiple-stores to be created on GCP

### DIFF
--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -64,7 +64,7 @@ if [ "${#disks[@]}" -eq "0" ]; then
   echo "No disks mounted, creating ${mountpoint}"
   mkdir -p ${mountpoint}
   chmod 777 ${mountpoint}
-elif [ "${#disks[@]}" -eq "1" ] || [ -n "use_multiple_disks" ]; then
+elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
   disknum=1
   for disk in "${disks[@]}"
   do


### PR DESCRIPTION
Port an existing flag from the AWS roachprod flags that allows multiple
stores to be created. When this flag is enabled, multiple data
directories are created and mounted as `/mnt/data{1..N}`.

Standardize the existing ext4 disk creation logic in the GCE setup
script to match the AWS functionality. Interleave the existing ZFS setup
commands based on the `--filesystem` flag.

Fix a bug introduced in #54986 that will always create multiple data
disks, ignoring the value of the flag. This has the effect of never
creating a RAID 0 array, which is the intended default behavior.

The ability to create a RAID 0 array on GCE VMs is required for the
Pebble write-throughput benchmarks.

Release note: None