### PR TITLE
sql: mark unique implicit columns as stored in information_schema.sta…

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1218,7 +1218,7 @@ var informationSchemaStatisticsTable = virtualSchemaTable{
 							if _, isImplicit := implicitCols[col]; isImplicit {
 								// We add a row for each implicit column of index.
 								if err := appendRow(index, col, sequence,
-									indexDirectionAsc, false, true); err != nil {
+									indexDirectionAsc, index.IsUnique(), true); err != nil {
 									return err
 								}
 								sequence++

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -54,7 +54,7 @@ SHOW INDEXES FROM t
 ----
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
 t           foo         false       1             b            ASC        false    false
-t           foo         false       2             a            ASC        false    true
+t           foo         false       2             a            ASC        true     true
 t           t_f_idx     true        1             f            ASC        false    false
 t           t_f_idx     true        2             a            ASC        false    true
 t           t_pkey      false       1             a            ASC        false    false

--- a/pkg/sql/logictest/testdata/logic_test/cross_join
+++ b/pkg/sql/logictest/testdata/logic_test/cross_join
@@ -81,4 +81,3 @@ SELECT *
        )
  WHERE r < .01
  LIMIT 1
-

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -173,4 +173,3 @@ INSERT INTO system.scheduled_jobs (schedule_name, owner, executor_type,execution
 
 statement error pq: cannot drop role/user user1; it owns 1 scheduled jobs.
 DROP USER user1
-

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3949,7 +3949,7 @@ other_db       public        teststatics  YES         public        idx_c       
 other_db       public        teststatics  YES         public        idx_c             2             id           NULL       NULL         ASC        NO       YES
 other_db       public        teststatics  NO          public        idx_cd            1             c            NULL       NULL         ASC        NO       NO
 other_db       public        teststatics  NO          public        idx_cd            2             d            NULL       NULL         ASC        NO       NO
-other_db       public        teststatics  NO          public        idx_cd            3             id           NULL       NULL         ASC        NO       YES
+other_db       public        teststatics  NO          public        idx_cd            3             id           NULL       NULL         ASC        YES      YES
 other_db       public        teststatics  NO          public        teststatics_pkey  1             id           NULL       NULL         ASC        NO       NO
 other_db       public        teststatics  NO          public        teststatics_pkey  2             c            NULL       NULL         N/A        YES      NO
 other_db       public        teststatics  NO          public        teststatics_pkey  3             d            NULL       NULL         N/A        YES      NO

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -729,17 +729,17 @@ SHOW INDEXES FROM tIndex
 ----
 table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit
 tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false
-tindex      bar          true        2             a                ASC        false    true
+tindex      bar          true        2             a                         ASC        false    true
 tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false
-tindex      bar2         true        2             a                ASC        false    true
+tindex      bar2         true        2             a                         ASC        false    true
 tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false
-tindex      bar3         false       2             a                ASC        false    true
+tindex      bar3         false       2             a                         ASC        true     true
 tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false
-tindex      bar4         true        2             a                ASC        false    true
-tindex      foo          true        1             b                ASC        false    false
-tindex      foo          true        2             a                ASC        false    true
-tindex      tindex_pkey  false       1             a                ASC        false    false
-tindex      tindex_pkey  false       2             b                N/A        true     false
+tindex      bar4         true        2             a                         ASC        false    true
+tindex      foo          true        1             b                         ASC        false    false
+tindex      foo          true        2             a                         ASC        false    true
+tindex      tindex_pkey  false       1             a                         ASC        false    false
+tindex      tindex_pkey  false       2             b                         N/A        true     false
 
 statement error  duplicate key value violates unique constraint "bar3"
 INSERT INTO tIndex VALUES (2,1)
@@ -754,19 +754,19 @@ INSERT INTO tIndex VALUES (20000,10000)
 query TTBITTBB colnames
 SHOW INDEXES FROM tIndex
 ----
-table_name  index_name   non_unique  seq_in_index  column_name      direction  storing  implicit
+table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit
 tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false
-tindex      bar          true        2             a                ASC        false    true
+tindex      bar          true        2             a                         ASC        false    true
 tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false
-tindex      bar2         true        2             a                ASC        false    true
+tindex      bar2         true        2             a                         ASC        false    true
 tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false
-tindex      bar3         false       2             a                ASC        false    true
+tindex      bar3         false       2             a                         ASC        true     true
 tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false
-tindex      bar4         true        2             a                ASC        false    true
-tindex      foo          true        1             b                ASC        false    false
-tindex      foo          true        2             a                ASC        false    true
-tindex      tindex_pkey  false       1             a                ASC        false    false
-tindex      tindex_pkey  false       2             b                N/A        true     false
+tindex      bar4         true        2             a                         ASC        false    true
+tindex      foo          true        1             b                         ASC        false    false
+tindex      foo          true        2             a                         ASC        false    true
+tindex      tindex_pkey  false       1             a                         ASC        false    false
+tindex      tindex_pkey  false       2             b                         N/A        true     false
 
 # test for DESC index
 

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_types
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_types
@@ -50,4 +50,3 @@ SHOW CREATE ALL TYPES
 create_statement
 CREATE TYPE public.tableobj AS ENUM ('row', 'col');
 CREATE TYPE s.status AS ENUM ('a', 'b', 'c');
-

--- a/pkg/sql/logictest/testdata/logic_test/show_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/show_indexes
@@ -18,7 +18,7 @@ t1          c_idx       true        2             a            ASC        false 
 t1          c_idx       true        3             b            ASC        false    true
 t1          d_b_idx     false       1             d            ASC        false    false
 t1          d_b_idx     false       2             b            ASC        false    false
-t1          d_b_idx     false       3             a            ASC        false    true
+t1          d_b_idx     false       3             a            ASC        true     true
 t1          t1_pkey     false       1             a            ASC        false    false
 t1          t1_pkey     false       2             b            ASC        false    false
 t1          t1_pkey     false       3             c            N/A        true     false
@@ -48,13 +48,13 @@ t2          a_e_c_idx    true        3             c            ASC        false
 t2          a_e_c_idx    true        4             b            ASC        false    true
 t2          b_d_idx      false       1             b            ASC        false    false
 t2          b_d_idx      false       2             d            ASC        false    false
-t2          b_d_idx      false       3             c            ASC        false    true
-t2          b_d_idx      false       4             a            ASC        false    true
+t2          b_d_idx      false       3             c            ASC        true     true
+t2          b_d_idx      false       4             a            ASC        true     true
 t2          c_e_d_a_idx  false       1             c            ASC        false    false
 t2          c_e_d_a_idx  false       2             e            ASC        false    false
 t2          c_e_d_a_idx  false       3             d            ASC        false    false
 t2          c_e_d_a_idx  false       4             a            ASC        false    false
-t2          c_e_d_a_idx  false       5             b            ASC        false    true
+t2          c_e_d_a_idx  false       5             b            ASC        true     true
 t2          d_idx        true        1             d            ASC        false    false
 t2          d_idx        true        2             c            ASC        false    true
 t2          d_idx        true        3             b            ASC        false    true

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -19,7 +19,7 @@ t           b_idx       true        4             a            ASC        false 
 t           c_idx       false       1             c            ASC        false    false
 t           c_idx       false       2             b            N/A        true     false
 t           c_idx       false       3             d            N/A        true     false
-t           c_idx       false       4             a            ASC        false    true
+t           c_idx       false       4             a            ASC        true     true
 t           t_pkey      false       1             a            ASC        false    false
 t           t_pkey      false       2             b            N/A        true     false
 t           t_pkey      false       3             c            N/A        true     false

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -68,7 +68,7 @@ SHOW INDEXES FROM c
 ----
 table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit
 c           c_bar_key      false       1             bar          ASC        false    false
-c           c_bar_key      false       2             id           ASC        false    true
+c           c_bar_key      false       2             id           ASC        true     true
 c           c_foo_bar_idx  true        1             foo          ASC        false    false
 c           c_foo_bar_idx  true        2             bar          DESC       false    false
 c           c_foo_bar_idx  true        3             id           ASC        false    true
@@ -85,7 +85,7 @@ SHOW INDEXES FROM c WITH COMMENT
 ----
 table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  comment
 c           c_bar_key      false       1             bar          ASC        false    false     NULL
-c           c_bar_key      false       2             id           ASC        false    true      NULL
+c           c_bar_key      false       2             id           ASC        true     true      NULL
 c           c_foo_bar_idx  true        1             foo          ASC        false    false     NULL
 c           c_foo_bar_idx  true        2             bar          DESC       false    false     NULL
 c           c_foo_bar_idx  true        3             id           ASC        false    true      NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -536,7 +536,7 @@ t           b_idx       true        4             a            ASC        false 
 t           c_idx       false       1             c            ASC        false    false
 t           c_idx       false       2             b            N/A        true     false
 t           c_idx       false       3             d            N/A        true     false
-t           c_idx       false       4             a            ASC        false    true
+t           c_idx       false       4             a            ASC        true     true
 t           t_pkey      false       1             a            ASC        false    false
 t           t_pkey      false       2             b            N/A        true     false
 t           t_pkey      false       3             c            N/A        true     false

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -771,7 +771,7 @@ CREATE TABLE abz(a INT, b INT, c INT, PRIMARY KEY (a DESC, b ASC), UNIQUE(c DESC
 ----
 abz  abz_c_b_key  false  1  c  DESC  false  false
 abz  abz_c_b_key  false  2  b  ASC   false  false
-abz  abz_c_b_key  false  3  a  ASC   false  true
+abz  abz_c_b_key  false  3  a  ASC   true   true
 abz  abz_pkey     false  1  a  DESC  false  false
 abz  abz_pkey     false  2  b  ASC   false  false
 abz  abz_pkey     false  3  c  N/A   true   false


### PR DESCRIPTION
…tistics

In unique secondary indexes, we don't index the primary key column. Honestly
it's sort of an implementation detail that we don't do that. We certainly
could one day. This is more correct though.

Fixes #72654.

Release note (sql change): Primary key columns which are not part of a
unique secondary index (but are "implicitly" included because all indexes
include all primary key columns) are now marked as `storing` in the
information_schema.statistics table and in `SHOW INDEX`. This is technically
more correct; the column is in the value in KV and not in the indexed key.