### PR TITLE
roachprod: remove special cases for defunct versions

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -1933,15 +1932,6 @@ func (c *SyncedCluster) Init() error {
 	// See Start(). We reserve a few special operations for the first node, so we
 	// strive to maintain the same here for interoperability.
 	const firstNodeIdx = 0
-
-	vers, err := getCockroachVersion(c, c.TargetNodes()[firstNodeIdx])
-	if err != nil {
-		return errors.WithDetail(err, "install.Init() failed: unable to retrieve cockroach version.")
-	}
-
-	if !vers.AtLeast(version.MustParse("v20.1.0")) {
-		return errors.New("install.Init() failed: `roachprod init` only supported for v20.1 and beyond")
-	}
 
 	fmt.Printf("%s: initializing cluster\n", c.Name)
 	initOut, err := c.initializeCluster(firstNodeIdx)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -80,34 +79,13 @@ func getCockroachVersion(c *SyncedCluster, node Node) (*version.Version, error) 
 	}
 	defer sess.Close()
 
-	var verString string
-
 	cmd := cockroachNodeBinary(c, node) + " version"
 	out, err := sess.CombinedOutput(cmd + " --build-tag")
 	if err != nil {
-		// The --build-tag may not be supported. Try without.
-		// Note: this way to extract the version number is brittle.
-		// It should be removed once 'roachprod' is not used
-		// to invoke pre-v20.2 binaries any more.
-		sess, err := c.newSession(node)
-		if err != nil {
-			return nil, err
-		}
-		defer sess.Close()
-		out, err = sess.CombinedOutput(cmd)
-		if err != nil {
-			return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
-		}
-
-		matches := regexp.MustCompile(`(?m)^Build Tag:\s+(.*)$`).FindSubmatch(out)
-		if len(matches) != 2 {
-			return nil, fmt.Errorf("unable to parse cockroach version output:%s", out)
-		}
-
-		verString = string(matches[1])
-	} else {
-		verString = strings.TrimSpace(string(out))
+		return nil, errors.Wrapf(err, "~ %s --build-tag\n%s", cmd, out)
 	}
+
+	verString := strings.TrimSpace(string(out))
 	return version.Parse(verString)
 }
 
