### PR TITLE
sql, cli: support basic auto complete for sql keywords

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -934,6 +934,7 @@ unreserved_keyword ::=
 	| 'COMMITTED'
 	| 'COMPACT'
 	| 'COMPLETE'
+	| 'COMPLETIONS'
 	| 'CONFLICT'
 	| 'CONFIGURATION'
 	| 'CONFIGURATIONS'

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -255,6 +255,7 @@ ALL_TESTS = [
     "//pkg/sql/contention/txnidcache:txnidcache_test",
     "//pkg/sql/contention:contention_test",
     "//pkg/sql/covering:covering_test",
+    "//pkg/sql/delegate:delegate_test",
     "//pkg/sql/distsql:distsql_test",
     "//pkg/sql/doctor:doctor_test",
     "//pkg/sql/enum:enum_test",

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -1656,6 +1658,8 @@ func (ex *connExecutor) runObserverStatement(
 		return ex.runShowLastQueryStatistics(ctx, res, sqlStmt)
 	case *tree.ShowTransferState:
 		return ex.runShowTransferState(ctx, res, sqlStmt)
+	case *tree.ShowCompletions:
+		return ex.runShowCompletions(ctx, sqlStmt, res)
 	default:
 		res.SetError(errors.AssertionFailedf("unrecognized observer statement type %T", ast))
 		return nil
@@ -1777,6 +1781,33 @@ func (ex *connExecutor) runShowTransferState(
 		row = append(row, tree.NewDString(stmt.TransferKey.RawString()))
 	}
 	return res.AddRow(ctx, row)
+}
+
+// runShowCompletions executes a SHOW COMPLETIONS statement.
+func (ex *connExecutor) runShowCompletions(
+	ctx context.Context, n *tree.ShowCompletions, res RestrictedCommandResult,
+) error {
+	res.SetColumns(ctx, colinfo.ResultColumns{{Name: "COMPLETIONS", Typ: types.String}})
+	offsetVal, ok := n.Offset.AsConstantInt()
+	if !ok {
+		return errors.Newf("invalid offset %v", n.Offset)
+	}
+	offset, err := strconv.Atoi(offsetVal.String())
+	if err != nil {
+		return err
+	}
+	completions, err := delegate.RunShowCompletions(n.Statement.RawString(), offset)
+	if err != nil {
+		return err
+	}
+
+	for _, completion := range completions {
+		err = res.AddRow(ctx, tree.Datums{tree.NewDString(completion)})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // showQueryStatsFns maps column names as requested by the SQL clients

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "delegate",
@@ -7,6 +7,7 @@ go_library(
         "job_control.go",
         "show_all_cluster_settings.go",
         "show_changefeed_jobs.go",
+        "show_completions.go",
         "show_database_indexes.go",
         "show_databases.go",
         "show_default_privileges.go",
@@ -56,4 +57,10 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",
     ],
+)
+
+go_test(
+    name = "delegate_test",
+    srcs = ["show_completions_test.go"],
+    embed = [":delegate"],
 )

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -141,6 +141,9 @@ func TryDelegate(
 	case *tree.ShowSchedules:
 		return d.delegateShowSchedules(t)
 
+	case *tree.ShowCompletions:
+		return d.delegateShowCompletions(t)
+
 	case *tree.ControlJobsForSchedules:
 		return d.delegateJobControl(ControlJobsDelegate{
 			Schedules: t.Schedules,

--- a/pkg/sql/delegate/show_completions.go
+++ b/pkg/sql/delegate/show_completions.go
@@ -1,0 +1,122 @@
+package delegate
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+func (d *delegator) delegateShowCompletions(n *tree.ShowCompletions) (tree.Statement, error) {
+	offsetVal, ok := n.Offset.AsConstantInt()
+	if !ok {
+		return nil, errors.Newf("invalid offset %v", n.Offset)
+	}
+	offset, err := strconv.Atoi(offsetVal.String())
+	if err != nil {
+		return nil, err
+	}
+
+	completions, err := runShowCompletions(n.Statement, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(completions) == 0 {
+		return parse(`SELECT '' as completions`)
+	}
+
+	var query bytes.Buffer
+	fmt.Fprint(&query, "SELECT @1 AS completions FROM (VALUES ")
+
+	comma := ""
+	for _, completion := range completions {
+		fmt.Fprintf(&query, "%s(", comma)
+		lexbase.EncodeSQLString(&query, completion)
+		query.WriteByte(')')
+		comma = ", "
+	}
+
+	fmt.Fprintf(&query, ")")
+
+	return parse(query.String())
+}
+
+func runShowCompletions(stmt string, offset int) ([]string, error) {
+	if offset <= 0 || offset > len(stmt) {
+		return nil, nil
+	}
+
+	// For simplicity, if we're on a whitespace, return no completions.
+	// Currently, parser.
+	// parser.TokensIgnoreErrors does not consider whitespaces
+	// after the last token.
+	// Ie "SELECT ", will only return one token being "SELECT".
+	// If we're at the whitespace, we do not want to return completion
+	// recommendations for "SELECT".
+	if unicode.IsSpace([]rune(stmt)[offset-1]) {
+		return nil, nil
+	}
+
+	sqlTokens := parser.TokensIgnoreErrors(string([]rune(stmt)[:offset]))
+	if len(sqlTokens) == 0 {
+		return nil, nil
+	}
+
+	sqlTokenStrings := make([]string, len(sqlTokens))
+	for i, sqlToken := range sqlTokens {
+		sqlTokenStrings[i] = sqlToken.Str
+	}
+
+	lastWordTruncated := sqlTokenStrings[len(sqlTokenStrings)-1]
+
+	// If the offset is in the middle of a word, we return the full word.
+	// For example if the stmt is SELECT with offset 2, even though SEARCH would
+	// come first for "SE", we want to return "SELECT".
+	// Similarly, if we have SEL with offset 2, we want to return "SEL".
+	allSqlTokens := parser.TokensIgnoreErrors(stmt)
+	lastWordFull := allSqlTokens[len(sqlTokenStrings)-1]
+	if lastWordFull.Str != lastWordTruncated {
+		return []string{strings.ToUpper(lastWordFull.Str)}, nil
+	}
+
+	return getCompletionsForWord(lastWordTruncated, lexbase.KeywordNames), nil
+}
+
+// Binary search for range with matching prefixes
+// Return the range of matching prefixes for w.
+func binarySearch(w string, words []string) (int, int) {
+	// First binary search for the first string in the sorted lexbase.KeywordNames list
+	// that matches the prefix w.
+	left := sort.Search(len(words), func(i int) bool { return words[i] >= w })
+
+	// Binary search for the last string in the sorted lexbase.KeywordNames list that matches
+	// the prefix w.
+	right := sort.Search(len(words), func(i int) bool { return words[i][:min(len(words[i]), len(w))] > w })
+
+	return left, right
+}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func getCompletionsForWord(w string, words []string) []string {
+	left, right := binarySearch(strings.ToLower(w), words)
+	completions := make([]string, right-left)
+
+	for i, word := range words[left:right] {
+		completions[i] = strings.ToUpper(word)
+	}
+	return completions
+}

--- a/pkg/sql/delegate/show_completions.go
+++ b/pkg/sql/delegate/show_completions.go
@@ -1,3 +1,13 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 package delegate
 
 import (
@@ -24,7 +34,7 @@ func (d *delegator) delegateShowCompletions(n *tree.ShowCompletions) (tree.State
 		return nil, err
 	}
 
-	completions, err := runShowCompletions(n.Statement, offset)
+	completions, err := RunShowCompletions(n.Statement.RawString(), offset)
 	if err != nil {
 		return nil, err
 	}
@@ -49,14 +59,15 @@ func (d *delegator) delegateShowCompletions(n *tree.ShowCompletions) (tree.State
 	return parse(query.String())
 }
 
-func runShowCompletions(stmt string, offset int) ([]string, error) {
+// RunShowCompletions returns a list of completion keywords for the given
+// statement and offset.
+func RunShowCompletions(stmt string, offset int) ([]string, error) {
 	if offset <= 0 || offset > len(stmt) {
 		return nil, nil
 	}
 
 	// For simplicity, if we're on a whitespace, return no completions.
-	// Currently, parser.
-	// parser.TokensIgnoreErrors does not consider whitespaces
+	// Currently, parser.TokensIgnoreErrors does not consider whitespaces
 	// after the last token.
 	// Ie "SELECT ", will only return one token being "SELECT".
 	// If we're at the whitespace, we do not want to return completion
@@ -81,8 +92,8 @@ func runShowCompletions(stmt string, offset int) ([]string, error) {
 	// For example if the stmt is SELECT with offset 2, even though SEARCH would
 	// come first for "SE", we want to return "SELECT".
 	// Similarly, if we have SEL with offset 2, we want to return "SEL".
-	allSqlTokens := parser.TokensIgnoreErrors(stmt)
-	lastWordFull := allSqlTokens[len(sqlTokenStrings)-1]
+	allSQLTokens := parser.TokensIgnoreErrors(stmt)
+	lastWordFull := allSQLTokens[len(sqlTokenStrings)-1]
 	if lastWordFull.Str != lastWordTruncated {
 		return []string{strings.ToUpper(lastWordFull.Str)}, nil
 	}

--- a/pkg/sql/delegate/show_completions_test.go
+++ b/pkg/sql/delegate/show_completions_test.go
@@ -1,0 +1,95 @@
+package delegate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompletions(t *testing.T) {
+	tests := []struct {
+		stmt                string
+		offset              int
+		expectedCompletions []string
+	}{
+		{
+			stmt:                "creat",
+			expectedCompletions: []string{"CREATE", "CREATEDB", "CREATELOGIN", "CREATEROLE"},
+		},
+		{
+			stmt:                "CREAT",
+			expectedCompletions: []string{"CREATE", "CREATEDB", "CREATELOGIN", "CREATEROLE"},
+		},
+		{
+			stmt:                "creat ",
+			expectedCompletions: []string{},
+		},
+		{
+			stmt:                "SHOW CREAT",
+			expectedCompletions: []string{"CREATE", "CREATEDB", "CREATELOGIN", "CREATEROLE"},
+		},
+		{
+			stmt:                "show creat",
+			expectedCompletions: []string{"CREATE", "CREATEDB", "CREATELOGIN", "CREATEROLE"},
+		},
+		{
+			stmt: "se",
+			expectedCompletions: []string{
+				"SEARCH", "SECOND", "SELECT", "SEQUENCE", "SEQUENCES",
+				"SERIALIZABLE", "SERVER", "SESSION", "SESSIONS", "SESSION_USER",
+				"SET", "SETS", "SETTING", "SETTINGS",
+			},
+		},
+		{
+			stmt:                "sel",
+			expectedCompletions: []string{"SELECT"},
+		},
+		{
+			stmt:                "create ta",
+			expectedCompletions: []string{"TABLE", "TABLES", "TABLESPACE"},
+		},
+		{
+			stmt:                "create ta",
+			expectedCompletions: []string{"CREATE"},
+			offset:              3,
+		},
+		{
+			stmt:                "select",
+			expectedCompletions: []string{"SELECT"},
+			offset:              2,
+		},
+		{
+			stmt:                "select ",
+			expectedCompletions: []string{},
+			offset:              7,
+		},
+		{
+			stmt:                "你好，我的名字是鲍勃 SELECT",
+			expectedCompletions: []string{"你好，我的名字是鲍勃"},
+			offset:              2,
+		},
+		{
+			stmt:                "你好，我的名字是鲍勃 SELECT",
+			expectedCompletions: []string{},
+			offset:              11,
+		},
+		{
+			stmt:                "你好，我的名字是鲍勃 SELECT",
+			expectedCompletions: []string{"SELECT"},
+			offset:              12,
+		},
+	}
+	for _, tc := range tests {
+		offset := tc.offset
+		if tc.offset == 0 {
+			offset = len(tc.stmt)
+		}
+		completions, err := runShowCompletions(tc.stmt, offset)
+		if err != nil {
+			t.Error(err)
+		}
+		if !(len(completions) == 0 && len(tc.expectedCompletions) == 0) &&
+			!reflect.DeepEqual(completions, tc.expectedCompletions) {
+			t.Errorf("expected %v, got %v", tc.expectedCompletions, completions)
+		}
+	}
+}

--- a/pkg/sql/delegate/show_completions_test.go
+++ b/pkg/sql/delegate/show_completions_test.go
@@ -1,3 +1,13 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 package delegate
 
 import (
@@ -83,7 +93,7 @@ func TestCompletions(t *testing.T) {
 		if tc.offset == 0 {
 			offset = len(tc.stmt)
 		}
-		completions, err := runShowCompletions(tc.stmt, offset)
+		completions, err := RunShowCompletions(tc.stmt, offset)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/sql/delegate/show_syntax.go
+++ b/pkg/sql/delegate/show_syntax.go
@@ -65,5 +65,6 @@ func (d *delegator) delegateShowSyntax(n *tree.ShowSyntax) (tree.Statement, erro
 		nil, /* reportErr */
 	)
 	query.WriteByte(')')
+
 	return parse(query.String())
 }

--- a/pkg/sql/logictest/testdata/logic_test/show_completions
+++ b/pkg/sql/logictest/testdata/logic_test/show_completions
@@ -1,0 +1,61 @@
+query T
+show completions at offset 1 for 'select 1'
+----
+SELECT
+
+query T
+show completions at offset 7 for 'select 1'
+----
+·
+
+query T
+show completions at offset 7 for 'select 2'
+----
+·
+
+query T
+show completions at offset 10 for 'select * fro'
+----
+FRO
+
+query T
+show completions at offset 11 for 'select * fro'
+----
+FRO
+
+query T
+show completions at offset 12 for 'select * fro'
+----
+FROM
+
+query T
+show completions at offset 10 for 'select * from'
+----
+FROM
+
+query T
+show completions at offset 11 for 'select * from'
+----
+FROM
+
+# This case doesn't really make sense - completing this as SELECT doesn't
+# really make sense but we'll need to add more complex logic to determine
+# whether our SQL token is a string const.
+# However we do want to test this so we can ensure we handle escaped strings.
+query T
+show completions at offset 4 for e'\'se\'';
+----
+SEARCH
+SECOND
+SELECT
+SEQUENCE
+SEQUENCES
+SERIALIZABLE
+SERVER
+SESSION
+SESSIONS
+SESSION_USER
+SET
+SETS
+SETTING
+SETTINGS

--- a/pkg/sql/logictest/testdata/logic_test/show_completions
+++ b/pkg/sql/logictest/testdata/logic_test/show_completions
@@ -1,40 +1,38 @@
 query T
-show completions at offset 1 for 'select 1'
+SHOW COMPLETIONS AT OFFSET 1 FOR 'select 1'
 ----
 SELECT
 
 query T
-show completions at offset 7 for 'select 1'
+SHOW COMPLETIONS AT OFFSET 7 FOR 'select 1'
 ----
-·
 
 query T
-show completions at offset 7 for 'select 2'
+SHOW COMPLETIONS AT OFFSET 7 FOR 'select 2'
 ----
-·
 
 query T
-show completions at offset 10 for 'select * fro'
+SHOW COMPLETIONS AT OFFSET 10 FOR 'select * fro'
 ----
 FRO
 
 query T
-show completions at offset 11 for 'select * fro'
+SHOW COMPLETIONS AT OFFSET 11 FOR 'select * fro'
 ----
 FRO
 
 query T
-show completions at offset 12 for 'select * fro'
+SHOW COMPLETIONS AT OFFSET 12 FOR 'select * fro'
 ----
 FROM
 
 query T
-show completions at offset 10 for 'select * from'
+SHOW COMPLETIONS AT OFFSET 10 FOR 'select * from'
 ----
 FROM
 
 query T
-show completions at offset 11 for 'select * from'
+SHOW COMPLETIONS AT OFFSET 11 FOR 'select * from'
 ----
 FROM
 
@@ -43,7 +41,7 @@ FROM
 # whether our SQL token is a string const.
 # However we do want to test this so we can ensure we handle escaped strings.
 query T
-show completions at offset 4 for e'\'se\'';
+SHOW COMPLETIONS AT OFFSET 4 FOR e'\'se\'';
 ----
 SEARCH
 SECOND

--- a/pkg/sql/parser/scanner.go
+++ b/pkg/sql/parser/scanner.go
@@ -56,6 +56,21 @@ func Tokens(sql string) (tokens []TokenString, ok bool) {
 	return tokens, true
 }
 
+// TokensIgnoreErrors decomposes the input into lexical tokens and
+// ignores errors.
+func TokensIgnoreErrors(sql string) (tokens []TokenString) {
+	s := makeScanner(sql)
+	for {
+		var lval = &sqlSymType{}
+		s.Scan(lval)
+		if lval.ID() == 0 {
+			break
+		}
+		tokens = append(tokens, TokenString{TokenID: lval.ID(), Str: lval.Str()})
+	}
+	return tokens
+}
+
 // TokenString is the unit value returned by Tokens.
 type TokenString struct {
 	TokenID int32

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6114,7 +6114,7 @@ show_completions_stmt:
   {
     /* SKIP DOC */
     $$.val = &tree.ShowCompletions{
-        Statement: $7,
+        Statement: tree.NewStrVal($7),
         Offset: $5.numVal(),
     }
   }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -800,7 +800,7 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 %token <str> CACHE CANCEL CANCELQUERY CASCADE CASE CAST CBRT CHANGEFEED CHAR
 %token <str> CHARACTER CHARACTERISTICS CHECK CLOSE
 %token <str> CLUSTER COALESCE COLLATE COLLATION COLUMN COLUMNS COMMENT COMMENTS COMMIT
-%token <str> COMMITTED COMPACT COMPLETE CONCAT CONCURRENTLY CONFIGURATION CONFIGURATIONS CONFIGURE
+%token <str> COMMITTED COMPACT COMPLETE COMPLETIONS CONCAT CONCURRENTLY CONFIGURATION CONFIGURATIONS CONFIGURE
 %token <str> CONFLICT CONNECTION CONSTRAINT CONSTRAINTS CONTAINS CONTROLCHANGEFEED CONTROLJOB
 %token <str> CONVERSION CONVERT COPY COVERING CREATE CREATEDB CREATELOGIN CREATEROLE
 %token <str> CROSS CSV CUBE CURRENT CURRENT_CATALOG CURRENT_DATE CURRENT_SCHEMA
@@ -1132,6 +1132,7 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 %type <tree.Statement> show_zone_stmt
 %type <tree.Statement> show_schedules_stmt
 %type <tree.Statement> show_full_scans_stmt
+%type <tree.Statement> show_completions_stmt
 
 %type <str> statements_or_queries
 
@@ -5251,6 +5252,7 @@ show_stmt:
 | show_last_query_stats_stmt
 | show_full_scans_stmt
 | show_default_privileges_stmt // EXTEND WITH HELP: SHOW DEFAULT PRIVILEGES
+| show_completions_stmt
 
 // %Help: CLOSE - close SQL cursor
 // %Category: Misc
@@ -6106,6 +6108,16 @@ show_syntax_stmt:
     $$.val = &tree.ShowSyntax{Statement: $3}
   }
 | SHOW SYNTAX error // SHOW HELP: SHOW SYNTAX
+
+show_completions_stmt:
+  SHOW COMPLETIONS AT OFFSET ICONST FOR SCONST
+  {
+    /* SKIP DOC */
+    $$.val = &tree.ShowCompletions{
+        Statement: $7,
+        Offset: $5.numVal(),
+    }
+  }
 
 show_last_query_stats_stmt:
   SHOW LAST QUERY STATISTICS query_stats_cols
@@ -13772,6 +13784,7 @@ unreserved_keyword:
 | COMMITTED
 | COMPACT
 | COMPLETE
+| COMPLETIONS
 | CONFLICT
 | CONFIGURATION
 | CONFIGURATIONS

--- a/pkg/sql/parser/testdata/show_completions
+++ b/pkg/sql/parser/testdata/show_completions
@@ -1,0 +1,47 @@
+parse
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat'
+----
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat'
+SHOW COMPLETIONS AT OFFSET 1 FOR ('creat') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 1 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat' -- identifiers removed
+
+parse
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat'
+----
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat'
+SHOW COMPLETIONS AT OFFSET 1 FOR ('creat') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 1 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 1 FOR 'creat' -- identifiers removed
+
+parse
+SHOW COMPLETIONS AT OFFSET 1 FOR 'CREAT'
+----
+SHOW COMPLETIONS AT OFFSET 1 FOR 'CREAT'
+SHOW COMPLETIONS AT OFFSET 1 FOR ('CREAT') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 1 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 1 FOR 'CREAT' -- identifiers removed
+
+parse
+SHOW COMPLETIONS AT OFFSET 7 FOR 'SELECT 1'
+----
+SHOW COMPLETIONS AT OFFSET 7 FOR 'SELECT 1'
+SHOW COMPLETIONS AT OFFSET 7 FOR ('SELECT 1') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 7 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 7 FOR 'SELECT 1' -- identifiers removed
+
+parse
+show completions at offset 10 for 'select * fro'
+----
+SHOW COMPLETIONS AT OFFSET 10 FOR 'select * fro' -- normalized!
+SHOW COMPLETIONS AT OFFSET 10 FOR ('select * fro') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 10 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 10 FOR 'select * fro' -- identifiers removed
+
+parse
+SHOW COMPLETIONS AT OFFSET 4 FOR e'\'se\'';
+----
+SHOW COMPLETIONS AT OFFSET 4 FOR e'\'se\'' -- normalized!
+SHOW COMPLETIONS AT OFFSET 4 FOR (e'\'se\'') -- fully parenthesized
+SHOW COMPLETIONS AT OFFSET 4 FOR '_' -- literals removed
+SHOW COMPLETIONS AT OFFSET 4 FOR e'\'se\'' -- identifiers removed

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -20,56 +20,56 @@
 package tree
 
 import (
-  "fmt"
+	"fmt"
 
-  "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 )
 
 // ShowVar represents a SHOW statement.
 type ShowVar struct {
-  Name string
+	Name string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowVar) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  // Session var names never contain PII and should be distinguished
-  // for feature tracking purposes.
-  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-    ctx.FormatNameP(&node.Name)
-  })
+	ctx.WriteString("SHOW ")
+	// Session var names never contain PII and should be distinguished
+	// for feature tracking purposes.
+	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+		ctx.FormatNameP(&node.Name)
+	})
 }
 
 // ShowClusterSetting represents a SHOW CLUSTER SETTING statement.
 type ShowClusterSetting struct {
-  Name string
+	Name string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CLUSTER SETTING ")
-  // Cluster setting names never contain PII and should be distinguished
-  // for feature tracking purposes.
-  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-    ctx.FormatNameP(&node.Name)
-  })
+	ctx.WriteString("SHOW CLUSTER SETTING ")
+	// Cluster setting names never contain PII and should be distinguished
+	// for feature tracking purposes.
+	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+		ctx.FormatNameP(&node.Name)
+	})
 }
 
 // ShowClusterSettingList represents a SHOW [ALL|PUBLIC] CLUSTER SETTINGS statement.
 type ShowClusterSettingList struct {
-  // All indicates whether to include non-public settings in the output.
-  All bool
+	// All indicates whether to include non-public settings in the output.
+	All bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  qual := "PUBLIC"
-  if node.All {
-    qual = "ALL"
-  }
-  ctx.WriteString(qual)
-  ctx.WriteString(" CLUSTER SETTINGS")
+	ctx.WriteString("SHOW ")
+	qual := "PUBLIC"
+	if node.All {
+		qual = "ALL"
+	}
+	ctx.WriteString(qual)
+	ctx.WriteString(" CLUSTER SETTINGS")
 }
 
 // BackupDetails represents the type of details to display for a SHOW BACKUP
@@ -77,90 +77,90 @@ func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
 type BackupDetails int
 
 const (
-  // BackupDefaultDetails identifies a bare SHOW BACKUP statement.
-  BackupDefaultDetails BackupDetails = iota
-  // BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
-  BackupRangeDetails
-  // BackupFileDetails identifies a SHOW BACKUP FILES statement.
-  BackupFileDetails
-  // BackupManifestAsJSON displays full backup manifest as json
-  BackupManifestAsJSON
+	// BackupDefaultDetails identifies a bare SHOW BACKUP statement.
+	BackupDefaultDetails BackupDetails = iota
+	// BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
+	BackupRangeDetails
+	// BackupFileDetails identifies a SHOW BACKUP FILES statement.
+	BackupFileDetails
+	// BackupManifestAsJSON displays full backup manifest as json
+	BackupManifestAsJSON
 )
 
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
-  Path                 Expr
-  InCollection         Expr
-  Details              BackupDetails
-  ShouldIncludeSchemas bool
-  Options              KVOptions
+	Path                 Expr
+	InCollection         Expr
+	Details              BackupDetails
+	ShouldIncludeSchemas bool
+	Options              KVOptions
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowBackup) Format(ctx *FmtCtx) {
-  if node.InCollection != nil && node.Path == nil {
-    ctx.WriteString("SHOW BACKUPS IN ")
-    ctx.FormatNode(node.InCollection)
-    return
-  }
-  ctx.WriteString("SHOW BACKUP ")
-  if node.Details == BackupRangeDetails {
-    ctx.WriteString("RANGES ")
-  } else if node.Details == BackupFileDetails {
-    ctx.WriteString("FILES ")
-  }
-  if node.ShouldIncludeSchemas {
-    ctx.WriteString("SCHEMAS ")
-  }
-  ctx.FormatNode(node.Path)
-  if node.InCollection != nil {
-    ctx.WriteString(" IN ")
-    ctx.FormatNode(node.InCollection)
-  }
-  if len(node.Options) > 0 {
-    ctx.WriteString(" WITH ")
-    ctx.FormatNode(&node.Options)
-  }
+	if node.InCollection != nil && node.Path == nil {
+		ctx.WriteString("SHOW BACKUPS IN ")
+		ctx.FormatNode(node.InCollection)
+		return
+	}
+	ctx.WriteString("SHOW BACKUP ")
+	if node.Details == BackupRangeDetails {
+		ctx.WriteString("RANGES ")
+	} else if node.Details == BackupFileDetails {
+		ctx.WriteString("FILES ")
+	}
+	if node.ShouldIncludeSchemas {
+		ctx.WriteString("SCHEMAS ")
+	}
+	ctx.FormatNode(node.Path)
+	if node.InCollection != nil {
+		ctx.WriteString(" IN ")
+		ctx.FormatNode(node.InCollection)
+	}
+	if len(node.Options) > 0 {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
+	}
 }
 
 // ShowColumns represents a SHOW COLUMNS statement.
 type ShowColumns struct {
-  Table       *UnresolvedObjectName
-  WithComment bool
+	Table       *UnresolvedObjectName
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowColumns) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW COLUMNS FROM ")
-  ctx.FormatNode(node.Table)
+	ctx.WriteString("SHOW COLUMNS FROM ")
+	ctx.FormatNode(node.Table)
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.
 type ShowDatabases struct {
-  WithComment bool
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowDatabases) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW DATABASES")
+	ctx.WriteString("SHOW DATABASES")
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowEnums represents a SHOW ENUMS statement.
 type ShowEnums struct {
-  ObjectNamePrefix
+	ObjectNamePrefix
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowEnums) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ENUMS")
+	ctx.WriteString("SHOW ENUMS")
 }
 
 // ShowTypes represents a SHOW TYPES statement.
@@ -168,7 +168,7 @@ type ShowTypes struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTypes) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW TYPES")
+	ctx.WriteString("SHOW TYPES")
 }
 
 // ShowTraceType is an enum of SHOW TRACE variants.
