### PR TITLE
server: export metrics for database and table count

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1632,6 +1632,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 			}
 		}
 		emitRestoreJobEvent(ctx, p, jobs.StatusSucceeded, r.job)
+		refreshSchemaMetrics(ctx, p)
 		return nil
 	}
 
@@ -1760,6 +1761,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 
 	// Emit an event now that the restore job has completed.
 	emitRestoreJobEvent(ctx, p, jobs.StatusSucceeded, r.job)
+	refreshSchemaMetrics(ctx, p)
 
 	// Collect telemetry.
 	{
@@ -2082,6 +2084,10 @@ func emitRestoreJobEvent(
 	}); err != nil {
 		log.Warningf(ctx, "failed to log event: %v", err)
 	}
+}
+
+func refreshSchemaMetrics(ctx context.Context, p sql.JobExecContext) {
+	p.ExecCfg().RefreshLocalSchemaMetrics(ctx)
 }
 
 // OnFailOrCancel is part of the jobs.Resumer interface. Removes KV data that

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -940,6 +940,8 @@ func (r *importResumer) publishTables(
 		execCfg.StatsRefresher.NotifyMutation(desc, math.MaxInt32 /* rowsAffected */)
 	}
 
+	execCfg.RefreshLocalSchemaMetrics(ctx)
+
 	return nil
 }
 

--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     name = "statusccl_test",
     srcs = [
         "main_test.go",
+        "schema_metrics_test.go",
         "tenant_grpc_test.go",
         "tenant_status_test.go",
     ],
@@ -47,6 +48,7 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",
         "//pkg/testutils",
