### PR TITLE
backupccl: fix span-after-finish and some other races in processors

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -110,6 +110,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -158,11 +159,19 @@ func (bp *backupDataProcessor) Start(ctx context.Context) {
 		for range bp.progCh {
 		}
 	}
-	go func() {
-		defer cancel()
-		defer close(bp.progCh)
+	if err := bp.flowCtx.Stopper().RunAsyncTaskEx(ctx, stop.TaskOpts{
+		TaskName: "backup-worker",
+		SpanOpt:  stop.ChildSpan,
+	}, func(ctx context.Context) {
 		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
-	}()
+		cancel()
+		close(bp.progCh)
+	}); err != nil {
+		// The closure above hasn't run, so we have to do the cleanup.
+		bp.backupErr = err
+		cancel()
+		close(bp.progCh)
+	}
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -112,8 +112,11 @@ type backupDataProcessor struct {
 	spec    execinfrapb.BackupDataSpec
 	output  execinfra.RowReceiver
 
-	progCh    chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
-	backupErr error
+	// cancelAndWaitForWorker cancels the producer goroutine and waits for it to
+	// finish. It can be called multiple times.
+	cancelAndWaitForWorker func()
+	progCh                 chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
+	backupErr              error
 }
 
 var _ execinfra.Processor = &backupDataProcessor{}
@@ -136,6 +139,10 @@ func newBackupDataProcessor(
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				bp.close()
+				return nil
+			},
 		}); err != nil {
 		return nil, err
 	}
@@ -145,7 +152,14 @@ func newBackupDataProcessor(
 // Start is part of the RowSource interface.
 func (bp *backupDataProcessor) Start(ctx context.Context) {
 	ctx = bp.StartInternal(ctx, backupProcessorName)
+	ctx, cancel := context.WithCancel(ctx)
+	bp.cancelAndWaitForWorker = func() {
+		cancel()
+		for range bp.progCh {
+		}
+	}
 	go func() {
+		defer cancel()
 		defer close(bp.progCh)
 		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
 	}()
@@ -171,6 +185,17 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 
 	bp.MoveToDraining(nil /* error */)
 	return nil, bp.DrainHelper()
+}
+
+func (bp *backupDataProcessor) close() {
+	bp.cancelAndWaitForWorker()
+	bp.ProcessorBase.InternalClose()
+}
+
+// ConsumerClosed is part of the RowSource interface. We have to override the
+// implementation provided by ProcessorBase.
+func (bp *backupDataProcessor) ConsumerClosed() {
+	bp.close()
 }
 
 type spanAndTime struct {

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 )
 
@@ -255,12 +256,19 @@ func (ssp *splitAndScatterProcessor) Start(ctx context.Context) {
 		cancel()
 		<-workerDone
 	}
-	go func() {
-		defer close(workerDone)
-		defer close(ssp.doneScatterCh)
-		defer cancel()
-		ssp.scatterErr = ssp.runSplitAndScatter(scatterCtx, ssp.flowCtx, &ssp.spec, ssp.scatterer)
-	}()
+	if err := ssp.flowCtx.Stopper().RunAsyncTaskEx(scatterCtx, stop.TaskOpts{
+		TaskName: "splitAndScatter-worker",
+		SpanOpt:  stop.ChildSpan,
+	}, func(ctx context.Context) {
+		ssp.scatterErr = runSplitAndScatter(scatterCtx, ssp.flowCtx, &ssp.spec, ssp.scatterer, ssp.doneScatterCh)
+		cancel()
+		close(ssp.doneScatterCh)
+		close(workerDone)
+	}); err != nil {
+		ssp.scatterErr = err
+		cancel()
+		close(workerDone)
+	}
 }
 
 type entryNode struct {
@@ -327,11 +335,12 @@ type scatteredChunk struct {
 	entries     []execinfrapb.RestoreSpanEntry
 }
 
-func (ssp *splitAndScatterProcessor) runSplitAndScatter(
+func runSplitAndScatter(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	spec *execinfrapb.SplitAndScatterSpec,
 	scatterer splitAndScatterer,
+	doneScatterCh chan<- entryNode,
 ) error {
 	g := ctxgroup.WithContext(ctx)
 
@@ -397,7 +406,7 @@ func (ssp *splitAndScatterProcessor) runSplitAndScatter(
 					select {
 					case <-ctx.Done():
 						return ctx.Err()
-					case ssp.doneScatterCh <- scatteredEntry:
+					case doneScatterCh <- scatteredEntry:
 					}
 				}
 			}

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -234,6 +234,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 					Settings: st,
 					DB:       kvDB,
 					Codec:    keys.SystemSQLCodec,
+					Stopper:  tc.Stopper(),
 				},
 				EvalCtx:     &evalCtx,
 				DiskMonitor: testDiskMonitor,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -433,28 +433,26 @@ func (ca *changeAggregator) setupSpansAndFrontier(
 // processor did not finish completion, there is an excessive amount of nil
 // checking.
 func (ca *changeAggregator) close() {
-	if ca.InternalClose() {
-		// Shut down the poller if it wasn't already. Note that it will cancel
-		// the context used by all components, but ca.Ctx has been updated by
-		// InternalClose() to the "original" context (the one passed into
-		// StartInternal()).
-		ca.cancel()
-		// Wait for the poller to finish shutting down.
-		if ca.kvFeedDoneCh != nil {
-			<-ca.kvFeedDoneCh
-		}
-		if ca.sink != nil {
-			if err := ca.sink.Close(); err != nil {
-				log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
-			}
-		}
-
-		ca.memAcc.Close(ca.Ctx)
-		if ca.kvFeedMemMon != nil {
-			ca.kvFeedMemMon.Stop(ca.Ctx)
-		}
-		ca.MemMonitor.Stop(ca.Ctx)
+	if ca.Closed {
+		return
 	}
+	ca.cancel()
+	// Wait for the poller to finish shutting down.
+	if ca.kvFeedDoneCh != nil {
+		<-ca.kvFeedDoneCh
+	}
+	if ca.sink != nil {
+		if err := ca.sink.Close(); err != nil {
+			log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
+		}
+	}
+
+	ca.memAcc.Close(ca.Ctx)
+	if ca.kvFeedMemMon != nil {
+		ca.kvFeedMemMon.Stop(ca.Ctx)
+	}
+	ca.MemMonitor.Stop(ca.Ctx)
+	ca.InternalClose()
 }
 
 // Next is part of the RowSource interface.


### PR DESCRIPTION
See individual commits.
This is all happening because I want to make using Spans after they've been FInish()ed less tolerated than it has historically been.