### PR TITLE
sql/opt: cleanup and fixes for assignment casts

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -118,9 +118,7 @@ INSERT into assn_cast(b) VALUES ('1')
 statement ok
 INSERT INTO assn_cast(b) VALUES (null), ('1')
 
-# TODO(mgartner): To match Postgres behavior, this statement should fail with
-# the message "value too long for type BIT".
-statement ok
+statement error bit string length 2 does not match type BIT
 INSERT into assn_cast(b) VALUES ('01')
 
 statement error value type int doesn't match type bit of column \"b\"
@@ -148,6 +146,12 @@ statement ok
 INSERT INTO assn_cast(d) VALUES (11.22), (88.99)
 
 statement ok
+INSERT INTO assn_cast(d) VALUES (22.33::DECIMAL(10, 0)), (99.11::DECIMAL(10, 2))
+
+statement ok
+INSERT INTO assn_cast(d) VALUES (33.11::DECIMAL(10, 0)), (44.44::DECIMAL(10, 0))
+
+statement ok
 PREPARE insert_d AS INSERT INTO assn_cast(d) VALUES ($1)
 
 statement ok
@@ -164,8 +168,18 @@ SELECT d FROM assn_cast WHERE d IS NOT NULL
 ----
 11
 89
+22
+99
+33
+44
 123
 68
+
+statement ok
+INSERT INTO assn_cast(a) VALUES (ARRAY[2.88, NULL, 15])
+
+statement ok
+INSERT INTO assn_cast(a) VALUES (ARRAY[3.99, NULL, 16]::DECIMAL(10, 2)[])
 
 statement ok
 INSERT INTO assn_cast(a) VALUES (ARRAY[5.55, 6.66::DECIMAL(10, 2)])
@@ -179,6 +193,8 @@ EXECUTE insert_a(ARRAY[7.77, 8.88::DECIMAL(10, 2)])
 query T rowsort
 SELECT a FROM assn_cast WHERE a IS NOT NULL
 ----
+{3,NULL,15}
+{4,NULL,16}
 {6,7}
 {8,9}
 

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -349,7 +349,7 @@ explain(shape):
 │       │
 │       └── • lookup join (anti)
 │           │ table: status_type@status_type_pkey
-│           │ equality: (?column?) = (st_id)
+│           │ equality: (th_st_id) = (st_id)
 │           │ equality cols are key
 │           │
 │           └── • scan buffer

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1438,43 +1437,6 @@ func (mb *mutationBuilder) addAssignmentCasts(inScope *scope, outTypes []*types.
 
 	projectionScope.expr = mb.b.constructProject(expr, projectionScope.cols)
 	return projectionScope
-}
-
-// checkColumnIsNotGeneratedAlwaysAsIdentity verifies that if current column
-// is not created as an IDENTITY column with the
-// `GENERATED ALWAYS AS IDENTITY` syntax.
-// Such an IDENTITY column is not allowed to be overridden explicitly.
-// Users need to specify the INSERT/UPSERT/UPDATE statement with
-// the OVERRIDING SYSTEM VALUE syntax.
-//
-// TODO(janexing): to implement the OVERRIDING SYSTEM VALUE syntax
-// under `INSERT/UPSERT/UPDATE` statement.
-// check also https://github.com/cockroachdb/cockroach/issues/68201.
-//
-// This function is used in code for UPDATE, INSERT and UPSERT statement.
-func checkColumnIsNotGeneratedAlwaysAsIdentity(col *cat.Column) {
-	if !col.IsGeneratedAlwaysAsIdentity() {
-		return
-	}
-	colName := string(col.ColName())
-	err := sqlerrors.NewGeneratedAlwaysAsIdentityColumnOverrideError(colName)
-	panic(err)
-}
-
-// checkUpdateExpression verifies if current column
-// is compatible with the update expression.
-func checkUpdateExpression(col *cat.Column, updateExpr *tree.UpdateExpr) {
-	if col.IsGeneratedAlwaysAsIdentity() {
-		switch updateExpr.Expr.(type) {
-		// if current column was created with the `GENERATED ALWAYS` syntax,
-		// this column can only be updated to DEFAULT in the update statement.
-		case tree.DefaultVal:
-			return
-		default:
-			err := sqlerrors.NewGeneratedAlwaysAsIdentityColumnUpdateError(string(col.ColName()))
-			panic(err)
-		}
-	}
 }
 
 // partialIndexCount returns the number of public, write-only, and delete-only

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -759,18 +759,18 @@ INSERT INTO xyz (x) VALUES (10)
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:7 => x:1
+ │    ├── x:7 => xyz.x:1
  │    ├── y_default:8 => y:2
  │    └── z_default:9 => z:3
  └── project
-      ├── columns: y_default:8 z_default:9 column1:7
+      ├── columns: y_default:8 z_default:9 x:7
       ├── project
-      │    ├── columns: column1:7
+      │    ├── columns: x:7
       │    ├── values
       │    │    ├── columns: column1:6!null
       │    │    └── (10,)
       │    └── projections
-      │         └── assignment-cast: STRING [as=column1:7]
+      │         └── assignment-cast: STRING [as=x:7]
       │              └── column1:6
       └── projections
            ├── NULL::INT8 [as=y_default:8]
@@ -1190,32 +1190,34 @@ INSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95, NULL, 15])
 insert decimals
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:9 => a:1
- │    ├── column2:8 => b:2
- │    ├── c_default:10 => c:3
- │    └── d_comp:11 => d:4
- ├── check columns: check1:12 check2:13
+ │    ├── a:9 => decimals.a:1
+ │    ├── b:10 => decimals.b:2
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:12 => d:4
+ ├── check columns: check1:13 check2:14
  └── project
-      ├── columns: check1:12 check2:13 column2:8 column1:9 c_default:10!null d_comp:11
+      ├── columns: check1:13 check2:14 a:9 b:10 c_default:11!null d_comp:12
       ├── project
-      │    ├── columns: d_comp:11 column2:8 column1:9 c_default:10!null
+      │    ├── columns: d_comp:12 a:9 b:10 c_default:11!null
       │    ├── project
-      │    │    ├── columns: c_default:10!null column2:8 column1:9
+      │    │    ├── columns: c_default:11!null a:9 b:10
       │    │    ├── project
-      │    │    │    ├── columns: column1:9 column2:8
+      │    │    │    ├── columns: a:9 b:10
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:7!null column2:8
       │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
       │    │    │    └── projections
-      │    │    │         └── assignment-cast: DECIMAL(10) [as=column1:9]
-      │    │    │              └── column1:7
+      │    │    │         ├── assignment-cast: DECIMAL(10) [as=a:9]
+      │    │    │         │    └── column1:7
+      │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b:10]
+      │    │    │              └── column2:8
       │    │    └── projections
-      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:10]
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:11]
       │    └── projections
-      │         └── (column1:9::DECIMAL + c_default:10::DECIMAL)::DECIMAL(10,1) [as=d_comp:11]
+      │         └── (a:9::DECIMAL + c_default:11::DECIMAL)::DECIMAL(10,1) [as=d_comp:12]
       └── projections
-           ├── round(column1:9) = column1:9 [as=check1:12]
-           └── column2:8[0] > 1 [as=check2:13]
+           ├── round(a:9) = a:9 [as=check1:13]
+           └── b:10[0] > 1 [as=check2:14]
 
 assign-placeholders-norm query-args=(1.1, (ARRAY[0.95, NULL, 15]))
 INSERT INTO decimals (a, b) VALUES ($1, $2)
@@ -1223,15 +1225,15 @@ INSERT INTO decimals (a, b) VALUES ($1, $2)
 insert decimals
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:9 => a:1
- │    ├── column2:10 => b:2
+ │    ├── a:9 => decimals.a:1
+ │    ├── b:10 => decimals.b:2
  │    ├── c_default:11 => c:3
  │    └── d_comp:12 => d:4
  ├── check columns: check1:13 check2:14
  └── project
-      ├── columns: check1:13 check2:14 d_comp:12 column1:9 column2:10 c_default:11!null
+      ├── columns: check1:13 check2:14 d_comp:12 a:9 b:10 c_default:11!null
       ├── values
-      │    ├── columns: c_default:11!null column1:9 column2:10
+      │    ├── columns: c_default:11!null a:9 b:10
       │    └── tuple
       │         ├── 1.2
       │         ├── assignment-cast: DECIMAL(10)
@@ -1239,9 +1241,185 @@ insert decimals
       │         └── assignment-cast: DECIMAL(5,1)[]
       │              └── ARRAY[0.95,NULL,15]
       └── projections
