### PR TITLE
sql: use tmp dir with smaller name on mac/bsd

### DIFF
--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -136,7 +136,11 @@ func makeSocketFile(t *testing.T) (socketDir, socketFile string, cleanupFn func(
 	//
 	// macOS has a tendency to produce very long temporary directory names, so
 	// we are careful to keep all the constants involved short.
-	tempDir, err := ioutil.TempDir("", "TestAuth")
+	baseTmpDir := ""
+	if runtime.GOOS == "darwin" || strings.Contains(runtime.GOOS, "bsd") {
+		baseTmpDir = "/tmp"
+	}
+	tempDir, err := ioutil.TempDir(baseTmpDir, "TestAuth")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1693,7 +1693,11 @@ func TestPGWireOverUnixSocket(t *testing.T) {
 	//
 	// macOS has a tendency to produce very long temporary directory names, so
 	// we are careful to keep all the constants involved short.
-	tempDir, err := ioutil.TempDir("", "PGSQL")
+	baseTmpDir := ""
+	if runtime.GOOS == "darwin" || strings.Contains(runtime.GOOS, "bsd") {
+		baseTmpDir = "/tmp"
+	}
+	tempDir, err := ioutil.TempDir(baseTmpDir, "PGSQL")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/72027

This is required in order to have these tests work with bazel.

Release note: None