### PR TITLE
jobs: hang  the job registry off the server context

### DIFF
--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -217,17 +217,17 @@ func TestJobSchedulerDaemonGetWaitPeriod(t *testing.T) {
 	schedulerEnabledSetting.Override(ctx, sv, false)
 
 	// When disabled, we wait 5 minutes before rechecking.
-	require.EqualValues(t, 5*time.Minute, getWaitPeriod(sv, nil))
+	require.EqualValues(t, 5*time.Minute, getWaitPeriod(ctx, sv, nil))
 	schedulerEnabledSetting.Override(ctx, sv, true)
 
 	// When pace is too low, we use something more reasonable.
 	schedulerPaceSetting.Override(ctx, sv, time.Nanosecond)
-	require.EqualValues(t, minPacePeriod, getWaitPeriod(sv, nil))
+	require.EqualValues(t, minPacePeriod, getWaitPeriod(ctx, sv, nil))
 
 	// Otherwise, we use user specified setting.
 	pace := 42 * time.Second
 	schedulerPaceSetting.Override(ctx, sv, pace)
-	require.EqualValues(t, pace, getWaitPeriod(sv, nil))
+	require.EqualValues(t, pace, getWaitPeriod(ctx, sv, nil))
 }
 
 type recordScheduleExecutor struct {

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -375,6 +375,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 
 		td := tracedumper.NewTraceDumper(ctx, cfg.InflightTraceDirName, cfg.Settings)
 		*jobRegistry = *jobs.MakeRegistry(
+			ctx,
 			cfg.AmbientCtx,
 			cfg.stopper,
 			cfg.clock,


### PR DESCRIPTION
Informs #58938.

Prior to this patch, log messages related to jobs were disconnected
from the server context and were thus missing the node ID and other
log tags.

This patch fixes it.

Release note: None