### PR TITLE
pg_catalog: fix pg_indexes so it respects intervalstyle

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -623,3 +623,30 @@ SELECT i, i::INTERVAL FROM interval_parsing ORDER BY pk
 -10 years -22 months 1 day 01:02:03   -11-10 +1 +1:02:03
 -10 years 22 months -1 day 01:02:03   -8-2 -1 +1:02:03
 -10 years 22 months -1 day -01:02:03  -8-2 -1 -1:02:03
+
+# Test intervalstyle being respected in pg_indexes.
+
+statement ok
+CREATE TABLE intervalstyle_in_index (
+  a INT8 PRIMARY KEY, b INTERVAL,
+  INDEX idx (b) WHERE b > 'P3Y'
+)
+
+query TT
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'intervalstyle_in_index'
+AND indexname = 'idx'
+----
+idx  CREATE INDEX idx ON test.public.intervalstyle_in_index USING btree (b ASC) WHERE (b > '3-0'::INTERVAL)
+
+statement ok
+SET intervalstyle = 'iso_8601'
+
+query TT
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'intervalstyle_in_index'
+AND indexname = 'idx'
+----
+idx  CREATE INDEX idx ON test.public.intervalstyle_in_index USING btree (b ASC) WHERE (b > 'P3Y'::INTERVAL)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1889,7 +1889,7 @@ func indexDefFromDescriptor(
 		}
 		indexDef.Predicate = pred
 	}
-	fmtCtx := tree.NewFmtCtx(tree.FmtPGCatalog)
+	fmtCtx := tree.NewFmtCtx(tree.FmtPGCatalog, tree.FmtDataConversionConfig(p.SessionData().DataConversionConfig))
 	fmtCtx.FormatNode(&indexDef)
 	return fmtCtx.String(), nil
 }


### PR DESCRIPTION
Release note (bug fix): Previously, index definitions in
pg_catalog.pg_indexes would not format intervals according to the
intervalstyle session variable. This is fixed now.