### PR TITLE
release-21.2: sql: support `"{}"` format for array column in COPY FROM STDIN WITH CSV

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -463,7 +463,7 @@ func (c *copyMachine) readCSVTuple(ctx context.Context, record []string) error {
 			exprs[i] = tree.DNull
 			continue
 		}
-		d, err := rowenc.ParseDatumStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+		d, _, err := tree.ParseAndRequireString(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
 		if err != nil {
 			return err
 		}
@@ -719,7 +719,16 @@ func (c *copyMachine) readTextTuple(ctx context.Context, line []byte) error {
 			types.UuidFamily:
 			s = decodeCopy(s)
 		}
-		d, err := rowenc.ParseDatumStringAsWithRawBytes(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+
+		var d tree.Datum
+		var err error
+		switch c.resultColumns[i].Typ.Family() {
+		case types.BytesFamily:
+			d = tree.NewDBytes(tree.DBytes(s))
+		default:
+			d, _, err = tree.ParseAndRequireString(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -527,3 +527,103 @@ ReadyForQuery
 {"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
 {"Type":"ErrorResponse","Code":"22P04"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE t (i INT8, t TIMESTAMPTZ)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY t FROM STDIN CSV"}
+CopyData {"Data": "1,2021-09-20T06:05:04\n"}
+CopyData {"Data": "\\.\n"}
+CopyDone
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SET TIME ZONE \"America/Chicago\""}
+Query {"String": "COPY t FROM STDIN CSV"}
+CopyData {"Data": "2,2021-09-20T06:05:04\n"}
+CopyData {"Data": "\\.\n"}
+CopyDone
+Query {"String": "SELECT i, t FROM t ORDER BY i"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"ParameterStatus","Name":"TimeZone","Value":"America/Chicago"}
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
+{"Type":"CommandComplete","CommandTag":"COPY 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"2021-09-20 01:05:04-05"}]}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"2021-09-20 06:05:04-05"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS c"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE c (d INT ARRAY);"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "COPY c(d) FROM STDIN WITH CSV"}
+CopyData {"Data": "\"{0,1}\"\n"}
+CopyData {"Data": "\"{2,3,4,5,6}\"\n"}
+CopyData {"Data": "\\.\n"}
+CopyDone
+Query {"String": "SELECT * FROM c"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CopyInResponse","ColumnFormatCodes":[0]}
+{"Type":"CommandComplete","CommandTag":"COPY 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"{0,1}"}]}
+{"Type":"DataRow","Values":[{"text":"{2,3,4,5,6}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Backport 1/1 commits from #71688.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/70728

In postgreSQL, user can use the `"{}"` format
to insert an array column. Currently, Cockroach does not
supports this format, but it allows the `"ARRAY[]"`
format.

This commit adds support for the `"{}"` format with
`COPY FROM STDIN WITH CSV` syntax.

Usage:

```
movr=> CREATE TABLE c (d INT ARRAY);
CREATE TABLE

movr=> COPY c(d) FROM STDIN WITH CSV;
Enter data to be copied followed by a newline.
End with a backslash and a period on a line by itself, or an EOF signal.
>> "{1,2}"
>> "{3,4,5}"
>> \.
COPY 2
movr=> SELECT * FROM c;
   d
-------
 {1,2}
 {3,4,5}
(2 rows)
```

Release note (bug fix): support `"{}"` format for array column in COPY FROM STDIN WITH CSV
Release justification: None
