### PR TITLE
indexrec: add hypothetical tables and hypothetical indexes

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -133,6 +133,9 @@ type Table interface {
 	// Unique returns the ith unique constraint defined on this table, where
 	// i < UniqueCount.
 	Unique(i UniqueOrdinal) UniqueConstraint
+
+	// Zone returns a table's zone.
+	Zone() Zone
 }
 
 // CheckConstraint contains the SQL text and the validity status for a check

--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -2,20 +2,34 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "indexrec",
-    srcs = ["index_candidate_set.go"],
+    srcs = [
+        "hypothetical_index.go",
+        "hypothetical_table.go",
+        "index_candidate_set.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/indexrec",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/zonepb",
+        "//pkg/geo/geoindex",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
+        "//pkg/sql/sem/tree",
         "//pkg/util",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
 go_test(
     name = "indexrec_test",
-    srcs = ["index_candidate_set_test.go"],
+    srcs = [
+        "hypothetical_table_test.go",
+        "index_candidate_set_test.go",
+    ],
     embed = [":indexrec"],
     deps = [
         "//pkg/sql/opt/cat",

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -1,0 +1,189 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package indexrec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+)
+
+// hypotheticalIndex is a dummy implementation of cat.Index, used with
+// hypotheticalTable for index recommendations.
+type hypotheticalIndex struct {
+	tab  *hypotheticalTable
+	name tree.Name
+
+	// cols stores the index columns, in order.
+	cols []cat.IndexColumn
+
+	// indexOrdinal stores the index's ordinal position on the hypothetical table.
+	indexOrdinal int
+
+	// zone stores the table's zone.
+	zone *zonepb.ZoneConfig
+
+	// suffixKeyColsOrdList contains all implicit column ordinals. Implicit
+	// columns are columns that are in the table's primary key but are not already
+	// in the index columns.
+	suffixKeyColsOrdList []int
+}
+
+var _ cat.Index = &hypotheticalIndex{}
+
+func (hi *hypotheticalIndex) init(
+	tab *hypotheticalTable,
+	name tree.Name,
+	cols []cat.IndexColumn,
+	indexOrd int,
+	zone *zonepb.ZoneConfig,
+) {
+	hi.tab = tab
+	hi.name = name
+	hi.cols = cols
+	hi.indexOrdinal = indexOrd
+	hi.zone = zone
+
+	// Build an index column ordinal set.
+	var colsOrdSet util.FastIntSet
+	for _, col := range hi.cols {
+		colsOrdSet.Add(col.Ordinal())
+	}
+
+	// Build the suffix key column list.
+	suffixKeyColsSet := hi.tab.primaryKeyColsOrdSet.Difference(colsOrdSet)
+	hi.suffixKeyColsOrdList = suffixKeyColsSet.Ordered()
+}
+
+// ID is part of the cat.Index interface.
+func (hi *hypotheticalIndex) ID() cat.StableID {
+	return cat.StableID(hi.indexOrdinal)
+}
+
+// Name is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Name() tree.Name {
+	return hi.name
+}
+
+// IsUnique is part of the cat.Index interface.
+func (hi *hypotheticalIndex) IsUnique() bool {
+	// A hypotheticalIndex is not unique because there is no motivation to enforce
+	// a unique constraint.
+	return false
+}
+
+// IsInverted is part of the cat.Index interface.
+func (hi *hypotheticalIndex) IsInverted() bool {
+	// Hypothetical indexes are not inverted.
+	// TODO(nehageorge): Add support for inverted index recommendations.
+	return false
+}
+
+// ColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) ColumnCount() int {
+	// For now, this is the same as the KeyColumnCount, because there are no
+	// stored columns.
+	return len(hi.cols) + len(hi.suffixKeyColsOrdList)
+}
+
+// KeyColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) KeyColumnCount() int {
+	// Since hypothetical indexes are not unique, we build a key by including all
+	// the index key columns and then appending any primary key columns that are
+	// not already included.
+	return len(hi.cols) + len(hi.suffixKeyColsOrdList)
+}
+
+// LaxKeyColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) LaxKeyColumnCount() int {
+	// Hypothetical indexes are never unique, so their lax key is the same as
+	// their regular key.
+	return hi.KeyColumnCount()
+}
+
+// NonInvertedPrefixColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) NonInvertedPrefixColumnCount() int {
+	panic(errors.AssertionFailedf("hypothetical indexes are not inverted"))
+}
+
+// Column is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Column(i int) cat.IndexColumn {
+	if i >= len(hi.cols) {
+		// The column is an added suffix primary key column. Construct the
+		// corresponding cat.Column.
+		suffixColOrd := hi.suffixKeyColsOrdList[i-len(hi.cols)]
+		return cat.IndexColumn{Column: hi.tab.Column(suffixColOrd)}
+	}
+	return hi.cols[i]
+}
+
+// InvertedColumn is part of the cat.Index interface.
+func (hi *hypotheticalIndex) InvertedColumn() cat.IndexColumn {
+	panic(errors.AssertionFailedf("hypothetical indexes are not inverted"))
+}
+
+// Predicate is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Predicate() (string, bool) {
+	return "", false
+}
+
+// Zone is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Zone() cat.Zone {
+	return hi.zone
+}
+
+// Span is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Span() roachpb.Span {
+	panic(errors.AssertionFailedf("no span"))
+}
+
+// Table is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Table() cat.Table {
+	return hi.tab
+}
+
+// Ordinal is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Ordinal() int {
+	return hi.indexOrdinal
+}
+
+// ImplicitPartitioningColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) ImplicitPartitioningColumnCount() int {
+	return 0
+}
+
+// GeoConfig is part of the cat.Index interface.
+func (hi *hypotheticalIndex) GeoConfig() *geoindex.Config {
+	return nil
+}
+
+// Version is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Version() descpb.IndexDescriptorVersion {
+	// Return the latest version for non-primary indexes, since hypothetical
+	// indexes are not primary indexes.
+	return tabledesc.LatestNonPrimaryIndexDescriptorVersion
+}
+
+// PartitionCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) PartitionCount() int {
+	return 0
+}
+
+// Partition is part of the cat.Index interface.
+func (hi *hypotheticalIndex) Partition(i int) cat.Partition {
+	return nil
+}

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package indexrec
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// BuildOptAndHypTableMaps builds a hypotheticalTable for each table in
+// indexCandidates. This hypotheticalTable stores a hypothetical index for each
+// of the table's index candidates. The function returns a map from each table's
+// cat.StableID to its original sql.optTable, as well as a map from each table's
+// cat.StableID to its constructed hypotheticalTable. These tables will be used
+// to update the table query metadata when making index recommendations.
+func BuildOptAndHypTableMaps(
+	indexCandidates, existingIndexes map[cat.Table][][]cat.IndexColumn,
+) (optTables, hypTables map[cat.StableID]cat.Table) {
+	numTables := len(indexCandidates)
+	hypTables = make(map[cat.StableID]cat.Table, numTables)
+	optTables = make(map[cat.StableID]cat.Table, numTables)
+
+	for t, indexes := range indexCandidates {
+		hypIndexes := make([]hypotheticalIndex, 0, len(indexes))
+		var hypTable hypotheticalTable
+		hypTable.init(t, existingIndexes[t], hypIndexes)
+
+		indexOrd := t.IndexCount()
+		for _, index := range indexes {
+			// Do not add the index if it is equivalent to an existing index.
+			if hypTable.indexExists(index) {
+				continue
+			}
+			var hypIndex hypotheticalIndex
+			hypIndex.init(
+				&hypTable,
+				tree.Name(fmt.Sprintf("_hyp_%d", indexOrd)),
+				index,
+				indexOrd,
+				t.Zone().(*zonepb.ZoneConfig),
+			)
+			hypIndexes = append(hypIndexes, hypIndex)
+			indexOrd++
+		}
+
+		hypTable.hypotheticalIndexes = hypIndexes
+		optTables[t.ID()] = t
+		hypTables[t.ID()] = &hypTable
+	}
+
+	return optTables, hypTables
+}
+
+// hypotheticalTable is a wrapper around cat.Table, used for creating index
+// recommendations. The hypotheticalIndexes slice stores fake indexes that could
+// potentially speed up queries to this table.
+type hypotheticalTable struct {
+	cat.Table
+	primaryKeyColsOrdSet util.FastIntSet
+	existingIndexes      [][]cat.IndexColumn
+	hypotheticalIndexes  []hypotheticalIndex
+}
+
+var _ cat.Table = &hypotheticalTable{}
+
+func (ht *hypotheticalTable) init(
+	table cat.Table, existingIndexes [][]cat.IndexColumn, hypIndexes []hypotheticalIndex,
+) {
+	ht.Table = table
+	ht.existingIndexes = existingIndexes
+	ht.hypotheticalIndexes = hypIndexes
+
+	// Get PK column ordinals.
+	primaryIndex := ht.Index(cat.PrimaryIndex)
+	numPrimaryKeyCols := primaryIndex.KeyColumnCount()
+	for i := 0; i < numPrimaryKeyCols; i++ {
+		ht.primaryKeyColsOrdSet.Add(primaryIndex.Column(i).Ordinal())
+	}
+}
+
+// IndexCount is part of the cat.Table interface.
+func (ht *hypotheticalTable) IndexCount() int {
+	return len(ht.hypotheticalIndexes) + ht.Table.IndexCount()
+}
+
+// WritableIndexCount is part of the cat.Table interface.
+func (ht *hypotheticalTable) WritableIndexCount() int {
+	return ht.IndexCount()
+}
+
+// DeletableIndexCount is part of the cat.Table interface.
+func (ht *hypotheticalTable) DeletableIndexCount() int {
+	return ht.IndexCount()
+}
+
+// Index is part of the cat.Table interface.
+func (ht *hypotheticalTable) Index(i cat.IndexOrdinal) cat.Index {
+	existingIndexCount := ht.Table.IndexCount()
+	if i < existingIndexCount {
+		return ht.Table.Index(i)
+	}
+	hypOrd := i - existingIndexCount
+	return &ht.hypotheticalIndexes[hypOrd]
+}
+
+// indexExists checks whether an index is present in the slice of
+// existingIndexes containing a table's existing indexes.
+func (ht *hypotheticalTable) indexExists(index []cat.IndexColumn) bool {
+	for _, existingIndex := range ht.existingIndexes {
+		if len(existingIndex) != len(index) {
+			continue
+		}
+		indexExists := true
+		for i := range existingIndex {
+			if existingIndex[i].ColID() != index[i].ColID() ||
+				existingIndex[i].Descending != index[i].Descending {
+				indexExists = false
+				break
+			}
+		}
+		if indexExists {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/opt/indexrec/hypothetical_table_test.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package indexrec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+)
+
+func TestBuildOptAndHypTableMaps(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	table1 := tables[0]
+	table2 := tables[1]
+	indexCandidates := testIndexCandidates1(tables, indexCols)
+	existingIndexes := testExistingIndexes(tables, indexCols)
+
+	oldTables, hypTables := BuildOptAndHypTableMaps(
+		indexCandidates, existingIndexes,
+	)
+
+	if oldTables[table1.ID()] != table1 {
+		t.Errorf("expected table1 to be %+v,\n got %+v\n", table1, oldTables[table1.ID()])
+	}
+
+	if oldTables[table2.ID()] != table2 {
+		t.Errorf("expected table2 to be %+v,\n got %+v\n", table2, oldTables[table2.ID()])
+	}
+
+	// Both existing indexes are also index candidates.
+	newIndexesTable1 := len(indexCandidates[table1]) - 2
+
+	// Only one existing index is an index candidate.
+	newIndexesTable2 := len(indexCandidates[table2]) - 1
+
+	if hypTables[1].IndexCount()-oldTables[1].IndexCount() != newIndexesTable1 {
+		t.Errorf(
+			"expected table1's index count to be %d, got %d\n",
+			hypTables[1].IndexCount()-oldTables[1].IndexCount(),
+			newIndexesTable1,
+		)
+	}
+
+	if hypTables[2].IndexCount()-oldTables[2].IndexCount() != newIndexesTable2 {
+		t.Errorf("expected table2's index count to be %d, got %d\n",
+			hypTables[2].IndexCount()-oldTables[2].IndexCount(),
+			newIndexesTable2,
+		)
+	}
+}
+
+func TestBuildOptAndHypTableMaps_NoExistingIndexes(t *testing.T) {
+	tables, indexCols := testTablesAndIndexCols()
+	table1 := tables[0]
+	table2 := tables[1]
+	indexCandidates := testIndexCandidates1(tables, indexCols)
+
+	oldTables, hypTables := BuildOptAndHypTableMaps(
+		indexCandidates, make(map[cat.Table][][]cat.IndexColumn),
+	)
+
+	if oldTables[table1.ID()] != table1 {
+		t.Errorf("expected table1 to be %+v,\n got %+v\n", table1, oldTables[table1.ID()])
+	}
+
+	if oldTables[table2.ID()] != table2 {
+		t.Errorf("expected table2 to be %+v,\n got %+v\n", table2, oldTables[table2.ID()])
+	}
+
+	newIndexesTable1 := len(indexCandidates[table1])
+	newIndexesTable2 := len(indexCandidates[table2])
+
+	if hypTables[1].IndexCount()-oldTables[1].IndexCount() != newIndexesTable1 {
+		t.Errorf(
+			"expected table1's index count to be %d, got %d\n",
+			hypTables[1].IndexCount()-oldTables[1].IndexCount(),
+			newIndexesTable1,
+		)
+	}
+
+	if hypTables[2].IndexCount()-oldTables[2].IndexCount() != newIndexesTable2 {
+		t.Errorf("expected table2's index count to be %d, got %d\n",
+			hypTables[2].IndexCount()-oldTables[2].IndexCount(),
+			newIndexesTable2,
+		)
+	}
+}
+
+func testExistingIndexes(
+	tables []cat.Table, indexCols []cat.IndexColumn,
+) map[cat.Table][][]cat.IndexColumn {
+	existingIndexes := make(map[cat.Table][][]cat.IndexColumn)
+	table1 := tables[0]
+	table2 := tables[1]
+	existingIndexes[table1] = [][]cat.IndexColumn{{indexCols[1]}, {indexCols[0], indexCols[1]}}
+	existingIndexes[table2] = [][]cat.IndexColumn{{indexCols[0]}, {indexCols[1], indexCols[0]}}
+	return existingIndexes
+}

--- a/pkg/sql/opt/indexrec/index_candidate_set_test.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set_test.go
@@ -229,6 +229,10 @@ func testTablesAndIndexCols() ([]cat.Table, []cat.IndexColumn) {
 	indexCol2 := cat.IndexColumn{Column: &col2, Descending: false}
 	indexCol3 := cat.IndexColumn{Column: &col3, Descending: true}
 
+	// Add arbitrary primary indexes.
+	table1.Indexes = []*testcat.Index{{Columns: []cat.IndexColumn{indexCol1}}}
+	table2.Indexes = []*testcat.Index{{Columns: []cat.IndexColumn{indexCol1}}}
+
 	return []cat.Table{&table1, &table2}, []cat.IndexColumn{indexCol1, indexCol2, indexCol3}
 }
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -749,6 +749,12 @@ func (tt *Table) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	return &tt.uniqueConstraints[i]
 }
 
+// Zone is part of the cat.Table interface.
+func (tt *Table) Zone() cat.Zone {
+	zone := zonepb.DefaultZoneConfig()
+	return &zone
+}
+
 // FindOrdinal returns the ordinal of the column with the given name.
 func (tt *Table) FindOrdinal(name string) int {
 	for i, col := range tt.Columns {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1133,6 +1133,11 @@ func (ot *optTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	return &ot.uniqueConstraints[i]
 }
 
+// Zone is part of the cat.Table interface.
+func (ot *optTable) Zone() cat.Zone {
+	return ot.zone
+}
+
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optTable) lookupColumnOrdinal(colID descpb.ColumnID) (int, error) {
@@ -2003,6 +2008,11 @@ func (ot *optVirtualTable) UniqueCount() int {
 // Unique is part of the cat.Table interface.
 func (ot *optVirtualTable) Unique(i cat.UniqueOrdinal) cat.UniqueConstraint {
 	panic(errors.AssertionFailedf("no unique constraints"))
+}
+
+// Zone is part of the cat.Table interface.
+func (ot *optVirtualTable) Zone() cat.Zone {
+	panic(errors.AssertionFailedf("no zone"))
 }
 
 // CollectTypes is part of the cat.DataSource interface.


### PR DESCRIPTION
**indexrec: add hypothetical tables and hypothetical indexes** 

This commit creates hypotheticalTable and hypotheticalIndex structs.
These are "fake" in-memory implementations of cat.Table and cat.Index,
respectively, to be used for index recommendations.

Informs #72757.