### PR TITLE
roachprod: flags, start options cleanup

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "roachprod_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "bash_completion.go",
+        "flags.go",
+        "main.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod",
     visibility = ["//visibility:private"],
     deps = [

--- a/pkg/cmd/roachprod/bash_completion.go
+++ b/pkg/cmd/roachprod/bash_completion.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// setBashCompletionFunction sets up a custom bash completion function to
+// autocomplete cluster names in various commands.
+func setBashCompletionFunction() {
+	// Generate a list of commands that DON'T take a cluster argument.
+	var s []string
+	for _, cmd := range []*cobra.Command{createCmd, listCmd, syncCmd, gcCmd} {
+		s = append(s, fmt.Sprintf("%s_%s", rootCmd.Name(), cmd.Name()))
+	}
+	excluded := strings.Join(s, " | ")
+
+	rootCmd.BashCompletionFunction = fmt.Sprintf(
+		`__custom_func()
+{
+    # only complete the 2nd arg, e.g. adminurl <foo>
+    if ! [ $c -eq 2 ]; then
+    	return
+    fi
+    
+    # don't complete commands which do not accept a cluster/host arg
+    case ${last_command} in
+    	%s)
+    		return
+    		;;
+    esac
+    
+    local hosts_out
+    if hosts_out=$(roachprod cached-hosts --cluster="${cur}" 2>/dev/null); then
+    		COMPREPLY=( $( compgen -W "${hosts_out[*]}" -- "$cur" ) )
+    fi
+}`,
+		excluded,
+	)
+}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -43,7 +43,6 @@ var (
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
 	}
-	nodeArgs     []string
 	tag          string
 	external     = false
 	certsDir     string
@@ -55,7 +54,7 @@ var (
 	sig          = 9
 	waitFlag     = false
 	createVMOpts = vm.DefaultCreateOpts()
-	startOpts    = install.StartOptsType{
+	startOpts    = install.StartOpts{
 		Encrypt:    false,
 		Sequential: true,
 		SkipInit:   false,
@@ -175,7 +174,7 @@ func initFlags() {
 		"racks", "r", 0, "the number of racks to partition the nodes into")
 	startCmd.Flags().BoolVar(&startOpts.Sequential,
 		"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
-	startCmd.Flags().StringArrayVarP(&nodeArgs,
+	startCmd.Flags().StringArrayVarP(&startOpts.ExtraArgs,
 		"args", "a", nil, "node arguments")
 	startCmd.Flags().StringArrayVarP(&nodeEnv,
 		"env", "e", nodeEnv, "node environment variables")

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -43,21 +43,24 @@ var (
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
 	}
-	nodeArgs          []string
-	tag               string
-	external          = false
-	certsDir          string
-	adminurlOpen      = false
-	adminurlPath      = ""
-	adminurlIPs       = false
-	useTreeDist       = true
-	encrypt           = false
-	skipInit          = false
-	quiet             = false
-	sig               = 9
-	waitFlag          = false
-	createVMOpts      = vm.DefaultCreateOpts()
-	startOpts         = install.StartOptsType{}
+	nodeArgs     []string
+	tag          string
+	external     = false
+	certsDir     string
+	adminurlOpen = false
+	adminurlPath = ""
+	adminurlIPs  = false
+	useTreeDist  = true
+	quiet        = false
+	sig          = 9
+	waitFlag     = false
+	createVMOpts = vm.DefaultCreateOpts()
+	startOpts    = install.StartOptsType{
+		Encrypt:    false,
+		Sequential: true,
+		SkipInit:   false,
+		StoreCount: 1,
+	}
 	stageOS           string
 	stageDir          string
 	logsDir           string
@@ -79,18 +82,6 @@ func initFlags() {
 	rootCmd.PersistentFlags().IntVarP(&maxConcurrency, "max-concurrency", "", 32,
 		"maximum number of operations to execute on nodes concurrently, set to zero for infinite",
 	)
-	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
-		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
-			"Username to run under, detect if blank")
-	}
-
-	for _, cmd := range []*cobra.Command{statusCmd, monitorCmd, startCmd,
-		stopCmd, runCmd, wipeCmd, reformatCmd, installCmd, putCmd, getCmd,
-		sqlCmd, pgurlCmd, adminurlCmd, ipCmd,
-	} {
-		cmd.Flags().BoolVar(
-			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
-	}
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
@@ -100,17 +91,16 @@ func initFlags() {
 		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
 		"local-ssd-no-ext4-barrier", true,
-		`Mount the local SSD with the "-o nobarrier" flag. `+
-			`Ignored if --local-ssd=false is specified.`)
+		`Mount the local SSD with the "-o nobarrier" flag. Ignored if --local-ssd=false is specified.`)
 	createCmd.Flags().IntVarP(&numNodes,
 		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
-
 	createCmd.Flags().IntVarP(&createVMOpts.OsVolumeSize,
 		"os-volume-size", "", 10, "OS disk volume size in GB")
-
 	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,
 		"clouds", "c", []string{gce.ProviderName},
-		fmt.Sprintf("The cloud provider(s) to use when creating new vm instances: %s", vm.AllProviderNames()))
+		fmt.Sprintf(
+			"The cloud provider(s) to use when creating new vm instances: %s",
+			vm.AllProviderNames()))
 	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
 		"geo", false, "Create geo-distributed cluster")
 	createCmd.Flags().StringToStringVar(&createVMOpts.CustomLabels,
@@ -151,52 +141,106 @@ func initFlags() {
 	listCmd.Flags().StringVar(&listPattern,
 		"pattern", "", "Show only clusters matching the regex pattern. Empty string matches everything.")
 
-	adminurlCmd.Flags().BoolVar(
-		&adminurlOpen, `open`, false, `Open the url in a browser`)
-	adminurlCmd.Flags().StringVar(
-		&adminurlPath, `path`, "/", `Path to add to URL (e.g. to open a same page on each node)`)
-	adminurlCmd.Flags().BoolVar(
-		&adminurlIPs, `ips`, false, `Use Public IPs instead of DNS names in URL`)
+	adminurlCmd.Flags().BoolVar(&adminurlOpen, "open", false, "Open the url in a browser")
+	adminurlCmd.Flags().StringVar(&adminurlPath,
+		"path", "/", "Path to add to URL (e.g. to open a same page on each node)")
+	adminurlCmd.Flags().BoolVar(&adminurlIPs,
+		"ips", false, `Use Public IPs instead of DNS names in URL`)
 
-	gcCmd.Flags().BoolVarP(
-		&dryrun, "dry-run", "n", dryrun, "dry run (don't perform any actions)")
+	gcCmd.Flags().BoolVarP(&dryrun,
+		"dry-run", "n", dryrun, "dry run (don't perform any actions)")
 	gcCmd.Flags().StringVar(&config.SlackToken, "slack-token", "", "Slack bot token")
 
-	pgurlCmd.Flags().BoolVar(
-		&external, "external", false, "return pgurls for external connections")
-	pgurlCmd.Flags().StringVar(
-		&certsDir, "certs-dir", "./certs", "cert dir to use for secure connections")
+	pgurlCmd.Flags().BoolVar(&external,
+		"external", false, "return pgurls for external connections")
+	pgurlCmd.Flags().StringVar(&certsDir,
+		"certs-dir", "./certs", "cert dir to use for secure connections")
 
-	pprofCmd.Flags().DurationVar(
-		&pprofOptions.duration, "duration", 30*time.Second, "Duration of profile to capture")
-	pprofCmd.Flags().BoolVar(
-		&pprofOptions.heap, "heap", false, "Capture a heap profile instead of a CPU profile")
-	pprofCmd.Flags().BoolVar(
-		&pprofOptions.open, "open", false, "Open the profile using `go tool pprof -http`")
-	pprofCmd.Flags().IntVar(
-		&pprofOptions.startingPort, "starting-port", 9000, "Initial port to use when opening pprof's HTTP interface")
+	pprofCmd.Flags().DurationVar(&pprofOptions.duration,
+		"duration", 30*time.Second, "Duration of profile to capture")
+	pprofCmd.Flags().BoolVar(&pprofOptions.heap,
+		"heap", false, "Capture a heap profile instead of a CPU profile")
+	pprofCmd.Flags().BoolVar(&pprofOptions.open,
+		"open", false, "Open the profile using `go tool pprof -http`")
+	pprofCmd.Flags().IntVar(&pprofOptions.startingPort,
+		"starting-port", 9000, "Initial port to use when opening pprof's HTTP interface")
 
-	ipCmd.Flags().BoolVar(
-		&external, "external", false, "return external IP addresses")
+	ipCmd.Flags().BoolVar(&external,
+		"external", false, "return external IP addresses")
 
-	runCmd.Flags().BoolVar(
-		&secure, "secure", false, "use a secure cluster")
-	runCmd.Flags().StringVarP(
-		&extraSSHOptions, "ssh-options", "O", "", "extra args to pass to ssh")
+	runCmd.Flags().StringVarP(&extraSSHOptions,
+		"ssh-options", "O", "", "extra args to pass to ssh")
 
 	startCmd.Flags().IntVarP(&numRacks,
 		"racks", "r", 0, "the number of racks to partition the nodes into")
+	startCmd.Flags().BoolVar(&startOpts.Sequential,
+		"sequential", startOpts.Sequential, "start nodes sequentially so node IDs match hostnames")
+	startCmd.Flags().StringArrayVarP(&nodeArgs,
+		"args", "a", nil, "node arguments")
+	startCmd.Flags().StringArrayVarP(&nodeEnv,
+		"env", "e", nodeEnv, "node environment variables")
+	startCmd.Flags().BoolVar(&startOpts.Encrypt,
+		"encrypt", startOpts.Encrypt, "start nodes with encryption at rest turned on")
+	startCmd.Flags().BoolVar(&startOpts.SkipInit,
+		"skip-init", startOpts.SkipInit, "skip initializing the cluster")
+	startCmd.Flags().IntVar(&startOpts.StoreCount,
+		"store-count", startOpts.StoreCount, "number of stores to start each node with")
 
 	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 
 	wipeCmd.Flags().BoolVar(&wipePreserveCerts, "preserve-certs", false, "do not wipe certificates")
 
+	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
+
+	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
+	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
+
+	stageURLCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
+
+	logsCmd.Flags().StringVar(&logsFilter,
+		"filter", "", "re to filter log messages")
+	logsCmd.Flags().Var(flagutil.Time(&logsFrom),
+		"from", "time from which to stream logs")
+	logsCmd.Flags().Var(flagutil.Time(&logsTo),
+		"to", "time to which to stream logs")
+	logsCmd.Flags().DurationVar(&logsInterval,
+		"interval", 200*time.Millisecond, "interval to poll logs from host")
+	logsCmd.Flags().StringVar(&logsDir,
+		"logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
+	logsCmd.Flags().StringVar(&logsProgramFilter,
+		"logs-program", "^cockroach$", "regular expression of the name of program in log files to search")
+
+	monitorCmd.Flags().BoolVar(&monitorIgnoreEmptyNodes,
+		"ignore-empty-nodes", false,
+		"Automatically detect the (subset of the given) nodes which to monitor "+
+			"based on the presence of a nontrivial data directory.")
+
+	monitorCmd.Flags().BoolVar(&monitorOneShot,
+		"oneshot", false,
+		"Report the status of all targeted nodes once, then exit. The exit "+
+			"status is nonzero if (and only if) any node was found not running.")
+
+	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster,
+		"cluster", "", "print hosts matching cluster")
+
+	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
+		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
+			"Username to run under, detect if blank")
+	}
+
+	for _, cmd := range []*cobra.Command{statusCmd, monitorCmd, startCmd,
+		stopCmd, runCmd, wipeCmd, reformatCmd, installCmd, putCmd, getCmd,
+		sqlCmd, pgurlCmd, adminurlCmd, ipCmd,
+	} {
+		cmd.Flags().BoolVar(
+			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
+	}
+
 	for _, cmd := range []*cobra.Command{
 		startCmd, statusCmd, stopCmd, runCmd,
 	} {
-		cmd.Flags().StringVar(
-			&tag, "tag", "", "the process tag")
+		cmd.Flags().StringVar(&tag, "tag", "", "the process tag")
 	}
 
 	for _, cmd := range []*cobra.Command{
@@ -206,70 +250,12 @@ func initFlags() {
 		_ = cmd.Flags().MarkDeprecated("scp", "always true")
 	}
 
-	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
-
-	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
-	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
-
-	stageURLCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
-
-	logsCmd.Flags().StringVar(
-		&logsFilter, "filter", "", "re to filter log messages")
-	logsCmd.Flags().Var(
-		flagutil.Time(&logsFrom), "from", "time from which to stream logs")
-	logsCmd.Flags().Var(
-		flagutil.Time(&logsTo), "to", "time to which to stream logs")
-	logsCmd.Flags().DurationVar(
-		&logsInterval, "interval", 200*time.Millisecond, "interval to poll logs from host")
-	logsCmd.Flags().StringVar(
-		&logsDir, "logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
-	logsCmd.Flags().StringVar(
-		&logsProgramFilter, "logs-program", "^cockroach$", "regular expression of the name of program in log files to search")
-
-	monitorCmd.Flags().BoolVar(
-		&monitorIgnoreEmptyNodes,
-		"ignore-empty-nodes",
-		false,
-		"Automatically detect the (subset of the given) nodes which to monitor "+
-			"based on the presence of a nontrivial data directory.")
-
-	monitorCmd.Flags().BoolVar(
-		&monitorOneShot,
-		"oneshot",
-		false,
-		"Report the status of all targeted nodes once, then exit. The exit "+
-			"status is nonzero if (and only if) any node was found not running.")
-
-	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster, "cluster", "", "print hosts matching cluster")
-
-	for _, cmd := range []*cobra.Command{
-		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd,
-		wipeCmd, pgurlCmd, adminurlCmd, sqlCmd, installCmd,
-	} {
-		switch cmd {
-		case startCmd:
-			cmd.Flags().BoolVar(
-				&startOpts.Sequential, "sequential", true,
-				"start nodes sequentially so node IDs match hostnames")
-			cmd.Flags().StringArrayVarP(
-				&nodeArgs, "args", "a", nil, "node arguments")
-			cmd.Flags().StringArrayVarP(
-				&nodeEnv, "env", "e", nodeEnv, "node environment variables")
-			cmd.Flags().BoolVar(
-				&startOpts.Encrypt, "encrypt", encrypt, "start nodes with encryption at rest turned on")
-			cmd.Flags().BoolVar(
-				&startOpts.SkipInit, "skip-init", skipInit, "skip initializing the cluster")
-			cmd.Flags().IntVar(
-				&startOpts.StoreCount, "store-count", 1, "number of stores to start each node with")
-			fallthrough
-		case sqlCmd:
-			cmd.Flags().StringVarP(
-				&config.Binary, "binary", "b", config.Binary,
-				"the remote cockroach binary to use")
-			fallthrough
-		case pgurlCmd, adminurlCmd:
-			cmd.Flags().BoolVar(
-				&secure, "secure", false, "use a secure cluster")
-		}
+	for _, cmd := range []*cobra.Command{startCmd, sqlCmd} {
+		cmd.Flags().StringVarP(&config.Binary,
+			"binary", "b", config.Binary, "the remote cockroach binary to use")
+	}
+	for _, cmd := range []*cobra.Command{startCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd} {
+		cmd.Flags().BoolVar(&secure,
+			"secure", false, "use a secure cluster")
 	}
 }

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -1,0 +1,275 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	numNodes          int
+	numRacks          int
+	username          string
+	dryrun            bool
+	destroyAllMine    bool
+	destroyAllLocal   bool
+	extendLifetime    time.Duration
+	wipePreserveCerts bool
+	listDetails       bool
+	listJSON          bool
+	listMine          bool
+	listPattern       string
+	secure            = false
+	extraSSHOptions   = ""
+	nodeEnv           = []string{
+		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
+		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
+	}
+	nodeArgs          []string
+	tag               string
+	external          = false
+	certsDir          string
+	adminurlOpen      = false
+	adminurlPath      = ""
+	adminurlIPs       = false
+	useTreeDist       = true
+	encrypt           = false
+	skipInit          = false
+	quiet             = false
+	sig               = 9
+	waitFlag          = false
+	createVMOpts      = vm.DefaultCreateOpts()
+	startOpts         = install.StartOptsType{}
+	stageOS           string
+	stageDir          string
+	logsDir           string
+	logsFilter        string
+	logsProgramFilter string
+	logsFrom          time.Time
+	logsTo            time.Time
+	logsInterval      time.Duration
+	maxConcurrency    int
+
+	monitorIgnoreEmptyNodes bool
+	monitorOneShot          bool
+
+	cachedHostsCluster string
+)
+
+func initFlags() {
+	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "disable fancy progress output")
+	rootCmd.PersistentFlags().IntVarP(&maxConcurrency, "max-concurrency", "", 32,
+		"maximum number of operations to execute on nodes concurrently, set to zero for infinite",
+	)
+	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
+		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
+			"Username to run under, detect if blank")
+	}
+
+	for _, cmd := range []*cobra.Command{statusCmd, monitorCmd, startCmd,
+		stopCmd, runCmd, wipeCmd, reformatCmd, installCmd, putCmd, getCmd,
+		sqlCmd, pgurlCmd, adminurlCmd, ipCmd,
+	} {
+		cmd.Flags().BoolVar(
+			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
+	}
+
+	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
+		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
+		"local-ssd", true, "Use local SSD")
+	createCmd.Flags().StringVar(&createVMOpts.SSDOpts.FileSystem,
+		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
+		"local-ssd-no-ext4-barrier", true,
+		`Mount the local SSD with the "-o nobarrier" flag. `+
+			`Ignored if --local-ssd=false is specified.`)
+	createCmd.Flags().IntVarP(&numNodes,
+		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
+
+	createCmd.Flags().IntVarP(&createVMOpts.OsVolumeSize,
+		"os-volume-size", "", 10, "OS disk volume size in GB")
+
+	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,
+		"clouds", "c", []string{gce.ProviderName},
+		fmt.Sprintf("The cloud provider(s) to use when creating new vm instances: %s", vm.AllProviderNames()))
+	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
+		"geo", false, "Create geo-distributed cluster")
+	createCmd.Flags().StringToStringVar(&createVMOpts.CustomLabels,
+		"label", make(map[string]string),
+		"The label(s) to be used when creating new vm instances, must be in '--label name=value' format "+
+			"and value can't be empty string after trimming space, a value that has space must be quoted by single "+
+			"quotes, gce label name only allows hyphens (-), underscores (_), lowercase characters, numbers and "+
+			"international characters. Examples: usage=cloud-report-2021, namewithspaceinvalue='s o s'")
+
+	// Allow each Provider to inject additional configuration flags
+	for _, p := range vm.Providers {
+		p.Flags().ConfigureCreateFlags(createCmd.Flags())
+
+		for _, cmd := range []*cobra.Command{
+			destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
+		} {
+			p.Flags().ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
+		}
+		// createCmd only accepts a single GCE project, as opposed to all the other
+		// commands.
+		p.Flags().ConfigureClusterFlags(createCmd.Flags(), vm.SingleProject)
+	}
+
+	destroyCmd.Flags().BoolVarP(&destroyAllMine,
+		"all-mine", "m", false, "Destroy all non-local clusters belonging to the current user")
+	destroyCmd.Flags().BoolVarP(&destroyAllLocal,
+		"all-local", "l", false, "Destroy all local clusters")
+
+	extendCmd.Flags().DurationVarP(&extendLifetime,
+		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
+
+	listCmd.Flags().BoolVarP(&listDetails,
+		"details", "d", false, "Show cluster details")
+	listCmd.Flags().BoolVar(&listJSON,
+		"json", false, "Show cluster specs in a json format")
+	listCmd.Flags().BoolVarP(&listMine,
+		"mine", "m", false, "Show only clusters belonging to the current user")
+	listCmd.Flags().StringVar(&listPattern,
+		"pattern", "", "Show only clusters matching the regex pattern. Empty string matches everything.")
+
+	adminurlCmd.Flags().BoolVar(
+		&adminurlOpen, `open`, false, `Open the url in a browser`)
+	adminurlCmd.Flags().StringVar(
+		&adminurlPath, `path`, "/", `Path to add to URL (e.g. to open a same page on each node)`)
+	adminurlCmd.Flags().BoolVar(
+		&adminurlIPs, `ips`, false, `Use Public IPs instead of DNS names in URL`)
+
+	gcCmd.Flags().BoolVarP(
+		&dryrun, "dry-run", "n", dryrun, "dry run (don't perform any actions)")
+	gcCmd.Flags().StringVar(&config.SlackToken, "slack-token", "", "Slack bot token")
+
+	pgurlCmd.Flags().BoolVar(
+		&external, "external", false, "return pgurls for external connections")
+	pgurlCmd.Flags().StringVar(
+		&certsDir, "certs-dir", "./certs", "cert dir to use for secure connections")
+
+	pprofCmd.Flags().DurationVar(
+		&pprofOptions.duration, "duration", 30*time.Second, "Duration of profile to capture")
+	pprofCmd.Flags().BoolVar(
+		&pprofOptions.heap, "heap", false, "Capture a heap profile instead of a CPU profile")
+	pprofCmd.Flags().BoolVar(
+		&pprofOptions.open, "open", false, "Open the profile using `go tool pprof -http`")
+	pprofCmd.Flags().IntVar(
+		&pprofOptions.startingPort, "starting-port", 9000, "Initial port to use when opening pprof's HTTP interface")
+
+	ipCmd.Flags().BoolVar(
+		&external, "external", false, "return external IP addresses")
+
+	runCmd.Flags().BoolVar(
+		&secure, "secure", false, "use a secure cluster")
+	runCmd.Flags().StringVarP(
+		&extraSSHOptions, "ssh-options", "O", "", "extra args to pass to ssh")
+
+	startCmd.Flags().IntVarP(&numRacks,
+		"racks", "r", 0, "the number of racks to partition the nodes into")
+
+	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
+	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
+
+	wipeCmd.Flags().BoolVar(&wipePreserveCerts, "preserve-certs", false, "do not wipe certificates")
+
+	for _, cmd := range []*cobra.Command{
+		startCmd, statusCmd, stopCmd, runCmd,
+	} {
+		cmd.Flags().StringVar(
+			&tag, "tag", "", "the process tag")
+	}
+
+	for _, cmd := range []*cobra.Command{
+		startCmd, putCmd, getCmd,
+	} {
+		cmd.Flags().BoolVar(new(bool), "scp", false, "DEPRECATED")
+		_ = cmd.Flags().MarkDeprecated("scp", "always true")
+	}
+
+	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
+
+	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
+	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
+
+	stageURLCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
+
+	logsCmd.Flags().StringVar(
+		&logsFilter, "filter", "", "re to filter log messages")
+	logsCmd.Flags().Var(
+		flagutil.Time(&logsFrom), "from", "time from which to stream logs")
+	logsCmd.Flags().Var(
+		flagutil.Time(&logsTo), "to", "time to which to stream logs")
+	logsCmd.Flags().DurationVar(
+		&logsInterval, "interval", 200*time.Millisecond, "interval to poll logs from host")
+	logsCmd.Flags().StringVar(
+		&logsDir, "logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
+	logsCmd.Flags().StringVar(
+		&logsProgramFilter, "logs-program", "^cockroach$", "regular expression of the name of program in log files to search")
+
+	monitorCmd.Flags().BoolVar(
+		&monitorIgnoreEmptyNodes,
+		"ignore-empty-nodes",
+		false,
+		"Automatically detect the (subset of the given) nodes which to monitor "+
+			"based on the presence of a nontrivial data directory.")
+
+	monitorCmd.Flags().BoolVar(
+		&monitorOneShot,
+		"oneshot",
+		false,
+		"Report the status of all targeted nodes once, then exit. The exit "+
+			"status is nonzero if (and only if) any node was found not running.")
+
+	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster, "cluster", "", "print hosts matching cluster")
+
+	for _, cmd := range []*cobra.Command{
+		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd,
+		wipeCmd, pgurlCmd, adminurlCmd, sqlCmd, installCmd,
+	} {
+		switch cmd {
+		case startCmd:
+			cmd.Flags().BoolVar(
+				&startOpts.Sequential, "sequential", true,
+				"start nodes sequentially so node IDs match hostnames")
+			cmd.Flags().StringArrayVarP(
+				&nodeArgs, "args", "a", nil, "node arguments")
+			cmd.Flags().StringArrayVarP(
+				&nodeEnv, "env", "e", nodeEnv, "node environment variables")
+			cmd.Flags().BoolVar(
+				&startOpts.Encrypt, "encrypt", encrypt, "start nodes with encryption at rest turned on")
+			cmd.Flags().BoolVar(
+				&startOpts.SkipInit, "skip-init", skipInit, "skip initializing the cluster")
+			cmd.Flags().IntVar(
+				&startOpts.StoreCount, "store-count", 1, "number of stores to start each node with")
+			fallthrough
+		case sqlCmd:
+			cmd.Flags().StringVarP(
+				&config.Binary, "binary", "b", config.Binary,
+				"the remote cockroach binary to use")
+			fallthrough
+		case pgurlCmd, adminurlCmd:
+			cmd.Flags().BoolVar(
+				&secure, "secure", false, "use a secure cluster")
+		}
+	}
+}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -26,14 +26,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	_ "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
 	_ "github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	_ "github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
-	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -61,56 +57,6 @@ destroy the cluster.
 `,
 	Version: "details:\n" + build.GetInfo().Long(),
 }
-
-var (
-	numNodes          int
-	numRacks          int
-	username          string
-	dryrun            bool
-	destroyAllMine    bool
-	destroyAllLocal   bool
-	extendLifetime    time.Duration
-	wipePreserveCerts bool
-	listDetails       bool
-	listJSON          bool
-	listMine          bool
-	listPattern       string
-	secure            = false
-	extraSSHOptions   = ""
-	nodeEnv           = []string{
-		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
-		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
-	}
-	nodeArgs          []string
-	tag               string
-	external          = false
-	certsDir          string
-	adminurlOpen      = false
-	adminurlPath      = ""
-	adminurlIPs       = false
-	useTreeDist       = true
-	encrypt           = false
-	skipInit          = false
-	quiet             = false
-	sig               = 9
-	waitFlag          = false
-	createVMOpts      = vm.DefaultCreateOpts()
-	startOpts         = install.StartOptsType{}
-	stageOS           string
-	stageDir          string
-	logsDir           string
-	logsFilter        string
-	logsProgramFilter string
-	logsFrom          time.Time
-	logsTo            time.Time
-	logsInterval      time.Duration
-	maxConcurrency    int
-
-	monitorIgnoreEmptyNodes bool
-	monitorOneShot          bool
-
-	cachedHostsCluster string
-)
 
 // Provide `cobra.Command` functions with a standard return code handler.
 // Exit codes come from rperrors.Error.ExitCode().
@@ -912,232 +858,13 @@ func main() {
 		cachedHostsCmd,
 		versionCmd,
 	)
-	rootCmd.BashCompletionFunction = fmt.Sprintf(`__custom_func()
-	{
-		# only complete the 2nd arg, e.g. adminurl <foo>
-		if ! [ $c -eq 2 ]; then
-			return
-		fi
+	setBashCompletionFunction()
 
-		# don't complete commands which do not accept a cluster/host arg
-		case ${last_command} in
-			%s)
-				return
-				;;
-		esac
-
-		local hosts_out
-		if hosts_out=$(roachprod cached-hosts --cluster="${cur}" 2>/dev/null); then
-				COMPREPLY=( $( compgen -W "${hosts_out[*]}" -- "$cur" ) )
-		fi
-
-	}`,
-		strings.Join(func(cmds ...*cobra.Command) (s []string) {
-			for _, cmd := range cmds {
-				s = append(s, fmt.Sprintf("%s_%s", rootCmd.Name(), cmd.Name()))
-			}
-			return s
-		}(createCmd, listCmd, syncCmd, gcCmd), " | "),
-	)
-
-	rootCmd.PersistentFlags().BoolVarP(
-		&quiet, "quiet", "q", false, "disable fancy progress output")
-	rootCmd.PersistentFlags().IntVarP(
-		&maxConcurrency, "max-concurrency", "", 32,
-		"maximum number of operations to execute on nodes concurrently, set to zero for infinite")
-	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
-		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
-			"Username to run under, detect if blank")
-	}
-
-	for _, cmd := range []*cobra.Command{statusCmd, monitorCmd, startCmd,
-		stopCmd, runCmd, wipeCmd, reformatCmd, installCmd, putCmd, getCmd,
-		sqlCmd, pgurlCmd, adminurlCmd, ipCmd,
-	} {
-		cmd.Flags().BoolVar(
-			&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
-	}
-
-	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
-		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
-	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
-		"local-ssd", true, "Use local SSD")
-	createCmd.Flags().StringVar(&createVMOpts.SSDOpts.FileSystem,
-		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
-	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
-		"local-ssd-no-ext4-barrier", true,
-		`Mount the local SSD with the "-o nobarrier" flag. `+
-			`Ignored if --local-ssd=false is specified.`)
-	createCmd.Flags().IntVarP(&numNodes,
-		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
-
-	createCmd.Flags().IntVarP(&createVMOpts.OsVolumeSize,
-		"os-volume-size", "", 10, "OS disk volume size in GB")
-
-	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,
-		"clouds", "c", []string{gce.ProviderName},
-		fmt.Sprintf("The cloud provider(s) to use when creating new vm instances: %s", vm.AllProviderNames()))
-	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
-		"geo", false, "Create geo-distributed cluster")
-	createCmd.Flags().StringToStringVar(&createVMOpts.CustomLabels,
-		"label", make(map[string]string),
-		"The label(s) to be used when creating new vm instances, must be in '--label name=value' format "+
-			"and value can't be empty string after trimming space, a value that has space must be quoted by single "+
-			"quotes, gce label name only allows hyphens (-), underscores (_), lowercase characters, numbers and "+
-			"international characters. Examples: usage=cloud-report-2021, namewithspaceinvalue='s o s'")
-
-	// Allow each Provider to inject additional configuration flags
-	for _, p := range vm.Providers {
-		p.Flags().ConfigureCreateFlags(createCmd.Flags())
-
-		for _, cmd := range []*cobra.Command{
-			destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
-		} {
-			p.Flags().ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
-		}
-		// createCmd only accepts a single GCE project, as opposed to all the other
-		// commands.
-		p.Flags().ConfigureClusterFlags(createCmd.Flags(), vm.SingleProject)
-	}
-
-	destroyCmd.Flags().BoolVarP(&destroyAllMine,
-		"all-mine", "m", false, "Destroy all non-local clusters belonging to the current user")
-	destroyCmd.Flags().BoolVarP(&destroyAllLocal,
-		"all-local", "l", false, "Destroy all local clusters")
-
-	extendCmd.Flags().DurationVarP(&extendLifetime,
-		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
-
-	listCmd.Flags().BoolVarP(&listDetails,
-		"details", "d", false, "Show cluster details")
-	listCmd.Flags().BoolVar(&listJSON,
-		"json", false, "Show cluster specs in a json format")
-	listCmd.Flags().BoolVarP(&listMine,
-		"mine", "m", false, "Show only clusters belonging to the current user")
-	listCmd.Flags().StringVar(&listPattern,
-		"pattern", "", "Show only clusters matching the regex pattern. Empty string matches everything.")
-
-	adminurlCmd.Flags().BoolVar(
-		&adminurlOpen, `open`, false, `Open the url in a browser`)
-	adminurlCmd.Flags().StringVar(
-		&adminurlPath, `path`, "/", `Path to add to URL (e.g. to open a same page on each node)`)
-	adminurlCmd.Flags().BoolVar(
-		&adminurlIPs, `ips`, false, `Use Public IPs instead of DNS names in URL`)
-
-	gcCmd.Flags().BoolVarP(
-		&dryrun, "dry-run", "n", dryrun, "dry run (don't perform any actions)")
-	gcCmd.Flags().StringVar(&config.SlackToken, "slack-token", "", "Slack bot token")
-
-	pgurlCmd.Flags().BoolVar(
-		&external, "external", false, "return pgurls for external connections")
-	pgurlCmd.Flags().StringVar(
-		&certsDir, "certs-dir", "./certs", "cert dir to use for secure connections")
-
-	pprofCmd.Flags().DurationVar(
-		&pprofOptions.duration, "duration", 30*time.Second, "Duration of profile to capture")
-	pprofCmd.Flags().BoolVar(
-		&pprofOptions.heap, "heap", false, "Capture a heap profile instead of a CPU profile")
-	pprofCmd.Flags().BoolVar(
-		&pprofOptions.open, "open", false, "Open the profile using `go tool pprof -http`")
-	pprofCmd.Flags().IntVar(
-		&pprofOptions.startingPort, "starting-port", 9000, "Initial port to use when opening pprof's HTTP interface")
-
-	ipCmd.Flags().BoolVar(
-		&external, "external", false, "return external IP addresses")
-
-	runCmd.Flags().BoolVar(
-		&secure, "secure", false, "use a secure cluster")
-	runCmd.Flags().StringVarP(
-		&extraSSHOptions, "ssh-options", "O", "", "extra args to pass to ssh")
-
-	startCmd.Flags().IntVarP(&numRacks,
-		"racks", "r", 0, "the number of racks to partition the nodes into")
-
-	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
-	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
-
-	wipeCmd.Flags().BoolVar(&wipePreserveCerts, "preserve-certs", false, "do not wipe certificates")
-
-	for _, cmd := range []*cobra.Command{
-		startCmd, statusCmd, stopCmd, runCmd,
-	} {
-		cmd.Flags().StringVar(
-			&tag, "tag", "", "the process tag")
-	}
-
-	for _, cmd := range []*cobra.Command{
-		startCmd, putCmd, getCmd,
-	} {
-		cmd.Flags().BoolVar(new(bool), "scp", false, "DEPRECATED")
-		_ = cmd.Flags().MarkDeprecated("scp", "always true")
-	}
-
-	putCmd.Flags().BoolVar(&useTreeDist, "treedist", useTreeDist, "use treedist copy algorithm")
-
-	stageCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
-	stageCmd.Flags().StringVar(&stageDir, "dir", "", "destination for staged binaries")
-
-	stageURLCmd.Flags().StringVar(&stageOS, "os", "", "operating system override for staged binaries")
-
-	logsCmd.Flags().StringVar(
-		&logsFilter, "filter", "", "re to filter log messages")
-	logsCmd.Flags().Var(
-		flagutil.Time(&logsFrom), "from", "time from which to stream logs")
-	logsCmd.Flags().Var(
-		flagutil.Time(&logsTo), "to", "time to which to stream logs")
-	logsCmd.Flags().DurationVar(
-		&logsInterval, "interval", 200*time.Millisecond, "interval to poll logs from host")
-	logsCmd.Flags().StringVar(
-		&logsDir, "logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
-	logsCmd.Flags().StringVar(
-		&logsProgramFilter, "logs-program", "^cockroach$", "regular expression of the name of program in log files to search")
-
-	monitorCmd.Flags().BoolVar(
-		&monitorIgnoreEmptyNodes,
-		"ignore-empty-nodes",
-		false,
-		"Automatically detect the (subset of the given) nodes which to monitor "+
-			"based on the presence of a nontrivial data directory.")
-
-	monitorCmd.Flags().BoolVar(
-		&monitorOneShot,
-		"oneshot",
-		false,
-		"Report the status of all targeted nodes once, then exit. The exit "+
-			"status is nonzero if (and only if) any node was found not running.")
-
-	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster, "cluster", "", "print hosts matching cluster")
-
+	// Add help about specifying nodes
 	for _, cmd := range []*cobra.Command{
 		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd,
 		wipeCmd, pgurlCmd, adminurlCmd, sqlCmd, installCmd,
 	} {
-		switch cmd {
-		case startCmd:
-			cmd.Flags().BoolVar(
-				&startOpts.Sequential, "sequential", true,
-				"start nodes sequentially so node IDs match hostnames")
-			cmd.Flags().StringArrayVarP(
-				&nodeArgs, "args", "a", nil, "node arguments")
-			cmd.Flags().StringArrayVarP(
-				&nodeEnv, "env", "e", nodeEnv, "node environment variables")
-			cmd.Flags().BoolVar(
-				&startOpts.Encrypt, "encrypt", encrypt, "start nodes with encryption at rest turned on")
-			cmd.Flags().BoolVar(
-				&startOpts.SkipInit, "skip-init", skipInit, "skip initializing the cluster")
-			cmd.Flags().IntVar(
-				&startOpts.StoreCount, "store-count", 1, "number of stores to start each node with")
-			fallthrough
-		case sqlCmd:
-			cmd.Flags().StringVarP(
-				&config.Binary, "binary", "b", config.Binary,
-				"the remote cockroach binary to use")
-			fallthrough
-		case pgurlCmd, adminurlCmd:
-			cmd.Flags().BoolVar(
-				&secure, "secure", false, "use a secure cluster")
-		}
-
 		if cmd.Long == "" {
 			cmd.Long = cmd.Short
 		}
@@ -1160,6 +887,8 @@ Node specification
     marc-test-9
 `, cmd.Name())
 	}
