### PR TITLE
sql: miscellaneous cleanup

### DIFF
--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -44,7 +44,7 @@ func TestDiskQueue(t *testing.T) {
 		for _, bufferSizeBytes := range []int{0, 16<<10 + rng.Intn(1<<20) /* 16 KiB up to 1 MiB */} {
 			for _, maxFileSizeBytes := range []int{10 << 10 /* 10 KiB */, 1<<20 + rng.Intn(64<<20) /* 1 MiB up to 64 MiB */} {
 				alwaysCompress := rng.Float64() < 0.5
-				diskQueueCacheMode := colcontainer.DiskQueueCacheModeDefault
+				diskQueueCacheMode := colcontainer.DiskQueueCacheModeIntertwinedCalls
 				// testReuseCache will test the reuse cache modes.
 				testReuseCache := rng.Float64() < 0.5
 				dequeuedProbabilityBeforeAllEnqueuesAreDone := 0.5
@@ -79,8 +79,7 @@ func TestDiskQueue(t *testing.T) {
 					op.Init(ctx)
 					typs := op.Typs()
 
-					queueCfg.CacheMode = diskQueueCacheMode
-					queueCfg.SetDefaultBufferSizeBytesForCacheMode()
+					queueCfg.SetCacheMode(diskQueueCacheMode)
 					if !rewindable {
 						if !testReuseCache {
 							queueCfg.BufferSizeBytes = bufferSizeBytes

--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/col/coldataext",
         "//pkg/col/typeconv",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/colcontainer",
         "//pkg/sql/colconv",
         "//pkg/sql/colexec",
         "//pkg/sql/colexec/colexecagg",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -346,8 +346,6 @@ func (r opResult) createDiskBackedSort(
 	opNamePrefix string,
 	factory coldata.ColumnFactory,
 ) colexecop.Operator {
-	streamingMemAccount := args.StreamingMemAccount
-	useStreamingMemAccountForBuffering := args.TestingKnobs.UseStreamingMemAccountForBuffering
 	var (
 		sorterMemMonitorName string
 		inMemorySorter       colexecop.Operator
@@ -364,13 +362,9 @@ func (r opResult) createDiskBackedSort(
 		// sorter should output. Use a top K sorter, which uses a heap to avoid
 		// storing more rows than necessary.
 		var topKSorterMemAccount *mon.BoundAccount
-		if useStreamingMemAccountForBuffering {
-			topKSorterMemAccount = streamingMemAccount
-		} else {
-			topKSorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
-				ctx, flowCtx, spoolMemLimit, opNamePrefix+"topk-sort", processorID,
-			)
-		}
+		topKSorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
+			ctx, flowCtx, spoolMemLimit, opNamePrefix+"topk-sort", processorID,
+		)
 		inMemorySorter = colexec.NewTopKSorter(
 			colmem.NewAllocator(ctx, topKSorterMemAccount, factory), input,
 			inputTypes, ordering.Columns, int(matchLen), uint64(limit), maxOutputBatchMemSize,
@@ -379,13 +373,9 @@ func (r opResult) createDiskBackedSort(
 		// The input is already partially ordered. Use a chunks sorter to avoid
 		// loading all the rows into memory.
 		var sortChunksMemAccount *mon.BoundAccount
-		if useStreamingMemAccountForBuffering {
-			sortChunksMemAccount = streamingMemAccount
-		} else {
-			sortChunksMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
-				ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-chunks", processorID,
-			)
-		}
+		sortChunksMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
+			ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-chunks", processorID,
+		)
 		inMemorySorter = colexec.NewSortChunks(
 			colmem.NewAllocator(ctx, sortChunksMemAccount, factory), input, inputTypes,
 			ordering.Columns, int(matchLen), maxOutputBatchMemSize,
@@ -393,22 +383,15 @@ func (r opResult) createDiskBackedSort(
 	} else {
 		// No optimizations possible. Default to the standard sort operator.
 		var sorterMemAccount *mon.BoundAccount
-		if useStreamingMemAccountForBuffering {
-			sorterMemAccount = streamingMemAccount
-		} else {
-			sorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
-				ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-all", processorID,
-			)
-		}
+		sorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
+			ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-all", processorID,
+		)
 		inMemorySorter = colexec.NewSorter(
 			colmem.NewAllocator(ctx, sorterMemAccount, factory), input,
 			inputTypes, ordering.Columns, maxOutputBatchMemSize,
 		)
 	}
-	if inMemorySorter == nil {
-		colexecerror.InternalError(errors.AssertionFailedf("unexpectedly inMemorySorter is nil"))
-	}
-	if useStreamingMemAccountForBuffering || args.TestingKnobs.DiskSpillingDisabled {
+	if args.TestingKnobs.DiskSpillingDisabled {
 		// In some testing scenarios we actually don't want to create a
 		// disk-backed sort.
 		return inMemorySorter
@@ -665,7 +648,6 @@ func NewColOperator(
 	}
 	streamingMemAccount := args.StreamingMemAccount
 	streamingAllocator := colmem.NewAllocator(ctx, streamingMemAccount, factory)
-	useStreamingMemAccountForBuffering := args.TestingKnobs.UseStreamingMemAccountForBuffering
 	if args.ExprHelper == nil {
 		args.ExprHelper = colexecargs.NewExprHelper()
 		args.ExprHelper.SemaCtx = flowCtx.TypeResolverFactory.NewSemaContext(flowCtx.Txn)
@@ -1034,21 +1016,13 @@ func NewColOperator(
 				)
 				result.ToClose = append(result.ToClose, result.Root.(colexecop.Closer))
 			} else {
-				var hashJoinerMemMonitorName string
-				var hashJoinerMemAccount *mon.BoundAccount
-				var hashJoinerUnlimitedAllocator *colmem.Allocator
-				if useStreamingMemAccountForBuffering {
-					hashJoinerMemAccount = streamingMemAccount
-					hashJoinerUnlimitedAllocator = streamingAllocator
-				} else {
-					opName := "hash-joiner"
-					hashJoinerMemAccount, hashJoinerMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategy(
-						ctx, flowCtx, opName, spec.ProcessorID,
-					)
-					hashJoinerUnlimitedAllocator = colmem.NewAllocator(
-						ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, spec.ProcessorID), factory,
-					)
-				}
+				opName := "hash-joiner"
+				hashJoinerMemAccount, hashJoinerMemMonitorName := args.MonitorRegistry.CreateMemAccountForSpillStrategy(
+					ctx, flowCtx, opName, spec.ProcessorID,
+				)
+				hashJoinerUnlimitedAllocator := colmem.NewAllocator(
+					ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, spec.ProcessorID), factory,
+				)
 				hjSpec := colexecjoin.MakeHashJoinerSpec(
 					core.HashJoiner.Type,
 					core.HashJoiner.LeftEqColumns,
@@ -1063,7 +1037,7 @@ func NewColOperator(
 					hashJoinerUnlimitedAllocator, hjSpec, inputs[0].Root, inputs[1].Root,
 					colexecjoin.HashJoinerInitialNumBuckets,
 				)
-				if useStreamingMemAccountForBuffering || args.TestingKnobs.DiskSpillingDisabled {
+				if args.TestingKnobs.DiskSpillingDisabled {
 					// We will not be creating a disk-backed hash joiner because
 					// we're running a test that explicitly asked for only
 					// in-memory hash joiner.

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg"
@@ -883,9 +882,6 @@ func NewColOperator(
 					spillingQueueMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
 						ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID,
 					)
-					spillingQueueCfg := args.DiskQueueCfg
-					spillingQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-					spillingQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
 					newAggArgs.Allocator = colmem.NewAllocator(ctx, hashAggregatorMemAccount, factory)
 					newAggArgs.MemAccount = hashAggregatorMemAccount
 					inMemoryHashAggregator := colexec.NewHashAggregator(
@@ -894,7 +890,7 @@ func NewColOperator(
 							UnlimitedAllocator: colmem.NewAllocator(ctx, spillingQueueMemAccount, factory),
 							Types:              inputTypes,
 							MemoryLimit:        totalMemLimit / 2,
-							DiskQueueCfg:       spillingQueueCfg,
+							DiskQueueCfg:       args.DiskQueueCfg,
 							FDSemaphore:        args.FDSemaphore,
 							DiskAcc:            args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID),
 						},

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -438,6 +438,8 @@ type aggAllocBase struct {
 
 // ProcessAggregations processes all aggregate functions specified in
 // aggregations.
+//
+// evalCtx will not be mutated.
 func ProcessAggregations(
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,

--- a/pkg/sql/colexec/colexecargs/expr.go
+++ b/pkg/sql/colexec/colexecargs/expr.go
@@ -39,6 +39,8 @@ type ExprHelper struct {
 
 // ProcessExpr processes the given expression and returns a well-typed
 // expression. Note that SemaCtx must be already set on h.
+//
+// evalCtx will not be mutated.
 func (h *ExprHelper) ProcessExpr(
 	expr execinfrapb.Expression, evalCtx *tree.EvalContext, typs []*types.T,
 ) (tree.TypedExpr, error) {

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -74,14 +74,6 @@ type NewColOperatorArgs struct {
 		// partitions; for sorter it is merging already created partitions into
 		// new one before proceeding to the next partition from the input).
 		NumForcedRepartitions int
-		// UseStreamingMemAccountForBuffering specifies whether to use
-		// StreamingMemAccount when creating buffering operators and should only
-		// be set to 'true' in tests. The idea behind this flag is reducing the
-		// number of memory accounts and monitors we need to close, so we
-		// plumbed it into the planning code so that it doesn't create extra
-		// memory monitoring infrastructure (and so that we could use
-		// testMemAccount defined in main_test.go).
-		UseStreamingMemAccountForBuffering bool
 		// DiskSpillingDisabled specifies whether only in-memory operators
 		// should be created.
 		DiskSpillingDisabled bool

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -305,6 +305,8 @@ type mergeJoinInput struct {
 // implements sort-merge join. It performs a merge on the left and right input
 // sources, based on the equality columns, assuming both inputs are in sorted
 // order.
+//
+// evalCtx will not be mutated.
 func NewMergeJoinOp(
 	unlimitedAllocator *colmem.Allocator,
 	memoryLimit int64,

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -509,8 +509,6 @@ func newMergeJoinBase(
 		rDirections[i] = c.Direction
 	}
 
-	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-	diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
 	base := &mergeJoinBase{
 		joinHelper:         newJoinHelper(left, right),
 		unlimitedAllocator: unlimitedAllocator,

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -116,15 +116,14 @@ func NewSpillingBuffer(
 		storedTypes[i] = inputTypes[idx]
 	}
 
-	// Memory used by the AppendOnlyBufferedBatch cannot be partially released
-	// (and we would like to keep as many tuples in-memory as possible), so we
-	// must reserve memory for the disk queue and dequeue scratch batch.
-	diskReservedMem := colmem.EstimateBatchSizeBytes(storedTypes, coldata.BatchSize()) +
-		int64(diskQueueCfg.BufferSizeBytes)
 	// The SpillingBuffer disk queue always uses
 	// DiskQueueCacheModeClearAndReuseCache since all writes happen before any
 	// reads.
-	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeClearAndReuseCache
+	diskQueueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeClearAndReuseCache)
+	// Memory used by the AppendOnlyBufferedBatch cannot be partially released
+	// (and we would like to keep as many tuples in-memory as possible), so we
+	// must reserve memory for the disk queue and dequeue scratch batch.
+	diskReservedMem := colmem.EstimateBatchSizeBytes(storedTypes, coldata.BatchSize()) + int64(diskQueueCfg.BufferSizeBytes)
 	return &SpillingBuffer{
 		unlimitedAllocator: unlimitedAllocator,
 		memoryLimit:        memoryLimit,

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -107,8 +107,7 @@ func TestSpillingBuffer(t *testing.T) {
 		})
 		op.Init(ctx)
 
-		queueCfg.CacheMode = colcontainer.DiskQueueCacheModeClearAndReuseCache
-		queueCfg.SetDefaultBufferSizeBytesForCacheMode()
+		queueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeClearAndReuseCache)
 		queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
 
 		// We need to create a separate unlimited allocator for the spilling

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -416,7 +416,7 @@ func (q *SpillingQueue) Dequeue(ctx context.Context) (coldata.Batch, error) {
 }
 
 func (q *SpillingQueue) numFDsOpenAtAnyGivenTime() int {
-	if q.diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeDefault {
+	if q.diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeIntertwinedCalls {
 		// The access pattern must be write-everything then read-everything so
 		// either a read FD or a write FD are open at any one point.
 		return 1

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -46,7 +46,7 @@ func TestSpillingQueue(t *testing.T) {
 			1 << 30,                         /* 1 GiB */
 		} {
 			alwaysCompress := rng.Float64() < 0.5
-			diskQueueCacheMode := colcontainer.DiskQueueCacheModeDefault
+			diskQueueCacheMode := colcontainer.DiskQueueCacheModeIntertwinedCalls
 			var dequeuedProbabilityBeforeAllEnqueuesAreDone float64
 			// testReuseCache will test the reuse cache modes.
 			testReuseCache := rng.Float64() < 0.5
@@ -106,8 +106,7 @@ func TestSpillingQueue(t *testing.T) {
 			op.Init(ctx)
 			typs := op.Typs()
 
-			queueCfg.CacheMode = diskQueueCacheMode
-			queueCfg.SetDefaultBufferSizeBytesForCacheMode()
+			queueCfg.SetCacheMode(diskQueueCacheMode)
 			queueCfg.TestingKnobs.AlwaysCompress = alwaysCompress
 
 			// We need to create a separate unlimited allocator for the spilling
@@ -258,7 +257,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeDefault
+	queueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeIntertwinedCalls)
 
 	rng, _ := randutil.NewTestRand()
 	numBatches := int(spillingQueueInitialItemsLen)*(1+rng.Intn(4)) + rng.Intn(int(spillingQueueInitialItemsLen))

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -37,12 +37,16 @@ func newBufferedWindowOperator(
 	outputTypes = append(outputTypes, outputColType)
 	input := colexecutils.NewVectorTypeEnforcer(
 		args.MainAllocator, args.Input, outputColType, args.OutputColIdx)
+	queueCfg := args.QueueCfg
+	// bufferedWindowOp intertwines calls to Enqueue and Dequeue, so we have to
+	// use the corresponding disk queue cache mode.
+	queueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeIntertwinedCalls)
 	return &bufferedWindowOp{
 		windowInitFields: windowInitFields{
 			OneInputNode: colexecop.NewOneInputNode(input),
 			allocator:    args.MainAllocator,
 			memoryLimit:  memoryLimit,
-			diskQueueCfg: args.QueueCfg,
+			diskQueueCfg: queueCfg,
 			fdSemaphore:  args.FdSemaphore,
 			outputTypes:  outputTypes,
 			diskAcc:      args.DiskAcc,

--- a/pkg/sql/colexec/colexecwindow/window_framer_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_test.go
@@ -54,13 +54,14 @@ func TestWindowFramer(t *testing.T) {
 	defer evalCtx.Stop(context.Background())
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	// The spilling buffer used by the window framers always uses
+	// colcontainer.DiskQueueCacheModeClearAndReuseCache mode.
+	queueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeClearAndReuseCache)
 	memAcc := testMemMonitor.MakeBoundAccount()
 	defer memAcc.Close(evalCtx.Ctx())
 
 	factory := coldataext.NewExtendedColumnFactory(evalCtx)
 	allocator := colmem.NewAllocator(evalCtx.Ctx(), &memAcc, factory)
-	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeClearAndReuseCache
-	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 
 	var memLimits = []int64{1, 1 << 10, 1 << 20}
 

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -232,10 +232,6 @@ func NewExternalSorter(
 	fdSemaphore semaphore.Semaphore,
 	diskAcc *mon.BoundAccount,
 ) colexecop.Operator {
-	// The cache mode is chosen to reuse the cache to have a smaller cache per
-	// partition without affecting performance.
-	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-	diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
 	if diskQueueCfg.BufferSizeBytes > 0 && maxNumberPartitions == 0 {
 		// With the default limit of 256 file descriptors, this results in 16
 		// partitions. This is a hard maximum of partitions that will be used by

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -253,8 +253,6 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
-	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 	var monitorRegistry colexecargs.MonitorRegistry
 	defer monitorRegistry.Close(ctx)
 

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -460,8 +459,6 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
-	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 
 	aggFn := execinfrapb.Min
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
@@ -523,8 +520,6 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
-	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
-	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 
 	aggFn := execinfrapb.Min
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -227,8 +227,7 @@ func newHashBasedPartitioner(
 	// operators. The cache mode is chosen to automatically close the cache
 	// belonging to partitions at a parent level when repartitioning.
 	diskQueueCfg := args.DiskQueueCfg
-	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeClearAndReuseCache
-	diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
+	diskQueueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeClearAndReuseCache)
 	partitionedDiskQueueSemaphore := args.FDSemaphore
 	if !args.TestingKnobs.DelegateFDAcquisitions {
 		// To avoid deadlocks with other disk queues, we manually attempt to

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -59,6 +59,7 @@ func randTypes(rng *rand.Rand, numCols int) ([]*types.T, []func(tree.Datum) inte
 
 func TestValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	rng, _ := randutil.NewTestRand()
 	for _, numRows := range []int{0, 1, 10, 13, 15} {
 		for _, numCols := range []int{1, 3} {

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -199,6 +199,7 @@ func newRouterOutputOp(args routerOutputOpArgs) *routerOutputOp {
 		testingKnobs:        args.testingKnobs,
 	}
 	o.mu.cond = sync.NewCond(&o.mu)
+	args.cfg.SetCacheMode(colcontainer.DiskQueueCacheModeIntertwinedCalls)
 	o.mu.data = colexecutils.NewSpillingQueue(
 		&colexecutils.NewSpillingQueueArgs{
 			UnlimitedAllocator: args.unlimitedAllocator,
@@ -462,9 +463,6 @@ func NewHashRouter(
 	fdSemaphore semaphore.Semaphore,
 	diskAccounts []*mon.BoundAccount,
 ) (*HashRouter, []colexecop.DrainableOperator) {
-	if diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeDefault {
-		colexecerror.InternalError(errors.Errorf("hash router instantiated with incompatible disk queue cache mode: %d", diskQueueCfg.CacheMode))
-	}
 	outputs := make([]routerOutput, len(unlimitedAllocators))
 	outputsAsOps := make([]colexecop.DrainableOperator, len(unlimitedAllocators))
 	// unblockEventsChan is buffered to 2*numOutputs as we don't want the outputs

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1083,14 +1083,12 @@ func (s *vectorizedFlowCreator) setupFlow(
 				return
 			}
 
-			var inputs []colexecargs.OpWithMetaInfo
+			inputs := make([]colexecargs.OpWithMetaInfo, len(pspec.Input))
 			for i := range pspec.Input {
-				input, localErr := s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
-				if localErr != nil {
-					err = localErr
+				inputs[i], err = s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
+				if err != nil {
 					return
 				}
-				inputs = append(inputs, input)
 			}
 
 			// Before we can safely use types we received over the wire in the

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -456,6 +456,7 @@ func (ds *ServerImpl) newFlowContext(
 		Cfg:            &ds.ServerConfig,
 		ID:             id,
 		EvalCtx:        evalCtx,
+		Txn:            evalCtx.Txn,
 		NodeID:         ds.ServerConfig.NodeID,
 		TraceKV:        traceKV,
 		CollectStats:   collectStats,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -356,15 +356,14 @@ func (dsp *DistSQLPlanner) setupFlows(
 	}
 
 	// Set up the flow on this node.
-	localReq := setupReq
-	localReq.Flow = *flows[thisNodeID]
+	setupReq.Flow = *flows[thisNodeID]
 	var batchReceiver execinfra.BatchReceiver
 	if recv.batchWriter != nil {
 		// Use the DistSQLReceiver as an execinfra.BatchReceiver only if the
 		// former has the corresponding writer set.
 		batchReceiver = recv
 	}
-	return dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, batchReceiver, localState)
+	return dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &setupReq, recv, batchReceiver, localState)
 }
 
 // Run executes a physical plan. The plan should have been finalized using

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -48,6 +48,8 @@ func (*ivarBinder) VisitPost(expr tree.Expr) tree.Expr { return expr }
 
 // processExpression parses the string expression inside an Expression,
 // and associates ordinal references (@1, @2, etc) with the given helper.
+//
+// evalCtx will not be mutated.
 func processExpression(
 	exprSpec Expression,
 	evalCtx *tree.EvalContext,
@@ -143,6 +145,8 @@ func (eh *ExprHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 
 // DeserializeExpr deserializes expr, binds the indexed variables to the
 // provided IndexedVarHelper, and evaluates any constants in the expression.
+//
+// evalCtx will not be mutated.
 func DeserializeExpr(
 	expr string, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, vars *tree.IndexedVarHelper,
 ) (tree.TypedExpr, error) {

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -86,6 +86,8 @@ func GetAggregateInfo(
 
 // GetAggregateConstructor processes the specification of a single aggregate
 // function.
+//
+// evalCtx will not be mutated.
 func GetAggregateConstructor(
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -137,6 +137,8 @@ func TestEval(t *testing.T) {
 	})
 
 	t.Run("vectorized", func(t *testing.T) {
+		var monitorRegistry colexecargs.MonitorRegistry
+		defer monitorRegistry.Close(ctx)
 		walk(t, func(t *testing.T, d *datadriven.TestData) string {
 			st := cluster.MakeTestingClusterSettings()
 			flowCtx := &execinfra.FlowCtx{
@@ -188,12 +190,11 @@ func TestEval(t *testing.T) {
 						}},
 				},
 				},
-				StreamingMemAccount: &acc,
 				// Unsupported post processing specs are wrapped and run through the
 				// row execution engine.
 				ProcessorConstructor: rowexec.NewProcessor,
+				MonitorRegistry:      &monitorRegistry,
 			}
-			args.TestingKnobs.UseStreamingMemAccountForBuffering = true
 			result, err := colbuilder.NewColOperator(ctx, flowCtx, args)
 			require.NoError(t, err)
 


### PR DESCRIPTION
**sql: don't make a redundant copy of the SetupFlowRequest for local flow**

We can just use the setup request directly since all remote requests (if
any) did make copies of the original request.

Release note: None

**colbuilder: don't create a copy of the eval context in most cases**

Previously, on every `NewColOperator` call we would create a copy of the
eval context. This was copied over from the row engine where making
a copy was needed since the row-by-row processors use `ProcOutputHelper`
which might modify the eval context when evaluating the expresssions. In
the vectorized engine we almost never modify the eval context, so there
is no reason to make a copy.

Release note: None

**colflow: minor optimization to the setup of inputs**

Release note: None

**colcontainer: make ReuseCache the default cache mode**

Previously, the uninitialized disk queue cache mode was the mode that
allowed the intertwined calls to Enqueue and Dequeue. However, such mode
of operation is only used by the hash routers and the buffered windower,
so this commit switches the uninitialized mode to be the "reuse cache"
mode (which is used by most components). This commit additionally cleans
up the way the mode is updated.

Release note: None

**colexecargs: remove no longer useful testing knob**

This commit removes a testing knob that tells the colbuilder to use
a streaming memory account for the buffering operations. The idea behind
this knob was to reduce the boilerplate of managing the memory
monitoring infrastructure in tests, and with the recent cleanup in that
area it is now easy to do properly. Thus, the knob seems no longer
needed and is now removed.

Release note: None

**colbuilder: instantiate a streaming allocator lazily**

Release note: None