@@ -176,354 +176,354 @@ type ShowTraceType string
 
 // A list of the SHOW TRACE variants.
 const (
-  ShowTraceRaw     ShowTraceType = "TRACE"
-  ShowTraceKV      ShowTraceType = "KV TRACE"
-  ShowTraceReplica ShowTraceType = "EXPERIMENTAL_REPLICA TRACE"
+	ShowTraceRaw     ShowTraceType = "TRACE"
+	ShowTraceKV      ShowTraceType = "KV TRACE"
+	ShowTraceReplica ShowTraceType = "EXPERIMENTAL_REPLICA TRACE"
 )
 
 // ShowTraceForSession represents a SHOW TRACE FOR SESSION statement.
 type ShowTraceForSession struct {
-  TraceType ShowTraceType
-  Compact   bool
+	TraceType ShowTraceType
+	Compact   bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTraceForSession) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  if node.Compact {
-    ctx.WriteString("COMPACT ")
-  }
-  ctx.WriteString(string(node.TraceType))
-  ctx.WriteString(" FOR SESSION")
+	ctx.WriteString("SHOW ")
+	if node.Compact {
+		ctx.WriteString("COMPACT ")
+	}
+	ctx.WriteString(string(node.TraceType))
+	ctx.WriteString(" FOR SESSION")
 }
 
 // ShowIndexes represents a SHOW INDEX statement.
 type ShowIndexes struct {
-  Table       *UnresolvedObjectName
-  WithComment bool
+	Table       *UnresolvedObjectName
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowIndexes) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW INDEXES FROM ")
-  ctx.FormatNode(node.Table)
+	ctx.WriteString("SHOW INDEXES FROM ")
+	ctx.FormatNode(node.Table)
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowDatabaseIndexes represents a SHOW INDEXES FROM DATABASE statement.
 type ShowDatabaseIndexes struct {
-  Database    Name
-  WithComment bool
+	Database    Name
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowDatabaseIndexes) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW INDEXES FROM DATABASE ")
-  ctx.FormatNode(&node.Database)
+	ctx.WriteString("SHOW INDEXES FROM DATABASE ")
+	ctx.FormatNode(&node.Database)
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowQueries represents a SHOW STATEMENTS statement.
 type ShowQueries struct {
-  All     bool
-  Cluster bool
+	All     bool
+	Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowQueries) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  if node.All {
-    ctx.WriteString("ALL ")
-  }
-  if node.Cluster {
-    ctx.WriteString("CLUSTER STATEMENTS")
-  } else {
-    ctx.WriteString("LOCAL STATEMENTS")
-  }
+	ctx.WriteString("SHOW ")
+	if node.All {
+		ctx.WriteString("ALL ")
+	}
+	if node.Cluster {
+		ctx.WriteString("CLUSTER STATEMENTS")
+	} else {
+		ctx.WriteString("LOCAL STATEMENTS")
+	}
 }
 
 // ShowJobs represents a SHOW JOBS statement
 type ShowJobs struct {
-  // If non-nil, a select statement that provides the job ids to be shown.
-  Jobs *Select
+	// If non-nil, a select statement that provides the job ids to be shown.
+	Jobs *Select
 
-  // If Automatic is true, show only automatically-generated jobs such
-  // as automatic CREATE STATISTICS jobs. If Automatic is false, show
-  // only non-automatically-generated jobs.
-  Automatic bool
+	// If Automatic is true, show only automatically-generated jobs such
+	// as automatic CREATE STATISTICS jobs. If Automatic is false, show
+	// only non-automatically-generated jobs.
+	Automatic bool
 
-  // Whether to block and wait for completion of all running jobs to be displayed.
-  Block bool
+	// Whether to block and wait for completion of all running jobs to be displayed.
+	Block bool
 
-  // If non-nil, only display jobs started by the specified
-  // schedules.
-  Schedules *Select
+	// If non-nil, only display jobs started by the specified
+	// schedules.
+	Schedules *Select
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowJobs) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  if node.Automatic {
-    ctx.WriteString("AUTOMATIC ")
-  }
-  ctx.WriteString("JOBS")
-  if node.Block {
-    ctx.WriteString(" WHEN COMPLETE")
-  }
-  if node.Jobs != nil {
-    ctx.WriteString(" ")
-    ctx.FormatNode(node.Jobs)
-  }
-  if node.Schedules != nil {
-    ctx.WriteString(" FOR SCHEDULES ")
-    ctx.FormatNode(node.Schedules)
-  }
+	ctx.WriteString("SHOW ")
+	if node.Automatic {
+		ctx.WriteString("AUTOMATIC ")
+	}
+	ctx.WriteString("JOBS")
+	if node.Block {
+		ctx.WriteString(" WHEN COMPLETE")
+	}
+	if node.Jobs != nil {
+		ctx.WriteString(" ")
+		ctx.FormatNode(node.Jobs)
+	}
+	if node.Schedules != nil {
+		ctx.WriteString(" FOR SCHEDULES ")
+		ctx.FormatNode(node.Schedules)
+	}
 }
 
 // ShowChangefeedJobs represents a SHOW CHANGEFEED JOBS statement
 type ShowChangefeedJobs struct {
-  // If non-nil, a select statement that provides the job ids to be shown.
-  Jobs *Select
+	// If non-nil, a select statement that provides the job ids to be shown.
+	Jobs *Select
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowChangefeedJobs) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CHANGEFEED JOBS")
-  if node.Jobs != nil {
-    ctx.WriteString(" ")
-    ctx.FormatNode(node.Jobs)
-  }
+	ctx.WriteString("SHOW CHANGEFEED JOBS")
+	if node.Jobs != nil {
+		ctx.WriteString(" ")
+		ctx.FormatNode(node.Jobs)
+	}
 }
 
 // ShowSurvivalGoal represents a SHOW REGIONS statement
 type ShowSurvivalGoal struct {
-  DatabaseName Name
+	DatabaseName Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSurvivalGoal) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW SURVIVAL GOAL FROM DATABASE")
-  if node.DatabaseName != "" {
-    ctx.WriteString(" ")
-    ctx.FormatNode(&node.DatabaseName)
-  }
+	ctx.WriteString("SHOW SURVIVAL GOAL FROM DATABASE")
+	if node.DatabaseName != "" {
+		ctx.WriteString(" ")
+		ctx.FormatNode(&node.DatabaseName)
+	}
 }
 
 // ShowRegionsFrom denotes what kind of SHOW REGIONS command is being used.
 type ShowRegionsFrom int
 
 const (
-  // ShowRegionsFromCluster represents SHOW REGIONS FROM CLUSTER.
-  ShowRegionsFromCluster ShowRegionsFrom = iota
-  // ShowRegionsFromDatabase represents SHOW REGIONS FROM DATABASE.
-  ShowRegionsFromDatabase
-  // ShowRegionsFromAllDatabases represents SHOW REGIONS FROM ALL DATABASES.
-  ShowRegionsFromAllDatabases
-  // ShowRegionsFromDefault represents SHOW REGIONS.
-  ShowRegionsFromDefault
+	// ShowRegionsFromCluster represents SHOW REGIONS FROM CLUSTER.
+	ShowRegionsFromCluster ShowRegionsFrom = iota
+	// ShowRegionsFromDatabase represents SHOW REGIONS FROM DATABASE.
+	ShowRegionsFromDatabase
+	// ShowRegionsFromAllDatabases represents SHOW REGIONS FROM ALL DATABASES.
+	ShowRegionsFromAllDatabases
+	// ShowRegionsFromDefault represents SHOW REGIONS.
+	ShowRegionsFromDefault
 )
 
 // ShowRegions represents a SHOW REGIONS statement
 type ShowRegions struct {
-  ShowRegionsFrom ShowRegionsFrom
-  DatabaseName    Name
+	ShowRegionsFrom ShowRegionsFrom
+	DatabaseName    Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRegions) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW REGIONS")
-  switch node.ShowRegionsFrom {
-  case ShowRegionsFromDefault:
-  case ShowRegionsFromAllDatabases:
-    ctx.WriteString(" FROM ALL DATABASES")
-  case ShowRegionsFromDatabase:
-    ctx.WriteString(" FROM DATABASE")
-    if node.DatabaseName != "" {
-      ctx.WriteString(" ")
-      ctx.FormatNode(&node.DatabaseName)
-    }
-  case ShowRegionsFromCluster:
-    ctx.WriteString(" FROM CLUSTER")
-  default:
-    panic(fmt.Sprintf("unknown ShowRegionsFrom: %v", node.ShowRegionsFrom))
-  }
+	ctx.WriteString("SHOW REGIONS")
+	switch node.ShowRegionsFrom {
+	case ShowRegionsFromDefault:
+	case ShowRegionsFromAllDatabases:
+		ctx.WriteString(" FROM ALL DATABASES")
+	case ShowRegionsFromDatabase:
+		ctx.WriteString(" FROM DATABASE")
+		if node.DatabaseName != "" {
+			ctx.WriteString(" ")
+			ctx.FormatNode(&node.DatabaseName)
+		}
+	case ShowRegionsFromCluster:
+		ctx.WriteString(" FROM CLUSTER")
+	default:
+		panic(fmt.Sprintf("unknown ShowRegionsFrom: %v", node.ShowRegionsFrom))
+	}
 }
 
 // ShowSessions represents a SHOW SESSIONS statement
 type ShowSessions struct {
-  All     bool
-  Cluster bool
+	All     bool
+	Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSessions) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  if node.All {
-    ctx.WriteString("ALL ")
-  }
-  if node.Cluster {
-    ctx.WriteString("CLUSTER SESSIONS")
-  } else {
-    ctx.WriteString("LOCAL SESSIONS")
-  }
+	ctx.WriteString("SHOW ")
+	if node.All {
+		ctx.WriteString("ALL ")
+	}
+	if node.Cluster {
+		ctx.WriteString("CLUSTER SESSIONS")
+	} else {
+		ctx.WriteString("LOCAL SESSIONS")
+	}
 }
 
 // ShowSchemas represents a SHOW SCHEMAS statement.
 type ShowSchemas struct {
-  Database Name
+	Database Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSchemas) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW SCHEMAS")
-  if node.Database != "" {
-    ctx.WriteString(" FROM ")
-    ctx.FormatNode(&node.Database)
-  }
+	ctx.WriteString("SHOW SCHEMAS")
+	if node.Database != "" {
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.Database)
+	}
 }
 
 // ShowSequences represents a SHOW SEQUENCES statement.
 type ShowSequences struct {
-  Database Name
+	Database Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSequences) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW SEQUENCES")
-  if node.Database != "" {
-    ctx.WriteString(" FROM ")
-    ctx.FormatNode(&node.Database)
-  }
+	ctx.WriteString("SHOW SEQUENCES")
+	if node.Database != "" {
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.Database)
+	}
 }
 
 // ShowTables represents a SHOW TABLES statement.
 type ShowTables struct {
-  ObjectNamePrefix
-  WithComment bool
+	ObjectNamePrefix
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTables) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW TABLES")
-  if node.ExplicitSchema {
-    ctx.WriteString(" FROM ")
-    ctx.FormatNode(&node.ObjectNamePrefix)
-  }
+	ctx.WriteString("SHOW TABLES")
+	if node.ExplicitSchema {
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.ObjectNamePrefix)
+	}
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowTransactions represents a SHOW TRANSACTIONS statement
 type ShowTransactions struct {
-  All     bool
-  Cluster bool
+	All     bool
+	Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransactions) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ")
-  if node.All {
-    ctx.WriteString("ALL ")
-  }
-  if node.Cluster {
-    ctx.WriteString("CLUSTER TRANSACTIONS")
-  } else {
-    ctx.WriteString("LOCAL TRANSACTIONS")
-  }
+	ctx.WriteString("SHOW ")
+	if node.All {
+		ctx.WriteString("ALL ")
+	}
+	if node.Cluster {
+		ctx.WriteString("CLUSTER TRANSACTIONS")
+	} else {
+		ctx.WriteString("LOCAL TRANSACTIONS")
+	}
 }
 
 // ShowConstraints represents a SHOW CONSTRAINTS statement.
 type ShowConstraints struct {
-  Table       *UnresolvedObjectName
-  WithComment bool
+	Table       *UnresolvedObjectName
+	WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowConstraints) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CONSTRAINTS FROM ")
-  ctx.FormatNode(node.Table)
+	ctx.WriteString("SHOW CONSTRAINTS FROM ")
+	ctx.FormatNode(node.Table)
 
