### PR TITLE
release-21.2: backup: fix backup during 21.2 upgrade

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1003,7 +1003,8 @@ func backupPlanHook(
 			}
 
 			tenantInfo, err := retrieveSingleTenantMetadata(
-				ctx, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn, backupStmt.Targets.Tenant,
+				ctx, p.ExecCfg().Settings, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn,
+				backupStmt.Targets.Tenant,
 			)
 			if err != nil {
 				return err
@@ -1019,7 +1020,7 @@ func backupPlanHook(
 			if p.ExecCfg().Codec.ForSystemTenant() {
 				// Include all tenants.
 				tenants, err = retrieveAllTenantsMetadata(
-					ctx, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn,
+					ctx, p.ExecCfg().Settings, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn,
 				)
 				if err != nil {
 					return err


### PR DESCRIPTION
The part of the backup code that retrieves the tenant metadata was
updated in #70778. The new code depends on the `system.tenant_usage`
table which is not present in 21.1.

Consequently, this query fails when running 21.2 code on a cluster
that was not finalized to 21.2 version.

This change fixes this by adding an alternate variant of the query
when the tenant usage table is not present (according to the cluster
version).

Fixes #72839.

Release note (bug fix): Fixes "backup-lookup-tenants: descriptor not
found" when doing full cluster backup while upgrading from 21.1 to 21.2.

CC @cockroachdb/release 