### PR TITLE
pg_catalog: check UndefinedTable error code when looking up table

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2960,7 +2960,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				if typDesc.GetKind() == descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE {
 					table, err := p.Descriptors().GetImmutableTableByID(ctx, p.txn, id, tree.ObjectLookupFlags{})
 					if err != nil {
-						if errors.Is(err, catalog.ErrDescriptorNotFound) || pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+						if errors.Is(err, catalog.ErrDescriptorNotFound) ||
+							pgerror.GetPGCode(err) == pgcode.UndefinedObject ||
+							pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 							return false, nil
 						}
 						return false, err


### PR DESCRIPTION
I don't actually know how to get to this code path, but I'm adding this
just in case as a companion to ac6415a5d389d3cbf05723a33c118c906e97292f
which I added on release-21.2.

Release note: None