### PR TITLE
Fix the CRDB build env Dockerfile

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20210714-130445
+version=20211115-160140
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:focal-20210119
 # gnupg2 - for apt
 # libncurses-dev - CRDB build system
 # make - CRDB build system
-# python - awscli install
+# python3,python3-venv - awscli install
 # rsync - sed build
 # texinfo - sed build
 RUN apt-get update \
@@ -39,7 +39,9 @@ RUN apt-get update \
     make \
     patch \
     patchelf \
-    python \
+    python-is-python3 \
+    python3 \
+    python3.8-venv \
     rsync \
     texinfo \
  && apt-get clean \
@@ -202,7 +204,8 @@ RUN ln -s /go/src/github.com/cockroachdb/cockroach/build/builder/mkrelease.sh /u
 
 RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
   && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
-  && tar xzf autouseradd.tar.gz --strip-components 1 \
+  && tar xzf autouseradd.tar.gz -C / --strip-components 1 \
+  && chmod +x /usr/local/bin/autouseradd \
   && rm autouseradd.tar.gz
 
 COPY entrypoint.sh /usr/local/bin


### PR DESCRIPTION
The CRDB build env Dockerfile is out of date. This PR will fix several issues:
1. AWS CLI
1.1. AWS CLI requires python3 instead of python2 now
1.2. the AWS CLI installer still expect the python binary executable name as `python` instead of `python3`
2. `autouseradd` 
2.1. extracted location is not correct
2.2. not an executable permission after the initial extraction