+        "//pkg/testutils/metrictestutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/serverccl/statusccl/schema_metrics_test.go
+++ b/pkg/ccl/serverccl/statusccl/schema_metrics_test.go
@@ -1,0 +1,184 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package statusccl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestTenantSchemaMetrics_DatabaseCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+	helper := newTestTenantHelper(t, 3, base.TestingKnobs{})
+	defer helper.cleanup(ctx, t)
+
+	storage, cleanup := makeStorageServer()
+	defer cleanup()
+
+	sql0 := helper.testCluster().tenantConn(0)
+	sql1 := helper.testCluster().tenantConn(1)
+	sql2 := helper.testCluster().tenantConn(2)
+
+	http0 := helper.testCluster().tenantHTTPClient(t, 0)
+	defer http0.Close()
+	http1 := helper.testCluster().tenantHTTPClient(t, 1)
+	defer http0.Close()
+	http2 := helper.testCluster().tenantHTTPClient(t, 2)
+	defer http0.Close()
+
+	maxUpdatedAt := scrapingMetricsFrom(t, http0, http1, http2).
+		LabelingSources("sql_instance_id", strconv.Itoa).
+		Gauge("sql_schema_updated_at").
+		Max()
+
+	databaseCount := scrapingMetricsFrom(t, http0, http1, http2).
+		LabelingSources("sql_instance_id", strconv.Itoa).
+		Gauge("sql_schema_database_count").
+		WithLabel("internal", "false").
+		WithLabelf("sql_instance_id", maxUpdatedAt.Label, "sql_instance_id").
+		Single()
+
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+
+	sql0.Exec(t, "CREATE DATABASE foo")
+	databaseCount.ShouldEventuallyEqual(2) // defaultdb, foo
+
+	sql1.Exec(t, "BACKUP DATABASE foo INTO $1", storage.Path())
+	sql1.Exec(t, "DROP DATABASE foo")
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+
+	sql2.Exec(t, "RESTORE DATABASE foo FROM $1", storage.Path())
+	databaseCount.ShouldEventuallyEqual(2) // defaultdb, foo
+
+	sql0.Exec(t, "ALTER DATABASE foo CONVERT TO SCHEMA WITH PARENT defaultdb")
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+}
+
+func TestTenantSchemaMetrics_TableCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+	helper := newTestTenantHelper(t, 3, base.TestingKnobs{})
+	defer helper.cleanup(ctx, t)
+
+	storage, cleanup := makeStorageServer()
+	defer cleanup()
+
+	sql0 := helper.testCluster().tenantConn(0)
+	sql1 := helper.testCluster().tenantConn(1)
+	sql2 := helper.testCluster().tenantConn(2)
+
+	http0 := helper.testCluster().tenantHTTPClient(t, 0)
+	defer http0.Close()
+	http1 := helper.testCluster().tenantHTTPClient(t, 1)
+	defer http1.Close()
+	http2 := helper.testCluster().tenantHTTPClient(t, 2)
+	defer http2.Close()
+
+	maxUpdatedAt := scrapingMetricsFrom(t, http0, http1, http2).
+		LabelingSources("sql_instance_id", strconv.Itoa).
+		Gauge("sql_schema_updated_at").
+		Max()
+
+	tableCount := scrapingMetricsFrom(t, http0, http1, http2).
+		LabelingSources("sql_instance_id", strconv.Itoa).
+		Gauge("sql_schema_table_count").
+		WithLabel("internal", "false").
+		WithLabelf("sql_instance_id", maxUpdatedAt.Label, "sql_instance_id").
+		Single()
+
+	tableCount.ShouldEventuallyEqual(0)
+
+	sql0.Exec(t, "CREATE TABLE foo (id INT)")
+	tableCount.ShouldEventuallyEqual(1)
+
+	sql1.Exec(t, "DROP TABLE foo")
+	tableCount.ShouldEventuallyEqual(0)
+
+	storage.Seed("pgdump", "create table bar (id int); insert into bar (id) values (1);")
+	sql2.Exec(t, "IMPORT TABLE bar FROM PGDUMP $1", storage.Path("pgdump"))
+	tableCount.ShouldEventuallyEqual(1)
+}
+
+func scrapingMetricsFrom(t *testing.T, clients ...*httpClient) *metrictestutils.MetricsTester {
+	var loaders []func() string
+	for _, client := range clients {
+		client := client
+		loaders = append(loaders, func() string {
+			return client.GetPlainText("/_status/vars")
+		})
+	}
+	return metrictestutils.NewMetricsTester(t, loaders...)
+}
+
+type storageServer struct {
+	blobs  map[string][]byte
+	server *httptest.Server
+}
+
+func makeStorageServer() (*storageServer, func()) {
+	s := storageServer{
+		blobs: map[string][]byte{},
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(s.serve))
+	return &s, s.server.Close
+}
+
+func (s *storageServer) Path(segments ...string) string {
+	return strings.Join([]string{s.server.URL, strings.Join(segments, "/")}, "/")
+}
+
+func (s *storageServer) Seed(path, content string) {
+	s.blobs[path] = []byte(content)
+}
+
+func (s *storageServer) serve(w http.ResponseWriter, r *http.Request) {
+	path := filepath.Base(r.URL.Path)
+
+	switch r.Method {
+	case "PUT":
+		s.blobs[path], _ = io.ReadAll(r.Body)
+		w.WriteHeader(201)
+	case "GET", "HEAD":
+		blob, ok := s.blobs[path]
+		if !ok {
+			http.Error(w, path, 404)
+			return
+		}
+		http.ServeContent(w, r, path, time.Time{}, bytes.NewReader(blob))
+	case "DELETE":
+		delete(s.blobs, path)
+		w.WriteHeader(204)
+	default:
+		http.Error(w, fmt.Sprintf("unsupported method %s", r.Method), 400)
+	}
+}

