### PR TITLE
release-21.2: util/admission: avoid write to tenantInfo after releasing it

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -442,8 +442,7 @@ func (q *WorkQueue) gcTenantsAndResetTokens() {
 		if info.used == 0 && len(info.waitingWorkHeap) == 0 {
 			delete(q.mu.tenants, id)
 			releaseTenantInfo(info)
-		}
-		if q.usesTokens {
+		} else if q.usesTokens {
 			info.used = 0
 			// All the heap members will reset used=0, so no need to change heap
 			// ordering.


### PR DESCRIPTION
Backport 1/1 commits from #72220.

/cc @cockroachdb/release

---

Previously, `releaseTenantInfo(info)` put the *tenantInfo back into
the pool, but we then wrote to `info.used` directly after. This is a data 
race leading to multiple test failures.

Since releaseTenantInfo resets the tenantInfo, we don't care about
resetting the used field in that case anyway.

Release note: None

Release justification: Low risk fix for correctness bug in admission control.