### PR TITLE
changefeedcc: Do not emit epoch resolved events.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1500,7 +1500,7 @@ func (cf *changeFrontier) maybeProtectTimestamp(
 }
 
 func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
-	if cf.freqEmitResolved == emitNoResolved {
+	if cf.freqEmitResolved == emitNoResolved || newResolved.IsEmpty() {
 		return nil
 	}
 	sinceEmitted := newResolved.GoTime().Sub(cf.lastEmitResolved)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4509,7 +4509,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 
 		// Checkpoint progress frequently, and set the checkpoint size limit.
 		changefeedbase.FrontierCheckpointFrequency.Override(
-			context.Background(), &f.Server().ClusterSettings().SV, 10*time.Millisecond)
+			context.Background(), &f.Server().ClusterSettings().SV, 1)
 		changefeedbase.FrontierCheckpointMaxBytes.Override(
 			context.Background(), &f.Server().ClusterSettings().SV, maxCheckpointSize)
 
@@ -4519,15 +4519,25 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 		g := ctxgroup.WithContext(context.Background())
 		g.Go(func() error {
 			for {
-				_, err := foo.Next()
+				m, err := foo.Next()
 				if err != nil {
 					return err
 				}
+
+				if m.Resolved != nil {
+					ts := extractResolvedTimestamp(t, m)
+					if ts.IsEmpty() {
+						return errors.New("unexpected epoch resolved event")
+					}
+				}
 			}
 		})
+
 		defer func() {
 			closeFeed(t, foo)
-			_ = g.Wait()
+			if err := g.Wait(); err != nil {
+				require.Truef(t, jobs.HasErrJobCanceled(err), "err=%v", err)
+			}
 		}()
 
 		jobFeed := foo.(cdctest.EnterpriseTestFeed)


### PR DESCRIPTION
Do not emit resolved events with unix epoch timestamp.

Fixes #72917

Release Notes: None