### PR TITLE
release-21.2: pg_catalog: fix lookup of non-existent ID in pg_type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5240,3 +5240,13 @@ datname     rolname   deptype
 sh_db       sh_owner  o
 sh_db       sh_role   a
 sh_db_root  sh_role   a
+
+# Test for pg_type virtual index query with non-existent ID.
+# It's a useful test since pg_type includes implicit types that cause the
+# lookup logic to be quite special.
+
+query O
+SELECT oid
+FROM pg_catalog.pg_type
+WHERE oid = 2000000
+----

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2899,7 +2899,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				if typDesc == nil {
 					table, err := p.Descriptors().GetImmutableTableByID(ctx, p.txn, id, tree.ObjectLookupFlags{})
 					if err != nil {
-						if errors.Is(err, catalog.ErrDescriptorNotFound) || pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+						if errors.Is(err, catalog.ErrDescriptorNotFound) ||
+							pgerror.GetPGCode(err) == pgcode.UndefinedObject ||
+							pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 							return false, nil
 						}
 						return false, err


### PR DESCRIPTION
When ccd53144e94d9d42d781cbfc9aed337f9ec1bc71 was added it was a bit too
picky on checking the error code for not-found IDs.

This was later fixed on master with
ec5adc644c42334b8df0fa8fbd97816df65b231c.

That change can't be backported, so I made this smaller fix.

Release note (bug fix): Some queries on pg_catalog.pg_type could
previously error if they looked up a non-existent ID. This is fixed.