--- a/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
@@ -11,6 +11,7 @@ package statusccl
 import (
 	"context"
 	gosql "database/sql"
+	"io"
 	"net/http"
 	"testing"
 
@@ -174,6 +175,15 @@ type httpClient struct {
 	t       *testing.T
 	client  http.Client
 	baseURL string
+}
+
+func (c *httpClient) GetPlainText(path string) string {
+	c.t.Helper()
+	resp, err := c.client.Get(c.baseURL + path)
+	require.NoError(c.t, err)
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(c.t, err)
+	return string(b)
 }
 
 func (c *httpClient) GetJSON(path string, response protoutil.Message) {

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -125,6 +125,7 @@ go_test(
         "recorder_test.go",
         "runtime_stats_test.go",
         "runtime_test.go",
+        "schema_metrics_test.go",
     ],
     embed = [":status"],
     deps = [
@@ -136,7 +137,9 @@ go_test(
         "//pkg/server",
         "//pkg/server/status/statuspb:statuspb_go_proto",
         "//pkg/settings/cluster",
+        "//pkg/testutils/metrictestutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/ts/tspb",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
@@ -148,5 +151,6 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_kr_pretty//:pretty",
         "@com_github_shirou_gopsutil//net",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/status/schema_metrics_test.go
+++ b/pkg/server/status/schema_metrics_test.go
@@ -1,0 +1,103 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package status_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaMetrics_DatabaseCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+	server, sql0, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	http0, err := server.GetAdminAuthenticatedHTTPClient()
+	require.NoError(t, err)
+
+	databaseCount := scrapingMetricsFrom(t, http0, server.HTTPAddr()).
+		Gauge("sql_schema_database_count").
+		WithLabel("internal", "false").
+		Single()
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+
+	_, err = sql0.Exec("CREATE DATABASE foo")
+	require.NoError(t, err)
+	databaseCount.ShouldEventuallyEqual(2) // defaultdb, foo
+
+	_, err = sql0.Exec("DROP DATABASE foo")
+	require.NoError(t, err)
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+
+	_, err = sql0.Exec("CREATE DATABASE bar")
+	require.NoError(t, err)
+	databaseCount.ShouldEventuallyEqual(2) // defaultdb, bar
+
+	_, err = sql0.Exec("ALTER DATABASE bar CONVERT TO SCHEMA WITH PARENT defaultdb")
+	require.NoError(t, err)
+	databaseCount.ShouldEventuallyEqual(1) // defaultdb
+}
+
+func TestSchemaMetrics_TableCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+	server, sql0, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	http0, err := server.GetAdminAuthenticatedHTTPClient()
+	require.NoError(t, err)
+
+	tableCount := scrapingMetricsFrom(t, http0, server.HTTPAddr()).
+		Gauge("sql_schema_table_count").
+		WithLabel("internal", "false").
+		Single()
+	tableCount.ShouldEventuallyEqual(0)
+
+	_, err = sql0.Exec("CREATE TABLE foo (id INT)")
+	require.NoError(t, err)
+	tableCount.ShouldEventuallyEqual(1)
+
+	_, err = sql0.Exec("DROP TABLE foo")
+	require.NoError(t, err)
+	tableCount.ShouldEventuallyEqual(0)
+}
+
+func scrapingMetricsFrom(
+	t *testing.T, client http.Client, addr string,
+) *metrictestutils.MetricsTester {
+	return metrictestutils.NewMetricsTester(t, func() string {
+		resp, err := client.Get(fmt.Sprintf("https://%s/_status/vars", addr))
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return string(body)
+	})
+}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -171,6 +171,7 @@ go_library(
         "schema_changer.go",
         "schema_changer_metrics.go",
         "schema_changer_state.go",
+        "schema_metrics.go",
         "scrub.go",
         "scrub_constraint.go",
         "scrub_fk.go",

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -162,6 +162,8 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 			}); err != nil {
 			return err
 		}
+
+		params.EvalContext().Txn.AddCommitTrigger(params.ExecCfg().RefreshLocalSchemaMetrics)
 	}
 	return nil
 }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -488,6 +488,8 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
