### PR TITLE
build/builder: don't purge python packages

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20211115-184924
+version=20211117-113545
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -192,9 +192,6 @@ RUN apt-get purge -y \
     autopoint \
     gettext \
     golang \
-    python-is-python3 \
-    python3 \
-    python3.8-venv \
     rsync \
     texinfo \
  && apt-get autoremove -y


### PR DESCRIPTION
Doing so causes `gcloud` to be purged as well since it depends on
Python, which breaks nightlies.

Release note: None