### PR TITLE
bazel: properly generate `.eg.go` code in `pkg/sql/colconv` via bazel

### DIFF
--- a/pkg/sql/colconv/BUILD.bazel
+++ b/pkg/sql/colconv/BUILD.bazel
@@ -1,36 +1,28 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/sql/colexecop:EXECGEN.bzl", "eg_go_filegroup", "gen_eg_go_rules")
 
-# TODO(irfansharif): The dependency tree for *.eg.go needs
-# sorting out. It depends on execgen+templates from elsewhere. Look towards
-# colexec for how this should be done. For now we just lazily depend on the
-# already generated+checked in file.
-#
-# keep
 go_library(
     name = "colconv",
     srcs = [
-        "batch.go",  # keep
-        "datum_to_vec.eg.go",
-        "vec_to_datum.eg.go",
+        "batch.go",
+        ":gen-exec",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colconv",
     visibility = ["//visibility:public"],
-    # Pin dependencies used by auto-generated code.
     deps = [
         "//pkg/col/coldata",
-        "//pkg/col/coldataext",
-        "//pkg/col/typeconv",
-        "//pkg/sql/colexecerror",
+        "//pkg/col/typeconv",  # keep
+        "//pkg/sql/colexecerror",  # keep
         "//pkg/sql/execinfra",  # keep
-        "//pkg/sql/rowenc",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/types",
+        "//pkg/sql/rowenc",  # keep
+        "//pkg/sql/sem/tree",  # keep
+        "//pkg/sql/types",  # keep
         "//pkg/util/encoding",  # keep
         "//pkg/util/json",  # keep
-        "//pkg/util/timeutil/pgdate",
-        "//pkg/util/uuid",
+        "//pkg/util/timeutil/pgdate",  # keep
+        "//pkg/util/uuid",  # keep
         "@com_github_cockroachdb_errors//:errors",  # keep
-        "@com_github_lib_pq//oid",
+        "@com_github_lib_pq//oid",  # keep
     ],
 )
 
@@ -45,3 +37,18 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+# Map between target name and relevant template.
+targets = [
+    ("datum_to_vec.eg.go", "datum_to_vec_tmpl.go"),
+    ("vec_to_datum.eg.go", "vec_to_datum_tmpl.go"),
+]
+
+# Define a file group for all the .eg.go targets.
+eg_go_filegroup(
+    name = "gen-exec",
+    targets = targets,
+)
+
+# Define gen rules for individual eg.go files.
+gen_eg_go_rules(targets)

--- a/pkg/sql/colconv/datum_to_vec.eg.go
+++ b/pkg/sql/colconv/datum_to_vec.eg.go
@@ -18,6 +18,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ encoding.Direction
+	_ = typeconv.DatumVecCanonicalTypeFamily
+)
+
 // GetDatumToPhysicalFn returns a function for converting a datum of the given
 // ColumnType to the corresponding Go type. Note that the signature of the
 // return function doesn't contain an error since we assume that the conversion

--- a/pkg/sql/colconv/datum_to_vec_tmpl.go
+++ b/pkg/sql/colconv/datum_to_vec_tmpl.go
@@ -22,10 +22,19 @@
 package colconv
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/errors"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ encoding.Direction
+	_ = typeconv.DatumVecCanonicalTypeFamily
 )
 
 // GetDatumToPhysicalFn returns a function for converting a datum of the given

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -26,6 +26,16 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ colexecerror.StorageError
+	_ json.JSON
+	_ pgdate.Date
+	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ uuid.UUID
+)
+
 // VecToDatumConverter is a helper struct that converts vectors from batches to
 // their datum representations.
 // TODO(yuzefovich): the result of converting the vectors to datums is usually

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -25,11 +25,26 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/lib/pq/oid"
+)
+
+// Workaround for bazel auto-generated code. goimports does not automatically
+// pick up the right packages when run within the bazel sandbox.
+var (
+	_ colexecerror.StorageError
+	_ json.JSON
+	_ pgdate.Date
+	_ = typeconv.DatumVecCanonicalTypeFamily
+	_ uuid.UUID
 )
 
 // VecToDatumConverter is a helper struct that converts vectors from batches to


### PR DESCRIPTION
Release note: None