-           ├── column1:9 = round(column1:9) [as=check1:13]
-           ├── column2:10[0] > 1 [as=check2:14]
-           └── (column1:9::DECIMAL + 1.2)::DECIMAL(10,1) [as=d_comp:12]
+           ├── a:9 = round(a:9) [as=check1:13]
+           ├── b:10[0] > 1 [as=check2:14]
+           └── (a:9::DECIMAL + 1.2)::DECIMAL(10,1) [as=d_comp:12]
+
+build
+INSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95, NULL, 15]::DECIMAL(10, 2)[])
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:9 => decimals.a:1
+ │    ├── b:10 => decimals.b:2
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:12 => d:4
+ ├── check columns: check1:13 check2:14
+ └── project
+      ├── columns: check1:13 check2:14 a:9 b:10 c_default:11!null d_comp:12
+      ├── project
+      │    ├── columns: d_comp:12 a:9 b:10 c_default:11!null
+      │    ├── project
+      │    │    ├── columns: c_default:11!null a:9 b:10
+      │    │    ├── project
+      │    │    │    ├── columns: a:9 b:10
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:7!null column2:8
+      │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15]::DECIMAL(10,2)[])
+      │    │    │    └── projections
+      │    │    │         ├── assignment-cast: DECIMAL(10) [as=a:9]
+      │    │    │         │    └── column1:7
+      │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b:10]
+      │    │    │              └── column2:8
+      │    │    └── projections
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:11]
+      │    └── projections
+      │         └── (a:9::DECIMAL + c_default:11::DECIMAL)::DECIMAL(10,1) [as=d_comp:12]
+      └── projections
+           ├── round(a:9) = a:9 [as=check1:13]
+           └── b:10[0] > 1 [as=check2:14]
+
+build
+INSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95, NULL, 15::DECIMAL(10, 2)])
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:9 => decimals.a:1
+ │    ├── b:10 => decimals.b:2
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:12 => d:4
+ ├── check columns: check1:13 check2:14
+ └── project
+      ├── columns: check1:13 check2:14 a:9 b:10 c_default:11!null d_comp:12
+      ├── project
+      │    ├── columns: d_comp:12 a:9 b:10 c_default:11!null
+      │    ├── project
+      │    │    ├── columns: c_default:11!null a:9 b:10
+      │    │    ├── project
+      │    │    │    ├── columns: a:9 b:10
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:7!null column2:8
+      │    │    │    │    └── (1.1, ARRAY[0.95, NULL, 15::DECIMAL(10,2)])
+      │    │    │    └── projections
+      │    │    │         ├── assignment-cast: DECIMAL(10) [as=a:9]
+      │    │    │         │    └── column1:7
+      │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b:10]
+      │    │    │              └── column2:8
+      │    │    └── projections
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:11]
+      │    └── projections
+      │         └── (a:9::DECIMAL + c_default:11::DECIMAL)::DECIMAL(10,1) [as=d_comp:12]
+      └── projections
+           ├── round(a:9) = a:9 [as=check1:13]
+           └── b:10[0] > 1 [as=check2:14]
+
+# Multi-value inserts with non-identical column types should infer the column type to
+# be the canonical type and an assignment cast should be added.
+build
+INSERT INTO decimals (a) VALUES (10.0::DECIMAL(10, 0)), (10.2::DECIMAL(10, 2))
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:8 => decimals.a:1
+ │    ├── b_default:9 => b:2
+ │    ├── c_default:10 => c:3
+ │    └── d_comp:11 => d:4
+ ├── check columns: check1:12 check2:13
+ └── project
+      ├── columns: check1:12 check2:13 a:8 b_default:9 c_default:10!null d_comp:11
+      ├── project
+      │    ├── columns: d_comp:11 a:8 b_default:9 c_default:10!null
+      │    ├── project
+      │    │    ├── columns: b_default:9 c_default:10!null a:8
+      │    │    ├── project
+      │    │    │    ├── columns: a:8
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:7
+      │    │    │    │    ├── (10.0::DECIMAL(10),)
+      │    │    │    │    └── (10.2::DECIMAL(10,2),)
+      │    │    │    └── projections
+      │    │    │         └── assignment-cast: DECIMAL(10) [as=a:8]
+      │    │    │              └── column1:7
+      │    │    └── projections
+      │    │         ├── NULL::DECIMAL(5,1)[] [as=b_default:9]
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:10]
+      │    └── projections
+      │         └── (a:8::DECIMAL + c_default:10::DECIMAL)::DECIMAL(10,1) [as=d_comp:11]
+      └── projections
+           ├── round(a:8) = a:8 [as=check1:12]
+           └── b_default:9[0] > 1 [as=check2:13]
+
+# Multi-value inserts with non-identical column types should infer the column type to
+# be the canonical type and an assignment cast should be added.
+build
+INSERT INTO decimals (a) VALUES (10.2::DECIMAL(10, 2)), (10.0::DECIMAL(10, 0))
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:8 => decimals.a:1
+ │    ├── b_default:9 => b:2
+ │    ├── c_default:10 => c:3
+ │    └── d_comp:11 => d:4
+ ├── check columns: check1:12 check2:13
+ └── project
+      ├── columns: check1:12 check2:13 a:8 b_default:9 c_default:10!null d_comp:11
+      ├── project
+      │    ├── columns: d_comp:11 a:8 b_default:9 c_default:10!null
+      │    ├── project
+      │    │    ├── columns: b_default:9 c_default:10!null a:8
+      │    │    ├── project
+      │    │    │    ├── columns: a:8
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:7
+      │    │    │    │    ├── (10.2::DECIMAL(10,2),)
+      │    │    │    │    └── (10.0::DECIMAL(10),)
+      │    │    │    └── projections
+      │    │    │         └── assignment-cast: DECIMAL(10) [as=a:8]
+      │    │    │              └── column1:7
+      │    │    └── projections
+      │    │         ├── NULL::DECIMAL(5,1)[] [as=b_default:9]
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:10]
+      │    └── projections
+      │         └── (a:8::DECIMAL + c_default:10::DECIMAL)::DECIMAL(10,1) [as=d_comp:11]
+      └── projections
+           ├── round(a:8) = a:8 [as=check1:12]
+           └── b_default:9[0] > 1 [as=check2:13]
+
+# An assignment cast is not necessary for multi-value inserts when the type of
+# every value is identical to the target column type.
+build
+INSERT INTO decimals (a) VALUES (10.0::DECIMAL(10, 0)), (10.2::DECIMAL(10, 0))
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── b_default:8 => b:2
+ │    ├── c_default:9 => c:3
+ │    └── d_comp:10 => d:4
+ ├── check columns: check1:11 check2:12
+ └── project
+      ├── columns: check1:11 check2:12 column1:7 b_default:8 c_default:9!null d_comp:10
+      ├── project
+      │    ├── columns: d_comp:10 column1:7 b_default:8 c_default:9!null
+      │    ├── project
+      │    │    ├── columns: b_default:8 c_default:9!null column1:7
+      │    │    ├── values
+      │    │    │    ├── columns: column1:7
+      │    │    │    ├── (10.0::DECIMAL(10),)
+      │    │    │    └── (10.2::DECIMAL(10),)
+      │    │    └── projections
+      │    │         ├── NULL::DECIMAL(5,1)[] [as=b_default:8]
+      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:9]
+      │    └── projections
+      │         └── (column1:7::DECIMAL + c_default:9::DECIMAL)::DECIMAL(10,1) [as=d_comp:10]
+      └── projections
+           ├── round(column1:7) = column1:7 [as=check1:11]
+           └── b_default:8[0] > 1 [as=check2:12]
 
 build
 INSERT INTO assn_cast (c, qc, i, s) VALUES (' ', 'foo', '1', 2)
@@ -1249,24 +1427,24 @@ INSERT INTO assn_cast (c, qc, i, s) VALUES (' ', 'foo', '1', 2)
 insert assn_cast
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:12 => c:1
- │    ├── column2:13 => qc:2
+ │    ├── c:12 => assn_cast.c:1
+ │    ├── qc:13 => assn_cast.qc:2
  │    ├── column3:10 => i:3
- │    ├── column4:14 => s:4
+ │    ├── s:14 => assn_cast.s:4
  │    └── rowid_default:15 => rowid:5
  └── project
-      ├── columns: rowid_default:15 column3:10!null column1:12 column2:13 column4:14
+      ├── columns: rowid_default:15 column3:10!null c:12 qc:13 s:14
       ├── project
-      │    ├── columns: column1:12 column2:13 column4:14 column3:10!null
+      │    ├── columns: c:12 qc:13 s:14 column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
-      │    │    └── ('', 'f', 1, 2)
+      │    │    └── (' ', 'foo', 1, 2)
       │    └── projections
-      │         ├── assignment-cast: CHAR [as=column1:12]
+      │         ├── assignment-cast: CHAR [as=c:12]
       │         │    └── column1:8
-      │         ├── assignment-cast: "char" [as=column2:13]
+      │         ├── assignment-cast: "char" [as=qc:13]
       │         │    └── column2:9
-      │         └── assignment-cast: STRING [as=column4:14]
+      │         └── assignment-cast: STRING [as=s:14]
       │              └── column4:11
       └── projections
            └── unique_rowid() [as=rowid_default:15]
@@ -1277,13 +1455,13 @@ INSERT INTO assn_cast (c, qc, i) VALUES ($1, $2, $3)
 insert assn_cast
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:11 => c:1
- │    ├── column2:12 => qc:2
+ │    ├── c:11 => assn_cast.c:1
+ │    ├── qc:12 => assn_cast.qc:2
  │    ├── column3:10 => i:3
  │    ├── s_default:13 => s:4
  │    └── rowid_default:14 => rowid:5
  └── values
-      ├── columns: column3:10!null s_default:13 rowid_default:14 column1:11 column2:12
+      ├── columns: column3:10!null s_default:13 rowid_default:14 c:11 qc:12
       └── tuple
            ├── 1
            ├── CAST(NULL AS STRING)

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -90,6 +90,12 @@ func (b *Builder) buildValuesClause(
 				} else if !typ.Equivalent(colTypes[colIdx]) {
 					panic(pgerror.Newf(pgcode.DatatypeMismatch,
 						"VALUES types %s and %s cannot be matched", typ, colTypes[colIdx]))
+				} else if !colTypes[colIdx].IsCanonicalType() && !colTypes[colIdx].Identical(typ) {
+					// If the earlier expression is not a canonical type, and it
+					// is not identical to the current expression's type, then
+					// set the type to be the canonical type of both
+					// expressions.
+					colTypes[colIdx] = colTypes[colIdx].CanonicalType()
 				}
 			}
 			elems[elemPos] = b.buildScalar(texpr, inScope, nil, nil, nil)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -366,13 +366,13 @@ insert order_line
  │    ├── column6:18 => order_line.ol_supply_w_id:6
  │    ├── ol_delivery_d_default:24 => ol_delivery_d:7
  │    ├── column7:19 => ol_quantity:8
- │    ├── column8:22 => ol_amount:9
- │    └── column9:23 => ol_dist_info:10
+ │    ├── ol_amount:22 => order_line.ol_amount:9
+ │    └── ol_dist_info:23 => order_line.ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_delivery_d_default:24 column8:22 column9:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
+ │    ├── columns: ol_delivery_d_default:24 ol_amount:22 ol_dist_info:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(24)
@@ -387,9 +387,9 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:24]
- │         ├── assignment-cast: DECIMAL(6,2) [as=column8:22, outer=(20), immutable]
+ │         ├── assignment-cast: DECIMAL(6,2) [as=ol_amount:22, outer=(20), immutable]
  │         │    └── column8:20
