### PR TITLE
release-21.2: update app filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -29,7 +29,7 @@ import { MultiSelectCheckbox } from "../multiSelectCheckbox/multiSelectCheckbox"
 interface QueryFilter {
   onSubmitFilters: (filters: Filters) => void;
   smth?: string;
-  appNames: SelectOptions[];
+  appNames: string[];
   activeFilters: number;
   filters: Filters;
   dbNames?: string[];
@@ -69,7 +69,7 @@ const timeUnit = [
 ];
 
 export const defaultFilters: Filters = {
-  app: "All",
+  app: "",
   timeNumber: "0",
   timeUnit: "seconds",
   fullScan: false,
@@ -116,7 +116,7 @@ export const getFiltersFromQueryString = (
  * we want to consider 0 active Filters
  */
 export const inactiveFiltersState: Filters = {
-  app: "All",
+  app: "",
   timeNumber: "0",
   fullScan: false,
   sqlType: "",
@@ -289,6 +289,27 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
       border: "none",
     });
 
+    const appsOptions = appNames.map(app => ({
+      label: app,
+      value: app,
+      isSelected: this.isOptionSelected(app, filters.app),
+    }));
+    const appValue = appsOptions.filter(option => {
+      return filters.app.split(",").includes(option.label);
+    });
+    const appFilter = (
+      <div>
+        <div className={filterLabel.margin}>App</div>
+        <MultiSelectCheckbox
+          options={appsOptions}
+          placeholder="All"
+          field="app"
+          parent={this}
+          value={appValue}
+        />
+      </div>
+    );
+
     const databasesOptions = showDB
       ? dbNames.map(db => ({
           label: db,
@@ -413,14 +434,6 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     );
     // TODO replace all onChange actions in Selects and Checkboxes with one onSubmit in <form />
 
-    // Some app names could be empty strings, so we're adding " " to those names,
-    // this way it's easier for the user to recognize the blank name.
-    const apps = appNames.map(app => {
-      const label =
-        app.label.trim().length === 0 ? '"' + app.label + '"' : app.label;
-      return { label: label, value: app.value };
-    });
-
     return (
       <div onClick={this.insideClick} ref={this.dropdownRef}>
         <div className={dropdownButton} onClick={this.toggleFilters}>
@@ -429,14 +442,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         </div>
         <div className={dropdownArea}>
           <div className={dropdownContentWrapper}>
-            <div className={filterLabel.top}>App</div>
-            <Select
-              options={apps}
-              onChange={e => this.handleSelectChange(e, "app")}
-              value={apps.filter(app => app.value === filters.app)}
-              placeholder="All"
-              styles={customStyles}
-            />
+            {appFilter}
             {showDB ? dbFilter : ""}
             {showSqlType ? sqlTypeFilter : ""}
             {showRegions ? regionsFilter : ""}

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -153,13 +153,13 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
 
   dropdownRef: React.RefObject<HTMLDivElement> = React.createRef();
 
-  componentDidMount() {
+  componentDidMount(): void {
     window.addEventListener("click", this.outsideClick, false);
   }
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     window.removeEventListener("click", this.outsideClick, false);
   }
-  componentDidUpdate(prevProps: QueryFilter) {
+  componentDidUpdate(prevProps: QueryFilter): void {
     if (prevProps.filters !== this.props.filters) {
       this.setState({
         filters: {
@@ -168,21 +168,21 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
       });
     }
   }
-  outsideClick = (event: any) => {
+  outsideClick = (event: any): void => {
     this.setState({ hide: true });
   };
 
-  insideClick = (event: any) => {
+  insideClick = (event: any): void => {
     event.stopPropagation();
   };
 
-  toggleFilters = () => {
+  toggleFilters = (): void => {
     this.setState({
       hide: !this.state.hide,
     });
   };
 
-  handleSubmit = () => {
+  handleSubmit = (): void => {
     this.props.onSubmitFilters(this.state.filters);
     this.setState({ hide: true });
   };
@@ -220,14 +220,14 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
   };
 
-  validateInput = (value: string) => {
+  validateInput = (value: string): string => {
     const isInteger = /^[0-9]+$/;
     return (value === "" || isInteger.test(value)) && value.length <= 3
       ? value
       : this.state.filters.timeNumber;
   };
 
-  clearInput = () => {
+  clearInput = (): void => {
     this.setState({
       filters: {
         ...this.state.filters,
@@ -238,11 +238,10 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
 
   isOptionSelected = (option: string, field: string): boolean => {
     const selection = field.split(",");
-    if (selection.length > 0 && selection.includes(option)) return true;
-    return false;
+    return selection.length > 0 && selection.includes(option);
   };
 
-  render() {
+  render(): React.ReactElement {
     const { hide, filters } = this.state;
     const {
       appNames,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -117,7 +117,7 @@ function filterByRouterParamsPredicate(
     app = "";
   }
 
-  if (app === "(internal)") {
+  if (app === internalAppNamePrefix) {
     return (stmt: ExecutionStatistics) =>
       filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
   }
@@ -152,7 +152,9 @@ export const selectStatement = createSelector(
       byNode: coalesceNodeStats(results),
       app: _.uniq(
         results.map(s =>
-          s.app.startsWith(internalAppNamePrefix) ? "(internal)" : s.app,
+          s.app.startsWith(internalAppNamePrefix)
+            ? internalAppNamePrefix
+            : s.app,
         ),
       ),
       database: queryByName(props.location, databaseAttr),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -98,8 +98,13 @@ function filterByRouterParamsPredicate(
 ): (stat: ExecutionStatistics) => boolean {
   const statement = getMatchParamByName(match, statementAttr);
   const implicitTxn = getMatchParamByName(match, implicitTxnAttr) === "true";
-  const database = queryByName(location, databaseAttr);
-  let app = queryByName(location, appAttr);
+  const database =
+    queryByName(location, databaseAttr) === "(unset)"
+      ? ""
+      : queryByName(location, databaseAttr);
+  const apps = queryByName(location, appAttr)
+    ? queryByName(location, appAttr).split(",")
+    : null;
   // If the aggregatedTs is unset, we will aggregate across the current date range.
   const aggregatedTs = queryByName(location, aggregatedTsAttr);
 
@@ -109,20 +114,21 @@ function filterByRouterParamsPredicate(
     stmt.implicit_txn === implicitTxn &&
     (stmt.database === database || database === null);
 
-  if (!app) {
+  if (!apps) {
     return filterByKeys;
   }
-
-  if (app === "(unset)") {
-    app = "";
+  if (apps.includes("(unset)")) {
+    apps.push("");
+  }
+  let showInternal = false;
+  if (apps.includes(internalAppNamePrefix)) {
+    showInternal = true;
   }
 
-  if (app === internalAppNamePrefix) {
-    return (stmt: ExecutionStatistics) =>
-      filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
-  }
-
-  return (stmt: ExecutionStatistics) => filterByKeys(stmt) && stmt.app === app;
+  return (stmt: ExecutionStatistics) =>
+    filterByKeys(stmt) &&
+    ((showInternal && stmt.app.startsWith(internalAppNamePrefix)) ||
+      apps.includes(stmt.app));
 }
 
 export const selectStatement = createSelector(

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -176,7 +176,7 @@ function statementsRequestFromProps(
 
 function AppLink(props: { app: string }) {
   if (!props.app) {
-    return <span className={cx("app-name", "app-name__unset")}>(unset)</span>;
+    return <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>;
   }
 
   const searchParams = new URLSearchParams({ [appAttr]: props.app });
@@ -184,7 +184,7 @@ function AppLink(props: { app: string }) {
   return (
     <Link
       className={cx("app-name")}
-      to={`/statements/?${searchParams.toString()}`}
+      to={`/sql-activity?tab=statements&${searchParams.toString()}`}
     >
       {props.app}
     </Link>
@@ -536,6 +536,12 @@ export class StatementDetails extends React.Component<
     const showRowsWritten =
       stats.sql_type === "TypeDML" && summary.statement !== "select";
 
+    const db = database ? (
+      <Text>{database}</Text>
+    ) : (
+      <Text className={cx("app-name", "app-name__unset")}>(unset)</Text>
+    );
+
     return (
       <Tabs
         defaultActiveKey="1"
@@ -685,7 +691,7 @@ export class StatementDetails extends React.Component<
 
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Database</Text>
-                  <Text>{database}</Text>
+                  {db}
                 </div>
                 <p
                   className={summaryCardStylesCx(

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -629,7 +629,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   ],
   statementsError: null,
   dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
-  apps: ["(internal)", "movr", "$ cockroach demo"],
+  apps: ["$ internal", "movr", "$ cockroach demo"],
   totalFingerprints: 95,
   lastReset: "2020-04-13 07:22:23",
   columns: null,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -84,7 +84,9 @@ export const selectApps = createSelector(
       },
     );
     return []
-      .concat(sawInternal ? ["(internal)"] : [])
+      .concat(
+        sawInternal ? [statementsState.data.internal_app_name_prefix] : [],
+      )
       .concat(sawBlank ? ["(unset)"] : [])
       .concat(Object.keys(apps));
   },
@@ -153,7 +155,7 @@ export const selectStatements = createSelector(
       let showInternal = false;
       if (criteria === "(unset)") {
         criteria = "";
-      } else if (criteria === "(internal)") {
+      } else if (criteria === state.data.internal_app_name_prefix) {
         showInternal = true;
       }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -103,7 +103,9 @@ export const selectDatabases = createSelector(
 
     return Array.from(
       new Set(
-        statementsState.data.statements.map(s => s.key.key_data.database),
+        statementsState.data.statements.map(s =>
+          s.key.key_data.database ? s.key.key_data.database : "(unset)",
+        ),
       ),
     ).filter((dbName: string) => dbName !== null && dbName.length > 0);
   },
@@ -151,17 +153,19 @@ export const selectStatements = createSelector(
       statement.app.startsWith(state.data.internal_app_name_prefix);
 
     if (app && app !== "All") {
-      let criteria = decodeURIComponent(app);
+      const criteria = decodeURIComponent(app).split(",");
       let showInternal = false;
-      if (criteria === "(unset)") {
-        criteria = "";
-      } else if (criteria === state.data.internal_app_name_prefix) {
+      if (criteria.includes(state.data.internal_app_name_prefix)) {
         showInternal = true;
+      }
+      if (criteria.includes("(unset)")) {
+        criteria.push("");
       }
 
       statements = statements.filter(
         (statement: ExecutionStatistics) =>
-          (showInternal && isInternal(statement)) || statement.app === criteria,
+          (showInternal && isInternal(statement)) ||
+          criteria.includes(statement.app),
       );
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -167,6 +167,11 @@ export const selectStatements = createSelector(
           (showInternal && isInternal(statement)) ||
           criteria.includes(statement.app),
       );
+    } else {
+      // We don't want to show internal statements by default.
+      statements = statements.filter(
+        (statement: ExecutionStatistics) => !isInternal(statement),
+      );
     }
 
     const statsByStatementKey: {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -339,6 +339,9 @@ export class StatementsPage extends React.Component<
         : [];
     const databases =
       filters.database.length > 0 ? filters.database.split(",") : [];
+    if (databases.includes("(unset)")) {
+      databases.push("");
+    }
     const regions =
       filters.regions.length > 0 ? filters.regions.split(",") : [];
     const nodes = filters.nodes.length > 0 ? filters.nodes.split(",") : [];
@@ -409,6 +412,7 @@ export class StatementsPage extends React.Component<
     const { pagination, search, filters, activeFilters } = this.state;
     const {
       statements,
+      apps,
       databases,
       location,
       onDiagnosticsReportDownload,
@@ -421,8 +425,6 @@ export class StatementsPage extends React.Component<
     } = this.props;
     const appAttrValue = queryByName(location, appAttr);
     const selectedApp = appAttrValue || "";
-    const appOptions = [{ value: "", label: "All" }];
-    this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
     const data = this.filteredStatementsData();
     const totalWorkload = calculateTotalWorkload(data);
     const totalCount = data.length;
@@ -495,7 +497,7 @@ export class StatementsPage extends React.Component<
           <PageConfigItem>
             <Filter
               onSubmitFilters={this.onSubmitFilters}
-              appNames={appOptions}
+              appNames={apps}
               dbNames={databases}
               regions={regions}
               nodes={nodes.map(n => "n" + n)}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -28,7 +28,7 @@ storiesOf("StatementsSortedTable", module)
       data={statements}
       columns={makeStatementsColumns(
         statements,
-        "(internal)",
+        "$ internal",
         calculateTotalWorkload(statements),
         { "1": "gcp-europe-west1", "2": "gcp-us-east1", "3": "gcp-us-west1" },
         "statement",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -45,7 +45,7 @@ export const StatementTableCell = {
     search?: string,
     selectedApp?: string,
     onStatementClick?: (statement: string) => void,
-  ) => (stmt: any) => (
+  ) => (stmt: AggregateStatistics): React.ReactElement => (
     <StatementLink
       statement={stmt.label}
       aggregatedTs={stmt.aggregatedTs}
@@ -59,7 +59,7 @@ export const StatementTableCell = {
   diagnostics: (
     activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>,
     onDiagnosticsDownload: (report: IStatementDiagnosticsReport) => void = noop,
-  ) => (stmt: AggregateStatistics) => {
+  ) => (stmt: AggregateStatistics): React.ReactElement => {
     /*
      * Diagnostics cell might display different components depending
      * on following states:
@@ -124,7 +124,9 @@ export const StatementTableCell = {
       </div>
     );
   },
-  nodeLink: (nodeNames: NodeNames) => (stmt: any) => (
+  nodeLink: (nodeNames: NodeNames) => (
+    stmt: AggregateStatistics,
+  ): React.ReactElement => (
     <NodeLink nodeId={stmt.label} nodeNames={nodeNames} />
   ),
 };
@@ -217,7 +219,10 @@ export const StatementLink = ({
   );
 };
 
-export const NodeLink = (props: { nodeId: string; nodeNames?: NodeNames }) => (
+export const NodeLink = (props: {
+  nodeId: string;
+  nodeNames?: NodeNames;
+}): React.ReactElement => (
   <Link to={`/node/${props.nodeId}`}>
     <div className={cx("node-name-tooltip__info-icon")}>
       {props.nodeNames ? props.nodeNames[props.nodeId] : "N" + props.nodeId}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -14,7 +14,7 @@ import {
   getStatementsByFingerprintIdAndTime,
   statementFingerprintIdsToText,
 } from "./utils";
-import { Filters } from "../queryFilter/filter";
+import { Filters } from "../queryFilter";
 import { data, nodeRegions, timestamp } from "./transactions.fixture";
 import Long from "long";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
@@ -46,7 +46,7 @@ const txData = (data.transactions as any) as Transaction[];
 describe("Filter transactions", () => {
   it("show all if no filters applied", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",
@@ -107,6 +107,27 @@ describe("Filter transactions", () => {
     );
   });
 
+  it("filters by 2 apps", () => {
+    const filter: Filters = {
+      app: "$ TEST EXACT,$ TEST",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      nodes: "",
+      regions: "",
+    };
+    assert.equal(
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+        false,
+      ).transactions.length,
+      4,
+    );
+  });
+
   it("filters by internal prefix", () => {
     const filter: Filters = {
       app: data.internal_app_name_prefix,
@@ -130,7 +151,7 @@ describe("Filter transactions", () => {
 
   it("filters by time", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "40",
       timeUnit: "miliseconds",
       nodes: "",
@@ -151,7 +172,7 @@ describe("Filter transactions", () => {
 
   it("filters by one node", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n1",
@@ -172,7 +193,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple nodes", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n2,n4",
@@ -193,7 +214,7 @@ describe("Filter transactions", () => {
 
   it("filters by one region", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",
@@ -214,7 +235,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple regions", () => {
     const filter: Filters = {
-      app: "All",
+      app: "",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -44,7 +44,7 @@ describe("getStatementsByFingerprintIdAndTime", () => {
 const txData = (data.transactions as any) as Transaction[];
 
 describe("Filter transactions", () => {
-  it("show all if no filters applied", () => {
+  it("show non internal if no filters applied", () => {
     const filter: Filters = {
       app: "",
       timeNumber: "0",
@@ -61,7 +61,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      11,
+      4,
     );
   });
 
@@ -151,7 +151,7 @@ describe("Filter transactions", () => {
 
   it("filters by time", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "40",
       timeUnit: "miliseconds",
       nodes: "",
@@ -172,7 +172,7 @@ describe("Filter transactions", () => {
 
   it("filters by one node", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n1",
@@ -193,7 +193,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple nodes", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST,$ TEST EXACT",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "n2,n4",
@@ -214,7 +214,7 @@ describe("Filter transactions", () => {
 
   it("filters by one region", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",
@@ -235,7 +235,7 @@ describe("Filter transactions", () => {
 
   it("filters by multiple regions", () => {
     const filter: Filters = {
-      app: "",
+      app: "$ internal,$ TEST,$ TEST EXACT",
       timeNumber: "0",
       timeUnit: "seconds",
       nodes: "",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -11,7 +11,6 @@
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import {
   Filters,
-  SelectOptions,
   getTimeValueInSeconds,
   calculateActiveFilters,
 } from "../queryFilter";
@@ -37,20 +36,15 @@ type Timestamp = protos.google.protobuf.ITimestamp;
 export const getTrxAppFilterOptions = (
   transactions: Transaction[],
   prefix: string,
-): SelectOptions[] => {
-  const defaultAppFilters = ["All", prefix];
+): string[] => {
+  const defaultAppFilters = [prefix];
   const uniqueAppNames = new Set(
     transactions
       .filter(t => !t.stats_data.app.startsWith(prefix))
-      .map(t => t.stats_data.app),
+      .map(t => (t.stats_data.app ? t.stats_data.app : "(unset)")),
   );
 
-  return defaultAppFilters
-    .concat(Array.from(uniqueAppNames))
-    .map(filterValue => ({
-      label: filterValue,
-      value: filterValue,
-    }));
+  return defaultAppFilters.concat(Array.from(uniqueAppNames));
 };
 
 export const collectStatementsText = (statements: Statement[]): string =>
@@ -146,13 +140,25 @@ export const filterTransactions = (
   // transaction must match all selected filters.
   // Current filters: app, service latency, nodes and regions.
   const filteredTransactions = data
-    .filter(
-      (t: Transaction) =>
-        filters.app === "All" ||
+    .filter((t: Transaction) => {
+      const isInternal = (t: Transaction) =>
+        t.stats_data.app.startsWith(internalAppNamePrefix);
+      const apps = filters.app.split(",");
+      let showInternal = false;
+      if (apps.includes(internalAppNamePrefix)) {
+        showInternal = true;
+      }
+      if (apps.includes("(unset)")) {
+        apps.push("");
+      }
+
+      return (
+        filters.app === "" ||
+        (showInternal && isInternal(t)) ||
         t.stats_data.app === filters.app ||
-        (filters.app === internalAppNamePrefix &&
-          t.stats_data.app.includes(filters.app)),
-    )
+        apps.includes(t.stats_data.app)
+      );
+    })
     .filter(
       (t: Transaction) =>
         t.stats_data.stats.service_lat.mean >= timeValue ||

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -138,26 +138,32 @@ export const filterTransactions = (
 
   // Return transactions filtered by the values selected on the filter. A
   // transaction must match all selected filters.
+  // We don't want to show statements that are internal or with unset App names by default.
   // Current filters: app, service latency, nodes and regions.
   const filteredTransactions = data
     .filter((t: Transaction) => {
       const isInternal = (t: Transaction) =>
         t.stats_data.app.startsWith(internalAppNamePrefix);
-      const apps = filters.app.split(",");
-      let showInternal = false;
-      if (apps.includes(internalAppNamePrefix)) {
-        showInternal = true;
-      }
-      if (apps.includes("(unset)")) {
-        apps.push("");
-      }
 
-      return (
-        filters.app === "" ||
-        (showInternal && isInternal(t)) ||
-        t.stats_data.app === filters.app ||
-        apps.includes(t.stats_data.app)
-      );
+      if (filters.app && filters.app != "All") {
+        const apps = filters.app.split(",");
+        let showInternal = false;
+        if (apps.includes(internalAppNamePrefix)) {
+          showInternal = true;
+        }
+        if (apps.includes("(unset)")) {
+          apps.push("");
+        }
+
+        return (
+          (showInternal && isInternal(t)) ||
+          t.stats_data.app === filters.app ||
+          apps.includes(t.stats_data.app)
+        );
+      } else {
+        // We don't want to show internal transactions by default.
+        return !isInternal(t);
+      }
     })
     .filter(
       (t: Transaction) =>

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -319,14 +319,14 @@ describe("Routing to", () => {
 
   describe("'/statements/:${appAttr}' path", () => {
     it("routes to <StatementsPage> component", () => {
-      navigateToPath("/statements/(internal)");
+      navigateToPath("/statements/%24+internal");
       assert.lengthOf(appWrapper.find(StatementsPage), 1);
     });
   });
 
   describe("'/statements/:${appAttr}/:${statementAttr}' path", () => {
     it("routes to <StatementDetails> component", () => {
-      navigateToPath("/statements/(internal)/true");
+      navigateToPath("/statements/%24+internal/true");
       assert.lengthOf(appWrapper.find(StatementDetails), 1);
     });
   });

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -151,7 +151,7 @@ function filterByRouterParamsPredicate(
     app = "";
   }
 
-  if (app === "(internal)") {
+  if (app === internalAppNamePrefix) {
     return (stmt: ExecutionStatistics) =>
       filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
   }
@@ -186,7 +186,9 @@ export const selectStatement = createSelector(
       byNode: coalesceNodeStats(results),
       app: _.uniq(
         results.map(s =>
-          s.app.startsWith(internalAppNamePrefix) ? "(internal)" : s.app,
+          s.app.startsWith(internalAppNamePrefix)
+            ? internalAppNamePrefix
+            : s.app,
         ),
       ),
       database: queryByName(props.location, databaseAttr),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -132,8 +132,13 @@ function filterByRouterParamsPredicate(
 ): (stat: ExecutionStatistics) => boolean {
   const statement = getMatchParamByName(match, statementAttr);
   const implicitTxn = getMatchParamByName(match, implicitTxnAttr) === "true";
-  const database = queryByName(location, databaseAttr);
-  let app = queryByName(location, appAttr);
+  const database =
+    queryByName(location, databaseAttr) === "(unset)"
+      ? ""
+      : queryByName(location, databaseAttr);
+  const apps = queryByName(location, appAttr)
+    ? queryByName(location, appAttr).split(",")
+    : null;
   // If the aggregatedTs is unset, we will aggregate across the current date range.
   const aggregatedTs = queryByName(location, aggregatedTsAttr);
 
@@ -143,20 +148,21 @@ function filterByRouterParamsPredicate(
     stmt.implicit_txn === implicitTxn &&
     (stmt.database === database || database === null);
 
-  if (!app) {
+  if (!apps) {
     return filterByKeys;
   }
-
-  if (app === "(unset)") {
-    app = "";
+  if (apps.includes("(unset)")) {
+    apps.push("");
+  }
+  let showInternal = false;
+  if (apps.includes(internalAppNamePrefix)) {
+    showInternal = true;
   }
 
-  if (app === internalAppNamePrefix) {
-    return (stmt: ExecutionStatistics) =>
-      filterByKeys(stmt) && stmt.app.startsWith(internalAppNamePrefix);
-  }
-
-  return (stmt: ExecutionStatistics) => filterByKeys(stmt) && stmt.app === app;
+  return (stmt: ExecutionStatistics) =>
+    filterByKeys(stmt) &&
+    ((showInternal && stmt.app.startsWith(internalAppNamePrefix)) ||
+      apps.includes(stmt.app));
 }
 
 export const selectStatement = createSelector(
@@ -164,7 +170,6 @@ export const selectStatement = createSelector(
   (_state: AdminUIState, props: RouteComponentProps) => props,
   (statementsState, props) => {
     const statements = statementsState.data?.statements;
-
     if (!statements) {
       return null;
     }

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -65,7 +65,7 @@ describe("selectStatements", () => {
     assert.deepEqual(actualFingerprints, expectedFingerprints);
   });
 
-  it("returns the statements with Internal for default ALL filter", () => {
+  it("returns the statements without Internal for default ALL filter", () => {
     const stmtA = makeFingerprint(1);
     const stmtB = makeFingerprint(2, INTERNAL_STATEMENT_PREFIX);
     const stmtC = makeFingerprint(3, INTERNAL_STATEMENT_PREFIX);
@@ -75,7 +75,7 @@ describe("selectStatements", () => {
 
     const result = selectStatements(state, props);
 
-    assert.equal(result.length, 3);
+    assert.equal(result.length, 2);
   });
 
   it("coalesces statements from different apps", () => {

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -148,13 +148,13 @@ describe("selectStatements", () => {
     assert.equal(result.length, 1);
   });
 
-  it('filters out statements with app set when app param is "(internal)"', () => {
+  it('filters out statements with app set when app param is "$ internal"', () => {
     const state = makeStateWithStatements([
       makeFingerprint(1, "$ internal_stmnt_app"),
       makeFingerprint(2, "bar"),
       makeFingerprint(3, "baz"),
     ]);
-    const props = makeRoutePropsWithApp("(internal)");
+    const props = makeRoutePropsWithApp("$ internal");
     const result = selectStatements(state, props);
     assert.equal(result.length, 1);
   });
@@ -429,7 +429,7 @@ describe("selectStatement", () => {
     assert.deepEqual(result.node_id, [stmtA.key.node_id]);
   });
 
-  it('filters out statements with app set when app param is "(internal)"', () => {
+  it('filters out statements with app set when app param is "$ internal"', () => {
     const stmtA = makeFingerprint(1, "$ internal_stmnt_app");
     const state = makeStateWithStatements([
       stmtA,
@@ -438,15 +438,15 @@ describe("selectStatement", () => {
     ]);
     const props = makeRoutePropsWithStatementAndApp(
       stmtA.key.key_data.query,
-      "(internal)",
+      "$ internal",
     );
 
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
     assert.equal(result.stats.count.toNumber(), stmtA.stats.count.toNumber());
-    // Statements with internal app prefix should have "(internal)" as app name
-    assert.deepEqual(result.app, ["(internal)"]);
+    // Statements with internal app prefix should have "$ internal" as app name
+    assert.deepEqual(result.app, ["$ internal"]);
     assert.deepEqual(result.distSQL, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.vec, { numerator: 0, denominator: 1 });
     assert.deepEqual(result.opt, { numerator: 0, denominator: 1 });

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -546,7 +546,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
   ],
   statementsError: null,
-  apps: ["(internal)", "movr", "$ cockroach demo"],
+  apps: ["$ internal", "movr", "$ cockroach demo"],
   totalFingerprints: 95,
   lastReset: "2020-04-13 07:22:23",
   dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -88,7 +88,7 @@ export const selectStatements = createSelector(
       let showInternal = false;
       if (criteria === "(unset)") {
         criteria = "";
-      } else if (criteria === "(internal)") {
+      } else if (criteria === state.data.internal_app_name_prefix) {
         showInternal = true;
       }
 
@@ -160,7 +160,7 @@ export const selectApps = createSelector(
       },
     );
     return []
-      .concat(sawInternal ? ["(internal)"] : [])
+      .concat(sawInternal ? [state.data.internal_app_name_prefix] : [])
       .concat(sawBlank ? ["(unset)"] : [])
       .concat(Object.keys(apps));
   },

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -98,6 +98,11 @@ export const selectStatements = createSelector(
           (showInternal && isInternal(statement)) ||
           criteria.includes(statement.app),
       );
+    } else {
+      // We don't want to show internal statements by default.
+      statements = statements.filter(
+        (statement: ExecutionStatistics) => !isInternal(statement),
+      );
     }
 
     const statsByStatementKey: {

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -84,17 +84,19 @@ export const selectStatements = createSelector(
       statement.app.startsWith(state.data.internal_app_name_prefix);
 
     if (app && app !== "All") {
-      let criteria = decodeURIComponent(app);
+      const criteria = decodeURIComponent(app).split(",");
       let showInternal = false;
-      if (criteria === "(unset)") {
-        criteria = "";
-      } else if (criteria === state.data.internal_app_name_prefix) {
+      if (criteria.includes(state.data.internal_app_name_prefix)) {
         showInternal = true;
+      }
+      if (criteria.includes("(unset)")) {
+        criteria.push("");
       }
 
       statements = statements.filter(
         (statement: ExecutionStatistics) =>
-          (showInternal && isInternal(statement)) || statement.app === criteria,
+          (showInternal && isInternal(statement)) ||
+          criteria.includes(statement.app),
       );
     }
 
@@ -175,7 +177,11 @@ export const selectDatabases = createSelector(
       return [];
     }
     return Array.from(
-      new Set(state.data.statements.map(s => s.key.key_data.database)),
+      new Set(
+        state.data.statements.map(s =>
+          s.key.key_data.database ? s.key.key_data.database : "(unset)",
+        ),
+      ),
     ).filter((dbName: string) => dbName !== null && dbName.length > 0);
   },
 );


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: use $internal instead of (internal) for filter" (#71581)
  * 1/1 commits from "ui:app filter now has multi select option" (#71897)
  * 1/1 commits from "ui: default filter on Transaction and Statement pages now exclude internals" (#71966)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Category 4