### PR TITLE
sem/tree: protect against double panic in EvalCtx.Stop

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3687,7 +3687,12 @@ func NewTestingEvalContext(st *cluster.Settings) *EvalContext {
 
 // Stop closes out the EvalContext and must be called once it is no longer in use.
 func (ctx *EvalContext) Stop(c context.Context) {
-	ctx.Mon.Stop(c)
+	if r := recover(); r != nil {
+		ctx.Mon.EmergencyStop(c)
+		panic(r)
+	} else {
+		ctx.Mon.Stop(c)
+	}
 }
 
 // FmtCtx creates a FmtCtx with the given options as well as the EvalContext's session data.

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -381,8 +381,9 @@ func NewUnlimitedMonitor(
 	return m
 }
 
-// EmergencyStop completes a monitoring region, and disables checking
-// that all accounts have been closed.
+// EmergencyStop completes a monitoring region, and disables checking that all
+// accounts have been closed. This is useful when recovering from panics so that
+// we don't panic again.
 func (mm *BytesMonitor) EmergencyStop(ctx context.Context) {
 	mm.doStop(ctx, false)
 }


### PR DESCRIPTION
Sometimes in tests EvalCtx.Stop() is called in a defer. When the defer
runs because of a panic, it would likely panic again because its memory
monitor is not empty.

Release note: None