### PR TITLE
server: report the SQL instance ID as log tag `sqli`

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -3,6 +3,7 @@ The following types are considered always safe for reporting:
 File | Type
 --|--
 pkg/base/node_id.go | `*NodeIDContainer`
+pkg/base/node_id.go | `*SQLIDContainer`
 pkg/base/node_id.go | `*StoreIDContainer`
 pkg/cli/exit/exit.go | `Code`
 pkg/jobs/jobspb/wrap.go | `JobID`


### PR DESCRIPTION
Informs #58938.

Prior to this patch, the SQL instance ID was not reported in log
messages, which made it hard to distinguish log messages coming from
different in-memory SQL instance servers (e.g. in tests).

This patch fixes it.

The patch also changes the log tag for SQL instances from just `sql`
to `sqli`, which is easier to search for and recognize.

Release note: None