-  if node.WithComment {
-    ctx.WriteString(" WITH COMMENT")
-  }
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowGrants represents a SHOW GRANTS statement.
 // TargetList is defined in grant.go.
 type ShowGrants struct {
-  Targets  *TargetList
-  Grantees RoleSpecList
+	Targets  *TargetList
+	Grantees RoleSpecList
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowGrants) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW GRANTS")
-  if node.Targets != nil {
-    ctx.WriteString(" ON ")
-    ctx.FormatNode(node.Targets)
-  }
-  if node.Grantees != nil {
-    ctx.WriteString(" FOR ")
-    ctx.FormatNode(&node.Grantees)
-  }
+	ctx.WriteString("SHOW GRANTS")
+	if node.Targets != nil {
+		ctx.WriteString(" ON ")
+		ctx.FormatNode(node.Targets)
+	}
+	if node.Grantees != nil {
+		ctx.WriteString(" FOR ")
+		ctx.FormatNode(&node.Grantees)
+	}
 }
 
 // ShowRoleGrants represents a SHOW GRANTS ON ROLE statement.
 type ShowRoleGrants struct {
-  Roles    RoleSpecList
-  Grantees RoleSpecList
+	Roles    RoleSpecList
+	Grantees RoleSpecList
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW GRANTS ON ROLE")
-  if node.Roles != nil {
-    ctx.WriteString(" ")
-    ctx.FormatNode(&node.Roles)
-  }
-  if node.Grantees != nil {
-    ctx.WriteString(" FOR ")
-    ctx.FormatNode(&node.Grantees)
-  }
+	ctx.WriteString("SHOW GRANTS ON ROLE")
+	if node.Roles != nil {
+		ctx.WriteString(" ")
+		ctx.FormatNode(&node.Roles)
+	}
+	if node.Grantees != nil {
+		ctx.WriteString(" FOR ")
+		ctx.FormatNode(&node.Grantees)
+	}
 }
 
 // ShowCreateMode denotes what kind of SHOW CREATE should be used
 type ShowCreateMode int
 
 const (
-  // ShowCreateModeTable represents SHOW CREATE TABLE
-  ShowCreateModeTable ShowCreateMode = iota
-  // ShowCreateModeView represents SHOW CREATE VIEW
-  ShowCreateModeView
-  // ShowCreateModeSequence represents SHOW CREATE SEQUENCE
-  ShowCreateModeSequence
-  // ShowCreateModeDatabase represents SHOW CREATE DATABASE
-  ShowCreateModeDatabase
+	// ShowCreateModeTable represents SHOW CREATE TABLE
+	ShowCreateModeTable ShowCreateMode = iota
+	// ShowCreateModeView represents SHOW CREATE VIEW
+	ShowCreateModeView
+	// ShowCreateModeSequence represents SHOW CREATE SEQUENCE
+	ShowCreateModeSequence
+	// ShowCreateModeDatabase represents SHOW CREATE DATABASE
+	ShowCreateModeDatabase
 )
 
 // ShowCreate represents a SHOW CREATE statement.
 type ShowCreate struct {
-  Mode ShowCreateMode
-  Name *UnresolvedObjectName
+	Mode ShowCreateMode
+	Name *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreate) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CREATE ")
+	ctx.WriteString("SHOW CREATE ")
 
