### PR TITLE
sql: handle no cluster_inflight_traces table on tenants

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -65,3 +65,8 @@ ALTER TABLE kv EXPERIMENTAL_RELOCATE LEASE VALUES (1, 'k')
 
 statement error operation is unsupported in multi-tenancy mode
 SELECT crdb_internal.check_consistency(true, '', '')
+
+# Can not query inflight traces on sql pods
+
+statement error table crdb_internal.cluster_inflight_traces is not implemented on tenants
+SELECT * from crdb_internal.cluster_inflight_traces WHERE trace_id = 42

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/sql",
+        "//pkg/sql/distsql",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -224,4 +226,25 @@ func TestTenantRowIDs(t *testing.T) {
 		rowCount++
 	}
 	require.Equal(t, numRows, rowCount)
+}
+
+// TestNoInflightTracesVirtualTableOnTenant verifies that internal inflight traces table
+// is correctly handled by tenants (which don't provide this functionality as of now).
+func TestNoInflightTracesVirtualTableOnTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	args := base.TestClusterArgs{}
+	tc := testcluster.StartTestCluster(t, 2 /* nodes */, args)
+	defer tc.Stopper().Stop(ctx)
+
+	tenn, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{TenantID: serverutils.TestTenantID()})
+	require.NoError(t, err, "Failed to start tenant node")
+	ex := tenn.DistSQLServer().(*distsql.ServerImpl).ServerConfig.Executor
+	_, err = ex.Exec(ctx, "get table", nil, /* txn */
+		"select * from crdb_internal.cluster_inflight_traces WHERE trace_id = 4;")
+	require.Error(t, err, "cluster_inflight_traces should be unsupported")
+	require.Contains(t, err.Error(), "table crdb_internal.cluster_inflight_traces is not implemented on tenants")
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1287,6 +1287,11 @@ CREATE TABLE crdb_internal.cluster_inflight_traces (
 				"unexpected type %T for trace_id column in virtual table crdb_internal.cluster_inflight_traces", d)
 		}
 
+		if !p.ExecCfg().Codec.ForSystemTenant() {
+			// Tenant nodes doesn't have trace collector so can't serve this table.
+			return false, pgerror.New(pgcode.FeatureNotSupported,
+				"table crdb_internal.cluster_inflight_traces is not implemented on tenants")
+		}
 		traceCollector := p.ExecCfg().TraceCollector
 		var iter *collector.Iterator
 		for iter, err = traceCollector.StartIter(ctx, traceID); err == nil && iter.Valid(); iter.Next() {


### PR DESCRIPTION
Previously query for traces under tenant will fail with NPE.
This was happening because trace collector is not available
and virtual table was not aware of the case.
This patch adds handling of the table on tenant sql pods.

Release note: None

Fixes #72564