### PR TITLE
tracing: stop collecting recordings after Finish in tests

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -245,13 +245,15 @@ func (ih *instrumentationHelper) Finish(
 	if ih.sp == nil {
 		return retErr
 	}
-	if ih.shouldFinishSpan {
-		ih.sp.Finish()
-	}
 
 	// Record the statement information that we've collected.
 	// Note that in case of implicit transactions, the trace contains the auto-commit too.
-	trace := ih.sp.GetRecording(ih.sp.RecordingType())
+	var trace tracing.Recording
+	if ih.shouldFinishSpan {
+		trace = ih.sp.FinishAndGetRecording(ih.sp.RecordingType())
+	} else {
+		trace = ih.sp.GetRecording(ih.sp.RecordingType())
+	}
 
 	if ih.withStatementTrace != nil {
 		ih.withStatementTrace(trace, stmtRawSQL)

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -56,9 +56,8 @@ func TestAnnotateCtxSpan(t *testing.T) {
 
 	Event(ctx1, "c")
 	sp2.Finish()
-	sp1.Finish()
 
-	if err := tracing.CheckRecordedSpans(sp1.GetRecording(tracing.RecordingVerbose), `
+	if err := tracing.CheckRecordedSpans(sp1.FinishAndGetRecording(tracing.RecordingVerbose), `
 		span: root
 			tags: _verbose=1
 			event: a

--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -25,7 +25,7 @@ func TestTrace(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		init  func(context.Context) (context.Context, *tracing.Span)
-		check func(*testing.T, context.Context, *tracing.Span)
+		check func(*testing.T, context.Context, tracing.Recording, *tracing.Tracer)
 	}{
 		{
 			name: "verbose",
@@ -35,8 +35,8 @@ func TestTrace(t *testing.T) {
 				ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 				return ctxWithSpan, sp
 			},
-			check: func(t *testing.T, _ context.Context, sp *tracing.Span) {
-				if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
+			check: func(t *testing.T, _ context.Context, rec tracing.Recording, _ *tracing.Tracer) {
+				if err := tracing.CheckRecordedSpans(rec, `
 		span: s
 			tags: _verbose=1
 			event: test1
@@ -57,13 +57,13 @@ func TestTrace(t *testing.T) {
 				tr.Configure(ctx, &st.SV)
 				return tr.StartSpanCtx(context.Background(), "foo")
 			},
-			check: func(t *testing.T, ctx context.Context, sp *tracing.Span) {
+			check: func(t *testing.T, ctx context.Context, _ tracing.Recording, tr *tracing.Tracer) {
 				// This isn't quite a real end-to-end-check, but it is good enough
 				// to give us confidence that we're really passing log events to
 				// the span, and the tracing package in turn has tests that verify
 				// that a span so configured will actually log them to the external
 				// trace.
-				require.True(t, sp.Tracer().HasExternalSink())
+				require.True(t, tr.HasExternalSink())
 				require.True(t, log.HasSpanOrEvent(ctx))
 				require.True(t, log.ExpensiveLogEnabled(ctx, 0 /* level */))
 			},
@@ -83,8 +83,8 @@ func TestTrace(t *testing.T) {
 			// Events to parent context should still be no-ops.
 			log.Event(ctx, "should-not-show-up")
 
-			sp.Finish()
-			tc.check(t, ctxWithSpan, sp)
+			tr := sp.Tracer()
+			tc.check(t, ctxWithSpan, sp.FinishAndGetRecording(tracing.RecordingVerbose), tr)
 		})
 	}
 }
@@ -102,8 +102,7 @@ func TestTraceWithTags(t *testing.T) {
 	log.VErrEvent(ctxWithSpan, log.NoLogV(), "testerr")
 	log.Info(ctxWithSpan, "log")
 
-	sp.Finish()
-	if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
+	if err := tracing.CheckRecordedSpans(sp.FinishAndGetRecording(tracing.RecordingVerbose), `
 		span: s
 			tags: _verbose=1
 			event: [tag=1] test1

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -126,10 +126,10 @@ func TestEventLogAndTrace(t *testing.T) {
 	// Events to parent context should still go to the event log.
 	Event(ctxWithEventLog, "test6")
 
-	sp.Finish()
+	rec := sp.FinishAndGetRecording(tracing.RecordingVerbose)
 	el.Finish()
 
-	if err := tracing.CheckRecordedSpans(sp.GetRecording(tracing.RecordingVerbose), `
+	if err := tracing.CheckRecordedSpans(rec, `
 		span: s
 			tags: _verbose=1
 			event: test3

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -86,8 +86,7 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 
 	// Start another remote child span on "node 2" that we finish.
 	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithParentAndManualCollection(child.Meta()))
-	childRemoteChildFinished.Finish()
-	child.ImportRemoteSpans(childRemoteChildFinished.GetRecording(tracing.RecordingVerbose))
+	child.ImportRemoteSpans(childRemoteChildFinished.FinishAndGetRecording(tracing.RecordingVerbose))
 
 	// Start a root span on "node 2".
 	root2 := t2.StartSpan("root2", tracing.WithRecording(tracing.RecordingVerbose))

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -194,9 +194,8 @@ func TestGRPCInterceptors(t *testing.T) {
 			require.NoError(t, types.UnmarshalAny(recAny, &rec))
 			require.Len(t, rec.StructuredRecords, 1)
 			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
-			sp.Finish()
 			var n int
-			finalRecs := sp.GetRecording(tracing.RecordingVerbose)
+			finalRecs := sp.FinishAndGetRecording(tracing.RecordingVerbose)
 			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
 				n += len(rec.StructuredRecords)

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -91,6 +91,17 @@ func (sp *Span) Finish() {
 	sp.i.Finish()
 }
 
+// FinishAndGetRecording finishes the span and gets a recording at the same
+// time. This is offered as a combined operation because, otherwise, the caller
+// would be forced to collect the recording before finishing and so the span
+// would appear to be unfinished in the recording (it's illegal to collect the
+// recording after the span finishes, except by using this method).
+func (sp *Span) FinishAndGetRecording(recType RecordingType) Recording {
+	sp.Finish()
+	// Reach directly into sp.i to avoide the done() check in sp.GetRecording().
+	return sp.i.GetRecording(recType)
+}
+
 // GetRecording retrieves the current recording, if the Span has recording
 // enabled. This can be called while spans that are part of the recording are
 // still open; it can run concurrently with operations on those spans.
@@ -114,7 +125,6 @@ func (sp *Span) Finish() {
 // If recType is RecordingStructured, the return value will be nil if the span
 // doesn't have any structured events.
 func (sp *Span) GetRecording(recType RecordingType) Recording {
-	// It's always valid to get the recording, even for a finished span.
 	return sp.i.GetRecording(recType)
 }
 

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -30,8 +30,7 @@ func TestLogTags(t *testing.T) {
 	l = l.Add("tag2", "val2")
 	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
 	sp1.SetVerbose(true)
-	sp1.Finish()
-	require.NoError(t, CheckRecordedSpans(sp1.GetRecording(RecordingVerbose), `
+	require.NoError(t, CheckRecordedSpans(sp1.FinishAndGetRecording(RecordingVerbose), `
 		span: foo
 			tags: _verbose=1 tag1=val1 tag2=val2
 	`))
@@ -50,8 +49,7 @@ func TestLogTags(t *testing.T) {
 
 	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
 	sp2.SetVerbose(true)
-	sp2.Finish()
-	require.NoError(t, CheckRecordedSpans(sp2.GetRecording(RecordingVerbose), `
+	require.NoError(t, CheckRecordedSpans(sp2.FinishAndGetRecording(RecordingVerbose), `
 		span: bar
 			tags: _verbose=1 one=val1 two=val2
 	`))
@@ -68,8 +66,7 @@ func TestLogTags(t *testing.T) {
 
 	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
 	sp3.SetVerbose(true)
-	sp3.Finish()
-	require.NoError(t, CheckRecordedSpans(sp3.GetRecording(RecordingVerbose), `
+	require.NoError(t, CheckRecordedSpans(sp3.FinishAndGetRecording(RecordingVerbose), `
 		span: baz
 			tags: _verbose=1 one=val1 two=val2
 	`))

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1110,8 +1110,7 @@ func ContextWithRecordingSpan(
 			if rec != nil {
 				return rec
 			}
-			sp.Finish()
-			rec = sp.GetRecording(RecordingVerbose)
+			rec = sp.FinishAndGetRecording(RecordingVerbose)
 			return rec
 		}
 }


### PR DESCRIPTION
Calling Span.GetRecording() after Span.Finish() used to be allowed as a
convenience (in fact, it was the best way to do it since Finish()ing
first would avoid the root span appearing with an "_unfinished" tag in
the recording), but I'm moving away from that since I want Finish() to
ultimately make the span available for reuse. This patch adds a way to
finish a span and collect its recording at the same time (which covers
the _unfinished business above), and changes tests to use that.

Release note: None