### PR TITLE
sql: fix ALTER COLUMN TYPE erasing ON UPDATE clause

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -387,9 +387,10 @@ func alterColumnTypeGeneral(
 		Name:            shadowColName,
 		Type:            toType,
 		Nullable:        col.IsNullable(),
-		DefaultExpr:     col.ColumnDesc().DefaultExpr,
 		UsesSequenceIds: col.ColumnDesc().UsesSequenceIds,
 		OwnsSequenceIds: col.ColumnDesc().OwnsSequenceIds,
+		DefaultExpr:     col.ColumnDesc().DefaultExpr,
+		OnUpdateExpr:    col.ColumnDesc().OnUpdateExpr,
 		ComputeExpr:     newColComputeExpr,
 	}
 	// Ensure new column is created in the same column family as the original

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -593,3 +593,16 @@ INSERT INTO regression_54844 VALUES (-9223372036854775807)
 
 statement error integer out of range for type int2
 ALTER TABLE regression_54844 ALTER COLUMN i TYPE int2
+
+# Due to the column swap being down using a computed column both default and on update
+# clauses should return an error
+
+statement ok
+CREATE TABLE checkExpr (x INT DEFAULT 5, y INT ON UPDATE 0)
+
+statement error pq: relation .*: computed column .* cannot also have a DEFAULT expression
+ALTER TABLE checkExpr ALTER COLUMN x TYPE STRING
+
+statement error pq: relation .*: computed column .* cannot also have an ON UPDATE expression
+ALTER TABLE checkExpr ALTER COLUMN y TYPE STRING
+


### PR DESCRIPTION
Resolves #71571

When changing the data type of a column the ON UPDATE
clause was erased. As of 22.1, using alter column type
on a column with an on update clause should cause an error.

Release note: None