### PR TITLE
roachtest: run restore health checks by querying system instead of defaultdb

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -116,7 +116,11 @@ func (hc *HealthChecker) Runner(ctx context.Context) (err error) {
 		}
 		// TODO(tschottdorf): remove replicate queue failures when the cluster first starts.
 		// Ditto queue.raftsnapshot.process.failure.
-		rows, err := db.QueryContext(ctx, `SELECT * FROM crdb_internal.gossip_alerts ORDER BY node_id ASC, store_id ASC`)
+		_, err = db.Exec(`USE system`)
+		if err != nil {
+			return err
+		}
+		rows, err := db.QueryContext(ctx, `SELECT * FROM crdb_internal.gossip_alerts ORDER BY node_id ASC, store_id ASC `)
 		_ = db.Close()
 		if err != nil {
 			return err


### PR DESCRIPTION
the roachtest restoreTPCCInc/nodes=10 began failing consistently after #71890
merged to master because the HealthChecker queried defaultdb by default, but the
linked pr drops defaultdb during restore.

In this PR, I add an additional sql query to ensure the health checker
checks on the system database instead.

Fixes #72600

Release note: None