### PR TITLE
roachtest: prevent configuring timeouts above 18h

### DIFF
--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -102,11 +102,7 @@ case "${CLOUD}" in
     ;;
 esac
 
-# Teamcity has a 1300 minute timeout that, when reached, kills the process
-# without a stack trace (probably SIGKILL).  We'd love to see a stack trace
-# though, so after 1200 minutes, kill with SIGINT which will allow roachtest to
-# fail tests and cleanup.
-timeout -s INT $((1200*60)) "build/teamcity-roachtest-invoke.sh" \
+build/teamcity-roachtest-invoke.sh \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
   --parallelism="${PARALLELISM}" \

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -191,8 +191,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 			// By default, the timeout is 10 hours which might not be sufficient
 			// given that a single iteration of checkConcurrency might take on
 			// the order of one hour, so in order to let each test run to
-			// complete we'll give it 24 hours.
-			Timeout: 24 * time.Hour,
+			// complete we'll give it 18 hours. Successful runs typically take
+			// a lot less, around six hours.
+			Timeout: 18 * time.Hour,
 		})
 	}
 }


### PR DESCRIPTION
- build: drop timeout in roachtest nightly
- roachtest: reduce tpch timeout to 18h
- roachtest: enforce max timeout of 18h for non-weekly tests