- │         └── assignment-cast: CHAR(24) [as=column9:23, outer=(21), immutable]
+ │         └── assignment-cast: CHAR(24) [as=ol_dist_info:23, outer=(21), immutable]
  │              └── column9:21
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -610,13 +610,13 @@ insert history
  │    ├── column4:15 => history.h_d_id:5
  │    ├── column5:16 => history.h_w_id:6
  │    ├── column7:18 => h_date:7
- │    ├── column6:20 => h_amount:8
- │    └── column8:21 => h_data:9
+ │    ├── h_amount:20 => history.h_amount:8
+ │    └── h_data:21 => history.h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null column6:20 column8:21 rowid_default:22
+ │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null h_amount:20 h_data:21 rowid_default:22
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -369,13 +369,13 @@ insert order_line
  │    ├── column6:18 => order_line.ol_supply_w_id:6
  │    ├── ol_delivery_d_default:24 => ol_delivery_d:7
  │    ├── column7:19 => ol_quantity:8
- │    ├── column8:22 => ol_amount:9
- │    └── column9:23 => ol_dist_info:10
+ │    ├── ol_amount:22 => order_line.ol_amount:9
+ │    └── ol_dist_info:23 => order_line.ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_delivery_d_default:24 column8:22 column9:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
+ │    ├── columns: ol_delivery_d_default:24 ol_amount:22 ol_dist_info:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(24)
@@ -390,9 +390,9 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:24]
- │         ├── assignment-cast: DECIMAL(6,2) [as=column8:22, outer=(20), immutable]
+ │         ├── assignment-cast: DECIMAL(6,2) [as=ol_amount:22, outer=(20), immutable]
  │         │    └── column8:20
- │         └── assignment-cast: CHAR(24) [as=column9:23, outer=(21), immutable]
+ │         └── assignment-cast: CHAR(24) [as=ol_dist_info:23, outer=(21), immutable]
  │              └── column9:21
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -613,13 +613,13 @@ insert history
  │    ├── column4:15 => history.h_d_id:5
  │    ├── column5:16 => history.h_w_id:6
  │    ├── column7:18 => h_date:7
- │    ├── column6:20 => h_amount:8
- │    └── column8:21 => h_data:9
+ │    ├── h_amount:20 => history.h_amount:8
+ │    └── h_data:21 => history.h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null column6:20 column8:21 rowid_default:22
+ │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null h_amount:20 h_data:21 rowid_default:22
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -363,13 +363,13 @@ insert order_line
  │    ├── column6:18 => order_line.ol_supply_w_id:6
  │    ├── ol_delivery_d_default:24 => ol_delivery_d:7
  │    ├── column7:19 => ol_quantity:8
- │    ├── column8:22 => ol_amount:9
- │    └── column9:23 => ol_dist_info:10
+ │    ├── ol_amount:22 => order_line.ol_amount:9
+ │    └── ol_dist_info:23 => order_line.ol_dist_info:10
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_delivery_d_default:24 column8:22 column9:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
+ │    ├── columns: ol_delivery_d_default:24 ol_amount:22 ol_dist_info:23 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(24)
@@ -384,9 +384,9 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:24]
- │         ├── assignment-cast: DECIMAL(6,2) [as=column8:22, outer=(20), immutable]
+ │         ├── assignment-cast: DECIMAL(6,2) [as=ol_amount:22, outer=(20), immutable]
  │         │    └── column8:20
- │         └── assignment-cast: CHAR(24) [as=column9:23, outer=(21), immutable]
+ │         └── assignment-cast: CHAR(24) [as=ol_dist_info:23, outer=(21), immutable]
  │              └── column9:21
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
@@ -607,13 +607,13 @@ insert history
  │    ├── column4:15 => history.h_d_id:5
  │    ├── column5:16 => history.h_w_id:6
  │    ├── column7:18 => h_date:7
- │    ├── column6:20 => h_amount:8
- │    └── column8:21 => h_data:9
+ │    ├── h_amount:20 => history.h_amount:8
+ │    └── h_data:21 => history.h_data:9
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null column6:20 column8:21 rowid_default:22
+ │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null h_amount:20 h_data:21 rowid_default:22
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -674,13 +674,13 @@ with &2 (update_last_trade)
                 │    │    ├── insert-mapping:
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
-                │    │    │    └── "?column?":62 => trade_history.th_st_id:53
+                │    │    │    └── th_st_id:62 => trade_history.th_st_id:53
                 │    │    ├── input binding: &5
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
                 │    │    ├── project
-                │    │    │    ├── columns: "?column?":62 timestamp:61!null tr_t_id:56!null
+                │    │    │    ├── columns: th_st_id:62 timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── immutable
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
@@ -690,7 +690,7 @@ with &2 (update_last_trade)
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
                 │    │    │    │    └── key: (56)
                 │    │    │    └── projections
-                │    │    │         ├── assignment-cast: VARCHAR(4) [as="?column?":62, immutable]
+                │    │    │         ├── assignment-cast: VARCHAR(4) [as=th_st_id:62, immutable]
                 │    │    │         │    └── 'SBMT'
                 │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:61]
                 │    │    └── f-k-checks
@@ -715,7 +715,7 @@ with &2 (update_last_trade)
                 │    │                   ├── with-scan &5
                 │    │                   │    ├── columns: th_st_id:81
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  "?column?":62 => th_st_id:81
+                │    │                   │    │    └──  th_st_id:62 => th_st_id:81
                 │    │                   │    └── fd: ()-->(81)
                 │    │                   └── filters (true)
                 │    └── projections
@@ -2923,59 +2923,58 @@ insert_trade_history AS (
 SELECT 1;
 ----
 with &2 (insert_trade)
- ├── columns: "?column?":121!null
+ ├── columns: "?column?":122!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(121)
+ ├── fd: ()-->(122)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":88!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(88)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:18 => t_id:1
  │    │    │    ├── column2:19 => t_dts:2
- │    │    │    ├── column3:33 => trade.t_st_id:3
- │    │    │    ├── column4:34 => trade.t_tt_id:4
+ │    │    │    ├── t_st_id:33 => trade.t_st_id:3
+ │    │    │    ├── t_tt_id:34 => trade.t_tt_id:4
  │    │    │    ├── column5:22 => t_is_cash:5
- │    │    │    ├── column6:35 => trade.t_s_symb:6
- │    │    │    ├── column7:36 => t_qty:7
- │    │    │    ├── column8:37 => t_bid_price:8
+ │    │    │    ├── t_s_symb:35 => trade.t_s_symb:6
+ │    │    │    ├── t_qty:36 => trade.t_qty:7
+ │    │    │    ├── t_bid_price:37 => trade.t_bid_price:8
  │    │    │    ├── column9:26 => trade.t_ca_id:9
- │    │    │    ├── column10:38 => t_exec_name:10
- │    │    │    ├── column11:28 => t_trade_price:11
- │    │    │    ├── column12:39 => t_chrg:12
- │    │    │    ├── column13:40 => t_comm:13
- │    │    │    ├── column14:41 => t_tax:14
+ │    │    │    ├── t_exec_name:38 => trade.t_exec_name:10
+ │    │    │    ├── t_trade_price:39 => trade.t_trade_price:11
+ │    │    │    ├── t_chrg:40 => trade.t_chrg:12
+ │    │    │    ├── t_comm:41 => trade.t_comm:13
+ │    │    │    ├── t_tax:42 => trade.t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check1:42 check2:43 check3:44 check4:45 check5:46 column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    ├── columns: check1:43 check2:44 check3:45 check4:46 check5:47 column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,32-47)
  │    │    │    ├── values
- │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41)
+ │    │    │    │    ├── fd: ()-->(18,19,22,26,32-42)
  │    │    │    │    └── tuple
  │    │    │    │         ├── 0
  │    │    │    │         ├── '2020-06-17 22:27:42.148484'
  │    │    │    │         ├── true
  │    │    │    │         ├── 0
- │    │    │    │         ├── CAST(NULL AS DECIMAL(8,2))
  │    │    │    │         ├── true
  │    │    │    │         ├── assignment-cast: VARCHAR(4)
  │    │    │    │         │    └── 'SBMT'
@@ -2989,6 +2988,8 @@ with &2 (insert_trade)
  │    │    │    │         │    └── 1E+2
  │    │    │    │         ├── assignment-cast: VARCHAR(49)
  │    │    │    │         │    └── 'Name'
+ │    │    │    │         ├── assignment-cast: DECIMAL(8,2)
+ │    │    │    │         │    └── CAST(NULL AS DECIMAL)
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
  │    │    │    │         │    └── 1
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
@@ -2996,107 +2997,107 @@ with &2 (insert_trade)
  │    │    │    │         └── assignment-cast: DECIMAL(10,2)
  │    │    │    │              └── 0
  │    │    │    └── projections
- │    │    │         ├── column7:36 > 0 [as=check1:42, outer=(36)]
- │    │    │         ├── column8:37 > 0 [as=check2:43, outer=(37), immutable]
- │    │    │         ├── column12:39 >= 0 [as=check3:44, outer=(39), immutable]
- │    │    │         ├── column13:40 >= 0 [as=check4:45, outer=(40), immutable]
- │    │    │         └── column14:41 >= 0 [as=check5:46, outer=(41), immutable]
+ │    │    │         ├── t_qty:36 > 0 [as=check1:43, outer=(36)]
+ │    │    │         ├── t_bid_price:37 > 0 [as=check2:44, outer=(37), immutable]
+ │    │    │         ├── t_chrg:40 >= 0 [as=check3:45, outer=(40), immutable]
+ │    │    │         ├── t_comm:41 >= 0 [as=check4:46, outer=(41), immutable]
+ │    │    │         └── t_tax:42 >= 0 [as=check5:47, outer=(42), immutable]
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47
+ │    │         │         │    ├── columns: t_st_id:48
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column3:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52
+ │    │         │         │    ├── columns: t_tt_id:53
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column4:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59
+ │    │         │         │    ├── columns: t_s_symb:60
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column6:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":88]
  └── with &4 (insert_trade_history)
-      ├── columns: "?column?":121!null
+      ├── columns: "?column?":122!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(121)
+      ├── fd: ()-->(122)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":121!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(121)
       │    ├── insert trade_history
-      │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
+      │    │    ├── columns: trade_history.th_t_id:89!null trade_history.th_st_id:91!null
       │    │    ├── insert-mapping:
