### PR TITLE
sql: remove unnecessary parens from cluster_contended_indexes

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1932,16 +1932,12 @@ CREATE VIEW crdb_internal.cluster_contended_indexes (
     crdb_internal.tables,
     crdb_internal.table_indexes
   WHERE
-    (
-      crdb_internal.cluster_contention_events.index_id
-      = crdb_internal.table_indexes.index_id
-      AND crdb_internal.cluster_contention_events.table_id
-        = crdb_internal.table_indexes.descriptor_id
-    )
-    AND (
-        crdb_internal.cluster_contention_events.table_id
-        = crdb_internal.tables.table_id
-      )
+    crdb_internal.cluster_contention_events.index_id
+    = crdb_internal.table_indexes.index_id
+    AND crdb_internal.cluster_contention_events.table_id
+      = crdb_internal.table_indexes.descriptor_id
+    AND crdb_internal.cluster_contention_events.table_id
+      = crdb_internal.tables.table_id
   ORDER BY
     num_contention_events DESC
 `,


### PR DESCRIPTION
The modified query introduced in #72780 had unnecessary parentheses in
its where clause. This change removes them.

Release note: None