### PR TITLE
sql: fix placeholder type inference for arrays and tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -10,6 +10,7 @@ CREATE TABLE assn_cast (
   i INT,
   t timestamp,
   d DECIMAL(10, 0),
+  a DECIMAL(10, 0)[],
   s STRING
 )
 
@@ -165,6 +166,21 @@ SELECT d FROM assn_cast WHERE d IS NOT NULL
 89
 123
 68
+
+statement ok
+INSERT INTO assn_cast(a) VALUES (ARRAY[5.55, 6.66::DECIMAL(10, 2)])
+
+statement ok
+PREPARE insert_a AS INSERT INTO assn_cast(a) VALUES ($1)
+
+statement ok
+EXECUTE insert_a(ARRAY[7.77, 8.88::DECIMAL(10, 2)])
+
+query T rowsort
+SELECT a FROM assn_cast WHERE a IS NOT NULL
+----
+{6,7}
+{8,9}
 
 statement ok
 INSERT INTO assn_cast(s) VALUES (1)

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1224,23 +1224,24 @@ insert decimals
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:9 => a:1
- │    ├── column2:8 => b:2
- │    ├── c_default:10 => c:3
- │    └── d_comp:11 => d:4
- ├── check columns: check1:12 check2:13
+ │    ├── column2:10 => b:2
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:12 => d:4
+ ├── check columns: check1:13 check2:14
  └── project
-      ├── columns: check1:12 check2:13 d_comp:11 column2:8!null column1:9 c_default:10!null
+      ├── columns: check1:13 check2:14 d_comp:12 column1:9 column2:10 c_default:11!null
       ├── values
-      │    ├── columns: column2:8!null c_default:10!null column1:9
+      │    ├── columns: c_default:11!null column1:9 column2:10
       │    └── tuple
-      │         ├── ARRAY[0.95,NULL,15]
       │         ├── 1.2
-      │         └── assignment-cast: DECIMAL(10)
-      │              └── 1.1
+      │         ├── assignment-cast: DECIMAL(10)
+      │         │    └── 1.1
+      │         └── assignment-cast: DECIMAL(5,1)[]
+      │              └── ARRAY[0.95,NULL,15]
       └── projections
-           ├── column1:9 = round(column1:9) [as=check1:12]
-           ├── CAST(NULL AS BOOL) [as=check2:13]
-           └── (column1:9::DECIMAL + 1.2)::DECIMAL(10,1) [as=d_comp:11]
+           ├── column1:9 = round(column1:9) [as=check1:13]
+           ├── column2:10[0] > 1 [as=check2:14]
+           └── (column1:9::DECIMAL + 1.2)::DECIMAL(10,1) [as=d_comp:12]
 
 build
 INSERT INTO assn_cast (c, qc, i, s) VALUES (' ', 'foo', '1', 2)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1324,8 +1324,10 @@ func (f Family) Name() string {
 	return ret
 }
 
