### PR TITLE
col/coldata: batch allocate memColumn objects

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -119,9 +119,12 @@ func NewMemBatch(typs []*types.T, factory ColumnFactory) Batch {
 // column size. Use for operators that have a precisely-sized output batch.
 func NewMemBatchWithCapacity(typs []*types.T, capacity int, factory ColumnFactory) Batch {
 	b := NewMemBatchNoCols(typs, capacity).(*MemBatch)
+	cols := make([]memColumn, len(typs))
 	for i, t := range typs {
-		b.b[i] = NewMemColumn(t, capacity, factory)
-		if b.b[i].IsBytesLike() {
+		col := &cols[i]
+		col.init(t, capacity, factory)
+		b.b[i] = col
+		if col.IsBytesLike() {
 			b.bytesVecIdxs.Add(i)
 		}
 	}

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -199,7 +199,14 @@ func (cf *defaultColumnFactory) MakeColumn(t *types.T, length int) Column {
 // NewMemColumn returns a new memColumn, initialized with a length using the
 // given column factory.
 func NewMemColumn(t *types.T, length int, factory ColumnFactory) Vec {
-	return &memColumn{
+	var m memColumn
+	m.init(t, length, factory)
+	return &m
+}
+
+// init initializes the receiver with a length using the given column factory.
+func (m *memColumn) init(t *types.T, length int, factory ColumnFactory) {
+	*m = memColumn{
 		t:                   t,
 		canonicalTypeFamily: typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()),
 		col:                 factory.MakeColumn(t, length),


### PR DESCRIPTION
This commit updates `NewMemBatchWithCapacity` to batch allocate all necessary
`memColumn` objects in a single chunk. Outside of #72798, this was the single
largest source of heap allocations by object count (`alloc_objects`) in TPC-E.
With #72798 applied, calls to `NewMemColumn` were responsible for **3.18%** of
total heap allocations in the workload:

```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                         355202097 97.92% |   github.com/cockroachdb/cockroach/pkg/col/coldata.NewMemBatchWithCapacity /go/src/github.com/cockroachdb/cockroach/pkg/col/coldata/batch.go:123
                                           7561654  2.08% |   github.com/cockroachdb/cockroach/pkg/sql/colmem.(*Allocator).NewMemColumn /go/src/github.com/cockroachdb/cockroach/pkg/sql/colmem/allocator.go:217
 362763751  3.18%  3.18%  362763751  3.18%                | github.com/cockroachdb/cockroach/pkg/col/coldata.NewMemColumn /go/src/github.com/cockroachdb/cockroach/pkg/col/coldata/vec.go:202
----------------------------------------------------------+-------------
```

Lower in the heap profile, we see that each of the other heap allocations that
are performed once per call to `NewMemBatchWithCapacity` were observed 39625411
times. So we can estimate that the average batch contains `362763751 / 39625411 = 9.15`
columns.

This lines up with the improvement we see due to this change. Heap allocations
due to `memColumn` objects drop by about a factor of 9, down to **0.33%** of all
heap allocations:

```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                          12082615   100% |   github.com/cockroachdb/cockroach/pkg/sql/colmem.(*Allocator).NewMemBatchWithFixedCapacity /go/src/github.com/cockroachdb/cockroach/pkg/sql/colmem/allocator.go:131
  12082615  0.33% 38.80%   12082615  0.33%                | github.com/cockroachdb/cockroach/pkg/col/coldata.NewMemBatchWithCapacity /go/src/github.com/cockroachdb/cockroach/pkg/col/coldata/batch.go:122
----------------------------------------------------------+-------------
```

Despite this change, we will still probably want to address Jordan's TODO a few
lines earlier about pooling all allocations it this level:

https://github.com/cockroachdb/cockroach/blob/28bb1ea049da5bfb6e15a7003cd7b678cbc4b67f/pkg/col/coldata/batch.go#L113