-      │    │    │    ├── column1:93 => trade_history.th_t_id:88
-      │    │    │    ├── column2:94 => th_dts:89
-      │    │    │    └── column3:96 => trade_history.th_st_id:90
+      │    │    │    ├── column1:94 => trade_history.th_t_id:89
+      │    │    │    ├── column2:95 => th_dts:90
+      │    │    │    └── th_st_id:97 => trade_history.th_st_id:91
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(88,90)
+      │    │    ├── fd: ()-->(89,91)
       │    │    ├── values
-      │    │    │    ├── columns: column1:93!null column2:94!null column3:96
+      │    │    │    ├── columns: column1:94!null column2:95!null th_st_id:97
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(93,94,96)
+      │    │    │    ├── fd: ()-->(94,95,97)
       │    │    │    └── tuple
       │    │    │         ├── 0
       │    │    │         ├── '2020-06-15 22:27:42.148484'
@@ -3105,43 +3106,43 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:94 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115
+      │    │                   │    ├── columns: th_st_id:116
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column3:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id:97 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":121]
       └── values
-           ├── columns: "?column?":121!null
+           ├── columns: "?column?":122!null
            ├── cardinality: [1 - 1]
            ├── key: ()
-           ├── fd: ()-->(121)
+           ├── fd: ()-->(122)
            └── (1,)
 
 # Q12
@@ -3215,59 +3216,58 @@ insert_trade_request AS (
 SELECT 1;
 ----
 with &2 (insert_trade)
- ├── columns: "?column?":195!null
+ ├── columns: "?column?":196!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(195)
+ ├── fd: ()-->(196)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":88!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(88)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:18 => t_id:1
  │    │    │    ├── column2:19 => t_dts:2
- │    │    │    ├── column3:33 => trade.t_st_id:3
- │    │    │    ├── column4:34 => trade.t_tt_id:4
+ │    │    │    ├── t_st_id:33 => trade.t_st_id:3
+ │    │    │    ├── t_tt_id:34 => trade.t_tt_id:4
  │    │    │    ├── column5:22 => t_is_cash:5
- │    │    │    ├── column6:35 => trade.t_s_symb:6
- │    │    │    ├── column7:36 => t_qty:7
- │    │    │    ├── column8:37 => t_bid_price:8
+ │    │    │    ├── t_s_symb:35 => trade.t_s_symb:6
+ │    │    │    ├── t_qty:36 => trade.t_qty:7
+ │    │    │    ├── t_bid_price:37 => trade.t_bid_price:8
  │    │    │    ├── column9:26 => trade.t_ca_id:9
- │    │    │    ├── column10:38 => t_exec_name:10
- │    │    │    ├── column11:28 => t_trade_price:11
- │    │    │    ├── column12:39 => t_chrg:12
- │    │    │    ├── column13:40 => t_comm:13
- │    │    │    ├── column14:41 => t_tax:14
+ │    │    │    ├── t_exec_name:38 => trade.t_exec_name:10
+ │    │    │    ├── t_trade_price:39 => trade.t_trade_price:11
+ │    │    │    ├── t_chrg:40 => trade.t_chrg:12
+ │    │    │    ├── t_comm:41 => trade.t_comm:13
+ │    │    │    ├── t_tax:42 => trade.t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check1:42 check2:43 check3:44 check4:45 check5:46 column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    ├── columns: check1:43 check2:44 check3:45 check4:46 check5:47 column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,32-47)
  │    │    │    ├── values
- │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41)
+ │    │    │    │    ├── fd: ()-->(18,19,22,26,32-42)
  │    │    │    │    └── tuple
  │    │    │    │         ├── 0
  │    │    │    │         ├── '2020-06-17 22:27:42.148484'
  │    │    │    │         ├── true
  │    │    │    │         ├── 0
- │    │    │    │         ├── CAST(NULL AS DECIMAL(8,2))
  │    │    │    │         ├── true
  │    │    │    │         ├── assignment-cast: VARCHAR(4)
  │    │    │    │         │    └── 'SBMT'
@@ -3281,6 +3281,8 @@ with &2 (insert_trade)
  │    │    │    │         │    └── 1E+2
  │    │    │    │         ├── assignment-cast: VARCHAR(49)
  │    │    │    │         │    └── 'Name'
+ │    │    │    │         ├── assignment-cast: DECIMAL(8,2)
+ │    │    │    │         │    └── CAST(NULL AS DECIMAL)
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
  │    │    │    │         │    └── 1
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
@@ -3288,107 +3290,107 @@ with &2 (insert_trade)
  │    │    │    │         └── assignment-cast: DECIMAL(10,2)
  │    │    │    │              └── 0
  │    │    │    └── projections
- │    │    │         ├── column7:36 > 0 [as=check1:42, outer=(36)]
- │    │    │         ├── column8:37 > 0 [as=check2:43, outer=(37), immutable]
- │    │    │         ├── column12:39 >= 0 [as=check3:44, outer=(39), immutable]
- │    │    │         ├── column13:40 >= 0 [as=check4:45, outer=(40), immutable]
- │    │    │         └── column14:41 >= 0 [as=check5:46, outer=(41), immutable]
+ │    │    │         ├── t_qty:36 > 0 [as=check1:43, outer=(36)]
+ │    │    │         ├── t_bid_price:37 > 0 [as=check2:44, outer=(37), immutable]
+ │    │    │         ├── t_chrg:40 >= 0 [as=check3:45, outer=(40), immutable]
+ │    │    │         ├── t_comm:41 >= 0 [as=check4:46, outer=(41), immutable]
+ │    │    │         └── t_tax:42 >= 0 [as=check5:47, outer=(42), immutable]
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47
+ │    │         │         │    ├── columns: t_st_id:48
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column3:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52
+ │    │         │         │    ├── columns: t_tt_id:53
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column4:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59
+ │    │         │         │    ├── columns: t_s_symb:60
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column6:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":88]
  └── with &4 (insert_trade_history)
-      ├── columns: "?column?":195!null
+      ├── columns: "?column?":196!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(195)
+      ├── fd: ()-->(196)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":121!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(121)
       │    ├── insert trade_history
-      │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
+      │    │    ├── columns: trade_history.th_t_id:89!null trade_history.th_st_id:91!null
       │    │    ├── insert-mapping:
-      │    │    │    ├── column1:93 => trade_history.th_t_id:88
-      │    │    │    ├── column2:94 => th_dts:89
-      │    │    │    └── column3:96 => trade_history.th_st_id:90
+      │    │    │    ├── column1:94 => trade_history.th_t_id:89
+      │    │    │    ├── column2:95 => th_dts:90
+      │    │    │    └── th_st_id:97 => trade_history.th_st_id:91
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(88,90)
+      │    │    ├── fd: ()-->(89,91)
       │    │    ├── values
-      │    │    │    ├── columns: column1:93!null column2:94!null column3:96
+      │    │    │    ├── columns: column1:94!null column2:95!null th_st_id:97
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(93,94,96)
+      │    │    │    ├── fd: ()-->(94,95,97)
       │    │    │    └── tuple
       │    │    │         ├── 0
       │    │    │         ├── '2020-06-15 22:27:42.148484'
@@ -3397,78 +3399,78 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:94 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115
+      │    │                   │    ├── columns: th_st_id:116
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column3:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id:97 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":121]
       └── with &6 (insert_trade_request)
-           ├── columns: "?column?":195!null
+           ├── columns: "?column?":196!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
            ├── key: ()
-           ├── fd: ()-->(195)
+           ├── fd: ()-->(196)
            ├── project
-           │    ├── columns: "?column?":194!null
+           │    ├── columns: "?column?":195!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(194)
+           │    ├── fd: ()-->(195)
            │    ├── insert trade_request
-           │    │    ├── columns: trade_request.tr_t_id:121!null
+           │    │    ├── columns: trade_request.tr_t_id:122!null
            │    │    ├── insert-mapping:
-           │    │    │    ├── column1:129 => trade_request.tr_t_id:121
-           │    │    │    ├── column2:135 => trade_request.tr_tt_id:122
-           │    │    │    ├── column3:136 => trade_request.tr_s_symb:123
-           │    │    │    ├── column4:137 => tr_qty:124
-           │    │    │    ├── column5:138 => tr_bid_price:125
-           │    │    │    └── column6:134 => trade_request.tr_b_id:126
-           │    │    ├── check columns: check1:139 check2:140
-           │    │    ├── partial index put columns: partial_index_put1:141
+           │    │    │    ├── column1:130 => trade_request.tr_t_id:122
+           │    │    │    ├── tr_tt_id:136 => trade_request.tr_tt_id:123
+           │    │    │    ├── tr_s_symb:137 => trade_request.tr_s_symb:124
+           │    │    │    ├── tr_qty:138 => trade_request.tr_qty:125
+           │    │    │    ├── tr_bid_price:139 => trade_request.tr_bid_price:126
+           │    │    │    └── column6:135 => trade_request.tr_b_id:127
+           │    │    ├── check columns: check1:140 check2:141
+           │    │    ├── partial index put columns: partial_index_put1:142
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
-           │    │    ├── fd: ()-->(121)
+           │    │    ├── fd: ()-->(122)
            │    │    ├── project
-           │    │    │    ├── columns: partial_index_put1:141 check1:139 check2:140 column1:129!null column6:134!null column2:135 column3:136 column4:137 column5:138
+           │    │    │    ├── columns: partial_index_put1:142 check1:140 check2:141 column1:130!null column6:135!null tr_tt_id:136 tr_s_symb:137 tr_qty:138 tr_bid_price:139
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── immutable
            │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(129,134-141)
+           │    │    │    ├── fd: ()-->(130,135-142)
            │    │    │    ├── values
-           │    │    │    │    ├── columns: column1:129!null column6:134!null column2:135 column3:136 column4:137 column5:138
+           │    │    │    │    ├── columns: column1:130!null column6:135!null tr_tt_id:136 tr_s_symb:137 tr_qty:138 tr_bid_price:139
            │    │    │    │    ├── cardinality: [1 - 1]
            │    │    │    │    ├── immutable
            │    │    │    │    ├── key: ()