-// CanonicalType returns the canonical type of the given type's family. If the
-// family does not have a canonical type, the original type is returned.
+// CanonicalType returns the canonical type of the given type's family. The
+// original type is returned for some types that do not have a canonical type.
+// For array and tuple types, a new type is returned where the content types
+// have been set to their canonical types.
 func (t *T) CanonicalType() *T {
 	switch t.Family() {
 	case BoolFamily:
@@ -1358,8 +1360,11 @@ func (t *T) CanonicalType() *T {
 	case UuidFamily:
 		return Uuid
 	case ArrayFamily:
-		// ArrayFamily has no canonical type.
-		return t
+		newContents := t.ArrayContents().CanonicalType()
+		if newContents == t.ArrayContents() {
+			return t
+		}
+		return MakeArray(newContents)
 	case INetFamily:
 		return INet
 	case TimeFamily:
@@ -1369,8 +1374,22 @@ func (t *T) CanonicalType() *T {
 	case TimeTZFamily:
 		return TimeTZ
 	case TupleFamily:
-		// TupleFamily has no canonical type.
-		return t
+		isCanonical := true
+		oldContents := t.TupleContents()
+		for i := range oldContents {
+			if oldContents[i].CanonicalType() != oldContents[i] {
+				isCanonical = false
+				break
+			}
+		}
+		if isCanonical {
+			return t
+		}
+		newContents := make([]*T, len(oldContents))
+		for i := range newContents {
+			newContents[i] = oldContents[i].CanonicalType()
+		}
+		return MakeTuple(newContents)
 	case BitFamily:
 		return VarBit
 	case GeometryFamily:

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -979,3 +979,116 @@ func TestSQLStandardName(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalType(t *testing.T) {
+	testCases := []struct {
+		typ      *T
+		expected *T
+	}{
+		// BOOL
+		{Bool, Bool},
+
+		// INT
+		{Int, Int},
+		{Int4, Int},
+		{Int2, Int},
+
+		// FLOAT
+		{Float, Float},
+		{Float4, Float},
+
+		// DECIMAL
+		{Decimal, Decimal},
+		{MakeDecimal(10, 0), Decimal},
+		{MakeDecimal(5, 1), Decimal},
+
+		// DATE
+		{Date, Date},
+
+		// TIMESTAMP
+		{Timestamp, Timestamp},
+		{MakeTimestamp(10), Timestamp},
+
+		// TIMESTAMPTZ
+		{TimestampTZ, TimestampTZ},
+		{MakeTimestampTZ(10), TimestampTZ},
+
+		// TIME
+		{Time, Time},
+		{MakeTime(10), Time},
+
+		// TIMETZ
+		{TimeTZ, TimeTZ},
+		{MakeTimeTZ(10), TimeTZ},
+
+		// INTERVAL
+		{Interval, Interval},
+		{MakeInterval(IntervalTypeMetadata{Precision: 10, PrecisionIsSet: true}), Interval},
+
+		// STRING
+		{String, String},
+		{MakeString(10), String},
+
+		// BYTES
+		{Bytes, Bytes},
+
+		// COLLATEDSTRING
+		// Collated strings do not have a canonical type.
+		{MakeCollatedString(String, "en-US"), MakeCollatedString(String, "en-US")},
+
+		// OID
+		{Oid, Oid},
+
+		// UNKNOWN
+		{Unknown, Unknown},
+
+		// UUID
+		{Uuid, Uuid},
+
+		// INET
+		{INet, INet},
+
+		// JSON
+		{Jsonb, Jsonb},
+
+		// BIT
+		{VarBit, VarBit},
+		{MakeVarBit(10), VarBit},
+		{MakeBit(10), VarBit},
+
+		// GEOMETRY
+		{Geometry, Geometry},
+		{MakeGeometry(geopb.ShapeType_MultiPoint, 4325), Geometry},
+
+		// GEOGRAPHY
+		{Geography, Geography},
+		{MakeGeography(geopb.ShapeType_MultiPoint, 4325), Geography},
+
+		// ENUM
+		// Enums do not have a canonical type.
+		{MakeEnum(15210, 15213), MakeEnum(15210, 15213)},
+
+		// BOX2D
+		{Box2D, Box2D},
+
+		// ANY
+		{Any, Any},
+
+		// ARRAY
+		{IntArray, IntArray},
+		{MakeArray(Int4), IntArray},
+		{DecimalArray, DecimalArray},
+		{MakeArray(MakeDecimal(10, 2)), DecimalArray},
+
+		// TUPLE
+		{MakeTuple([]*T{Int, Decimal}), MakeTuple([]*T{Int, Decimal})},
+		{MakeTuple([]*T{Int4, MakeDecimal(10, 2)}), MakeTuple([]*T{Int, Decimal})},
+	}
+
+	for _, tc := range testCases {
+		actual := tc.typ.CanonicalType()
+		if !actual.Identical(tc.expected) {
+			t.Errorf("expect <%v>, got <%v>", tc.expected.DebugString(), actual.DebugString())
+		}
+	}
+}


### PR DESCRIPTION
To correctly synthesize assignment casts in prepared statements,
placeholder type resolution was recently changed so that placeholders
are always typed as a canonical type. However, array
placeholders could retain non-canonical content types. This resulted in
logical bugs because assignment casts were not synthesized for columns
with array types. This commit fixes the issue by resolving array
placeholders with canonical content types. It makes a similar change for
tuple types for completeness, however, table columns cannot have tuple
types, so there is no known bugs that this fixes.

There is no release note because this bug is not present in any previous
release.

Release note: None