### PR TITLE
opt: bump size of `memo` test

### DIFF
--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -51,7 +51,7 @@ go_library(
 
 go_test(
     name = "memo_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "cost_test.go",
         "expr_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None