### PR TITLE
tabledesc: add latest index descriptor version constants

### DIFF
--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -68,6 +68,8 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/geo/geoindex",
+        "//pkg/jobs",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -576,3 +576,17 @@ func PrimaryKeyString(desc catalog.TableDescriptor) string {
 	}
 	return f.CloseAndGetString()
 }
+
+const (
+	// LatestPrimaryIndexDescriptorVersion is the latest index descriptor version
+	// value for primary indexes, and so will be found in all newly-created
+	// primary indexes.
+	// This property is tested by TestLatestIndexDescriptorVersionValues.
+	LatestPrimaryIndexDescriptorVersion descpb.IndexDescriptorVersion = descpb.PrimaryIndexWithStoredColumnsVersion
+
+	// LatestNonPrimaryIndexDescriptorVersion is the latest index descriptor
+	// version value for non-primary indexes, and so will be found in all
+	// newly-created secondary indexes, as well as index mutations.
+	// This property is tested by TestLatestIndexDescriptorVersionValues.
+	LatestNonPrimaryIndexDescriptorVersion descpb.IndexDescriptorVersion = descpb.StrictIndexColumnIDGuaranteesVersion
+)


### PR DESCRIPTION
There now exist a variety of index descriptor versions and due to the
need to remain backward-compatible, any of there may be legitimately
be encountered in a live production cluster.

However, when creating a new index, we expect its index descriptor
version field to be set to its latest possible value. Which value this
is, is now set to a pair of constants: one for primary indexes and
another for all others.

Over time, new values may be added, so the bulk of this commit consists
in a test that verifies that these constants are up to date.

Release note: None