+	params.p.Txn().AddCommitTrigger(params.p.ExecCfg().RefreshLocalSchemaMetrics)
+
 	// If we are in an explicit txn or the source has placeholders, we execute the
 	// CTAS query synchronously.
 	if n.n.As() && !params.p.ExtendedEvalContext().TxnImplicit {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1067,6 +1067,7 @@ type ExecutorConfig struct {
 	InternalExecutor *InternalExecutor
 	QueryCache       *querycache.C
 
+	SchemaMetrics        *SchemaMetrics
 	SchemaChangerMetrics *SchemaChangerMetrics
 	FeatureFlagMetrics   *featureflag.DenialMetrics
 	RowMetrics           *row.Metrics
@@ -1186,6 +1187,14 @@ func (cfg *ExecutorConfig) Organization() string {
 // GetFeatureFlagMetrics returns the value of the FeatureFlagMetrics struct.
 func (cfg *ExecutorConfig) GetFeatureFlagMetrics() *featureflag.DenialMetrics {
 	return cfg.FeatureFlagMetrics
+}
+
+// RefreshLocalSchemaMetrics trues up the schema metrics (database and table
+// count) on this node / pod only.
+func (cfg *ExecutorConfig) RefreshLocalSchemaMetrics(ctx context.Context) {
+	if err := cfg.SchemaMetrics.Refresh(ctx, cfg.InternalExecutor); err != nil {
+		log.Warningf(ctx, "failed to refresh schema metrics: %v", err)
+	}
 }
 
 // SV returns the setting values.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -613,6 +613,9 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 		if refreshStats {
 			sc.refreshStats(latestDesc)
 		}
+
+		sc.execCfg.RefreshLocalSchemaMetrics(ctx)
+
 		return nil
 	}
 

--- a/pkg/sql/schema_metrics.go
+++ b/pkg/sql/schema_metrics.go
@@ -1,0 +1,132 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	metaDatabaseCount = metric.Metadata{
+		Name:        "sql.schema.database_count",
+		Help:        "The number of databases hosted by this cluster",
+		Measurement: "Databases",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaTableCount = metric.Metadata{
+		Name:        "sql.schema.table_count",
+		Help:        "The number of tables hosted by this cluster",
+		Measurement: "Tables",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaUpdatedAt = metric.Metadata{
+		Name:        "sql.schema.updated_at",
+		Help:        "The unix timestamp of the most recent update to schema metrics",
+		Measurement: "Update Time",
+		Unit:        metric.Unit_TIMESTAMP_NS,
+	}
+
+	internalDatabaseNames = map[string]struct{}{
+		"system":   {},
+		"postgres": {},
+	}
+)
+
+// SchemaMetrics holds gauges counting the number of databases and tables in the cluster.
+type SchemaMetrics struct {
+	DatabaseCountExternal *metric.Gauge
+	DatabaseCountInternal *metric.Gauge
+	TableCountExternal    *metric.Gauge
+	TableCountInternal    *metric.Gauge
+	UpdatedAt             *metric.Gauge
+}
+
+// MetricStruct makes SchemaMetrics a metric.Struct.
+func (s *SchemaMetrics) MetricStruct() {}
+
+var _ metric.Struct = (*SchemaMetrics)(nil)
+
+// NewSchemaMetrics constructs a new SchemaMetrics.
+func NewSchemaMetrics() *SchemaMetrics {
+	return &SchemaMetrics{
+		DatabaseCountExternal: metric.NewGauge(labelInternal(metaDatabaseCount, false)),
+		DatabaseCountInternal: metric.NewGauge(labelInternal(metaDatabaseCount, true)),
+		TableCountExternal:    metric.NewGauge(labelInternal(metaTableCount, false)),
+		TableCountInternal:    metric.NewGauge(labelInternal(metaTableCount, true)),
+		UpdatedAt:             metric.NewGauge(metaUpdatedAt),
+	}
+}
+
+func labelInternal(metadata metric.Metadata, internal bool) metric.Metadata {
+	metadata.AddLabel("internal", strconv.FormatBool(internal))
+	return metadata
+}
+
+// Refresh runs a SQL query to update our gauges.
+func (s *SchemaMetrics) Refresh(ctx context.Context, ie *InternalExecutor) (retErr error) {
+	it, err := ie.QueryIterator(
+		ctx,
+		"refresh-schema-metrics",
+		nil,
+		`
+			SELECT
+				d.name, count(t.name)
+			FROM
+				crdb_internal.databases AS d
+				LEFT JOIN crdb_internal.tables AS t ON
+						d.name = t.database_name
+			WHERE
+				t.state IS NULL OR t.state != 'DROP'
+			GROUP BY
+				d.name`,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+
+	var externalDatabaseCount, externalTableCount int64
+	var internalDatabaseCount, internalTableCount int64
+
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		databaseName := string(*it.Cur()[0].(*tree.DString))
+		tableCount := int64(*it.Cur()[1].(*tree.DInt))
+
+		if _, ok := internalDatabaseNames[databaseName]; ok {
+			internalDatabaseCount++
+			internalTableCount += tableCount
+		} else {
+			externalDatabaseCount++
+			externalTableCount += tableCount
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	s.DatabaseCountExternal.Update(externalDatabaseCount)
+	s.DatabaseCountInternal.Update(internalDatabaseCount)
+	s.TableCountExternal.Update(externalTableCount)
+	s.TableCountInternal.Update(internalTableCount)
+	s.UpdatedAt.Update(timeutil.Now().UnixNano())
+
+	return nil
+}

--- a/pkg/testutils/metrictestutils/BUILD.bazel
+++ b/pkg/testutils/metrictestutils/BUILD.bazel
@@ -2,8 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "metrictestutils",
-    srcs = ["metrics_text.go"],
+    srcs = [
+        "metrics_tester.go",
+        "metrics_text.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util/metric"],
+    deps = [
+        "//pkg/testutils",
+        "//pkg/util/metric",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_prometheus_client_model//go",
+        "@com_github_prometheus_common//expfmt",
+    ],
 )

--- a/pkg/testutils/metrictestutils/metrics_tester.go
+++ b/pkg/testutils/metrictestutils/metrics_tester.go
@@ -1,0 +1,228 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metrictestutils
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/errors"
+	prometheus "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// MetricsTester scrapes metrics sources.
+type MetricsTester struct {
+	t            *testing.T
+	sources      []func() string
+	sourceLabels []func(int) *prometheus.LabelPair
+}
+
+// MetricFamilyTester focuses on a single metric name matching any given labels.
+type MetricFamilyTester struct {
+	t             *testing.T
+	parent        *MetricsTester
+	name          string
+	kind          prometheus.MetricType
+	value         func(*prometheus.Metric) float64
+	labelMatchers map[string]func() (string, error)
+}
+
+// MetricValueTester aggregates the matched metric values.
+type MetricValueTester struct {
+	t         *testing.T
+	parent    *MetricFamilyTester
+	aggregate func([]*prometheus.Metric) (*prometheus.Metric, error)
+}
+
+// NewMetricsTester builds a MetricsTester.
+func NewMetricsTester(t *testing.T, sources ...func() string) *MetricsTester {
+	return &MetricsTester{
+		t:       t,
+		sources: sources,
+	}
+}
+
+// LabelingSources specifies an additional prometheus.LabelPair to be added to
+// all the metrics from a source. We can use this when scraping multiple
+// sources to differentiate their metrics.
+func (a *MetricsTester) LabelingSources(
+	name string, valuef func(sourceIdx int) string,
+) *MetricsTester {
+	a.sourceLabels = append(a.sourceLabels, func(sourceIdx int) *prometheus.LabelPair {
+		value := valuef(sourceIdx)
+		return &prometheus.LabelPair{
+			Name:  &name,
+			Value: &value,
+		}
+	})
+	return a
+}
+
+// Gauge selects the named gauge for testing.
+func (a *MetricsTester) Gauge(name string) *MetricFamilyTester {
+	return &MetricFamilyTester{
+		t:      a.t,
+		parent: a,
+		name:   name,
+		kind:   prometheus.MetricType_GAUGE,
+		value: func(m *prometheus.Metric) float64 {
+			return m.GetGauge().GetValue()
+		},
+		labelMatchers: make(map[string]func() (string, error)),
+	}
+}
+
+func (a *MetricsTester) metricFamily(name string) (*prometheus.MetricFamily, error) {
+	var parser expfmt.TextParser
+	result := prometheus.MetricFamily{
+		Name: &name,
+	}
+	for i, source := range a.sources {
+		sourceFamilies, err := parser.TextToMetricFamilies(strings.NewReader(source()))
+		if err != nil {
+			return nil, err
+		}
+		sourceFamily, ok := sourceFamilies[name]
+		if !ok {
+			return nil, errors.Errorf("metric %s not found in source %d: %v", name, i, sourceFamilies)
+		}
+		result.Type = sourceFamily.Type
+		for _, m := range sourceFamily.GetMetric() {
+			for _, sourceLabel := range a.sourceLabels {
+				m.Label = append(m.Label, sourceLabel(i))
+			}
+			result.Metric = append(result.Metric, m)
+		}
+	}
+	return &result, nil
+}
+
+// WithLabel selects only metrics with the given label.
+func (a *MetricFamilyTester) WithLabel(name, value string) *MetricFamilyTester {
+	a.labelMatchers[name] = func() (string, error) {
+		return value, nil
+	}
+	return a
+}
+
+// WithLabelf selects only metrics with the given label, lazily calculating the matching value.
+func (a *MetricFamilyTester) WithLabelf(
+	name string, f func(arg string) (string, error), arg string,
+) *MetricFamilyTester {
+	a.labelMatchers[name] = func() (string, error) {
+		return f(arg)
+	}
+	return a
+}
+
+// Max selects the metric with the largest value in the set.
+func (a *MetricFamilyTester) Max() *MetricValueTester {
+	return &MetricValueTester{
+		t:      a.t,
+		parent: a,
+		aggregate: func(metrics []*prometheus.Metric) (*prometheus.Metric, error) {
+			if len(metrics) == 0 {
+				return nil, errors.Errorf("no metrics selected")
+			}
+			max := metrics[0]
+			for _, m := range metrics {
+				if a.value(m) > a.value(max) {
+					max = m
+				}
+			}
+			return max, nil
+		},
+	}
+}
+
+// Single asserts there is only one metric in the set and selects it.
+func (a *MetricFamilyTester) Single() *MetricValueTester {
+	return &MetricValueTester{
+		t:      a.t,
+		parent: a,
+		aggregate: func(m []*prometheus.Metric) (*prometheus.Metric, error) {
+			if len(m) != 1 {
+				return nil, errors.Errorf("not a single metric: %v", m)
+			}
+			return m[0], nil
+		},
+	}
+}
+
+func (a *MetricFamilyTester) metrics() ([]*prometheus.Metric, error) {
+	family, err := a.parent.metricFamily(a.name)
+	if err != nil {
+		return nil, err
+	}
+	if family.GetType() != a.kind {
+		return nil, errors.Errorf("metric %s is not a %s %v", a.name, a.kind, family)
+	}
+	all := family.GetMetric()
+	var matched []*prometheus.Metric
+nextMetric:
+	for _, m := range all {
+		labels := make(map[string]string, len(m.GetLabel()))
+		for _, label := range m.GetLabel() {
+			labels[label.GetName()] = label.GetValue()
+		}
+		for name, valuef := range a.labelMatchers {
+			expected, err := valuef()
+			if err != nil {
+				a.t.Logf("error calculating expected value for label %s: %v", name, err)
+			}
+			if actual, ok := labels[name]; !ok || expected != actual {
+				continue nextMetric
+			}
+		}
+		matched = append(matched, m)
+	}
+	return matched, nil
+}
+
+// Label accesses the value of the named label for this metric.
+func (a *MetricValueTester) Label(name string) (string, error) {
+	metrics, err := a.parent.metrics()
+	if err != nil {
+		return "", err
+	}
+	m, err := a.aggregate(metrics)
+	if err != nil {
+		return "", err
+	}
+	for _, label := range m.GetLabel() {
+		if label.GetName() == name {
+			return label.GetValue(), nil
+		}
+	}
+	return "", errors.Errorf("no such label %s", name)
+}
+
+// ShouldEventuallyEqual asserts on the aggregated value of this metric, retrying for up to 1 second.
+func (a *MetricValueTester) ShouldEventuallyEqual(expected float64) {
+	testutils.SucceedsWithin(a.t, func() error {
+		metrics, err := a.parent.metrics()
+		if err != nil {
+			return err
+		}
+		m, err := a.aggregate(metrics)
+		if err != nil {
+			return err
+		}
+		value := a.parent.value(m)
+		if value != expected {
+			return errors.Errorf("expected %f but was %f aggregating %v", expected, value, metrics)
+		}
+		return nil
+	}, 1*time.Second)
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1588,6 +1588,23 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "Schema"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Databases",
+				Metrics: []string{"sql.schema.database_count"},
+			},
+			{
+				Title:   "Tables",
+				Metrics: []string{"sql.schema.table_count"},
+			},
+			{
+				Title:   "Updated",
+				Metrics: []string{"sql.schema.updated_at"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "Schema Changer"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
Partially addresses #71573

Previously, we didn't have a way to get these numbers in Cockroach Cloud
without waking up a tenant SQL pod, costing us and our customers money.

Publishing these values as metrics gives us an out-of-band way to see
what they are, but it's not without its challenges:

1. We would like to avoid polling the database for the latest counts:
   it's a fairly heavyweight approach, and new databases and tables
   aren't added all *that* often. So, we instead rely on responding to
   schema changes to update our metrics. This strategy has an inherent
   risk that we'll miss some of the schema change call sites, leading to
   stale metrics.

2. Since any given schema change runs on only one of the SQL pods, the
   others will continue to publish stale values (unless we intervene in
   some way), and we will need some scheme for reconciling them.

As for point 1., our best answer right now, other than catching missing
call sites in code review (see the oss and ccl schema_metrics_test.go
files for the cases we know about), is that tenant SQL pods refresh
their metrics when they start, so even one new pod coming online will
true up the metrics. This isn't a satisfying answer, though, and it may
expose us to longer periods of stale metrics than we're comfortable
with.

For point 2., we publish an `updated_at` metric alongside the counts,
allowing metrics clients to figure out which pod's numbers to trust. The
queries are awkward but manageable, and they're demonstrated in the
tests here. This strategy may be all that we need; should we want
metrics that are easier to work with, we can explore some inter-pod
communication in follow-on work. (An initial attempt was made in an
earlier version of this work, but it ran into trouble trying to make RPC
calls too early in the server startup lifecycle.) It is perhaps true
that, given the potential fallibility of pod-to-pod communication, we
will need to depend on this `updated_at` metric anyway.

It's additionally worth noting that we segment both the `database_count`
and `table_count` metrics by an `internal` label, carrying the (string)
value of either `"true"` or `"false"`, since our customers may not care
to count, e.g., the `system` database and its tables in their cluster
overview.

Release note (api change): We publish three new metrics,
`sql.schema.database_count`, `sql.schema.table_count`, and
`sql.schema.updated_at`, carrying the counts of databases and tables in
the cluster.