-  switch node.Mode {
-  case ShowCreateModeDatabase:
-    ctx.WriteString("DATABASE ")
-  }
-  ctx.FormatNode(node.Name)
+	switch node.Mode {
+	case ShowCreateModeDatabase:
+		ctx.WriteString("DATABASE ")
+	}
+	ctx.FormatNode(node.Name)
 }
 
 // ShowCreateAllSchemas represents a SHOW CREATE ALL SCHEMAS statement.
@@ -531,7 +531,7 @@ type ShowCreateAllSchemas struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllSchemas) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CREATE ALL SCHEMAS")
+	ctx.WriteString("SHOW CREATE ALL SCHEMAS")
 }
 
 // ShowCreateAllTables represents a SHOW CREATE ALL TABLES statement.
@@ -539,7 +539,7 @@ type ShowCreateAllTables struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllTables) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CREATE ALL TABLES")
+	ctx.WriteString("SHOW CREATE ALL TABLES")
 }
 
 // ShowCreateAllTypes represents a SHOW CREATE ALL TYPES statement.
@@ -547,22 +547,22 @@ type ShowCreateAllTypes struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllTypes) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW CREATE ALL TYPES")
+	ctx.WriteString("SHOW CREATE ALL TYPES")
 }
 
 // ShowCreateSchedules represents a SHOW CREATE SCHEDULE statement.
 type ShowCreateSchedules struct {
-  ScheduleID Expr
+	ScheduleID Expr
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateSchedules) Format(ctx *FmtCtx) {
-  if node.ScheduleID != nil {
-    ctx.WriteString("SHOW CREATE SCHEDULE ")
-    ctx.FormatNode(node.ScheduleID)
-    return
-  }
-  ctx.Printf("SHOW CREATE ALL SCHEDULES")
+	if node.ScheduleID != nil {
+		ctx.WriteString("SHOW CREATE SCHEDULE ")
+		ctx.FormatNode(node.ScheduleID)
+		return
+	}
+	ctx.Printf("SHOW CREATE ALL SCHEDULES")
 }
 
 // ShowSyntax represents a SHOW SYNTAX statement.
@@ -571,17 +571,17 @@ func (node *ShowCreateSchedules) Format(ctx *FmtCtx) {
 // any processing. Meant for use for syntax checking on clients,
 // when the client version might differ from the server.
 type ShowSyntax struct {
-  Statement string
+	Statement string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSyntax) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW SYNTAX ")
-  if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
-    ctx.WriteString("'_'")
-  } else {
-    ctx.WriteString(lexbase.EscapeSQLString(node.Statement))
-  }
+	ctx.WriteString("SHOW SYNTAX ")
+	if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
+		ctx.WriteString("'_'")
+	} else {
+		ctx.WriteString(lexbase.EscapeSQLString(node.Statement))
+	}
 }
 
 // ShowTransactionStatus represents a SHOW TRANSACTION STATUS statement.
@@ -590,12 +590,12 @@ type ShowTransactionStatus struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransactionStatus) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW TRANSACTION STATUS")
+	ctx.WriteString("SHOW TRANSACTION STATUS")
 }
 
 // ShowLastQueryStatistics represents a SHOW LAST QUERY STATS statement.
 type ShowLastQueryStatistics struct {
-  Columns NameList
+	Columns NameList
 }
 
 // ShowLastQueryStatisticsDefaultColumns is the default list of columns
@@ -603,21 +603,21 @@ type ShowLastQueryStatistics struct {
 // Note: the form that does not specify the USING clause is deprecated.
 // Remove it when there are no more clients using it (22.1 or later).
 var ShowLastQueryStatisticsDefaultColumns = NameList([]Name{
-  "parse_latency",
-  "plan_latency",
-  "exec_latency",
-  "service_latency",
-  "post_commit_jobs_latency",
+	"parse_latency",
+	"plan_latency",
+	"exec_latency",
+	"service_latency",
+	"post_commit_jobs_latency",
 })
 
 // Format implements the NodeFormatter interface.
 func (node *ShowLastQueryStatistics) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW LAST QUERY STATISTICS RETURNING ")
-  // The column names for this statement never contain PII and should
-  // be distinguished for feature tracking purposes.
-  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-    ctx.FormatNode(&node.Columns)
-  })
+	ctx.WriteString("SHOW LAST QUERY STATISTICS RETURNING ")
+	// The column names for this statement never contain PII and should
+	// be distinguished for feature tracking purposes.
+	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+		ctx.FormatNode(&node.Columns)
+	})
 }
 
 // ShowFullTableScans represents a SHOW FULL TABLE SCANS statement.
@@ -626,7 +626,7 @@ type ShowFullTableScans struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowFullTableScans) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW FULL TABLE SCANS")
+	ctx.WriteString("SHOW FULL TABLE SCANS")
 }
 
 // ShowSavepointStatus represents a SHOW SAVEPOINT STATUS statement.
@@ -635,7 +635,7 @@ type ShowSavepointStatus struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSavepointStatus) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW SAVEPOINT STATUS")
+	ctx.WriteString("SHOW SAVEPOINT STATUS")
 }
 
 // ShowUsers represents a SHOW USERS statement.
@@ -644,7 +644,7 @@ type ShowUsers struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowUsers) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW USERS")
+	ctx.WriteString("SHOW USERS")
 }
 
 // ShowRoles represents a SHOW ROLES statement.
@@ -653,111 +653,111 @@ type ShowRoles struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRoles) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW ROLES")
+	ctx.WriteString("SHOW ROLES")
 }
 
 // ShowRanges represents a SHOW RANGES statement.
 type ShowRanges struct {
-  TableOrIndex TableIndexName
-  DatabaseName Name
+	TableOrIndex TableIndexName
+	DatabaseName Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRanges) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW RANGES FROM ")
-  if node.DatabaseName != "" {
-    ctx.WriteString("DATABASE ")
-    ctx.FormatNode(&node.DatabaseName)
-  } else if node.TableOrIndex.Index != "" {
-    ctx.WriteString("INDEX ")
-    ctx.FormatNode(&node.TableOrIndex)
-  } else {
-    ctx.WriteString("TABLE ")
-    ctx.FormatNode(&node.TableOrIndex)
-  }
+	ctx.WriteString("SHOW RANGES FROM ")
+	if node.DatabaseName != "" {
+		ctx.WriteString("DATABASE ")
+		ctx.FormatNode(&node.DatabaseName)
+	} else if node.TableOrIndex.Index != "" {
+		ctx.WriteString("INDEX ")
+		ctx.FormatNode(&node.TableOrIndex)
+	} else {
+		ctx.WriteString("TABLE ")
+		ctx.FormatNode(&node.TableOrIndex)
+	}
 }
 
 // ShowRangeForRow represents a SHOW RANGE FOR ROW statement.
 type ShowRangeForRow struct {
-  TableOrIndex TableIndexName
-  Row          Exprs
+	TableOrIndex TableIndexName
+	Row          Exprs
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRangeForRow) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW RANGE FROM ")
-  if node.TableOrIndex.Index != "" {
-    ctx.WriteString("INDEX ")
-  } else {
-    ctx.WriteString("TABLE ")
-  }
-  ctx.FormatNode(&node.TableOrIndex)
-  ctx.WriteString(" FOR ROW (")
-  ctx.FormatNode(&node.Row)
-  ctx.WriteString(")")
+	ctx.WriteString("SHOW RANGE FROM ")
+	if node.TableOrIndex.Index != "" {
+		ctx.WriteString("INDEX ")
+	} else {
+		ctx.WriteString("TABLE ")
+	}
+	ctx.FormatNode(&node.TableOrIndex)
+	ctx.WriteString(" FOR ROW (")
+	ctx.FormatNode(&node.Row)
+	ctx.WriteString(")")
 }
 
 // ShowFingerprints represents a SHOW EXPERIMENTAL_FINGERPRINTS statement.
 type ShowFingerprints struct {
-  Table *UnresolvedObjectName
+	Table *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowFingerprints) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
-  ctx.FormatNode(node.Table)
+	ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
+	ctx.FormatNode(node.Table)
 }
 
 // ShowTableStats represents a SHOW STATISTICS FOR TABLE statement.
 type ShowTableStats struct {
-  Table     *UnresolvedObjectName
-  UsingJSON bool
+	Table     *UnresolvedObjectName
+	UsingJSON bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTableStats) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW STATISTICS ")
-  if node.UsingJSON {
-    ctx.WriteString("USING JSON ")
-  }
-  ctx.WriteString("FOR TABLE ")
-  ctx.FormatNode(node.Table)
+	ctx.WriteString("SHOW STATISTICS ")
+	if node.UsingJSON {
+		ctx.WriteString("USING JSON ")
+	}
+	ctx.WriteString("FOR TABLE ")
+	ctx.FormatNode(node.Table)
 }
 
 // ShowHistogram represents a SHOW HISTOGRAM statement.
 type ShowHistogram struct {
-  HistogramID int64
+	HistogramID int64
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowHistogram) Format(ctx *FmtCtx) {
-  ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
+	ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
 }
 
 // ShowPartitions represents a SHOW PARTITIONS statement.
 type ShowPartitions struct {
-  IsDB     bool
-  Database Name
+	IsDB     bool
+	Database Name
 
-  IsIndex bool
-  Index   TableIndexName
+	IsIndex bool
+	Index   TableIndexName
 
-  IsTable bool
-  Table   *UnresolvedObjectName
+	IsTable bool
+	Table   *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowPartitions) Format(ctx *FmtCtx) {
-  if node.IsDB {
-    ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
-    ctx.FormatNode(&node.Database)
-  } else if node.IsIndex {
-    ctx.Printf("SHOW PARTITIONS FROM INDEX ")
-    ctx.FormatNode(&node.Index)
-  } else {
-    ctx.Printf("SHOW PARTITIONS FROM TABLE ")
-    ctx.FormatNode(node.Table)
-  }
+	if node.IsDB {
+		ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
+		ctx.FormatNode(&node.Database)
+	} else if node.IsIndex {
+		ctx.Printf("SHOW PARTITIONS FROM INDEX ")
+		ctx.FormatNode(&node.Index)
+	} else {
+		ctx.Printf("SHOW PARTITIONS FROM TABLE ")
+		ctx.FormatNode(node.Table)
+	}
 }
 
 // ScheduledJobExecutorType is a type identifying the names of
