### PR TITLE
ui: save sort on cache for Sessions page 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -158,9 +158,14 @@ export const sessionsPagePropsFixture: SessionsPageProps = {
   },
   sessions: sessionsList,
   sessionsError: null,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "statementAge",
+  },
   refreshSessions: () => {},
   cancelSession: (req: CancelSessionRequestMessage) => {},
   cancelQuery: (req: CancelQueryRequestMessage) => {},
+  onSortingChange: () => {},
 };
 
 export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
@@ -179,7 +184,12 @@ export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
   },
   sessions: [],
   sessionsError: null,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "statementAge",
+  },
   refreshSessions: () => {},
   cancelSession: (req: CancelSessionRequestMessage) => {},
   cancelQuery: (req: CancelQueryRequestMessage) => {},
+  onSortingChange: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -29,6 +29,7 @@ export type LocalStorageState = {
   "dateRange/StatementsPage": StatementsDateRangeState;
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
+  "sortSetting/SessionsPage": SortSetting;
 };
 
 type Payload = {
@@ -49,6 +50,11 @@ const defaultSortSetting: SortSetting = {
   columnTitle: "executionCount",
 };
 
+const defaultSessionsSortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "statementAge",
+};
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
@@ -67,6 +73,9 @@ const initialState: LocalStorageState = {
   "sortSetting/TransactionsPage":
     JSON.parse(localStorage.getItem("sortSetting/TransactionsPage")) ||
     defaultSortSetting,
+  "sortSetting/SessionsPage":
+    JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
+    defaultSessionsSortSetting,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -28,6 +28,7 @@ export type LocalStorageState = {
   "showColumns/TransactionPage": string;
   "dateRange/StatementsPage": StatementsDateRangeState;
   "sortSetting/StatementsPage": SortSetting;
+  "sortSetting/TransactionsPage": SortSetting;
 };
 
 type Payload = {
@@ -62,6 +63,9 @@ const initialState: LocalStorageState = {
     defaultDateRange,
   "sortSetting/StatementsPage":
     JSON.parse(localStorage.getItem("sortSetting/StatementsPage")) ||
+    defaultSortSetting,
+  "sortSetting/TransactionsPage":
+    JSON.parse(localStorage.getItem("sortSetting/TransactionsPage")) ||
     defaultSortSetting,
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -13,6 +13,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
 import moment from "moment";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { SortSetting } from "../sortedtable";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -46,6 +47,11 @@ export const dateRange: [moment.Moment, moment.Moment] = [
 export const timestamp = new protos.google.protobuf.Timestamp({
   seconds: new Long(Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3),
 });
+
+export const sortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "executionCount",
+};
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {
   statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -40,3 +40,8 @@ export const selectTxnColumns = createSelector(
       ? localStorage["showColumns/TransactionPage"].split(",")
       : null,
 );
+
+export const selectSortSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["sortSetting/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -17,6 +17,7 @@ import {
   nodeRegions,
   routeProps,
   dateRange,
+  sortSetting,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -38,6 +39,8 @@ storiesOf("Transactions Page", module)
       nodeRegions={nodeRegions}
       refreshData={noop}
       resetSQLStats={noop}
+      sortSetting={sortSetting}
+      onSortingChange={noop}
     />
   ))
   .add("without data", () => {
@@ -49,6 +52,8 @@ storiesOf("Transactions Page", module)
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -68,6 +73,8 @@ storiesOf("Transactions Page", module)
         refreshData={noop}
         history={history}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -80,6 +87,8 @@ storiesOf("Transactions Page", module)
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -99,6 +108,8 @@ storiesOf("Transactions Page", module)
         }
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -69,7 +69,6 @@ type Timestamp = protos.google.protobuf.ITimestamp;
 const cx = classNames.bind(styles);
 
 interface TState {
-  sortSetting: SortSetting;
   pagination: ISortedTablePagination;
   search?: string;
   filters?: Filters;
@@ -87,6 +86,7 @@ export interface TransactionsPageStateProps {
   pageSize?: number;
   isTenant?: UIConfigState["isTenant"];
   columns: string[];
+  sortSetting: SortSetting;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -94,6 +94,11 @@ export interface TransactionsPageDispatchProps {
   resetSQLStats: () => void;
   onDateRangeChange?: (start: Moment, end: Moment) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
@@ -113,31 +118,44 @@ export class TransactionsPage extends React.Component<
   TransactionsPageProps,
   TState
 > {
+  constructor(props: TransactionsPageProps) {
+    super(props);
+    const filters = getFiltersFromQueryString(
+      this.props.history.location.search,
+    );
+
+    const trxSearchParams = getSearchParams(this.props.history.location.search);
+    this.state = {
+      pagination: {
+        pageSize: this.props.pageSize || 20,
+        current: 1,
+      },
+      search: trxSearchParams("q", "").toString(),
+      filters: filters,
+      aggregatedTs: null,
+      statementFingerprintIds: null,
+      transactionStats: null,
+      transactionFingerprintId: null,
+    };
+
+    const ascending = trxSearchParams("ascending", false).toString() === "true";
+    const columnTitle = trxSearchParams("columnTitle", undefined);
+    if (
+      this.props.onSortingChange &&
+      columnTitle &&
+      (this.props.sortSetting.columnTitle != columnTitle ||
+        this.props.sortSetting.ascending != ascending)
+    ) {
+      this.props.onSortingChange(
+        "Transactions",
+        columnTitle.toString(),
+        ascending,
+      );
+    }
+  }
+
   static defaultProps: Partial<TransactionsPageProps> = {
     isTenant: false,
-  };
-
-  trxSearchParams = getSearchParams(this.props.history.location.search);
-  filters = getFiltersFromQueryString(this.props.history.location.search);
-  state: TState = {
-    sortSetting: {
-      // Sort by Execution Count column as default option.
-      ascending: this.trxSearchParams("ascending", false).toString() === "true",
-      columnTitle: this.trxSearchParams(
-        "columnTitle",
-        "execution count",
-      ).toString(),
-    },
-    pagination: {
-      pageSize: this.props.pageSize || 20,
-      current: 1,
-    },
-    search: this.trxSearchParams("q", "").toString(),
-    filters: this.filters,
-    aggregatedTs: null,
-    statementFingerprintIds: null,
-    transactionStats: null,
-    transactionFingerprintId: null,
   };
 
   refreshData = (): void => {
@@ -153,9 +171,6 @@ export class TransactionsPage extends React.Component<
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {
-    this.setState({
-      sortSetting: ss,
-    });
     syncHistory(
       {
         ascending: ss.ascending.toString(),
@@ -163,6 +178,9 @@ export class TransactionsPage extends React.Component<
       },
       this.props.history,
     );
+    if (this.props.onSortingChange) {
+      this.props.onSortingChange("Transactions", ss.columnTitle, ss.ascending);
+    }
   };
 
   onChangePage = (current: number): void => {
@@ -284,6 +302,7 @@ export class TransactionsPage extends React.Component<
               isTenant,
               onColumnsChange,
               columns: userSelectedColumnsToShow,
+              sortSetting,
             } = this.props;
             const { pagination, search, filters } = this.state;
             const { statements, internal_app_name_prefix } = data;
@@ -435,7 +454,7 @@ export class TransactionsPage extends React.Component<
                   <TransactionsTable
                     columns={displayColumns}
                     transactions={transactionsToDisplay}
-                    sortSetting={this.state.sortSetting}
+                    sortSetting={sortSetting}
                     onChangeSortSetting={this.onChangeSortSetting}
                     pagination={pagination}
                     renderNoResult={

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -26,12 +26,14 @@ import {
   selectTransactionsData,
   selectTransactionsLastError,
   selectTxnColumns,
+  selectSortSetting,
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
+import { actions as analyticsActions } from "../store/analytics";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -46,6 +48,7 @@ export const TransactionsPageConnected = withRouter(
       isTenant: selectIsTenant(state),
       dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
+      sortSetting: selectSortSetting(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -71,6 +74,18 @@ export const TransactionsPageConnected = withRouter(
               selectedColumns.length === 0 ? " " : selectedColumns.join(","),
           }),
         ),
+      onSortingChange: (
+        tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) => {
+        dispatch(
+          localStorageActions.update({
+            key: "sortSetting/TransactionsPage",
+            value: { columnTitle: columnName, ascending: ascending },
+          }),
+        );
+      },
     }),
   )(TransactionsPage),
 );

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
@@ -12,6 +12,7 @@ import { Pick } from "src/util/pick";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { AdminUIState } from "src/redux/state";
+import { LocalSetting } from "src/redux/localsettings";
 import { CachedDataReducerState, refreshSessions } from "src/redux/apiReducers";
 
 import { createSelector } from "reselect";
@@ -41,16 +42,32 @@ export const selectSessions = createSelector(
   },
 );
 
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/SessionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "statementAge" },
+);
+
 const SessionsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
       sessions: selectSessions(state, props),
       sessionsError: state.cachedData.sessions.lastError,
+      sortSetting: sortSettingLocalSetting.selector(state),
     }),
     {
       refreshSessions,
       cancelSession: terminateSessionAction,
       cancelQuery: terminateQueryAction,
+      onSortingChange: (
+        _tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) =>
+        sortSettingLocalSetting.set({
+          ascending: ascending,
+          columnTitle: columnName,
+        }),
     },
   )(SessionsPage),
 );

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -62,6 +62,12 @@ export const selectDateRange = createSelector(
   },
 );
 
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "executionCount" },
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -78,6 +84,7 @@ const TransactionsPageConnected = withRouter(
       error: selectLastError(state),
       nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
     }),
     {
       refreshData: refreshStatements,
@@ -91,6 +98,15 @@ const TransactionsPageConnected = withRouter(
         transactionColumnsLocalSetting.set(
           value.length === 0 ? " " : value.join(","),
         ),
+      onSortingChange: (
+        _tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) =>
+        sortSettingLocalSetting.set({
+          ascending: ascending,
+          columnTitle: columnName,
+        }),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Previously, a sort selection was not maintained when
the page change (e.g. coming back from Sessions details).
This commits saves the selected value to be used.

Partially adresses #68199
Check only second commit, the first being reviewed at https://github.com/cockroachdb/cockroach/pull/72882

Release note: None