### PR TITLE
release-21.2: save sort on cache for Statement, Transaction and Session

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -158,9 +158,14 @@ export const sessionsPagePropsFixture: SessionsPageProps = {
   },
   sessions: sessionsList,
   sessionsError: null,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "statementAge",
+  },
   refreshSessions: () => {},
   cancelSession: (req: CancelSessionRequestMessage) => {},
   cancelQuery: (req: CancelQueryRequestMessage) => {},
+  onSortingChange: () => {},
 };
 
 export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
@@ -179,7 +184,12 @@ export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
   },
   sessions: [],
   sessionsError: null,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "statementAge",
+  },
   refreshSessions: () => {},
   cancelSession: (req: CancelSessionRequestMessage) => {},
   cancelQuery: (req: CancelQueryRequestMessage) => {},
+  onSortingChange: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { isNil, merge } from "lodash";
+import { isNil } from "lodash";
 
 import { syncHistory } from "src/util/query";
 import { appAttr } from "src/util/constants";
@@ -51,19 +51,23 @@ const sessionsPageCx = classNames.bind(sessionPageStyles);
 export interface OwnProps {
   sessions: SessionInfo[];
   sessionsError: Error | Error[];
+  sortSetting: SortSetting;
   refreshSessions: () => void;
   cancelSession: (payload: ICancelSessionRequest) => void;
   cancelQuery: (payload: ICancelQueryRequest) => void;
   isCloud?: boolean;
   onPageChanged?: (newPage: number) => void;
-  onSortingChange?: (columnName: string) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
   onSessionClick?: () => void;
   onTerminateSessionClick?: () => void;
   onTerminateStatementClick?: () => void;
 }
 
 export interface SessionsPageState {
-  sortSetting: SortSetting;
   pagination: ISortedTablePagination;
 }
 