@@ -765,158 +765,160 @@ func (node *ShowPartitions) Format(ctx *FmtCtx) {
 type ScheduledJobExecutorType int
 
 const (
-  // InvalidExecutor is a placeholder for an invalid executor type.
-  InvalidExecutor ScheduledJobExecutorType = iota
+	// InvalidExecutor is a placeholder for an invalid executor type.
+	InvalidExecutor ScheduledJobExecutorType = iota
 
-  // ScheduledBackupExecutor is an executor responsible for
-  // the execution of the scheduled backups.
-  ScheduledBackupExecutor
+	// ScheduledBackupExecutor is an executor responsible for
+	// the execution of the scheduled backups.
+	ScheduledBackupExecutor
 
-  // ScheduledSQLStatsCompactionExecutor is an executor responsible for the
-  // execution of the scheduled SQL Stats compaction.
-  ScheduledSQLStatsCompactionExecutor
+	// ScheduledSQLStatsCompactionExecutor is an executor responsible for the
+	// execution of the scheduled SQL Stats compaction.
+	ScheduledSQLStatsCompactionExecutor
 
-  // ScheduledRowLevelTTLExecutor is an executor responsible for the cleanup
-  // of rows on row level TTL tables.
-  ScheduledRowLevelTTLExecutor
+	// ScheduledRowLevelTTLExecutor is an executor responsible for the cleanup
+	// of rows on row level TTL tables.
+	ScheduledRowLevelTTLExecutor
 )
 
 var scheduleExecutorInternalNames = map[ScheduledJobExecutorType]string{
-  InvalidExecutor:                     "unknown-executor",
-  ScheduledBackupExecutor:             "scheduled-backup-executor",
-  ScheduledSQLStatsCompactionExecutor: "scheduled-sql-stats-compaction-executor",
-  ScheduledRowLevelTTLExecutor:        "scheduled-row-level-ttl-executor",
+	InvalidExecutor:                     "unknown-executor",
+	ScheduledBackupExecutor:             "scheduled-backup-executor",
+	ScheduledSQLStatsCompactionExecutor: "scheduled-sql-stats-compaction-executor",
+	ScheduledRowLevelTTLExecutor:        "scheduled-row-level-ttl-executor",
 }
 
 // InternalName returns an internal executor name.
 // This name can be used to filter matching schedules.
 func (t ScheduledJobExecutorType) InternalName() string {
-  return scheduleExecutorInternalNames[t]
+	return scheduleExecutorInternalNames[t]
 }
 
 // UserName returns a user friendly executor name.
 func (t ScheduledJobExecutorType) UserName() string {
-  switch t {
-  case ScheduledBackupExecutor:
-    return "BACKUP"
-  case ScheduledSQLStatsCompactionExecutor:
-    return "SQL STATISTICS"
-  case ScheduledRowLevelTTLExecutor:
-    return "ROW LEVEL TTL"
-  }
-  return "unsupported-executor"
+	switch t {
+	case ScheduledBackupExecutor:
+		return "BACKUP"
+	case ScheduledSQLStatsCompactionExecutor:
+		return "SQL STATISTICS"
+	case ScheduledRowLevelTTLExecutor:
+		return "ROW LEVEL TTL"
+	}
+	return "unsupported-executor"
 }
 
 // ScheduleState describes what kind of schedules to display
 type ScheduleState int
 
 const (
-  // SpecifiedSchedules indicates that show schedules should
-  // only show subset of schedules.
-  SpecifiedSchedules ScheduleState = iota
+	// SpecifiedSchedules indicates that show schedules should
+	// only show subset of schedules.
+	SpecifiedSchedules ScheduleState = iota
 
-  // ActiveSchedules indicates that show schedules should
-  // only show those schedules that are currently active.
-  ActiveSchedules
+	// ActiveSchedules indicates that show schedules should
+	// only show those schedules that are currently active.
+	ActiveSchedules
 
-  // PausedSchedules indicates that show schedules should
-  // only show those schedules that are currently paused.
-  PausedSchedules
+	// PausedSchedules indicates that show schedules should
+	// only show those schedules that are currently paused.
+	PausedSchedules
 )
 
 // Format implements the NodeFormatter interface.
 func (s ScheduleState) Format(ctx *FmtCtx) {
-  switch s {
-  case ActiveSchedules:
-    ctx.WriteString("RUNNING")
-  case PausedSchedules:
-    ctx.WriteString("PAUSED")
-  default:
-    // Nothing
-  }
+	switch s {
+	case ActiveSchedules:
+		ctx.WriteString("RUNNING")
+	case PausedSchedules:
+		ctx.WriteString("PAUSED")
+	default:
+		// Nothing
+	}
 }
 
 // ShowSchedules represents a SHOW SCHEDULES statement.
 type ShowSchedules struct {
-  WhichSchedules ScheduleState
-  ExecutorType   ScheduledJobExecutorType
-  ScheduleID     Expr
+	WhichSchedules ScheduleState
+	ExecutorType   ScheduledJobExecutorType
+	ScheduleID     Expr
 }
 
 var _ Statement = &ShowSchedules{}
 
 // Format implements the NodeFormatter interface.
 func (n *ShowSchedules) Format(ctx *FmtCtx) {
-  if n.ScheduleID != nil {
-    ctx.WriteString("SHOW SCHEDULE ")
-    ctx.FormatNode(n.ScheduleID)
-    return
-  }
-  ctx.Printf("SHOW")
+	if n.ScheduleID != nil {
+		ctx.WriteString("SHOW SCHEDULE ")
+		ctx.FormatNode(n.ScheduleID)
+		return
+	}
+	ctx.Printf("SHOW")
 
-  if n.WhichSchedules != SpecifiedSchedules {
-    ctx.WriteString(" ")
-    ctx.FormatNode(&n.WhichSchedules)
-  }
+	if n.WhichSchedules != SpecifiedSchedules {
+		ctx.WriteString(" ")
+		ctx.FormatNode(&n.WhichSchedules)
+	}
 
-  ctx.Printf(" SCHEDULES")
+	ctx.Printf(" SCHEDULES")
 
-  if n.ExecutorType != InvalidExecutor {
-    // TODO(knz): beware of using ctx.FormatNode here if
-    // FOR changes to support expressions.
-    ctx.Printf(" FOR %s", n.ExecutorType.UserName())
-  }
+	if n.ExecutorType != InvalidExecutor {
+		// TODO(knz): beware of using ctx.FormatNode here if
+		// FOR changes to support expressions.
+		ctx.Printf(" FOR %s", n.ExecutorType.UserName())
+	}
 }
 
 // ShowDefaultPrivileges represents a SHOW DEFAULT PRIVILEGES statement.
 type ShowDefaultPrivileges struct {
-  Roles       RoleSpecList
-  ForAllRoles bool
+	Roles       RoleSpecList
+	ForAllRoles bool
 }
 
 var _ Statement = &ShowDefaultPrivileges{}
 
 // Format implements the NodeFormatter interface.
 func (n *ShowDefaultPrivileges) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
-  if len(n.Roles) > 0 {
-    ctx.WriteString("FOR ROLE ")
-    for i, role := range n.Roles {
-      if i > 0 {
-        ctx.WriteString(", ")
-      }
-      ctx.FormatNode(&role)
-    }
-    ctx.WriteString(" ")
-  } else if n.ForAllRoles {
-    ctx.WriteString("FOR ALL ROLES ")
-  }
+	ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
+	if len(n.Roles) > 0 {
+		ctx.WriteString("FOR ROLE ")
+		for i, role := range n.Roles {
+			if i > 0 {
+				ctx.WriteString(", ")
+			}
+			ctx.FormatNode(&role)
+		}
+		ctx.WriteString(" ")
+	} else if n.ForAllRoles {
+		ctx.WriteString("FOR ALL ROLES ")
+	}
 }
 
 // ShowTransferState represents a SHOW TRANSFER STATE statement.
 type ShowTransferState struct {
-  TransferKey *StrVal
+	TransferKey *StrVal
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransferState) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW TRANSFER STATE")
-  if node.TransferKey != nil {
-    ctx.WriteString(" WITH ")
-    ctx.FormatNode(node.TransferKey)
-  }
+	ctx.WriteString("SHOW TRANSFER STATE")
+	if node.TransferKey != nil {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.TransferKey)
+	}
 }
 
+// ShowCompletions represents a SHOW COMPLETIONS statement.
 type ShowCompletions struct {
-  Statement string
-  Offset    *NumVal
+	Statement *StrVal
+	Offset    *NumVal
 }
 
+// Format implements the NodeFormatter interface.
 func (s ShowCompletions) Format(ctx *FmtCtx) {
-  ctx.WriteString("SHOW COMPLETIONS AT OFFSET ")
-  s.Offset.Format(ctx)
-  ctx.WriteString(" FOR ")
-  ctx.WriteString(lexbase.EscapeSQLString(s.Statement))
+	ctx.WriteString("SHOW COMPLETIONS AT OFFSET ")
+	s.Offset.Format(ctx)
+	ctx.WriteString(" FOR ")
+	ctx.FormatNode(s.Statement)
 }
 
 var _ Statement = &ShowCompletions{}

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -20,56 +20,56 @@
 package tree
 
 import (
-	"fmt"
+  "fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+  "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 )
 
 // ShowVar represents a SHOW statement.
 type ShowVar struct {
-	Name string
+  Name string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowVar) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	// Session var names never contain PII and should be distinguished
-	// for feature tracking purposes.
-	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-		ctx.FormatNameP(&node.Name)
-	})
+  ctx.WriteString("SHOW ")
+  // Session var names never contain PII and should be distinguished
+  // for feature tracking purposes.
+  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+    ctx.FormatNameP(&node.Name)
+  })
 }
 
 // ShowClusterSetting represents a SHOW CLUSTER SETTING statement.
 type ShowClusterSetting struct {
-	Name string
+  Name string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CLUSTER SETTING ")
-	// Cluster setting names never contain PII and should be distinguished
-	// for feature tracking purposes.
-	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-		ctx.FormatNameP(&node.Name)
-	})
+  ctx.WriteString("SHOW CLUSTER SETTING ")
+  // Cluster setting names never contain PII and should be distinguished
+  // for feature tracking purposes.
+  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+    ctx.FormatNameP(&node.Name)
+  })
 }
 
 // ShowClusterSettingList represents a SHOW [ALL|PUBLIC] CLUSTER SETTINGS statement.
 type ShowClusterSettingList struct {
-	// All indicates whether to include non-public settings in the output.
-	All bool
+  // All indicates whether to include non-public settings in the output.
+  All bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	qual := "PUBLIC"
-	if node.All {
-		qual = "ALL"
-	}
-	ctx.WriteString(qual)
-	ctx.WriteString(" CLUSTER SETTINGS")
+  ctx.WriteString("SHOW ")
+  qual := "PUBLIC"
+  if node.All {
+    qual = "ALL"
+  }
+  ctx.WriteString(qual)
+  ctx.WriteString(" CLUSTER SETTINGS")
 }
 
 // BackupDetails represents the type of details to display for a SHOW BACKUP
