### PR TITLE
sql: fix bug with type name conflict, allow resolving any object

### DIFF
--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -407,7 +407,13 @@ func DescriptorsMatchingTargets(
 		switch p := pattern.(type) {
 		case *tree.TableName:
 			un := p.ToUnresolvedObjectName()
-			found, prefix, descI, err := resolver.ResolveExisting(ctx, un, r, tree.ObjectLookupFlags{}, currentDatabase, searchPath)
+			found, prefix, descI, err := resolver.ResolveExisting(ctx, un, r, tree.ObjectLookupFlags{
+				CommonLookupFlags: tree.CommonLookupFlags{
+					AvoidCached: true,
+					Required:    true,
+				},
+				DesiredObjectKind: tree.TableObject,
+			}, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -382,7 +382,9 @@ func GetSystemTableIDsToExcludeFromClusterBackup(
 		if backupConfig.shouldIncludeInClusterBackup == optOutOfClusterBackup {
 			err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 				tn := tree.MakeTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(systemTableName))
-				found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
+				found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{
+					DesiredObjectKind: tree.TableObject,
+				})
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/catalog/descs/object.go
+++ b/pkg/sql/catalog/descs/object.go
@@ -95,7 +95,7 @@ func (tc *Collection) getObjectByName(
 		// requested descriptor type, we return either the table descriptor itself,
 		// or the table descriptor's implicit record type.
 		switch flags.DesiredObjectKind {
-		case tree.TableObject, tree.TypeObject:
+		case tree.TableObject, tree.TypeObject, tree.AnyObject:
 		default:
 			return prefix, nil, nil
 		}
@@ -120,7 +120,9 @@ func (tc *Collection) getObjectByName(
 			}
 		}
 	case catalog.TypeDescriptor:
-		if flags.DesiredObjectKind != tree.TypeObject {
+		switch flags.DesiredObjectKind {
+		case tree.TypeObject, tree.AnyObject:
+		default:
 			return prefix, nil, nil
 		}
 	default:

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -221,15 +221,21 @@ func ResolveExistingObject(
 	}
 
 	switch lookupFlags.DesiredObjectKind {
+	case tree.AnyObject:
+		return obj, prefix, nil
 	case tree.TypeObject:
 		typ, isType := obj.(catalog.TypeDescriptor)
 		if !isType {
+			// TODO(ajwerner): This probably should not return an error here if
+			// the required flag is not set.
 			return nil, prefix, sqlerrors.NewUndefinedTypeError(getResolvedTn())
 		}
 		return typ, prefix, nil
 	case tree.TableObject:
 		table, ok := obj.(catalog.TableDescriptor)
 		if !ok {
+			// TODO(ajwerner): This probably should not return an error here if
+			// the required flag is not set.
 			return nil, prefix, sqlerrors.NewUndefinedRelationError(getResolvedTn())
 		}
 		goodType := true

--- a/pkg/sql/catalog/resolver/resolver_test.go
+++ b/pkg/sql/catalog/resolver/resolver_test.go
@@ -450,7 +450,9 @@ func TestResolveTablePatternOrName(t *testing.T) {
 					ctPrefix = tpv.Catalog()
 				case *tree.TableName:
 					if tc.expected {
-						flags := tree.ObjectLookupFlags{}
+						flags := tree.ObjectLookupFlags{
+							DesiredObjectKind: tree.TableObject,
+						}
 						// TODO: As part of work for #34240, we should be operating on
 						//  UnresolvedObjectNames here, rather than TableNames.
 						un := tpv.ToUnresolvedObjectName()

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2029,3 +2029,20 @@ CREATE SEQUENCE seqas_error
   INCREMENT BY 1
   MAXVALUE 123456
   CACHE 1
+
+subtest serial_normalization_type_name_conflict
+
+statement ok
+set serial_normalization = 'sql_sequence';
+set default_int_size=8;
+create type t72820_i_seq AS enum ('a');
+create table t72820 (i SERIAL PRIMARY KEY)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t72820]
+----
+CREATE TABLE public.t72820 (
+   i INT8 NOT NULL DEFAULT nextval('public.t72820_i_seq1'::REGCLASS),
+   CONSTRAINT t72820_pkey PRIMARY KEY (i ASC),
+   FAMILY "primary" (i)
+)

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -87,35 +87,6 @@ func (p *planner) ResolveMutableTableDescriptor(
 	return prefix, desc, nil
 }
 
-// TODO(ajwerner): Remove this and things like it to use more generic
-// functionality. We really need to centralize the privilege checking.
-func (p *planner) resolveUncachedTableDescriptor(
-	ctx context.Context, tn *tree.TableName, required bool, requiredType tree.RequiredTableKind,
-) (table catalog.TableDescriptor, err error) {
-	var prefix catalog.ResolvedObjectPrefix
-	var desc catalog.Descriptor
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		lookupFlags := tree.ObjectLookupFlags{
-			CommonLookupFlags:    tree.CommonLookupFlags{Required: required},
-			DesiredObjectKind:    tree.TableObject,
-			DesiredTableDescKind: requiredType,
-		}
-		desc, prefix, err = resolver.ResolveExistingObject(
-			ctx, p, tn.ToUnresolvedObjectName(), lookupFlags,
-		)
-	})
-	if err != nil || desc == nil {
-		return nil, err
-	}
-	table = desc.(catalog.TableDescriptor)
-	// Ensure that the current user can access the target schema.
-	if err := p.canResolveDescUnderSchema(ctx, prefix.Schema, table); err != nil {
-		return nil, err
-	}
-
-	return table, nil
-}
-
 func (p *planner) ResolveTargetObject(
 	ctx context.Context, un *tree.UnresolvedObjectName,
 ) (

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -178,11 +178,12 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		tbNames = append(tbNames, toAppend...)
 	}
 
+	flags := p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/)
+	flags.DesiredObjectKind = tree.TableObject
 	for i := range tbNames {
 		tableName := &tbNames[i]
 		_, objDesc, err := p.Accessor().GetObjectDesc(
-			ctx, p.txn, tableName.Catalog(), tableName.Schema(), tableName.Table(),
-			p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/),
+			ctx, p.txn, tableName.Catalog(), tableName.Schema(), tableName.Table(), flags,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -255,10 +255,14 @@ type DatabaseListFlags struct {
 type DesiredObjectKind int
 
 const (
+	_ DesiredObjectKind = iota
 	// TableObject is used when a table-like object is desired from resolution.
-	TableObject DesiredObjectKind = iota
+	TableObject
 	// TypeObject is used when a type-like object is desired from resolution.
 	TypeObject
+	// AnyObject is used when any object is acceptable. This is primary used when
+	// looking for name conflicts.
+	AnyObject
 )
 
 // NewQualifiedObjectName returns an ObjectName of the corresponding kind.
@@ -272,6 +276,10 @@ func NewQualifiedObjectName(catalog, schema, object string, kind DesiredObjectKi
 	case TypeObject:
 		name := MakeQualifiedTypeName(catalog, schema, object)
 		return &name
+	case AnyObject:
+		return &UnspecifiedObjectName{
+			objName: makeQualifiedObjName(Name(catalog), Name(schema), Name(object)),
+		}
 	}
 	return nil
 }

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -22,6 +22,7 @@ type ObjectName interface {
 
 var _ ObjectName = &TableName{}
 var _ ObjectName = &TypeName{}
+var _ ObjectName = &UnspecifiedObjectName{}
 
 // objName is the internal type for a qualified object.
 type objName struct {
@@ -32,6 +33,22 @@ type objName struct {
 	// ObjectNamePrefix is the path to the object.  This can be modified
 	// further by name resolution, see name_resolution.go.
 	ObjectNamePrefix
+}
+
+func makeQualifiedObjName(db, schema, object Name) objName {
+	return makeObjNameWithPrefix(ObjectNamePrefix{
+		CatalogName:     db,
+		SchemaName:      schema,
+		ExplicitSchema:  true,
+		ExplicitCatalog: true,
+	}, object)
+}
+
+func makeObjNameWithPrefix(prefix ObjectNamePrefix, object Name) objName {
+	return objName{
+		ObjectName:       object,
+		ObjectNamePrefix: prefix,
+	}
 }
 
 func (o *objName) Object() string {
@@ -56,6 +73,36 @@ func (o *objName) ToUnresolvedObjectName() *UnresolvedObjectName {
 	}
 	return u
 }
+
+func (o *objName) String() string { return AsString(o) }
+
+// FQString renders the table name in full, not omitting the prefix
+// schema and catalog names. Suitable for logging, etc.
+func (o *objName) FQString() string {
+	ctx := NewFmtCtx(FmtSimple)
+	ctx.FormatNode(&o.CatalogName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&o.SchemaName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&o.ObjectName)
+	return ctx.CloseAndGetString()
+}
+
+// Format implements the NodeFormatter interface.
+func (o *objName) Format(ctx *FmtCtx) {
+	ctx.FormatNode(&o.ObjectNamePrefix)
+	if o.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
+		ctx.WriteByte('.')
+	}
+	ctx.FormatNode(&o.ObjectName)
+}
+
+// UnspecifiedObjectName is an object name correspond to any object type.
+type UnspecifiedObjectName struct {
+	objName
+}
+
+func (u UnspecifiedObjectName) objectName() {}
 
 // ObjectNamePrefix corresponds to the path prefix of an object name.
 type ObjectNamePrefix struct {

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -32,27 +32,10 @@ func (t *TableName) Format(ctx *FmtCtx) {
 		ctx.tableNameFormatter(ctx, t)
 		return
 	}
-	t.ObjectNamePrefix.Format(ctx)
-	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&t.ObjectName)
+	t.objName.Format(ctx)
 }
-func (t *TableName) String() string { return AsString(t) }
 
 func (t *TableName) objectName() {}
-
-// FQString renders the table name in full, not omitting the prefix
-// schema and catalog names. Suitable for logging, etc.
-func (t *TableName) FQString() string {
-	ctx := NewFmtCtx(FmtSimple)
-	ctx.FormatNode(&t.CatalogName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.SchemaName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.ObjectName)
-	return ctx.CloseAndGetString()
-}
 
 // Table retrieves the unqualified table name.
 func (t *TableName) Table() string {
@@ -77,31 +60,22 @@ func NewTableNameWithSchema(db, sc, tbl Name) *TableName {
 
 // MakeTableNameWithSchema creates a new fully qualified table name.
 func MakeTableNameWithSchema(db, schema, tbl Name) TableName {
-	return TableName{objName{
-		ObjectName: tbl,
-		ObjectNamePrefix: ObjectNamePrefix{
-			CatalogName:     db,
-			SchemaName:      schema,
-			ExplicitSchema:  true,
-			ExplicitCatalog: true,
-		},
-	}}
+	return TableName{
+		objName: makeQualifiedObjName(db, schema, tbl),
+	}
 }
 
 // MakeTableNameFromPrefix creates a table name from an unqualified name
 // and a resolved prefix.
 func MakeTableNameFromPrefix(prefix ObjectNamePrefix, object Name) TableName {
-	return TableName{objName{
-		ObjectName:       object,
-		ObjectNamePrefix: prefix,
-	}}
+	return TableName{
+		objName: makeObjNameWithPrefix(prefix, object),
+	}
 }
 
 // MakeUnqualifiedTableName creates a new base table name.
 func MakeUnqualifiedTableName(tbl Name) TableName {
-	return TableName{objName{
-		ObjectName: tbl,
-	}}
+	return MakeTableNameFromPrefix(ObjectNamePrefix{}, tbl)
 }
 
 // NewUnqualifiedTableName creates a new base table name.
@@ -111,10 +85,10 @@ func NewUnqualifiedTableName(tbl Name) *TableName {
 }
 
 func makeTableNameFromUnresolvedName(n *UnresolvedName) TableName {
-	return TableName{objName{
-		ObjectName:       Name(n.Parts[0]),
-		ObjectNamePrefix: makeObjectNamePrefixFromUnresolvedName(n),
-	}}
+	return MakeTableNameFromPrefix(
+		makeObjectNamePrefixFromUnresolvedName(n),
+		Name(n.Parts[0]),
+	)
 }
 
 func makeObjectNamePrefixFromUnresolvedName(n *UnresolvedName) ObjectNamePrefix {

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -41,35 +41,11 @@ func (t *TypeName) Type() string {
 }
 
 // Format implements the NodeFormatter interface.
-func (t *TypeName) Format(ctx *FmtCtx) {
-	ctx.FormatNode(&t.ObjectNamePrefix)
-	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&t.ObjectName)
-}
-
-// String implements the Stringer interface.
-func (t *TypeName) String() string {
-	return AsString(t)
-}
 
 // SQLString implements the ResolvableTypeReference interface.
 func (t *TypeName) SQLString() string {
 	// FmtBareIdentifiers prevents the TypeName string from being wrapped in quotations.
 	return AsStringWithFlags(t, FmtBareIdentifiers)
-}
-
-// FQString renders the type name in full, not omitting the prefix
-// schema and catalog names. Suitable for logging, etc.
-func (t *TypeName) FQString() string {
-	ctx := NewFmtCtx(FmtSimple)
-	ctx.FormatNode(&t.CatalogName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.SchemaName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.ObjectName)
-	return ctx.CloseAndGetString()
 }
 
 func (t *TypeName) objectName() {}
@@ -103,12 +79,9 @@ func MakeTypeNameWithPrefix(prefix ObjectNamePrefix, typ string) TypeName {
 
 // MakeQualifiedTypeName creates a fully qualified type name.
 func MakeQualifiedTypeName(db, schema, typ string) TypeName {
-	return MakeTypeNameWithPrefix(ObjectNamePrefix{
-		ExplicitCatalog: true,
-		CatalogName:     Name(db),
-		ExplicitSchema:  true,
-		SchemaName:      Name(schema),
-	}, typ)
+	return TypeName{
+		objName: makeQualifiedObjName(Name(db), Name(schema), Name(typ)),
+	}
 }
 
 // NewQualifiedTypeName returns a fully qualified type name.


### PR DESCRIPTION
Prior to this change there was a bug when a type name conflicted with a
sequence name (#72820). This resolves that problem by adding logic to resolve
any sort of object with a given name.

It also removes a bad method from sql/resolver.go

Fixes #72820.

Release note (bug fix): Fixed a bug which caused an inscrutable error when a
sequence name allocated by `SERIAL` conflicted with an existing type name.