### PR TITLE
indexrec, opttester: add index candidate set

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -257,6 +257,7 @@ ALL_TESTS = [
     "//pkg/sql/opt/exec/execbuilder:execbuilder_test",
     "//pkg/sql/opt/exec/explain:explain_test",
     "//pkg/sql/opt/idxconstraint:idxconstraint_test",
+    "//pkg/sql/opt/indexrec:indexrec_test",
     "//pkg/sql/opt/invertedexpr:invertedexpr_test",
     "//pkg/sql/opt/invertedidx:invertedidx_test",
     "//pkg/sql/opt/memo:memo_test",

--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "indexrec",
+    srcs = ["index_candidate_set.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
+        "//pkg/sql/opt/memo",
+        "//pkg/util",
+    ],
+)
+
+go_test(
+    name = "indexrec_test",
+    srcs = ["index_candidate_set_test.go"],
+    embed = [":indexrec"],
+    deps = [
+        "//pkg/sql/opt/cat",
+        "//pkg/sql/opt/testutils/testcat",
+    ],
+)

--- a/pkg/sql/opt/indexrec/index_candidate_set.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set.go
@@ -1,0 +1,362 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package indexrec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// FindIndexCandidateSet returns a map storing potential indexes for each table
+// referenced in a query. The index candidates are constructed based on the
+// following rules:
+//
+// 	1. Add a single index on all columns in a Group By or Order By expression if
+//	   the columns are from the same table. Otherwise, group expressions into
+//	   indexes by table. For Order By, the first column of each index will be
+//     ascending. If that is the opposite of the column's ordering, each
+//     subsequent column will also be ordered opposite to its ordering (and vice
+//     versa).
+//  2. Add a single-column index on any Range expression, comparison
+//     expression (=, <, >, <=, >=), and IS expression.
+// 	3. Add a single-column index on any column that appears in a JOIN predicate.
+//  4. If there exist multiple columns from the same table in a JOIN predicate,
+//     create a single index on all such columns.
+//  5. Construct three groups for each table: EQ, R, and J.
+//     - EQ is a single index of all columns that appear in equality predicates.
+//     - R is all indexes that come from rule 2.
+//     - J is all indexes that come from rules 3 and 4.
+//     From these groups, construct the following multi-column index
+//     combinations: EQ, EQ + R, J + R, EQ + J, EQ + J + R.
+// TODO(nehageorge): Add a rule for columns that are referenced in the statement
+// but do not fall into one of these categories. In order to account for this,
+// *memo.VariableExpr would be the final case in the switch statement, hit only
+// if no other expressions have been matched. See the papers referenced in this
+// RFC for inspiration: https://github.com/cockroachdb/cockroach/pull/71784. We
+// may also consider matching more types of SQL expressions, including LIKE
+// expressions.
+func FindIndexCandidateSet(rootExpr opt.Expr, md *opt.Metadata) map[cat.Table][][]cat.IndexColumn {
+	candidateSet := indexCandidateSet{md: md}
+	candidateSet.init()
+	candidateSet.categorizeIndexCandidates(rootExpr)
+	candidateSet.combineIndexCandidates()
+	return candidateSet.overallCandidates
+}
+
+// indexCandidateSet stores potential indexes that could be recommended for a
+// given query, as well as the query's metadata.
+type indexCandidateSet struct {
+	md                *opt.Metadata
+	equalCandidates   map[cat.Table][][]cat.IndexColumn
+	rangeCandidates   map[cat.Table][][]cat.IndexColumn
+	joinCandidates    map[cat.Table][][]cat.IndexColumn
+	overallCandidates map[cat.Table][][]cat.IndexColumn
+}
+
+// init allocates memory for the maps in the set.
+func (ics *indexCandidateSet) init() {
+	numTables := len(ics.md.AllTables())
+	ics.equalCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.rangeCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.joinCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.overallCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+}
+
+// combineIndexCandidates adds index candidates that are combinations of
+// candidates in the JOIN, EQUAL, and RANGE categories. See rule 5 in
+// FindIndexCandidateSet.
+func (ics *indexCandidateSet) combineIndexCandidates() {
+	// Copy indexes in each category to overallCandidates without duplicates.
+	copyIndexes(ics.equalCandidates, ics.overallCandidates)
+	copyIndexes(ics.rangeCandidates, ics.overallCandidates)
+	copyIndexes(ics.joinCandidates, ics.overallCandidates)
+
+	numTables := len(ics.overallCandidates)
+	equalJoinCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
+	equalGroupedCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
+
+	// Construct EQ, EQ + R, J + R, EQ + J, EQ + J + R.
+	groupIndexesByTable(ics.equalCandidates, equalGroupedCandidates)
+	copyIndexes(equalGroupedCandidates, ics.overallCandidates)
+	constructIndexCombinations(equalGroupedCandidates, ics.rangeCandidates, ics.overallCandidates)
+	constructIndexCombinations(ics.joinCandidates, ics.rangeCandidates, ics.overallCandidates)
+	constructIndexCombinations(equalGroupedCandidates, ics.joinCandidates, equalJoinCandidates)
+	copyIndexes(equalJoinCandidates, ics.overallCandidates)
+	constructIndexCombinations(equalJoinCandidates, ics.rangeCandidates, ics.overallCandidates)
+}
+
+// categorizeIndexCandidates finds potential index candidates for a given
+// query. See FindIndexCandidateSet for the list of candidate creation rules.
+//
+// TODO(nehageorge): Add information about potential STORING columns to add for
+// indexes where including them could avoid index-joins.
+func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
+	switch expr := expr.(type) {
+	case *memo.SortExpr:
+		ics.addOrderingIndex(expr.ProvidedPhysical().Ordering)
+	case *memo.GroupByExpr:
+		addMultiColumnIndex(expr.GroupingCols.ToList(), nil /* desc */, ics.md, ics.overallCandidates)
+	case *memo.EqExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.equalCandidates)
+		addVariableExprIndex(expr.Right, ics.md, ics.equalCandidates)
+	case *memo.IsExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.equalCandidates)
+	case *memo.LtExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
+		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+	case *memo.GtExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
+		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+	case *memo.LeExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
+		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+	case *memo.GeExpr:
+		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
+		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+	case *memo.InnerJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	case *memo.LeftJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	case *memo.RightJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	case *memo.FullJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	case *memo.SemiJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	case *memo.AntiJoinExpr:
+		ics.addJoinIndexes(expr.On)
+	}
+	for i, n := 0, expr.ChildCount(); i < n; i++ {
+		ics.categorizeIndexCandidates(expr.Child(i))
+	}
+}
+
+// addOrderingIndex adds indexes for a *memo.SortExpr. One index is constructed
+// per table, with a column corresponding to each of the table's columns in the
+// sort, in order of appearance. The first column of each table's index will be
+// ordered ascending. If that matches the column's actual sort ordering (it's
+// ascending), then each subsequent index column will also be ordered the same
+// way it is in the sort. However, if the first column's ordering in the sort is
+// actually descending, then each subsequent column in the index will also be
+// ordered opposite to its ordering in the sort. This will allow the index to be
+// useful for scans or reverse scans.
+//
+// TODO(neha): The convention of having the first column being ascending is to
+// avoid redundant indexes. However, since reverse scans are slightly less
+// efficient than forward scans, we shouldn't have this convention and should
+// remove redundant indexes later.
+func (ics indexCandidateSet) addOrderingIndex(ordering opt.Ordering) {
+	if len(ordering) == 0 {
+		return
+	}
+	columnList := make(opt.ColList, len(ordering))
+	descList := make([]bool, len(ordering))
+	numTables := len(ics.md.AllTables())
+	reverseOrder := make(map[cat.Table]bool, numTables)
+
+	for i, orderingCol := range ordering {
+		colID := orderingCol.ID()
+		columnList[i] = colID
+		colTable := ics.md.Table(ics.md.ColumnMeta(colID).Table)
+
+		// Set descending bool for ordering column.
+		if _, found := reverseOrder[colTable]; !found {
+			reverseOrder[colTable] = orderingCol.Descending()
+		}
+		if reverseOrder[colTable] {
+			descList[i] = orderingCol.Ascending()
+		} else {
+			descList[i] = orderingCol.Descending()
+		}
+	}
+
+	addMultiColumnIndex(columnList, descList, ics.md, ics.overallCandidates)
+}
+
+// addJoinIndexes adds single-column indexes to joinCandidates for each outer
+// column in a join predicate, if these indexes do not already exist. For each
+// table with multiple columns in the JOIN predicate, it also creates a single
+// index on all such columns.
+func (ics *indexCandidateSet) addJoinIndexes(expr memo.FiltersExpr) {
+	outerCols := expr.OuterCols().ToList()
+	for _, col := range outerCols {
+		addSingleColumnIndex(col, false /* desc */, ics.md, ics.joinCandidates)
+	}
+	addMultiColumnIndex(outerCols, nil /* desc */, ics.md, ics.joinCandidates)
+}
+
+// copyIndexes copies indexes from one map to another, getting rid of duplicates
+// in the output map.
+func copyIndexes(inputIndexMap, outputIndexMap map[cat.Table][][]cat.IndexColumn) {
+	for t, indexes := range inputIndexMap {
+		for _, index := range indexes {
+			addIndexToCandidates(index, t, outputIndexMap)
+		}
+	}
+}
+
+// groupIndexesByTable creates a single multi-column index from all indexes in a
+// table. It is the caller's responsibility to ensure that there are no
+// duplicate columns between indexes on a given table.
+func groupIndexesByTable(inputIndexMap, outputIndexMap map[cat.Table][][]cat.IndexColumn) {
+	for t, indexes := range inputIndexMap {
+		newIndex := make([]cat.IndexColumn, 0, len(indexes))
+		for _, index := range indexes {
+			newIndex = append(newIndex, index...)
+		}
+		outputIndexMap[t] = [][]cat.IndexColumn{newIndex}
+	}
+}
+
+// constructIndexCombinations constructs all concatenated index combinations
+// from indexes in the left map and indexes in the right map, with the left
+// index always coming first. This is done for every table where at least one
+// index exists in both maps. If there are columns in the right index that
+// already exist in the left index, we discard them.
+func constructIndexCombinations(
+	leftIndexMap, rightIndexMap, outputIndexes map[cat.Table][][]cat.IndexColumn,
+) {
+	for t, leftIndexes := range leftIndexMap {
+		if rightIndexes, found := rightIndexMap[t]; found {
+			for _, leftIndex := range leftIndexes {
+				constructLeftIndexCombination(leftIndex, t, rightIndexes, outputIndexes)
+			}
+		}
+	}
+}
+
+// constructLeftIndexCombination adds all valid concatenated index combinations
+// for a single left index and a slice of right indexes, with the left index
+// appearing first.
+func constructLeftIndexCombination(
+	leftIndex []cat.IndexColumn,
+	tab cat.Table,
+	rightIndexes [][]cat.IndexColumn,
+	outputIndexes map[cat.Table][][]cat.IndexColumn,
+) {
+	var leftIndexColSet util.FastIntSet
+	// Store left columns in a set for fast access.
+	for _, leftCol := range leftIndex {
+		leftIndexColSet.Add(int(leftCol.ColID()))
+	}
+	for _, rightIndex := range rightIndexes {
+		// Remove columns in the right index that exist in the left index.
+		updatedRightIndex := make([]cat.IndexColumn, 0, len(rightIndex))
+		for _, rightCol := range rightIndex {
+			if !leftIndexColSet.Contains(int(rightCol.ColID())) {
+				updatedRightIndex = append(updatedRightIndex, rightCol)
+			}
+		}
+		if len(updatedRightIndex) > 0 {
+			addIndexToCandidates(append(leftIndex, updatedRightIndex...), tab, outputIndexes)
+		}
+	}
+}
+
+// addVariableExprIndex adds an index candidate to indexCandidates if the expr
+// argument can be cast to a *memo.VariableExpr and the index does not already
+// exist.
+func addVariableExprIndex(
+	expr opt.Expr, md *opt.Metadata, indexCandidates map[cat.Table][][]cat.IndexColumn,
+) {
+	switch expr := expr.(type) {
+	case *memo.VariableExpr:
+		addSingleColumnIndex(expr.Col, false /* desc */, md, indexCandidates)
+	}
+}
+
+// addMultiColumnIndex adds indexes to indexCandidates for groups of columns
+// in a column set that are from the same table, without duplicates.
+func addMultiColumnIndex(
+	cols opt.ColList,
+	desc []bool,
+	md *opt.Metadata,
+	indexCandidates map[cat.Table][][]cat.IndexColumn,
+) {
+	// Group columns by table in a temporary map as single-column indexes,
+	// getting rid of duplicates.
+	tableToCols := make(map[cat.Table][][]cat.IndexColumn)
+	for i, colID := range cols {
+		if desc != nil {
+			addSingleColumnIndex(colID, desc[i], md, tableToCols)
+		} else {
+			addSingleColumnIndex(colID, false /* desc */, md, tableToCols)
+		}
+	}
+
+	// Combine all single-column indexes for a given table into one, and add
+	// the corresponding multi-column index.
+	for currTable := range tableToCols {
+		index := make([]cat.IndexColumn, len(tableToCols[currTable]))
+		for i, colSlice := range tableToCols[currTable] {
+			index[i] = colSlice[0]
+		}
+		addIndexToCandidates(index, currTable, indexCandidates)
+	}
+}
+
+// addSingleColumnIndex adds an index to indexCandidates on the column with the
+// given opt.ColumnID if it does not already exist.
+func addSingleColumnIndex(
+	colID opt.ColumnID,
+	desc bool,
+	md *opt.Metadata,
+	indexCandidates map[cat.Table][][]cat.IndexColumn,
+) {
+	// If the column is unknown, return.
+	if colID == 0 {
+		return
+	}
+	columnMeta := md.ColumnMeta(colID)
+
+	// If there's no base table for the column, return.
+	tableID := columnMeta.Table
+	if tableID == 0 {
+		return
+	}
+
+	// Find the column instance in the current table and add the corresponding
+	// index to indexCandidates.
+	currTable := md.Table(tableID)
+	currCol := currTable.Column(tableID.ColumnOrdinal(colID))
+	indexCol := cat.IndexColumn{Column: currCol, Descending: desc}
+	addIndexToCandidates([]cat.IndexColumn{indexCol}, currTable, indexCandidates)
+}
+
+// addIndexToCandidates adds an index to indexCandidates if it does not already
+// exist.
+func addIndexToCandidates(
+	newIndex []cat.IndexColumn,
+	currTable cat.Table,
+	indexCandidates map[cat.Table][][]cat.IndexColumn,
+) {
+	// Do not add duplicate indexes.
+	for _, existingIndex := range indexCandidates[currTable] {
+		if len(existingIndex) != len(newIndex) {
+			continue
+		}
+		potentialDuplicate := true
+		for i := range existingIndex {
+			if newIndex[i] != existingIndex[i] {
+				potentialDuplicate = false
+				break
+			}
+		}
+		if potentialDuplicate {
+			// Duplicate index found, return.
+			return
+		}
+	}
+	// Index does not exist already, so add it.
+	indexCandidates[currTable] = append(indexCandidates[currTable], newIndex)
+}

