### PR TITLE
kv: improve a test

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -892,7 +892,7 @@ func TestRangeCacheHandleDoubleSplit(t *testing.T) {
 					var desc *roachpb.RangeDescriptor
 					// Each request goes to a different key.
 					var err error
-					ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tracing.NewTracer(), "test")
+					ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, db.cache.tracer, "test")
 					defer getRecAndFinish()
 					tok, err := db.cache.lookupInternal(
 						ctx, key, oldToken,

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -208,7 +208,7 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	startTS := db.Clock().Now()
 	rangefeedCtx, rangefeedCancel := context.WithCancel(ctx)
 	rangefeedCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(rangefeedCtx,
-		tracing.NewTracer(),
+		tc.Server(1).TracerI().(*tracing.Tracer),
 		"rangefeed over non-voter")
 	defer getRecAndFinish()
 

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -341,6 +341,7 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 	for _, s := range tc.Servers {
 		store, err := s.Stores().GetStore(s.GetFirstStoreID())
 		require.NoError(t, err)
+		tracer := s.Tracer()
 		g.Go(func() error {
 			// Prime range cache so that follower read attempts don't initially miss.
 			if _, err := store.DB().Scan(ctx, keySpan.Key, keySpan.EndKey, 0); err != nil {
@@ -381,8 +382,7 @@ func testTxnNegotiateAndSendDoesNotBlock(t *testing.T, multiRange, strict, route
 					// Trace the request so we can determine whether it was served as a
 					// follower read. If running on a store with a follower replica and
 					// with a NEAREST routing policy, we expect follower reads.
-					ctx, collectAndFinish := tracing.ContextWithRecordingSpan(
-						ctx, tracing.NewTracer(), "reader")
+					ctx, collectAndFinish := tracing.ContextWithRecordingSpan(ctx, tracer, "reader")
 					defer collectAndFinish()
 
 					br, pErr := txn.NegotiateAndSend(ctx, ba)


### PR DESCRIPTION
This test was mixing a new tracer with a server that was using its own
tracer. Mixing tracers like this in a single trace will not be supported
any more.

Release note: None