@@ -77,90 +77,90 @@ func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
 type BackupDetails int
 
 const (
-	// BackupDefaultDetails identifies a bare SHOW BACKUP statement.
-	BackupDefaultDetails BackupDetails = iota
-	// BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
-	BackupRangeDetails
-	// BackupFileDetails identifies a SHOW BACKUP FILES statement.
-	BackupFileDetails
-	// BackupManifestAsJSON displays full backup manifest as json
-	BackupManifestAsJSON
+  // BackupDefaultDetails identifies a bare SHOW BACKUP statement.
+  BackupDefaultDetails BackupDetails = iota
+  // BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
+  BackupRangeDetails
+  // BackupFileDetails identifies a SHOW BACKUP FILES statement.
+  BackupFileDetails
+  // BackupManifestAsJSON displays full backup manifest as json
+  BackupManifestAsJSON
 )
 
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
-	Path                 Expr
-	InCollection         Expr
-	Details              BackupDetails
-	ShouldIncludeSchemas bool
-	Options              KVOptions
+  Path                 Expr
+  InCollection         Expr
+  Details              BackupDetails
+  ShouldIncludeSchemas bool
+  Options              KVOptions
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowBackup) Format(ctx *FmtCtx) {
-	if node.InCollection != nil && node.Path == nil {
-		ctx.WriteString("SHOW BACKUPS IN ")
-		ctx.FormatNode(node.InCollection)
-		return
-	}
-	ctx.WriteString("SHOW BACKUP ")
-	if node.Details == BackupRangeDetails {
-		ctx.WriteString("RANGES ")
-	} else if node.Details == BackupFileDetails {
-		ctx.WriteString("FILES ")
-	}
-	if node.ShouldIncludeSchemas {
-		ctx.WriteString("SCHEMAS ")
-	}
-	ctx.FormatNode(node.Path)
-	if node.InCollection != nil {
-		ctx.WriteString(" IN ")
-		ctx.FormatNode(node.InCollection)
-	}
-	if len(node.Options) > 0 {
-		ctx.WriteString(" WITH ")
-		ctx.FormatNode(&node.Options)
-	}
+  if node.InCollection != nil && node.Path == nil {
+    ctx.WriteString("SHOW BACKUPS IN ")
+    ctx.FormatNode(node.InCollection)
+    return
+  }
+  ctx.WriteString("SHOW BACKUP ")
+  if node.Details == BackupRangeDetails {
+    ctx.WriteString("RANGES ")
+  } else if node.Details == BackupFileDetails {
+    ctx.WriteString("FILES ")
+  }
+  if node.ShouldIncludeSchemas {
+    ctx.WriteString("SCHEMAS ")
+  }
+  ctx.FormatNode(node.Path)
+  if node.InCollection != nil {
+    ctx.WriteString(" IN ")
+    ctx.FormatNode(node.InCollection)
+  }
+  if len(node.Options) > 0 {
+    ctx.WriteString(" WITH ")
+    ctx.FormatNode(&node.Options)
+  }
 }
 
 // ShowColumns represents a SHOW COLUMNS statement.
 type ShowColumns struct {
-	Table       *UnresolvedObjectName
-	WithComment bool
+  Table       *UnresolvedObjectName
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowColumns) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW COLUMNS FROM ")
-	ctx.FormatNode(node.Table)
+  ctx.WriteString("SHOW COLUMNS FROM ")
+  ctx.FormatNode(node.Table)
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.
 type ShowDatabases struct {
-	WithComment bool
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowDatabases) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW DATABASES")
+  ctx.WriteString("SHOW DATABASES")
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowEnums represents a SHOW ENUMS statement.
 type ShowEnums struct {
-	ObjectNamePrefix
+  ObjectNamePrefix
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowEnums) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ENUMS")
+  ctx.WriteString("SHOW ENUMS")
 }
 
 // ShowTypes represents a SHOW TYPES statement.
@@ -168,7 +168,7 @@ type ShowTypes struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTypes) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW TYPES")
+  ctx.WriteString("SHOW TYPES")
 }
 
 // ShowTraceType is an enum of SHOW TRACE variants.
@@ -176,354 +176,354 @@ type ShowTraceType string
 
 // A list of the SHOW TRACE variants.
 const (
-	ShowTraceRaw     ShowTraceType = "TRACE"
-	ShowTraceKV      ShowTraceType = "KV TRACE"
-	ShowTraceReplica ShowTraceType = "EXPERIMENTAL_REPLICA TRACE"
+  ShowTraceRaw     ShowTraceType = "TRACE"
+  ShowTraceKV      ShowTraceType = "KV TRACE"
+  ShowTraceReplica ShowTraceType = "EXPERIMENTAL_REPLICA TRACE"
 )
 
 // ShowTraceForSession represents a SHOW TRACE FOR SESSION statement.
 type ShowTraceForSession struct {
-	TraceType ShowTraceType
-	Compact   bool
+  TraceType ShowTraceType
+  Compact   bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTraceForSession) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	if node.Compact {
-		ctx.WriteString("COMPACT ")
-	}
-	ctx.WriteString(string(node.TraceType))
-	ctx.WriteString(" FOR SESSION")
+  ctx.WriteString("SHOW ")
+  if node.Compact {
+    ctx.WriteString("COMPACT ")
+  }
+  ctx.WriteString(string(node.TraceType))
+  ctx.WriteString(" FOR SESSION")
 }
 
 // ShowIndexes represents a SHOW INDEX statement.
 type ShowIndexes struct {
-	Table       *UnresolvedObjectName
-	WithComment bool
+  Table       *UnresolvedObjectName
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowIndexes) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW INDEXES FROM ")
-	ctx.FormatNode(node.Table)
+  ctx.WriteString("SHOW INDEXES FROM ")
+  ctx.FormatNode(node.Table)
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowDatabaseIndexes represents a SHOW INDEXES FROM DATABASE statement.
 type ShowDatabaseIndexes struct {
-	Database    Name
-	WithComment bool
+  Database    Name
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowDatabaseIndexes) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW INDEXES FROM DATABASE ")
-	ctx.FormatNode(&node.Database)
+  ctx.WriteString("SHOW INDEXES FROM DATABASE ")
+  ctx.FormatNode(&node.Database)
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowQueries represents a SHOW STATEMENTS statement.
 type ShowQueries struct {
-	All     bool
-	Cluster bool
+  All     bool
+  Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowQueries) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	if node.All {
-		ctx.WriteString("ALL ")
-	}
-	if node.Cluster {
-		ctx.WriteString("CLUSTER STATEMENTS")
-	} else {
-		ctx.WriteString("LOCAL STATEMENTS")
-	}
+  ctx.WriteString("SHOW ")
+  if node.All {
+    ctx.WriteString("ALL ")
+  }
+  if node.Cluster {
+    ctx.WriteString("CLUSTER STATEMENTS")
+  } else {
+    ctx.WriteString("LOCAL STATEMENTS")
+  }
 }
 
 // ShowJobs represents a SHOW JOBS statement
 type ShowJobs struct {
-	// If non-nil, a select statement that provides the job ids to be shown.
-	Jobs *Select
+  // If non-nil, a select statement that provides the job ids to be shown.
+  Jobs *Select
 
-	// If Automatic is true, show only automatically-generated jobs such
-	// as automatic CREATE STATISTICS jobs. If Automatic is false, show
-	// only non-automatically-generated jobs.
-	Automatic bool
+  // If Automatic is true, show only automatically-generated jobs such
+  // as automatic CREATE STATISTICS jobs. If Automatic is false, show
+  // only non-automatically-generated jobs.
+  Automatic bool
 
-	// Whether to block and wait for completion of all running jobs to be displayed.
-	Block bool
+  // Whether to block and wait for completion of all running jobs to be displayed.
+  Block bool
 
-	// If non-nil, only display jobs started by the specified
-	// schedules.
-	Schedules *Select
+  // If non-nil, only display jobs started by the specified
+  // schedules.
+  Schedules *Select
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowJobs) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	if node.Automatic {
-		ctx.WriteString("AUTOMATIC ")
-	}
-	ctx.WriteString("JOBS")
-	if node.Block {
-		ctx.WriteString(" WHEN COMPLETE")
-	}
-	if node.Jobs != nil {
-		ctx.WriteString(" ")
-		ctx.FormatNode(node.Jobs)
-	}
-	if node.Schedules != nil {
-		ctx.WriteString(" FOR SCHEDULES ")
-		ctx.FormatNode(node.Schedules)
-	}
+  ctx.WriteString("SHOW ")
+  if node.Automatic {
+    ctx.WriteString("AUTOMATIC ")
+  }
+  ctx.WriteString("JOBS")
+  if node.Block {
+    ctx.WriteString(" WHEN COMPLETE")
+  }
+  if node.Jobs != nil {
+    ctx.WriteString(" ")
+    ctx.FormatNode(node.Jobs)
+  }
+  if node.Schedules != nil {
+    ctx.WriteString(" FOR SCHEDULES ")
+    ctx.FormatNode(node.Schedules)
+  }
 }
 
 // ShowChangefeedJobs represents a SHOW CHANGEFEED JOBS statement
 type ShowChangefeedJobs struct {
-	// If non-nil, a select statement that provides the job ids to be shown.
-	Jobs *Select
+  // If non-nil, a select statement that provides the job ids to be shown.
+  Jobs *Select
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowChangefeedJobs) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CHANGEFEED JOBS")
-	if node.Jobs != nil {
-		ctx.WriteString(" ")
-		ctx.FormatNode(node.Jobs)
-	}
+  ctx.WriteString("SHOW CHANGEFEED JOBS")
+  if node.Jobs != nil {
+    ctx.WriteString(" ")
+    ctx.FormatNode(node.Jobs)
+  }
 }
 
 // ShowSurvivalGoal represents a SHOW REGIONS statement
 type ShowSurvivalGoal struct {
-	DatabaseName Name
+  DatabaseName Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSurvivalGoal) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW SURVIVAL GOAL FROM DATABASE")
-	if node.DatabaseName != "" {
-		ctx.WriteString(" ")
-		ctx.FormatNode(&node.DatabaseName)
-	}
+  ctx.WriteString("SHOW SURVIVAL GOAL FROM DATABASE")
+  if node.DatabaseName != "" {
+    ctx.WriteString(" ")
+    ctx.FormatNode(&node.DatabaseName)
+  }
 }
 
 // ShowRegionsFrom denotes what kind of SHOW REGIONS command is being used.
 type ShowRegionsFrom int
 
 const (
-	// ShowRegionsFromCluster represents SHOW REGIONS FROM CLUSTER.
-	ShowRegionsFromCluster ShowRegionsFrom = iota
-	// ShowRegionsFromDatabase represents SHOW REGIONS FROM DATABASE.
-	ShowRegionsFromDatabase
-	// ShowRegionsFromAllDatabases represents SHOW REGIONS FROM ALL DATABASES.
-	ShowRegionsFromAllDatabases
-	// ShowRegionsFromDefault represents SHOW REGIONS.
-	ShowRegionsFromDefault
+  // ShowRegionsFromCluster represents SHOW REGIONS FROM CLUSTER.
+  ShowRegionsFromCluster ShowRegionsFrom = iota
+  // ShowRegionsFromDatabase represents SHOW REGIONS FROM DATABASE.
+  ShowRegionsFromDatabase
+  // ShowRegionsFromAllDatabases represents SHOW REGIONS FROM ALL DATABASES.
+  ShowRegionsFromAllDatabases
+  // ShowRegionsFromDefault represents SHOW REGIONS.
+  ShowRegionsFromDefault
 )
 
 // ShowRegions represents a SHOW REGIONS statement
 type ShowRegions struct {
-	ShowRegionsFrom ShowRegionsFrom
-	DatabaseName    Name
+  ShowRegionsFrom ShowRegionsFrom
+  DatabaseName    Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRegions) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW REGIONS")
-	switch node.ShowRegionsFrom {
-	case ShowRegionsFromDefault:
-	case ShowRegionsFromAllDatabases:
-		ctx.WriteString(" FROM ALL DATABASES")
-	case ShowRegionsFromDatabase:
-		ctx.WriteString(" FROM DATABASE")
-		if node.DatabaseName != "" {
-			ctx.WriteString(" ")
-			ctx.FormatNode(&node.DatabaseName)
-		}
-	case ShowRegionsFromCluster:
-		ctx.WriteString(" FROM CLUSTER")
-	default:
-		panic(fmt.Sprintf("unknown ShowRegionsFrom: %v", node.ShowRegionsFrom))
-	}
+  ctx.WriteString("SHOW REGIONS")
+  switch node.ShowRegionsFrom {
+  case ShowRegionsFromDefault:
+  case ShowRegionsFromAllDatabases:
+    ctx.WriteString(" FROM ALL DATABASES")
+  case ShowRegionsFromDatabase:
+    ctx.WriteString(" FROM DATABASE")
+    if node.DatabaseName != "" {
+      ctx.WriteString(" ")
+      ctx.FormatNode(&node.DatabaseName)
+    }
+  case ShowRegionsFromCluster:
+    ctx.WriteString(" FROM CLUSTER")
+  default:
+    panic(fmt.Sprintf("unknown ShowRegionsFrom: %v", node.ShowRegionsFrom))
+  }
 }
 
 // ShowSessions represents a SHOW SESSIONS statement
 type ShowSessions struct {
-	All     bool
-	Cluster bool
+  All     bool
+  Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSessions) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	if node.All {
-		ctx.WriteString("ALL ")
-	}
-	if node.Cluster {
-		ctx.WriteString("CLUSTER SESSIONS")
-	} else {
-		ctx.WriteString("LOCAL SESSIONS")
-	}
+  ctx.WriteString("SHOW ")
+  if node.All {
+    ctx.WriteString("ALL ")
+  }
+  if node.Cluster {
+    ctx.WriteString("CLUSTER SESSIONS")
+  } else {
+    ctx.WriteString("LOCAL SESSIONS")
+  }
 }
 
 // ShowSchemas represents a SHOW SCHEMAS statement.
 type ShowSchemas struct {
-	Database Name
+  Database Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSchemas) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW SCHEMAS")
-	if node.Database != "" {
-		ctx.WriteString(" FROM ")
-		ctx.FormatNode(&node.Database)
-	}
+  ctx.WriteString("SHOW SCHEMAS")
+  if node.Database != "" {
+    ctx.WriteString(" FROM ")
+    ctx.FormatNode(&node.Database)
+  }
 }
 
 // ShowSequences represents a SHOW SEQUENCES statement.
 type ShowSequences struct {
-	Database Name
+  Database Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSequences) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW SEQUENCES")
-	if node.Database != "" {
-		ctx.WriteString(" FROM ")
-		ctx.FormatNode(&node.Database)
-	}
+  ctx.WriteString("SHOW SEQUENCES")
+  if node.Database != "" {
+    ctx.WriteString(" FROM ")
+    ctx.FormatNode(&node.Database)
+  }
 }
 
 // ShowTables represents a SHOW TABLES statement.
 type ShowTables struct {
-	ObjectNamePrefix
-	WithComment bool
+  ObjectNamePrefix
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTables) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW TABLES")
-	if node.ExplicitSchema {
-		ctx.WriteString(" FROM ")
-		ctx.FormatNode(&node.ObjectNamePrefix)
-	}
+  ctx.WriteString("SHOW TABLES")
+  if node.ExplicitSchema {
+    ctx.WriteString(" FROM ")
+    ctx.FormatNode(&node.ObjectNamePrefix)
+  }
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowTransactions represents a SHOW TRANSACTIONS statement
 type ShowTransactions struct {
-	All     bool
-	Cluster bool
+  All     bool
+  Cluster bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransactions) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ")
-	if node.All {
-		ctx.WriteString("ALL ")
-	}
-	if node.Cluster {
-		ctx.WriteString("CLUSTER TRANSACTIONS")
-	} else {
-		ctx.WriteString("LOCAL TRANSACTIONS")
-	}
+  ctx.WriteString("SHOW ")
+  if node.All {
+    ctx.WriteString("ALL ")
+  }
+  if node.Cluster {
+    ctx.WriteString("CLUSTER TRANSACTIONS")
+  } else {
+    ctx.WriteString("LOCAL TRANSACTIONS")
+  }
 }
 
 // ShowConstraints represents a SHOW CONSTRAINTS statement.
 type ShowConstraints struct {
-	Table       *UnresolvedObjectName
-	WithComment bool
+  Table       *UnresolvedObjectName
+  WithComment bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowConstraints) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CONSTRAINTS FROM ")
-	ctx.FormatNode(node.Table)
+  ctx.WriteString("SHOW CONSTRAINTS FROM ")
+  ctx.FormatNode(node.Table)
 
