### PR TITLE
opt: add missing LogicTest directives

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -1,3 +1,4 @@
+# LogicTest: local
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/expression_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/expression_index
@@ -1,3 +1,5 @@
+# LogicTest: local
+
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,


### PR DESCRIPTION
Add LogicTest directives to avoid running these tests under all
configurations.

Release note: None