### PR TITLE
roachprod: remove ClusterImpl interface

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -43,18 +43,18 @@ var (
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
 	}
-	tag          string
-	external     = false
-	certsDir     string
-	adminurlOpen = false
-	adminurlPath = ""
-	adminurlIPs  = false
-	useTreeDist  = true
-	quiet        = false
-	sig          = 9
-	waitFlag     = false
-	createVMOpts = vm.DefaultCreateOpts()
-	startOpts    = install.StartOpts{
+	tag           string
+	external      = false
+	pgurlCertsDir string
+	adminurlOpen  = false
+	adminurlPath  = ""
+	adminurlIPs   = false
+	useTreeDist   = true
+	quiet         = false
+	sig           = 9
+	waitFlag      = false
+	createVMOpts  = vm.DefaultCreateOpts()
+	startOpts     = install.StartOpts{
 		Encrypt:    false,
 		Sequential: true,
 		SkipInit:   false,
@@ -152,7 +152,7 @@ func initFlags() {
 
 	pgurlCmd.Flags().BoolVar(&external,
 		"external", false, "return pgurls for external connections")
-	pgurlCmd.Flags().StringVar(&certsDir,
+	pgurlCmd.Flags().StringVar(&pgurlCertsDir,
 		"certs-dir", "./certs", "cert dir to use for secure connections")
 
 	pprofCmd.Flags().DurationVar(&pprofOptions.duration,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -85,7 +85,7 @@ func wrap(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Comma
 func clusterOpts() install.ClusterSettings {
 	return install.ClusterSettings{
 		Tag:            tag,
-		CertsDir:       certsDir,
+		PGUrlCertsDir:  pgurlCertsDir,
 		Secure:         secure,
 		Quiet:          quiet || !term.IsTerminal(int(os.Stdout.Fd())),
 		UseTreeDist:    useTreeDist,

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -153,7 +153,7 @@ func (e *expander) maybeExpandPgPort(c *SyncedCluster, s string) (string, bool, 
 	if e.pgPorts == nil {
 		e.pgPorts = make(map[int]string, len(c.VMs))
 		for _, i := range allNodes(len(c.VMs)) {
-			e.pgPorts[i] = fmt.Sprint(c.Impl.NodePort(c, i))
+			e.pgPorts[i] = fmt.Sprint(c.NodePort(i))
 		}
 	}
 
@@ -171,7 +171,7 @@ func (e *expander) maybeExpandUIPort(c *SyncedCluster, s string) (string, bool, 
 	if e.uiPorts == nil {
 		e.uiPorts = make(map[int]string, len(c.VMs))
 		for _, i := range allNodes(len(c.VMs)) {
-			e.uiPorts[i] = fmt.Sprint(c.Impl.NodeUIPort(c, i))
+			e.uiPorts[i] = fmt.Sprint(c.NodeUIPort(i))
 		}
 	}
 
@@ -184,7 +184,7 @@ func (e *expander) maybeExpandStoreDir(c *SyncedCluster, s string) (string, bool
 	if !storeDirRe.MatchString(s) {
 		return s, false, nil
 	}
-	return c.Impl.NodeDir(c, e.node, 1 /* storeIndex */), true, nil
+	return c.NodeDir(e.node, 1 /* storeIndex */), true, nil
 }
 
 // maybeExpandLogDir is an expanderFunc for "{log-dir}"
@@ -192,7 +192,7 @@ func (e *expander) maybeExpandLogDir(c *SyncedCluster, s string) (string, bool, 
 	if !logDirRe.MatchString(s) {
 		return s, false, nil
 	}
-	return c.Impl.LogDir(c, e.node), true, nil
+	return c.LogDir(e.node), true, nil
 }
 
 // maybeExpandCertsDir is an expanderFunc for "{certs-dir}"
@@ -200,5 +200,5 @@ func (e *expander) maybeExpandCertsDir(c *SyncedCluster, s string) (string, bool
 	if !certsDirRe.MatchString(s) {
 		return s, false, nil
 	}
-	return c.Impl.CertsDir(c, e.node), true, nil
+	return c.CertsDir(e.node), true, nil
 }


### PR DESCRIPTION
The ClusterImpl interface was useful when roachprod had some (very
limited) support for Cassandra, but that has been removed. We're left
with an unnecessary indirection that lacks documentation. The code
doesn't follow any layering, with `Cockroach` working directly with
`SyncedCluster` internals and plenty of cockroach-specific code in
`SyncedCluster`.

This commit removes this interface and improves the documentation of
the methods that are simplified.

Release note: None