### PR TITLE
sql: return more verbose error message from ReturnSST

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -167,10 +167,11 @@ func registerBackupMixedVersion(r registry.Registry) {
 			// `cockroach` will be used.
 			const mainVersion = ""
 			roachNodes := c.All()
+			newNode := 1
+			oldNode := 3
 			predV, err := PredecessorVersion(*t.BuildVersion())
 			require.NoError(t, err)
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
-
 			loadBackupDataStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 				rows := rows3GiB
 				if c.IsLocal() {
@@ -179,11 +180,20 @@ func registerBackupMixedVersion(r registry.Registry) {
 				runImportBankDataSplit(ctx, rows, 0 /* ranges */, t, u.c)
 			}
 			successfulBackupStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-				backupQuery := fmt.Sprintf("BACKUP bank.bank TO 'nodelocal://1/%s'", destinationName(c))
-				gatewayDB := c.Conn(ctx, 1)
+				backupQuery := fmt.Sprintf("BACKUP bank.bank TO 'nodelocal://%d/%s'", newNode, destinationName(c))
+				gatewayDB := c.Conn(ctx, newNode)
 				defer gatewayDB.Close()
 				_, err = gatewayDB.ExecContext(ctx, backupQuery)
 				require.NoError(t, err)
+			}
+			backupFailsWithExpectedErrorStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+				backupQuery := fmt.Sprintf("BACKUP bank.bank TO 'nodelocal://%d/%s'", oldNode, destinationName(c))
+				// We run the backup on an oldNode, which should result in an error message
+				gatewayDB := c.Conn(ctx, oldNode)
+				defer gatewayDB.Close()
+				_, err = gatewayDB.ExecContext(ctx, backupQuery)
+				require.Error(t, err)
+				require.True(t, strings.Contains(err.Error(), "ExportRequest was issued from a node running"))
 			}
 			u := newVersionUpgradeTest(c,
 				uploadAndStartFromCheckpointFixture(roachNodes, predV),
@@ -194,6 +204,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 				binaryUpgradeStep(c.Node(1), mainVersion),
 				binaryUpgradeStep(c.Node(2), mainVersion),
 				successfulBackupStep,
+				backupFailsWithExpectedErrorStep,
 			)
 			u.run(ctx, t)
 		},


### PR DESCRIPTION
21.1 nodes send ExportRequest's with ReturnSST set to true. In a
mixed-version cluster, this can lead to failures during
BACKUP. Preventing this error is costly in comparison to the other
solutions available to the user. This PR updates the error to point
users towards a technical advisory that will outline the available
remediation steps.

Fixes #72872
Informs #72852

Release note: Backups taken while a cluster contains a mix of 21.2 and
21.1 nodes may fail. Upgrading the entire cluster to 21.2 should
resolve the issues. Users can see http://TECHNICAL_ADVISORY more
information about possible remediations. The error returned in this
case now also directs the user to the above advisory.