### PR TITLE
ui: save filters on cache for Statements page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -27,6 +27,7 @@ export * from "./loading";
 export * from "./modal";
 export * from "./pageConfig";
 export * from "./pagination";
+export * from "./queryFilter";
 export * from "./search";
 export * from "./sortedtable";
 export * from "./statementsDiagnostics";

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -271,6 +271,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount"
   },
+  filters: {
+    app: "",
+    timeNumber: "0",
+    timeUnit: "seconds",
+    fullScan: false,
+    sqlType: "",
+    database: "",
+    regions: "",
+    nodes: "",
+  },
   statements: [
     {
       label:
@@ -743,6 +753,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onDiagnosticsReportDownload: noop,
   onColumnsChange: noop,
   onSortingChange: noop,
+  onFilterChange: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -245,3 +245,8 @@ export const selectSortSetting = createSelector(
   localStorageSelector,
   localStorage => localStorage["sortSetting/StatementsPage"],
 );
+
+export const selectFilters = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["filters/StatementsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { isNil, merge } from "lodash";
+import { isNil, merge, isEqual } from "lodash";
 import moment, { Moment } from "moment";
 import classNames from "classnames/bind";
 import { Loading } from "src/loading";
@@ -30,11 +30,9 @@ import {
 } from "../queryFilter";
 
 import {
-  appAttr,
   calculateTotalWorkload,
   unique,
   containAny,
-  queryByName,
   syncHistory,
 } from "src/util";
 import {
@@ -90,7 +88,7 @@ export interface StatementsPageDispatchProps {
     ascending: boolean,
   ) => void;
   onDiagnosticsReportDownload?: (report: IStatementDiagnosticsReport) => void;
-  onFilterChange?: (value: string) => void;
+  onFilterChange?: (value: Filters) => void;
   onStatementClick?: (statement: string) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
   onDateRangeChange: (start: Moment, end: Moment) => void;
@@ -107,6 +105,7 @@ export interface StatementsPageStateProps {
   columns: string[];
   nodeRegions: { [key: string]: string };
   sortSetting: SortSetting;
+  filters: Filters;
   isTenant?: UIConfigState["isTenant"];
 }
 
@@ -138,36 +137,28 @@ export class StatementsPage extends React.Component<
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
   constructor(props: StatementsPageProps) {
     super(props);
-    const filters = getFiltersFromQueryString(
-      this.props.history.location.search,
-    );
     const defaultState = {
       pagination: {
         pageSize: 20,
         current: 1,
       },
       search: "",
-      filters: filters,
-      activeFilters: calculateActiveFilters(filters),
     };
-
     const stateFromHistory = this.getStateFromHistory();
     this.state = merge(defaultState, stateFromHistory);
     this.activateDiagnosticsRef = React.createRef();
   }
 
-  static defaultProps: Partial<StatementsPageProps> = {
-    isTenant: false,
-  };
-
   getStateFromHistory = (): Partial<StatementsPageState> => {
-    const { history } = this.props;
+    const { history, sortSetting, filters } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
+
+    // Search query.
     const searchQuery = searchParams.get("q") || undefined;
+
+    // Sort Settings.
     const ascending = (searchParams.get("ascending") || undefined) === "true";
     const columnTitle = searchParams.get("columnTitle") || undefined;
-    const sortSetting = this.props.sortSetting;
-
     if (
       this.props.onSortingChange &&
       columnTitle &&
@@ -177,8 +168,45 @@ export class StatementsPage extends React.Component<
       this.props.onSortingChange("Statements", columnTitle, ascending);
     }
 
+    // Filters.
+    const filtersQueryString = getFiltersFromQueryString(
+      history.location.search,
+    );
+    const hasFilter = searchParams.get("app") || undefined;
+    if (
+      this.props.onFilterChange &&
+      hasFilter &&
+      !isEqual(filtersQueryString, filters)
+    ) {
+      // If we have filters on query string and they're different
+      // from the current filter state on props (localStorage),
+      // we want to update the value on localStorage.
+      this.props.onFilterChange(filtersQueryString);
+    } else if (!isEqual(filters, defaultFilters)) {
+      // If the filters on props (localStorage) are different
+      // from the default values, we want to update the History,
+      // so the url can be easily shared with the filters selected.
+      syncHistory(
+        {
+          app: filters.app,
+          timeNumber: filters.timeNumber,
+          timeUnit: filters.timeUnit,
+          sqlType: filters.sqlType,
+          database: filters.database,
+          regions: filters.regions,
+          nodes: filters.nodes,
+        },
+        this.props.history,
+      );
+    }
+    // If we have a new filter selection on query params, they
+    // take precedent on what is stored on localStorage.
+    const latestFilter = hasFilter ? filtersQueryString : filters;
+
     return {
       search: searchQuery,
+      filters: latestFilter,
+      activeFilters: calculateActiveFilters(latestFilter),
     };
   };
 
@@ -232,10 +260,47 @@ export class StatementsPage extends React.Component<
     }
   }
 
+  // When we change tabs inside the SQL Activity page,
+  // the constructor is called only on the first time.
+  // The component update event is called frequently
+  // and can be used to update the query params by using
+  // this function that makes sure it's only updating
+  // if the values did change and we're on the correct
+  // tab (Statements).
+  updateQueryParamsOnTabSwitch(): void {
+    const { filters } = this.state;
+    const filtersQueryString = getFiltersFromQueryString(
+      this.props.history.location.search,
+    );
+    const searchParams = new URLSearchParams(
+      this.props.history.location.search,
+    );
+    const tab = searchParams.get("tab") || "";
+    if (
+      tab === "Statements" &&
+      !isEqual(filters, defaultFilters) &&
+      !isEqual(filters, filtersQueryString)
+    ) {
+      syncHistory(
+        {
+          app: filters.app,
+          timeNumber: filters.timeNumber,
+          timeUnit: filters.timeUnit,
+          sqlType: filters.sqlType,
+          database: filters.database,
+          regions: filters.regions,
+          nodes: filters.nodes,
+        },
+        this.props.history,
+      );
+    }
+  }
+
   componentDidUpdate = (
     __: StatementsPageProps,
     prevState: StatementsPageState,
   ): void => {
+    this.updateQueryParamsOnTabSwitch();
     if (this.state.search && this.state.search !== prevState.search) {
       this.props.onSearchComplete(this.filteredStatementsData());
     }
@@ -267,11 +332,12 @@ export class StatementsPage extends React.Component<
   };
 
   onSubmitFilters = (filters: Filters): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(filters);
+    }
+
     this.setState({
-      filters: {
-        ...this.state.filters,
-        ...filters,
-      },
+      filters: filters,
       activeFilters: calculateActiveFilters(filters),
     });
 
@@ -301,12 +367,15 @@ export class StatementsPage extends React.Component<
   };
 
   onClearFilters = (): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(defaultFilters);
