### PR TITLE
importccl: use jobs.LoadClaimedJob

### DIFF
--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -1170,7 +1170,7 @@ func ingestWithRetry(
 
 		// Re-load the job in order to update our progress object, which may have
 		// been updated by the changeFrontier processor since the flow started.
-		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadJob(ctx, job.ID())
+		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadClaimedJob(ctx, job.ID())
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return res, ctx.Err()


### PR DESCRIPTION
The LoadJob API is unsafe as it can lead to multiple nodes updating
the same job regardless of who has it claimed.

Release note: None