### PR TITLE
pkg/storage: remove `rocksdb` from error string

### DIFF
--- a/pkg/storage/enginepb/engine.go
+++ b/pkg/storage/enginepb/engine.go
@@ -43,7 +43,7 @@ func (e *EngineType) Set(s string) error {
 		*e = EngineTypePebble
 	default:
 		return fmt.Errorf("invalid storage engine: %s "+
-			"(possible values: rocksdb, pebble)", s)
+			"(possible values: pebble)", s)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix a documentation issue where starting a Cockroach instance with a
value other than `default` or `pebble` prints an error stating that
`rocksdb` is an allowed value. Remove mention of `rocksdb`.

Fixes #72823.

Release note: None