### PR TITLE
logic: fix racy forceProductionBatchSizes bool

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3482,8 +3482,10 @@ func RunLogicTestWithDefaultConfig(
 					if *printErrorSummary {
 						defer lt.printErrorSummary()
 					}
-					serverArgs.forceProductionBatchSizes = onlyNonMetamorphic
-					lt.setup(cfg, serverArgs, readClusterOptions(t, path))
+					// Each test needs a copy because of Parallel
+					serverArgsCopy := serverArgs
+					serverArgsCopy.forceProductionBatchSizes = onlyNonMetamorphic
+					lt.setup(cfg, serverArgsCopy, readClusterOptions(t, path))
 					lt.runFile(path, cfg)
 
 					progress.Lock()


### PR DESCRIPTION
Previously because of Parallel usage we would be writing
serverArgs.forceProductionBatchSizes from multiple go routines.   Avoid
that with a separate copy for the nonMetamorphic tests.

Fixes #72802

Release note: None

