### PR TITLE
release-20.2: sql: use correct encoding type when creating unique index in ALTER PRIMARY KEY

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -223,6 +223,13 @@ func (p *planner) AlterPrimaryKey(
 		// Make the copy of the old primary index not-interleaved. This decision
 		// can be revisited based on user experience.
 		oldPrimaryIndexCopy.Interleave = descpb.InterleaveDescriptor{}
+		// Set correct encoding type and format version (issue #71552).
+		oldPrimaryIndexCopy.EncodingType = descpb.SecondaryIndexEncoding
+		oldPrimaryIndexCopy.Version = descpb.BaseIndexFormatVersion
+		if p.EvalContext().Settings.Version.IsActive(ctx, clusterversion.VersionSecondaryIndexColumnFamilies) {
+			oldPrimaryIndexCopy.Version = descpb.SecondaryIndexFamilyFormatVersion
+		}
+
 		if err := addIndexMutationWithSpecificPrimaryKey(tableDesc, oldPrimaryIndexCopy, newPrimaryIndexDesc); err != nil {
 			return err
 		}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2259,7 +2259,7 @@ func TestVisibilityDuringPrimaryKeyChange(t *testing.T) {
 			},
 		},
 	}
-	s, sqlDB, _ := serverutils.StartServer(t, params)
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	if _, err := sqlDB.Exec(`
@@ -2318,6 +2318,28 @@ INSERT INTO t.test VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
 )`
 	if create != expected {
 		t.Fatalf("expected %s, found %s", expected, create)
+	}
+
+	// Regression test for issue #71552.
+	wg.Add(1)
+	go func() {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (x)`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	<-swapNotification
+	// Let the schema change process continue.
+	waitBeforeContinuing <- struct{}{}
+	// Wait for the primary key swap to happen.
+	wg.Wait()
+
+	desc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+	for _, idx := range desc.Indexes {
+		if idx.EncodingType != descpb.SecondaryIndexEncoding {
+			t.Fatalf("expected SecondaryIndexEncoding for index %q, found %d", idx.Name, idx.EncodingType)
+		}
 	}
 }
 


### PR DESCRIPTION
In versions 21.1 and earlier, the unique index sometimes created as
a side-effect of ALTER PRIMARY KEY could have the wrong encoding type
set. It could be set to the encoding type used for primary indexes,
instead of the one for secondary indexes such as these.

This commit fixes this bug at creation time, but does nothing for
any unique indexes that have already been created.

Partly fixes #71552.

Release note: None