### PR TITLE
tracing: remove SetOperationName

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -742,9 +742,9 @@ func (r *Replica) executeAdminBatch(
 	}
 
 	args := ba.Requests[0].GetInner()
-	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		sp.SetOperationName(reflect.TypeOf(args).String())
-	}
+
+	ctx, sp := tracing.EnsureChildSpan(ctx, r.AmbientContext.Tracer, reflect.TypeOf(args).String())
+	defer sp.Finish()
 
 	// Verify that the batch can be executed, which includes verifying that the
 	// current replica has the range lease.

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -36,6 +36,7 @@ type crdbSpan struct {
 	spanID       tracingpb.SpanID  // probabilistically unique
 	parentSpanID tracingpb.SpanID
 	goroutineID  uint64
+	operation    string // name of operation associated with the span
 
 	startTime time.Time
 
@@ -69,8 +70,7 @@ type crdbSpanMu struct {
 
 	finished bool
 	// duration is initialized to -1 and set on Finish().
-	duration  time.Duration
-	operation string // name of operation associated with the span
+	duration time.Duration
 
 	recording struct {
 		// recordingType is the recording type of the ongoing recording, if any.
@@ -490,7 +490,7 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		SpanID:         s.spanID,
 		ParentSpanID:   s.parentSpanID,
 		GoroutineID:    s.goroutineID,
-		Operation:      s.mu.operation,
+		Operation:      s.operation,
 		StartTime:      s.startTime,
 		Duration:       s.mu.duration,
 		RedactableLogs: true,

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -74,14 +74,6 @@ func (sp *Span) Tracer() *Tracer {
 	return sp.i.Tracer()
 }
 
-// SetOperationName sets the name of the operation.
-func (sp *Span) SetOperationName(operationName string) {
-	if sp.done() {
-		return
-	}
-	sp.i.SetOperationName(operationName)
-}
-
 // Finish idempotently marks the Span as completed (at which point it will
 // silently drop any new data added to it). Finishing a nil *Span is a noop.
 func (sp *Span) Finish() {
@@ -220,6 +212,18 @@ func (sp *Span) SetTag(key string, value attribute.Value) {
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {
 	return sp.i.TraceID()
+}
+
+// OperationName returns the name of this span assigned when the span was
+// created.
+func (sp *Span) OperationName() string {
+	if sp == nil {
+		return "<nil>"
+	}
+	if sp.IsNoop() {
+		return "noop"
+	}
+	return sp.i.crdb.operation
 }
 
 // IsSterile returns true if this span does not want to have children spans. In

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -135,19 +135,6 @@ func (s *spanInner) Meta() SpanMeta {
 	}
 }
 
-func (s *spanInner) SetOperationName(operationName string) *spanInner {
-	if s.isNoop() {
-		return s
-	}
-	if s.otelSpan != nil {
-		s.otelSpan.SetName(operationName)
-	}
-	s.crdb.mu.Lock()
-	s.crdb.mu.operation = operationName
-	s.crdb.mu.Unlock()
-	return s
-}
-
 func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
 	if s.isNoop() {
 		return s

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -30,6 +30,17 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+func TestStartSpan(t *testing.T) {
+	tr := NewTracer()
+	sp := tr.StartSpan("test")
+	defer sp.Finish()
+	require.Equal(t, "noop", sp.OperationName())
+
+	sp2 := tr.StartSpan("test", WithRecording(RecordingStructured))
+	defer sp2.Finish()
+	require.Equal(t, "test", sp2.OperationName())
+}
+
 func TestRecordingString(t *testing.T) {
 	tr := NewTracer()
 	tr2 := NewTracer()

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -708,7 +708,7 @@ func (t *Tracer) startSpanGeneric(
 			tags:     helper.tagsAlloc[:0],
 		},
 	}
-	helper.crdbSpan.mu.operation = opName
+	helper.crdbSpan.operation = opName
 	helper.crdbSpan.mu.recording.logs = makeSizeLimitedBuffer(maxLogBytesPerSpan, nil /* scratch */)
 	helper.crdbSpan.mu.recording.structured = makeSizeLimitedBuffer(maxStructuredBytesPerSpan, helper.structuredEventsAlloc[:])
 	helper.crdbSpan.mu.recording.openChildren = helper.childrenAlloc[:0]


### PR DESCRIPTION
This method was barely used. Because of it, the span's name had to be
treated as mutable and protected by the span's mutex. That's a
complication that's not worth it. In particular, I want to start
exporting the span's name and use it in assertions in places where it's
unclear whether that mutex can be taken. I'd rather make the name
immutable and avoid headaches.

Release note: None