+
+	initFlags()
 
 	var err error
 	config.OSUser, err = user.Current()

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -89,7 +89,6 @@ func clusterOpts() install.ClusterSettings {
 		Secure:         secure,
 		Quiet:          quiet || !term.IsTerminal(int(os.Stdout.Fd())),
 		UseTreeDist:    useTreeDist,
-		Args:           nodeArgs,
 		Env:            nodeEnv,
 		NumRacks:       numRacks,
 		MaxConcurrency: maxConcurrency,

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -47,7 +47,7 @@ import (
 
 // ClusterImpl TODO(peter): document
 type ClusterImpl interface {
-	Start(c *SyncedCluster, extraArgs []string) error
+	Start(c *SyncedCluster, opts StartOpts) error
 	CertsDir(c *SyncedCluster, index int) string
 	NodeDir(c *SyncedCluster, index, storeIndex int) string
 	LogDir(c *SyncedCluster, index int) string
@@ -61,7 +61,6 @@ type ClusterSettings struct {
 	Secure         bool
 	CertsDir       string
 	Env            []string
-	Args           []string
 	Tag            string
 	UseTreeDist    bool
 	Quiet          bool
@@ -79,7 +78,6 @@ func DefaultClusterSettings() ClusterSettings {
 		Secure:      false,
 		Quiet:       false,
 		UseTreeDist: true,
-		Args:        nil,
 		Env: []string{
 			"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 			"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
@@ -255,9 +253,18 @@ func (c *SyncedCluster) roachprodEnvRegex(node int) string {
 	return fmt.Sprintf(`ROACHPROD=%s[ \/]`, escaped)
 }
 
+// StartOpts houses the options needed by Start().
+type StartOpts struct {
+	Encrypt    bool
+	Sequential bool
+	SkipInit   bool
+	StoreCount int
+	ExtraArgs  []string
+}
+
 // Start TODO(peter): document
-func (c *SyncedCluster) Start() error {
-	return c.Impl.Start(c, c.Args)
+func (c *SyncedCluster) Start(startOpts StartOpts) error {
+	return c.Impl.Start(c, startOpts)
 }
 
 func (c *SyncedCluster) newSession(i int) (session, error) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -67,6 +67,8 @@ type ClusterSettings struct {
 	Quiet          bool
 	NumRacks       int
 	MaxConcurrency int // used in Parallel
+	// DebugDir is used to stash debug information.
+	DebugDir string
 }
 
 // DefaultClusterSettings returns the default settings.
@@ -95,9 +97,6 @@ var _ = DefaultClusterSettings
 type SyncedCluster struct {
 	// Cluster metadata, obtained from the respective cloud provider.
 	cloud.Cluster
-
-	// Used to stash debug information.
-	DebugDir string
 
 	// Nodes is used by various commands like Start.
 	// TODO(radu): this is set externally; it does not belong as a field. Instead,

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -549,15 +549,12 @@ func Extend(clusterName string, clusterOpts install.ClusterSettings, lifetime ti
 }
 
 // Start starts nodes on a cluster.
-func Start(
-	name string, clusterOpts install.ClusterSettings, startOpts install.StartOptsType,
-) error {
-	install.StartOpts = startOpts
+func Start(name string, clusterOpts install.ClusterSettings, startOpts install.StartOpts) error {
 	c, err := newCluster(name, clusterOpts)
 	if err != nil {
 		return err
 	}
-	return c.Start()
+	return c.Start(startOpts)
 }
 
 // Monitor monitors the status of cockroach nodes in a cluster.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -160,12 +160,15 @@ func newCluster(
 		return nil, err
 	}
 
+	if clusterSettings.DebugDir == "" {
+		clusterSettings.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
+	}
+
 	c, err := install.NewSyncedCluster(metadata, clusterSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	c.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
 	nodes, err := install.ListNodes(nodeNames, len(c.VMs))
 	if err != nil {
 		return nil, err

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -136,12 +136,12 @@ func sortedClusters() []string {
 func newCluster(
 	name string, clusterSettings install.ClusterSettings,
 ) (*install.SyncedCluster, error) {
-	nodeNames := "all"
+	nodeSelector := "all"
 	{
 		parts := strings.Split(name, ":")
 		switch len(parts) {
 		case 2:
-			nodeNames = parts[1]
+			nodeSelector = parts[1]
 			fallthrough
 		case 1:
 			name = parts[0]
@@ -164,16 +164,11 @@ func newCluster(
 		clusterSettings.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
 	}
 
-	c, err := install.NewSyncedCluster(metadata, clusterSettings)
+	c, err := install.NewSyncedCluster(metadata, nodeSelector, clusterSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes, err := install.ListNodes(nodeNames, len(c.VMs))
-	if err != nil {
-		return nil, err
-	}
-	c.Nodes = nodes
 	return c, nil
 }
 


### PR DESCRIPTION
#### roachprod: extract flags and bash completion code

This change moves the flags and bash completion code to make the code
easier to navigate.

Release note: None

#### roachprod: minor flags cleanup

This change:
 - makes the formatting consistent when setting up flags;
 - reorganizes and simplifies the code that sets up flags for multiple
   commands at a time;
 - removes global values that are redundant.

Release note: None

#### roachprod: move DebugDir to ClusterSettings


#### roachprod: clean up Nodes initialization

This moves the initialization of Nodes into `NewSyncedCluster`, rather
than expecting the caller to modify the public field directly.

Release note: None

#### roachprod: clean up start options

This commit removes the `install.StartOpts` global and instead plumbs
it from `Start()`. The extra start args are also moved into this
structure.

Release note: None
