### PR TITLE
democluster: fix global mode in multitenant cluster

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -196,13 +196,6 @@ func checkDemoConfiguration(
 		}
 	}
 
-	// If the user has specified the --global flag, disable multi-tenant mode
-	// unless the user has requested it explicitly. This is required until we
-	// address #72231.
-	if demoCtx.SimulateLatency && !f.Lookup(cliflags.DemoMultitenant.Name).Changed {
-		demoCtx.Multitenant = false
-	}
-
 	return gen, nil
 }
 


### PR DESCRIPTION
Previously when launching multitenant cluster with global option
server testing knobs didn't contain latency map.
Without map tenants will use plain grpc connections. This
is not working because latency injection needs both connection
sides to be aware as it uses extra header to negotiate delay.
This inconsistency was causing tenants stuck without being able
to talk to any nodes.
This change introduces latency map on tenants in demo cluster.

Release note (bug fix): cockroach demo could be launched
with --global and --multitenant=true options.

Fixes #72231