### PR TITLE
ui: fix initial load graph's data on Metrics page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timewindow.ts
@@ -267,6 +267,14 @@ export const adjustTimeScale = (
       ...curTimeScale,
     },
   };
+  if (
+    !resolution30mStorageTTL ||
+    !resolution10sStorageTTL ||
+    !curTimeScale ||
+    !timeWindow
+  ) {
+    return result;
+  }
   const now = moment().utc();
   const ttl10secDate = now.subtract(resolution10sStorageTTL);
   const isOutsideOf10sResolution = timeWindow.start.isBefore(ttl10secDate);


### PR DESCRIPTION
This change prevents cases when page is loaded but response with
cluster settings haven't been received yet. `adjustTimeScale` function
relies on both `resolution10sStorageTTL` and `resolution30mStorageTTL` values
and was assumed that these values should always have valid duration.

Resolves: https://github.com/cockroachdb/cockroach/issues/72722

Release note: None