-           │    │    │    │    ├── fd: ()-->(129,134-138)
+           │    │    │    │    ├── fd: ()-->(130,135-139)
            │    │    │    │    └── tuple
            │    │    │    │         ├── 0
            │    │    │    │         ├── 0
@@ -3481,81 +3483,81 @@ with &2 (insert_trade)
            │    │    │    │         └── assignment-cast: DECIMAL(8,2)
            │    │    │    │              └── 1E+2
            │    │    │    └── projections
-           │    │    │         ├── column2:135 IN ('TLB', 'TLS', 'TSL') [as=partial_index_put1:141, outer=(135)]
-           │    │    │         ├── column4:137 > 0 [as=check1:139, outer=(137)]
-           │    │    │         └── column5:138 > 0 [as=check2:140, outer=(138), immutable]
+           │    │    │         ├── tr_tt_id:136 IN ('TLB', 'TLS', 'TSL') [as=partial_index_put1:142, outer=(136)]
+           │    │    │         ├── tr_qty:138 > 0 [as=check1:140, outer=(138)]
+           │    │    │         └── tr_bid_price:139 > 0 [as=check2:141, outer=(139), immutable]
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
+           │    │         │         ├── columns: tr_t_id:143!null
+           │    │         │         ├── key columns: [143] = [144]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(142)
+           │    │         │         ├── fd: ()-->(143)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_t_id:142!null
+           │    │         │         │    ├── columns: tr_t_id:143!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
+           │    │         │         │    │    └──  column1:130 => tr_t_id:143
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
            │    │         │    └── anti-join (lookup trade_type)
-           │    │         │         ├── columns: tr_tt_id:160
-           │    │         │         ├── key columns: [160] = [161]
+           │    │         │         ├── columns: tr_tt_id:161
+           │    │         │         ├── key columns: [161] = [162]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(160)
+           │    │         │         ├── fd: ()-->(161)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_tt_id:160
+           │    │         │         │    ├── columns: tr_tt_id:161
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column2:135 => tr_tt_id:160
+           │    │         │         │    │    └──  tr_tt_id:136 => tr_tt_id:161
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
            │    │         │    └── anti-join (lookup security)
-           │    │         │         ├── columns: tr_s_symb:167
-           │    │         │         ├── key columns: [167] = [168]
+           │    │         │         ├── columns: tr_s_symb:168
+           │    │         │         ├── key columns: [168] = [169]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(167)
+           │    │         │         ├── fd: ()-->(168)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_s_symb:167
+           │    │         │         │    ├── columns: tr_s_symb:168
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column3:136 => tr_s_symb:167
+           │    │         │         │    │    └──  tr_s_symb:137 => tr_s_symb:168
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
            │    │              └── anti-join (lookup broker)
-           │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
+           │    │                   ├── columns: tr_b_id:187!null
+           │    │                   ├── key columns: [187] = [188]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(186)
+           │    │                   ├── fd: ()-->(187)
            │    │                   ├── with-scan &5
-           │    │                   │    ├── columns: tr_b_id:186!null
+           │    │                   │    ├── columns: tr_b_id:187!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
+           │    │                   │    │    └──  column6:135 => tr_b_id:187
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":194]
+           │         └── 1 [as="?column?":195]
            └── values
-                ├── columns: "?column?":195!null
+                ├── columns: "?column?":196!null
                 ├── cardinality: [1 - 1]
                 ├── key: ()
-                ├── fd: ()-->(195)
+                ├── fd: ()-->(196)
                 └── (1,)
 
 # --------------------------------------------------
@@ -3706,13 +3708,13 @@ insert holding_summary
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => holding_summary.hs_ca_id:1
- │    ├── column2:9 => holding_summary.hs_s_symb:2
- │    └── column3:10 => hs_qty:3
+ │    ├── hs_s_symb:9 => holding_summary.hs_s_symb:2
+ │    └── hs_qty:10 => holding_summary.hs_qty:3
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:6!null column2:9 column3:10
+ │    ├── columns: column1:6!null hs_s_symb:9 hs_qty:10
  │    ├── cardinality: [1 - 1]
  │    ├── immutable
  │    ├── key: ()
@@ -3751,7 +3753,7 @@ insert holding_summary
                 ├── with-scan &1
                 │    ├── columns: hs_s_symb:20
                 │    ├── mapping:
-                │    │    └──  column2:9 => hs_s_symb:20
+                │    │    └──  hs_s_symb:9 => hs_s_symb:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
                 │    └── fd: ()-->(20)
@@ -3950,22 +3952,22 @@ insert holding
  ├── insert-mapping:
  │    ├── column1:9 => holding.h_t_id:1
  │    ├── column2:10 => holding.h_ca_id:2
- │    ├── column3:15 => holding.h_s_symb:3
+ │    ├── h_s_symb:15 => holding.h_s_symb:3
  │    ├── column4:12 => h_dts:4
- │    ├── column5:16 => h_price:5
- │    └── column6:17 => h_qty:6
+ │    ├── h_price:16 => holding.h_price:5
+ │    └── h_qty:17 => holding.h_qty:6
  ├── check columns: check1:18
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: check1:18 column1:9!null column2:10!null column4:12!null column3:15 column5:16 column6:17
+ │    ├── columns: check1:18 column1:9!null column2:10!null column4:12!null h_s_symb:15 h_price:16 h_qty:17
  │    ├── cardinality: [1 - 1]
  │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(9,10,12,15-18)
  │    ├── values
- │    │    ├── columns: column1:9!null column2:10!null column4:12!null column3:15 column5:16 column6:17
+ │    │    ├── columns: column1:9!null column2:10!null column4:12!null h_s_symb:15 h_price:16 h_qty:17
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── immutable
  │    │    ├── key: ()
@@ -3981,7 +3983,7 @@ insert holding
  │    │         └── assignment-cast: INT4
  │    │              └── 10
  │    └── projections
- │         └── column5:16 > 0 [as=check1:18, outer=(16), immutable]
+ │         └── h_price:16 > 0 [as=check1:18, outer=(16), immutable]
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
       │    └── anti-join (lookup trade)
@@ -4011,7 +4013,7 @@ insert holding
                 │    ├── columns: h_ca_id:37!null h_s_symb:38
                 │    ├── mapping:
                 │    │    ├──  column2:10 => h_ca_id:37
-                │    │    └──  column3:15 => h_s_symb:38
+                │    │    └──  h_s_symb:15 => h_s_symb:38
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
                 │    └── fd: ()-->(37,38)
@@ -4405,14 +4407,14 @@ with &2 (update_trade_commission)
            │    │    ├── insert-mapping:
            │    │    │    ├── column1:75 => trade_history.th_t_id:70
            │    │    │    ├── column2:76 => th_dts:71
-           │    │    │    └── column3:78 => trade_history.th_st_id:72
+           │    │    │    └── th_st_id:78 => trade_history.th_st_id:72
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(70,72)
            │    │    ├── values
-           │    │    │    ├── columns: column1:75!null column2:76!null column3:78
+           │    │    │    ├── columns: column1:75!null column2:76!null th_st_id:78
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── immutable
            │    │    │    ├── key: ()
@@ -4450,7 +4452,7 @@ with &2 (update_trade_commission)
            │    │                   ├── with-scan &5
            │    │                   │    ├── columns: th_st_id:97
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column3:78 => th_st_id:97
+           │    │                   │    │    └──  th_st_id:78 => th_st_id:97
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
            │    │                   │    └── fd: ()-->(97)
@@ -4506,16 +4508,16 @@ with &2 (insert_settlement)
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:7 => settlement.se_t_id:1
- │    │    │    ├── column2:11 => se_cash_type:2
+ │    │    │    ├── se_cash_type:11 => settlement.se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
- │    │    │    └── column4:12 => se_amt:4
+ │    │    │    └── se_amt:12 => settlement.se_amt:4
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column3:9!null column2:11 column4:12
+ │    │    │    ├── columns: column1:7!null column3:9!null se_cash_type:11 se_amt:12
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
@@ -4563,15 +4565,15 @@ with &2 (insert_settlement)
       │    │    ├── insert-mapping:
       │    │    │    ├── column1:38 => cash_transaction.ct_t_id:32
       │    │    │    ├── column2:39 => ct_dts:33
-      │    │    │    ├── column3:42 => ct_amt:34
-      │    │    │    └── column4:43 => ct_name:35
+      │    │    │    ├── ct_amt:42 => cash_transaction.ct_amt:34
+      │    │    │    └── ct_name:43 => cash_transaction.ct_name:35
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(32)
       │    │    ├── values
-      │    │    │    ├── columns: column1:38!null column2:39!null column3:42 column4:43
+      │    │    │    ├── columns: column1:38!null column2:39!null ct_amt:42 ct_name:43
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
@@ -4661,16 +4663,16 @@ with &2 (insert_settlement)
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:7 => settlement.se_t_id:1
- │    │    │    ├── column2:11 => se_cash_type:2
+ │    │    │    ├── se_cash_type:11 => settlement.se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
- │    │    │    └── column4:12 => se_amt:4
+ │    │    │    └── se_amt:12 => settlement.se_amt:4
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column3:9!null column2:11 column4:12
+ │    │    │    ├── columns: column1:7!null column3:9!null se_cash_type:11 se_amt:12
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -692,13 +692,13 @@ with &2 (update_last_trade)
                 │    │    ├── insert-mapping:
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
-                │    │    │    └── "?column?":62 => trade_history.th_st_id:53
+                │    │    │    └── th_st_id:62 => trade_history.th_st_id:53
                 │    │    ├── input binding: &5
                 │    │    ├── volatile, mutations
                 │    │    ├── key: (51)
                 │    │    ├── fd: ()-->(53)
                 │    │    ├── project
-                │    │    │    ├── columns: "?column?":62 timestamp:61!null tr_t_id:56!null
+                │    │    │    ├── columns: th_st_id:62 timestamp:61!null tr_t_id:56!null
                 │    │    │    ├── immutable
                 │    │    │    ├── key: (56)
                 │    │    │    ├── fd: ()-->(61,62)
@@ -708,7 +708,7 @@ with &2 (update_last_trade)
                 │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
                 │    │    │    │    └── key: (56)
                 │    │    │    └── projections