-	if node.WithComment {
-		ctx.WriteString(" WITH COMMENT")
-	}
+  if node.WithComment {
+    ctx.WriteString(" WITH COMMENT")
+  }
 }
 
 // ShowGrants represents a SHOW GRANTS statement.
 // TargetList is defined in grant.go.
 type ShowGrants struct {
-	Targets  *TargetList
-	Grantees RoleSpecList
+  Targets  *TargetList
+  Grantees RoleSpecList
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowGrants) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW GRANTS")
-	if node.Targets != nil {
-		ctx.WriteString(" ON ")
-		ctx.FormatNode(node.Targets)
-	}
-	if node.Grantees != nil {
-		ctx.WriteString(" FOR ")
-		ctx.FormatNode(&node.Grantees)
-	}
+  ctx.WriteString("SHOW GRANTS")
+  if node.Targets != nil {
+    ctx.WriteString(" ON ")
+    ctx.FormatNode(node.Targets)
+  }
+  if node.Grantees != nil {
+    ctx.WriteString(" FOR ")
+    ctx.FormatNode(&node.Grantees)
+  }
 }
 
 // ShowRoleGrants represents a SHOW GRANTS ON ROLE statement.
 type ShowRoleGrants struct {
-	Roles    RoleSpecList
-	Grantees RoleSpecList
+  Roles    RoleSpecList
+  Grantees RoleSpecList
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW GRANTS ON ROLE")
-	if node.Roles != nil {
-		ctx.WriteString(" ")
-		ctx.FormatNode(&node.Roles)
-	}
-	if node.Grantees != nil {
-		ctx.WriteString(" FOR ")
-		ctx.FormatNode(&node.Grantees)
-	}
+  ctx.WriteString("SHOW GRANTS ON ROLE")
+  if node.Roles != nil {
+    ctx.WriteString(" ")
+    ctx.FormatNode(&node.Roles)
+  }
+  if node.Grantees != nil {
+    ctx.WriteString(" FOR ")
+    ctx.FormatNode(&node.Grantees)
+  }
 }
 
 // ShowCreateMode denotes what kind of SHOW CREATE should be used
 type ShowCreateMode int
 
 const (
-	// ShowCreateModeTable represents SHOW CREATE TABLE
-	ShowCreateModeTable ShowCreateMode = iota
-	// ShowCreateModeView represents SHOW CREATE VIEW
-	ShowCreateModeView
-	// ShowCreateModeSequence represents SHOW CREATE SEQUENCE
-	ShowCreateModeSequence
-	// ShowCreateModeDatabase represents SHOW CREATE DATABASE
-	ShowCreateModeDatabase
+  // ShowCreateModeTable represents SHOW CREATE TABLE
+  ShowCreateModeTable ShowCreateMode = iota
+  // ShowCreateModeView represents SHOW CREATE VIEW
+  ShowCreateModeView
+  // ShowCreateModeSequence represents SHOW CREATE SEQUENCE
+  ShowCreateModeSequence
+  // ShowCreateModeDatabase represents SHOW CREATE DATABASE
+  ShowCreateModeDatabase
 )
 
 // ShowCreate represents a SHOW CREATE statement.
 type ShowCreate struct {
-	Mode ShowCreateMode
-	Name *UnresolvedObjectName
+  Mode ShowCreateMode
+  Name *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreate) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CREATE ")
+  ctx.WriteString("SHOW CREATE ")
 
-	switch node.Mode {
-	case ShowCreateModeDatabase:
-		ctx.WriteString("DATABASE ")
-	}
-	ctx.FormatNode(node.Name)
+  switch node.Mode {
+  case ShowCreateModeDatabase:
+    ctx.WriteString("DATABASE ")
+  }
+  ctx.FormatNode(node.Name)
 }
 
 // ShowCreateAllSchemas represents a SHOW CREATE ALL SCHEMAS statement.
@@ -531,7 +531,7 @@ type ShowCreateAllSchemas struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllSchemas) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CREATE ALL SCHEMAS")
+  ctx.WriteString("SHOW CREATE ALL SCHEMAS")
 }
 
 // ShowCreateAllTables represents a SHOW CREATE ALL TABLES statement.
@@ -539,7 +539,7 @@ type ShowCreateAllTables struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllTables) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CREATE ALL TABLES")
+  ctx.WriteString("SHOW CREATE ALL TABLES")
 }
 
 // ShowCreateAllTypes represents a SHOW CREATE ALL TYPES statement.
@@ -547,22 +547,22 @@ type ShowCreateAllTypes struct{}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateAllTypes) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW CREATE ALL TYPES")
+  ctx.WriteString("SHOW CREATE ALL TYPES")
 }
 
 // ShowCreateSchedules represents a SHOW CREATE SCHEDULE statement.
 type ShowCreateSchedules struct {
-	ScheduleID Expr
+  ScheduleID Expr
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowCreateSchedules) Format(ctx *FmtCtx) {
-	if node.ScheduleID != nil {
-		ctx.WriteString("SHOW CREATE SCHEDULE ")
-		ctx.FormatNode(node.ScheduleID)
-		return
-	}
-	ctx.Printf("SHOW CREATE ALL SCHEDULES")
+  if node.ScheduleID != nil {
+    ctx.WriteString("SHOW CREATE SCHEDULE ")
+    ctx.FormatNode(node.ScheduleID)
+    return
+  }
+  ctx.Printf("SHOW CREATE ALL SCHEDULES")
 }
 
 // ShowSyntax represents a SHOW SYNTAX statement.
@@ -571,17 +571,17 @@ func (node *ShowCreateSchedules) Format(ctx *FmtCtx) {
 // any processing. Meant for use for syntax checking on clients,
 // when the client version might differ from the server.
 type ShowSyntax struct {
-	Statement string
+  Statement string
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSyntax) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW SYNTAX ")
-	if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
-		ctx.WriteString("'_'")
-	} else {
-		ctx.WriteString(lexbase.EscapeSQLString(node.Statement))
-	}
+  ctx.WriteString("SHOW SYNTAX ")
+  if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
+    ctx.WriteString("'_'")
+  } else {
+    ctx.WriteString(lexbase.EscapeSQLString(node.Statement))
+  }
 }
 
 // ShowTransactionStatus represents a SHOW TRANSACTION STATUS statement.
@@ -590,12 +590,12 @@ type ShowTransactionStatus struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransactionStatus) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW TRANSACTION STATUS")
+  ctx.WriteString("SHOW TRANSACTION STATUS")
 }
 
 // ShowLastQueryStatistics represents a SHOW LAST QUERY STATS statement.
 type ShowLastQueryStatistics struct {
-	Columns NameList
+  Columns NameList
 }
 
 // ShowLastQueryStatisticsDefaultColumns is the default list of columns
@@ -603,21 +603,21 @@ type ShowLastQueryStatistics struct {
 // Note: the form that does not specify the USING clause is deprecated.
 // Remove it when there are no more clients using it (22.1 or later).
 var ShowLastQueryStatisticsDefaultColumns = NameList([]Name{
-	"parse_latency",
-	"plan_latency",
-	"exec_latency",
-	"service_latency",
-	"post_commit_jobs_latency",
+  "parse_latency",
+  "plan_latency",
+  "exec_latency",
+  "service_latency",
+  "post_commit_jobs_latency",
 })
 
 // Format implements the NodeFormatter interface.
 func (node *ShowLastQueryStatistics) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW LAST QUERY STATISTICS RETURNING ")
-	// The column names for this statement never contain PII and should
-	// be distinguished for feature tracking purposes.
-	ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
-		ctx.FormatNode(&node.Columns)
-	})
+  ctx.WriteString("SHOW LAST QUERY STATISTICS RETURNING ")
+  // The column names for this statement never contain PII and should
+  // be distinguished for feature tracking purposes.
+  ctx.WithFlags(ctx.flags & ^FmtAnonymize & ^FmtMarkRedactionNode, func() {
+    ctx.FormatNode(&node.Columns)
+  })
 }
 
 // ShowFullTableScans represents a SHOW FULL TABLE SCANS statement.
@@ -626,7 +626,7 @@ type ShowFullTableScans struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowFullTableScans) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW FULL TABLE SCANS")
+  ctx.WriteString("SHOW FULL TABLE SCANS")
 }
 
 // ShowSavepointStatus represents a SHOW SAVEPOINT STATUS statement.
@@ -635,7 +635,7 @@ type ShowSavepointStatus struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowSavepointStatus) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW SAVEPOINT STATUS")
+  ctx.WriteString("SHOW SAVEPOINT STATUS")
 }
 
 // ShowUsers represents a SHOW USERS statement.
@@ -644,7 +644,7 @@ type ShowUsers struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowUsers) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW USERS")
+  ctx.WriteString("SHOW USERS")
 }
 
 // ShowRoles represents a SHOW ROLES statement.
@@ -653,111 +653,111 @@ type ShowRoles struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRoles) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW ROLES")
+  ctx.WriteString("SHOW ROLES")
 }
 
 // ShowRanges represents a SHOW RANGES statement.
 type ShowRanges struct {
-	TableOrIndex TableIndexName
-	DatabaseName Name
+  TableOrIndex TableIndexName
+  DatabaseName Name
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRanges) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW RANGES FROM ")
-	if node.DatabaseName != "" {
-		ctx.WriteString("DATABASE ")
-		ctx.FormatNode(&node.DatabaseName)
-	} else if node.TableOrIndex.Index != "" {
-		ctx.WriteString("INDEX ")
-		ctx.FormatNode(&node.TableOrIndex)
-	} else {
-		ctx.WriteString("TABLE ")
-		ctx.FormatNode(&node.TableOrIndex)
-	}
+  ctx.WriteString("SHOW RANGES FROM ")
+  if node.DatabaseName != "" {
+    ctx.WriteString("DATABASE ")
+    ctx.FormatNode(&node.DatabaseName)
+  } else if node.TableOrIndex.Index != "" {
+    ctx.WriteString("INDEX ")
+    ctx.FormatNode(&node.TableOrIndex)
+  } else {
+    ctx.WriteString("TABLE ")
+    ctx.FormatNode(&node.TableOrIndex)
+  }
 }
 
 // ShowRangeForRow represents a SHOW RANGE FOR ROW statement.
 type ShowRangeForRow struct {
-	TableOrIndex TableIndexName
-	Row          Exprs
+  TableOrIndex TableIndexName
+  Row          Exprs
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowRangeForRow) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW RANGE FROM ")
-	if node.TableOrIndex.Index != "" {
-		ctx.WriteString("INDEX ")
-	} else {
-		ctx.WriteString("TABLE ")
-	}
-	ctx.FormatNode(&node.TableOrIndex)
-	ctx.WriteString(" FOR ROW (")
-	ctx.FormatNode(&node.Row)
-	ctx.WriteString(")")
+  ctx.WriteString("SHOW RANGE FROM ")
+  if node.TableOrIndex.Index != "" {
+    ctx.WriteString("INDEX ")
+  } else {
+    ctx.WriteString("TABLE ")
+  }
+  ctx.FormatNode(&node.TableOrIndex)
+  ctx.WriteString(" FOR ROW (")
+  ctx.FormatNode(&node.Row)
+  ctx.WriteString(")")
 }
 
 // ShowFingerprints represents a SHOW EXPERIMENTAL_FINGERPRINTS statement.
 type ShowFingerprints struct {
-	Table *UnresolvedObjectName
+  Table *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowFingerprints) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
-	ctx.FormatNode(node.Table)
+  ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
+  ctx.FormatNode(node.Table)
 }
 
 // ShowTableStats represents a SHOW STATISTICS FOR TABLE statement.
 type ShowTableStats struct {
-	Table     *UnresolvedObjectName
-	UsingJSON bool
+  Table     *UnresolvedObjectName
+  UsingJSON bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTableStats) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW STATISTICS ")
-	if node.UsingJSON {
-		ctx.WriteString("USING JSON ")
-	}
-	ctx.WriteString("FOR TABLE ")
-	ctx.FormatNode(node.Table)
+  ctx.WriteString("SHOW STATISTICS ")
+  if node.UsingJSON {
+    ctx.WriteString("USING JSON ")
+  }
+  ctx.WriteString("FOR TABLE ")
+  ctx.FormatNode(node.Table)
 }
 
 // ShowHistogram represents a SHOW HISTOGRAM statement.
 type ShowHistogram struct {
-	HistogramID int64
+  HistogramID int64
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowHistogram) Format(ctx *FmtCtx) {
-	ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
+  ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
 }
 
 // ShowPartitions represents a SHOW PARTITIONS statement.
 type ShowPartitions struct {
-	IsDB     bool
-	Database Name
+  IsDB     bool
+  Database Name
 
-	IsIndex bool
-	Index   TableIndexName
+  IsIndex bool
+  Index   TableIndexName
 
-	IsTable bool
-	Table   *UnresolvedObjectName
+  IsTable bool
+  Table   *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowPartitions) Format(ctx *FmtCtx) {
-	if node.IsDB {
-		ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
-		ctx.FormatNode(&node.Database)
-	} else if node.IsIndex {
-		ctx.Printf("SHOW PARTITIONS FROM INDEX ")
-		ctx.FormatNode(&node.Index)
-	} else {
-		ctx.Printf("SHOW PARTITIONS FROM TABLE ")
-		ctx.FormatNode(node.Table)
-	}
+  if node.IsDB {
+    ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
+    ctx.FormatNode(&node.Database)
+  } else if node.IsIndex {
+    ctx.Printf("SHOW PARTITIONS FROM INDEX ")
+    ctx.FormatNode(&node.Index)
+  } else {
+    ctx.Printf("SHOW PARTITIONS FROM TABLE ")
+    ctx.FormatNode(node.Table)
+  }
 }
 
 // ScheduledJobExecutorType is a type identifying the names of
