### PR TITLE
bazel: bump size of `execbuilder` test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -49,7 +49,7 @@ go_library(
 
 go_test(
     name = "execbuilder_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "builder_test.go",
         "main_test.go",


### PR DESCRIPTION
Saw this time out in CI.

Release note: None