### PR TITLE
ui: increase line height for event logs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/events.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/events.styl
@@ -36,7 +36,7 @@ $event-message-line-height = 22px
   overflow hidden
   line-height $event-message-line-height
   width 240px
-  max-height $event-message-line-height * 2
+  max-height $event-message-line-height * 3
 
 .events__timestamp
   font-size $font-size--small


### PR DESCRIPTION
Previously, the events logs were cutting messages. We
already cut messages that are too long, but we want to be
able to show the "completed", "reversed" etc from the message.
This commits increases the height so at least that message
can be displayed in full.

Before
<img width="361" alt="Screen Shot 2021-11-17 at 11 51 25 AM" src="https://user-images.githubusercontent.com/1017486/142246002-c4dd89e7-50ca-43aa-99ce-2be3a97ee753.png">

After
<img width="363" alt="Screen Shot 2021-11-17 at 11 51 03 AM" src="https://user-images.githubusercontent.com/1017486/142246025-41cbc9f1-6ca6-42bc-853f-0db85c5e0a82.png">


Release note: None