-                │    │    │         ├── assignment-cast: VARCHAR(4) [as="?column?":62, immutable]
+                │    │    │         ├── assignment-cast: VARCHAR(4) [as=th_st_id:62, immutable]
                 │    │    │         │    └── 'SBMT'
                 │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:61]
                 │    │    └── f-k-checks
@@ -733,7 +733,7 @@ with &2 (update_last_trade)
                 │    │                   ├── with-scan &5
                 │    │                   │    ├── columns: th_st_id:81
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  "?column?":62 => th_st_id:81
+                │    │                   │    │    └──  th_st_id:62 => th_st_id:81
                 │    │                   │    └── fd: ()-->(81)
                 │    │                   └── filters (true)
                 │    └── projections
@@ -2954,59 +2954,58 @@ insert_trade_history AS (
 SELECT 1;
 ----
 with &2 (insert_trade)
- ├── columns: "?column?":121!null
+ ├── columns: "?column?":122!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(121)
+ ├── fd: ()-->(122)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":88!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(88)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:18 => t_id:1
  │    │    │    ├── column2:19 => t_dts:2
- │    │    │    ├── column3:33 => trade.t_st_id:3
- │    │    │    ├── column4:34 => trade.t_tt_id:4
+ │    │    │    ├── t_st_id:33 => trade.t_st_id:3
+ │    │    │    ├── t_tt_id:34 => trade.t_tt_id:4
  │    │    │    ├── column5:22 => t_is_cash:5
- │    │    │    ├── column6:35 => trade.t_s_symb:6
- │    │    │    ├── column7:36 => t_qty:7
- │    │    │    ├── column8:37 => t_bid_price:8
+ │    │    │    ├── t_s_symb:35 => trade.t_s_symb:6
+ │    │    │    ├── t_qty:36 => trade.t_qty:7
+ │    │    │    ├── t_bid_price:37 => trade.t_bid_price:8
  │    │    │    ├── column9:26 => trade.t_ca_id:9
- │    │    │    ├── column10:38 => t_exec_name:10
- │    │    │    ├── column11:28 => t_trade_price:11
- │    │    │    ├── column12:39 => t_chrg:12
- │    │    │    ├── column13:40 => t_comm:13
- │    │    │    ├── column14:41 => t_tax:14
+ │    │    │    ├── t_exec_name:38 => trade.t_exec_name:10
+ │    │    │    ├── t_trade_price:39 => trade.t_trade_price:11
+ │    │    │    ├── t_chrg:40 => trade.t_chrg:12
+ │    │    │    ├── t_comm:41 => trade.t_comm:13
+ │    │    │    ├── t_tax:42 => trade.t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check1:42 check2:43 check3:44 check4:45 check5:46 column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    ├── columns: check1:43 check2:44 check3:45 check4:46 check5:47 column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,32-47)
  │    │    │    ├── values
- │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41)
+ │    │    │    │    ├── fd: ()-->(18,19,22,26,32-42)
  │    │    │    │    └── tuple
  │    │    │    │         ├── 0
  │    │    │    │         ├── '2020-06-17 22:27:42.148484'
  │    │    │    │         ├── true
  │    │    │    │         ├── 0
- │    │    │    │         ├── CAST(NULL AS DECIMAL(8,2))
  │    │    │    │         ├── true
  │    │    │    │         ├── assignment-cast: VARCHAR(4)
  │    │    │    │         │    └── 'SBMT'
@@ -3020,6 +3019,8 @@ with &2 (insert_trade)
  │    │    │    │         │    └── 1E+2
  │    │    │    │         ├── assignment-cast: VARCHAR(49)
  │    │    │    │         │    └── 'Name'
+ │    │    │    │         ├── assignment-cast: DECIMAL(8,2)
+ │    │    │    │         │    └── CAST(NULL AS DECIMAL)
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
  │    │    │    │         │    └── 1
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
@@ -3027,107 +3028,107 @@ with &2 (insert_trade)
  │    │    │    │         └── assignment-cast: DECIMAL(10,2)
  │    │    │    │              └── 0
  │    │    │    └── projections
- │    │    │         ├── column7:36 > 0 [as=check1:42, outer=(36)]
- │    │    │         ├── column8:37 > 0 [as=check2:43, outer=(37), immutable]
- │    │    │         ├── column12:39 >= 0 [as=check3:44, outer=(39), immutable]
- │    │    │         ├── column13:40 >= 0 [as=check4:45, outer=(40), immutable]
- │    │    │         └── column14:41 >= 0 [as=check5:46, outer=(41), immutable]
+ │    │    │         ├── t_qty:36 > 0 [as=check1:43, outer=(36)]
+ │    │    │         ├── t_bid_price:37 > 0 [as=check2:44, outer=(37), immutable]
+ │    │    │         ├── t_chrg:40 >= 0 [as=check3:45, outer=(40), immutable]
+ │    │    │         ├── t_comm:41 >= 0 [as=check4:46, outer=(41), immutable]
+ │    │    │         └── t_tax:42 >= 0 [as=check5:47, outer=(42), immutable]
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47
+ │    │         │         │    ├── columns: t_st_id:48
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column3:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52
+ │    │         │         │    ├── columns: t_tt_id:53
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column4:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59
+ │    │         │         │    ├── columns: t_s_symb:60
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column6:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":88]
  └── with &4 (insert_trade_history)
-      ├── columns: "?column?":121!null
+      ├── columns: "?column?":122!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(121)
+      ├── fd: ()-->(122)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":121!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(121)
       │    ├── insert trade_history
-      │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
+      │    │    ├── columns: trade_history.th_t_id:89!null trade_history.th_st_id:91!null
       │    │    ├── insert-mapping:
-      │    │    │    ├── column1:93 => trade_history.th_t_id:88
-      │    │    │    ├── column2:94 => th_dts:89
-      │    │    │    └── column3:96 => trade_history.th_st_id:90
+      │    │    │    ├── column1:94 => trade_history.th_t_id:89
+      │    │    │    ├── column2:95 => th_dts:90
+      │    │    │    └── th_st_id:97 => trade_history.th_st_id:91
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(88,90)
+      │    │    ├── fd: ()-->(89,91)
       │    │    ├── values
-      │    │    │    ├── columns: column1:93!null column2:94!null column3:96
+      │    │    │    ├── columns: column1:94!null column2:95!null th_st_id:97
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(93,94,96)
+      │    │    │    ├── fd: ()-->(94,95,97)
       │    │    │    └── tuple
       │    │    │         ├── 0
       │    │    │         ├── '2020-06-15 22:27:42.148484'
@@ -3136,43 +3137,43 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:94 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115
+      │    │                   │    ├── columns: th_st_id:116
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column3:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id:97 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":121]
       └── values
-           ├── columns: "?column?":121!null
+           ├── columns: "?column?":122!null
            ├── cardinality: [1 - 1]
            ├── key: ()
-           ├── fd: ()-->(121)
+           ├── fd: ()-->(122)
            └── (1,)
 
 # Q12
@@ -3246,59 +3247,58 @@ insert_trade_request AS (
 SELECT 1;
 ----
 with &2 (insert_trade)
- ├── columns: "?column?":195!null
+ ├── columns: "?column?":196!null
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(195)
+ ├── fd: ()-->(196)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":88!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(88)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:18 => t_id:1
  │    │    │    ├── column2:19 => t_dts:2
- │    │    │    ├── column3:33 => trade.t_st_id:3
- │    │    │    ├── column4:34 => trade.t_tt_id:4
+ │    │    │    ├── t_st_id:33 => trade.t_st_id:3
+ │    │    │    ├── t_tt_id:34 => trade.t_tt_id:4
  │    │    │    ├── column5:22 => t_is_cash:5
- │    │    │    ├── column6:35 => trade.t_s_symb:6
- │    │    │    ├── column7:36 => t_qty:7
- │    │    │    ├── column8:37 => t_bid_price:8
+ │    │    │    ├── t_s_symb:35 => trade.t_s_symb:6
+ │    │    │    ├── t_qty:36 => trade.t_qty:7
+ │    │    │    ├── t_bid_price:37 => trade.t_bid_price:8
  │    │    │    ├── column9:26 => trade.t_ca_id:9
- │    │    │    ├── column10:38 => t_exec_name:10
- │    │    │    ├── column11:28 => t_trade_price:11
- │    │    │    ├── column12:39 => t_chrg:12
- │    │    │    ├── column13:40 => t_comm:13
- │    │    │    ├── column14:41 => t_tax:14
+ │    │    │    ├── t_exec_name:38 => trade.t_exec_name:10
+ │    │    │    ├── t_trade_price:39 => trade.t_trade_price:11
+ │    │    │    ├── t_chrg:40 => trade.t_chrg:12
+ │    │    │    ├── t_comm:41 => trade.t_comm:13
+ │    │    │    ├── t_tax:42 => trade.t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check1:42 check2:43 check3:44 check4:45 check5:46 column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    ├── columns: check1:43 check2:44 check3:45 check4:46 check5:47 column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,32-47)
  │    │    │    ├── values
- │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null column3:33 column4:34 column6:35 column7:36 column8:37 column10:38 column12:39 column13:40 column14:41
+ │    │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column15:32!null t_st_id:33 t_tt_id:34 t_s_symb:35 t_qty:36 t_bid_price:37 t_exec_name:38 t_trade_price:39 t_chrg:40 t_comm:41 t_tax:42
  │    │    │    │    ├── cardinality: [1 - 1]
  │    │    │    │    ├── immutable
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41)
+ │    │    │    │    ├── fd: ()-->(18,19,22,26,32-42)
  │    │    │    │    └── tuple
  │    │    │    │         ├── 0
  │    │    │    │         ├── '2020-06-17 22:27:42.148484'
  │    │    │    │         ├── true
  │    │    │    │         ├── 0
- │    │    │    │         ├── CAST(NULL AS DECIMAL(8,2))
  │    │    │    │         ├── true
  │    │    │    │         ├── assignment-cast: VARCHAR(4)
  │    │    │    │         │    └── 'SBMT'
@@ -3312,6 +3312,8 @@ with &2 (insert_trade)
  │    │    │    │         │    └── 1E+2
  │    │    │    │         ├── assignment-cast: VARCHAR(49)
  │    │    │    │         │    └── 'Name'
