### PR TITLE
sql: refactor sql server metrics

### DIFF
--- a/pkg/sql/compact_sql_stats.go
+++ b/pkg/sql/compact_sql_stats.go
@@ -81,7 +81,7 @@ func (r *sqlStatsCompactionResumer) Resume(ctx context.Context, execCtx interfac
 		r.st,
 		ie,
 		db,
-		ie.s.Metrics.StatsMetrics.SQLStatsRemovedRows,
+		ie.s.ServerMetrics.StatsMetrics.SQLStatsRemovedRows,
 		p.ExecCfg().SQLStatsTestingKnobs)
 	if err = statsCompactor.DeleteOldestEntries(ctx); err != nil {
 		return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1928,7 +1928,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 			if log.V(1) {
 				log.Warningf(ctx, "failed to record transaction stats: %s", err)
 			}
-			ex.metrics.StatsMetrics.DiscardedStatsCount.Inc(1)
+			ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(1)
 		}
 	}
 }

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -212,7 +212,7 @@ func (ex *connExecutor) recordStatementSummary(
 		if log.V(1) {
 			log.Warningf(ctx, "failed to record statement: %s", err)
 		}
-		ex.metrics.StatsMetrics.DiscardedStatsCount.Inc(1)
+		ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(1)
 	}
 
 	// Do some transaction level accounting for the transaction this statement is

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -362,13 +362,12 @@ func (s *Server) Metrics() (res []interface{}) {
 		&s.SQLServer.Metrics.StartedStatementCounters,
 		&s.SQLServer.Metrics.ExecutedStatementCounters,
 		&s.SQLServer.Metrics.EngineMetrics,
-		&s.SQLServer.Metrics.StatsMetrics,
 		&s.SQLServer.Metrics.GuardrailMetrics,
 		&s.SQLServer.InternalMetrics.StartedStatementCounters,
 		&s.SQLServer.InternalMetrics.ExecutedStatementCounters,
 		&s.SQLServer.InternalMetrics.EngineMetrics,
-		&s.SQLServer.InternalMetrics.StatsMetrics,
 		&s.SQLServer.InternalMetrics.GuardrailMetrics,
+		&s.SQLServer.ServerMetrics.StatsMetrics,
 	}
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1778,26 +1778,6 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.stats.discarded.current"},
 			},
 			{
-				Title:   "Memory usage for internal fingerprint storage",
-				Metrics: []string{"sql.stats.mem.max.internal"},
-			},
-			{
-				Title:   "Current memory usage for internal fingerprint storage",
-				Metrics: []string{"sql.stats.mem.current.internal"},
-			},
-			{
-				Title:   "Memory usage for internal reported fingerprint storage",
-				Metrics: []string{"sql.stats.reported.mem.max.internal"},
-			},
-			{
-				Title:   "Current memory usage for internal reported fingerprint storage",
-				Metrics: []string{"sql.stats.reported.mem.current.internal"},
-			},
-			{
-				Title:   "Number of internal fingerprint statistics being discarded",
-				Metrics: []string{"sql.stats.discarded.current.internal"},
-			},
-			{
 				Title:   "Number of times SQL Stats are flushed to persistent storage",
 				Metrics: []string{"sql.stats.flush.count"},
 			},
@@ -1810,24 +1790,8 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.stats.flush.duration"},
 			},
 			{
-				Title:   "Number of times internal SQL Stats are flushed to persistent storage",
-				Metrics: []string{"sql.stats.flush.count.internal"},
-			},
-			{
-				Title:   "Number of errors encountered when flushing internal SQL Stats",
-				Metrics: []string{"sql.stats.flush.error.internal"},
-			},
-			{
-				Title:   "Time took to complete internal SQL Stats flush",
-				Metrics: []string{"sql.stats.flush.duration.internal"},
-			},
-			{
 				Title:   "Number of stale statement/transaction roles removed by cleanup job",
 				Metrics: []string{"sql.stats.cleanup.rows_removed"},
-			},
-			{
-				Title:   "Number of internal stale statement/transaction roles removed by cleanup job",
-				Metrics: []string{"sql.stats.cleanup.rows_removed.internal"},
 			},
 		},
 	},


### PR DESCRIPTION
Previously, SQL Server kept track of two sets of metrics:
1. regular metrics: these are metrics related to queries issued
   by an external source.
2. internal metrics: these are metrics related to queries issued
   internally by CRDB. (That is, executed via internal executor)
However, some of these metrics didn't quite make sense to be
split this way. For instance, SQL Stats subsystem emits metrics for
monitoring purpose. A SQL Server only contains one copy of
SQL Stats subsystem and the subsystem is used to track both regular
queries as well as internal queries. Therefore, only one copy
of the metrics was emitted. The SQL Stats metrics with
`*_internal` suffix remained unused.

This commit removes the unnecessary duplicated metrics.

Release note (sql change): SQL Stats metrics with *_internal suffix
in their labels are now removed.