@@ -78,45 +82,35 @@ export class SessionsPage extends React.Component<
 
   constructor(props: SessionsPageProps) {
     super(props);
-    const defaultState = {
-      sortSetting: {
-        // Sort by Statement Age column as default option.
-        ascending: false,
-        columnTitle: "statementAge",
-      },
+    this.state = {
       pagination: {
         pageSize: 20,
         current: 1,
       },
     };
-
-    const stateFromHistory = this.getStateFromHistory();
-    this.state = merge(defaultState, stateFromHistory);
     this.terminateSessionRef = React.createRef();
     this.terminateQueryRef = React.createRef();
-  }
 
-  getStateFromHistory = (): Partial<SessionsPageState> => {
     const { history } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
-    const ascending = searchParams.get("ascending") || undefined;
+    const ascending = (searchParams.get("ascending") || undefined) === "true";
     const columnTitle = searchParams.get("columnTitle") || undefined;
+    const sortSetting = this.props.sortSetting;
 
-    return {
-      sortSetting: {
-        ascending: ascending === "true",
-        columnTitle: columnTitle,
-      },
-    };
-  };
+    if (
+      this.props.onSortingChange &&
+      columnTitle &&
+      (sortSetting.columnTitle != columnTitle ||
+        sortSetting.ascending != ascending)
+    ) {
+      this.props.onSortingChange("Sessions", columnTitle, ascending);
+    }
+  }
 
   changeSortSetting = (ss: SortSetting): void => {
-    const { onSortingChange } = this.props;
-    onSortingChange && onSortingChange(ss.columnTitle);
-
-    this.setState({
-      sortSetting: ss,
-    });
+    if (this.props.onSortingChange) {
+      this.props.onSortingChange("Sessions", ss.columnTitle, ss.ascending);
+    }
 
     syncHistory(
       {
@@ -142,7 +136,7 @@ export class SessionsPage extends React.Component<
     this.props.refreshSessions();
   }
 
-  componentDidUpdate = (__: SessionsPageProps, _: SessionsPageState): void => {
+  componentDidUpdate = (): void => {
     this.props.refreshSessions();
   };
 
@@ -194,7 +188,7 @@ export class SessionsPage extends React.Component<
                 }
               />
             }
-            sortSetting={this.state.sortSetting}
+            sortSetting={this.props.sortSetting}
             onChangeSortSetting={this.changeSortSetting}
             pagination={pagination}
           />

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -267,6 +267,10 @@ const statementsPagePropsFixture: StatementsPageProps = {
     "3": "gcp-us-west1",
     "4": "gcp-europe-west1",
   },
+  sortSetting: {
+    ascending: false,
+    columnTitle: "executionCount"
+  },
   statements: [
     {
       label:
@@ -686,6 +690,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onSearchComplete: noop,
   onDiagnosticsReportDownload: noop,
   onColumnsChange: noop,
+  onSortingChange: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -237,3 +237,8 @@ export const selectDateRange = createSelector(
       Moment,
     ],
 );
+
+export const selectSortSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["sortSetting/StatementsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -37,10 +37,10 @@ describe("StatementsPage", () => {
       const statementsPageInstance = statementsPageWrapper.instance();
 
       assert.equal(
-        statementsPageInstance.state.sortSetting.columnTitle,
+        statementsPageInstance.props.sortSetting.columnTitle,
         "executionCount",
       );
-      assert.equal(statementsPageInstance.state.sortSetting.ascending, false);
+      assert.equal(statementsPageInstance.props.sortSetting.ascending, false);
     });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -34,6 +34,7 @@ import {
   selectTotalFingerprints,
   selectColumns,
   selectDateRange,
+  selectSortSetting,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { AggregateStatistics } from "../statementsTable";
@@ -55,8 +56,9 @@ export const ConnectedStatementsPage = withRouter(
       lastReset: selectLastReset(state),
       columns: selectColumns(state),
       nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
-      isTenant: selectIsTenant(state),
       dateRange: selectDateRange(state),
+      sortSetting: selectSortSetting(state),
+      isTenant: selectIsTenant(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>
@@ -115,7 +117,11 @@ export const ConnectedStatementsPage = withRouter(
             value,
           }),
         ),
-      onSortingChange: (tableName: string, columnName: string) =>
+      onSortingChange: (
+        tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) => {
         dispatch(
           analyticsActions.track({
             name: "Column Sorted",
@@ -123,7 +129,14 @@ export const ConnectedStatementsPage = withRouter(
             tableName,
             columnName,
           }),
-        ),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "sortSetting/StatementsPage",
+            value: { columnTitle: columnName, ascending: ascending },
+          }),
+        );
+      },
       onStatementClick: () =>
         dispatch(
           analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -29,6 +29,7 @@ export type LocalStorageState = {
   "dateRange/StatementsPage": StatementsDateRangeState;
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
+  "sortSetting/SessionsPage": SortSetting;
 };
 
 type Payload = {
@@ -49,6 +50,11 @@ const defaultSortSetting: SortSetting = {
   columnTitle: "executionCount",
 };
 
+const defaultSessionsSortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "statementAge",
+};
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
@@ -67,6 +73,9 @@ const initialState: LocalStorageState = {
   "sortSetting/TransactionsPage":
     JSON.parse(localStorage.getItem("sortSetting/TransactionsPage")) ||
     defaultSortSetting,
+  "sortSetting/SessionsPage":
+    JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
+    defaultSessionsSortSetting,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -28,6 +28,7 @@ export type LocalStorageState = {
   "showColumns/TransactionPage": string;
   "dateRange/StatementsPage": StatementsDateRangeState;
   "sortSetting/StatementsPage": SortSetting;
+  "sortSetting/TransactionsPage": SortSetting;
 };
 
 type Payload = {
@@ -62,6 +63,9 @@ const initialState: LocalStorageState = {
     defaultDateRange,
   "sortSetting/StatementsPage":
     JSON.parse(localStorage.getItem("sortSetting/StatementsPage")) ||
+    defaultSortSetting,
+  "sortSetting/TransactionsPage":
+    JSON.parse(localStorage.getItem("sortSetting/TransactionsPage")) ||
     defaultSortSetting,
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -17,11 +17,17 @@ type StatementsDateRangeState = {
   end: number;
 };
 
+type SortSetting = {
+  ascending: boolean;
+  columnTitle: string;
+};
+
 export type LocalStorageState = {
   "adminUi/showDiagnosticsModal": boolean;
   "showColumns/StatementsPage": string;
   "showColumns/TransactionPage": string;
   "dateRange/StatementsPage": StatementsDateRangeState;
+  "sortSetting/StatementsPage": SortSetting;
 };
 
 type Payload = {
@@ -37,6 +43,11 @@ const defaultDateRange: StatementsDateRangeState = {
   end: moment.utc().unix() + 60, // Add 1 minute to account for potential lag.
 };
 
+const defaultSortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "executionCount",
+};
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
@@ -49,6 +60,9 @@ const initialState: LocalStorageState = {
   "dateRange/StatementsPage":
     JSON.parse(localStorage.getItem("dateRange/StatementsPage")) ||
     defaultDateRange,
+  "sortSetting/StatementsPage":
+    JSON.parse(localStorage.getItem("sortSetting/StatementsPage")) ||
+    defaultSortSetting,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -13,6 +13,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
 import moment from "moment";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { SortSetting } from "../sortedtable";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -46,6 +47,11 @@ export const dateRange: [moment.Moment, moment.Moment] = [
 export const timestamp = new protos.google.protobuf.Timestamp({
   seconds: new Long(Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3),
 });
+
+export const sortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "executionCount",
+};
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {
   statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -40,3 +40,8 @@ export const selectTxnColumns = createSelector(
       ? localStorage["showColumns/TransactionPage"].split(",")
       : null,
 );
+
+export const selectSortSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["sortSetting/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -17,6 +17,7 @@ import {
   nodeRegions,
   routeProps,
   dateRange,
+  sortSetting,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -38,6 +39,8 @@ storiesOf("Transactions Page", module)
       nodeRegions={nodeRegions}
       refreshData={noop}
       resetSQLStats={noop}
+      sortSetting={sortSetting}
+      onSortingChange={noop}
     />
   ))
   .add("without data", () => {
@@ -49,6 +52,8 @@ storiesOf("Transactions Page", module)
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -68,6 +73,8 @@ storiesOf("Transactions Page", module)
         refreshData={noop}
         history={history}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -80,6 +87,8 @@ storiesOf("Transactions Page", module)
         nodeRegions={nodeRegions}
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   })
@@ -99,6 +108,8 @@ storiesOf("Transactions Page", module)
         }
         refreshData={noop}
         resetSQLStats={noop}
+        sortSetting={sortSetting}
+        onSortingChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -68,7 +68,6 @@ type Timestamp = protos.google.protobuf.ITimestamp;
 const cx = classNames.bind(styles);
 
 interface TState {
-  sortSetting: SortSetting;
   pagination: ISortedTablePagination;
   search?: string;
   filters?: Filters;
@@ -86,6 +85,7 @@ export interface TransactionsPageStateProps {
   pageSize?: number;
   isTenant?: UIConfigState["isTenant"];
   columns: string[];
+  sortSetting: SortSetting;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -93,6 +93,11 @@ export interface TransactionsPageDispatchProps {
   resetSQLStats: () => void;
   onDateRangeChange?: (start: Moment, end: Moment) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
@@ -112,6 +117,42 @@ export class TransactionsPage extends React.Component<
   TransactionsPageProps,
   TState
 > {
+  constructor(props: TransactionsPageProps) {
+    super(props);
+    const filters = getFiltersFromQueryString(
+      this.props.history.location.search,
+    );
+
+    const trxSearchParams = getSearchParams(this.props.history.location.search);
+    this.state = {
+      pagination: {
+        pageSize: this.props.pageSize || 20,
+        current: 1,
+      },
+      search: trxSearchParams("q", "").toString(),
+      filters: filters,
+      aggregatedTs: null,
+      statementFingerprintIds: null,
+      transactionStats: null,
+      transactionFingerprintId: null,
+    };
+
+    const ascending = trxSearchParams("ascending", false).toString() === "true";
+    const columnTitle = trxSearchParams("columnTitle", undefined);
+    if (
+      this.props.onSortingChange &&
+      columnTitle &&
+      (this.props.sortSetting.columnTitle != columnTitle ||
+        this.props.sortSetting.ascending != ascending)
+    ) {
+      this.props.onSortingChange(
+        "Transactions",
+        columnTitle.toString(),
+        ascending,
+      );
+    }
+  }
+
   static defaultProps: Partial<TransactionsPageProps> = {
     isTenant: false,
   };
@@ -152,9 +193,6 @@ export class TransactionsPage extends React.Component<
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {
-    this.setState({
-      sortSetting: ss,
-    });
     syncHistory(
       {
         ascending: ss.ascending.toString(),
@@ -162,6 +200,9 @@ export class TransactionsPage extends React.Component<
       },
       this.props.history,
     );
+    if (this.props.onSortingChange) {
+      this.props.onSortingChange("Transactions", ss.columnTitle, ss.ascending);
+    }
   };
 
   onChangePage = (current: number): void => {
@@ -283,6 +324,7 @@ export class TransactionsPage extends React.Component<
               isTenant,
               onColumnsChange,
               columns: userSelectedColumnsToShow,
+              sortSetting,
             } = this.props;
             const { pagination, search, filters } = this.state;
             const { statements, internal_app_name_prefix } = data;
@@ -434,7 +476,7 @@ export class TransactionsPage extends React.Component<
                   <TransactionsTable
                     columns={displayColumns}
                     transactions={transactionsToDisplay}
-                    sortSetting={this.state.sortSetting}
+                    sortSetting={sortSetting}
                     onChangeSortSetting={this.onChangeSortSetting}
                     pagination={pagination}
                     renderNoResult={

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -26,12 +26,14 @@ import {
   selectTransactionsData,
   selectTransactionsLastError,
   selectTxnColumns,
+  selectSortSetting,
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
+import { actions as analyticsActions } from "../store/analytics";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -46,6 +48,7 @@ export const TransactionsPageConnected = withRouter(
       isTenant: selectIsTenant(state),
       dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
+      sortSetting: selectSortSetting(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -71,6 +74,18 @@ export const TransactionsPageConnected = withRouter(
               selectedColumns.length === 0 ? " " : selectedColumns.join(","),
           }),
         ),
+      onSortingChange: (
+        tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) => {
+        dispatch(
+          localStorageActions.update({
+            key: "sortSetting/TransactionsPage",
+            value: { columnTitle: columnName, ascending: ascending },
+          }),
+        );
+      },
     }),
   )(TransactionsPage),
 );

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
@@ -12,6 +12,7 @@ import { Pick } from "src/util/pick";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { AdminUIState } from "src/redux/state";
+import { LocalSetting } from "src/redux/localsettings";
 import { CachedDataReducerState, refreshSessions } from "src/redux/apiReducers";
 
 import { createSelector } from "reselect";
@@ -41,16 +42,32 @@ export const selectSessions = createSelector(
   },
 );
 
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/SessionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "statementAge" },
+);
+
 const SessionsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
       sessions: selectSessions(state, props),
       sessionsError: state.cachedData.sessions.lastError,
+      sortSetting: sortSettingLocalSetting.selector(state),
     }),
     {
       refreshSessions,
       cancelSession: terminateSessionAction,
       cancelQuery: terminateQueryAction,
+      onSortingChange: (
+        _tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) =>
+        sortSettingLocalSetting.set({
+          ascending: ascending,
+          columnTitle: columnName,
+        }),
     },
   )(SessionsPage),
 );

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -180,6 +180,10 @@ const statementsPagePropsFixture: StatementsPageProps = {
     "3": "gcp-us-west1",
     "4": "gcp-europe-west1",
   },