+ │    │    │    │         ├── assignment-cast: DECIMAL(8,2)
+ │    │    │    │         │    └── CAST(NULL AS DECIMAL)
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
  │    │    │    │         │    └── 1
  │    │    │    │         ├── assignment-cast: DECIMAL(10,2)
@@ -3319,107 +3321,107 @@ with &2 (insert_trade)
  │    │    │    │         └── assignment-cast: DECIMAL(10,2)
  │    │    │    │              └── 0
  │    │    │    └── projections
- │    │    │         ├── column7:36 > 0 [as=check1:42, outer=(36)]
- │    │    │         ├── column8:37 > 0 [as=check2:43, outer=(37), immutable]
- │    │    │         ├── column12:39 >= 0 [as=check3:44, outer=(39), immutable]
- │    │    │         ├── column13:40 >= 0 [as=check4:45, outer=(40), immutable]
- │    │    │         └── column14:41 >= 0 [as=check5:46, outer=(41), immutable]
+ │    │    │         ├── t_qty:36 > 0 [as=check1:43, outer=(36)]
+ │    │    │         ├── t_bid_price:37 > 0 [as=check2:44, outer=(37), immutable]
+ │    │    │         ├── t_chrg:40 >= 0 [as=check3:45, outer=(40), immutable]
+ │    │    │         ├── t_comm:41 >= 0 [as=check4:46, outer=(41), immutable]
+ │    │    │         └── t_tax:42 >= 0 [as=check5:47, outer=(42), immutable]
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47
+ │    │         │         │    ├── columns: t_st_id:48
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column3:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52
+ │    │         │         │    ├── columns: t_tt_id:53
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column4:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59
+ │    │         │         │    ├── columns: t_s_symb:60
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  column6:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":88]
  └── with &4 (insert_trade_history)
