### PR TITLE
backupccl: don't include tenants in non-cluster backups

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -839,7 +839,7 @@ func backupPlanHook(
 			}
 			spans = append(spans, tableSpans...)
 
-			if p.ExecCfg().Codec.ForSystemTenant() {
+			if p.ExecCfg().Codec.ForSystemTenant() && backupStmt.Coverage() == tree.AllDescriptors {
 				// Include all tenants.
 				tenants, err = retrieveAllTenantsMetadata(
 					ctx, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7011,6 +7011,9 @@ func TestBackupRestoreTenant(t *testing.T) {
 		return nil
 	})
 
+	systemDB.Exec(t, `BACKUP system.users TO 'nodelocal://1/users'`)
+	systemDB.CheckQueryResults(t, `SELECT manifest->>'tenants' FROM [SHOW BACKUP 'nodelocal://1/users' WITH as_json]`, [][]string{{"[]"}})
+
 	// Prevent a logging assertion that the server ID is initialized multiple times.
 	log.TestingClearServerIdentifiers()
 


### PR DESCRIPTION
Release note (bug fix): System tenant backups of individual tables and databases no longer include tenants as well.