### PR TITLE
server,ccl: replace a few usages of keys.TODOSQLCodec

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1828,7 +1828,7 @@ func doRestorePlan(
 			if err := catalog.ForEachNonDropIndex(
 				tabledesc.NewBuilder(table).BuildImmutable().(catalog.TableDescriptor),
 				func(index catalog.Index) error {
-					if index.Adding() && spans.ContainsKey(keys.TODOSQLCodec.IndexPrefix(uint32(table.ID), uint32(index.GetID()))) {
+					if index.Adding() && spans.ContainsKey(p.ExecCfg().Codec.IndexPrefix(uint32(table.ID), uint32(index.GetID()))) {
 						k := tableAndIndex{tableID: table.ID, indexID: index.GetID()}
 						if _, ok := wasOffline[k]; !ok {
 							wasOffline[k] = m.EndTime

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -276,7 +276,8 @@ func (m *randomStreamClient) getDescriptorAndNamespaceKVForTableID(
 	}
 
 	// Generate namespace entry.
-	key := catalogkeys.MakePublicObjectNameKey(keys.TODOSQLCodec, 50, testTable.Name)
+	codec := keys.MakeSQLCodec(config.tenantID)
+	key := catalogkeys.MakePublicObjectNameKey(codec, 50, testTable.Name)
 	k := rekey(config.tenantID, key)
 	var value roachpb.Value
 	value.SetInt(int64(testTable.GetID()))
@@ -287,7 +288,7 @@ func (m *randomStreamClient) getDescriptorAndNamespaceKVForTableID(
 	}
 
 	// Generate descriptor entry.
-	descKey := catalogkeys.MakeDescMetadataKey(keys.TODOSQLCodec, testTable.GetID())
+	descKey := catalogkeys.MakeDescMetadataKey(codec, testTable.GetID())
 	descKey = rekey(config.tenantID, descKey)
 	descDesc := testTable.DescriptorProto()
 	var descValue roachpb.Value

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2411,12 +2411,16 @@ func (s *adminServer) DataDistribution(
 			if err := kv.ValueProto(&rangeDesc); err != nil {
 				return err
 			}
-
-			_, tableID, err := keys.TODOSQLCodec.DecodeTablePrefix(rangeDesc.StartKey.AsRawKey())
+			// TODO(embrown): Tables can use one codec since they
+			// seem to all share the same id.
+			_, tenID, err := keys.DecodeTenantPrefix(rangeDesc.StartKey.AsRawKey())
 			if err != nil {
 				return err
 			}
-
+			_, tableID, err := keys.MakeSQLCodec(tenID).DecodeTablePrefix(rangeDesc.StartKey.AsRawKey())
+			if err != nil {
+				return err
+			}
 			for _, replicaDesc := range rangeDesc.Replicas().Descriptors() {
 				tableInfo, found := tableInfosByTableID[tableID]
 				if !found {


### PR DESCRIPTION
references #48123

Replaced a few instances of keys.TODOSQLCodec with proper codecs.

Release note: None