### PR TITLE
colfetcher: don't fetch an extra key when limit hint is present

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -153,12 +153,12 @@ func (f *txnKVFetcher) getBatchKeyLimitForIdx(batchIdx int) rowinfra.KeyLimit {
 		// size and at least 1/10 of the default batch size). Sample
 		// progressions of batch sizes:
 		//
-		//  First batch | Second batch | Subsequent batches
+		//  First batch |  Second batch  | Subsequent batches
 		//  -----------------------------------------------
-		//         1    |     1,000     |     10,000
-		//       100    |     1,000     |     10,000
-		//       500    |     5,000     |     10,000
-		//      1000    |    10,000     |     10,000
+		//         1    |     10,000     |     100,000
+		//       100    |     10,000     |     100,000
+		//      5000    |     50,000     |     100,000
+		//     10000    |    100,000     |     100,000
 		secondBatch := f.firstBatchKeyLimit * 10
 		switch {
 		case secondBatch < kvBatchSize/10:


### PR DESCRIPTION
**row: update examples in the comment on batch sizes**

We recently bumped the KV batch size from 10k to 100k but forgot to
update the examples.

Release note: None

**colfetcher: don't fetch an extra key when limit hint is present**

Previously, the SQL fetchers - in presence of the limit hints - would
always ask for an extra key for the first KV batch so that it is
guaranteed that the last row can be finalized. This extra key is needed
for the row fetcher (where we rely on the KV coming from the next row to
indicate that the last row is safe to finalize); however, it is not
needed for the cFetcher at all because the cFetcher is eagerly
finalizing each row once it knows that all KVs comprising that row have
been fetched.

Consider several cases:
- the table has only one column family - then we can finalize each
  row right after the first KV is decoded;
- the table has multiple column families:
  - KVs for all column families are present for all rows - then for
    each row, when its last KV is fetched, the row can be finalized
    (and cFetcher knows that);
  - KVs for some column families are omitted for some rows - then we
    will actually fetch more KVs than necessary, but we'll decode
    `limitHint` number of rows.

Touches: #72739.

Release note: None