### PR TITLE
release-21.2: parser: normalize usernames correctly in more places

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2505,11 +2505,10 @@ role_spec:
 username_or_sconst:
   non_reserved_word
   {
-    // Username was entered as a SQL keyword, or as a SQL identifier
-    // already subject to case normalization and NFC reduction.
-    // (or is it? In fact, there is a bug here: https://github.com/cockroachdb/cockroach/issues/55396
-    // which needs to be fixed to make this fully correct.)
-    $$.val = security.MakeSQLUsernameFromPreNormalizedString($1)
+    // We use UsernameValidation because username_or_sconst and role_spec
+    // are only used for usernames of existing accounts, not when
+    // creating new users or roles.
+    $$.val, _ = security.MakeSQLUsernameFromUserInput($1, security.UsernameValidation)
   }
 | SCONST
   {

--- a/pkg/sql/parser/testdata/alter_table
+++ b/pkg/sql/parser/testdata/alter_table
@@ -618,6 +618,14 @@ ALTER TABLE a OWNER TO foo -- literals removed
 ALTER TABLE _ OWNER TO _ -- identifiers removed
 
 parse
+ALTER TABLE a OWNER TO "Foo"
+----
+ALTER TABLE a OWNER TO foo -- normalized!
+ALTER TABLE a OWNER TO foo -- fully parenthesized
+ALTER TABLE a OWNER TO foo -- literals removed
+ALTER TABLE _ OWNER TO _ -- identifiers removed
+
+parse
 ALTER TABLE IF EXISTS a OWNER TO foo
 ----
 ALTER TABLE IF EXISTS a OWNER TO foo


### PR DESCRIPTION
refs #51663

Release note (bug fix): Previously usernames in ALTER TABLE ... OWNER TO
would not be normalized to lower case. This is fixed now.

Release justification: low-risk bug fix