### PR TITLE
logictest: introduce cluster configuration directives

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
+++ b/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
@@ -1,4 +1,4 @@
-# LogicTest: experimental-span-configs
+# cluster-opt: enable-span-configs
 
 statement ok
 SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.enabled = true;


### PR DESCRIPTION
This patch introduces a new class of directives for logic tests: cluster
options.
They look like: # cluster-opt: enable-span-configs

These directives control options on the cluster(s) created for a test,
across the possibly multiple configurations that the test runs under
(local, 5node, etc).

I've got my own use case for these options coming. For now, I've
transitioned over the "span configs" test. This test was running under a
single test configuration with a cluster with a special option. Now,
the test runs under all configurations, and all the clusters specified
by these configurations are modified with the setting that the test
needs.

Release note: None