### PR TITLE
server: don't mix Tracers in test tenant

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -242,7 +242,6 @@ type TestTenantArgs struct {
 	// Settings allows the caller to control the settings object used for the
 	// tenant cluster.
 	Settings *cluster.Settings
-	Tracer   *tracing.Tracer
 
 	// AllowSettingClusterSettings, if true, allows the tenant to set in-memory
 	// cluster settings.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -582,11 +582,21 @@ func (ts *TestServer) StartTenant(
 	if params.TempStorageConfig != nil {
 		sqlCfg.TempStorageConfig = *params.TempStorageConfig
 	}
-	tr := params.Tracer
-	if params.Tracer == nil {
-		tr = tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+
+	stopper := params.Stopper
+	if stopper == nil {
+		// We don't share the stopper with the server because we want their Tracers
+		// to be different, to simulate them being different processes.
+		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+		stopper = stop.NewStopper(stop.WithTracer(tr))
+		// The server's stopper stops the tenant, for convenience.
+		ts.Stopper().AddCloser(stop.CloserFn(func() { stopper.Stop(context.Background()) }))
+	} else if stopper.Tracer() == nil {
+		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+		stopper.SetTracer(tr)
 	}
-	baseCfg := makeTestBaseConfig(st, tr)
+
+	baseCfg := makeTestBaseConfig(st, stopper.Tracer())
 	baseCfg.TestingKnobs = params.TestingKnobs
 	baseCfg.Insecure = params.ForceInsecure
 	baseCfg.Locality = params.Locality
@@ -602,10 +612,6 @@ func (ts *TestServer) StartTenant(
 		if tenantKnobs.ClusterSettingsUpdater == nil {
 			tenantKnobs.ClusterSettingsUpdater = st.MakeUpdater()
 		}
-	}
-	stopper := params.Stopper
-	if stopper == nil {
-		stopper = ts.Stopper()
 	}
 	sqlServer, addr, httpAddr, err := StartTenant(
 		ctx,

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -620,3 +620,8 @@ func (s *Stopper) Quiesce(ctx context.Context) {
 func (s *Stopper) SetTracer(tr *tracing.Tracer) {
 	s.tracer = tr
 }
+
+// Tracer returns the Tracer that the Stopper will use for tasks.
+func (s *Stopper) Tracer() *tracing.Tracer {
+	return s.tracer
+}


### PR DESCRIPTION
Before this patch, TestServer.StartTenant() would share the Stopper
between the server and the tenant, and it would also proceed to give the
Tenant a new Tracer. The stopper in question has the server's Tracer in
it, and so this sharing is no bueno, because the tenant ends up having
two different Tracers, and it uses either of them fairly arbitrarily at
different points. Intermingling two Tracers like this was never
intended, and attempting to create a child with a different tracer then
the parent will become illegal shortly. This shows that sharing stoppers
between different "server" is a bad idea. This patch stops the practice.

The patch also removes the tracer config options for test tenants
because it was unused and supporting it in combination with the stopper
configuration would require more sanity checks.

Release note: None