### PR TITLE
sql/catalog/lease: permit gaps in descriptor history

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -14,6 +14,7 @@ package lease
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -207,15 +208,23 @@ func getDescriptorsFromStoreForInterval(
 	lowerBound, upperBound hlc.Timestamp,
 ) ([]historicalDescriptor, error) {
 	// Ensure lower bound is not an empty timestamp (now).
-	if lowerBound.Logical == 0 && lowerBound.WallTime == 0 {
-		return nil, errors.New("Lower bound for export request cannot be 0")
+	if lowerBound.IsEmpty() {
+		return nil, errors.AssertionFailedf(
+			"getDescriptorsFromStoreForInterval: lower bound cannot be empty")
+	}
+	// TODO(ajwerner): We'll want to lift this limitation in order to allow this
+	// function to find descriptors which could not be found by leasing. This
+	// will also require some careful managing of expiration timestamps for the
+	// final descriptor.
+	if upperBound.IsEmpty() {
+		return nil, errors.AssertionFailedf(
+			"getDescriptorsFromStoreForInterval: upper bound cannot be empty")
 	}
 
 	// Create an export request (1 kv call) for all descriptors for given
 	// descriptor ID written during the interval [timestamp, endTimestamp).
-	batchRequestHeader := roachpb.Header{}
-	if upperBound.WallTime != 0 {
-		batchRequestHeader = roachpb.Header{Timestamp: upperBound.Prev()}
+	batchRequestHeader := roachpb.Header{
+		Timestamp: upperBound.Prev(),
 	}
 	descriptorKey := catalogkeys.MakeDescMetadataKey(codec, id)
 	requestHeader := roachpb.RequestHeader{
@@ -308,17 +317,50 @@ func getDescriptorsFromStoreForInterval(
 func (m *Manager) readOlderVersionForTimestamp(
 	ctx context.Context, id descpb.ID, timestamp hlc.Timestamp,
 ) ([]historicalDescriptor, error) {
-	// Retrieve the endTimestamp for our query, which will be the modification
-	// time of the first descriptor in the manager's active set.
+	// Retrieve the endTimestamp for our query, which will be the first
+	// modification timestamp above our query timestamp.
 	t := m.findDescriptorState(id, false /*create*/)
-	endTimestamp := func() hlc.Timestamp {
+	// A missing descriptor state indicates that this descriptor has been
+	// purged in the meantime. We should go back around in the acquisition
+	// loop to make the appropriate error appear.
+	if t == nil {
+		return nil, nil
+	}
+	endTimestamp, done := func() (hlc.Timestamp, bool) {
 		t.mu.Lock()
 		defer t.mu.Unlock()
+
+		// If there are no descriptors, then we won't have a valid end timestamp.
 		if len(t.mu.active.data) == 0 {
-			return hlc.Timestamp{}
+			return hlc.Timestamp{}, true
 		}
-		return t.mu.active.data[0].GetModificationTime()
+		// We permit gaps in historical versions. We want to find the timestamp
+		// that represents the start of the validity interval for the known version
+		// which immediately follows the timestamps we're searching for.
+		i := sort.Search(len(t.mu.active.data), func(i int) bool {
+			return timestamp.Less(t.mu.active.data[i].GetModificationTime())
+		})
+
+		// If the timestamp we're searching for is somehow after the last descriptor
+		// we have in play, then either we have the right descriptor, or some other
+		// shenanigans where we've evicted the descriptor has occurred.
+		//
+		// TODO(ajwerner): When we come to modify this code to allow us to find
+		// historical descriptors which have been dropped, we'll need to rework
+		// this case and support providing no upperBound to
+		// getDescriptorFromStoreForInterval.
+		if i == len(t.mu.active.data) ||
+			// If we found a descriptor that isn't the first descriptor, go and check
+			// whether the descriptor for which we're searching actually exists. This
+			// will deal with cases where a concurrent fetch filled it in for us.
+			i > 0 && timestamp.Less(t.mu.active.data[i-1].getExpiration()) {
+			return hlc.Timestamp{}, true
+		}
+		return t.mu.active.data[i].GetModificationTime(), false
 	}()
+	if done {
+		return nil, nil
+	}
 
 	// Retrieve descriptors in range [timestamp, endTimestamp) in decreasing
 	// modification time order.


### PR DESCRIPTION
In #71239, we added a new mechanism to look up historical descriptors. I
erroneously informed @jameswsj10 that we would never have gaps in the
descriptor history, and, thus, when looking up historical descriptors, we
could always use the earliest descriptor's modification time as the bounds
for the relevant query.

This turns out to not be true. Consider the case where version 3 is a
historical version and then version 4 pops up and gets leased. Version 3 will
get removed if it is not referenced. In the meantime, version 3 existed when we
went to go find version 2. At that point, we'll inject version 2 and have
version 4 leased.  We need to make sure we can handle the case where we need to
go fetch version 3.

In the meantime, this change also removes some logic added to support the
eventual resurrection of #59606 whereby we'll use the export request to fetch
descriptor history to power historical queries even in the face of descriptors
having been deleted.

Fixes #72706.

Release note: None