### PR TITLE
util/humanizeutil: return `redact.SafeString`

### DIFF
--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -703,7 +703,7 @@ func (f backupFileDisplayMsg) MarshalJSON() ([]byte, error) {
 	}{
 		Path:         f.Path,
 		Span:         fmt.Sprint(f.Span),
-		DataSize:     humanizeutil.IBytes(f.EntryCounts.DataSize),
+		DataSize:     string(humanizeutil.IBytes(f.EntryCounts.DataSize)),
 		IndexEntries: f.EntryCounts.IndexEntries,
 		Rows:         f.EntryCounts.Rows,
 	}
@@ -736,7 +736,7 @@ func (b backupMetaDisplayMsg) MarshalJSON() ([]byte, error) {
 	}{
 		StartTime:           timeutil.Unix(0, b.StartTime.WallTime).Format(time.RFC3339),
 		EndTime:             timeutil.Unix(0, b.EndTime.WallTime).Format(time.RFC3339),
-		DataSize:            humanizeutil.IBytes(b.EntryCounts.DataSize),
+		DataSize:            string(humanizeutil.IBytes(b.EntryCounts.DataSize)),
 		Rows:                b.EntryCounts.Rows,
 		IndexEntries:        b.EntryCounts.IndexEntries,
 		FormatVersion:       b.FormatVersion,

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -38,7 +38,7 @@ func TestEncryptDecrypt(t *testing.T) {
 				for _, chunkSize := range []int{1, 7, 64, 1 << 10, 1 << 20} {
 					encryptionChunkSizeV2 = chunkSize
 
-					t.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(t *testing.T) {
+					t.Run("chunk="+string(humanizeutil.IBytes(int64(chunkSize))), func(t *testing.T) {
 						ciphertext, err := EncryptFile(plaintext, key)
 						require.NoError(t, err)
 						require.True(t, AppearsEncrypted(ciphertext), "cipher text should appear encrypted")
@@ -225,10 +225,10 @@ func BenchmarkEncryption(b *testing.B) {
 
 	b.Run("EncryptFile", func(b *testing.B) {
 		for _, plaintext := range [][]byte{plaintext1KB, plaintext100KB, plaintext1MB, plaintext64MB} {
-			b.Run(humanizeutil.IBytes(int64(len(plaintext))), func(b *testing.B) {
+			b.Run(string(humanizeutil.IBytes(int64(len(plaintext)))), func(b *testing.B) {
 				for _, chunkSize := range chunkSizes {
 					encryptionChunkSizeV2 = chunkSize
-					b.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(b *testing.B) {
+					b.Run("chunk="+string(humanizeutil.IBytes(int64(chunkSize))), func(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							_, err := EncryptFile(plaintext, key)
 							if err != nil {
@@ -258,11 +258,11 @@ func BenchmarkEncryption(b *testing.B) {
 	b.Run("DecryptFile", func(b *testing.B) {
 		for _, ciphertextOriginal := range [][][]byte{ciphertext1KB, ciphertext100KB, ciphertext1MB, ciphertext64MB} {
 			// Decrypt reuses/clobbers the original ciphertext slice.
-			b.Run(humanizeutil.IBytes(int64(len(ciphertextOriginal[0]))), func(b *testing.B) {
+			b.Run(string(humanizeutil.IBytes(int64(len(ciphertextOriginal[0])))), func(b *testing.B) {
 				for chunkSizeNum, chunkSize := range chunkSizes {
 					encryptionChunkSizeV2 = chunkSize
 
-					b.Run("chunk="+humanizeutil.IBytes(int64(chunkSize)), func(b *testing.B) {
+					b.Run("chunk="+string(humanizeutil.IBytes(int64(chunkSize))), func(b *testing.B) {
 						ciphertext := bytes.NewReader(ciphertextOriginal[chunkSizeNum])
 						for i := 0; i < b.N; i++ {
 							ciphertext.Reset(ciphertextOriginal[chunkSizeNum])

--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var (
@@ -41,7 +42,12 @@ var (
 type sz int64
 
 func (b sz) String() string {
-	return humanizeutil.IBytes(int64(b))
+	return redact.StringWithoutMarkers(b)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (b sz) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(humanizeutil.IBytes(int64(b)))
 }
 
 // SSTBatcher is a helper for bulk-adding many KVs in chunks via AddSSTable. An

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -75,7 +74,7 @@ type snapshotStrategy interface {
 
 	// Status provides a status report on the work performed during the
 	// snapshot. Only valid if the strategy succeeded.
-	Status() redact.SafeString
+	Status() redact.RedactableString
 
 	// Close cleans up any resources associated with the snapshot strategy.
 	Close(context.Context)
@@ -106,7 +105,7 @@ func assertStrategy(
 // kvBatchSnapshotStrategy is an implementation of snapshotStrategy that streams
 // batches of KV pairs in the BatchRepr format.
 type kvBatchSnapshotStrategy struct {
-	status redact.SafeString
+	status redact.RedactableString
 
 	// The size of the batches of PUT operations to send to the receiver of the
 	// snapshot. Only used on the sender side.
@@ -297,7 +296,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 				raftAppliedIndex:  header.State.RaftAppliedIndex,
 			}
 
-			kvSS.status = redact.SafeString(fmt.Sprintf("ssts: %d", len(kvSS.scratch.SSTs())))
+			kvSS.status = redact.Sprintf("ssts: %d", len(kvSS.scratch.SSTs()))
 			return inSnap, nil
 		}
 	}
@@ -362,7 +361,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 		bytesSent += int64(b.Len())
 	}
 
-	kvSS.status = redact.SafeString(fmt.Sprintf("kv pairs: %d", kvs))
+	kvSS.status = redact.Sprintf("kv pairs: %d", kvs)
 	return bytesSent, nil
 }
 
@@ -376,7 +375,7 @@ func (kvSS *kvBatchSnapshotStrategy) sendBatch(
 }
 
 // Status implements the snapshotStrategy interface.
-func (kvSS *kvBatchSnapshotStrategy) Status() redact.SafeString {
+func (kvSS *kvBatchSnapshotStrategy) Status() redact.RedactableString {
 	return kvSS.status
 }
 
@@ -974,9 +973,9 @@ func sendSnapshot(
 		snap,
 		to,
 		durSent.Seconds(),
-		redact.Safe(humanizeutil.IBytes(int64(float64(numBytesSent)/durSent.Seconds()))),
+		humanizeutil.IBytes(int64(float64(numBytesSent)/durSent.Seconds())),
 		ss.Status(),
-		redact.Safe(humanizeutil.IBytes(int64(targetRate))),
+		humanizeutil.IBytes(int64(targetRate)),
 		durQueued.Seconds(),
 	)
 

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -550,8 +550,8 @@ func (sc StoreCapacity) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("disk (capacity=%s, available=%s, used=%s, logicalBytes=%s), "+
 		"ranges=%d, leases=%d, queries=%.2f, writes=%.2f, "+
 		"bytesPerReplica={%s}, writesPerReplica={%s}",
-		redact.Safe(humanizeutil.IBytes(sc.Capacity)), redact.Safe(humanizeutil.IBytes(sc.Available)),
-		redact.Safe(humanizeutil.IBytes(sc.Used)), redact.Safe(humanizeutil.IBytes(sc.LogicalBytes)),
+		humanizeutil.IBytes(sc.Capacity), humanizeutil.IBytes(sc.Available),
+		humanizeutil.IBytes(sc.Used), humanizeutil.IBytes(sc.LogicalBytes),
 		sc.RangeCount, sc.LeaseCount, sc.QueriesPerSecond, sc.WritesPerSecond,
 		sc.BytesPerReplica, sc.WritesPerReplica)
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -484,7 +484,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 		return Engines{}, errors.Errorf("engines already created")
 	}
 	cfg.enginesCreated = true
-	details := []redact.RedactableString{redact.Sprintf("Pebble cache size: %s", redact.SafeString(humanizeutil.IBytes(cfg.CacheSize)))}
+	details := []redact.RedactableString{redact.Sprintf("Pebble cache size: %s", humanizeutil.IBytes(cfg.CacheSize))}
 	pebbleCache := pebble.NewCache(cfg.CacheSize)
 	defer pebbleCache.Unref()
 
@@ -528,7 +528,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					spec.Size.Percent, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
 			details = append(details, redact.Sprintf("store %d: in-memory, size %s",
-				i, redact.SafeString(humanizeutil.IBytes(sizeInBytes))))
+				i, humanizeutil.IBytes(sizeInBytes)))
 			if spec.StickyInMemoryEngineID != "" {
 				if cfg.TestingKnobs.Server == nil {
 					return Engines{}, errors.AssertionFailedf("Could not create a sticky " +
@@ -578,7 +578,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			}
 
 			details = append(details, redact.Sprintf("store %d: max size %s, max open file limit %d",
-				i, redact.SafeString(humanizeutil.IBytes(sizeInBytes)), openFileLimitPerStore))
+				i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
 
 			storageConfig := base.StorageConfig{
 				Attrs:                   spec.Attributes,

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -30,7 +30,7 @@ func (*ByteSizeSetting) Typ() string {
 }
 
 func (b *ByteSizeSetting) String(sv *Values) string {
-	return humanizeutil.IBytes(b.Get(sv))
+	return string(humanizeutil.IBytes(b.Get(sv)))
 }
 
 // WithPublic sets public visibility and can be chained.

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -655,7 +655,7 @@ func (s *externalSorter) createMergerForPartitions(n int) colexecop.Operator {
 			}
 			partitionOrdinal := s.numPartitions - n + i
 			counts.WriteString(fmt.Sprintf("%d", s.partitionsInfo.tupleCount[partitionOrdinal]))
-			sizes.WriteString(humanizeutil.IBytes(s.partitionsInfo.totalSize[partitionOrdinal]))
+			sizes.WriteString(string(humanizeutil.IBytes(s.partitionsInfo.totalSize[partitionOrdinal])))
 		}
 		log.Infof(s.Ctx,
 			"external sorter is merging partitions with partition indices %v with counts [%s] and sizes [%s]",

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -537,7 +537,7 @@ StateChanged:
 				if partitionInfo.memSize <= op.maxPartitionSizeToProcessUsingMain {
 					log.VEventf(op.Ctx, 2,
 						`%s processes partition with idx %d of size %s using the "main" strategy`,
-						op.name, partitionIdx, redact.SafeString(humanizeutil.IBytes(partitionInfo.memSize)),
+						op.name, partitionIdx, humanizeutil.IBytes(partitionInfo.memSize),
 					)
 					for i := range op.partitionedInputs {
 						op.partitionedInputs[i].partitionIdx = partitionIdx

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -369,22 +369,23 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			e.ob.AddRedactableField(RedactNodes, "regions", strings.Join(s.Regions, ", "))
 		}
 		if s.RowCount.HasValue() {
-			e.ob.AddField("actual row count", humanizeutil.Count(s.RowCount.Value()))
+			e.ob.AddField("actual row count", string(humanizeutil.Count(s.RowCount.Value())))
 		}
 		// Omit vectorized batches in non-verbose mode.
 		if e.ob.flags.Verbose {
 			if s.VectorizedBatchCount.HasValue() {
-				e.ob.AddField("vectorized batch count", humanizeutil.Count(s.VectorizedBatchCount.Value()))
+				e.ob.AddField("vectorized batch count",
+					string(humanizeutil.Count(s.VectorizedBatchCount.Value())))
 			}
 		}
 		if s.KVTime.HasValue() {
-			e.ob.AddField("KV time", humanizeutil.Duration(s.KVTime.Value()))
+			e.ob.AddField("KV time", string(humanizeutil.Duration(s.KVTime.Value())))
 		}
 		if s.KVContentionTime.HasValue() {
-			e.ob.AddField("KV contention time", humanizeutil.Duration(s.KVContentionTime.Value()))
+			e.ob.AddField("KV contention time", string(humanizeutil.Duration(s.KVContentionTime.Value())))
 		}
 		if s.KVRowsRead.HasValue() {
-			e.ob.AddField("KV rows read", humanizeutil.Count(s.KVRowsRead.Value()))
+			e.ob.AddField("KV rows read", string(humanizeutil.Count(s.KVRowsRead.Value())))
 		}
 		if s.KVBytesRead.HasValue() {
 			e.ob.AddField("KV bytes read", humanize.IBytes(s.KVBytesRead.Value()))
@@ -419,7 +420,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			estimatedRowCountString = fmt.Sprintf("%s - %s", humanizeutil.Count(minEstimatedRowCount), humanizeutil.Count(maxEstimatedRowCount))
 		} else {
 			estimatedRowCount := uint64(math.Round(s.RowCount))
-			estimatedRowCountString = humanizeutil.Count(estimatedRowCount)
+			estimatedRowCountString = string(humanizeutil.Count(estimatedRowCount))
 		}
 
 		// Show the estimated row count (except Values, where it is redundant).
@@ -449,7 +450,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 						if timeSinceStats < 0 {
 							timeSinceStats = 0
 						}
-						duration = humanizeutil.LongDuration(timeSinceStats)
+						duration = string(humanizeutil.LongDuration(timeSinceStats))
 					}
 					e.ob.AddField("estimated row count", fmt.Sprintf(
 						"%s (%s%% of the table; stats collected %s ago)",

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -351,7 +351,7 @@ func (ob *OutputBuilder) AddPlanningTime(delta time.Duration) {
 	if ob.flags.Redact.Has(RedactVolatile) {
 		delta = 10 * time.Microsecond
 	}
-	ob.AddTopLevelField("planning time", humanizeutil.Duration(delta))
+	ob.AddTopLevelField("planning time", string(humanizeutil.Duration(delta)))
 }
 
 // AddExecutionTime adds a top-level execution time field. Cannot be called
@@ -360,7 +360,7 @@ func (ob *OutputBuilder) AddExecutionTime(delta time.Duration) {
 	if ob.flags.Redact.Has(RedactVolatile) {
 		delta = 100 * time.Microsecond
 	}
-	ob.AddTopLevelField("execution time", humanizeutil.Duration(delta))
+	ob.AddTopLevelField("execution time", string(humanizeutil.Duration(delta)))
 }
 
 // AddKVReadStats adds a top-level field for the bytes/rows read from KV.
@@ -372,7 +372,8 @@ func (ob *OutputBuilder) AddKVReadStats(rows, bytes int64) {
 
 // AddKVTime adds a top-level field for the cumulative time spent in KV.
 func (ob *OutputBuilder) AddKVTime(kvTime time.Duration) {
-	ob.AddRedactableTopLevelField(RedactVolatile, "cumulative time spent in KV", humanizeutil.Duration(kvTime))
+	ob.AddRedactableTopLevelField(
+		RedactVolatile, "cumulative time spent in KV", string(humanizeutil.Duration(kvTime)))
 }
 
 // AddContentionTime adds a top-level field for the cumulative contention time.
@@ -380,14 +381,14 @@ func (ob *OutputBuilder) AddContentionTime(contentionTime time.Duration) {
 	ob.AddRedactableTopLevelField(
 		RedactVolatile,
 		"cumulative time spent due to contention",
-		humanizeutil.Duration(contentionTime),
+		string(humanizeutil.Duration(contentionTime)),
 	)
 }
 
 // AddMaxMemUsage adds a top-level field for the memory used by the query.
 func (ob *OutputBuilder) AddMaxMemUsage(bytes int64) {
 	ob.AddRedactableTopLevelField(
-		RedactVolatile, "maximum memory usage", humanizeutil.IBytes(bytes),
+		RedactVolatile, "maximum memory usage", string(humanizeutil.IBytes(bytes)),
 	)
 }
 
@@ -409,7 +410,7 @@ func (ob *OutputBuilder) AddNetworkStats(messages, bytes int64) {
 func (ob *OutputBuilder) AddMaxDiskUsage(bytes int64) {
 	if !ob.flags.Redact.Has(RedactVolatile) && bytes > 0 {
 		ob.AddTopLevelField("max sql temp disk usage",
-			humanizeutil.IBytes(bytes))
+			string(humanizeutil.IBytes(bytes)))
 	}
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -508,10 +508,10 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) (string, error) {
-			return humanizeutil.IBytes(evalCtx.SessionData().WorkMemLimit), nil
+			return string(humanizeutil.IBytes(evalCtx.SessionData().WorkMemLimit)), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return humanizeutil.IBytes(settingWorkMemBytes.Get(sv))
+			return string(humanizeutil.IBytes(settingWorkMemBytes.Get(sv)))
 		},
 	},
 

--- a/pkg/util/humanizeutil/BUILD.bazel
+++ b/pkg/util/humanizeutil/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/humanizeutil",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_spf13_pflag//:pflag",
     ],
@@ -23,5 +25,8 @@ go_test(
         "humanize_test.go",
     ],
     embed = [":humanizeutil"],
-    deps = ["//pkg/util/leaktest"],
+    deps = [
+        "//pkg/util/leaktest",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
 )

--- a/pkg/util/humanizeutil/count.go
+++ b/pkg/util/humanizeutil/count.go
@@ -10,10 +10,13 @@
 
 package humanizeutil
 
-import "github.com/dustin/go-humanize"
+import (
+	"github.com/cockroachdb/redact"
+	"github.com/dustin/go-humanize"
+)
 
 // Count formats a unitless integer value like a row count. It uses separating
 // commas for large values (e.g. "1,000,000").
-func Count(val uint64) string {
-	return humanize.Comma(int64(val))
+func Count(val uint64) redact.SafeString {
+	return redact.SafeString(humanize.Comma(int64(val)))
 }

--- a/pkg/util/humanizeutil/duration.go
+++ b/pkg/util/humanizeutil/duration.go
@@ -13,6 +13,8 @@ package humanizeutil
 import (
 	"fmt"
 	"time"
+
+	"github.com/cockroachdb/redact"
 )
 
 // Duration formats a duration in a user-friendly way. The result is not exact
@@ -24,7 +26,7 @@ import (
 //   12345678ns     ->  "12ms"
 //   12345678912ns  ->  "1.2s"
 //
-func Duration(val time.Duration) string {
+func Duration(val time.Duration) redact.SafeString {
 	val = val.Round(time.Microsecond)
 	if val == 0 {
 		return "0µs"
@@ -32,19 +34,19 @@ func Duration(val time.Duration) string {
 
 	// Everything under 1ms will show up as µs.
 	if val < time.Millisecond {
-		return val.String()
+		return redact.SafeString(val.String())
 	}
 	// Everything in-between 1ms and 1s will show up as ms.
 	if val < time.Second {
-		return val.Round(time.Millisecond).String()
+		return redact.SafeString(val.Round(time.Millisecond).String())
 	}
 	// Everything in-between 1s and 1m will show up as seconds with one decimal.
 	if val < time.Minute {
-		return val.Round(100 * time.Millisecond).String()
+		return redact.SafeString(val.Round(100 * time.Millisecond).String())
 	}
 
 	// Everything larger is rounded to the nearest second.
-	return val.Round(time.Second).String()
+	return redact.SafeString(val.Round(time.Second).String())
 }
 
 // LongDuration formats a duration that is expected to be on the order of
@@ -58,7 +60,7 @@ func Duration(val time.Duration) string {
 //  - 1 hour
 //  - 5 days
 //  - 1000 days
-func LongDuration(val time.Duration) string {
+func LongDuration(val time.Duration) redact.SafeString {
 	var round time.Duration
 	var unit string
 
@@ -85,5 +87,5 @@ func LongDuration(val time.Duration) string {
 	if n != 1 {
 		s = "s"
 	}
-	return fmt.Sprintf("%d %s%s", n, unit, s)
+	return redact.SafeString(fmt.Sprintf("%d %s%s", n, unit, s))
 }

--- a/pkg/util/humanizeutil/duration_test.go
+++ b/pkg/util/humanizeutil/duration_test.go
@@ -13,12 +13,14 @@ package humanizeutil
 import (
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/redact"
 )
 
 func TestDuration(t *testing.T) {
 	testCases := []struct {
 		val time.Duration
-		exp string
+		exp redact.SafeString
 	}{
 		{val: 0, exp: "0µs"},
 		{val: 12, exp: "0µs"},
@@ -56,7 +58,7 @@ func TestDuration(t *testing.T) {
 func TestLongDuration(t *testing.T) {
 	testCases := []struct {
 		val time.Duration
-		exp string
+		exp redact.SafeString
 	}{
 		{val: 0, exp: "0 seconds"},
 		{val: time.Second, exp: "1 second"},

--- a/pkg/util/humanizeutil/humanize_test.go
+++ b/pkg/util/humanizeutil/humanize_test.go
@@ -42,11 +42,11 @@ func TestBytes(t *testing.T) {
 
 	for i, testCase := range testCases {
 		// Test IBytes.
-		if actual := humanizeutil.IBytes(testCase.value); actual != testCase.exp {
+		if actual := string(humanizeutil.IBytes(testCase.value)); actual != testCase.exp {
 			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, testCase.value, actual, testCase.exp)
 		}
 		// Test negative IBytes.
-		if actual := humanizeutil.IBytes(-testCase.value); actual != testCase.expNeg {
+		if actual := string(humanizeutil.IBytes(-testCase.value)); actual != testCase.expNeg {
 			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, -testCase.value, actual,
 				testCase.expNeg)
 		}


### PR DESCRIPTION
This allows formatting values in e.g. log entries without explicitly
marking them as safe.

Release note: None