### PR TITLE
ui: fix disappearing metrics graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -176,22 +176,27 @@ class MetricsDataProvider extends React.Component<
   /**
    * Refresh nodes status query when props are changed; this will immediately
    * trigger a new request if the previous query is no longer valid.
+   * The query will not be considered stale until 10 seconds have passed,
+   * even if this provider has just been mounted. So, we can force a refresh
+   * when the provider mounts.
    */
-  refreshMetricsIfStale(props: MetricsDataProviderProps) {
+  refreshMetricsIfStale(props: MetricsDataProviderProps, forceRefresh = false) {
     const request = this.requestMessage(props);
     if (!request) {
       return;
     }
     const { metrics, requestMetrics, id } = props;
     const nextRequest = metrics && metrics.nextRequest;
-    if (!nextRequest || !_.isEqual(nextRequest, request)) {
+    const needsRefresh = forceRefresh || !nextRequest || !_.isEqual(nextRequest, request);
+    
+    if (needsRefresh) {
       requestMetrics(id, request);
     }
   }
 
   componentDidMount() {
     // Refresh nodes status query when mounting.
-    this.refreshMetricsIfStale(this.props);
+    this.refreshMetricsIfStale(this.props, true);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Previously, graphs would disappear if a user toggled
away from a metric and then toggled back.

To address this, this patch adds an optional forceRefresh flag
so the MetricDataProvider can request fresh metrics when it mounts.

Release note (bug fix): Fixed a bug where toggling between
metrics would result in disappearing graphs.