### PR TITLE
gitignore: ignore `roachprod logs` local log buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build/Railroad.jar
 
 # Per-user .bazelrc
 /.bazelrc.user
+
+# Local disk buffers for "roachprod logs" command
+/*.logs


### PR DESCRIPTION
The `roachprod logs` command fetches cluster logs into the local
directory `<cluster>.logs` before displaying them. This patch ignores
those logs.

Release note: None