### PR TITLE
changefeedccl: remove flaky test for changefeed option 'min_checkpoint_frequency'

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -177,6 +177,7 @@ func newChangeAggregatorProcessor(
 	// from the poller (which should always happen, even if the watched data is
 	// not changing), then this is sufficient and we don't have to do anything
 	// fancy with timers.
+	// // TODO(casper): add test for OptMinCheckpointFrequency.
 	if r, ok := ca.spec.Feed.Opts[changefeedbase.OptMinCheckpointFrequency]; ok && r != `` {
 		ca.flushFrequency, err = time.ParseDuration(r)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -585,56 +585,33 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var resolvedFreq, checkpointFreq time.Duration
-	durationString := func(duration time.Duration) string {
-		if duration == 0 {
-			return ""
-		}
-		return duration.String()
-	}
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved=$1, min_checkpoint_frequency=$2`,
-			durationString(resolvedFreq), durationString(checkpointFreq))
+		const freq = 10 * time.Millisecond
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved=$1`, freq.String())
 		defer closeFeed(t, foo)
 
 		// We get each resolved timestamp notification once in each partition.
 		// Grab the first `2 * #partitions`, sort because we might get all from
 		// one partition first, and compare the first and last.
 		resolved := make([]hlc.Timestamp, 2*len(foo.Partitions()))
-		receivedPerPartition := make(map[string]time.Time)
-		var partition string
 		for i := range resolved {
-			resolved[i], partition = expectResolvedTimestamp(t, foo)
-			now := timeutil.Now()
-			if lastReceived, ok := receivedPerPartition[partition]; ok {
-				if d := now.Sub(lastReceived); d < checkpointFreq {
-					t.Errorf(`expected %s between two resolved timestamp emission time within same partition, but got %s`, checkpointFreq, d)
-				}
-			}
-			receivedPerPartition[partition] = now
+			resolved[i], _ = expectResolvedTimestamp(t, foo)
 		}
 		sort.Slice(resolved, func(i, j int) bool { return resolved[i].Less(resolved[j]) })
 		first, last := resolved[0], resolved[len(resolved)-1]
 
-		if d := last.GoTime().Sub(first.GoTime()); d < resolvedFreq {
-			t.Errorf(`expected %s between resolved timestamps, but got %s`, resolvedFreq, d)
+		if d := last.GoTime().Sub(first.GoTime()); d < freq {
+			t.Errorf(`expected %s between resolved timestamps, but got %s`, freq, d)
 		}
 	}
 
-	runTests := func(testResolvedFreq, testCheckpointFreq time.Duration) {
-		resolvedFreq, checkpointFreq = testResolvedFreq, testCheckpointFreq
-		t.Run(`sinkless`, sinklessTest(testFn))
-		t.Run(`enterprise`, enterpriseTest(testFn))
-		t.Run(`kafka`, kafkaTest(testFn))
-		t.Run(`webhook`, webhookTest(testFn))
-	}
-
-	runTests(1*time.Second, 0)
-	runTests(0, 1*time.Second)
-	runTests(600*time.Millisecond, 1*time.Second)
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`kafka`, kafkaTest(testFn))
+	t.Run(`webhook`, webhookTest(testFn))
 }
 
 // Test how Changefeeds react to schema changes that do not require a backfill


### PR DESCRIPTION
TestChangefeedResolvedFrequency under changefeed_test.go is flaky when
testing 'min_checkpoint_frequency' due to clock skew.

This PR removes the the code that tests the option. A follow-up PR will test it in a non-flaky way.

fixes #72799

Release note: none