### PR TITLE
ui: create custom legend for line plots

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -399,11 +399,23 @@ export function fillGaps(
 // and store its ref in a global variable.
 // Once we receive updates to props, we push new data to the
 // uPlot object.
-export class LineGraph extends React.Component<LineGraphProps, {}> {
+export class LineGraph extends React.Component<
+  LineGraphProps,
+  { legend: LegendProps }
+> {
   constructor(props: LineGraphProps) {
     super(props);
 
     this.setNewTimeRange = this.setNewTimeRange.bind(this);
+
+    this.state = {
+      legend: {
+        show: false,
+        cursor: undefined,
+        xValue: undefined,
+        yValues: [],
+      },
+    };
   }
 
   // axis is copied from the nvd3 LineGraph component above
@@ -494,6 +506,12 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   // to a closure that holds a reference to this value.
   xAxisDomain: AxisDomain;
 
+  setLegendState = (legendProps: LegendProps) => {
+    this.setState({
+      legend: legendProps,
+    });
+  };
+
   componentDidUpdate(prevProps: Readonly<LineGraphProps>) {
     if (
       !this.props.data?.results ||
@@ -551,6 +569,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
         this.setNewTimeRange,
         () => this.xAxisDomain,
         () => this.yAxisDomain,
+        this.setLegendState,
       );
 
       if (this.u) {
@@ -581,7 +600,45 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
         <div className="linegraph">
           <div ref={this.el} />
         </div>
+        <Legend {...this.state.legend} />
       </Visualization>
+    );
+  }
+}
+
+interface YValue {
+  raw: number;
+  value: string;
+  color: string;
+  name: string;
+}
+
+export interface LegendProps {
+  show: boolean;
+  cursor: uPlot.Cursor;
+  xValue: string;
+  yValues: YValue[];
+}
+
+class Legend extends React.Component<LegendProps> {
+  render() {
+    return (
+      <div>
+        <div>{this.props.xValue}</div>
+        <ul>
+          {this.props.yValues
+            .sort((a, b) => {
+              return b.raw - a.raw;
+            })
+            .map(y => {
+              return (
+                <li style={{ border: `2px solid ${y.color}` }}>
+                  {y.name}: {y.value}
+                </li>
+              );
+            })}
+        </ul>
+      </div>
     );
   }
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -588,7 +588,12 @@ export class LineGraph extends React.Component<
 
   render() {
     const { title, subtitle, tooltip, data, preCalcGraphSize } = this.props;
-
+    const lineGraph = (
+      <div className="linegraph">
+        <div ref={this.el} />
+      </div>
+    );
+    const legend = <Legend {...this.state.legend} />;
     return (
       <Visualization
         title={title}
@@ -596,12 +601,9 @@ export class LineGraph extends React.Component<
         tooltip={tooltip}
         loading={!data}
         preCalcGraphSize={preCalcGraphSize}
-      >
-        <div className="linegraph">
-          <div ref={this.el} />
-        </div>
-        <Legend {...this.state.legend} />
-      </Visualization>
+        canvasWrapper={lineGraph}
+        legend={legend}
+      />
     );
   }
 }
@@ -623,7 +625,7 @@ export interface LegendProps {
 class Legend extends React.Component<LegendProps> {
   render() {
     return (
-      <div>
+      <div style={{ height: "350px", overflow: "scroll" }}>
         <div>{this.props.xValue}</div>
         <ul>
           {this.props.yValues
@@ -632,7 +634,7 @@ class Legend extends React.Component<LegendProps> {
             })
             .map(y => {
               return (
-                <li style={{ border: `2px solid ${y.color}` }}>
+                <li style={{ border: `2px solid ${y.color}` }} key={y.name}>
                   {y.name}: {y.value}
                 </li>
               );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/index.tsx
@@ -28,6 +28,8 @@ interface VisualizationProps {
   // If loading is true a spinner is shown instead of the graph.
   loading?: boolean;
   preCalcGraphSize?: boolean;
+  canvasWrapper: JSX.Element;
+  legend: JSX.Element;
 }
 
 /**
@@ -74,14 +76,17 @@ export default class extends React.Component<VisualizationProps, {}> {
 
     return (
       <div className={vizClasses}>
-        <div className="visualization__header">{tooltipNode}</div>
-        <div className={contentClasses}>
-          {this.props.loading ? (
-            <img className="visualization__spinner" src={spinner} />
-          ) : (
-            this.props.children
-          )}
+        <div>
+          <div className="visualization__header">{tooltipNode}</div>
+          <div className={contentClasses}>
+            {this.props.loading ? (
+              <img className="visualization__spinner" src={spinner} />
+            ) : (
+              this.props.canvasWrapper
+            )}
+          </div>
         </div>
+        {this.props.legend}
       </div>
     );
   }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/visualization/visualizations.styl
@@ -23,6 +23,7 @@ $viz-sides = 62px
   border 1px solid rgba(0, 0, 0, .1)
   // prevents borders from doubling up
   margin-bottom 10px
+  display flex
 
   &__content
     padding 0 10px 15px

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -554,7 +554,7 @@ export function configureUPlotLineChart(
   // graph will always have the first color, etc.
   const strokeColors = [...seriesPalette];
 
-  const debouncedSetCursor = _.throttle((self: uPlot) => {
+  const throttledLegendCallback = _.throttle((self: uPlot) => {
     setLegendState({
       show: true, // TODO(davidh): manage cursor entering/leaving the plot
       cursor: self.cursor,
@@ -573,13 +573,12 @@ export function configureUPlotLineChart(
           };
         }),
     });
-  }, 50);
+  }, 100);
 
   const tooltipPlugin = () => {
     return {
       hooks: {
-        init: (self: uPlot) => {},
-        setCursor: debouncedSetCursor,
+        setCursor: throttledLegendCallback,
       },
     };
   };
@@ -589,16 +588,14 @@ export function configureUPlotLineChart(
   return {
     width: 947,
     height: 300,
-    // TODO(davidh): Enable sync-ed guidelines once legend is redesigned
-    // currently, if you enable this with a hovering legend, the FPS
-    // gets quite choppy on large clusters.
-    // cursor: {
-    //   sync: {
-    //     // graphs with matching keys will get their guidelines
-    //     // sync-ed so we just use the same key for the page
-    //     key: "sync-everything",
-    //   },
-    // },
+    cursor: {
+      lock: true,
+      sync: {
+        // graphs with matching keys will get their guidelines
+        // sync-ed so we just use the same key for the page
+        key: "sync-everything",
+      },
+    },
     legend: {
       show: false,
     },


### PR DESCRIPTION
In order for us to support more complex customization of legends that we
render alongside our line graphs, this commit replaces the built-in
uPlot legend with a custom React component we have control over. This
unlocks features like: sorting the series in the legend, omitting
certain datapoints, etc.

Release note: None