### PR TITLE
rowexec: fix bulkRowWriter summary

### DIFF
--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -78,7 +78,9 @@ func (sp *bulkRowWriter) Start(ctx context.Context) {
 	ctx = sp.StartInternal(ctx, "bulkRowWriter")
 	sp.input.Start(ctx)
 	err := sp.work(ctx)
-	sp.MoveToDraining(err)
+	if err != nil {
+		sp.MoveToDraining(err)
+	}
 }
 
 // Next is part of the RowSource interface.


### PR DESCRIPTION
This processor was entering the draining state too early, which was
causing it to not output its summary.

Release note: None