--- a/pkg/sql/opt/indexrec/index_candidate_set_test.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set_test.go
@@ -1,0 +1,269 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package indexrec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+)
+
+func TestCopyIndexes(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	inputIndexes1 := testIndexCandidates1(tables, indexCols)
+	inputIndexes2 := testIndexCandidates2(tables, indexCols)
+	duplicateInputIndexes1 := testDuplicateIndexCandidates1(tables, indexCols)
+	testData := []struct {
+		inputIndexes    map[cat.Table][][]cat.IndexColumn
+		outputIndexes   map[cat.Table][][]cat.IndexColumn
+		expectedIndexes map[cat.Table][][]cat.IndexColumn
+	}{
+		{
+			inputIndexes1,
+			make(map[cat.Table][][]cat.IndexColumn),
+			inputIndexes1,
+		},
+		{
+			inputIndexes2,
+			make(map[cat.Table][][]cat.IndexColumn),
+			inputIndexes2,
+		},
+		// Ensure duplicate indexes are removed when copying.
+		{
+			duplicateInputIndexes1,
+			make(map[cat.Table][][]cat.IndexColumn),
+			inputIndexes1,
+		},
+	}
+
+	for _, d := range testData {
+		copyIndexes(d.inputIndexes, d.outputIndexes)
+		if !candidatesAreEqual(d.expectedIndexes, d.outputIndexes) {
+			t.Errorf(
+				"expected copied indexes to be %+v,\ngot %+v\n", d.expectedIndexes, d.outputIndexes,
+			)
+		}
+	}
+}
+
+func TestGroupIndexesByTable(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	inputIndexes := testIndexCandidates2(tables, indexCols)
+	outputIndexes := make(map[cat.Table][][]cat.IndexColumn)
+	expectedIndexes := map[cat.Table][][]cat.IndexColumn{
+		tables[1]: {[]cat.IndexColumn{indexCols[0], indexCols[2], indexCols[1]}},
+	}
+
+	groupIndexesByTable(inputIndexes, outputIndexes)
+
+	if !candidatesAreEqual(expectedIndexes, outputIndexes) {
+		t.Errorf(
+			"expected grouped indexes to be %+v,\ngot %+v\n", expectedIndexes, outputIndexes,
+		)
+	}
+}
+
+func TestConstructIndexCombinations(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	inputIndexes1 := testIndexCandidates1(tables, indexCols)
+	inputIndexes2 := testIndexCandidates2(tables, indexCols)
+	outputIndexes := make(map[cat.Table][][]cat.IndexColumn)
+	expectedIndexes := map[cat.Table][][]cat.IndexColumn{
+		tables[1]: {
+			[]cat.IndexColumn{
+				indexCols[1], indexCols[2], indexCols[0],
+			},
+			[]cat.IndexColumn{
+				indexCols[0], indexCols[2],
+			},
+			[]cat.IndexColumn{
+				indexCols[0], indexCols[1],
+			},
+		},
+	}
+
+	constructIndexCombinations(inputIndexes1, inputIndexes2, outputIndexes)
+
+	if !candidatesAreEqual(expectedIndexes, outputIndexes) {
+		t.Errorf(
+			"expected index combinations to be %+v,\ngot %+v\n", expectedIndexes, outputIndexes,
+		)
+	}
+}
+
+func TestAddIndexToCandidates(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	newIndex := []cat.IndexColumn{indexCols[0]}
+	existingIndex := []cat.IndexColumn{indexCols[0], indexCols[1]}
+	indexCandidates := testIndexCandidates1(tables, indexCols)
+	updatedIndexCandidates := testUpdatedIndexCandidates1(tables, indexCols, newIndex)
+	testData := []struct {
+		newIndex        []cat.IndexColumn
+		table           cat.Table
+		inputIndexes    map[cat.Table][][]cat.IndexColumn
+		expectedIndexes map[cat.Table][][]cat.IndexColumn
+	}{
+		{
+			newIndex,
+			tables[0],
+			make(map[cat.Table][][]cat.IndexColumn),
+			map[cat.Table][][]cat.IndexColumn{tables[0]: {newIndex}},
+		},
+		{
+			existingIndex,
+			tables[0],
+			indexCandidates,
+			indexCandidates,
+		},
+		{
+			newIndex,
+			tables[0],
+			indexCandidates,
+			updatedIndexCandidates,
+		},
+	}
+
+	for _, d := range testData {
+		addIndexToCandidates(d.newIndex, d.table, d.inputIndexes)
+		if !candidatesAreEqual(d.expectedIndexes, d.inputIndexes) {
+			t.Errorf("expected indexes to be %+v,\ngot %+v\n", d.expectedIndexes, d.inputIndexes)
+		}
+	}
+}
+
+func testIndexCandidates1(
+	tables []cat.Table, indexCols []cat.IndexColumn,
+) map[cat.Table][][]cat.IndexColumn {
+	outputMap := map[cat.Table][][]cat.IndexColumn{
+		tables[0]: {[]cat.IndexColumn{indexCols[1]}, []cat.IndexColumn{indexCols[0], indexCols[1]}},
+		tables[1]: {
+			[]cat.IndexColumn{indexCols[1], indexCols[2]},
+			[]cat.IndexColumn{indexCols[0]},
+			[]cat.IndexColumn{indexCols[0], indexCols[2], indexCols[1]},
+		},
+	}
+	return outputMap
+}
+
+func testDuplicateIndexCandidates1(
+	tables []cat.Table, indexCols []cat.IndexColumn,
+) map[cat.Table][][]cat.IndexColumn {
+	outputMap := testIndexCandidates1(tables, indexCols)
+	outputMap[tables[0]] = append(outputMap[tables[0]], outputMap[tables[0]][0])
+	outputMap[tables[1]] = append(outputMap[tables[1]], outputMap[tables[1]][0])
+	outputMap[tables[1]] = append(outputMap[tables[1]], outputMap[tables[1]][1])
+	return outputMap
+}
+
+func testUpdatedIndexCandidates1(
+	tables []cat.Table, indexCols []cat.IndexColumn, index []cat.IndexColumn,
+) map[cat.Table][][]cat.IndexColumn {
+	outputMap := testIndexCandidates1(tables, indexCols)
+	outputMap[tables[0]] = append(outputMap[tables[0]], index)
+	return outputMap
+}
+
+func testIndexCandidates2(
+	tables []cat.Table, indexCols []cat.IndexColumn,
+) map[cat.Table][][]cat.IndexColumn {
+	outputMap := map[cat.Table][][]cat.IndexColumn{
+		tables[1]: {[]cat.IndexColumn{indexCols[0], indexCols[2]}, []cat.IndexColumn{indexCols[1]}},
+	}
+	return outputMap
+}
+
+func testTablesAndIndexCols() ([]cat.Table, []cat.IndexColumn) {
+	table1 := testcat.Table{TabID: 1}
+	table2 := testcat.Table{TabID: 2}
+	col1 := cat.Column{}
+	col2 := cat.Column{}
+	col3 := cat.Column{}
+
+	col1.Init(0,
+		1,
+		"k",
+		cat.Ordinary,
+		nil,
+		false,
+		cat.Visible,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
+		nil, /* onUpdateExpr */
+		cat.NotGeneratedAsIdentity,
+		nil /* generatedAsIdentitySequenceOption */)
+	col2.Init(1,
+		2,
+		"i",
+		cat.Ordinary,
+		nil,
+		false,
+		cat.Visible,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
+		nil, /* onUpdateExpr */
+		cat.NotGeneratedAsIdentity,
+		nil /* generatedAsIdentitySequenceOption */)
+	col3.Init(2,
+		3,
+		"j",
+		cat.Ordinary,
+		nil,
+		false,
+		cat.Visible,
+		nil, /* defaultExpr */
+		nil, /* computedExpr */
+		nil, /* onUpdateExpr */
+		cat.NotGeneratedAsIdentity,
+		nil /* generatedAsIdentitySequenceOption */)
+
+	indexCol1 := cat.IndexColumn{Column: &col1, Descending: false}
+	indexCol2 := cat.IndexColumn{Column: &col2, Descending: false}
+	indexCol3 := cat.IndexColumn{Column: &col3, Descending: true}
+
+	return []cat.Table{&table1, &table2}, []cat.IndexColumn{indexCol1, indexCol2, indexCol3}
+}
+
+func candidatesAreEqual(leftCandidates, rightCandidates map[cat.Table][][]cat.IndexColumn) bool {
+	// Check that both candidate sets have the same table keys.
+	for t := range leftCandidates {
+		if _, found := rightCandidates[t]; !found {
+			return false
+		}
+	}
+	for t := range rightCandidates {
+		if _, found := leftCandidates[t]; !found {
+			return false
+		}
+	}
+
+	// Since the tables are the same, we can equivalently iterate over either map.
+	for t := range leftCandidates {
+		leftIndexes := leftCandidates[t]
+		rightIndexes := rightCandidates[t]
+		if len(leftIndexes) != len(rightIndexes) {
+			return false
+		}
+		for i := range leftIndexes {
+			leftIndex := leftIndexes[i]
+			rightIndex := rightIndexes[i]
+			if len(leftIndex) != len(rightIndex) {
+				return false
+			}
+			for j := range leftIndex {
+				if leftIndex[j] != rightIndex[j] {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/exec/execbuilder",
+        "//pkg/sql/opt/indexrec",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
         "//pkg/sql/opt/optbuilder",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -393,6 +394,11 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //    check-size will result in a test error if the rule application or memo
 //    group count exceeds the corresponding limit.
 //
+//  - index-candidates
+//
+//    Walks through the SQL statement to determine candidates for index
+//    recommendation. See the indexrec package.
+//
 // Supported flags:
 //
 //  - format: controls the formatting of expressions for build, opt, and
@@ -706,6 +712,10 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		if err != nil {
 			d.Fatalf(tb, "%+v", err)
 		}
+		return result
+
+	case "index-candidates":
+		result := ot.IndexCandidates()
 		return result
 
 	default:
@@ -1971,6 +1981,44 @@ func (ot *OptTester) CheckSize() (string, error) {
 		return "", fmt.Errorf("memo groups exceeded limit: %d groups", groups)
 	}
 	return fmt.Sprintf("Rules Applied: %d\nGroups Added: %d\n", ruleApplications, groups), nil
+}
+
+// IndexCandidates is used with the index-candidates option. It finds index
+// candidates for the SQL statement and formats them as a sorted string.
+func (ot *OptTester) IndexCandidates() string {
+	expr, _ := ot.OptNorm()
+	indexCandidates := indexrec.FindIndexCandidateSet(expr, expr.(memo.RelExpr).Memo().Metadata())
+
+	// Build a formatted string to output from the map of indexCandidates.
+	tablesOutput := make([]string, 0, len(indexCandidates))
+	for t, indexes := range indexCandidates {
+		var tableSb strings.Builder
+		tableName := t.Name()
+		tableSb.WriteString(tableName.String())
+		tableSb.WriteString(":\n")
+		indexesOutput := make([]string, len(indexes))
+		for i, index := range indexes {
+			var indexSb strings.Builder
+			indexSb.WriteString(" (")
+			for j, indexCol := range index {
+				if j > 0 {
+					indexSb.WriteString(", ")
+				}
+				colName := indexCol.Column.ColName()
+				indexSb.WriteString(colName.String())
+				if indexCol.Descending {
+					indexSb.WriteString(" DESC")
+				}
+			}
+			indexSb.WriteString(")\n")
+			indexesOutput[i] = indexSb.String()
+		}
+		sort.Strings(indexesOutput)
+		tableSb.WriteString(strings.Join(indexesOutput, ""))
+		tablesOutput = append(tablesOutput, tableSb.String())
+	}
+	sort.Strings(tablesOutput)
+	return strings.Join(tablesOutput, "")
 }
 
 func (ot *OptTester) buildExpr(factory *norm.Factory) error {

--- a/pkg/sql/opt/testutils/opttester/testdata/index-candidates
+++ b/pkg/sql/opt/testutils/opttester/testdata/index-candidates
@@ -1,0 +1,216 @@
+exec-ddl
+CREATE TABLE t1 (k INT, i INT, f FLOAT, s STRING)
+----
+
+exec-ddl
+CREATE TABLE t2 (k INT, i INT, s STRING)
+----
+
+exec-ddl
+CREATE TABLE t3 (k INT, i INT, f FLOAT)
+----
+
+# Basic tests for comparison operator, range, equality, join, order by, and
+# group by candidates.
+
+index-candidates
+SELECT * FROM t1 WHERE i >= 3
+----
+t1:
+ (i)
+
+index-candidates
+SELECT f FROM t1 WHERE k < 3 AND i > 5
+----
+t1:
+ (i)
+ (k)
+
+index-candidates
+SELECT * FROM t1 WHERE f > 2 AND f < 8
+----
+t1:
+ (f)
+
+index-candidates
+SELECT i, f FROM t1 WHERE k = 3
+----
+t1:
+ (k)
+
+index-candidates
+SELECT * FROM t1 WHERE k = 1 AND i = 2
+----
+t1:
+ (i)
+ (k)
+ (k, i)
+
+index-candidates
+SELECT * FROM t1 JOIN t2 ON t1.k = t2.i
+----
+t1:
+ (k)
+t2:
+ (i)
+
+index-candidates
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.s LIKE t2.s
+----
+t1:
+ (s)
+t2:
+ (s)
+
+index-candidates
+SELECT * FROM t1 ORDER BY i
+----
+t1:
+ (i)
+
+index-candidates
+SELECT * FROM t1 ORDER BY k DESC, i ASC
+----
+t1:
+ (k, i DESC)
+
+index-candidates
+SELECT count(*) FROM t1 GROUP BY k
+----
+t1:
+ (k)
+
+index-candidates
+SELECT sum(k) FROM t1 GROUP BY i, f, k
+----
+t1:
+ (k, i, f)
+
+# Test joins with more complicated predicates. See rule 3 and rule 4 in
+# indexrec.FindIndexCandidates.
+
+index-candidates
+SELECT *
+FROM t1 FULL JOIN t2
+ON t2.k IS NULL
+AND t1.f::STRING NOT LIKE t2.i::STRING
+----
+t1:
+ (f)
+t2:
+ (i)
+ (k)
+ (k, i)
+
+index-candidates
+SELECT *
+FROM t1 LEFT JOIN t2
+ON t1.k != t2.k
+AND t1.s IS NOT NULL
+AND t2.i IS NULL
+----
+t1:
+ (k)
+ (k, s)
+ (s)
+t2:
+ (i)
+ (i, k)
+ (k)
+
+# Test more complex queries. See rule 5 in indexrec.FindIndexCandidates. The
+# aspects of rule 5 that are demonstrated by each test are highlighted the
+# test's comment.
+
+# Multi-column combinations used: EQ + R.
+index-candidates
+SELECT * FROM t1 WHERE k = 1 AND f > 0
+----
+t1:
+ (f)
+ (k)
+ (k, f)
+
+# Multi-column combinations used: EQ, EQ + R.
+index-candidates
+SELECT * FROM t1 WHERE k = 1 AND i = 2 AND f > 0
+----
+t1:
+ (f)
+ (i)
+ (k)
+ (k, i)
+ (k, i, f)
+
+# Multi-column combinations used: J + R.
+index-candidates
+SELECT * FROM t1 JOIN t2 ON t1.k != t2.k WHERE t1.f > 0
+----
+t1:
+ (f)
+ (k)
+ (k, f)
+t2:
+ (k)
+
+# Multi-column combinations used: EQ, EQ + J.
+index-candidates
+SELECT * FROM t1 JOIN t2 ON t1.k != t2.k WHERE t1.i = 2 AND t1.s = 'NG'
+----
+t1:
+ (i)
+ (i, s)
+ (i, s, k)
+ (k)
+ (s)
+t2:
+ (k)
+
+# Multi-column combinations used: EQ, EQ + R, J + R, EQ + J, EQ + J + R.
+index-candidates
+SELECT count(*)
+FROM t1 LEFT JOIN t2
+ON t1.k != t2.k
+GROUP BY t2.s, t2.i
+UNION ALL
+SELECT count(*)
+FROM (
+  SELECT *
+  FROM t1
+  WHERE t1.f > t1.i
+  AND t1.s = 'NG'
+)
+----
+t1:
+ (f)
+ (i)
+ (k)
+ (k, f)
+ (k, i)
+ (s)
+ (s, f)
+ (s, i)
+ (s, k)
+ (s, k, f)
+ (s, k, i)
+t2:
+ (i, s)
+ (k)
+
+# No rule 5 multi-column index combinations.
+index-candidates
+SELECT *
+FROM t1 LEFT JOIN t2
+ON t1.k = t2.k
+WHERE EXISTS (SELECT * FROM t3 WHERE t3.f > t3.k)
+ORDER BY t1.k, t2.i, t1.i DESC
+----
+t1:
+ (k)
+ (k, i DESC)
+t2:
+ (i)
+ (k)
+t3:
+ (f)
+ (k)


### PR DESCRIPTION
**indexrec: add index candidate set**

This commit adds the logic to walk a normalized expression to find
index candidates for recommendation. It also adds the associated testing.
There are unit tests for some unexported functions in
`pkg/sql/opt/indexrec/index_candidate_set.go`. Additionally, there are
datadriven tests using the opttester for the exported `FindIndexCandidates`
function.

See the function comment in `FindIndexCandidates` to see how these index
candidates are chosen.

Informs #72753.