-      ├── columns: "?column?":195!null
+      ├── columns: "?column?":196!null
       ├── cardinality: [1 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(195)
+      ├── fd: ()-->(196)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":121!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(121)
       │    ├── insert trade_history
-      │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
+      │    │    ├── columns: trade_history.th_t_id:89!null trade_history.th_st_id:91!null
       │    │    ├── insert-mapping:
-      │    │    │    ├── column1:93 => trade_history.th_t_id:88
-      │    │    │    ├── column2:94 => th_dts:89
-      │    │    │    └── column3:96 => trade_history.th_st_id:90
+      │    │    │    ├── column1:94 => trade_history.th_t_id:89
+      │    │    │    ├── column2:95 => th_dts:90
+      │    │    │    └── th_st_id:97 => trade_history.th_st_id:91
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(88,90)
+      │    │    ├── fd: ()-->(89,91)
       │    │    ├── values
-      │    │    │    ├── columns: column1:93!null column2:94!null column3:96
+      │    │    │    ├── columns: column1:94!null column2:95!null th_st_id:97
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(93,94,96)
+      │    │    │    ├── fd: ()-->(94,95,97)
       │    │    │    └── tuple
       │    │    │         ├── 0
       │    │    │         ├── '2020-06-15 22:27:42.148484'
@@ -3428,78 +3430,78 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:94 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115
+      │    │                   │    ├── columns: th_st_id:116
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column3:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id:97 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":121]
       └── with &6 (insert_trade_request)
-           ├── columns: "?column?":195!null
+           ├── columns: "?column?":196!null
            ├── cardinality: [1 - 1]
            ├── volatile, mutations
            ├── key: ()
-           ├── fd: ()-->(195)
+           ├── fd: ()-->(196)
            ├── project
-           │    ├── columns: "?column?":194!null
+           │    ├── columns: "?column?":195!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(194)
+           │    ├── fd: ()-->(195)
            │    ├── insert trade_request
-           │    │    ├── columns: trade_request.tr_t_id:121!null
+           │    │    ├── columns: trade_request.tr_t_id:122!null
            │    │    ├── insert-mapping:
-           │    │    │    ├── column1:129 => trade_request.tr_t_id:121
-           │    │    │    ├── column2:135 => trade_request.tr_tt_id:122
-           │    │    │    ├── column3:136 => trade_request.tr_s_symb:123
-           │    │    │    ├── column4:137 => tr_qty:124
-           │    │    │    ├── column5:138 => tr_bid_price:125
-           │    │    │    └── column6:134 => trade_request.tr_b_id:126
-           │    │    ├── check columns: check1:139 check2:140
-           │    │    ├── partial index put columns: partial_index_put1:141
+           │    │    │    ├── column1:130 => trade_request.tr_t_id:122
+           │    │    │    ├── tr_tt_id:136 => trade_request.tr_tt_id:123
+           │    │    │    ├── tr_s_symb:137 => trade_request.tr_s_symb:124
+           │    │    │    ├── tr_qty:138 => trade_request.tr_qty:125
+           │    │    │    ├── tr_bid_price:139 => trade_request.tr_bid_price:126
+           │    │    │    └── column6:135 => trade_request.tr_b_id:127
+           │    │    ├── check columns: check1:140 check2:141
+           │    │    ├── partial index put columns: partial_index_put1:142
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
-           │    │    ├── fd: ()-->(121)
+           │    │    ├── fd: ()-->(122)
            │    │    ├── project
-           │    │    │    ├── columns: partial_index_put1:141 check1:139 check2:140 column1:129!null column6:134!null column2:135 column3:136 column4:137 column5:138
+           │    │    │    ├── columns: partial_index_put1:142 check1:140 check2:141 column1:130!null column6:135!null tr_tt_id:136 tr_s_symb:137 tr_qty:138 tr_bid_price:139
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── immutable
            │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(129,134-141)
+           │    │    │    ├── fd: ()-->(130,135-142)
            │    │    │    ├── values
-           │    │    │    │    ├── columns: column1:129!null column6:134!null column2:135 column3:136 column4:137 column5:138
+           │    │    │    │    ├── columns: column1:130!null column6:135!null tr_tt_id:136 tr_s_symb:137 tr_qty:138 tr_bid_price:139
            │    │    │    │    ├── cardinality: [1 - 1]
            │    │    │    │    ├── immutable
            │    │    │    │    ├── key: ()
-           │    │    │    │    ├── fd: ()-->(129,134-138)
+           │    │    │    │    ├── fd: ()-->(130,135-139)
            │    │    │    │    └── tuple
            │    │    │    │         ├── 0
            │    │    │    │         ├── 0
@@ -3512,81 +3514,81 @@ with &2 (insert_trade)
            │    │    │    │         └── assignment-cast: DECIMAL(8,2)
            │    │    │    │              └── 1E+2
            │    │    │    └── projections
-           │    │    │         ├── column2:135 IN ('TLB', 'TLS', 'TSL') [as=partial_index_put1:141, outer=(135)]
-           │    │    │         ├── column4:137 > 0 [as=check1:139, outer=(137)]
-           │    │    │         └── column5:138 > 0 [as=check2:140, outer=(138), immutable]
+           │    │    │         ├── tr_tt_id:136 IN ('TLB', 'TLS', 'TSL') [as=partial_index_put1:142, outer=(136)]
+           │    │    │         ├── tr_qty:138 > 0 [as=check1:140, outer=(138)]
+           │    │    │         └── tr_bid_price:139 > 0 [as=check2:141, outer=(139), immutable]
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
+           │    │         │         ├── columns: tr_t_id:143!null
+           │    │         │         ├── key columns: [143] = [144]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(142)
+           │    │         │         ├── fd: ()-->(143)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_t_id:142!null
+           │    │         │         │    ├── columns: tr_t_id:143!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
+           │    │         │         │    │    └──  column1:130 => tr_t_id:143
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
            │    │         │    └── anti-join (lookup trade_type)
-           │    │         │         ├── columns: tr_tt_id:160
-           │    │         │         ├── key columns: [160] = [161]
+           │    │         │         ├── columns: tr_tt_id:161
+           │    │         │         ├── key columns: [161] = [162]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(160)
+           │    │         │         ├── fd: ()-->(161)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_tt_id:160
+           │    │         │         │    ├── columns: tr_tt_id:161
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column2:135 => tr_tt_id:160
+           │    │         │         │    │    └──  tr_tt_id:136 => tr_tt_id:161
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
            │    │         │    └── anti-join (lookup security)
-           │    │         │         ├── columns: tr_s_symb:167
-           │    │         │         ├── key columns: [167] = [168]
+           │    │         │         ├── columns: tr_s_symb:168
+           │    │         │         ├── key columns: [168] = [169]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(167)
+           │    │         │         ├── fd: ()-->(168)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_s_symb:167
+           │    │         │         │    ├── columns: tr_s_symb:168
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column3:136 => tr_s_symb:167
+           │    │         │         │    │    └──  tr_s_symb:137 => tr_s_symb:168
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
            │    │              └── anti-join (lookup broker)
-           │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
+           │    │                   ├── columns: tr_b_id:187!null
+           │    │                   ├── key columns: [187] = [188]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(186)
+           │    │                   ├── fd: ()-->(187)
            │    │                   ├── with-scan &5
-           │    │                   │    ├── columns: tr_b_id:186!null
+           │    │                   │    ├── columns: tr_b_id:187!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
+           │    │                   │    │    └──  column6:135 => tr_b_id:187
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":194]
+           │         └── 1 [as="?column?":195]
            └── values
-                ├── columns: "?column?":195!null
+                ├── columns: "?column?":196!null
                 ├── cardinality: [1 - 1]
                 ├── key: ()
-                ├── fd: ()-->(195)
+                ├── fd: ()-->(196)
                 └── (1,)
 
 # --------------------------------------------------
@@ -3737,13 +3739,13 @@ insert holding_summary
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => holding_summary.hs_ca_id:1
- │    ├── column2:9 => holding_summary.hs_s_symb:2
- │    └── column3:10 => hs_qty:3
+ │    ├── hs_s_symb:9 => holding_summary.hs_s_symb:2
+ │    └── hs_qty:10 => holding_summary.hs_qty:3
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:6!null column2:9 column3:10
+ │    ├── columns: column1:6!null hs_s_symb:9 hs_qty:10
  │    ├── cardinality: [1 - 1]
  │    ├── immutable
  │    ├── key: ()
@@ -3782,7 +3784,7 @@ insert holding_summary
                 ├── with-scan &1
                 │    ├── columns: hs_s_symb:20
                 │    ├── mapping:
-                │    │    └──  column2:9 => hs_s_symb:20
+                │    │    └──  hs_s_symb:9 => hs_s_symb:20
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
                 │    └── fd: ()-->(20)
@@ -3981,22 +3983,22 @@ insert holding
  ├── insert-mapping:
  │    ├── column1:9 => holding.h_t_id:1
  │    ├── column2:10 => holding.h_ca_id:2
- │    ├── column3:15 => holding.h_s_symb:3
+ │    ├── h_s_symb:15 => holding.h_s_symb:3
  │    ├── column4:12 => h_dts:4
- │    ├── column5:16 => h_price:5
- │    └── column6:17 => h_qty:6
+ │    ├── h_price:16 => holding.h_price:5
+ │    └── h_qty:17 => holding.h_qty:6
  ├── check columns: check1:18
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: check1:18 column1:9!null column2:10!null column4:12!null column3:15 column5:16 column6:17
+ │    ├── columns: check1:18 column1:9!null column2:10!null column4:12!null h_s_symb:15 h_price:16 h_qty:17
  │    ├── cardinality: [1 - 1]
  │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(9,10,12,15-18)
  │    ├── values
- │    │    ├── columns: column1:9!null column2:10!null column4:12!null column3:15 column5:16 column6:17
+ │    │    ├── columns: column1:9!null column2:10!null column4:12!null h_s_symb:15 h_price:16 h_qty:17
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── immutable
  │    │    ├── key: ()
@@ -4012,7 +4014,7 @@ insert holding
  │    │         └── assignment-cast: INT4
  │    │              └── 10
  │    └── projections
- │         └── column5:16 > 0 [as=check1:18, outer=(16), immutable]
+ │         └── h_price:16 > 0 [as=check1:18, outer=(16), immutable]
  └── f-k-checks
       ├── f-k-checks-item: holding(h_t_id) -> trade(t_id)
       │    └── anti-join (lookup trade)
@@ -4042,7 +4044,7 @@ insert holding
                 │    ├── columns: h_ca_id:37!null h_s_symb:38
                 │    ├── mapping:
                 │    │    ├──  column2:10 => h_ca_id:37
-                │    │    └──  column3:15 => h_s_symb:38
+                │    │    └──  h_s_symb:15 => h_s_symb:38
                 │    ├── cardinality: [1 - 1]
                 │    ├── key: ()
                 │    └── fd: ()-->(37,38)
@@ -4434,14 +4436,14 @@ with &2 (update_trade_commission)
            │    │    ├── insert-mapping:
            │    │    │    ├── column1:75 => trade_history.th_t_id:70
            │    │    │    ├── column2:76 => th_dts:71
-           │    │    │    └── column3:78 => trade_history.th_st_id:72
+           │    │    │    └── th_st_id:78 => trade_history.th_st_id:72
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(70,72)
            │    │    ├── values
-           │    │    │    ├── columns: column1:75!null column2:76!null column3:78
+           │    │    │    ├── columns: column1:75!null column2:76!null th_st_id:78
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── immutable
            │    │    │    ├── key: ()
@@ -4479,7 +4481,7 @@ with &2 (update_trade_commission)
            │    │                   ├── with-scan &5
            │    │                   │    ├── columns: th_st_id:97
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column3:78 => th_st_id:97
+           │    │                   │    │    └──  th_st_id:78 => th_st_id:97
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
            │    │                   │    └── fd: ()-->(97)
@@ -4535,16 +4537,16 @@ with &2 (insert_settlement)
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:7 => settlement.se_t_id:1
- │    │    │    ├── column2:11 => se_cash_type:2
+ │    │    │    ├── se_cash_type:11 => settlement.se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
- │    │    │    └── column4:12 => se_amt:4
+ │    │    │    └── se_amt:12 => settlement.se_amt:4
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column3:9!null column2:11 column4:12
+ │    │    │    ├── columns: column1:7!null column3:9!null se_cash_type:11 se_amt:12
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()
@@ -4592,15 +4594,15 @@ with &2 (insert_settlement)
       │    │    ├── insert-mapping:
       │    │    │    ├── column1:38 => cash_transaction.ct_t_id:32
       │    │    │    ├── column2:39 => ct_dts:33
-      │    │    │    ├── column3:42 => ct_amt:34
-      │    │    │    └── column4:43 => ct_name:35
+      │    │    │    ├── ct_amt:42 => cash_transaction.ct_amt:34
+      │    │    │    └── ct_name:43 => cash_transaction.ct_name:35
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(32)
       │    │    ├── values
-      │    │    │    ├── columns: column1:38!null column2:39!null column3:42 column4:43
+      │    │    │    ├── columns: column1:38!null column2:39!null ct_amt:42 ct_name:43
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── immutable
       │    │    │    ├── key: ()
@@ -4690,16 +4692,16 @@ with &2 (insert_settlement)
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
  │    │    │    ├── column1:7 => settlement.se_t_id:1
- │    │    │    ├── column2:11 => se_cash_type:2
+ │    │    │    ├── se_cash_type:11 => settlement.se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
- │    │    │    └── column4:12 => se_amt:4
+ │    │    │    └── se_amt:12 => settlement.se_amt:4
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column3:9!null column2:11 column4:12
+ │    │    │    ├── columns: column1:7!null column3:9!null se_cash_type:11 se_amt:12
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── immutable
  │    │    │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1245,14 +1245,14 @@ insert transactions
  │    ├── column1:10 => dealerid:1
  │    ├── column2:11 => isbuy:2
  │    ├── column3:12 => date:3
- │    ├── column4:16 => accountname:4
- │    ├── column5:17 => customername:5
+ │    ├── accountname:16 => transactions.accountname:4
+ │    ├── customername:17 => transactions.customername:5
  │    ├── column6:15 => operationid:6
  │    └── version_default:18 => version:7
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column1:10!null column2:11!null column3:12!null column6:15!null column4:16 column5:17 version_default:18
+      ├── columns: column1:10!null column2:11!null column3:12!null column6:15!null accountname:16 customername:17 version_default:18
       ├── cardinality: [1 - 1]
       ├── volatile
       ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1249,15 +1249,15 @@ insert transactions
  │    ├── column1:12 => dealerid:1
  │    ├── column2:13 => isbuy:2
  │    ├── column3:14 => date:3
- │    ├── column4:18 => accountname:4
- │    ├── column5:19 => customername:5
+ │    ├── accountname:18 => transactions.accountname:4
+ │    ├── customername:19 => transactions.customername:5
  │    ├── column6:17 => operationid:6
  │    ├── version_default:20 => version:7
  │    └── olddate_default:21 => olddate:8
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column1:12!null column2:13!null column3:14!null column6:17!null column4:18 column5:19 version_default:20 olddate_default:21!null
+      ├── columns: column1:12!null column2:13!null column3:14!null column6:17!null accountname:18 customername:19 version_default:20 olddate_default:21!null
       ├── cardinality: [1 - 1]
       ├── volatile
       ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/ycsb
+++ b/pkg/sql/opt/xform/testdata/external/ycsb
@@ -93,7 +93,7 @@ INSERT INTO usertable VALUES (
 insert usertable
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:25 => ycsb_key:1
+ │    ├── ycsb_key:25 => usertable.ycsb_key:1
  │    ├── column2:15 => field0:2
  │    ├── column3:16 => field1:3
  │    ├── column4:17 => field2:4
@@ -107,7 +107,7 @@ insert usertable
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column2:15!null column3:16!null column4:17!null column5:18!null column6:19!null column7:20!null column8:21!null column9:22!null column10:23!null column11:24!null column1:25
+      ├── columns: column2:15!null column3:16!null column4:17!null column5:18!null column6:19!null column7:20!null column8:21!null column9:22!null column10:23!null column11:24!null ycsb_key:25
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -47,6 +48,22 @@ func NewTransactionCommittedError() error {
 // NewNonNullViolationError creates an error for a violation of a non-NULL constraint.
 func NewNonNullViolationError(columnName string) error {
 	return pgerror.Newf(pgcode.NotNullViolation, "null value in column %q violates not-null constraint", columnName)
+}
+
+// NewInvalidAssignmentCastError creates an error that is used when a mutation
+// cannot be performed because there is not a valid assignment cast from a
+// value's type to the type of the target column.
+func NewInvalidAssignmentCastError(
+	sourceType *types.T, targetType *types.T, targetColName string,
+) error {
+	return errors.WithHint(
+		pgerror.Newf(
+			pgcode.DatatypeMismatch,
+			"value type %s doesn't match type %s of column %q",
+			sourceType, targetType, tree.ErrNameString(targetColName),
+		),
+		"you will need to rewrite or cast the expression",
+	)
 }
 
 // NewGeneratedAlwaysAsIdentityColumnOverrideError creates an error for


### PR DESCRIPTION
#### opt: do not rely on column names for validating updates to GENERATED ALWAYS AS IDENTITY columns

Previously, optbuilder relied on matching column names to validate that
mutations do not explicitly write to `GENERATED ALWAYS AS IDENTITY`
columns. There are no known bugs caused by this, but relying on column
names can be brittle. This commit updates the logic to use ordinals of
columns within their table instead.

Release note: None

#### opt: simplify optbuilder update logic

Release note: None

#### opt: fix type inference of insert values

Previously, the optimizer could infer non-canonical types for constant
values in inserts based on the target column's type. For example, when
inserting the value `1.45` into column `d DECIMAL(5, 1)`, the type of
`1.45` would be inferred as `DECIMAL(5, 1)`. As a result, assignment
casts weren't added in some cases, and incorrect values could be
inserted. This commit fixes the issue by inferring only canonical types
for values that have an ambiguous type.

This commit also changes the type inference of columns for inserts with
multi-row `VALUES` clauses. If constants in a `VALUES` column have
different types but belong to the same family, the canonical type of the
family will be inferred as the `VALUES` column type. This ensures that
an assignment cast will be planned when some constants in a multi-row
`VALUES` clause do not have types identical to their target column's
type.

There is no release note because this bug is not present in any previous
release.

Release note: None
