### PR TITLE
logictest: enable more tenant tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,6 +1,4 @@
-# LogicTest: !3node-tenant(49854) !fakedist-spec-planning
-# TODO(asubiotto): Possibly split out the test that attempts to set a zone
-# config in order to run the other ones.
+# LogicTest: !fakedist-spec-planning
 
 statement ok
 CREATE TABLE foo (a int)
@@ -103,7 +101,7 @@ upper
 ROACH7
 
 query T
-SELECT unaccent(str) FROM ( VALUES 
+SELECT unaccent(str) FROM ( VALUES
    ('no_special_CHARACTERS1!'),
    ('Żółć'),
    ('⃞h̀ＥＬＬＯ`̀́⃞'),
@@ -2493,52 +2491,7 @@ SELECT pg_catalog.pg_client_encoding()
 ----
 UTF8
 
-subtest check_consistency
-
-# Sanity-check crdb_internal.check_consistency.
-
-statement error start key must be >= "\\x02"
-SELECT crdb_internal.check_consistency(true, '\x01', '\xffff')
-
-statement error end key must be < "\\xff\\xff"
-SELECT crdb_internal.check_consistency(true, '\x02', '\xffff00')
-
-statement error start key must be less than end key
-SELECT crdb_internal.check_consistency(true, '\x02', '\x02')
-
-statement error start key must be less than end key
-SELECT crdb_internal.check_consistency(true, '\x03', '\x02')
-
-query ITT
-SELECT range_id, status, regexp_replace(detail, '[0-9]+', '', 'g') FROM crdb_internal.check_consistency(true, '\x02', '\xffff') WHERE range_id = 1
-----
-1  RANGE_CONSISTENT  stats: {ContainsEstimates: LastUpdateNanos: IntentAge: GCBytesAge: LiveBytes: LiveCount: KeyBytes: KeyCount: ValBytes: ValCount: IntentBytes: IntentCount: SeparatedIntentCount: SysBytes: SysCount: AbortSpanBytes:}
-
-# Without explicit keys, scans all ranges (we don't test this too precisely to
-# avoid flaking the test when the range count changes, just want to know that
-# we're touching multiple ranges).
-query B
-SELECT count(*) > 5 FROM crdb_internal.check_consistency(true, '', '')
-----
-true
-
-# Query that should touch only a single range.
-query B
-SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\x03', '\x0300')
-----
-true
-
-# Ditto, but implicit start key \x02
-query B
-SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '', '\x0200')
-----
-true
-
-# Ditto, but implicit end key.
-query B
-SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\xff', '')
-----
-true
+subtest width_bucket
 
 # Tests for width_bucket builtin
 query I
@@ -2660,108 +2613,6 @@ query T
 select to_hex('abc')
 ----
 616263
-
-# Test crdb_internal commands which execute as root, but
-# only checks for permissions afterwards.
-subtest crdb_internal_privileged_only
-
-user root
-
-statement ok
-CREATE DATABASE root_test;
-REVOKE CONNECT ON DATABASE root_test FROM public
-
-statement ok
-CREATE TABLE root_test.t(a int)
-
-statement ok
-ALTER DATABASE root_test CONFIGURE ZONE USING num_replicas = 5
-
-query I
-SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
-----
-NULL
-
-query I
-SELECT crdb_internal.get_namespace_id(0, 'root_test')
-----
-63
-
-query I
-SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
-----
-64
-
-query T
-SELECT crdb_internal.get_zone_config(-1)::string
-----
-NULL
-
-query T
-SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
-----
-\x2805500158017800
-
-query T
-SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
-----
-NULL
-
-# switch users -- this one has no permissions so expect errors
-user testuser
-
-query I
-SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
-----
-NULL
-
-query error insufficient privilege
-SELECT crdb_internal.get_namespace_id(0, 'root_test')
-
-query T
-SELECT crdb_internal.get_zone_config(-1)::string
-----
-NULL
-
-query error insufficient privilege
-SELECT crdb_internal.get_zone_config(61)::string -- based on root query. having no permissions blocks us from this test rapidly changing though.
-
-# give testuser permissions on everything and retest
-user root
-
-statement ok
-GRANT ALL ON DATABASE root_test TO testuser
-
-statement ok
-GRANT ALL ON root_test.t TO testuser
-
-user testuser
-
-query I
-SELECT crdb_internal.get_namespace_id(0, 'root_test')
-----
-63
-
-query I
-SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
-----
-64
-
-query T
-SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
-----
-\x2805500158017800
-
-query T
-SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
-----
-NULL
-
-# reset state to default
-user root
-
-statement ok
-DROP DATABASE root_test CASCADE
 
 # Test for timezone builtin.
 subtest timezone_test

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
@@ -1,0 +1,150 @@
+# LogicTest: !3node-tenant !fakedist-spec-planning
+
+subtest check_consistency
+
+# Sanity-check crdb_internal.check_consistency.
+
+statement error start key must be >= "\\x02"
+SELECT crdb_internal.check_consistency(true, '\x01', '\xffff')
+
+statement error end key must be < "\\xff\\xff"
+SELECT crdb_internal.check_consistency(true, '\x02', '\xffff00')
+
+statement error start key must be less than end key
+SELECT crdb_internal.check_consistency(true, '\x02', '\x02')
+
+statement error start key must be less than end key
+SELECT crdb_internal.check_consistency(true, '\x03', '\x02')
+
+query ITT
+SELECT range_id, status, regexp_replace(detail, '[0-9]+', '', 'g') FROM crdb_internal.check_consistency(true, '\x02', '\xffff') WHERE range_id = 1
+----
+1  RANGE_CONSISTENT  stats: {ContainsEstimates: LastUpdateNanos: IntentAge: GCBytesAge: LiveBytes: LiveCount: KeyBytes: KeyCount: ValBytes: ValCount: IntentBytes: IntentCount: SeparatedIntentCount: SysBytes: SysCount: AbortSpanBytes:}
+
+# Without explicit keys, scans all ranges (we don't test this too precisely to
+# avoid flaking the test when the range count changes, just want to know that
+# we're touching multiple ranges).
+query B
+SELECT count(*) > 5 FROM crdb_internal.check_consistency(true, '', '')
+----
+true
+
+# Query that should touch only a single range.
+query B
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\x03', '\x0300')
+----
+true
+
+# Ditto, but implicit start key \x02
+query B
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '', '\x0200')
+----
+true
+
+# Ditto, but implicit end key.
+query B
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\xff', '')
+----
+true
+
+# Test crdb_internal commands which execute as root, but
+# only checks for permissions afterwards.
+subtest crdb_internal_privileged_only
+
+user root
+
+statement ok
+CREATE DATABASE root_test;
+REVOKE CONNECT ON DATABASE root_test FROM public
+
+statement ok
+CREATE TABLE root_test.t(a int)
+
+statement ok
+ALTER DATABASE root_test CONFIGURE ZONE USING num_replicas = 5
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
+----
+NULL
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+----
+53
+
+query I
+SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
+----
+54
+
+query T
+SELECT crdb_internal.get_zone_config(-1)::string
+----
+NULL
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
+----
+\x2805500158017800
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
+----
+NULL
+
+# switch users -- this one has no permissions so expect errors
+user testuser
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'does_not_exist')
+----
+NULL
+
+query error insufficient privilege
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+
+query T
+SELECT crdb_internal.get_zone_config(-1)::string
+----
+NULL
+
+query error insufficient privilege
+SELECT crdb_internal.get_zone_config(53)::string -- based on root query. having no permissions blocks us from this test rapidly changing though.
+
+# give testuser permissions on everything and retest
+user root
+
+statement ok
+GRANT ALL ON DATABASE root_test TO testuser
+
+statement ok
+GRANT ALL ON root_test.t TO testuser
+
+user testuser
+
+query I
+SELECT crdb_internal.get_namespace_id(0, 'root_test')
+----
+53
+
+query I
+SELECT crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't')
+----
+54
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_test'))::string
+----
+\x2805500158017800
+
+query T
+SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(crdb_internal.get_namespace_id(0, 'root_test'), 't'))::string
+----
+NULL
+
+# reset state to default
+user root
+
+statement ok
+DROP DATABASE root_test CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(50047)
-
 ###################
 # CREATE STATISTICS
 ###################

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(49854)
-
 statement ok
 CREATE TYPE t AS ENUM ()
 
