### PR TITLE
release-21.2: roachtest: add backup/mixed-version test

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // The following env variable names match those specified in the TeamCity
@@ -53,16 +54,20 @@ const (
 	rows3GiB   = rows30GiB / 10
 )
 
-func importBankDataSplit(
-	ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster,
-) string {
+func destinationName(c cluster.Cluster) string {
 	dest := c.Name()
-	// Randomize starting with encryption-at-rest enabled.
-	c.EncryptAtRandom(true)
-
 	if c.IsLocal() {
 		dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
 	}
+	return dest
+}
+
+func importBankDataSplit(
+	ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster,
+) string {
+	dest := destinationName(c)
+	// Randomize starting with encryption-at-rest enabled.
+	c.EncryptAtRandom(true)
 
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -70,17 +75,24 @@ func importBankDataSplit(
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
 	c.Start(ctx)
+	runImportBankDataSplit(ctx, rows, ranges, t, c)
+	return dest
+}
+
+func runImportBankDataSplit(ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster) {
 	c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 	time.Sleep(time.Second) // wait for csv server to open listener
-
 	importArgs := []string{
 		"./workload", "fixtures", "import", "bank",
-		"--db=bank", "--payload-bytes=10240", fmt.Sprintf("--ranges=%d", ranges), "--csv-server", "http://localhost:8081",
-		fmt.Sprintf("--rows=%d", rows), "--seed=1", "{pgurl:1}",
+		"--db=bank",
+		"--payload-bytes=10240",
+		"--csv-server", "http://localhost:8081",
+		"--seed=1",
+		fmt.Sprintf("--ranges=%d", ranges),
+		fmt.Sprintf("--rows=%d", rows),
+		"{pgurl:1}",
 	}
 	c.Run(ctx, c.Node(1), importArgs...)
-
-	return dest
 }
 
 func importBankData(ctx context.Context, rows int, t test.Test, c cluster.Cluster) string {
@@ -143,6 +155,49 @@ func registerBackupNodeShutdown(r registry.Registry) {
 		},
 	})
 
+}
+
+func registerBackupMixedVersion(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:    "backup/mixed-version",
+		Owner:   registry.OwnerBulkIO,
+		Cluster: r.MakeClusterSpec(4),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// An empty string means that the cockroach binary specified by flag
+			// `cockroach` will be used.
+			const mainVersion = ""
+			roachNodes := c.All()
+			predV, err := PredecessorVersion(*t.BuildVersion())
+			require.NoError(t, err)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
+
+			loadBackupDataStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+				rows := rows3GiB
+				if c.IsLocal() {
+					rows = 100
+				}
+				runImportBankDataSplit(ctx, rows, 0 /* ranges */, t, u.c)
+			}
+			successfulBackupStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+				backupQuery := fmt.Sprintf("BACKUP bank.bank TO 'nodelocal://1/%s'", destinationName(c))
+				gatewayDB := c.Conn(ctx, 1)
+				defer gatewayDB.Close()
+				_, err = gatewayDB.ExecContext(ctx, backupQuery)
+				require.NoError(t, err)
+			}
+			u := newVersionUpgradeTest(c,
+				uploadAndStartFromCheckpointFixture(roachNodes, predV),
+				waitForUpgradeStep(roachNodes),
+				preventAutoUpgradeStep(1),
+				loadBackupDataStep,
+				// Upgrade some of the nodes.
+				binaryUpgradeStep(c.Node(1), mainVersion),
+				binaryUpgradeStep(c.Node(2), mainVersion),
+				successfulBackupStep,
+			)
+			u.run(ctx, t)
+		},
+	})
 }
 
 // initBulkJobPerfArtifacts registers a histogram, creates a performance

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -20,6 +20,7 @@ func RegisterTests(r registry.Registry) {
 	registerAlterPK(r)
 	registerAutoUpgrade(r)
 	registerBackup(r)
+	registerBackupMixedVersion(r)
 	registerBackupNodeShutdown(r)
 	registerCancel(r)
 	registerCDC(r)


### PR DESCRIPTION
This test is for #72839. This test currently fails with the following
error without the fix in place:

    Error Trace:    backup.go:187
                                            versionupgrade.go:213
                                            backup.go:199
                                            test_runner.go:777
                                            asm_amd64.s:1581
    Error:          Received unexpected error:
                    pq: internal error: backup-lookup-tenants: descriptor not found
    Test:           backup/mixed-version

Release note: None