### PR TITLE
protectedts: improve a test

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
@@ -71,7 +71,7 @@ func TestReconciler(t *testing.T) {
 		},
 	}
 	r := ptreconcile.NewReconciler(cfg)
-	require.NoError(t, r.Start(ctx, tc.Stopper()))
+	require.NoError(t, r.Start(ctx, s0.Stopper()))
 	recMeta := "a"
 	rec1 := ptpb.Record{
 		ID:        uuid.MakeV4(),


### PR DESCRIPTION
This test was starting a Reconciler by hand, running against an existing
Server. The Reconciler was using the cluster's stopper (as opposed to
the server's stopper). In doing so, we ended up with two different Tracers
contributing to the same traces. This is pretty broken and will become
dissallowed. The patch fixes it by configuring the alien Reconciler with
the same stopper (and tracer) as the server it's running against.

Release note: None