### PR TITLE
streamingest: wait for all goroutines on streamIngestProcessor shutdown 

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/storage",
+        "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",
@@ -50,7 +51,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -298,12 +298,10 @@ func (sip *streamIngestionProcessor) close() {
 		if sip.maxFlushRateTimer != nil {
 			sip.maxFlushRateTimer.Stop()
 		}
-		if sip.closePoller != nil {
-			close(sip.closePoller)
-			// Wait for the goroutine to return so that we do not access processor
-			// state once it has shutdown.
-			sip.pollingWaitGroup.Wait()
-		}
+		close(sip.closePoller)
+		// Wait for the goroutine to return so that we do not access processor
+		// state once it has shutdown.
+		sip.pollingWaitGroup.Wait()
 	}
 }
 


### PR DESCRIPTION
This processor was failing to stop and wait for some of the goroutines it
spawned, which is not nice (in particular, it's likely that those
goroutines were using a tracing span after it was finished).

Release note: None