### PR TITLE
sql: improve a test

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2842,6 +2842,7 @@ func TestPrimaryKeyChangeKVOps(t *testing.T) {
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
+	defer close(waitBeforeContinuing)
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;


### PR DESCRIPTION
This test was deadlocking on t.Fatal(). I've ran into this through #72769.

Release note: None