### PR TITLE
release-21.1: ui: fix drag to zoom on custom charts

### DIFF
--- a/pkg/ui/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customChart/index.tsx
@@ -207,6 +207,7 @@ export class CustomChart extends React.Component<
         key={index}
         setTimeRange={this.props.setTimeRange}
         setTimeScale={this.props.setTimeScale}
+        history={this.props.history}
       >
         <LineGraph>
           <Axis units={units}>


### PR DESCRIPTION
Backport 1/1 commits from #70229 for fixing the resolution to the drag to zoom issue on custom charts

Release justification: drag to zoom issue on custom charts needs to be fixed in release 21.1

Release note (ui change): fix drag to zoom on custom charts