+    }
+
     this.setState({
-      filters: {
-        ...defaultFilters,
-      },
+      filters: defaultFilters,
       activeFilters: 0,
     });
+
     this.resetPagination();
     syncHistory(
       {
@@ -353,9 +422,7 @@ export class StatementsPage extends React.Component<
         statement =>
           databases.length == 0 || databases.includes(statement.database),
       )
-      .filter(statement =>
-        this.state.filters.fullScan ? statement.fullScan : true,
-      )
+      .filter(statement => (filters.fullScan ? statement.fullScan : true))
       .filter(statement =>
         search
           .split(" ")
@@ -411,7 +478,6 @@ export class StatementsPage extends React.Component<
       statements,
       apps,
       databases,
-      location,
       onDiagnosticsReportDownload,
       onStatementClick,
       resetSQLStats,
@@ -421,8 +487,6 @@ export class StatementsPage extends React.Component<
       isTenant,
       sortSetting,
     } = this.props;
-    const appAttrValue = queryByName(location, appAttr);
-    const selectedApp = appAttrValue || "";
     const data = this.filteredStatementsData();
     const totalWorkload = calculateTotalWorkload(data);
     const totalCount = data.length;
@@ -444,7 +508,7 @@ export class StatementsPage extends React.Component<
     // hiding columns that won't be displayed for tenants.
     const columns = makeStatementsColumns(
       statements,
-      selectedApp,
+      filters.app,
       totalWorkload,
       nodeRegions,
       "statement",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -35,6 +35,7 @@ import {
   selectColumns,
   selectDateRange,
   selectSortSetting,
+  selectFilters,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { AggregateStatistics } from "../statementsTable";
@@ -59,6 +60,7 @@ export const ConnectedStatementsPage = withRouter(
       dateRange: selectDateRange(state),
       sortSetting: selectSortSetting(state),
       isTenant: selectIsTenant(state),
+      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>
@@ -108,15 +110,22 @@ export const ConnectedStatementsPage = withRouter(
             page: "Statements",
           }),
         ),
-      onFilterChange: value =>
+      onFilterChange: value => {
         dispatch(
           analyticsActions.track({
             name: "Filter Clicked",
             page: "Statements",
             filterName: "app",
-            value,
+            value: value.toString(),
           }),
-        ),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "filters/StatementsPage",
+            value: { filters: value },
+          }),
+        );
+      },
       onSortingChange: (
         tableName: string,
         columnName: string,

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -11,6 +11,7 @@
 import moment from "moment";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../utils";
+import { defaultFilters, Filters } from "../../queryFilter";
 
 type StatementsDateRangeState = {
   start: number;
@@ -30,6 +31,7 @@ export type LocalStorageState = {
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
+  "filters/StatementsPage": Filters;
 };
 
 type Payload = {
@@ -76,6 +78,9 @@ const initialState: LocalStorageState = {
   "sortSetting/SessionsPage":
     JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
     defaultSessionsSortSetting,
+  "filters/StatementsPage":
+    JSON.parse(localStorage.getItem("filters/StatementsPage")) ||
+    defaultFilters,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -184,6 +184,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount",
   },
+  filters: {
+    app: "",
+    timeNumber: "0",
+    timeUnit: "seconds",
+    fullScan: false,
+    sqlType: "",
+    database: "",
+    regions: "",
+    nodes: "",
+  },
   columns: null,
   match: {
     path: "/statements",

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -36,7 +36,12 @@ import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { statementsDateRangeLocalSetting } from "src/redux/statementsDateRange";
 import { queryByName } from "src/util/query";
 
-import { StatementsPage, AggregateStatistics } from "@cockroachlabs/cluster-ui";
+import {
+  StatementsPage,
+  AggregateStatistics,
+  Filters,
+  defaultFilters,
+} from "@cockroachlabs/cluster-ui";
 import {
   createOpenDiagnosticsModalAction,
   createStatementDiagnosticsReportAction,
@@ -240,6 +245,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const filtersLocalSetting = new LocalSetting(
+  "filters/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  defaultFilters,
+);
+
 export default withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
@@ -253,6 +264,7 @@ export default withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       dateRange: selectDateRange(state),
       sortSetting: sortSettingLocalSetting.selector(state),
+      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshStatements: refreshStatements,
@@ -275,6 +287,7 @@ export default withRouter(
           ascending: ascending,
           columnTitle: columnName,
         }),
+      onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
       onDiagnosticsReportDownload: (report: IStatementDiagnosticsReport) =>
         trackDownloadDiagnosticsBundleAction(report.statement_fingerprint),
       // We use `null` when the value was never set and it will show all columns.


### PR DESCRIPTION
Previously, a sort selection was not maintained when
the page change (e.g. coming back from Statement details).
This commits saves the selected value to be used.

Partially adresses #71851

Showing behaviour: https://www.loom.com/share/681ca9d80f7145faa111b6aacab417f9

Release note: None