### PR TITLE
sql: plumb sessiondata into schemaexpr.FormatExprForDisplay

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -224,6 +225,7 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 			len(expectedIdx), idxNames(expectedIdx), len(gotIdx), idxNames(gotIdx),
 		)
 	}
+	sd := &sessiondata.SessionData{}
 	for i := range expected.Indexes {
 		ctx := context.Background()
 		semaCtx := tree.MakeSemaContext()
@@ -231,13 +233,13 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		expectedDesc := tabledesc.NewBuilder(expected).BuildImmutableTable()
 		gotDesc := tabledesc.NewBuilder(got).BuildImmutableTable()
 		e, err := catformat.IndexForDisplay(
-			ctx, expectedDesc, tableName, expectedDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx,
+			ctx, expectedDesc, tableName, expectedDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx, sd,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		g, err := catformat.IndexForDisplay(
-			ctx, gotDesc, tableName, gotDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx,
+			ctx, gotDesc, tableName, gotDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx, sd,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -818,7 +818,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						"constraint %q in the middle of being added, try again later", t.Constraint)
 				}
 				if err := validateCheckInTxn(
-					params.ctx, params.p.LeaseMgr(), &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
+					params.ctx, &params.p.semaCtx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, ck.Expr,
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -715,7 +715,9 @@ func (sc *SchemaChanger) validateConstraints(
 				//  after the check is validated.
 				defer func() { collection.ReleaseAll(ctx) }()
 				if c.IsCheck() {
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr); err != nil {
+					if err := validateCheckInTxn(
+						ctx, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr,
+					); err != nil {
 						return err
 					}
 				} else if c.IsForeignKey() {
@@ -727,7 +729,9 @@ func (sc *SchemaChanger) validateConstraints(
 						return err
 					}
 				} else if c.IsNotNull() {
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr); err != nil {
+					if err := validateCheckInTxn(
+						ctx, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr,
+					); err != nil {
 						// TODO (lucy): This should distinguish between constraint
 						// validation errors and other types of unexpected errors, and
 						// return a different error code in the former case
@@ -2057,7 +2061,7 @@ func runSchemaChangesInTxn(
 			check := &c.ConstraintToUpdateDesc().Check
 			if check.Validity == descpb.ConstraintValidity_Validating {
 				if err := validateCheckInTxn(
-					ctx, planner.LeaseMgr(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, check.Expr,
+					ctx, &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, check.Expr,
 				); err != nil {
 					return err
 				}
@@ -2153,7 +2157,6 @@ func runSchemaChangesInTxn(
 // reuse an existing kv.Txn safely.
 func validateCheckInTxn(
 	ctx context.Context,
-	leaseMgr *lease.Manager,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	tableDesc *tabledesc.Mutable,
@@ -2166,7 +2169,7 @@ func validateCheckInTxn(
 		syntheticDescs = append(syntheticDescs, tableDesc)
 	}
 	return ie.WithSyntheticDescriptors(syntheticDescs, func() error {
-		return validateCheckExpr(ctx, semaCtx, checkExpr, tableDesc, ie, txn)
+		return validateCheckExpr(ctx, semaCtx, evalCtx.SessionData(), checkExpr, tableDesc, ie, txn)
 	})
 }
 

--- a/pkg/sql/catalog/catformat/BUILD.bazel
+++ b/pkg/sql/catalog/catformat/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -24,6 +25,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
     ],
 )

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -122,10 +123,11 @@ func TestIndexForDisplay(t *testing.T) {
 		},
 	}
 
+	sd := &sessiondata.SessionData{}
 	for testIdx, tc := range testData {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
 			got, err := indexForDisplay(
-				ctx, tableDesc, &tc.tableName, &tc.index, false /* isPrimary */, tc.partition, &semaCtx,
+				ctx, tableDesc, &tc.tableName, &tc.index, false /* isPrimary */, tc.partition, &semaCtx, sd,
 			)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -78,7 +79,11 @@ func dequalifyColumnRefs(
 // converts user defined types in default and computed expressions to a
 // human-readable form.
 func FormatColumnForDisplay(
-	ctx context.Context, tbl catalog.TableDescriptor, col catalog.Column, semaCtx *tree.SemaContext,
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	col catalog.Column,
+	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	name := col.GetName()
@@ -108,7 +113,7 @@ func FormatColumnForDisplay(
 
 		} else {
 			f.WriteString(" DEFAULT ")
-			defExpr, err := FormatExprForDisplay(ctx, tbl, col.GetDefaultExpr(), semaCtx, tree.FmtParsable)
+			defExpr, err := FormatExprForDisplay(ctx, tbl, col.GetDefaultExpr(), semaCtx, sessionData, tree.FmtParsable)
 			if err != nil {
 				return "", err
 			}
@@ -117,7 +122,7 @@ func FormatColumnForDisplay(
 	}
 	if col.HasOnUpdate() {
 		f.WriteString(" ON UPDATE ")
-		onUpdateExpr, err := FormatExprForDisplay(ctx, tbl, col.GetOnUpdateExpr(), semaCtx, tree.FmtParsable)
+		onUpdateExpr, err := FormatExprForDisplay(ctx, tbl, col.GetOnUpdateExpr(), semaCtx, sessionData, tree.FmtParsable)
 		if err != nil {
 			return "", err
 		}
@@ -125,7 +130,7 @@ func FormatColumnForDisplay(
 	}
 	if col.IsComputed() {
 		f.WriteString(" AS (")
-		compExpr, err := FormatExprForDisplay(ctx, tbl, col.GetComputeExpr(), semaCtx, tree.FmtParsable)
+		compExpr, err := FormatExprForDisplay(ctx, tbl, col.GetComputeExpr(), semaCtx, sessionData, tree.FmtParsable)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -160,6 +161,7 @@ func FormatExprForDisplay(
 	desc catalog.TableDescriptor,
 	exprStr string,
 	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
 	fmtFlags tree.FmtFlags,
 ) (string, error) {
 	return formatExprForDisplayImpl(
@@ -167,6 +169,7 @@ func FormatExprForDisplay(
 		desc,
 		exprStr,
 		semaCtx,
+		sessionData,
 		fmtFlags,
 		false, /* wrapNonFuncExprs */
 	)
@@ -181,6 +184,7 @@ func FormatExprForExpressionIndexDisplay(
 	desc catalog.TableDescriptor,
 	exprStr string,
 	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
 	fmtFlags tree.FmtFlags,
 ) (string, error) {
 	return formatExprForDisplayImpl(
@@ -188,6 +192,7 @@ func FormatExprForExpressionIndexDisplay(
 		desc,
 		exprStr,
 		semaCtx,
+		sessionData,
 		fmtFlags,
 		true, /* wrapNonFuncExprs */
 	)
@@ -198,6 +203,7 @@ func formatExprForDisplayImpl(
 	desc catalog.TableDescriptor,
 	exprStr string,
 	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
 	fmtFlags tree.FmtFlags,
 	wrapNonFuncExprs bool,
 ) (string, error) {
@@ -210,7 +216,7 @@ func formatExprForDisplayImpl(
 	if err != nil {
 		return "", err
 	}
-	f := tree.NewFmtCtx(fmtFlags)
+	f := tree.NewFmtCtx(fmtFlags, tree.FmtDataConversionConfig(sessionData.DataConversionConfig))
 	_, isFunc := expr.(*tree.FuncExpr)
 	if wrapNonFuncExprs && !isFunc {
 		f.WriteByte('(')

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2368,7 +2368,7 @@ CREATE TABLE crdb_internal.create_statements (
 		var err error
 		if table.IsView() {
 			descType = typeView
-			stmt, err = ShowCreateView(ctx, &p.semaCtx, &name, table)
+			stmt, err = ShowCreateView(ctx, &p.semaCtx, p.SessionData(), &name, table)
 		} else if table.IsSequence() {
 			descType = typeSequence
 			stmt, err = ShowCreateSequence(ctx, &name, table)
@@ -2489,7 +2489,9 @@ CREATE TABLE crdb_internal.table_columns (
 					for _, col := range columns {
 						defStr := tree.DNull
 						if col.HasDefault() {
-							defExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, col.GetDefaultExpr(), &p.semaCtx, tree.FmtParsable)
+							defExpr, err := schemaexpr.FormatExprForDisplay(
+								ctx, table, col.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtParsable,
+							)
 							if err != nil {
 								return err
 							}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -435,7 +435,9 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				}
 				colDefault := tree.DNull
 				if column.HasDefault() {
-					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, column.GetDefaultExpr(), &p.semaCtx, tree.FmtParsable)
+					colExpr, err := schemaexpr.FormatExprForDisplay(
+						ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtParsable,
+					)
 					if err != nil {
 						return err
 					}
@@ -443,7 +445,9 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				}
 				colComputed := emptyString
 				if column.IsComputed() {
-					colExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, column.GetComputeExpr(), &p.semaCtx, tree.FmtSimple)
+					colExpr, err := schemaexpr.FormatExprForDisplay(
+						ctx, table, column.GetComputeExpr(), &p.semaCtx, p.SessionData(), tree.FmtSimple,
+					)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -149,7 +149,7 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	if !r.checkOrds.Empty() {
 		checkVals := rowVals[len(r.insertCols):]
 		if err := checkMutationInput(
-			params.ctx, &params.p.semaCtx, r.ti.tableDesc(), r.checkOrds, checkVals,
+			params.ctx, &params.p.semaCtx, params.p.SessionData(), r.ti.tableDesc(), r.checkOrds, checkVals,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1975,3 +1975,24 @@ ORDER BY pk
 ----
 0000-01-01 11:30:45.123 +0600 +0600  0000-01-01 11:30:45.123 +0600 +0600  0000-01-01 11:30:45.123 +0600 +0600  0000-01-01 11:30:45.123 +0600 +0600
 0000-01-01 11:30:45.123 +0300 +0300  0000-01-01 11:30:45.123 +0300 +0300  0000-01-01 11:30:45.123 +0300 +0300  0000-01-01 11:30:45.123 +0300 +0300
+
+# Regression test for #71776 -- intervalstyle should apply to pg_catalog.
+
+statement ok
+SET intervalstyle_enabled = true;
+SET intervalstyle = iso_8601;
+CREATE TABLE table_71776 (interval_col interval DEFAULT 'P3Y')
+
+query TTT
+SELECT a.attname,
+    format_type(a.atttypid, a.atttypmod),
+    pg_get_expr(d.adbin, d.adrelid)
+FROM pg_attribute a
+    LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+WHERE a.attrelid = 'table_71776'::regclass
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+ORDER BY a.attnum
+----
+interval_col  interval  'P3Y'::INTERVAL
+rowid         bigint    unique_rowid()

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -358,7 +358,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html`,
 				// pg_attrdef only expects rows for columns with default values.
 				continue
 			}
-			displayExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, column.GetDefaultExpr(), &p.semaCtx, tree.FmtPGCatalog)
+			displayExpr, err := schemaexpr.FormatExprForDisplay(
+				ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtPGCatalog,
+			)
 			if err != nil {
 				return err
 			}
@@ -897,12 +899,14 @@ func populateTableConstraints(
 					return err
 				}
 				f.WriteString("UNIQUE (")
-				if err := catformat.FormatIndexElements(ctx, table, con.Index, f, p.SemaCtx()); err != nil {
+				if err := catformat.FormatIndexElements(
+					ctx, table, con.Index, f, p.SemaCtx(), p.SessionData(),
+				); err != nil {
 					return err
 				}
 				f.WriteByte(')')
 				if con.Index.IsPartial() {
-					pred, err := schemaexpr.FormatExprForDisplay(ctx, table, con.Index.Predicate, p.SemaCtx(), tree.FmtPGCatalog)
+					pred, err := schemaexpr.FormatExprForDisplay(ctx, table, con.Index.Predicate, p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog)
 					if err != nil {
 						return err
 					}
@@ -923,9 +927,7 @@ func populateTableConstraints(
 					f.WriteString(" NOT VALID")
 				}
 				if con.UniqueWithoutIndexConstraint.Predicate != "" {
-					pred, err := schemaexpr.FormatExprForDisplay(
-						ctx, table, con.UniqueWithoutIndexConstraint.Predicate, p.SemaCtx(), tree.FmtPGCatalog,
-					)
+					pred, err := schemaexpr.FormatExprForDisplay(ctx, table, con.UniqueWithoutIndexConstraint.Predicate, p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog)
 					if err != nil {
 						return err
 					}
@@ -944,7 +946,7 @@ func populateTableConstraints(
 			if conkey, err = colIDArrayToDatum(con.CheckConstraint.ColumnIDs); err != nil {
 				return err
 			}
-			displayExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, con.Details, &p.semaCtx, tree.FmtPGCatalog)
+			displayExpr, err := schemaexpr.FormatExprForDisplay(ctx, table, con.Details, &p.semaCtx, p.SessionData(), tree.FmtPGCatalog)
 			if err != nil {
 				return err
 			}
@@ -1708,11 +1710,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 						if col.IsExpressionIndexColumn() {
 							colIDs = append(colIDs, 0)
 							formattedExpr, err := schemaexpr.FormatExprForDisplay(
-								ctx,
-								table,
-								col.GetComputeExpr(),
-								p.SemaCtx(),
-								tree.FmtPGCatalog,
+								ctx, table, col.GetComputeExpr(), p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog,
 							)
 							if err != nil {
 								return err
@@ -1758,11 +1756,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-index.html`,
 					indpred := tree.DNull
 					if index.IsPartial() {
 						formattedPred, err := schemaexpr.FormatExprForDisplay(
-							ctx,
-							table,
-							index.GetPredicate(),
-							p.SemaCtx(),
-							tree.FmtPGCatalog,
+							ctx, table, index.GetPredicate(), p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog,
 						)
 						if err != nil {
 							return err
@@ -1859,11 +1853,7 @@ func indexDefFromDescriptor(
 		}
 		if col.IsExpressionIndexColumn() {
 			formattedExpr, err := schemaexpr.FormatExprForDisplay(
-				ctx,
-				table,
-				col.GetComputeExpr(),
-				p.SemaCtx(),
-				tree.FmtPGCatalog,
+				ctx, table, col.GetComputeExpr(), p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog,
 			)
 			if err != nil {
 				return "", err
@@ -1886,7 +1876,9 @@ func indexDefFromDescriptor(
 	if index.IsPartial() {
 		// Format the raw predicate for display in order to resolve user-defined
 		// types to a human readable form.
-		formattedPred, err := schemaexpr.FormatExprForDisplay(ctx, table, index.GetPredicate(), p.SemaCtx(), tree.FmtPGCatalog)
+		formattedPred, err := schemaexpr.FormatExprForDisplay(
+			ctx, table, index.GetPredicate(), p.SemaCtx(), p.SessionData(), tree.FmtPGCatalog,
+		)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -88,7 +88,9 @@ func ShowCreateTable(
 			f.WriteString(",")
 		}
 		f.WriteString("\n\t")
-		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, desc, col, &p.RunParams(ctx).p.semaCtx)
+		colstr, err := schemaexpr.FormatColumnForDisplay(
+			ctx, desc, col, &p.RunParams(ctx).p.semaCtx, p.RunParams(ctx).p.SessionData(),
+		)
 		if err != nil {
 			return "", err
 		}
@@ -152,6 +154,7 @@ func ShowCreateTable(
 			idx,
 			partitionBuf.String(),
 			p.RunParams(ctx).p.SemaCtx(),
+			p.RunParams(ctx).p.SessionData(),
 		)
 		if err != nil {
 			return "", err
@@ -161,7 +164,7 @@ func ShowCreateTable(
 
 	// Create the FAMILY and CONSTRAINTs of the CREATE statement
 	showFamilyClause(desc, f)
-	if err := showConstraintClause(ctx, desc, &p.RunParams(ctx).p.semaCtx, f); err != nil {
+	if err := showConstraintClause(ctx, desc, &p.RunParams(ctx).p.semaCtx, p.RunParams(ctx).p.SessionData(), f); err != nil {
 		return "", err
 	}
 
@@ -215,7 +218,7 @@ func (p *planner) ShowCreate(
 	var err error
 	tn := tree.MakeUnqualifiedTableName(tree.Name(desc.GetName()))
 	if desc.IsView() {
-		stmt, err = ShowCreateView(ctx, &p.RunParams(ctx).p.semaCtx, &tn, desc)
+		stmt, err = ShowCreateView(ctx, &p.RunParams(ctx).p.semaCtx, p.RunParams(ctx).p.SessionData(), &tn, desc)
 	} else if desc.IsSequence() {
 		stmt, err = ShowCreateSequence(ctx, &tn, desc)
 	} else {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -89,7 +89,11 @@ func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc 
 // statement used to create the given view. It is used in the implementation of
 // the crdb_internal.create_statements virtual table.
 func ShowCreateView(
-	ctx context.Context, semaCtx *tree.SemaContext, tn *tree.TableName, desc catalog.TableDescriptor,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
+	tn *tree.TableName,
+	desc catalog.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	f.WriteString("CREATE ")
@@ -109,7 +113,7 @@ func ShowCreateView(
 	f.WriteString(") AS ")
 
 	// Deserialize user-defined types in the view query.
-	typeReplacedViewQuery, err := formatViewQueryTypesForDisplay(ctx, semaCtx, desc)
+	typeReplacedViewQuery, err := formatViewQueryTypesForDisplay(ctx, semaCtx, sessionData, desc)
 	if err != nil {
 		log.Warningf(ctx,
 			"error deserializing user defined types for view %s (%v): %+v",
@@ -162,7 +166,10 @@ func formatViewQuerySequencesForDisplay(
 // look for serialized user-defined types. If it finds any,
 // it will deserialize it to display its name.
 func formatViewQueryTypesForDisplay(
-	ctx context.Context, semaCtx *tree.SemaContext, desc catalog.TableDescriptor,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
+	desc catalog.TableDescriptor,
 ) (string, error) {
 	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		switch n := expr.(type) {
@@ -176,7 +183,8 @@ func formatViewQueryTypesForDisplay(
 			}
 
 			formattedExpr, err := schemaexpr.FormatExprForDisplay(
-				ctx, desc, expr.String(), semaCtx, tree.FmtParsable)
+				ctx, desc, expr.String(), semaCtx, sessionData, tree.FmtParsable,
+			)
 			if err != nil {
 				return false, expr, err
 			}
@@ -513,7 +521,11 @@ func ShowCreatePartitioning(
 // showConstraintClause creates the CONSTRAINT clauses for a CREATE statement,
 // writing them to tree.FmtCtx f
 func showConstraintClause(
-	ctx context.Context, desc catalog.TableDescriptor, semaCtx *tree.SemaContext, f *tree.FmtCtx,
+	ctx context.Context,
+	desc catalog.TableDescriptor,
+	semaCtx *tree.SemaContext,
+	sessionData *sessiondata.SessionData,
+	f *tree.FmtCtx,
 ) error {
 	for _, e := range desc.AllActiveAndInactiveChecks() {
 		f.WriteString(",\n\t")
@@ -523,7 +535,7 @@ func showConstraintClause(
 			f.WriteString(" ")
 		}
 		f.WriteString("CHECK (")
-		expr, err := schemaexpr.FormatExprForDisplay(ctx, desc, e.Expr, semaCtx, tree.FmtParsable)
+		expr, err := schemaexpr.FormatExprForDisplay(ctx, desc, e.Expr, semaCtx, sessionData, tree.FmtParsable)
 		if err != nil {
 			return err
 		}
@@ -549,7 +561,7 @@ func showConstraintClause(
 		f.WriteString(")")
 		if c.IsPartial() {
 			f.WriteString(" WHERE ")
-			pred, err := schemaexpr.FormatExprForDisplay(ctx, desc, c.Predicate, semaCtx, tree.FmtParsable)
+			pred, err := schemaexpr.FormatExprForDisplay(ctx, desc, c.Predicate, semaCtx, sessionData, tree.FmtParsable)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -292,7 +292,7 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	if !u.run.checkOrds.Empty() {
 		checkVals := sourceVals[len(u.run.tu.ru.FetchCols)+len(u.run.tu.ru.UpdateCols)+u.run.numPassthrough:]
 		if err := checkMutationInput(
-			params.ctx, &params.p.semaCtx, u.run.tu.tableDesc(), u.run.checkOrds, checkVals,
+			params.ctx, &params.p.semaCtx, params.p.SessionData(), u.run.tu.tableDesc(), u.run.checkOrds, checkVals,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -174,7 +174,9 @@ func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) err
 			ord++
 		}
 		checkVals := rowVals[ord:]
-		if err := checkMutationInput(params.ctx, &params.p.semaCtx, n.run.tw.tableDesc(), n.run.checkOrds, checkVals); err != nil {
+		if err := checkMutationInput(
+			params.ctx, &params.p.semaCtx, params.p.SessionData(), n.run.tw.tableDesc(), n.run.checkOrds, checkVals,
+		); err != nil {
 			return err
 		}
 		rowVals = rowVals[:ord]


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71776

Release note (bug fix): Previously, introspection tables and error
messages would not correctly display intervals according to the
`intervalstyle` session variable. This is fixed now.