### PR TITLE
ui: fix transaction page reset sql stats button not working on CC Console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -21,6 +21,7 @@ import {
   ResetSQLStatsState,
 } from "./sqlStats.reducer";
 import { actions as statementActions } from "src/store/statements/statements.reducer";
+import { actions as transactionActions } from "src/store/transactions/transactions.reducer";
 
 describe("SQL Stats sagas", () => {
   describe("resetSQLStatsSaga", () => {
@@ -31,7 +32,7 @@ describe("SQL Stats sagas", () => {
         .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(sqlStatsActions.received(resetSQLStatsResponse))
         .put(statementActions.invalidated())
-        .put(statementActions.refresh())
+        .put(transactionActions.invalidated())
         .withReducer(sqlStatsReducers)
         .hasFinalState<ResetSQLStatsState>({
           data: resetSQLStatsResponse,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -11,14 +11,21 @@
 import { all, call, put, takeEvery } from "redux-saga/effects";
 import { resetSQLStats } from "src/api/sqlStatsApi";
 import { actions as statementActions } from "src/store/statements";
+import { actions as transactionActions } from "src/store/transactions";
 import { actions as sqlStatsActions } from "./sqlStats.reducer";
 
 export function* resetSQLStatsSaga(): any {
   try {
     const response = yield call(resetSQLStats);
     yield put(sqlStatsActions.received(response));
+
+    // We dispatch INVALIDATE actions for both statements and transactions,
+    // but we only dispatch one REFRESH action for statements.
+    // The responsibility of issuing API call is delegated to the React
+    // components since the invalidation of the props will cause the React
+    // lifecycle hook to be called.
     yield put(statementActions.invalidated());
-    yield put(statementActions.refresh());
+    yield put(transactionActions.invalidated());
   } catch (e) {
     yield put(sqlStatsActions.failed(e));
   }

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "./sqlStatsActions";
 import { resetSQLStatsSaga } from "./sqlStatsSagas";
 import { resetSQLStats } from "src/util/api";
-import { invalidateStatements, refreshStatements } from "src/redux/apiReducers";
+import { invalidateStatements } from "src/redux/apiReducers";
 import { throwError } from "redux-saga-test-plan/providers";
 
 import { cockroach } from "src/js/protos";
@@ -31,7 +31,6 @@ describe("SQL Stats sagas", () => {
         .provide([[call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(resetSQLStatsCompleteAction())
         .put(invalidateStatements())
-        .put(refreshStatements() as any)
         .run();
     });
 

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
@@ -16,7 +16,7 @@ import {
   resetSQLStatsCompleteAction,
   resetSQLStatsFailedAction,
 } from "./sqlStatsActions";
-import { invalidateStatements, refreshStatements } from "src/redux/apiReducers";
+import { invalidateStatements } from "src/redux/apiReducers";
 
 import ResetSQLStatsRequest = cockroach.server.serverpb.ResetSQLStatsRequest;
 
@@ -30,7 +30,6 @@ export function* resetSQLStatsSaga() {
     yield call(resetSQLStats, resetSQLStatsRequest);
     yield put(resetSQLStatsCompleteAction());
     yield put(invalidateStatements());
-    yield put(refreshStatements() as any);
   } catch (e) {
     yield put(resetSQLStatsFailedAction());
   }

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -32,7 +32,7 @@ import { LocalSetting } from "src/redux/localsettings";
 export const selectData = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
   (state: CachedDataReducerState<StatementsResponseMessage>) => {
-    if (!state.data || state.inFlight) return null;
+    if (!state.data || state.inFlight || !state.valid) return null;
     return state.data;
   },
 );


### PR DESCRIPTION
Previously, reset SQL Stats button on CC Console Transaction Page was not
working properly. This was due to Redux not properly invalidating the
store backing the Transaction Page.
This commit addresses this issue by properly invalidating the Redux
store which causes the React Component to trigger Redux refresh aciton.

Resolves #72009

Release note: None

CC Console:

https://user-images.githubusercontent.com/9267198/141024422-8de7d6de-1571-47a0-9857-840943c9d9d4.mov

DB Console: 




https://user-images.githubusercontent.com/9267198/141048060-482d23e6-dc77-4868-98dd-e209d0965cf9.mov


