### PR TITLE
storage: avoid unnecessary buffering with MemFile

### DIFF
--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -313,6 +313,15 @@ func (*MemFile) Close() error {
 	return nil
 }
 
+// Flush implements the same interface as the standard library's *bufio.Writer's
+// Flush method. The Pebble sstable Writer tests whether files implement a Flush
+// method. If not, it wraps the file with a bufio.Writer to buffer writes to the
+// underlying file. This buffering is not necessary for an in-memory file. We
+// signal this by implementing Flush as a noop.
+func (*MemFile) Flush() error {
+	return nil
+}
+
 // Sync implements the writeCloseSyncer interface.
 func (*MemFile) Sync() error {
 	return nil


### PR DESCRIPTION
We use the `storage.MemFile` type when constructing sstables for ingestion
and backups. This type is wrapped by Pebble's `sstable.Writer`. The
`*sstable.Writer` type checks if files implement the `flusher` interface:

```
type flusher interface {
    Flush() error
}
```

If the file does not implement `flusher`, the sstable writer assumes `Write`s
to the file are expensive, possibly involving syscalls, and it wraps the file
in a 4kib-buffer `bufio.Writer`. This is unneccessary for `storage.MemFile`
which only performs a memory copy on `Write`.

```
name             old time/op    new time/op    delta
WriteSSTable-24    3.17µs ± 2%    3.05µs ± 1%   -3.78%  (p=0.000 n=24+21)

name             old speed      new speed      delta
WriteSSTable-24   375MB/s ± 2%   390MB/s ± 1%   +3.93%  (p=0.000 n=24+21)

name             old alloc/op   new alloc/op   delta
WriteSSTable-24      483B ± 4%      381B ± 5%  -21.11%  (p=0.000 n=22+23)

name             old allocs/op  new allocs/op  delta
WriteSSTable-24      0.00           0.00          ~     (all equal)
```

Informs #72528.

Release note: None