### PR TITLE
sql: improve some tests

### DIFF
--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -106,7 +106,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 	// Make a db with a short heartbeat interval, so that the aborted txn finds
 	// out quickly.
-	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	ambient := log.AmbientContext{Tracer: s.TracerI().(*tracing.Tracer)}
 	tsf := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
 			AmbientCtx: ambient,

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -738,7 +738,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	const biIndex = 1
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
-	tracer := tracing.NewTracer()
+	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1112,7 +1112,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	defer tempEngine.Close()
 
 	// Run the flow in a verbose trace so that we can test for tracing info.
-	tracer := tracing.NewTracer()
+	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -321,7 +321,7 @@ func TestTableReaderDrain(t *testing.T) {
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
 	// Run the flow in a verbose trace so that we can test for tracing info.
-	tracer := tracing.NewTracer()
+	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	st := s.ClusterSettings()
@@ -400,7 +400,7 @@ func TestLimitScans(t *testing.T) {
 	post := execinfrapb.PostProcessSpec{Limit: limit}
 
 	// Now we're going to run the tableReader and trace it.
-	tracer := tracing.NewTracer()
+	tracer := s.TracerI().(*tracing.Tracer)
 	sp := tracer.StartSpan("root", tracing.WithRecording(tracing.RecordingVerbose))
 	ctx = tracing.ContextWithSpan(ctx, sp)
 	flowCtx.EvalCtx.Context = ctx

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -575,7 +575,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	td := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t").TableDesc()
 
 	// Run the flow in a verbose trace so that we can test for tracing info.
-	tracer := tracing.NewTracer()
+	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracing.StartVerboseTrace(context.Background(), tracer, "test flow ctx")
 	defer sp.Finish()
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())


### PR DESCRIPTION
These tests were using a new tracer to trace operations that were going
into a Server. The Server has its own tracer that it uses. Combining
spans created by two tracers into a single trace like this is fairly
broken (spans can leak because it's not clear what registry they belong
to), and will be prohibited.

Release note: None