### PR TITLE
storage: delete deprecated PutProto function

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -955,25 +955,6 @@ type EncryptionRegistries struct {
 	KeyRegistry []byte
 }
 
-// PutProto sets the given key to the protobuf-serialized byte string
-// of msg. Returns the length in bytes of key and the value.
-//
-// Deprecated: use MVCCPutProto instead.
-func PutProto(
-	writer Writer, key roachpb.Key, msg protoutil.Message,
-) (keyBytes, valBytes int64, err error) {
-	bytes, err := protoutil.Marshal(msg)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if err := writer.PutUnversioned(key, bytes); err != nil {
-		return 0, 0, err
-	}
-
-	return int64(MVCCKey{Key: key}.EncodedSize()), int64(len(bytes)), nil
-}
-
 // Scan returns up to max key/value objects starting from start (inclusive)
 // and ending at end (non-inclusive). Specify max=0 for unbounded scans. Since
 // this code may use an intentInterleavingIter, the caller should not attempt


### PR DESCRIPTION
This function has been deprecated since 5e5eaa5. It was only used in one test, so this commit removes it.