@@ -765,144 +765,158 @@ func (node *ShowPartitions) Format(ctx *FmtCtx) {
 type ScheduledJobExecutorType int
 
 const (
-	// InvalidExecutor is a placeholder for an invalid executor type.
-	InvalidExecutor ScheduledJobExecutorType = iota
+  // InvalidExecutor is a placeholder for an invalid executor type.
+  InvalidExecutor ScheduledJobExecutorType = iota
 
-	// ScheduledBackupExecutor is an executor responsible for
-	// the execution of the scheduled backups.
-	ScheduledBackupExecutor
+  // ScheduledBackupExecutor is an executor responsible for
+  // the execution of the scheduled backups.
+  ScheduledBackupExecutor
 
-	// ScheduledSQLStatsCompactionExecutor is an executor responsible for the
-	// execution of the scheduled SQL Stats compaction.
-	ScheduledSQLStatsCompactionExecutor
+  // ScheduledSQLStatsCompactionExecutor is an executor responsible for the
+  // execution of the scheduled SQL Stats compaction.
+  ScheduledSQLStatsCompactionExecutor
 
-	// ScheduledRowLevelTTLExecutor is an executor responsible for the cleanup
-	// of rows on row level TTL tables.
-	ScheduledRowLevelTTLExecutor
+  // ScheduledRowLevelTTLExecutor is an executor responsible for the cleanup
+  // of rows on row level TTL tables.
+  ScheduledRowLevelTTLExecutor
 )
 
 var scheduleExecutorInternalNames = map[ScheduledJobExecutorType]string{
-	InvalidExecutor:                     "unknown-executor",
-	ScheduledBackupExecutor:             "scheduled-backup-executor",
-	ScheduledSQLStatsCompactionExecutor: "scheduled-sql-stats-compaction-executor",
-	ScheduledRowLevelTTLExecutor:        "scheduled-row-level-ttl-executor",
+  InvalidExecutor:                     "unknown-executor",
+  ScheduledBackupExecutor:             "scheduled-backup-executor",
+  ScheduledSQLStatsCompactionExecutor: "scheduled-sql-stats-compaction-executor",
+  ScheduledRowLevelTTLExecutor:        "scheduled-row-level-ttl-executor",
 }
 
 // InternalName returns an internal executor name.
 // This name can be used to filter matching schedules.
 func (t ScheduledJobExecutorType) InternalName() string {
-	return scheduleExecutorInternalNames[t]
+  return scheduleExecutorInternalNames[t]
 }
 
 // UserName returns a user friendly executor name.
 func (t ScheduledJobExecutorType) UserName() string {
-	switch t {
-	case ScheduledBackupExecutor:
-		return "BACKUP"
-	case ScheduledSQLStatsCompactionExecutor:
-		return "SQL STATISTICS"
-	case ScheduledRowLevelTTLExecutor:
-		return "ROW LEVEL TTL"
-	}
-	return "unsupported-executor"
+  switch t {
+  case ScheduledBackupExecutor:
+    return "BACKUP"
+  case ScheduledSQLStatsCompactionExecutor:
+    return "SQL STATISTICS"
+  case ScheduledRowLevelTTLExecutor:
+    return "ROW LEVEL TTL"
+  }
+  return "unsupported-executor"
 }
 
 // ScheduleState describes what kind of schedules to display
 type ScheduleState int
 
 const (
-	// SpecifiedSchedules indicates that show schedules should
-	// only show subset of schedules.
-	SpecifiedSchedules ScheduleState = iota
+  // SpecifiedSchedules indicates that show schedules should
+  // only show subset of schedules.
+  SpecifiedSchedules ScheduleState = iota
 
-	// ActiveSchedules indicates that show schedules should
-	// only show those schedules that are currently active.
-	ActiveSchedules
+  // ActiveSchedules indicates that show schedules should
+  // only show those schedules that are currently active.
+  ActiveSchedules
 
-	// PausedSchedules indicates that show schedules should
-	// only show those schedules that are currently paused.
-	PausedSchedules
+  // PausedSchedules indicates that show schedules should
+  // only show those schedules that are currently paused.
+  PausedSchedules
 )
 
 // Format implements the NodeFormatter interface.
 func (s ScheduleState) Format(ctx *FmtCtx) {
-	switch s {
-	case ActiveSchedules:
-		ctx.WriteString("RUNNING")
-	case PausedSchedules:
-		ctx.WriteString("PAUSED")
-	default:
-		// Nothing
-	}
+  switch s {
+  case ActiveSchedules:
+    ctx.WriteString("RUNNING")
+  case PausedSchedules:
+    ctx.WriteString("PAUSED")
+  default:
+    // Nothing
+  }
 }
 
 // ShowSchedules represents a SHOW SCHEDULES statement.
 type ShowSchedules struct {
-	WhichSchedules ScheduleState
-	ExecutorType   ScheduledJobExecutorType
-	ScheduleID     Expr
+  WhichSchedules ScheduleState
+  ExecutorType   ScheduledJobExecutorType
+  ScheduleID     Expr
 }
 
 var _ Statement = &ShowSchedules{}
 
 // Format implements the NodeFormatter interface.
 func (n *ShowSchedules) Format(ctx *FmtCtx) {
-	if n.ScheduleID != nil {
-		ctx.WriteString("SHOW SCHEDULE ")
-		ctx.FormatNode(n.ScheduleID)
-		return
-	}
-	ctx.Printf("SHOW")
+  if n.ScheduleID != nil {
+    ctx.WriteString("SHOW SCHEDULE ")
+    ctx.FormatNode(n.ScheduleID)
+    return
+  }
+  ctx.Printf("SHOW")
 
-	if n.WhichSchedules != SpecifiedSchedules {
-		ctx.WriteString(" ")
-		ctx.FormatNode(&n.WhichSchedules)
-	}
+  if n.WhichSchedules != SpecifiedSchedules {
+    ctx.WriteString(" ")
+    ctx.FormatNode(&n.WhichSchedules)
+  }
 
-	ctx.Printf(" SCHEDULES")
+  ctx.Printf(" SCHEDULES")
 
-	if n.ExecutorType != InvalidExecutor {
-		// TODO(knz): beware of using ctx.FormatNode here if
-		// FOR changes to support expressions.
-		ctx.Printf(" FOR %s", n.ExecutorType.UserName())
-	}
+  if n.ExecutorType != InvalidExecutor {
+    // TODO(knz): beware of using ctx.FormatNode here if
+    // FOR changes to support expressions.
+    ctx.Printf(" FOR %s", n.ExecutorType.UserName())
+  }
 }
 
 // ShowDefaultPrivileges represents a SHOW DEFAULT PRIVILEGES statement.
 type ShowDefaultPrivileges struct {
-	Roles       RoleSpecList
-	ForAllRoles bool
+  Roles       RoleSpecList
+  ForAllRoles bool
 }
 
 var _ Statement = &ShowDefaultPrivileges{}
 
 // Format implements the NodeFormatter interface.
 func (n *ShowDefaultPrivileges) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
-	if len(n.Roles) > 0 {
-		ctx.WriteString("FOR ROLE ")
-		for i, role := range n.Roles {
-			if i > 0 {
-				ctx.WriteString(", ")
-			}
-			ctx.FormatNode(&role)
-		}
-		ctx.WriteString(" ")
-	} else if n.ForAllRoles {
-		ctx.WriteString("FOR ALL ROLES ")
-	}
+  ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
+  if len(n.Roles) > 0 {
+    ctx.WriteString("FOR ROLE ")
+    for i, role := range n.Roles {
+      if i > 0 {
+        ctx.WriteString(", ")
+      }
+      ctx.FormatNode(&role)
+    }
+    ctx.WriteString(" ")
+  } else if n.ForAllRoles {
+    ctx.WriteString("FOR ALL ROLES ")
+  }
 }
 
 // ShowTransferState represents a SHOW TRANSFER STATE statement.
 type ShowTransferState struct {
-	TransferKey *StrVal
+  TransferKey *StrVal
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTransferState) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW TRANSFER STATE")
-	if node.TransferKey != nil {
-		ctx.WriteString(" WITH ")
-		ctx.FormatNode(node.TransferKey)
-	}
+  ctx.WriteString("SHOW TRANSFER STATE")
+  if node.TransferKey != nil {
+    ctx.WriteString(" WITH ")
+    ctx.FormatNode(node.TransferKey)
+  }
 }
+
+type ShowCompletions struct {
+  Statement string
+  Offset    *NumVal
+}
+
+func (s ShowCompletions) Format(ctx *FmtCtx) {
+  ctx.WriteString("SHOW COMPLETIONS AT OFFSET ")
+  s.Offset.Format(ctx)
+  ctx.WriteString(" FOR ")
+  ctx.WriteString(lexbase.EscapeSQLString(s.Statement))
+}
+
+var _ Statement = &ShowCompletions{}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1651,6 +1651,11 @@ func (*ShowCompletions) StatementType() StatementType { return TypeDML }
 // StatementTag returns a short string identifying the type of statement.
 func (*ShowCompletions) StatementTag() string { return "SHOW COMPLETIONS" }
 
+// observerStatement implements the ObserverStatement interface.
+func (*ShowCompletions) observerStatement() {}
+
+func (*ShowCompletions) hiddenFromShowQueries() {}
+
 // StatementReturnType implements the Statement interface.
 func (*Split) StatementReturnType() StatementReturnType { return Rows }
 

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1643,6 +1643,15 @@ func (*ShowDefaultPrivileges) StatementType() StatementType { return TypeDML }
 func (*ShowDefaultPrivileges) StatementTag() string { return "SHOW DEFAULT PRIVILEGES" }
 
 // StatementReturnType implements the Statement interface.
+func (*ShowCompletions) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*ShowCompletions) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowCompletions) StatementTag() string { return "SHOW COMPLETIONS" }
+
+// StatementReturnType implements the Statement interface.
 func (*Split) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
@@ -1868,6 +1877,7 @@ func (n *ShowVar) String() string                        { return AsString(n) }
 func (n *ShowZoneConfig) String() string                 { return AsString(n) }
 func (n *ShowFingerprints) String() string               { return AsString(n) }
 func (n *ShowDefaultPrivileges) String() string          { return AsString(n) }
+func (n *ShowCompletions) String() string                { return AsString(n) }
 func (n *Split) String() string                          { return AsString(n) }
 func (n *StreamIngestion) String() string                { return AsString(n) }
 func (n *Unsplit) String() string                        { return AsString(n) }


### PR DESCRIPTION
sql: add SHOW COMPLETIONS AT offset FOR syntax 

Release note (sql change): Support
SHOW COMPLETIONS AT OFFSET <offset> FOR <stmt> syntax that
returns a set of SQL keywords that can complete the keyword at
<offset> in the given <stmt>.

If the offset is in the middle of a word, then it returns the
full word.
For example SHOW COMPLETIONS AT OFFSET 1 FOR "SELECT" returns select.

cli: support autocomplete 

Release note (cli change): CLI now auto completes on tab
by using `SHOW COMPLETIONS AT OFFSET`.