### PR TITLE
rowflow: don't finish a tracing span too early

### DIFF
--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -375,10 +375,10 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, _ context.C
 						ro.stats.Exec.MaxAllocatedDisk.Set(uint64(ro.diskMonitor.MaximumBytes()))
 						span.RecordStructured(&ro.stats)
 						span.Finish()
-						if trace := execinfra.GetTraceData(ctx); trace != nil {
+						if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
 							ro.mu.Unlock()
 							rb.semaphore <- struct{}{}
-							status := ro.stream.Push(nil, &execinfrapb.ProducerMetadata{TraceData: trace})
+							status := ro.stream.Push(nil /* row */, meta)
 							rb.updateStreamState(&streamStatus, status)
 							<-rb.semaphore
 							ro.mu.Lock()

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -311,6 +311,7 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, _ context.C
 			var span *tracing.Span
 			if rb.statsCollectionEnabled {
 				ctx, span = execinfra.ProcessorSpan(ctx, "router output")
+				defer span.Finish()
 				span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(ro.streamID)))
 				ro.stats.Inputs = make([]execinfrapb.InputStats, 1)
 			}
@@ -374,7 +375,6 @@ func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, _ context.C
 						ro.stats.Exec.MaxAllocatedMem.Set(uint64(ro.memoryMonitor.MaximumBytes()))
 						ro.stats.Exec.MaxAllocatedDisk.Set(uint64(ro.diskMonitor.MaximumBytes()))
 						span.RecordStructured(&ro.stats)
-						span.Finish()
 						if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
 							ro.mu.Unlock()
 							rb.semaphore <- struct{}{}


### PR DESCRIPTION
The span was finished while its context was still being used. At the
very least, this resulted in the span's recording being collected after
the Finish() call, which is not going to be allowed any more.

Release note: None