### PR TITLE
opt: adds expect/expect-not support to memo in tests

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1307,7 +1307,7 @@ full-join (hash)
 # Verify that commuting works correctly when there is a lookup join hint
 # (specifically that it returns the original expression and flags when applied
 # twice; if it didn't, we'd see more inner-join expressions).
-memo expect=ReorderJoins
+memo expect-not=ReorderJoins
 SELECT * FROM abc INNER LOOKUP JOIN xyz ON a=x
 ----
 memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -19,41 +19,57 @@ CREATE TABLE kuvw (
 
 # All index orderings can be used.
 memo expect=GenerateStreamingSetOp
-SELECT * FROM kuvw UNION SELECT * FROM kuvw
+SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~10KB, required=[presentation: k:13,u:14,v:15,w:16])
- ├── G1: (distinct-on G2 G3 cols=(13)) (distinct-on G2 G3 cols=(13),ordering=+13)
- │    └── [presentation: k:13,u:14,v:15,w:16]
- │         ├── best: (distinct-on G2="[ordering: +13]" G3 cols=(13),ordering=+13)
- │         └── cost: 2329.69
- ├── G2: (union-all G4 G5)
- │    ├── [ordering: +13]
- │    │    ├── best: (union-all G4="[ordering: +1]" G5="[ordering: +7]")
- │    │    └── cost: 2229.66
+memo (optimized, ~9KB, required=[presentation: u:13,v:14,w:15])
+ ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
+ │    └── [presentation: u:13,v:14,w:15]
+ │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)
+ │         └── cost: 2209.46
+ ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
+ │    ├── [ordering: +2,+3,+4]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1094.72
+ │    ├── [ordering: +3,+2,+4]
+ │    │    ├── best: (sort G2="[ordering: +3]")
+ │    │    └── cost: 1225.50
+ │    ├── [ordering: +3,+4,+2]
+ │    │    ├── best: (sort G2="[ordering: +3,+4]")
+ │    │    └── cost: 1164.74
+ │    ├── [ordering: +3,+4]
+ │    │    ├── best: (scan kuvw@vw,cols=(2-4))
+ │    │    └── cost: 1094.72
+ │    ├── [ordering: +3]
+ │    │    ├── best: (scan kuvw@vw,cols=(2-4))
+ │    │    └── cost: 1094.72
+ │    ├── [ordering: +4,+3,+2]
+ │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    │    └── cost: 1094.72
  │    └── []
- │         ├── best: (union-all G4 G5)
- │         └── cost: 2229.66
- ├── G3: (aggregations G6 G7 G8)
- ├── G4: (scan kuvw,cols=(1-4)) (scan kuvw@uvw,cols=(1-4)) (scan kuvw@wvu,cols=(1-4)) (scan kuvw@vw,cols=(1-4)) (scan kuvw@w,cols=(1-4))
- │    ├── [ordering: +1]
- │    │    ├── best: (scan kuvw,cols=(1-4))
- │    │    └── cost: 1104.82
- │    └── []
- │         ├── best: (scan kuvw,cols=(1-4))
- │         └── cost: 1104.82
- ├── G5: (scan kuvw,cols=(7-10)) (scan kuvw@uvw,cols=(7-10)) (scan kuvw@wvu,cols=(7-10)) (scan kuvw@vw,cols=(7-10)) (scan kuvw@w,cols=(7-10))
- │    ├── [ordering: +7]
- │    │    ├── best: (scan kuvw,cols=(7-10))
- │    │    └── cost: 1104.82
- │    └── []
- │         ├── best: (scan kuvw,cols=(7-10))
- │         └── cost: 1104.82
- ├── G6: (const-agg G9)
- ├── G7: (const-agg G10)
- ├── G8: (const-agg G11)
- ├── G9: (variable u)
- ├── G10: (variable v)
- └── G11: (variable w)
+ │         ├── best: (scan kuvw,cols=(2-4))
+ │         └── cost: 1094.72
+ └── G3: (scan kuvw,cols=(8-10)) (scan kuvw@uvw,cols=(8-10)) (scan kuvw@wvu,cols=(8-10)) (scan kuvw@vw,cols=(8-10)) (scan kuvw@w,cols=(8-10))
+      ├── [ordering: +10,+9,+8]
+      │    ├── best: (scan kuvw@wvu,cols=(8-10))
+      │    └── cost: 1094.72
+      ├── [ordering: +8,+9,+10]
+      │    ├── best: (scan kuvw@uvw,cols=(8-10))
+      │    └── cost: 1094.72
+      ├── [ordering: +9,+10,+8]
+      │    ├── best: (sort G3="[ordering: +9,+10]")
+      │    └── cost: 1164.74
+      ├── [ordering: +9,+10]
+      │    ├── best: (scan kuvw@vw,cols=(8-10))
+      │    └── cost: 1094.72
+      ├── [ordering: +9,+8,+10]
+      │    ├── best: (sort G3="[ordering: +9]")
+      │    └── cost: 1225.50
+      ├── [ordering: +9]
+      │    ├── best: (scan kuvw@vw,cols=(8-10))
+      │    └── cost: 1094.72
+      └── []
+           ├── best: (scan kuvw,cols=(8-10))
+           └── cost: 1094.72
 
 memo expect=GenerateStreamingSetOp
 SELECT * FROM kuvw INTERSECT SELECT * FROM kuvw


### PR DESCRIPTION
Several exploration rule tests use "memo expect=[rule]" or "memo
expect-not=[rule]" to check that a rule was applied during optimization.
However, opt tester does not actually check that rules are applied or
not when evaluating a memo test, so these tests were passing whether or
not the expected rule was applied.

This change adds support for checking expected and unexpected rules to
the opt tester for the memo case. It also fixes a couple tests that
failed once the rules were checked.

Release note: None