### PR TITLE
backupccl: allow user to specify separate path for incremental backups

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -956,6 +956,7 @@ unreserved_keyword ::=
 	| 'INCLUDING'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
+	| 'INCREMENTAL_STORAGE'
 	| 'INDEXES'
 	| 'INHERITS'
 	| 'INJECT'
@@ -1875,6 +1876,7 @@ backup_options ::=
 	| 'REVISION_HISTORY'
 	| 'DETACHED'
 	| 'KMS' '=' string_or_placeholder_opt_list
+	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
 
 c_expr ::=
 	d_expr

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -317,7 +317,7 @@ func getURIsByLocalityKV(to []string, appendPath string) (string, map[string]str
 }
 
 func resolveOptionsForBackupJobDescription(
-	opts tree.BackupOptions, kmsURIs []string,
+	opts tree.BackupOptions, kmsURIs []string, incrementalStorage []string,
 ) (tree.BackupOptions, error) {
 	if opts.IsDefault() {
 		return opts, nil
@@ -332,12 +332,15 @@ func resolveOptionsForBackupJobDescription(
 		newOpts.EncryptionPassphrase = tree.NewDString("redacted")
 	}
 
-	for _, uri := range kmsURIs {
-		redactedURI, err := cloud.RedactKMSURI(uri)
-		if err != nil {
-			return tree.BackupOptions{}, err
-		}
-		newOpts.EncryptionKMSURI = append(newOpts.EncryptionKMSURI, tree.NewDString(redactedURI))
+	var err error
+	newOpts.EncryptionKMSURI, err = sanitizeURIList(kmsURIs)
+	if err != nil {
+		return tree.BackupOptions{}, err
+	}
+
+	newOpts.IncrementalStorage, err = sanitizeURIList(incrementalStorage)
+	if err != nil {
+		return tree.BackupOptions{}, err
 	}
 
 	return newOpts, nil
@@ -351,6 +354,7 @@ func GetRedactedBackupNode(
 	incrementalFrom []string,
 	kmsURIs []string,
 	resolvedSubdir string,
+	incrementalStorage []string,
 	hasBeenPlanned bool,
 ) (*tree.Backup, error) {
 	b := &tree.Backup{
@@ -371,28 +375,37 @@ func GetRedactedBackupNode(
 		b.Subdir = tree.NewDString(resolvedSubdir)
 	}
 
-	for _, t := range to {
-		sanitizedTo, err := cloud.SanitizeExternalStorageURI(t, nil /* extraParams */)
-		if err != nil {
-			return nil, err
-		}
-		b.To = append(b.To, tree.NewDString(sanitizedTo))
+	var err error
+	b.To, err = sanitizeURIList(to)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, from := range incrementalFrom {
-		sanitizedFrom, err := cloud.SanitizeExternalStorageURI(from, nil /* extraParams */)
-		if err != nil {
-			return nil, err
-		}
-		b.IncrementalFrom = append(b.IncrementalFrom, tree.NewDString(sanitizedFrom))
+	b.IncrementalFrom, err = sanitizeURIList(incrementalFrom)
+	if err != nil {
+		return nil, err
 	}
 
-	resolvedOpts, err := resolveOptionsForBackupJobDescription(backup.Options, kmsURIs)
+	resolvedOpts, err := resolveOptionsForBackupJobDescription(backup.Options, kmsURIs,
+		incrementalStorage)
 	if err != nil {
 		return nil, err
 	}
 	b.Options = resolvedOpts
 	return b, nil
+}
+
+// sanitizeURIList sanitizes a list of URIS in order to build an AST
+func sanitizeURIList(uris []string) ([]tree.Expr, error) {
+	var sanitizedURIs []tree.Expr
+	for _, uri := range uris {
+		sanitizedURI, err := cloud.SanitizeExternalStorageURI(uri, nil /* extraParams */)
+		if err != nil {
+			return nil, err
+		}
+		sanitizedURIs = append(sanitizedURIs, tree.NewDString(sanitizedURI))
+	}
+	return sanitizedURIs, nil
 }
 
 func backupJobDescription(
@@ -402,9 +415,10 @@ func backupJobDescription(
 	incrementalFrom []string,
 	kmsURIs []string,
 	resolvedSubdir string,
+	incrementalStorage []string,
 ) (string, error) {
-	b, err := GetRedactedBackupNode(backup, to, incrementalFrom, kmsURIs, resolvedSubdir,
-		true /* hasBeenPlanned */)
+	b, err := GetRedactedBackupNode(backup, to, incrementalFrom, kmsURIs,
+		resolvedSubdir, incrementalStorage, true /* hasBeenPlanned */)
 	if err != nil {
 		return "", err
 	}
@@ -594,6 +608,12 @@ func backupPlanHook(
 		return nil, nil, nil, false, err
 	}
 
+	incToFn, err := p.TypeAsStringArray(ctx, tree.Exprs(backupStmt.Options.IncrementalStorage),
+		"BACKUP")
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
 	encryptionParams := backupEncryptionParams{}
 
 	var pwFn func() (string, error)
@@ -675,6 +695,14 @@ func backupPlanHook(
 			return err
 		}
 
+		incrementalStorage, err := incToFn()
+		if err != nil {
+			return err
+		}
+		if !backupStmt.Nested && len(incrementalStorage) > 0 {
+			return errors.New("incremental_storage option not supported with `BACKUP TO` syntax")
+		}
+
 		endTime := p.ExecCfg().Clock.Now()
 		if backupStmt.AsOf.Expr != nil {
 			asOf, err := p.EvalAsOfTimestamp(ctx, backupStmt.AsOf)
@@ -715,11 +743,12 @@ func backupPlanHook(
 		// backupDestination struct.
 		collectionURI, defaultURI, resolvedSubdir, urisByLocalityKV, prevs, err :=
 			resolveDest(ctx, p.User(), backupStmt.Nested, backupStmt.AppendToLatest, defaultURI,
-				urisByLocalityKV, makeCloudStorage, endTime, to, incrementalFrom, subdir)
+				urisByLocalityKV, makeCloudStorage, endTime, to, incrementalFrom, subdir, incrementalStorage)
 		if err != nil {
 			return err
 		}
-		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p.User(), makeCloudStorage, prevs,
+		prevBackups, encryptionOptions, err := fetchPreviousBackups(ctx, p.User(), makeCloudStorage,
+			prevs,
 			encryptionParams)
 		if err != nil {
 			return err
@@ -960,7 +989,8 @@ func backupPlanHook(
 			return errors.Errorf("expected backup (along with any previous backups) to cover to %v, not %v", endTime, coveredEnd)
 		}
 
-		description, err := backupJobDescription(p, backupStmt.Backup, to, incrementalFrom, encryptionParams.kmsURIs, resolvedSubdir)
+		description, err := backupJobDescription(p, backupStmt.Backup, to, incrementalFrom,
+			encryptionParams.kmsURIs, resolvedSubdir, incrementalStorage)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -86,6 +86,7 @@ type scheduledBackupEval struct {
 	destination          func() ([]string, error)
 	encryptionPassphrase func() (string, error)
 	kmsURIs              func() ([]string, error)
+	incrementalStorage   func() ([]string, error)
 }
 
 func parseOnError(onError string, details *jobspb.ScheduleDetails) error {
@@ -441,6 +442,17 @@ func doCreateBackupSchedules(
 	if incRecurrence != nil {
 		chainProtectedTimestampRecords = canChainProtectedTimestampRecords(p, eval)
 		backupNode.AppendToLatest = true
+
+		var incDests []string
+		if eval.incrementalStorage != nil {
+			incDests, err = eval.incrementalStorage()
+			if err != nil {
+				return err
+			}
+			for _, incDest := range incDests {
+				backupNode.Options.IncrementalStorage = append(backupNode.Options.IncrementalStorage, tree.NewStrVal(incDest))
+			}
+		}
 		inc, incScheduledBackupArgs, err = makeBackupSchedule(
 			env, p.User(), scheduleLabel, incRecurrence, details, unpauseOnSuccessID,
 			updateMetricOnSuccess, backupNode, chainProtectedTimestampRecords)
@@ -454,8 +466,8 @@ func doCreateBackupSchedules(
 		if err := inc.Create(ctx, ex, p.ExtendedEvalContext().Txn); err != nil {
 			return err
 		}
-		if err := emitSchedule(inc, backupNode, destinations, nil /* incrementalFrom */, kmsURIs,
-			resultsCh); err != nil {
+		if err := emitSchedule(inc, backupNode, destinations, nil, /* incrementalFrom */
+			kmsURIs, incDests, resultsCh); err != nil {
 			return err
 		}
 		unpauseOnSuccessID = inc.ScheduleID()
@@ -463,6 +475,7 @@ func doCreateBackupSchedules(
 
 	// Create FULL backup schedule.
 	backupNode.AppendToLatest = false
+	backupNode.Options.IncrementalStorage = nil
 	var fullScheduledBackupArgs *ScheduledBackupExecutionArgs
 	full, fullScheduledBackupArgs, err := makeBackupSchedule(
 		env, p.User(), scheduleLabel, fullRecurrence, details, unpauseOnSuccessID,
@@ -503,8 +516,8 @@ func doCreateBackupSchedules(
 	}
 
 	collectScheduledBackupTelemetry(incRecurrence, firstRun, fullRecurrencePicked, details)
-	return emitSchedule(full, backupNode, destinations, nil /* incrementalFrom */, kmsURIs,
-		resultsCh)
+	return emitSchedule(full, backupNode, destinations, nil, /* incrementalFrom */
+		kmsURIs, nil, resultsCh)
 }
 
 func setDependentSchedule(
@@ -619,6 +632,7 @@ func emitSchedule(
 	sj *jobs.ScheduledJob,
 	backupNode *tree.Backup,
 	to, incrementalFrom, kmsURIs []string,
+	incrementalStorage []string,
 	resultsCh chan<- tree.Datums,
 ) error {
 	var nextRun tree.Datum
@@ -638,7 +652,7 @@ func emitSchedule(
 	}
 
 	redactedBackupNode, err := GetRedactedBackupNode(backupNode, to, incrementalFrom, kmsURIs, "",
-		false /* hasBeenPlanned */)
+		incrementalStorage, false /* hasBeenPlanned */)
 	if err != nil {
 		return err
 	}
@@ -862,6 +876,14 @@ func makeScheduledBackupEval(
 
 	if schedule.BackupOptions.EncryptionKMSURI != nil {
 		eval.kmsURIs, err = p.TypeAsStringArray(ctx, tree.Exprs(schedule.BackupOptions.EncryptionKMSURI),
+			scheduleBackupOp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if schedule.BackupOptions.IncrementalStorage != nil {
+		eval.incrementalStorage, err = p.TypeAsStringArray(ctx,
+			tree.Exprs(schedule.BackupOptions.IncrementalStorage),
 			scheduleBackupOp)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -420,6 +420,25 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			},
 		},
 		{
+			name:  "full-cluster-remote-incremental-storage",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH incremental_storage = 'nodelocal://1/incremental' RECURRING '@hourly'",
+			user:  enterpriseUser,
+			expectedSchedules: []expectedSchedule{
+				{
+					nameRe:     "BACKUP .*",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached, incremental_storage = 'nodelocal://1/incremental'",
+					period:     time.Hour,
+					paused:     true,
+				},
+				{
+					nameRe:     "BACKUP .+",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					period:     24 * time.Hour,
+					runsNow:    true,
+				},
+			},
+		},
+		{
 			name: "multiple-tables-with-revision-history",
 			user: enterpriseUser,
 			query: `

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -76,11 +76,15 @@ const (
 	// storing incremental backups for auto-appendable backups.
 	// It is exported for testing backup inspection tooling.
 	DateBasedIncFolderName = "/20060102/150405.00"
+
 	// DateBasedIntoFolderName is the date format used when creating sub-directories
 	// for storing backups in a collection.
 	// Also exported for testing backup inspection tooling.
 	DateBasedIntoFolderName = "/2006/01/02-150405.00"
-	latestFileName          = "LATEST"
+
+	// latestFileName is the name of a file in the collection which contains the
+	// path of the most recently taken full backup in the backup collection.
+	latestFileName = "LATEST"
 )
 
 // isGZipped detects whether the given bytes represent GZipped data. This check

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -292,8 +292,14 @@ func (e *scheduledBackupExecutor) GetCreateScheduleStatement(
 		kmsURIs = append(kmsURIs, kmsURI.RawString())
 	}
 
-	redactedBackupNode, err := GetRedactedBackupNode(backupNode.Backup, destinations,
-		nil /* incrementalFrom */, kmsURIs, "", false /* hasBeenPlanned */)
+	redactedBackupNode, err := GetRedactedBackupNode(
+		backupNode.Backup,
+		destinations,
+		nil, /* incrementalFrom */
+		kmsURIs,
+		"",
+		nil,
+		false /* hasBeenPlanned */)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -792,7 +792,8 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 %token <str> HAVING HASH HIGH HISTOGRAM HOUR
 
 %token <str> IDENTITY
-%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE INCLUDING INCREMENT INCREMENTAL
+%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE
+%token <str> INCLUDING INCREMENT INCREMENTAL INCREMENTAL_STORAGE
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INITIALLY
 %token <str> INNER INSERT INT INTEGER
@@ -2661,17 +2662,30 @@ opt_clear_data:
 // %Help: BACKUP - back up data to external storage
 // %Category: CCL
 // %Text:
-// BACKUP <targets...> TO <location...>
+//
+// Create a full backup
+// BACKUP <targets...> INTO <destination...>
 //        [ AS OF SYSTEM TIME <expr> ]
-//        [ INCREMENTAL FROM <location...> ]
-//        [ WITH <option> [= <value>] [, ...] ]
+//				[ WITH <option> [= <value>] [, ...] ]
+//
+// Append an incremental backup to the most recent backup added to a collection
+// BACKUP <targets...> INTO LATEST IN <destination...>
+//        [ AS OF SYSTEM TIME <expr> ]
+//				[ WITH <option> [= <value>] [, ...] ]
+//
+//
+// Append an incremental backup in the <subdir>. This command will create an
+// incremental backup iff there is a full backup in <destination>
+// BACKUP <targets...> INTO [<subdir...> IN] <destination>
+//        [ AS OF SYSTEM TIME <expr> ]
+//				[ WITH <option> [= <value>] [, ...] ]
 //
 // Targets:
 //    Empty targets list: backup full cluster.
 //    TABLE <pattern> [, ...]
 //    DATABASE <databasename> [, ...]
 //
-// Location:
+// Destination:
 //    "[scheme]://[host]/[path to backup]?[parameters]"
 //
 // Options:
@@ -2679,6 +2693,7 @@ opt_clear_data:
 //    encryption_passphrase="secret": encrypt backups
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : encrypt backups using KMS
 //    detached: execute backup job asynchronously, without waiting for its completion
+//    incremental_storage: specify a different path to store the incremental backup
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -2783,6 +2798,10 @@ backup_options:
 | KMS '=' string_or_placeholder_opt_list
   {
     $$.val = &tree.BackupOptions{EncryptionKMSURI: $3.stringOrPlaceholderOptList()}
+  }
+| INCREMENTAL_STORAGE '=' string_or_placeholder_opt_list
+  {
+  $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
   }
 
 
@@ -13298,6 +13317,7 @@ unreserved_keyword:
 | INCLUDING
 | INCREMENT
 | INCREMENTAL
+| INCREMENTAL_STORAGE
 | INDEXES
 | INHERITS
 | INJECT

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -47,6 +47,14 @@ BACKUP TABLE foo INTO LATEST IN '_' -- literals removed
 BACKUP TABLE _ INTO LATEST IN 'bar' -- identifiers removed
 
 parse
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
+----
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
+BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH incremental_storage = ('baz') -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '_' WITH incremental_storage = '_' -- literals removed
+BACKUP TABLE _ INTO LATEST IN 'bar' WITH incremental_storage = 'baz' -- identifiers removed
+
+parse
 BACKUP TABLE foo INTO 'subdir' IN 'bar'
 ----
 BACKUP TABLE foo INTO 'subdir' IN 'bar'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -40,23 +40,37 @@ type BackupOptions struct {
 	EncryptionPassphrase   Expr
 	Detached               bool
 	EncryptionKMSURI       StringOrPlaceholderOptList
+	IncrementalStorage     StringOrPlaceholderOptList
 }
 
 var _ NodeFormatter = &BackupOptions{}
 
 // Backup represents a BACKUP statement.
 type Backup struct {
-	Targets         *TargetList
-	To              StringOrPlaceholderOptList
+	Targets *TargetList
+
+	// To is set to the root directory of the backup (called the <destination> in
+	// the docs).
+	To StringOrPlaceholderOptList
+
+	// IncrementalFrom is only set for the old 'BACKUP .... TO ...' syntax.
 	IncrementalFrom Exprs
-	AsOf            AsOfClause
-	Options         BackupOptions
-	Nested          bool
-	AppendToLatest  bool
-	// Subdir may be set by the parser when the SQL query is of the form
-	// `BACKUP INTO 'subdir' IN...`. Alternatively, if Nested is true but a subdir
-	// was not explicitly specified by the user, then this will be set during
-	// BACKUP planning once the destination has been resolved.
+
+	AsOf    AsOfClause
+	Options BackupOptions
+
+	// Nested is set to true when the user creates a backup with
+	//`BACKUP ... INTO... ` syntax.
+	Nested bool
+
+	// AppendToLatest is set to true if the user creates a backup with
+	//`BACKUP...INTO LATEST...`
+	AppendToLatest bool
+
+	// Subdir may be set by the parser when the SQL query is of the form `BACKUP
+	// INTO 'subdir' IN...`. Alternatively, if Nested is true but a subdir was not
+	// explicitly specified by the user, then this will be set during BACKUP
+	// planning once the destination has been resolved.
 	Subdir Expr
 }
 
@@ -237,6 +251,12 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("kms = ")
 		ctx.FormatNode(&o.EncryptionKMSURI)
 	}
+
+	if o.IncrementalStorage != nil {
+		maybeAddSep()
+		ctx.WriteString("incremental_storage = ")
+		ctx.FormatNode(&o.IncrementalStorage)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -270,6 +290,12 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 		return errors.New("kms specified multiple times")
 	}
 
+	if o.IncrementalStorage == nil {
+		o.IncrementalStorage = other.IncrementalStorage
+	} else if other.IncrementalStorage != nil {
+		return errors.New("incremental_storage option specified multiple times")
+	}
+
 	return nil
 }
 
@@ -278,7 +304,8 @@ func (o BackupOptions) IsDefault() bool {
 	options := BackupOptions{}
 	return o.CaptureRevisionHistory == options.CaptureRevisionHistory &&
 		o.Detached == options.Detached && cmp.Equal(o.EncryptionKMSURI, options.EncryptionKMSURI) &&
-		o.EncryptionPassphrase == options.EncryptionPassphrase
+		o.EncryptionPassphrase == options.EncryptionPassphrase &&
+		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }
 
 // Format implements the NodeFormatter interface.


### PR DESCRIPTION
Previously, incremental backups had to be stored in the same directory as the
full backup they incremented on. This change allows the user to specify a
different directory to store their incremental backup via the new
'incremental_storage' parameter. This change also allows for locality aware
backups. Future work will add this ability to RESTORE,
SHOW BACKUP, and scheduled backups.

Informs: #72236

Release note (sql change): user can now specify a different path for their
incremental backups.