### PR TITLE
tracing: untangle local/remove parent vs recording collection

### DIFF
--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -152,9 +152,9 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 				cmd.ctx, cmd.sp = d.r.AmbientContext.Tracer.StartSpanCtx(
 					ctx,
 					opName,
-					// NB: we are lying here - we are not actually going to propagate
-					// the recording towards the root. That seems ok.
-					tracing.WithParentAndManualCollection(spanMeta),
+					// NB: Nobody is collecting the recording of this span; we have no
+					// mechanism for it.
+					tracing.WithRemoteParent(spanMeta),
 					tracing.WithFollowsFrom(),
 				)
 			}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -329,7 +329,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 		ctx, sp = tr.StartSpanCtx(
 			ctx,
 			opName,
-			tracing.WithParentAndAutoCollection(parentSp),
+			tracing.WithParent(parentSp),
 			tracing.WithFollowsFrom(),
 			tagsOpt,
 		)

--- a/pkg/migration/migrationmanager/manager_external_test.go
+++ b/pkg/migration/migrationmanager/manager_external_test.go
@@ -161,15 +161,13 @@ RETURNING id;`).Scan(&secondID))
 	}()
 
 	testutils.SucceedsSoon(t, func() error {
-		// TODO(yuzefovich): this check is quite unfortunate since it relies on
-		// the assumption that all recordings from the child spans are imported
-		// into the tracer. However, this is not the case for the DistSQL
-		// processors where child spans are created with
-		// WithParentAndManualCollection option which requires explicitly
-		// importing the recordings from the children. This only happens when
-		// the execution flow is drained which cannot happen until we close
-		// the 'unblock' channel, and this we cannot do until we see the
-		// expected message in the trace.
+		// TODO(yuzefovich): this check is quite unfortunate since it relies on the
+		// assumption that all recordings from the child spans are imported into the
+		// tracer. However, this is not the case for the DistSQL processors whose
+		// recordings require explicit importing. This only happens when the
+		// execution flow is drained which cannot happen until we close the
+		// 'unblock' channel, and this we cannot do until we see the expected
+		// message in the trace.
 		//
 		// At the moment it works in a very fragile manner (by making sure that
 		// no processors actually create their own spans). Instead, a different

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1353,7 +1353,7 @@ CREATE TABLE crdb_internal.node_inflight_trace_spans (
 				"only users with the admin role are allowed to read crdb_internal.node_inflight_trace_spans")
 		}
 		return p.ExecCfg().AmbientCtx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
-			for _, rec := range span.GetRecording(tracing.RecordingVerbose) {
+			for _, rec := range span.GetFullRecording(tracing.RecordingVerbose) {
 				traceID := rec.TraceID
 				parentSpanID := rec.ParentSpanID
 				spanID := rec.SpanID

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -253,13 +253,13 @@ func (ds *ServerImpl) setupFlow(
 		// TODO(andrei): localState.IsLocal is not quite the right thing to use.
 		//  If that field is unset, we might still want to create a child span if
 		//  this flow is run synchronously.
-		ctx, sp = ds.Tracer.StartSpanCtx(ctx, opName, tracing.WithParentAndAutoCollection(parentSpan))
+		ctx, sp = ds.Tracer.StartSpanCtx(ctx, opName, tracing.WithParent(parentSpan))
 	} else {
 		// We use FollowsFrom because the flow's span outlives the SetupFlow request.
 		ctx, sp = ds.Tracer.StartSpanCtx(
 			ctx,
 			opName,
-			tracing.WithParentAndAutoCollection(parentSpan),
+			tracing.WithParent(parentSpan),
 			tracing.WithFollowsFrom(),
 		)
 	}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -834,7 +834,12 @@ func (pb *ProcessorBase) AppendTrailingMeta(meta execinfrapb.ProducerMetadata) {
 // ProcessorSpan creates a child span for a processor (if we are doing any
 // tracing). The returned span needs to be finished using tracing.FinishSpan.
 func ProcessorSpan(ctx context.Context, name string) (context.Context, *tracing.Span) {
-	return tracing.ChildSpanRemote(ctx, name)
+	sp := tracing.SpanFromContext(ctx)
+	if sp == nil {
+		return ctx, nil
+	}
+	return sp.Tracer().StartSpanCtx(ctx, name,
+		tracing.WithParent(sp), tracing.WithDetachedRecording())
 }
 
 // StartInternal prepares the ProcessorBase for execution. It returns the

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1816,7 +1816,7 @@ func (p *payloadsForSpanGenerator) Start(_ context.Context, _ *kv.Txn) error {
 	// managing the iterator's position needs to start at -1 instead of 0.
 	p.payloadIndex = -1
 
-	rec := p.span.GetRecording(tracing.RecordingStructured)
+	rec := p.span.GetFullRecording(tracing.RecordingStructured)
 	if rec == nil {
 		// No structured records.
 		return nil

--- a/pkg/sql/tests/tracing_sql_test.go
+++ b/pkg/sql/tests/tracing_sql_test.go
@@ -46,11 +46,11 @@ func TestSetTraceSpansVerbosityBuiltin(t *testing.T) {
 	defer root.Finish()
 	require.False(t, root.IsVerbose())
 
-	child := tr.StartSpan("root.child", tracing.WithParentAndAutoCollection(root))
+	child := tr.StartSpan("root.child", tracing.WithParent(root))
 	defer child.Finish()
 	require.False(t, child.IsVerbose())
 
-	childChild := tr.StartSpan("root.child.child", tracing.WithParentAndAutoCollection(child))
+	childChild := tr.StartSpan("root.child.child", tracing.WithParent(child))
 	defer childChild.Finish()
 	require.False(t, childChild.IsVerbose())
 
@@ -79,7 +79,7 @@ func TestSetTraceSpansVerbosityBuiltin(t *testing.T) {
 	require.False(t, childChild.IsVerbose())
 
 	// New child of verbose child span should also be verbose by default.
-	newChild := tr.StartSpan("root.child.newchild", tracing.WithParentAndAutoCollection(root))
+	newChild := tr.StartSpan("root.child.newchild", tracing.WithParent(root))
 	defer newChild.Finish()
 	require.True(t, newChild.IsVerbose())
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -149,7 +149,7 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 			var buf strings.Builder
 			fmt.Fprintf(&buf, "unexpectedly found %d active spans:\n", len(sps))
 			for _, sp := range sps {
-				fmt.Fprintln(&buf, sp.GetRecording(tracing.RecordingVerbose))
+				fmt.Fprintln(&buf, sp.GetFullRecording(tracing.RecordingVerbose))
 				fmt.Fprintln(&buf)
 			}
 			return errors.Newf("%s", buf.String())

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -733,7 +733,7 @@ func TestStopperRunAsyncTaskTracing(t *testing.T) {
 					errC <- errors.Errorf("missing span")
 					return
 				}
-				sp = tr.StartSpan("child", tracing.WithParentAndAutoCollection(sp))
+				sp = tr.StartSpan("child", tracing.WithParent(sp))
 				if sp.TraceID() == traceID {
 					errC <- errors.Errorf("expected different trace")
 				}

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -52,10 +52,10 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 			WithForceRealSpan(), WithLogTags(&staticLogTags),
 		}},
 		{"real,autoparent", []SpanOption{
-			WithForceRealSpan(), WithParentAndAutoCollection(parSp),
+			WithForceRealSpan(), WithParent(parSp),
 		}},
 		{"real,manualparent", []SpanOption{
-			WithForceRealSpan(), WithParentAndManualCollection(parSp.Meta()),
+			WithForceRealSpan(), WithParent(parSp), WithDetachedRecording(),
 		}},
 	} {
 		b.Run(fmt.Sprintf("opts=%s", tc.name), func(b *testing.B) {
@@ -91,7 +91,7 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 		run(b, sp)
 	})
 
-	child := tr.StartSpan("bar", WithParentAndAutoCollection(sp), WithForceRealSpan())
+	child := tr.StartSpan("bar", WithParent(sp), WithForceRealSpan())
 	b.Run("child-only", func(b *testing.B) {
 		run(b, child)
 	})
@@ -110,7 +110,7 @@ func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		root := tr.StartSpan("foo")
 		root.RecordStructured(ev)
-		child := tr.StartSpan("bar", WithParentAndAutoCollection(root))
+		child := tr.StartSpan("bar", WithParent(root))
 		child.RecordStructured(ev)
 		child.Finish()
 		_ = root.GetRecording(RecordingStructured)

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -72,20 +72,20 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start a child span on "node 1".
-	child := t1.StartSpan("root.child", tracing.WithParentAndAutoCollection(root))
+	child := t1.StartSpan("root.child", tracing.WithParent(root))
 
 	// Sleep a bit so that everything that comes afterwards has higher timestamps
 	// than the one we just assigned. Otherwise the sorting is not deterministic.
 	time.Sleep(10 * time.Millisecond)
 
 	// Start a remote child span on "node 2".
-	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithParentAndManualCollection(child.Meta()))
+	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithRemoteParent(child.Meta()))
 	childRemoteChild.RecordStructured(newTestStructured("root.child.remotechild"))
 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start another remote child span on "node 2" that we finish.
-	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithParentAndManualCollection(child.Meta()))
+	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithRemoteParent(child.Meta()))
 	child.ImportRemoteSpans(childRemoteChildFinished.FinishAndGetRecording(tracing.RecordingVerbose))
 
 	// Start a root span on "node 2".
@@ -93,14 +93,14 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	root2.RecordStructured(newTestStructured("root2"))
 
 	// Start a child span on "node 2".
-	child2 := t2.StartSpan("root2.child", tracing.WithParentAndAutoCollection(root2))
+	child2 := t2.StartSpan("root2.child", tracing.WithParent(root2))
 	// Start a remote child span on "node 1".
-	child2RemoteChild := t1.StartSpan("root2.child.remotechild", tracing.WithParentAndManualCollection(child2.Meta()))
+	child2RemoteChild := t1.StartSpan("root2.child.remotechild", tracing.WithRemoteParent(child2.Meta()))
 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start another remote child span on "node 1".
-	anotherChild2RemoteChild := t1.StartSpan("root2.child.remotechild2", tracing.WithParentAndManualCollection(child2.Meta()))
+	anotherChild2RemoteChild := t1.StartSpan("root2.child.remotechild2", tracing.WithRemoteParent(child2.Meta()))
 	return root.TraceID(), root2.TraceID(), func() {
 		for _, span := range []*tracing.Span{root, child, childRemoteChild, root2, child2,
 			child2RemoteChild, anotherChild2RemoteChild} {

--- a/pkg/util/tracing/doc.go
+++ b/pkg/util/tracing/doc.go
@@ -94,7 +94,7 @@
 // [6]: `crdbSpan`
 // [7]: `Span.SetVerbose`. To understand the specifics of what exactly is
 //      captured in Span recording, when Spans have children that may be either
-//      local or remote, look towards `WithParentAnd{Auto,Manual}Collection`
+//      local or remote, look towards `WithParent` and `WithDetachedRecording`.
 // [8]: `Tracer.{InjectMetaInto,ExtractMetaFrom}`
 // [9]: `SpanMeta`
 // [10]: `{Client,Server}Interceptor`

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -118,7 +118,7 @@ func ServerInterceptor(tracer *Tracer) grpc.UnaryServerInterceptor {
 		ctx, serverSpan := tracer.StartSpanCtx(
 			ctx,
 			info.FullMethod,
-			WithParentAndManualCollection(spanMeta),
+			WithRemoteParent(spanMeta),
 			WithServerSpanKind,
 		)
 		defer serverSpan.Finish()
@@ -161,7 +161,7 @@ func StreamServerInterceptor(tracer *Tracer) grpc.StreamServerInterceptor {
 		ctx, serverSpan := tracer.StartSpanCtx(
 			ss.Context(),
 			info.FullMethod,
-			WithParentAndManualCollection(spanMeta),
+			WithRemoteParent(spanMeta),
 			WithServerSpanKind,
 		)
 		defer serverSpan.Finish()
@@ -243,7 +243,7 @@ func ClientInterceptor(tracer *Tracer, init func(*Span)) grpc.UnaryClientInterce
 		}
 		clientSpan := tracer.StartSpan(
 			method,
-			WithParentAndAutoCollection(parent),
+			WithParent(parent),
 			WithClientSpanKind,
 		)
 		init(clientSpan)
@@ -292,7 +292,7 @@ func StreamClientInterceptor(tracer *Tracer, init func(*Span)) grpc.StreamClient
 
 		clientSpan := tracer.StartSpan(
 			method,
-			WithParentAndAutoCollection(parent),
+			WithParent(parent),
 			WithClientSpanKind,
 		)
 		init(clientSpan)

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -227,7 +227,7 @@ func TestGRPCInterceptors(t *testing.T) {
 	runtime.GC()
 	testutils.SucceedsSoon(t, func() error {
 		return tr.VisitSpans(func(sp tracing.RegistrySpan) error {
-			rec := sp.GetRecording(tracing.RecordingVerbose)[0]
+			rec := sp.GetFullRecording(tracing.RecordingVerbose)[0]
 			return errors.Newf("leaked span: %s %s", rec.Operation, rec.Tags)
 		})
 	})

--- a/pkg/util/tracing/service/service.go
+++ b/pkg/util/tracing/service/service.go
@@ -53,7 +53,7 @@ func (s *Service) GetSpanRecordings(
 		if span.TraceID() != request.TraceID {
 			return nil
 		}
-		recording := span.GetRecording(tracing.RecordingVerbose)
+		recording := span.GetFullRecording(tracing.RecordingVerbose)
 		if recording != nil {
 			resp.Recordings = append(resp.Recordings,
 				tracingservicepb.GetSpanRecordingsResponse_Recording{RecordedSpans: recording})

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -42,8 +42,8 @@ const (
 // The CockroachDB-internal Span (crdbSpan) is more complex because
 // rather than reporting to some external sink, the caller's "owner"
 // must propagate the trace data back across process boundaries towards
-// the root of the trace span tree; see WithParentAndAutoCollection
-// and WithParentAndManualCollection, respectively.
+// the root of the trace span tree; see WithParent
+// and WithRemoteParent, respectively.
 //
 // Additionally, the internal span type also supports turning on, stopping,
 // and restarting its data collection (see Span.StartRecording), and this is
@@ -131,8 +131,8 @@ func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 
 // Meta returns the information which needs to be propagated across process
 // boundaries in order to derive child spans from this Span. This may return
-// nil, which is a valid input to `WithParentAndManualCollection`, if the Span
-// has been optimized out.
+// nil, which is a valid input to WithRemoteParent, if the Span has been
+// optimized out.
 func (sp *Span) Meta() SpanMeta {
 	// It shouldn't be done in practice, but it is allowed to call Meta on
 	// a finished span.

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -46,14 +46,30 @@ var followsFromAttribute = []attribute.KeyValue{attribute.String("follows-from",
 // field comment below are invoked as arguments to `Tracer.StartSpan`.
 // See the SpanOption interface for a synopsis.
 type spanOptions struct {
-	Parent        *Span                  // see WithParentAndAutoCollection
-	RemoteParent  SpanMeta               // see WithParentAndManualCollection
-	RefType       spanReferenceType      // see WithFollowsFrom
-	LogTags       *logtags.Buffer        // see WithLogTags
-	Tags          map[string]interface{} // see WithTags
-	ForceRealSpan bool                   // see WithForceRealSpan
-	SpanKind      oteltrace.SpanKind     // see WithSpanKind
-	Sterile       bool                   // see WithSterile
+	Parent *Span // see WithParent
+	// ParentDoesNotCollectRecording is set by WithDetachedRecording. It means
+	// that, although this span has a parent, the parent should generally not
+	// include this child's recording when the parent is asked for its own
+	// recording. Usually, a parent span includes all its children in its
+	// recording. However, sometimes that's not desired; sometimes the creator of
+	// a child span has a different plan for how the recording of that child will
+	// end up being collected and reported to where it ultimately needs to go.
+	// Still, even in these cases, a parent-child relationship is still useful
+	// (for example for the purposes of the active spans registry), so the child
+	// span cannot simply be created as a root.
+	//
+	// For example, in the case of DistSQL, each processor in a flow has its own
+	// span, as a child of the flow. The DistSQL infrastructure organizes the
+	// collection of each processor span recording independently, without relying
+	// on collecting the recording of the flow's span.
+	ParentDoesNotCollectRecording bool
+	RemoteParent                  SpanMeta               // see WithRemoteParent
+	RefType                       spanReferenceType      // see WithFollowsFrom
+	LogTags                       *logtags.Buffer        // see WithLogTags
+	Tags                          map[string]interface{} // see WithTags
+	ForceRealSpan                 bool                   // see WithForceRealSpan
+	SpanKind                      oteltrace.SpanKind     // see WithSpanKind
+	Sterile                       bool                   // see WithSterile
 
 	// recordingTypeExplicit is set if the WithRecording() option was used. In
 	// that case, spanOptions.recordingType() returns recordingTypeOpt below. If
@@ -111,23 +127,28 @@ func (opts *spanOptions) otelContext() (oteltrace.Span, oteltrace.SpanContext) {
 // SpanOption is the interface satisfied by options to `Tracer.StartSpan`.
 // A synopsis of the options follows. For details, see their comments.
 //
-// - WithParentAndAutoCollection: create a child Span from a Span.
-// - WithParentAndManualCollection: create a child Span from a SpanMeta.
-// - WithFollowsFrom: indicate that child may outlive parent.
+// - WithParent: create a child Span with a local parent.
+// - WithRemoteParent: create a child Span with a remote parent.
+// - WithFollowsFrom: hint that child may outlive parent.
 // - WithLogTags: populates the Span tags from a `logtags.Buffer`.
 // - WithCtxLogTags: like WithLogTags, but takes a `context.Context`.
 // - WithTags: adds tags to a Span on creation.
 // - WithForceRealSpan: prevents optimizations that can avoid creating a real span.
+// - WithDetachedRecording: don't include the recording in the parent.
 type SpanOption interface {
 	apply(spanOptions) spanOptions
 }
 
-type parentAndAutoCollectionOption Span
+type parentOption Span
 
-// WithParentAndAutoCollection instructs StartSpan to create a child Span
-// from a parent Span.
+// WithParent instructs StartSpan to create a child Span from a (local) parent
+// Span.
 //
-// WithParentAndAutoCollection will be a no-op (i.e. the span resulting from
+// In case when the parent span is created with a different Tracer (generally,
+// when the parent lives in a different process), WithRemoteParent should be
+// used.
+//
+// WithParent will be a no-op (i.e. the span resulting from
 // applying this option will be a root span, just as if this option hadn't been
 // specified) in the following cases:
 // - if `sp` is nil
@@ -153,56 +174,84 @@ type parentAndAutoCollectionOption Span
 // which corresponds to the expectation that the parent span will
 // wait for the child to Finish(). If this expectation does not hold,
 // WithFollowsFrom should be added to the StartSpan invocation.
-//
-// When the parent Span is not available at the caller,
-// WithParentAndManualCollection should be used, which incurs an
-// obligation to manually propagate the trace data to the parent Span.
-func WithParentAndAutoCollection(sp *Span) SpanOption {
+func WithParent(sp *Span) SpanOption {
 	if sp == nil || sp.IsNoop() || sp.IsSterile() {
-		return (*parentAndAutoCollectionOption)(nil)
+		return (*parentOption)(nil)
 	}
-	return (*parentAndAutoCollectionOption)(sp)
+	return (*parentOption)(sp)
 }
 
-func (p *parentAndAutoCollectionOption) apply(opts spanOptions) spanOptions {
+func (p *parentOption) apply(opts spanOptions) spanOptions {
 	opts.Parent = (*Span)(p)
 	return opts
 }
 
-type parentAndManualCollectionOption SpanMeta
+type remoteParent SpanMeta
 
-// WithParentAndManualCollection instructs StartSpan to create a
-// child span descending from a parent described via a SpanMeta. In
-// contrast with WithParentAndAutoCollection, the caller must call
-// `Span.GetRecording` when finishing the returned Span, and propagate the
-// result to the parent Span by calling `Span.ImportRemoteSpans` on it.
+// WithRemoteParent instructs StartSpan to create a child span descending from a
+// parent described via a SpanMeta. Generally this parent span lives in a
+// different process.
 //
-// The canonical use case for this is around RPC boundaries, where a
-// server handling a request wants to create a child span descending
-// from a parent on a remote machine.
+// For the purposes of trace recordings, there's no mechanism ensuring that the
+// child's recording will be passed to the parent span. When that's desired, it
+// has to be done manually by calling Span.GetRecording() and propagating the
+// result to the parent by calling Span.ImportRemoteSpans().
+//
+// The canonical use case for this is around RPC boundaries, where a server
+// handling a request wants to create a child span descending from a parent on a
+// remote machine.
 //
 // node 1                     (network)          node 2
 // --------------------------------------------------------------------------
 // Span.Meta()               ----------> sp2 := Tracer.StartSpan(
-//                                       		WithParentAndManualCollection(.))
+//                                       		WithRemoteParent(.))
 //                                       doSomething(sp2)
-//                                       sp2.Finish()
-// Span.ImportRemoteSpans(.) <---------- sp2.GetRecording()
+// Span.ImportRemoteSpans(.) <---------- sp2.FinishAndGetRecording()
 //
-// By default, the child span is derived using a ChildOf relationship,
-// which corresponds to the expectation that the parent span will
-// wait for the child to Finish(). If this expectation does not hold,
-// WithFollowsFrom should be added to the StartSpan invocation.
-func WithParentAndManualCollection(parent SpanMeta) SpanOption {
+// By default, the child span is derived using a ChildOf relationship, which
+// corresponds to the expectation that the parent span will usually wait for the
+// child to Finish(). If this expectation does not hold, WithFollowsFrom should
+// be added to the StartSpan invocation.
+func WithRemoteParent(parent SpanMeta) SpanOption {
 	if parent.sterile {
-		return parentAndManualCollectionOption{}
+		return remoteParent{}
 	}
-	return (parentAndManualCollectionOption)(parent)
+	return (remoteParent)(parent)
 }
 
-func (p parentAndManualCollectionOption) apply(opts spanOptions) spanOptions {
+func (p remoteParent) apply(opts spanOptions) spanOptions {
 	opts.RemoteParent = (SpanMeta)(p)
 	return opts
+}
+
+type detachedRecording struct{}
+
+var detachedRecordingSingleton = SpanOption(detachedRecording{})
+
+func (o detachedRecording) apply(opts spanOptions) spanOptions {
+	opts.ParentDoesNotCollectRecording = true
+	return opts
+}
+
+// WithDetachedRecording configures the span to not be included in the parent's
+// recording (if any) under most circumstances. Usually, a parent span includes
+// all its children in its recording. However, sometimes that's not desired;
+// sometimes the creator of a child span has a different plan for how the
+// recording of that child will end up being collected and reported to where it
+// ultimately needs to go. Still, even in these cases, a parent-child
+// relationship is still useful (for example for the purposes of the active
+// spans registry), so the child span cannot simply be created as a root.
+//
+// For example, in the case of DistSQL, each processor in a flow has its own
+// span, as a child of the flow. The DistSQL infrastructure organizes the
+// collection of each processor span recording independently, without relying
+// on collecting the recording of the flow's span.
+//
+// In the case when the parent's recording is collected through the span
+// registry, this option is ignore since, in that case, we want as much info as
+// possible.
+func WithDetachedRecording() SpanOption {
+	return detachedRecordingSingleton
 }
 
 type followsFromOpt struct{}
@@ -211,11 +260,11 @@ var followsFromSingleton = SpanOption(followsFromOpt{})
 
 // WithFollowsFrom instructs StartSpan to link the child span to its parent
 // using a different kind of relationship than the regular parent-child one,
-// should a child span be created (i.e. should WithParentAndAutoCollection or
-// WithParentAndManualCollection be supplied as well). This relationship was
+// should a child span be created (i.e. should WithParent or
+// WithRemoteParent be supplied as well). This relationship was
 // called "follows-from" in the old OpenTracing API. This only matters if the
 // trace is sent to an OpenTelemetry tracer; CRDB itself ignores it (what
-// matters for CRDB is the AutoCollection vs ManualCollection distinction).
+// matters for CRDB is the WithDetachedTrace option).
 // OpenTelemetry does not have a concept of a follows-from relationship at the
 // moment; specifying this option results in the child having a Link to the
 // parent.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -608,12 +608,12 @@ func (t *Tracer) startSpanGeneric(
 		if opts.Parent.IsNoop() {
 			// This method relies on the parent, if any, not being a no-op. A no-op
 			// parent should have been optimized away by the
-			// WithParentAndAutoCollection option.
+			// WithParent option.
 			panic("invalid no-op parent")
 		}
 		if opts.Parent.IsSterile() {
 			// A sterile parent should have been optimized away by
-			// WithParentAndAutoCollection.
+			// WithParent.
 			panic("invalid sterile parent")
 		}
 		if opts.Parent.Tracer() != t {
@@ -701,7 +701,7 @@ func (t *Tracer) startSpanGeneric(
 		octx     optimizedContext
 		// Pre-allocated buffers for the span.
 		tagsAlloc             [3]attribute.KeyValue
-		childrenAlloc         [4]*crdbSpan
+		childrenAlloc         [4]childRef
 		structuredEventsAlloc [3]interface{}
 	}{}
 
@@ -742,7 +742,7 @@ func (t *Tracer) startSpanGeneric(
 		if opts.Parent != nil && opts.Parent.i.crdb != nil {
 			if opts.Parent.i.crdb.recordingType() != RecordingOff {
 				s.i.crdb.mu.parent = opts.Parent.i.crdb
-				opts.Parent.i.crdb.addChild(s.i.crdb)
+				opts.Parent.i.crdb.addChild(s.i.crdb, !opts.ParentDoesNotCollectRecording)
 			}
 		}
 		s.i.crdb.enableRecording(opts.recordingType())
@@ -937,8 +937,13 @@ type RegistrySpan interface {
 	// TraceID returns an identifier for the trace that this span is part of.
 	TraceID() tracingpb.TraceID
 
-	// GetRecording returns the recording of the trace rooted at this span.
-	GetRecording(recType RecordingType) Recording
+	// GetFullRecording returns the recording of the trace rooted at this span.
+	//
+	// This includes the recording of child spans created with the
+	// WithDetachedRecording option. In other situations, the recording of such
+	// children is not included in the parent's recording but, in the case of the
+	// span registry, we want as much information as possible to be included.
+	GetFullRecording(recType RecordingType) Recording
 
 	// SetVerbose sets the verbosity of the span appropriately and
 	// recurses on its children.
@@ -1007,13 +1012,14 @@ func ForkSpan(ctx context.Context, opName string) (context.Context, *Span) {
 	if sp == nil {
 		return ctx, nil
 	}
-	collectionOpt := WithParentAndManualCollection(sp.Meta())
+	opts := make([]SpanOption, 0, 3)
 	if sp.Tracer().ShouldRecordAsyncSpans() {
-		// Using auto collection here ensures that recordings from async spans
-		// also show up at the parent.
-		collectionOpt = WithParentAndAutoCollection(sp)
+		opts = append(opts, WithParent(sp))
+	} else {
+		opts = append(opts, WithParent(sp), WithDetachedRecording())
 	}
-	return sp.Tracer().StartSpanCtx(ctx, opName, WithFollowsFrom(), collectionOpt)
+	opts = append(opts, WithFollowsFrom())
+	return sp.Tracer().StartSpanCtx(ctx, opName, opts...)
 }
 
 // EnsureForkSpan is like ForkSpan except that, if there is no span in ctx, it
@@ -1024,12 +1030,12 @@ func EnsureForkSpan(ctx context.Context, tr *Tracer, opName string) (context.Con
 	// If there's a span in ctx, we use it as a parent.
 	if sp != nil {
 		tr = sp.Tracer()
-		if !tr.ShouldRecordAsyncSpans() {
-			opts = append(opts, WithParentAndManualCollection(sp.Meta()))
+		if tr.ShouldRecordAsyncSpans() {
+			opts = append(opts, WithParent(sp))
 		} else {
 			// Using auto collection here ensures that recordings from async spans
 			// also show up at the parent.
-			opts = append(opts, WithParentAndAutoCollection(sp))
+			opts = append(opts, WithParent(sp), WithDetachedRecording())
 		}
 		opts = append(opts, WithFollowsFrom())
 	}
@@ -1048,23 +1054,11 @@ func ChildSpan(ctx context.Context, opName string) (context.Context, *Span) {
 	if sp == nil {
 		return ctx, nil
 	}
-	return sp.Tracer().StartSpanCtx(ctx, opName, WithParentAndAutoCollection(sp))
-}
-
-// ChildSpanRemote is like ChildSpan but the new Span is created using
-// WithParentAndManualCollection instead of WithParentAndAutoCollection. When
-// this is used, it's the caller's duty to collect this span's recording and
-// return it to the root span of the trace.
-func ChildSpanRemote(ctx context.Context, opName string) (context.Context, *Span) {
-	sp := SpanFromContext(ctx)
-	if sp == nil {
-		return ctx, nil
-	}
-	return sp.Tracer().StartSpanCtx(ctx, opName, WithParentAndManualCollection(sp.Meta()))
+	return sp.Tracer().StartSpanCtx(ctx, opName, WithParent(sp))
 }
 
 // EnsureChildSpan looks at the supplied Context. If it contains a Span, returns
-// a child span via the WithParentAndAutoCollection option; otherwise starts a
+// a child span via the WithParent option; otherwise starts a
 // new Span. In both cases, a context wrapping the Span is returned along with
 // the newly created Span.
 //
@@ -1073,7 +1067,7 @@ func EnsureChildSpan(
 	ctx context.Context, tr *Tracer, name string, os ...SpanOption,
 ) (context.Context, *Span) {
 	slp := optsPool.Get().(*[]SpanOption)
-	*slp = append(*slp, WithParentAndAutoCollection(SpanFromContext(ctx)))
+	*slp = append(*slp, WithParent(SpanFromContext(ctx)))
 	*slp = append(*slp, os...)
 	ctx, sp := tr.StartSpanCtx(ctx, name, *slp...)
 	// Clear and zero-length the slice. Note that we have to clear


### PR DESCRIPTION
Before this patch, two concepts were bundled together: whether or not
the parent of a span is local or remote to the child's node, and whether
or not the parent should include the child in its recording. You could
create a child span with either:
- the WithParentAndAutoCollection option, which would give you a local
  parent which includes the child in its recording, or
- the WithParentAndManualCollection option, which would give you a
  remote parent (which naturally would not / couldn't include the child
  in its recording).

The WithParentAndManualCollection is sometimes used even when the parent
is local, which is a) quite confusing, because at a lower level it
produced what was called a "remote parent" and b) sub-optimal, because
the child looked like a "local root", which meant it had to be put into
the active spans registry. Were it not for the bundling of the two
concerns together, such a child of a local parent, but for whom the
parent is not in charge of collecting the recording, would not need to
be put directly into the span registry; such a span (like other child
spans) should be part of the registry indirectly, through its parent -
which is cheaper because it doesn't add contention on the global mutex
lock.

The funky case of a local parent whose recording does not include the
child's is used by DistSQL processors - each processor gets a span whose
recording is collected by the DistSQL infrastructure, independent of the
parent.

This patch untangles the parent-child relationship from the
recording collection concern, and cleans up the API in the process. Now
you have the following options for creating a span:

WithParent(parent) - creates a parent/child relationship. The parent has
a reference to the child. The child is part of the active spans registry
through the parent. Unless WithDetachedRecording() is also specified,
the parent's recording includes the child's.

WithRemoteParent(parentMeta) - creates a parent/child relationship
across process boundaries.

WithDetachedRecording() - asks the parent to not include the new child
in its recording. This is a no-op in case WithRemoteParent() is used.
This option is used by DistSQL.

So, we get a cleaner API, and a more efficient active spans registry
implementation because the DistSQL spans are no longer directly part of
it. Also, we open the door for a new possibility in the future: you can
imagine that, in certain scenarios, it'd be interesting for a span to
collect the recording of all its children, including the ones whose
recording, under normal circumstances, is not the parent's
responsibility to collect. For example, when asking for the recording of
a span in the registry in an out-of-band way (i.e. when debugging), I
want all the info I can get. So, I should be able to point to a DistSQL
flow span and ask it for the recording of all processors on its node.
This is not implemented yet.

Release note: None