### PR TITLE
roachprod: remove install.Clusters

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -244,16 +244,20 @@ var cachedHostsCmd = &cobra.Command{
 	Short: "list all clusters (and optionally their host numbers) from local cache",
 	Args:  cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		cachedHosts, err := roachprod.CachedHosts(cachedHostsCluster)
-		if err != nil {
-			return err
-		}
-		for _, host := range cachedHosts {
-			if strings.HasPrefix(host, "teamcity") {
-				continue
+		roachprod.CachedClusters(func(clusterName string, numVMs int) {
+			if strings.HasPrefix(clusterName, "teamcity") {
+				return
 			}
-			fmt.Println(host)
-		}
+			fmt.Printf("%s", clusterName)
+			// When invoked by bash-completion, cachedHostsCluster is what the user
+			// has currently typed -- if this cluster matches that, expand its hosts.
+			if strings.HasPrefix(cachedHostsCluster, clusterName) {
+				for i := 1; i <= numVMs; i++ {
+					fmt.Printf(" %s:%d", clusterName, i)
+				}
+			}
+			fmt.Printf("\n")
+		})
 		return nil
 	}),
 }

--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,6 +33,10 @@ import (
 // clusters. It is also used as the "source of truth" for the local cluster.
 //
 // Each cluster corresponds to a json file in this directory.
+
+// syncedClusters stores the synced clusters metadata, populated from the
+// clusters cache.
+var syncedClusters cloud.Clusters
 
 // InitDirs initializes the directories for storing cluster metadata and debug
 // logs.
@@ -111,8 +114,11 @@ func shouldIgnoreCluster(c *cloud.Cluster) bool {
 }
 
 // LoadClusters reads the cached cluster metadata from config.ClustersDir and
-// populates install.Clusters.
+// populates syncedClusters. It is assumed that this is called when the process
+// starts, before any roachprod operations.
 func LoadClusters() error {
+	syncedClusters = make(cloud.Clusters)
+
 	clusterNames, err := listClustersInCache()
 	if err != nil {
 		return err
@@ -131,15 +137,7 @@ func LoadClusters() error {
 			continue
 		}
 
-		sc := &install.SyncedCluster{
-			Cluster: *c,
-		}
-
-		for _, vm := range c.VMs {
-			sc.Localities = append(sc.Localities, vm.Locality())
-		}
-
-		install.Clusters[sc.Name] = sc
+		syncedClusters[c.Name] = c
 
 		if config.IsLocalClusterName(c.Name) {
 			// Add the local cluster to the local provider.

--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -118,8 +118,6 @@ func LoadClusters() error {
 		return err
 	}
 
-	debugDir := os.ExpandEnv(config.DefaultDebugDir)
-
 	for _, name := range clusterNames {
 		c, err := loadCluster(name)
 		if err != nil {
@@ -134,8 +132,7 @@ func LoadClusters() error {
 		}
 
 		sc := &install.SyncedCluster{
-			Cluster:  *c,
-			DebugDir: debugDir,
+			Cluster: *c,
 		}
 
 		for _, vm := range c.VMs {

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -16,9 +16,6 @@ import (
 	"sort"
 )
 
-// Clusters memoizes cluster info for install operations
-var Clusters = map[string]*SyncedCluster{}
-
 var installCmds = map[string]string{
 	"cassandra": `
 echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | \

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -203,33 +203,13 @@ func Version() string {
 	return info.Long()
 }
 
-// CachedHosts returns a list of all roachprod clsuters from local cache.
-func CachedHosts(cachedHostsCluster string) ([]string, error) {
-	if err := LoadClusters(); err != nil {
-		return nil, err
-	}
-
-	names := make([]string, 0, len(install.Clusters))
-	for name := range install.Clusters {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	var retLines []string
-	for _, name := range names {
+// CachedClusters iterates over all roachprod clusters from the local cache, in
+// alphabetical order.
+func CachedClusters(fn func(clusterName string, numVMs int)) {
+	for _, name := range sortedClusters() {
 		c := install.Clusters[name]
-		newLine := c.Name
-		// when invokved by bash-completion, cachedHostsCluster is what the user
-		// has currently typed -- if this cluster matches that, expand its hosts.
-		if strings.HasPrefix(cachedHostsCluster, c.Name) {
-			for i := range c.VMs {
-				newLine += fmt.Sprintf(" %s:%d", c.Name, i+1)
-			}
-		}
-		retLines = append(retLines, newLine)
-
+		fn(c.Name, len(c.VMs))
 	}
-	return retLines, nil
 }
 
 // Sync grabs an exclusive lock on the roachprod state and then proceeds to

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -163,6 +163,7 @@ Available clusters:
 
 	c.Prepare(clusterOpts)
 
+	c.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
 	nodes, err := install.ListNodes(nodeNames, len(c.VMs))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### roachprod: initialize DebugDir with the other fields

Release note: None

#### roachprod: clean up cached clusters API

We now form the output for `cached-hosts` in the roachprod cmd.

Release note: None

#### roachprod: remove install.Clusters

We were using `SyncedCluster` in two "modes": it can be just a
metadata holder (only Cluster initialized) or it can be a usable
object (once `Prepare()` is called). This makes things harder to
follow, especially when we modify entries in the `Clusters` map in
place.

This change removes `install.Clusters` and replaces it with a
`syncedClusters` map which only stores the metadata. A `SyncedCluster`
only exists when we intend to perform an operation on a cluster.

Release note: None