### PR TITLE
ci: add bazel-based url check job for ci

### DIFF
--- a/build/teamcity/cockroach/nightlies/url_check.sh
+++ b/build/teamcity/cockroach/nightlies/url_check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run url check"
+run_bazel build/teamcity/cockroach/nightlies/url_check_impl.sh
+tc_end_block "Run url check"

--- a/build/teamcity/cockroach/nightlies/url_check_impl.sh
+++ b/build/teamcity/cockroach/nightlies/url_check_impl.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel run //pkg/cmd/urlcheck --config=ci --run_under="cd $PWD && "

--- a/pkg/cmd/urlcheck/BUILD.bazel
+++ b/pkg/cmd/urlcheck/BUILD.bazel
@@ -1,4 +1,3 @@
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck //pkg/cmd/urlcheck/lib/urlcheck:go_default_library
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -6,7 +5,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/urlcheck",
     visibility = ["//visibility:private"],
-    deps = ["//pkg/cmd/urlcheck/lib/urlcheck:go_default_library"],
+    deps = ["//pkg/cmd/urlcheck/lib/urlcheck"],
 )
 
 go_binary(


### PR DESCRIPTION
Closes #67336.

Release note: None