### PR TITLE
sql: move SET DATABASE var code to SetWithPlanner

### DIFF
--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -73,6 +73,12 @@ func resetSessionVar(ctx context.Context, m sessionDataMutator, varName string) 
 				return err
 			}
 		}
+	} else if varName == "database" {
+		// "database" has no `Set`, but has `SetWithPlanner`.
+		// If we're resetting, we are resetting to the initial connection setup,
+		// which matches postgresql (even if we lose CONNECT privileges, we are still
+		// allowed to reset).
+		m.SetDatabase(m.defaults[varName])
 	}
 	return nil
 }

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -823,6 +823,9 @@ func parseClientProvidedSessionParameters(
 					return sql.SessionArgs{}, pgerror.Wrapf(err, pgerror.GetPGCode(err), "options")
 				}
 			}
+		case "database":
+			// Catch. There is no `Set` defined on `database`, so move along and avoid
+			// the `loadParameter` call.
 		default:
 			err = loadParameter(ctx, key, value, &args)
 			if err != nil {


### PR DESCRIPTION
To enforce CONNECT privileges, we need the planner. This commit moves
`database` to use `SetWithPlanner` instead of `Set` for the session
variable. We then need to inject magic throughout the stack to account
for `database` not having `Set` set.

Release note: None