### PR TITLE
tracing: improve the ContextWithRecordingSpan interface

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -113,9 +113,9 @@ func TestSpanImport(t *testing.T) {
 	expectedErr := "my expected error"
 	server.pErr = roachpb.NewErrorf(expectedErr /* nolint:fmtsafe */)
 
-	recCtx, getRec, cancel := tracing.ContextWithRecordingSpan(
+	recCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(
 		ctx, tracing.NewTracer(), "test")
-	defer cancel()
+	defer getRecAndFinish()
 
 	server.tr = tracing.SpanFromContext(recCtx).Tracer()
 
@@ -127,7 +127,7 @@ func TestSpanImport(t *testing.T) {
 		t.Fatalf("expected err: %s, got: %q", expectedErr, br.Error)
 	}
 	expectedMsg := "mockInternalClient processing batch"
-	if tracing.FindMsgInRecording(getRec(), expectedMsg) == -1 {
+	if tracing.FindMsgInRecording(getRecAndFinish(), expectedMsg) == -1 {
 		t.Fatalf("didn't find expected message in trace: %s", expectedMsg)
 	}
 }

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -892,9 +892,8 @@ func TestRangeCacheHandleDoubleSplit(t *testing.T) {
 					var desc *roachpb.RangeDescriptor
 					// Each request goes to a different key.
 					var err error
-					ctx, getRecording, cancel := tracing.ContextWithRecordingSpan(
-						ctx, tracing.NewTracer(), "test")
-					defer cancel()
+					ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tracing.NewTracer(), "test")
+					defer getRecAndFinish()
 					tok, err := db.cache.lookupInternal(
 						ctx, key, oldToken,
 						tc.reverseScan)
@@ -910,7 +909,7 @@ func TestRangeCacheHandleDoubleSplit(t *testing.T) {
 						}
 					}
 					if expLog != "" {
-						rec := getRecording()
+						rec := getRecAndFinish()
 						_, ok := rec.FindLogMessage(expLog)
 						if !ok {
 							t.Errorf("didn't find expected message in trace for %s: %s. Recording:\n%s",

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -58,7 +58,7 @@ func RunNemesis(
 		for atomic.AddInt64(&stepsStartedAtomic, 1) <= int64(numSteps) {
 			step := g.RandStep(rng)
 
-			recCtx, collect, cancel := tracing.ContextWithRecordingSpan(
+			recCtx, collect := tracing.ContextWithRecordingSpan(
 				ctx, tracing.NewTracer(), "txn step")
 			buf.Reset()
 			fmt.Fprintf(&buf, "step:")
@@ -66,7 +66,6 @@ func RunNemesis(
 			log.VEventf(recCtx, 2, "%v", buf.String())
 			err := a.Apply(recCtx, &step)
 			step.Trace = collect().String()
-			cancel()
 			if err != nil {
 				buf.Reset()
 				step.format(&buf, formatCtx{indent: `  ` + workerName + ` ERR `})

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -126,14 +126,14 @@ func runTestDBAddSSTable(
 		}
 
 		// Do an initial ingest.
-		ingestCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
-		defer cancel()
+		ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
+		defer getRecAndFinish()
 		if err := db.AddSSTable(
 			ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		formatted := collect().String()
+		formatted := getRecAndFinish().String()
 		if err := testutils.MatchEach(formatted,
 			"evaluating AddSSTable",
 			"sideloadable proposal detected",
@@ -205,15 +205,15 @@ func runTestDBAddSSTable(
 			before = metrics.AddSSTableApplicationCopies.Count()
 		}
 		for i := 0; i < 2; i++ {
-			ingestCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
-			defer cancel()
+			ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
+			defer getRecAndFinish()
 
 			if err := db.AddSSTable(
 				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
-			if err := testutils.MatchEach(collect().String(),
+			if err := testutils.MatchEach(getRecAndFinish().String(),
 				"evaluating AddSSTable",
 				"sideloadable proposal detected",
 				"ingested SSTable at index",
@@ -260,15 +260,15 @@ func runTestDBAddSSTable(
 			before = metrics.AddSSTableApplications.Count()
 		}
 		for i := 0; i < 2; i++ {
-			ingestCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
-			defer cancel()
+			ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
+			defer getRecAndFinish()
 
 			if err := db.AddSSTable(
 				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsWrites, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
-			if err := testutils.MatchEach(collect().String(),
+			if err := testutils.MatchEach(getRecAndFinish().String(),
 				"evaluating AddSSTable",
 				"via regular write batch",
 			); err != nil {

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -207,10 +207,10 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 
 	startTS := db.Clock().Now()
 	rangefeedCtx, rangefeedCancel := context.WithCancel(ctx)
-	rangefeedCtx, getRec, cancel := tracing.ContextWithRecordingSpan(rangefeedCtx,
+	rangefeedCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(rangefeedCtx,
 		tracing.NewTracer(),
 		"rangefeed over non-voter")
-	defer cancel()
+	defer getRecAndFinish()
 
 	// Do a read on the range to make sure that the dist sender learns about the
 	// latest state of the range (with the new non-voter).
@@ -239,5 +239,5 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	}
 	rangefeedCancel()
 	require.Regexp(t, "context canceled", <-rangefeedErrChan)
-	require.Regexp(t, "attempting to create a RangeFeed over replica.*2NON_VOTER", getRec().String())
+	require.Regexp(t, "attempting to create a RangeFeed over replica.*2NON_VOTER", getRecAndFinish().String())
 }

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -912,15 +912,15 @@ func TestLearnerAndVoterOutgoingFollowerRead(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			// Trace the Send call so we can verify that it hit the exact `learner
 			// replicas cannot serve follower reads` branch that we're trying to test.
-			sendCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "manual read request")
-			defer cancel()
+			sendCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "manual read request")
+			defer getRecAndFinish()
 			_, pErr := repl.Send(sendCtx, req)
 			err := pErr.GoError()
 			if !testutils.IsError(err, `not lease holder`) {
 				return errors.Errorf(`expected "not lease holder" error got: %+v`, err)
 			}
 			const msg = `cannot serve follower reads`
-			formattedTrace := collect().String()
+			formattedTrace := getRecAndFinish().String()
 			if !strings.Contains(formattedTrace, msg) {
 				return errors.Errorf("expected a trace with `%s` got:\n%s", msg, formattedTrace)
 			}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8360,8 +8360,8 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 
 	tr := tc.store.cfg.AmbientCtx.Tracer
 	tr.TestingRecordAsyncSpans() // we assert on async span traces in this test
-	opCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
-	defer cancel()
+	opCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
+	defer getRecAndFinish()
 
 	ba = roachpb.BatchRequest{}
 	et, etH := endTxnArgs(txn, true /* commit */)
@@ -8372,7 +8372,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	if _, err := tc.Sender().Send(opCtx, ba); err != nil {
 		t.Fatal(err)
 	}
-	formatted := collect().String()
+	formatted := getRecAndFinish().String()
 	if err := testutils.MatchInOrder(formatted,
 		// The first proposal is rejected.
 		"retry proposal.*applied at lease index.*but required",

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -381,9 +381,9 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 					// Trace the request so we can determine whether it was served as a
 					// follower read. If running on a store with a follower replica and
 					// with a NEAREST routing policy, we expect follower reads.
-					ctx, collect, cancel := tracing.ContextWithRecordingSpan(
+					ctx, collectAndFinish := tracing.ContextWithRecordingSpan(
 						ctx, tracing.NewTracer(), "reader")
-					defer cancel()
+					defer collectAndFinish()
 
 					br, pErr := txn.NegotiateAndSend(ctx, ba)
 					if pErr != nil {
@@ -422,7 +422,7 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 					// where it would be valid for the request to be served by a follower
 					// or redirected to the leaseholder due to timing, so we make no
 					// assertion.
-					rec := collect()
+					rec := collectAndFinish()
 					expFollowerRead := store.StoreID() != lh.StoreID && strict && routeNearest
 					wasFollowerRead := kv.OnlyFollowerReads(rec)
 					ambiguous := !strict && routeNearest

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -123,8 +123,8 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	iter := 0
 	// We'll trace to make sure the test isn't fooling itself.
 	tr := s.TracerI().(*tracing.Tracer)
-	runningCtx, getRec, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test")
-	defer cancel()
+	runningCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test")
+	defer getRecAndFinish()
 	err = shortDB.Txn(runningCtx, func(ctx context.Context, txn *kv.Txn) error {
 		iter++
 		if iter == 1 {
@@ -189,7 +189,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	if iter != 2 {
 		t.Fatalf("expected two iterations, but txn took %d to succeed", iter)
 	}
-	if tracing.FindMsgInRecording(getRec(), clientRejectedMsg) == -1 {
+	if tracing.FindMsgInRecording(getRecAndFinish(), clientRejectedMsg) == -1 {
 		t.Fatalf("didn't find expected message in trace: %s", clientRejectedMsg)
 	}
 }

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -546,12 +546,12 @@ func TestInternalExecutorPushDetectionInTxn(t *testing.T) {
 	require.True(t, txn.IsSerializablePushAndRefreshNotPossible())
 
 	tr := s.Tracer()
-	execCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
-	defer cancel()
+	execCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
+	defer getRecAndFinish()
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
 	_, err = ie.Exec(execCtx, "test", txn, "select 42")
 	require.NoError(t, err)
-	require.NoError(t, testutils.MatchInOrder(collect().String(),
+	require.NoError(t, testutils.MatchInOrder(getRecAndFinish().String(),
 		"push detected for non-refreshable txn but auto-retry not possible"))
 	require.NotEqual(t, txn.ReadTimestamp(), txn.ProvisionalCommitTimestamp(), "expect txn wts to be pushed")
 

--- a/pkg/testutils/kvclientutils/txn_recovery.go
+++ b/pkg/testutils/kvclientutils/txn_recovery.go
@@ -76,8 +76,8 @@ func CheckPushResult(
 	ba := roachpb.BatchRequest{}
 	ba.Add(&pushReq)
 
-	recCtx, collectRec, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test trace")
-	defer cancel()
+	recCtx, collectRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test trace")
+	defer collectRecAndFinish()
 
 	resp, pErr := db.NonTransactionalSender().Send(recCtx, ba)
 	if pErr != nil {
@@ -101,7 +101,7 @@ func CheckPushResult(
 
 	// Verify that we're not fooling ourselves and that checking for the implicit
 	// commit actually caused the txn recovery procedure to run.
-	recording := collectRec()
+	recording := collectRecAndFinish()
 	var resolutionErr error
 	switch pushExpectation {
 	case ExpectPusheeTxnRecovery:

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -695,8 +695,8 @@ func TestStopperRunAsyncTaskTracing(t *testing.T) {
 		}))
 	s := stop.NewStopper(stop.WithTracer(tr))
 
-	ctx, getRecording, finish := tracing.ContextWithRecordingSpan(
-		context.Background(), tr, "parent")
+	ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(context.Background(), tr, "parent")
+	defer getRecAndFinish()
 	root := tracing.SpanFromContext(ctx)
 	require.NotNil(t, root)
 	traceID := root.TraceID()
@@ -744,8 +744,7 @@ func TestStopperRunAsyncTaskTracing(t *testing.T) {
 	}
 
 	s.Stop(ctx)
-	finish()
-	require.NoError(t, tracing.CheckRecordedSpans(getRecording(), `
+	require.NoError(t, tracing.CheckRecordedSpans(getRecAndFinish(), `
 		span: parent
 			tags: _verbose=1
 			span: async child same trace


### PR DESCRIPTION
Before this patch, it was technically illegal to call the callback
returned by ContextWithRecordingSpan multiple times, because it would
Finish() the respective span multiple times. This patch makes it legal.

Calling the callback multiple times is nice because it allows patterns
like:

  ..., cancel := ContextWithRecordingSpan(...)
  defer cance()
  ...
  cancel()
  ...

This allows the respective span to be closed as early as possible. At
least one test uses this pattern, and is currently getting away with it
because double finish is tolerated. But double finish won't be
tolerated for long, and so this patch adds extra precautions in order to
keep the pattern working.

This patch also changes the ContextWithRecordingSpan() interface. The
function used to return two callbacks - one for finishing the span, one
for collecting the recording. This was overkill, and pretty confusing.
The finish callback would also cancel the context, although nobody seems
to need that. There needed to be an order for calling the two callbacks,
which seemed complicated. Also, the allowed order (getRecording() first,
finish() second) is not great because the recording you get shows an
unfinished root span. This patch unifies the callbacks into a single
one.

Release note: None