### PR TITLE
server,log: use shared logging tags in AmbientContext

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -177,6 +177,7 @@ func MakeBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 		DefaultZoneConfig: zonepb.DefaultZoneConfig(),
 		StorageEngine:     storage.DefaultStorageEngine,
 	}
+	baseCfg.AmbientCtx.InitializeSharedLogTags()
 	baseCfg.InitDefaults()
 	return baseCfg
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -287,7 +287,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// is constructed. The node ID is set by the Store if this host was
 	// bootstrapped; otherwise a new one is allocated in Node.
 	nodeIDContainer := &base.NodeIDContainer{}
-	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
+	cfg.AmbientCtx.AddSharedLogTag("n", nodeIDContainer)
 	const sqlInstanceID = base.SQLInstanceID(0)
 	idContainer := base.NewSQLIDContainer(sqlInstanceID, nodeIDContainer)
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -380,7 +380,7 @@ func makeTenantSQLServerArgs(
 	// We use the tag "sqli" instead of just "sql" because the latter is
 	// too generic and would be hard to search if someone was looking at
 	// a log message and wondering what it stands for.
-	baseCfg.AmbientCtx.AddLogTag("sqli", instanceIDContainer)
+	baseCfg.AmbientCtx.AddSharedLogTag("sqli", instanceIDContainer)
 	startupCtx = baseCfg.AmbientCtx.AnnotateCtx(startupCtx)
 
 	// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/logtags"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,18 +26,14 @@ func TestAnnotateCtxTags(t *testing.T) {
 	ac.AddLogTag("b", 2)
 
 	ctx := ac.AnnotateCtx(context.Background())
-	if exp, val := "[a1,b2] test", FormatWithContextTags(ctx, "test"); val != exp {
-		t.Errorf("expected '%s', got '%s'", exp, val)
-	}
+	assert.Equal(t, "[a1,b2] test", FormatWithContextTags(ctx, "test"))
 
 	ctx = context.Background()
 	ctx = logtags.AddTag(ctx, "a", 10)
 	ctx = logtags.AddTag(ctx, "aa", nil)
 	ctx = ac.AnnotateCtx(ctx)
 
-	if exp, val := "[a1,aa,b2] test", FormatWithContextTags(ctx, "test"); val != exp {
-		t.Errorf("expected '%s', got '%s'", exp, val)
-	}
+	assert.Equal(t, "[a1,aa,b2] test", FormatWithContextTags(ctx, "test"))
 }
 
 func TestAnnotateCtxSpan(t *testing.T) {
@@ -57,7 +54,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 	Event(ctx1, "c")
 	sp2.Finish()
 
-	if err := tracing.CheckRecordedSpans(sp1.FinishAndGetRecording(tracing.RecordingVerbose), `
+	require.NoError(t, tracing.CheckRecordedSpans(sp1.FinishAndGetRecording(tracing.RecordingVerbose), `
 		span: root
 			tags: _verbose=1
 			event: a
@@ -65,9 +62,7 @@ func TestAnnotateCtxSpan(t *testing.T) {
 			span: child
 				tags: _verbose=1 ambient=
 				event: [ambient] b
-	`); err != nil {
-		t.Fatal(err)
-	}
+	`))
 
 	// Annotate a context that has no span. The tracer will create a non-recordable
 	// span. We just check here that AnnotateCtxWithSpan properly returns it to the
@@ -93,12 +88,8 @@ func TestAnnotateCtxNodeStoreReplica(t *testing.T) {
 	ctx := n.AnnotateCtx(context.Background())
 	ctx = s.AnnotateCtx(ctx)
 	ctx = r.AnnotateCtx(ctx)
-	if exp, val := "[n1,s2,r3] test", FormatWithContextTags(ctx, "test"); val != exp {
-		t.Errorf("expected '%s', got '%s'", exp, val)
-	}
-	if tags := logtags.FromContext(ctx); tags != r.tags {
-		t.Errorf("expected %p, got %p", r.tags, tags)
-	}
+	assert.Equal(t, "[n1,s2,r3] test", FormatWithContextTags(ctx, "test"))
+	require.Equal(t, r.privateTags, logtags.FromContext(ctx))
 }
 
 func TestResetAndAnnotateCtx(t *testing.T) {
@@ -108,7 +99,5 @@ func TestResetAndAnnotateCtx(t *testing.T) {
 	ctx := context.Background()
 	ctx = logtags.AddTag(ctx, "b", 2)
 	ctx = ac.ResetAndAnnotateCtx(ctx)
-	if exp, val := "[a1] test", FormatWithContextTags(ctx, "test"); val != exp {
-		t.Errorf("expected '%s', got '%s'", exp, val)
-	}
+	assert.Equal(t, "[a1] test", FormatWithContextTags(ctx, "test"))
 }


### PR DESCRIPTION
Informs #58938.

## log: enhance AmbientContext with shared tags

This change is motivated by a defect in the CockroachDB server
initialization: many components take `AmbientContext` by copy, and the
logging tags that define "interesting", common server properties
(such as the node ID) are only set after some components have been
initialized already.

How to feed these common properties in the log tags of every
AmbientContext instance?

This commit helps by extending the semantics of AmbientContext
with the notion of "shared tags", which are shared across
copies of AmbientContext from a common ancestor.

## server: use shared log tags for server ID across all components

Prior to this patch, we were not able to effectively ensure that
trace/logging output for all server components would reliably contain
a node ID or SQL instance ID. This is because many events are produced
via a fresh context populated via `(*AmbientContext).AnnotateCtx()`,
and we did not have a reliable way to ensure that all the
`AmbientContext` instances would have a common set of logging
tags.

This is because each component uses its own copy of AmbientContext taken
from `(server.BaseConfig).AmbientContext`, and components take that
copy before the code that instantiates `NodeIDContainer` /
`SQLInstanceIDContainer` gets a chance to run.

To alleviate this, this patch switches the `n` and `sqli` tags for the
node ID and SQL instance ID to use the new shared log tag facility
introduced in the previous commit.
