### PR TITLE
sql: disallow ALTER COLUMN TYPE for columns stored in secondary indexes

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -232,6 +232,13 @@ func alterColumnTypeGeneral(
 				return colInIndexNotSupportedErr
 			}
 		}
+		if !idx.Primary() {
+			for i := 0; i < idx.NumSecondaryStoredColumns(); i++ {
+				if idx.GetStoredColumnID(i) == col.GetID() {
+					return colInIndexNotSupportedErr
+				}
+			}
+		}
 	}
 
 	// Disallow ALTER COLUMN TYPE general inside an explicit transaction.

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -332,7 +332,7 @@ func TestSchemaChangeBeforeAlterColumnType(t *testing.T) {
 			},
 		},
 	}
-
+	defer close(waitBeforeContinuing)
 	s, db, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	defer s.Stopper().Stop(ctx)
@@ -353,7 +353,8 @@ ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (x);
 
 	<-swapNotification
 
-	expected := "pq: unimplemented: table test is currently undergoing a schema change"
+	expected := "pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not " +
+		"supported for columns that are part of an index"
 	sqlDB.ExpectErr(t, expected, `
 SET enable_experimental_alter_column_type_general = true;
 ALTER TABLE t.test ALTER COLUMN y TYPE STRING;`)

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -330,20 +330,14 @@ CREATE TABLE uniq (x INT, y INT, UNIQUE WITHOUT INDEX (x, y))
 statement error pq: unimplemented: ALTER COLUMN TYPE for a column that has a constraint is currently not supported
 ALTER TABLE uniq ALTER COLUMN x TYPE STRING
 
-# Ensure we can change the column type of a column stored in a secondary index.
+# Ensure we cannot change the column type of a column stored in a secondary index.
 statement ok
 CREATE TABLE t15 (x INT, y INT);
 CREATE INDEX ON t15 (x) STORING (y);
 INSERT INTO t15 VALUES (1, 1), (2, 2)
 
-statement ok
+statement error pq: unimplemented: ALTER COLUMN TYPE requiring rewrite of on-disk data is currently not supported for columns that are part of an index
 ALTER TABLE t15 ALTER COLUMN y TYPE STRING;
-
-query IT
-SELECT x, y FROM t15 ORDER BY x
-----
-1  1
-2  2
 
 # Ensure ALTER COLUMN TYPE works for collated strings.
 statement ok


### PR DESCRIPTION
It is broken. After the change, the index, after the change, refers to a column
which is not in the table.

Fixes #72718.
Relates to #72771.

Release note (sql change): The experimental `ALTER COLUMN TYPE` statement
is no longer permitted when the column is stored in a secondary index. Prior
to this change, that was the only sort of secondary index membership which
was allowed, but the result of the operation was a subtly corrupted table.