### PR TITLE
util: make FastIntMap return -1 when not found always

### DIFF
--- a/pkg/util/fast_int_map.go
+++ b/pkg/util/fast_int_map.go
@@ -68,7 +68,7 @@ func (m *FastIntMap) Unset(key int) {
 	delete(m.large, key)
 }
 
-// Get returns the current value mapped to key, or ok=false if the
+// Get returns the current value mapped to key, or (-1, false) if the
 // key is unmapped.
 func (m FastIntMap) Get(key int) (value int, ok bool) {
 	if m.large == nil {
@@ -78,8 +78,10 @@ func (m FastIntMap) Get(key int) (value int, ok bool) {
 		val := m.getSmallVal(uint32(key))
 		return int(val), (val != -1)
 	}
-	value, ok = m.large[key]
-	return value, ok
+	if value, ok = m.large[key]; ok {
+		return value, true
+	}
+	return -1, false
 }
 
 // GetDefault returns the current value mapped to key, or 0 if the key is
@@ -144,7 +146,7 @@ func (m FastIntMap) MaxKey() (_ int, ok bool) {
 }
 
 // MaxValue returns the maximum value that is in the map. If the map
-// is empty, returns ok=false.
+// is empty, returns (0, false).
 func (m FastIntMap) MaxValue() (_ int, ok bool) {
 	if m.large == nil {
 		// In the small case, all values are positive.

--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFastIntMap(t *testing.T) {
@@ -43,6 +44,9 @@ func TestFastIntMap(t *testing.T) {
 							"incorrect result for key %d: (%d, %t), expected (%d, %t)",
 							k, v, ok, expV, expOk,
 						)
+					}
+					if !ok {
+						require.Equal(t, -1, v)
 					}
 				}
 


### PR DESCRIPTION
Before this change, it would only return -1 if it had not outgrown
the small map. This lead to the oddities uncovered in #72718.

Release note: None