### PR TITLE
roachprod: introduce Node type

### DIFF
--- a/pkg/roachprod/install/cluster_synced_test.go
+++ b/pkg/roachprod/install/cluster_synced_test.go
@@ -19,7 +19,7 @@ import (
 func TestRoachprodEnv(t *testing.T) {
 	cases := []struct {
 		clusterName string
-		node        int
+		node        Node
 		tag         string
 		value       string
 		regex       string

--- a/pkg/roachprod/install/download.go
+++ b/pkg/roachprod/install/download.go
@@ -17,8 +17,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 )
 
 const (
@@ -76,7 +74,7 @@ func Download(c *SyncedCluster, sourceURLStr string, sha string, dest string) er
 	// If we are local and the destination is relative, then copy the file from
 	// the download node to the other nodes.
 	if c.IsLocal() && !filepath.IsAbs(dest) {
-		src := filepath.Join(local.VMDir(c.Name, downloadNodes[0]), dest)
+		src := filepath.Join(c.localVMDir(downloadNodes[0]), dest)
 		cpCmd := fmt.Sprintf(`cp "%s" "%s"`, src, dest)
 		return c.Run(os.Stdout, os.Stderr, c.Nodes[1:], "copying to remaining nodes", cpCmd)
 	}

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -31,12 +31,12 @@ var certsDirRe = regexp.MustCompile(`{certs-dir}`)
 // attributes like pgurl, pghost, pgport, uiport, store-dir, and log-dir with
 // the corresponding values.
 type expander struct {
-	node int
+	node Node
 
-	pgURLs  map[int]string
-	pgHosts map[int]string
-	pgPorts map[int]string
-	uiPorts map[int]string
+	pgURLs  map[Node]string
+	pgHosts map[Node]string
+	pgPorts map[Node]string
+	uiPorts map[Node]string
 }
 
 // expanderFunc is a function which may expand a string with a templated value.
@@ -80,7 +80,7 @@ func (e *expander) expand(c *SyncedCluster, arg string) (string, error) {
 // list of strings which correspond to the values in m for each node specified
 // by nodeSpec.
 func (e *expander) maybeExpandMap(
-	c *SyncedCluster, m map[int]string, nodeSpec string,
+	c *SyncedCluster, m map[Node]string, nodeSpec string,
 ) (string, error) {
 	if nodeSpec == "" {
 		nodeSpec = "all"
@@ -94,8 +94,8 @@ func (e *expander) maybeExpandMap(
 	}
 
 	var result []string
-	for _, i := range nodes {
-		if s, ok := m[i]; ok {
+	for _, node := range nodes {
+		if s, ok := m[node]; ok {
 			result = append(result, s)
 		}
 	}
@@ -151,9 +151,9 @@ func (e *expander) maybeExpandPgPort(c *SyncedCluster, s string) (string, bool, 
 	}
 
 	if e.pgPorts == nil {
-		e.pgPorts = make(map[int]string, len(c.VMs))
-		for _, i := range allNodes(len(c.VMs)) {
-			e.pgPorts[i] = fmt.Sprint(c.NodePort(i))
+		e.pgPorts = make(map[Node]string, len(c.VMs))
+		for _, node := range allNodes(len(c.VMs)) {
+			e.pgPorts[node] = fmt.Sprint(c.NodePort(node))
 		}
 	}
 
@@ -169,9 +169,9 @@ func (e *expander) maybeExpandUIPort(c *SyncedCluster, s string) (string, bool, 
 	}
 
 	if e.uiPorts == nil {
-		e.uiPorts = make(map[int]string, len(c.VMs))
-		for _, i := range allNodes(len(c.VMs)) {
-			e.uiPorts[i] = fmt.Sprint(c.NodeUIPort(i))
+		e.uiPorts = make(map[Node]string, len(c.VMs))
+		for _, node := range allNodes(len(c.VMs)) {
+			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(node))
 		}
 	}
 


### PR DESCRIPTION
There is a lot of confusion in the code around node "indexes".
Sometimes these are a (0-based) index in the target list of nodes,
sometimes they are a (1-based) node ID. This makes the code harder to
follow and more error-prone (in fact, there are a couple of places
where we convert from one to the other incorrectly).

This change introduces the types `Node` and `Nodes` and switches code
to use `Node` (rather than the 0-based index) whenever possible. This
enlists the compiler's help, as it is no longer legal to implicitly
convert from one to the other.

Release note: None