### PR TITLE
release-21.2: ui: show gaps on metrics charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -42,6 +42,7 @@ import { MilliToSeconds, NanoToMilli } from "src/util/convert";
 import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { findClosestTimeScale, TimeWindow } from "src/redux/timewindow";
+import Long from "long";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
@@ -306,7 +307,10 @@ export class LineGraphOld extends React.Component<
 // touPlot formats our timeseries data into the format
 // uPlot expects which is a 2-dimensional array where the
 // first array contains the x-values (time).
-function touPlot(data: formattedSeries[]): uPlot.AlignedData {
+function touPlot(
+  data: formattedSeries[],
+  sampleDuration?: Long,
+): uPlot.AlignedData {
   // Here's an example of what this code is attempting to control for.
   // We produce `result` series that contain their own x-values. uPlot
   // expects *one* x-series that all y-values match up to. So first we
@@ -336,8 +340,10 @@ function touPlot(data: formattedSeries[]): uPlot.AlignedData {
     ),
   ].sort((a, b) => a - b);
 
+  const xValuesWithGaps = fillGaps(xValuesComplete, sampleDuration);
+
   const yValuesComplete: (number | null)[][] = data.map(series => {
-    return xValuesComplete.map(ts => {
+    return xValuesWithGaps.map(ts => {
       const found = series.values.find(
         dp => dp.timestamp_nanos.toNumber() === ts,
       );
@@ -345,7 +351,45 @@ function touPlot(data: formattedSeries[]): uPlot.AlignedData {
     });
   });
 
-  return [xValuesComplete.map(ts => NanoToMilli(ts)), ...yValuesComplete];
+  return [xValuesWithGaps.map(ts => NanoToMilli(ts)), ...yValuesComplete];
+}
+
+// TODO (koorosh): the same logic can be achieved with uPlot's series.gaps API starting from 1.6.15 version.
+export function fillGaps(
+  data: uPlot.AlignedData[0],
+  sampleDuration?: Long,
+): uPlot.AlignedData[0] {
+  if (data.length === 0 || !sampleDuration) {
+    return data;
+  }
+  const sampleDurationMillis = sampleDuration.toNumber();
+  const dataPointsNumber = data.length;
+  const expectedPointsNumber =
+    (data[data.length - 1] - data[0]) / sampleDurationMillis + 1;
+  if (dataPointsNumber === expectedPointsNumber) {
+    return data;
+  }
+  const yDataWithGaps: number[] = [];
+  // validate time intervals for y axis data
+  data.forEach((d, idx, arr) => {
+    // case for the last item
+    if (idx === arr.length - 1) {
+      yDataWithGaps.push(d);
+    }
+    const nextItem = data[idx + 1];
+    if (nextItem - d <= sampleDurationMillis) {
+      yDataWithGaps.push(d);
+      return;
+    }
+    for (
+      let i = d;
+      nextItem - i >= sampleDurationMillis;
+      i = i + sampleDurationMillis
+    ) {
+      yDataWithGaps.push(i);
+    }
+  });
+  return yDataWithGaps;
 }
 
 // LineGraph wraps the uPlot library into a React component
@@ -463,7 +507,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     const axis = this.axis(this.props);
 
     const fData = formatMetricData(metrics, data);
-    const uPlotData = touPlot(fData);
+    const uPlotData = touPlot(fData, this.props.timeInfo?.sampleDuration);
 
     // The values of `this.yAxisDomain` and `this.xAxisDomain`
     // are captured in arguments to `configureUPlotLineChart`

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -16,7 +16,7 @@ import * as sinon from "sinon";
 import uPlot from "uplot";
 import _ from "lodash";
 
-import { LineGraph, LineGraphProps } from "./index";
+import { fillGaps, LineGraph, LineGraphProps } from "./index";
 import * as timewindow from "src/redux/timewindow";
 import * as protos from "src/js/protos";
 import { Axis } from "src/views/shared/components/metricQuery";
@@ -173,5 +173,27 @@ describe("<LineGraph>", function() {
       },
     });
     assert.isTrue(setDataSpy.called);
+  });
+});
+
+describe("fillGaps", () => {
+  it("fills gaps with missed points", () => {
+    const sampleDuration = Long.fromNumber(10000);
+    const data: uPlot.AlignedData[0] = [
+      1634735320000,
+      1634735330000,
+      1634735340000,
+      1634735350000,
+      1634735360000,
+      1634735370000,
+      1634735380000,
+      1634735390000, // missed 39 points after
+      1634735780000,
+      1634735790000,
+      1634735800000, // missed 1 data point after
+      1634735810000,
+    ];
+    const result = fillGaps(data, sampleDuration);
+    assert.equal(result.length, 50);
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -635,6 +635,7 @@ export function configureUPlotLineChart(
           // value determines how these values show up in the legend
           value: (_u: uPlot, rawValue: number) =>
             getLatestYAxisDomain().guideFormat(rawValue),
+          spanGaps: false,
         };
       }),
     ],


### PR DESCRIPTION
Backport 1/1 commits from #71810.

/cc @cockroachdb/release

---

Before, data for uPlot graphs were based on all available
data points were provided for specific metrics, so data included
the only point where at least one data point. But when for some
period of time no data was provided then this range was skipped
and the next date point was provided.
With this change, for a particular date range xAxis contains
all date points with respect to provided sample duration.
It allows to explicitly specify all date points for X-Axis
and then fill Y-Axis null values so uPlot can translate
them as gaps.

Depends on PR https://github.com/cockroachdb/cockroach/pull/70594 to fix issue
with correct behavior when zoom-in with mouse.

Release note (ui change): Show gaps for metrics graphs
instead of data interpolation.

Release justification: low risk, high benefit changes to existing functionality

**Before:**
<img width="984" alt="Screen Shot 2021-10-21 at 5 13 16 PM" src="https://user-images.githubusercontent.com/3106437/138295781-5de9d2ed-23b7-4adf-9675-0e08c9616bb2.png">

**After:**
<img width="983" alt="Screen Shot 2021-10-21 at 5 13 22 PM" src="https://user-images.githubusercontent.com/3106437/138295816-ae649a7f-6640-4cc6-8a23-55f490ac089e.png">