@@ -164,16 +142,12 @@ func (c *SyncedCluster) Start(startOpts StartOpts) error {
 
 		// 1. We don't init invoked using `--skip-init`.
 		// 2. We don't init when invoking with `start-single-node`.
-		// 3. For nodes running <20.1, the --join flags are constructed in a
-		//    manner such that the first node doesn't have any (see
-		//   `generateStartArgs`),which prompts CRDB to auto-initialize. For
-		//    nodes running >=20.1, we need to explicitly initialize.
 
 		if startOpts.SkipInit {
 			return nil, nil
 		}
 
-		shouldInit := !c.useStartSingleNode(vers) && vers.AtLeast(version.MustParse("v20.1.0"))
+		shouldInit := !c.useStartSingleNode()
 		if shouldInit {
 			fmt.Printf("%s: initializing cluster\n", c.Name)
 			initOut, err := c.initializeCluster(node)
@@ -183,26 +157,6 @@ func (c *SyncedCluster) Start(startOpts StartOpts) error {
 
 			if initOut != "" {
 				fmt.Println(initOut)
-			}
-		}
-
-		if !vers.AtLeast(version.MustParse("v20.1.0")) {
-			// Given #51897 remains unresolved, master-built roachprod is used
-			// to run roachtests against the 20.1 branch. Some of those
-			// roachtests test mixed-version clusters that start off at 19.2.
-			// Consequently, we manually add this `cluster-bootstrapped` file
-			// where roachprod expects to find it for already-initialized
-			// clusters. This is a pretty gross hack, that we should address by
-			// addressing #51897.
-			//
-			// TODO(irfansharif): Remove this once #51897 is resolved.
-			markBootstrap := fmt.Sprintf("touch %s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")
-			cmdOut, err := c.run(node, markBootstrap)
-			if err != nil {
-				return nil, errors.WithDetail(err, "unable to run cmd")
-			}
-			if cmdOut != "" {
-				fmt.Println(cmdOut)
 			}
 		}
 
@@ -408,7 +362,7 @@ func (c *SyncedCluster) generateStartCmd(
 	// For a one-node cluster, use `start-single-node` to disable replication.
 	// For everything else we'll fall back to using `cockroach start`.
 	var startCmd string
-	if c.useStartSingleNode(vers) {
+	if c.useStartSingleNode() {
 		startCmd = "start-single-node"
 	} else {
 		startCmd = "start"
@@ -504,24 +458,19 @@ func (c *SyncedCluster) generateStartArgs(
 		args = append(args, `--log-dir`, logDir)
 	}
 
-	if vers.AtLeast(version.MustParse("v1.1.0")) {
-		cache := 25
-		if c.IsLocal() {
-			cache /= len(nodes)
-			if cache == 0 {
-				cache = 1
-			}
+	cache := 25
+	if c.IsLocal() {
+		cache /= len(nodes)
+		if cache == 0 {
+			cache = 1
 		}
-		args = append(args, fmt.Sprintf("--cache=%d%%", cache))
-		args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", cache))
 	}
+	args = append(args, fmt.Sprintf("--cache=%d%%", cache))
+	args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", cache))
+
 	if c.IsLocal() {
 		// This avoids annoying firewall prompts on Mac OS X.
-		if vers.AtLeast(version.MustParse("v2.1.0")) {
-			args = append(args, "--listen-addr=127.0.0.1")
-		} else {
-			args = append(args, "--host=127.0.0.1")
-		}
+		args = append(args, "--listen-addr=127.0.0.1")
 	}
 
 	args = append(args,
@@ -534,17 +483,9 @@ func (c *SyncedCluster) generateStartArgs(
 		}
 	}
 
-	if !c.useStartSingleNode(vers) {
-		// --join flags are unsupported/unnecessary in `cockroach
-		// start-single-node`. That aside, setting up --join flags is a bit
-		// precise. We have every node point to node 1. For clusters running
-		// <20.1, we have node 1 not point to anything (which in turn is used to
-		// trigger auto-initialization node 1). For clusters running >=20.1,
-		// node 1 also points to itself, and an explicit `cockroach init` is
-		// needed.
-		if node != 1 || vers.AtLeast(version.MustParse("v20.1.0")) {
-			args = append(args, fmt.Sprintf("--join=%s:%d", c.Host(1), c.NodePort(1)))
-		}
+	// --join flags are unsupported/unnecessary in `cockroach start-single-node`.
+	if !c.useStartSingleNode() {
+		args = append(args, fmt.Sprintf("--join=%s:%d", c.Host(1), c.NodePort(1)))
 	}
 
 	var advertiseFirstIP bool
@@ -679,8 +620,8 @@ func (c *SyncedCluster) generateKeyCmd(node Node, startOpts StartOpts) string {
 	return keyCmd.String()
 }
 
-func (c *SyncedCluster) useStartSingleNode(vers *version.Version) bool {
-	return len(c.VMs) == 1 && vers.AtLeast(version.MustParse("v19.2.0"))
+func (c *SyncedCluster) useStartSingleNode() bool {
+	return len(c.VMs) == 1
 }
 
 // distributeCerts distributes certs if it's a secure cluster and we're
@@ -716,18 +657,4 @@ func getEnvVars() []string {
 		}
 	}
 	return sl
-}
-
-func (c *SyncedCluster) run(node Node, cmd string) (string, error) {
-	sess, err := c.newSession(node)
-	if err != nil {
-		return "", err
-	}
-	defer sess.Close()
-
-	out, err := sess.CombinedOutput(cmd)
-	if err != nil {
-		return "", errors.Wrapf(err, "~ %s\n%s", cmd, out)
-	}
-	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
We now run roachprod from the same branch with the release we are
testing. We may use roachprod with the previous major version for
mixed-version testing.

This change removes any code specific to versions before 21.1. We
still want to support 21.1 because this change is intended to get
backported to release-21.2.

Release note: None