@@ -1291,19 +1289,6 @@ CREATE TABLE table_ifne (x INT)
 # the implicit type with the same name as the table.
 statement ok
 CREATE TYPE IF NOT EXISTS table_ifne AS ENUM ('hi')
-
-# Regression test for incorrectly serializing NULL expression type annotation in
-# a enum tuple.
-statement ok
-CREATE TYPE greeting58889 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
-CREATE TABLE t58889 AS SELECT enum_range('hello'::greeting58889)[g] as _enum FROM generate_series(1, 5) as g;
-ALTER TABLE t58889 SPLIT AT SELECT i FROM generate_series(1, 5) as g(i);
-ALTER TABLE t58889 SCATTER;
-
-query T
-SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
-----
-hi
 
 
 subtest enum_array_cast

--- a/pkg/sql/logictest/testdata/logic_test/enums_notenant
+++ b/pkg/sql/logictest/testdata/logic_test/enums_notenant
@@ -1,0 +1,15 @@
+# Tenant tests disabled because of use of SPLIT AT and SCATTER.
+# LogicTest: !3node-tenant
+
+# Regression test for incorrectly serializing NULL expression type annotation in
+# a enum tuple.
+statement ok
+CREATE TYPE greeting58889 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
+CREATE TABLE t58889 AS SELECT enum_range('hello'::greeting58889)[g] as _enum FROM generate_series(1, 5) as g;
+ALTER TABLE t58889 SPLIT AT SELECT i FROM generate_series(1, 5) as g(i);
+ALTER TABLE t58889 SCATTER;
+
+query T
+SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
+----
+hi

--- a/pkg/sql/logictest/testdata/logic_test/grant_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/grant_in_txn
@@ -1,8 +1,3 @@
-# LogicTest: !3node-tenant
-
-# skip this test in the multi-tenant setting because the timeout seems to get
-# triggered.
-
 # This tests ensures that transactions to perform grants on entities created
 # inside of a transaction do not get blocked and take a very long time.
 

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(49854)
-
 statement ok
 GRANT CREATE ON DATABASE test TO testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1,4 +1,4 @@
-# LogicTest: local !3node-tenant(52567)
+# LogicTest: local
 
 ## Tests for ensuring that prepared statements can't get overwritten and for
 ## deallocate and deallocate all.

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,4 +1,3 @@
- # LogicTest: !3node-tenant(49854)
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/type_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/type_privileges
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(50049)
-
 # Types created in the public schema have usage provided to public.
 user root
 


### PR DESCRIPTION
This PR removes the 3node-tenant exclusion for test suites that worked
without modification locally.

Further, in the case of the enums and builtin_function suites, it
moves a few tests into a different file so that the rest of the tests
can be run in tenant mode.

This was the result of an initial pass through all the test files
marked !3node-tenant. There are likely more tests we can enable.

Release note: None