### PR TITLE
sql: allow point lookups on secondary indexes with 0 stored columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1029,7 +1029,7 @@ vectorized: true
   columns: (f float)
   estimated row count: 1 (missing stats)
   table: flt@flt_f_key
-  spans: /NaN-/NaN/PrefixEnd
+  spans: /NaN/0
 
 query T
 EXPLAIN (TYPES) SELECT * FROM flt WHERE f = 'NaN'
@@ -1041,7 +1041,7 @@ vectorized: true
   columns: (f float)
   estimated row count: 1 (missing stats)
   table: flt@flt_f_key
-  spans: /NaN-/NaN/PrefixEnd
+  spans: /NaN/0
 
 query T
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
@@ -1090,7 +1090,7 @@ vectorized: true
   columns: (i int)
   estimated row count: 1 (missing stats)
   table: num@num_i_key
-  spans: /-1-/0
+  spans: /-1/0
 
 query T
 EXPLAIN (TYPES) SELECT f FROM num WHERE f = -1:::FLOAT
@@ -1102,7 +1102,7 @@ vectorized: true
   columns: (f float)
   estimated row count: 1 (missing stats)
   table: num@num_f_key
-  spans: /-1-/-1/PrefixEnd
+  spans: /-1/0
 
 query T
 EXPLAIN (TYPES) SELECT d FROM num WHERE d = -1:::DECIMAL
@@ -1114,7 +1114,7 @@ vectorized: true
   columns: (d decimal)
   estimated row count: 1 (missing stats)
   table: num@num_d_key
-  spans: /-1-/-1/PrefixEnd
+  spans: /-1/0
 
 query T
 EXPLAIN (TYPES) SELECT n FROM num WHERE n = -'1h':::INTERVAL
@@ -1126,7 +1126,7 @@ vectorized: true
   columns: (n interval)
   estimated row count: 1 (missing stats)
   table: num@num_n_key
-  spans: /-01:00:00-/1 day -25:00:00
+  spans: /-01:00:00/0
 
 statement ok
 DROP TABLE num

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1044,7 +1044,7 @@ vectorized: true
           columns: (d, f)
           estimated row count: 1 (missing stats)
           table: def@def_f_key
-          spans: /1-/2
+          spans: /1/0
 
 statement ok
 DROP TABLE def
@@ -1073,7 +1073,7 @@ vectorized: true
           columns: (d, f)
           estimated row count: 1 (missing stats)
           table: def@def_f_key
-          spans: /1-/2
+          spans: /1/0
 
 # Regression test for #20504.
 query T

--- a/pkg/sql/rowexec/joinreader_span_generator.go
+++ b/pkg/sql/rowexec/joinreader_span_generator.go
@@ -666,8 +666,7 @@ func (g *multiSpanGenerator) generateSpans(
 			if inputRowIndices == nil {
 				// MaybeSplitSpanIntoSeparateFamilies is an optimization for doing more
 				// efficient point lookups when the span hits multiple column families.
-				// It doesn't work with inequality ranges because the prefixLen we pass
-				// in here is wrong and possibly other reasons.
+				// It doesn't work with inequality ranges because they aren't point lookups.
 				if g.inequalityColIdx != -1 {
 					g.scratchSpans = append(g.scratchSpans, *generatedSpan)
 				} else {

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -46,11 +46,6 @@ type Builder struct {
 	neededFamilies []descpb.FamilyID
 }
 
-// Use some functions that aren't needed right now to make the linter happy.
-var _ = (*Builder).UnsetNeededColumns
-var _ = (*Builder).SetNeededFamilies
-var _ = (*Builder).UnsetNeededFamilies
-
 var builderPool = sync.Pool{
 	New: func() interface{} { return &Builder{} },
 }
@@ -98,24 +93,6 @@ func MakeBuilder(
 // is used by MaybeSplitSpanIntoSeparateFamilies.
 func (s *Builder) SetNeededColumns(neededCols util.FastIntSet) {
 	s.neededFamilies = rowenc.NeededColumnFamilyIDs(neededCols, s.table, s.index)
-}
-
-// UnsetNeededColumns resets the needed columns for column family specific optimizations
-// that the Builder performs.
-func (s *Builder) UnsetNeededColumns() {
-	s.neededFamilies = nil
-}
-
-// SetNeededFamilies sets the needed families of the span builder directly. This information
-// is used by MaybeSplitSpanIntoSeparateFamilies.
-func (s *Builder) SetNeededFamilies(neededFamilies []descpb.FamilyID) {
-	s.neededFamilies = neededFamilies
-}
-
-// UnsetNeededFamilies resets the needed families for column family specific optimizations
-// that the Builder performs.
-func (s *Builder) UnsetNeededFamilies() {
-	s.neededFamilies = nil
 }
 
 // SpanFromEncDatums encodes a span with prefixLen constraint columns from the
@@ -275,11 +252,6 @@ func (s *Builder) CanSplitSpanIntoFamilySpans(
 		}
 		// * The index cannot be inverted.
 		if s.index.GetType() != descpb.IndexDescriptor_FORWARD {
-			return false
-		}
-
-		// * The index must store some columns.
-		if s.index.NumSecondaryStoredColumns() == 0 {
 			return false
 		}
 

--- a/pkg/sql/span_builder_test.go
+++ b/pkg/sql/span_builder_test.go
@@ -89,6 +89,22 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 			containsNull:      false,
 			canSplit:          true,
 		},
+		{
+			sql:               "a INT, b INT, c INT, UNIQUE INDEX i (b), FAMILY (a), FAMILY (b), FAMILY (c)",
+			index:             "i",
+			prefixLen:         1,
+			numNeededFamilies: 1,
+			containsNull:      false,
+			canSplit:          true,
+		},
+		{
+			sql:               "a INT, b INT, c INT, UNIQUE INDEX i (b), FAMILY (a), FAMILY (b), FAMILY (c)",
+			index:             "i",
+			prefixLen:         1,
+			numNeededFamilies: 1,
+			containsNull:      true,
+			canSplit:          false,
+		},
 	}
 	if _, err := sqlDB.Exec("CREATE DATABASE t"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Remove an unnecessary check that was preventing point lookups in some
TPCE queries.

Fixes #72735

Release note: None