+  sortSetting: {
+    ascending: false,
+    columnTitle: "executionCount",
+  },
   columns: null,
   match: {
     path: "/statements",

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -46,7 +46,6 @@ import {
   trackDownloadDiagnosticsBundleAction,
   trackStatementsPaginationAction,
   trackStatementsSearchAction,
-  trackTableSortAction,
 } from "src/redux/analyticsActions";
 import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { LocalSetting } from "src/redux/localsettings";
@@ -232,18 +231,25 @@ export const statementColumnsLocalSetting = new LocalSetting(
   null,
 );
 
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "executionCount" },
+);
+
 export default withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
       statements: selectStatements(state, props),
       statementsError: state.cachedData.statements.lastError,
-      dateRange: selectDateRange(state),
       apps: selectApps(state),
       databases: selectDatabases(state),
       totalFingerprints: selectTotalFingerprints(state),
       lastReset: selectLastReset(state),
       columns: statementColumnsLocalSetting.selectorToArray(state),
       nodeRegions: nodeRegionsByIDSelector(state),
+      dateRange: selectDateRange(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
     }),
     {
       refreshStatements: refreshStatements,
@@ -257,7 +263,15 @@ export default withRouter(
       onSearchComplete: (results: AggregateStatistics[]) =>
         trackStatementsSearchAction(results.length),
       onPageChanged: trackStatementsPaginationAction,
-      onSortingChange: trackTableSortAction,
+      onSortingChange: (
+        _tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) =>
+        sortSettingLocalSetting.set({
+          ascending: ascending,
+          columnTitle: columnName,
+        }),
       onDiagnosticsReportDownload: (report: IStatementDiagnosticsReport) =>
         trackDownloadDiagnosticsBundleAction(report.statement_fingerprint),
       // We use `null` when the value was never set and it will show all columns.

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -62,6 +62,12 @@ export const selectDateRange = createSelector(
   },
 );
 
+export const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "executionCount" },
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -78,6 +84,7 @@ const TransactionsPageConnected = withRouter(
       error: selectLastError(state),
       nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
     }),
     {
       refreshData: refreshStatements,
@@ -91,6 +98,15 @@ const TransactionsPageConnected = withRouter(
         transactionColumnsLocalSetting.set(
           value.length === 0 ? " " : value.join(","),
         ),
+      onSortingChange: (
+        _tableName: string,
+        columnName: string,
+        ascending: boolean,
+      ) =>
+        sortSettingLocalSetting.set({
+          ascending: ascending,
+          columnTitle: columnName,
+        }),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: save sort on cache for Statement page" (#72844)
  * 1/1 commits from "ui: save sort on cache for Transaction page" (#72882)
  * 2/2 commits from "ui: save sort on cache for Sessions page " (#72893)

Please see individual PRs for details.

/cc @cockroachdb/release

Release note: None
Release justification: Low risk, high benefit changes to existing functionality
