### PR TITLE
sql/catalog/descs: fix perf regression 

### DIFF
--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -11,6 +11,7 @@
 package descs
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -100,11 +101,16 @@ type uncommittedDescriptors struct {
 	//
 	// TODO(postamar): better uncommitted namespace changes handling after 22.1.
 	descNames nstree.Set
+
+	// addedSystemDatabase is used to mark whether the optimization to add the
+	// system database to the set of uncommitted descriptors has occurred.
+	addedSystemDatabase bool
 }
 
 func (ud *uncommittedDescriptors) reset() {
 	ud.descs.Clear()
 	ud.descNames.Clear()
+	ud.addedSystemDatabase = false
 }
 
 // add adds a descriptor to the set of uncommitted descriptors and returns
@@ -124,7 +130,9 @@ func (ud *uncommittedDescriptors) add(mut catalog.MutableDescriptor) (catalog.De
 // checkOut checks out an uncommitted mutable descriptor for use in the
 // transaction. This descriptor should later be checked in again.
 func (ud *uncommittedDescriptors) checkOut(id descpb.ID) (catalog.MutableDescriptor, error) {
-	ud.maybeInitialize()
+	if id == keys.SystemDatabaseID {
+		ud.maybeAddSystemDatabase()
+	}
 	entry := ud.descs.GetByID(id)
 	if entry == nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(
@@ -182,7 +190,9 @@ func maybeRefreshCachedFieldsOnTypeDescriptor(
 
 // getByID looks up an uncommitted descriptor by ID.
 func (ud *uncommittedDescriptors) getByID(id descpb.ID) catalog.Descriptor {
-	ud.maybeInitialize()
+	if id == keys.SystemDatabaseID && !ud.addedSystemDatabase {
+		ud.maybeAddSystemDatabase()
+	}
 	entry := ud.descs.GetByID(id)
 	if entry == nil {
 		return nil
@@ -200,7 +210,9 @@ func (ud *uncommittedDescriptors) getByID(id descpb.ID) catalog.Descriptor {
 func (ud *uncommittedDescriptors) getByName(
 	dbID descpb.ID, schemaID descpb.ID, name string,
 ) (hasKnownRename bool, desc catalog.Descriptor) {
-	ud.maybeInitialize()
+	if dbID == 0 && schemaID == 0 && name == systemschema.SystemDatabaseName {
+		ud.maybeAddSystemDatabase()
+	}
 	// Walk latest to earliest so that a DROP followed by a CREATE with the same
 	// name will result in the CREATE being seen.
 	if got := ud.descs.GetByName(dbID, schemaID, name); got != nil {
@@ -216,7 +228,6 @@ func (ud *uncommittedDescriptors) getByName(
 func (ud *uncommittedDescriptors) iterateNewVersionByID(
 	fn func(entry catalog.NameEntry, originalVersion lease.IDVersion) error,
 ) error {
-	ud.maybeInitialize()
 	return ud.descs.IterateByID(func(entry catalog.NameEntry) error {
 		mut := entry.(*uncommittedDescriptor).mutable
 		if mut == nil || mut.IsNew() || !mut.IsUncommittedVersion() {
@@ -229,7 +240,6 @@ func (ud *uncommittedDescriptors) iterateNewVersionByID(
 func (ud *uncommittedDescriptors) iterateImmutableByID(
 	fn func(imm catalog.Descriptor) error,
 ) error {
-	ud.maybeInitialize()
 	return ud.descs.IterateByID(func(entry catalog.NameEntry) error {
 		return fn(entry.(*uncommittedDescriptor).immutable)
 	})
@@ -286,8 +296,9 @@ var systemUncommittedDatabase = &uncommittedDescriptor{
 	// value lazily when this is needed, which ought to be exceedingly rare.
 }
 
-func (ud *uncommittedDescriptors) maybeInitialize() {
-	if ud.descs.Len() == 0 {
+func (ud *uncommittedDescriptors) maybeAddSystemDatabase() {
+	if !ud.addedSystemDatabase {
+		ud.addedSystemDatabase = true
 		ud.descs.Upsert(systemUncommittedDatabase)
 	}
 }

--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -218,6 +218,10 @@ func (ud *uncommittedDescriptors) getByName(
 	if got := ud.descs.GetByName(dbID, schemaID, name); got != nil {
 		return false, got.(*uncommittedDescriptor).immutable
 	}
+	// Check whether the set is empty to avoid allocating the NameInfo.
+	if ud.descNames.Empty() {
+		return false, nil
+	}
 	return ud.descNames.Contains(descpb.NameInfo{
 		ParentID:       dbID,
 		ParentSchemaID: schemaID,

--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -77,9 +77,7 @@ func (s *descriptorVersionState) Underlying() catalog.Descriptor {
 }
 
 func (s *descriptorVersionState) Expiration() hlc.Timestamp {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.mu.expiration
+	return s.getExpiration()
 }
 
 func (s *descriptorVersionState) SafeMessage() string {
@@ -113,15 +111,15 @@ func (s *descriptorVersionState) hasExpiredLocked(timestamp hlc.Timestamp) bool 
 	return s.mu.expiration.LessEq(timestamp)
 }
 
-func (s *descriptorVersionState) incRefCount(ctx context.Context) {
+func (s *descriptorVersionState) incRefCount(ctx context.Context, expensiveLogEnabled bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.incRefCountLocked(ctx)
+	s.incRefCountLocked(ctx, expensiveLogEnabled)
 }
 
-func (s *descriptorVersionState) incRefCountLocked(ctx context.Context) {
+func (s *descriptorVersionState) incRefCountLocked(ctx context.Context, expensiveLogEnabled bool) {
 	s.mu.refcount++
-	if log.ExpensiveLogEnabled(ctx, 2) {
+	if expensiveLogEnabled {
 		log.VEventf(ctx, 2, "descriptorVersionState.incRefCount: %s", s.stringLocked())
 	}
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -666,9 +666,9 @@ func NewLeaseManager(
 func NameMatchesDescriptor(
 	desc catalog.Descriptor, parentID descpb.ID, parentSchemaID descpb.ID, name string,
 ) bool {
-	return desc.GetParentID() == parentID &&
-		desc.GetParentSchemaID() == parentSchemaID &&
-		desc.GetName() == name
+	return desc.GetName() == name &&
+		desc.GetParentID() == parentID &&
+		desc.GetParentSchemaID() == parentSchemaID
 }
 
 // findNewest returns the newest descriptor version state for the ID.

--- a/pkg/sql/catalog/nstree/set.go
+++ b/pkg/sql/catalog/nstree/set.go
@@ -47,6 +47,11 @@ func (s *Set) Clear() {
 	*s = Set{}
 }
 
+// Empty returns true if the set has no entries.
+func (s *Set) Empty() bool {
+	return !s.initialized() || s.t.Len() == 0
+}
+
 func (s *Set) maybeInitialize() {
 	if s.initialized() {
 		return


### PR DESCRIPTION
This commit in #71936 had the unfortunate side-effect of allocating and forcing reads on the `uncommittedDescriptors` set even when we aren't looking for the system database. This has an outsized impact on the performance of the single-node, high-core-count KV runs. Instead of always initializing the system database, just do it when we access it. 

```
name             old ops/s   new ops/s   delta
KV95-throughput  88.6k ± 0%  94.8k ± 1%   +7.00%  (p=0.008 n=5+5)

name             old ms/s    new ms/s    delta
KV95-P50          1.60 ± 0%   1.40 ± 0%  -12.50%  (p=0.008 n=5+5)
KV95-Avg          0.60 ± 0%   0.50 ± 0%  -16.67%  (p=0.008 n=5+5)
```

The second commit is more speculative and came from looking at a profile where 1.6% of the allocated garbage was due to that `NameInfo` even though we'll never, ever hit it.

<img width="2345" alt="Screen Shot 2021-11-15 at 12 57 31 AM" src="https://user-images.githubusercontent.com/1839234/141729924-d00eebab-b35c-42bd-8d0b-ee39f3ac7d46.png">
 
 Fixes https://github.com/cockroachdb/cockroach/issues/72499