### PR TITLE
democluster: fix gateway_region() for `--multitenant`

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -375,6 +375,7 @@ func (c *transientCluster) Start(
 				Stopper:       c.stopper,
 				ForceInsecure: c.demoCtx.Insecure,
 				SSLCertsDir:   c.demoDir,
+				Locality:      c.demoCtx.Localities[i],
 				TestingKnobs: base.TestingKnobs{
 					TenantTestingKnobs: &sql.TenantTestingKnobs{DisableLogTags: true},
 				},

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -265,6 +265,11 @@ func TestTransientClusterMultitenant(t *testing.T) {
 	// Set up an empty 3-node cluster with tenants on each node.
 	demoCtx.NumNodes = 3
 	demoCtx.Multitenant = true
+	demoCtx.Localities = []roachpb.Locality{
+		{Tiers: []roachpb.Tier{{Key: "prize-winner", Value: "otan"}}},
+		{Tiers: []roachpb.Tier{{Key: "prize-winner", Value: "otan"}}},
+		{Tiers: []roachpb.Tier{{Key: "prize-winner", Value: "otan"}}},
+	}
 
 	security.ResetAssetLoader()
 	certsDir, err := ioutil.TempDir("", "cli-demo-mt-test")

--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl
@@ -20,6 +20,11 @@ eexpect "tenant 3"
 # Ensure db is defaultdb.
 eexpect "defaultdb>"
 
+# Ensure the gateway_region is set.
+send "SELECT gateway_region();\n"
+eexpect "us-east1"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 end_test


### PR DESCRIPTION
Resolves #72687

Release note (sql change): Fix `gateway_region` for `--multitenant` demo
clusters.