### PR TITLE
kvprober: add feature to bypass admission queue

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -820,6 +820,24 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	nodeID, _ := db.ctx.NodeID.OptionalNodeID() // zero if not available
 	txn := NewTxn(ctx, db, nodeID)
 	txn.SetDebugName("unnamed")
+	return runTxn(ctx, txn, retryable)
+}
+
+// TxnRootKV is the same as Txn, but specifically represents a request
+// originating within KV, and that is at the root of the tree of requests. For
+// KV usage that should be subject to admission control. Do not use this for
+// executing work originating in SQL. This distinction only causes this
+// transaction to undergo admission control. See AdmissionHeader_Source for more
+// details.
+func (db *DB) TxnRootKV(ctx context.Context, retryable func(context.Context, *Txn) error) error {
+	nodeID, _ := db.ctx.NodeID.OptionalNodeID() // zero if not available
+	txn := NewTxnRootKV(ctx, db, nodeID)
+	txn.SetDebugName("unnamed")
+	return runTxn(ctx, txn, retryable)
+}
+
+// runTxn runs the given retryable transaction function using the given *Txn.
+func runTxn(ctx context.Context, txn *Txn, retryable func(context.Context, *Txn) error) error {
 	err := txn.exec(ctx, func(ctx context.Context, txn *Txn) error {
 		return retryable(ctx, txn)
 	})

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -137,6 +137,69 @@ type Metrics struct {
 	ProbePlanFailures  *metric.Counter
 }
 
+// proberOps is an interface that the prober will use to run ops against some
+// system. This interface exists so that ops can be mocked for tests.
+type proberOps interface {
+	Read(key interface{}) func(context.Context, *kv.Txn) error
+	Write(key interface{}) func(context.Context, *kv.Txn) error
+}
+
+// proberTxn is an interface that the prober will use to run txns. This
+// interface exists so that txn can be mocked for tests.
+type proberTxn interface {
+	// Txn runs the given function with a transaction having the admission
+	// source in the header set to OTHER. Transaction work submitted from this
+	// source currently bypassess admission control.
+	Txn(context.Context, func(context.Context, *kv.Txn) error) error
+	// TxnRootKV runs the given function with a transaction having the admission
+	// source in the header set to ROOT KV. Transaction work submitted from this
+	// source should not bypass admission control.
+	TxnRootKV(context.Context, func(context.Context, *kv.Txn) error) error
+}
+
+// proberOpsImpl is used to probe the kv layer.
+type proberOpsImpl struct {
+}
+
+// We attempt to commit a txn that reads some data at the key.
+func (p *proberOpsImpl) Read(key interface{}) func(context.Context, *kv.Txn) error {
+	return func(ctx context.Context, txn *kv.Txn) error {
+		_, err := txn.Get(ctx, key)
+		return err
+	}
+}
+
+// We attempt to commit a txn that puts some data at the key then deletes
+// it. The test of the write code paths is good: We get a raft command that
+// goes thru consensus and is written to the pebble log. Importantly, no
+// *live* data is left at the key, which simplifies the kvprober, as then
+// there is no need to clean up data at the key post range split / merge.
+// Note that MVCC tombstones may be left by the probe, but this is okay, as
+// GC will clean it up.
+func (p *proberOpsImpl) Write(key interface{}) func(context.Context, *kv.Txn) error {
+	return func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.Put(ctx, key, putValue); err != nil {
+			return err
+		}
+		return txn.Del(ctx, key)
+	}
+}
+
+// proberTxnImpl is used to run transactions.
+type proberTxnImpl struct {
+	db *kv.DB
+}
+
+func (p *proberTxnImpl) Txn(ctx context.Context, f func(context.Context, *kv.Txn) error) error {
+	return p.db.Txn(ctx, f)
+}
+
+func (p *proberTxnImpl) TxnRootKV(
+	ctx context.Context, f func(context.Context, *kv.Txn) error,
+) error {
+	return p.db.TxnRootKV(ctx, f)
+}
+
 // NewProber creates a Prober from Opts.
 func NewProber(opts Opts) *Prober {
 	return &Prober{
@@ -209,14 +272,10 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 // Doesn't return an error. Instead increments error type specific metrics.
 func (p *Prober) readProbe(ctx context.Context, db *kv.DB, pl planner) {
-	p.readProbeImpl(ctx, db, pl)
+	p.readProbeImpl(ctx, &proberOpsImpl{}, &proberTxnImpl{db: p.db}, pl)
 }
 
-type dbGetter interface {
-	Get(ctx context.Context, key interface{}) (kv.KeyValue, error)
-}
-
-func (p *Prober) readProbeImpl(ctx context.Context, db dbGetter, pl planner) {
+func (p *Prober) readProbeImpl(ctx context.Context, ops proberOps, txns proberTxn, pl planner) {
 	if !readEnabled.Get(&p.settings.SV) {
 		return
 	}
@@ -249,8 +308,11 @@ func (p *Prober) readProbeImpl(ctx context.Context, db dbGetter, pl planner) {
 		// There is no data at the key, but that is okay. Even tho there is no data
 		// at the key, the prober still executes a read operation on the range.
 		// TODO(josh): Trace the probes.
-		_, err = db.Get(ctx, step.Key)
-		return err
+		f := ops.Read(step.Key)
+		if bypassAdmissionControl.Get(&p.settings.SV) {
+			return txns.Txn(ctx, f)
+		}
+		return txns.TxnRootKV(ctx, f)
 	})
 	if err != nil {
 		// TODO(josh): Write structured events with log.Structured.
@@ -268,14 +330,10 @@ func (p *Prober) readProbeImpl(ctx context.Context, db dbGetter, pl planner) {
 
 // Doesn't return an error. Instead increments error type specific metrics.
 func (p *Prober) writeProbe(ctx context.Context, db *kv.DB, pl planner) {
-	p.writeProbeImpl(ctx, db, pl)
+	p.writeProbeImpl(ctx, &proberOpsImpl{}, &proberTxnImpl{db: p.db}, pl)
 }
 
-type dbTxner interface {
-	Txn(ctx context.Context, f func(ctx context.Context, txn *kv.Txn) error) error
-}
-
-func (p *Prober) writeProbeImpl(ctx context.Context, db dbTxner, pl planner) {
+func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOps, txns proberTxn, pl planner) {
 	if !writeEnabled.Get(&p.settings.SV) {
 		return
 	}
@@ -297,20 +355,11 @@ func (p *Prober) writeProbeImpl(ctx context.Context, db dbTxner, pl planner) {
 	// perspective of the user.
 	timeout := writeTimeout.Get(&p.settings.SV)
 	err = contextutil.RunWithTimeout(ctx, "write probe", timeout, func(ctx context.Context) error {
-		// We attempt to commit a txn that puts some data at the key then
-		// deletes it. The test of the write code paths is good: We get
-		// a raft command that goes thru consensus and is written to the
-		// pebble log. Importantly, no *live* data is left at the key,
-		// which simplifies the kvprober, as then there is no need to clean
-		// up data at the key post range split / merge. Note that MVCC
-		// tombstones may be left by the probe, but this is okay, as GC will
-		// clean it up.
-		return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			if err := txn.Put(ctx, step.Key, putValue); err != nil {
-				return err
-			}
-			return txn.Del(ctx, step.Key)
-		})
+		f := ops.Write(step.Key)
+		if bypassAdmissionControl.Get(&p.settings.SV) {
+			return txns.Txn(ctx, f)
+		}
+		return txns.TxnRootKV(ctx, f)
 	})
 	if err != nil {
 		log.Health.Errorf(ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v", step.Key, step.RangeID, err)

--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -29,11 +29,9 @@ func TestReadProbe(t *testing.T) {
 		m := &mock{
 			t:      t,
 			noPlan: true,
-			noGet:  true,
 		}
-		p := initTestProber(m)
-
-		p.readProbeImpl(ctx, m, m)
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
 		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
@@ -42,11 +40,20 @@ func TestReadProbe(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		m := &mock{t: t}
-		p := initTestProber(m)
-		readEnabled.Override(ctx, &p.settings.SV, true)
+		m := &mock{t: t, read: true}
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
-		p.readProbeImpl(ctx, m, m)
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
+	})
+
+	t.Run("happy path with bypass cluster setting overridden", func(t *testing.T) {
+		m := &mock{t: t, bypass: true, read: true}
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
@@ -57,13 +64,11 @@ func TestReadProbe(t *testing.T) {
 	t.Run("planning fails", func(t *testing.T) {
 		m := &mock{
 			t:       t,
+			read:    true,
 			planErr: fmt.Errorf("inject plan failure"),
-			noGet:   true,
 		}
-		p := initTestProber(m)
-		readEnabled.Override(ctx, &p.settings.SV, true)
-
-		p.readProbeImpl(ctx, m, m)
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
@@ -71,15 +76,29 @@ func TestReadProbe(t *testing.T) {
 		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 
-	t.Run("get fails", func(t *testing.T) {
+	t.Run("txn fails", func(t *testing.T) {
 		m := &mock{
 			t:      t,
-			getErr: fmt.Errorf("inject get failure"),
+			read:   true,
+			txnErr: fmt.Errorf("inject txn failure"),
 		}
-		p := initTestProber(m)
-		readEnabled.Override(ctx, &p.settings.SV, true)
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
-		p.readProbeImpl(ctx, m, m)
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeFailures.Count())
+	})
+
+	t.Run("read fails", func(t *testing.T) {
+		m := &mock{
+			t:       t,
+			read:    true,
+			readErr: fmt.Errorf("inject read failure"),
+		}
+		p := initTestProber(ctx, m)
+		p.readProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
@@ -95,11 +114,9 @@ func TestWriteProbe(t *testing.T) {
 		m := &mock{
 			t:      t,
 			noPlan: true,
-			noGet:  true,
 		}
-		p := initTestProber(m)
-
-		p.writeProbeImpl(ctx, m, m)
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
 
 		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
@@ -108,11 +125,20 @@ func TestWriteProbe(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		m := &mock{t: t}
-		p := initTestProber(m)
-		writeEnabled.Override(ctx, &p.settings.SV, true)
+		m := &mock{t: t, write: true}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
 
-		p.writeProbeImpl(ctx, m, m)
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().WriteProbeFailures.Count())
+	})
+
+	t.Run("happy path with bypass cluster setting overridden", func(t *testing.T) {
+		m := &mock{t: t, bypass: true, write: true}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
@@ -123,13 +149,11 @@ func TestWriteProbe(t *testing.T) {
 	t.Run("planning fails", func(t *testing.T) {
 		m := &mock{
 			t:       t,
+			write:   true,
 			planErr: fmt.Errorf("inject plan failure"),
-			noGet:   true,
 		}
-		p := initTestProber(m)
-		writeEnabled.Override(ctx, &p.settings.SV, true)
-
-		p.writeProbeImpl(ctx, m, m)
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
@@ -140,27 +164,43 @@ func TestWriteProbe(t *testing.T) {
 	t.Run("open txn fails", func(t *testing.T) {
 		m := &mock{
 			t:      t,
+			write:  true,
 			txnErr: fmt.Errorf("inject txn failure"),
 		}
-		p := initTestProber(m)
-		writeEnabled.Override(ctx, &p.settings.SV, true)
-
-		p.writeProbeImpl(ctx, m, m)
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
 
 		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
 		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
 	})
-	// TODO(josh): Add cases for put & del failures.
+
+	t.Run("write fails", func(t *testing.T) {
+		m := &mock{
+			t:        t,
+			write:    true,
+			writeErr: fmt.Errorf("inject write failure"),
+		}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
+	})
 }
 
-func initTestProber(m *mock) *Prober {
+func initTestProber(ctx context.Context, m *mock) *Prober {
 	p := NewProber(Opts{
 		Tracer:                  tracing.NewTracer(),
 		HistogramWindowInterval: time.Minute, // actual value not important to test
 		Settings:                cluster.MakeTestingClusterSettings(),
 	})
+	readEnabled.Override(ctx, &p.settings.SV, m.read)
+	writeEnabled.Override(ctx, &p.settings.SV, m.write)
+	bypassAdmissionControl.Override(ctx, &p.settings.SV, m.bypass)
 	p.readPlanner = m
 	return p
 }
@@ -168,28 +208,61 @@ func initTestProber(m *mock) *Prober {
 type mock struct {
 	t *testing.T
 
+	bypass bool
+
 	noPlan  bool
 	planErr error
 
-	noGet  bool
-	getErr error
-	txnErr error
+	read     bool
+	write    bool
+	readErr  error
+	writeErr error
+	txnErr   error
 }
 
 func (m *mock) next(ctx context.Context) (Step, error) {
 	if m.noPlan {
-		m.t.Errorf("plan call made but not expected")
+		m.t.Error("plan call made but not expected")
 	}
 	return Step{}, m.planErr
 }
 
-func (m *mock) Get(ctx context.Context, key interface{}) (kv.KeyValue, error) {
-	if m.noGet {
-		m.t.Errorf("get call made but not expected")
+func (m *mock) Read(key interface{}) func(context.Context, *kv.Txn) error {
+	return func(context.Context, *kv.Txn) error {
+		if !m.read {
+			m.t.Error("read call made but not expected")
+		}
+		return m.readErr
 	}
-	return kv.KeyValue{}, m.getErr
+}
+
+func (m *mock) Write(key interface{}) func(context.Context, *kv.Txn) error {
+	return func(context.Context, *kv.Txn) error {
+		if !m.write {
+			m.t.Error("write call made but not expected")
+		}
+		return m.writeErr
+	}
 }
 
 func (m *mock) Txn(ctx context.Context, f func(ctx context.Context, txn *kv.Txn) error) error {
-	return m.txnErr
+	if !m.bypass {
+		m.t.Error("normal txn used but bypass is not set")
+	}
+	if m.txnErr != nil {
+		return m.txnErr
+	}
+	return f(ctx, &kv.Txn{})
+}
+
+func (m *mock) TxnRootKV(
+	ctx context.Context, f func(ctx context.Context, txn *kv.Txn) error,
+) error {
+	if m.bypass {
+		m.t.Error("root kv txn used but bypass is set")
+	}
+	if m.txnErr != nil {
+		return m.txnErr
+	}
+	return f(ctx, &kv.Txn{})
 }

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -17,6 +17,18 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// kv.prober.bypass_admission_control controls whether kvprober's requests
+// should bypass kv layer's admission control. Setting this value to true
+// ensures that kvprober will not be significantly affected if the cluster is
+// overloaded.
+var bypassAdmissionControl = settings.RegisterBoolSetting(
+	"kv.prober.bypass_admission_control.enabled",
+	"set to bypass admission control queue for kvprober requests; "+
+		"note that dedicated clusters should have this set as users own capacity planning "+
+		"but serverless clusters should not have this set as SREs own capacity planning",
+	true,
+)
+
 var readEnabled = settings.RegisterBoolSetting(
 	"kv.prober.read.enabled",
 	"whether the KV read prober is enabled",

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -100,6 +100,8 @@ type Txn struct {
 
 // NewTxn returns a new RootTxn.
 // Note: for SQL usage, prefer NewTxnWithSteppingEnabled() below.
+// Note: for KV usage that should be subject to admission control, prefer
+// NewTxnRootKV() below.
 //
 // If the transaction is used to send any operations, CommitOrCleanup() or
 // CleanupOnError() should eventually be called to commit/rollback the
@@ -144,6 +146,22 @@ func NewTxnWithSteppingEnabled(ctx context.Context, db *DB, gatewayNodeID roachp
 		Source:     roachpb.AdmissionHeader_FROM_SQL,
 	}
 	_ = txn.ConfigureStepping(ctx, SteppingEnabled)
+	return txn
+}
+
+// NewTxnRootKV is like NewTxn but specifically represents a transaction
+// originating within KV and that is at the root of the tree of requests. For KV
+// usage that should be subject to admission control. Do not use this for
+// executing transactions originating in SQL. This distinction only causes this
+// transaction to undergo admission control. See AdmissionHeader_Source for more
+// details.
+func NewTxnRootKV(ctx context.Context, db *DB, gatewayNodeID roachpb.NodeID) *Txn {
+	txn := NewTxn(ctx, db, gatewayNodeID)
+	txn.admissionHeader = roachpb.AdmissionHeader{
+		Priority:   int32(admission.NormalPri),
+		CreateTime: timeutil.Now().UnixNano(),
+		Source:     roachpb.AdmissionHeader_ROOT_KV,
+	}
 	return txn
 }
 

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -154,10 +154,10 @@ func TestInitPut(t *testing.T) {
 	}
 }
 
-// TestTransactionConfig verifies the proper unwrapping and
-// re-wrapping of the client's sender when starting a transaction.
-// Also verifies that the UserPriority is propagated to the
-// transactional client.
+// TestTransactionConfig verifies the proper unwrapping and re-wrapping of the
+// client's sender when starting a transaction. Also verifies that the
+// UserPriority is propagated to the transactional client and that the admission
+// header is set correctly depending on how the transaction is instantiated.
 func TestTransactionConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -170,14 +170,34 @@ func TestTransactionConfig(t *testing.T) {
 	db := NewDBWithContext(
 		testutils.MakeAmbientCtx(),
 		newTestTxnFactory(nil), clock, dbCtx)
-	if err := db.Txn(context.Background(), func(ctx context.Context, txn *Txn) error {
-		if txn.db.ctx.UserPriority != db.ctx.UserPriority {
-			t.Errorf("expected txn user priority %f; got %f",
-				db.ctx.UserPriority, txn.db.ctx.UserPriority)
+	for _, tc := range []struct {
+		label               string
+		txnCreator          func(context.Context, func(context.Context, *Txn) error) error
+		wantAdmissionHeader roachpb.AdmissionHeader_Source
+	}{
+		{
+			label:               "source is other",
+			txnCreator:          db.Txn,
+			wantAdmissionHeader: roachpb.AdmissionHeader_OTHER,
+		},
+		{
+			label:               "source is root kv",
+			txnCreator:          db.TxnRootKV,
+			wantAdmissionHeader: roachpb.AdmissionHeader_ROOT_KV,
+		},
+	} {
+		if err := tc.txnCreator(context.Background(), func(ctx context.Context, txn *Txn) error {
+			if txn.db.ctx.UserPriority != db.ctx.UserPriority {
+				t.Errorf("expected txn user priority %f; got %f",
+					db.ctx.UserPriority, txn.db.ctx.UserPriority)
+			}
+			if txn.admissionHeader.Source != tc.wantAdmissionHeader {
+				t.Errorf("expected txn source %d; got %d", tc.wantAdmissionHeader, txn.admissionHeader.Source)
+			}
+			return nil
+		}); err != nil {
+			t.Errorf("unexpected error on commit: %s", err)
 		}
-		return nil
-	}); err != nil {
-		t.Errorf("unexpected error on commit: %s", err)
 	}
 }
 


### PR DESCRIPTION
Currently kvprober is bypassing the kv admission queue unconditionally.
This is fine for dedicated clusters, since the user owns capacity
planning.  But it is a problem for serverless clusters because the SRE
team owns capacity scaling. When hardware resources are overloaded in
serverless clusters, the probes are expected to fail.

This commit adds a new cluster setting for kvprober that determines if
the admission control should be bypassed. The cluster setting works by
adjusting the admission source header in kvprober's transaction
requests:

- When set, it uses a txn sourced from OTHER which is going to bypass
  the admission queue.
- When not set, it uses a txn sourced from ROOT_KV which is not going to
  bypass admission queue.

Control over what the txn admission header is set to is provided through
kv.DB and kv.Txn.

Release note: None