### PR TITLE
cli: remove mention of RocksDB

### DIFF
--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -79,7 +79,7 @@ AES128_CTR:be235...   # AES-128 encryption with store key ID
 	}
 
 	// Add commands to the root debug command.
-	// We can't add them to the lists of commands (eg: DebugCmdsForRocksDB) as cli init() is called before us.
+	// We can't add them to the lists of commands (eg: DebugCmdsForPebble) as cli init() is called before us.
 	cli.DebugCmd.AddCommand(encryptionStatusCmd)
 	cli.DebugCmd.AddCommand(encryptionActiveKeyCmd)
 
@@ -91,7 +91,7 @@ AES128_CTR:be235...   # AES-128 encryption with store key ID
 		"print active store key ID and exit")
 
 	// Add encryption flag to all OSS debug commands that want it.
-	for _, cmd := range cli.DebugCmdsForRocksDB {
+	for _, cmd := range cli.DebugCmdsForPebble {
 		// storeEncryptionSpecs is in start.go.
 		cli.VarFlag(cmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
 	}
@@ -102,10 +102,10 @@ AES128_CTR:be235...   # AES-128 encryption with store key ID
 	cli.VarFlag(cli.DebugPebbleCmd.PersistentFlags(),
 		&storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
 
-	cli.PopulateRocksDBConfigHook = fillEncryptionOptionsForStore
+	cli.PopulateStorageConfigHook = fillEncryptionOptionsForStore
 }
 
-// fillEncryptionOptionsForStore fills the RocksDBConfig fields
+// fillEncryptionOptionsForStore fills the StorageConfig fields
 // based on the --enterprise-encryption flag value.
 func fillEncryptionOptionsForStore(cfg *base.StorageConfig) error {
 	opts, err := baseccl.EncryptionOptionsForStore(cfg.Dir, storeEncryptionSpecs)
@@ -294,7 +294,7 @@ func runEncryptionActiveKey(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// getActiveEncryptionkey opens the file registry directly, bypassing rocksdb.
+// getActiveEncryptionkey opens the file registry directly, bypassing Pebble.
 // This allows looking up the active encryption key ID without knowing it.
 func getActiveEncryptionkey(dir string) (string, string, error) {
 	registryFile := filepath.Join(dir, fileRegistryFilename)

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -234,7 +234,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					// At this point the intent has been written to rocksdb but this
+					// At this point the intent has been written to Pebble but this
 					// write was not synced (only the raft log append was synced). We
 					// need to force another sync, but we're far from the storage
 					// layer here so the easiest thing to do is simply perform a


### PR DESCRIPTION
This removes any reference to RocksDB in the `debug` CLI code, using
Pebble instead.

Release note: None