### PR TITLE
cmd/roachtest: fix `--cluster` for new `roachprod`

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1028,7 +1028,8 @@ func (c *clusterImpl) validate(
 ) error {
 	// Perform validation on the existing cluster.
 	c.status("checking that existing cluster matches spec")
-	sargs := []string{roachprod, "list", c.name, "--json", "--quiet"}
+	pattern := "^" + regexp.QuoteMeta(c.name) + "$"
+	sargs := []string{roachprod, "list", "--pattern", pattern, "--json", "--quiet"}
 	out, err := execCmdWithBuffer(ctx, l, sargs...)
 	if err != nil {
 		return err


### PR DESCRIPTION
The `roachprod list` command no longer takes a positional argument to filter
the results. This commit adopts the new `--pattern` flag in `roachtest`. This
is important when providing your own cluster for roachtest with the `--cluster`
flag.

Release note: None