### PR TITLE
roachprod: replace fatal logging by propagating errors

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -47,7 +47,7 @@ import (
 
 // ClusterImpl TODO(peter): document
 type ClusterImpl interface {
-	Start(c *SyncedCluster, extraArgs []string)
+	Start(c *SyncedCluster, extraArgs []string) error
 	CertsDir(c *SyncedCluster, index int) string
 	NodeDir(c *SyncedCluster, index, storeIndex int) string
 	LogDir(c *SyncedCluster, index int) string
@@ -117,7 +117,7 @@ type SyncedCluster struct {
 
 // NewSyncedCluster creates a SyncedCluster, given the cluster metadata and
 // settings.
-func NewSyncedCluster(metadata *cloud.Cluster, settings ClusterSettings) *SyncedCluster {
+func NewSyncedCluster(metadata *cloud.Cluster, settings ClusterSettings) (*SyncedCluster, error) {
 	c := &SyncedCluster{
 		Cluster:         *metadata,
 		ClusterSettings: settings,
@@ -125,7 +125,11 @@ func NewSyncedCluster(metadata *cloud.Cluster, settings ClusterSettings) *Synced
 	}
 	c.Localities = make([]string, len(c.VMs))
 	for i := range c.VMs {
-		c.Localities[i] = c.VMs[i].Locality()
+		var err error
+		c.Localities[i], err = c.VMs[i].Locality()
+		if err != nil {
+			return nil, err
+		}
 		if c.NumRacks > 0 {
 			rack := fmt.Sprintf("rack=%d", i%c.NumRacks)
 			if c.Localities[i] != "" {
@@ -134,7 +138,7 @@ func NewSyncedCluster(metadata *cloud.Cluster, settings ClusterSettings) *Synced
 			c.Localities[i] += rack
 		}
 	}
-	return c
+	return c, nil
 }
 
 func (c *SyncedCluster) host(index int) string {
@@ -246,8 +250,8 @@ func (c *SyncedCluster) roachprodEnvRegex(node int) string {
 }
 
 // Start TODO(peter): document
-func (c *SyncedCluster) Start() {
-	c.Impl.Start(c, c.Args)
+func (c *SyncedCluster) Start() error {
+	return c.Impl.Start(c, c.Args)
 }
 
 func (c *SyncedCluster) newSession(i int) (session, error) {
@@ -264,12 +268,12 @@ func (c *SyncedCluster) newSession(i int) (session, error) {
 //
 // When running roachprod stop without other flags, the signal is 9 (SIGKILL)
 // and wait is true.
-func (c *SyncedCluster) Stop(sig int, wait bool) {
+func (c *SyncedCluster) Stop(sig int, wait bool) error {
 	display := fmt.Sprintf("%s: stopping", c.Name)
 	if wait {
 		display += " and waiting"
 	}
-	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+	return c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
@@ -316,10 +320,12 @@ fi`,
 }
 
 // Wipe TODO(peter): document
-func (c *SyncedCluster) Wipe(preserveCerts bool) {
+func (c *SyncedCluster) Wipe(preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	c.Stop(9, true /* wait */)
-	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Stop(9, true /* wait */); err != nil {
+		return err
+	}
+	return c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
@@ -350,10 +356,10 @@ sudo rm -fr logs &&
 }
 
 // Status TODO(peter): document
-func (c *SyncedCluster) Status() {
+func (c *SyncedCluster) Status() error {
 	display := fmt.Sprintf("%s: status", c.Name)
 	results := make([]string, len(c.Nodes))
-	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			results[i] = err.Error()
@@ -385,11 +391,13 @@ fi
 		}
 		results[i] = msg
 		return nil, nil
-	})
-
+	}); err != nil {
+		return err
+	}
 	for i, r := range results {
 		fmt.Printf("  %2d: %s\n", c.Nodes[i], r)
 	}
+	return nil
 }
 
 // NodeMonitorInfo is a message describing a cockroach process' status.
@@ -590,7 +598,7 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 
 	errs := make([]error, len(nodes))
 	results := make([]string, len(nodes))
-	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(nodes[i])
 		if err != nil {
 			errs[i] = err
@@ -646,14 +654,15 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 		}
 		results[i] = msg
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	if !stream {
 		for i, r := range results {
 			fmt.Fprintf(stdout, "  %2d: %s\n", nodes[i], r)
 		}
 	}
-
 	return rperrors.SelectPriorityError(errs)
 }
 
@@ -661,7 +670,7 @@ func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd st
 func (c *SyncedCluster) Wait() error {
 	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)
 	errs := make([]error, len(c.Nodes))
-	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		for j := 0; j < 600; j++ {
 			sess, err := c.newSession(c.Nodes[i])
 			if err != nil {
@@ -679,7 +688,9 @@ func (c *SyncedCluster) Wait() error {
 		}
 		errs[i] = errors.New("timed out after 5m")
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	var foundErr bool
 	for i, err := range errs {
@@ -722,7 +733,7 @@ func (c *SyncedCluster) SetupSSH() error {
 	// Generate an ssh key that we'll distribute to all of the nodes in the
 	// cluster in order to allow inter-node ssh.
 	var sshTar []byte
-	c.Parallel("generating ssh key", 1, 0, func(i int) ([]byte, error) {
+	if err := c.Parallel("generating ssh key", 1, 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(1)
 		if err != nil {
 			return nil, err
@@ -749,11 +760,13 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 		}
 		sshTar = stdout.Bytes()
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	// Skip the first node which is where we generated the key.
 	nodes := c.Nodes[1:]
-	c.Parallel("distributing ssh key", len(nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel("distributing ssh key", len(nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(nodes[i])
 		if err != nil {
 			return nil, err
@@ -766,14 +779,16 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 			return nil, errors.Wrapf(err, "%s: output:\n%s", cmd, out)
 		}
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	// Populate the known_hosts file with both internal and external IPs of all
 	// of the nodes in the cluster. Note that as a side effect, this creates the
 	// known hosts file in unhashed format, working around a limitation of jsch
 	// (which is used in jepsen tests).
 	ips := make([]string, len(c.Nodes), len(c.Nodes)*2)
-	c.Parallel("retrieving hosts", len(c.Nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel("retrieving hosts", len(c.Nodes), 0, func(i int) ([]byte, error) {
 		for j := 0; j < 20 && ips[i] == ""; j++ {
 			var err error
 			ips[i], err = c.GetInternalIP(c.Nodes[i])
@@ -786,12 +801,15 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 			return nil, fmt.Errorf("retrieved empty IP address")
 		}
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
+
 	for _, i := range c.Nodes {
 		ips = append(ips, c.host(i))
 	}
 	var knownHostsData []byte
-	c.Parallel("scanning hosts", 1, 0, func(i int) ([]byte, error) {
+	if err := c.Parallel("scanning hosts", 1, 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
@@ -829,8 +847,11 @@ exit 1
 		}
 		knownHostsData = stdout.Bytes()
 		return nil, nil
-	})
-	c.Parallel("distributing known_hosts", len(c.Nodes), 0, func(i int) ([]byte, error) {
+	}); err != nil {
+		return err
+	}
+
+	if err := c.Parallel("distributing known_hosts", len(c.Nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
@@ -869,14 +890,17 @@ fi
 			return nil, errors.Wrapf(err, "%s: output:\n%s", cmd, out)
 		}
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
+
 	if len(c.AuthorizedKeys) > 0 {
 		// When clusters are created using cloud APIs they only have a subset of
 		// desired keys installed on a subset of users. This code distributes
 		// additional authorized_keys to both the current user (your username on
 		// gce and the shared user on aws) as well as to the shared user on both
 		// platforms.
-		c.Parallel("adding additional authorized keys", len(c.Nodes), 0, func(i int) ([]byte, error) {
+		if err := c.Parallel("adding additional authorized keys", len(c.Nodes), 0, func(i int) ([]byte, error) {
 			sess, err := c.newSession(c.Nodes[i])
 			if err != nil {
 				return nil, err
@@ -910,7 +934,9 @@ fi
 				return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
 			}
 			return nil, nil
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -918,7 +944,7 @@ fi
 
 // DistributeCerts will generate and distribute certificates to all of the
 // nodes.
-func (c *SyncedCluster) DistributeCerts() {
+func (c *SyncedCluster) DistributeCerts() error {
 	dir := ""
 	if c.IsLocal() {
 		dir = c.localVMDir(1)
@@ -927,7 +953,7 @@ func (c *SyncedCluster) DistributeCerts() {
 	// Check to see if the certs have already been initialized.
 	var existsErr error
 	display := fmt.Sprintf("%s: checking certs", c.Name)
-	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+	if err := c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(1)
 		if err != nil {
 			return nil, err
@@ -935,10 +961,11 @@ func (c *SyncedCluster) DistributeCerts() {
 		defer sess.Close()
 		_, existsErr = sess.CombinedOutput(`test -e ` + filepath.Join(dir, `certs.tar`))
 		return nil, nil
-	})
-
+	}); err != nil {
+		return err
+	}
 	if existsErr == nil {
-		return
+		return nil
 	}
 
 	// Gather the internal IP addresses for every node in the cluster, even
@@ -950,15 +977,17 @@ func (c *SyncedCluster) DistributeCerts() {
 	var ips []string
 	if !c.IsLocal() {
 		ips = make([]string, len(nodes))
-		c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
+		if err := c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
 			var err error
 			ips[i], err = c.GetInternalIP(nodes[i])
 			return nil, errors.Wrapf(err, "IPs")
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	// Generate the ca, client and node certificates on the first node.
-	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+	if err := c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(1)
 		if err != nil {
 			return nil, err
@@ -1004,7 +1033,9 @@ tar cvf certs.tar certs
 			msg = fmt.Sprintf("%s: %v", out, err)
 		}
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	if msg != "" {
 		fmt.Fprintln(os.Stderr, msg)
@@ -1047,7 +1078,7 @@ tar cvf certs.tar certs
 	// Skip the first node which is where we generated the certs.
 	display = c.Name + ": distributing certs"
 	nodes = nodes[1:]
-	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+	return c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
 		sess, err := c.newSession(nodes[i])
 		if err != nil {
 			return nil, err
@@ -1082,7 +1113,7 @@ func formatProgress(p float64) string {
 }
 
 // Put TODO(peter): document
-func (c *SyncedCluster) Put(src, dest string) {
+func (c *SyncedCluster) Put(src, dest string) error {
 	// NB: This value was determined with a few experiments. Higher values were
 	// not tested.
 	const treeDistFanout = 10
@@ -1294,8 +1325,9 @@ func (c *SyncedCluster) Put(src, dest string) {
 	}
 
 	if haveErr {
-		log.Fatalf(context.Background(), "put %s failed", src)
+		return errors.Newf("put %s failed", src)
 	}
+	return nil
 }
 
 // Logs will sync the logs from c to dest with each nodes logs under dest in
@@ -1447,7 +1479,7 @@ func (c *SyncedCluster) Logs(
 }
 
 // Get TODO(peter): document
-func (c *SyncedCluster) Get(src, dest string) {
+func (c *SyncedCluster) Get(src, dest string) error {
 	// TODO(peter): Only get 10 nodes at a time. When a node completes, output a
 	// line indicating that.
 	var detail string
@@ -1649,32 +1681,38 @@ func (c *SyncedCluster) Get(src, dest string) {
 	}
 
 	if haveErr {
-		log.Fatalf(context.Background(), "get %s failed", src)
+		return errors.Newf("get %s failed", src)
 	}
+	return nil
 }
 
-func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
-	hosts := c.pghosts(nodes)
+func (c *SyncedCluster) pgurls(nodes []int) (map[int]string, error) {
+	hosts, err := c.pghosts(nodes)
+	if err != nil {
+		return nil, err
+	}
 	m := make(map[int]string, len(hosts))
 	for node, host := range hosts {
 		m[node] = c.Impl.NodeURL(c, host, c.Impl.NodePort(c, node))
 	}
-	return m
+	return m, nil
 }
 
-func (c *SyncedCluster) pghosts(nodes []int) map[int]string {
+func (c *SyncedCluster) pghosts(nodes []int) (map[int]string, error) {
 	ips := make([]string, len(nodes))
-	c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
+	if err := c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
 		var err error
 		ips[i], err = c.GetInternalIP(nodes[i])
 		return nil, errors.Wrapf(err, "pghosts")
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	m := make(map[int]string, len(ips))
 	for i, ip := range ips {
 		m[nodes[i]] = ip
 	}
-	return m
+	return m, nil
 }
 
 // SSH TODO(peter): document
@@ -1769,15 +1807,16 @@ type ParallelResult struct {
 // See ParallelE for more information.
 func (c *SyncedCluster) Parallel(
 	display string, count, concurrency int, fn func(i int) ([]byte, error),
-) {
+) error {
 	failed, err := c.ParallelE(display, count, concurrency, fn)
 	if err != nil {
 		sort.Slice(failed, func(i, j int) bool { return failed[i].Index < failed[j].Index })
 		for _, f := range failed {
 			fmt.Fprintf(os.Stderr, "%d: %+v: %s\n", f.Index, f.Err, f.Out)
 		}
-		log.Fatal(context.Background(), "command failed")
+		return err
 	}
+	return nil
 }
 
 // ParallelE runs the given function in parallel across the given
@@ -1894,7 +1933,7 @@ func (c *SyncedCluster) ParallelE(
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified. The implementation should be kept in
 // sync with Cockroach.Start.
-func (c *SyncedCluster) Init() {
+func (c *SyncedCluster) Init() error {
 	r := c.Impl.(Cockroach)
 	h := &crdbInstallHelper{c: c, r: r}
 
@@ -1904,17 +1943,17 @@ func (c *SyncedCluster) Init() {
 
 	vers, err := getCockroachVersion(c, c.ServerNodes()[firstNodeIdx])
 	if err != nil {
-		log.Fatalf(context.Background(), "unable to retrieve cockroach version: %v", err)
+		return errors.WithDetail(err, "install.Init() failed: unable to retrieve cockroach version.")
 	}
 
 	if !vers.AtLeast(version.MustParse("v20.1.0")) {
-		log.Fatal(context.Background(), "`roachprod init` only supported for v20.1 and beyond")
+		return errors.New("install.Init() failed: `roachprod init` only supported for v20.1 and beyond")
 	}
 
 	fmt.Printf("%s: initializing cluster\n", h.c.Name)
 	initOut, err := h.initializeCluster(firstNodeIdx)
 	if err != nil {
-		log.Fatalf(context.Background(), "unable to initialize cluster: %v", err)
+		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
 	}
 	if initOut != "" {
 		fmt.Println(initOut)
@@ -1923,9 +1962,10 @@ func (c *SyncedCluster) Init() {
 	fmt.Printf("%s: setting cluster settings\n", h.c.Name)
 	clusterSettingsOut, err := h.setClusterSettings(firstNodeIdx)
 	if err != nil {
-		log.Fatalf(context.Background(), "unable to set cluster settings: %v", err)
+		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
 	}
 	if clusterSettingsOut != "" {
 		fmt.Println(clusterSettingsOut)
 	}
+	return nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -11,7 +11,6 @@
 package install
 
 import (
-	"context"
 	_ "embed" // required for go:embed
 	"fmt"
 	"net/url"
@@ -27,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 )
@@ -143,9 +141,11 @@ func argExists(args []string, target string) int {
 // "first" node (node 1, as understood by SyncedCluster.ServerNodes), we use
 // `start-single-node` (this was written to provide a short hand to start a
 // single node cluster with a replication factor of one).
-func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
+func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) error {
 	h := &crdbInstallHelper{c: c, r: r}
-	h.distributeCerts()
+	if err := h.distributeCerts(); err != nil {
+		return err
+	}
 
 	nodes := c.ServerNodes()
 	var parallelism = 0
@@ -154,7 +154,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 	}
 
 	fmt.Printf("%s: starting nodes\n", c.Name)
-	c.Parallel("", len(nodes), parallelism, func(nodeIdx int) ([]byte, error) {
+	return c.Parallel("", len(nodes), parallelism, func(nodeIdx int) ([]byte, error) {
 		vers, err := getCockroachVersion(c, nodes[nodeIdx])
 		if err != nil {
 			return nil, err
@@ -191,7 +191,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			fmt.Printf("%s: initializing cluster\n", h.c.Name)
 			initOut, err := h.initializeCluster(nodeIdx)
 			if err != nil {
-				log.Fatalf(context.Background(), "unable to initialize cluster: %v", err)
+				return nil, errors.WithDetail(err, "unable to initialize cluster")
 			}
 
 			if initOut != "" {
@@ -212,7 +212,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 			markBootstrap := fmt.Sprintf("touch %s/%s", h.c.Impl.NodeDir(h.c, nodes[nodeIdx], 1 /* storeIndex */), "cluster-bootstrapped")
 			cmdOut, err := h.run(nodeIdx, markBootstrap)
 			if err != nil {
-				log.Fatalf(context.Background(), "unable to run cmd: %v", err)
+				return nil, errors.WithDetail(err, "unable to run cmd")
 			}
 			if cmdOut != "" {
 				fmt.Println(cmdOut)
@@ -225,7 +225,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		fmt.Printf("%s: setting cluster settings\n", h.c.Name)
 		clusterSettingsOut, err := h.setClusterSettings(nodeIdx)
 		if err != nil {
-			log.Fatalf(context.Background(), "unable to set cluster settings: %v", err)
+			return nil, errors.Wrap(err, "unable to set cluster settings")
 		}
 		if clusterSettingsOut != "" {
 			fmt.Println(clusterSettingsOut)
@@ -314,7 +314,7 @@ func (r Cockroach) SQL(c *SyncedCluster, args []string) error {
 	resultChan := make(chan result, len(c.Nodes))
 
 	display := fmt.Sprintf("%s: executing sql", c.Name)
-	c.Parallel(display, len(c.Nodes), 0, func(nodeIdx int) ([]byte, error) {
+	if err := c.Parallel(display, len(c.Nodes), 0, func(nodeIdx int) ([]byte, error) {
 		sess, err := c.newSession(c.Nodes[nodeIdx])
 		if err != nil {
 			return nil, err
@@ -336,7 +336,9 @@ func (r Cockroach) SQL(c *SyncedCluster, args []string) error {
 
 		resultChan <- result{node: c.Nodes[nodeIdx], output: string(out)}
 		return nil, nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	results := make([]result, 0, len(c.Nodes))
 	for range c.Nodes {
@@ -702,13 +704,16 @@ func (h *crdbInstallHelper) useStartSingleNode(vers *version.Version) bool {
 
 // distributeCerts, like the name suggests, distributes certs if it's a secure
 // cluster and we're starting n1.
-func (h *crdbInstallHelper) distributeCerts() {
+func (h *crdbInstallHelper) distributeCerts() error {
 	for _, node := range h.c.ServerNodes() {
 		if node == 1 && h.c.Secure {
-			h.c.DistributeCerts()
+			if err := h.c.DistributeCerts(); err != nil {
+				return err
+			}
 			break
 		}
 	}
+	return nil
 }
 
 func (h *crdbInstallHelper) shouldAdvertisePublicIP() bool {

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -113,7 +113,11 @@ func (e *expander) maybeExpandPgURL(c *SyncedCluster, s string) (string, bool, e
 	}
 
 	if e.pgURLs == nil {
-		e.pgURLs = c.pgurls(allNodes(len(c.VMs)))
+		var err error
+		e.pgURLs, err = c.pgurls(allNodes(len(c.VMs)))
+		if err != nil {
+			return "", false, err
+		}
 	}
 
 	s, err := e.maybeExpandMap(c, e.pgURLs, m[1])
@@ -128,7 +132,11 @@ func (e *expander) maybeExpandPgHost(c *SyncedCluster, s string) (string, bool, 
 	}
 
 	if e.pgHosts == nil {
-		e.pgHosts = c.pghosts(allNodes(len(c.VMs)))
+		var err error
+		e.pgHosts, err = c.pghosts(allNodes(len(c.VMs)))
+		if err != nil {
+			return "", false, err
+		}
 	}
 
 	s, err := e.maybeExpandMap(c, e.pgHosts, m[1])

--- a/pkg/roachprod/vm/BUILD.bazel
+++ b/pkg/roachprod/vm/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachprod/config",
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -11,7 +11,6 @@
 package vm
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -20,7 +19,6 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -92,16 +90,16 @@ func (vm *VM) IsLocal() bool {
 
 // Locality returns the cloud, region, and zone for the VM.  We want to include the cloud, since
 // GCE and AWS use similarly-named regions (e.g. us-east-1)
-func (vm *VM) Locality() string {
+func (vm *VM) Locality() (string, error) {
 	var region string
 	if vm.IsLocal() {
 		region = vm.Zone
 	} else if match := regionRE.FindStringSubmatch(vm.Zone); len(match) == 2 {
 		region = match[1]
 	} else {
-		log.Fatalf(context.Background(), "unable to parse region from zone %q", vm.Zone)
+		return "", errors.Newf("unable to parse region from zone %q", vm.Zone)
 	}
-	return fmt.Sprintf("cloud=%s,region=%s,zone=%s", vm.Provider, region, vm.Zone)
+	return fmt.Sprintf("cloud=%s,region=%s,zone=%s", vm.Provider, region, vm.Zone), nil
 }
 
 // ZoneEntry returns a line representing the VMs DNS zone entry


### PR DESCRIPTION
Fatal logging prevented errors from being properly propagated back
to the binary error wrapper.

Release note: None