### PR TITLE
release-21.1: workload: log histogram write/encode failures, close output file

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -462,6 +462,15 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 			return err
 		}
 		jsonEnc = json.NewEncoder(jsonF)
+		defer func() {
+			if err := jsonF.Sync(); err != nil {
+				log.Warningf(ctx, "histogram: %v", err)
+			}
+
+			if err := jsonF.Close(); err != nil {
+				log.Warningf(ctx, "histogram: %v", err)
+			}
+		}()
 	}
 
 	everySecond := log.Every(*displayEvery)
@@ -482,7 +491,9 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 			reg.Tick(func(t histogram.Tick) {
 				formatter.outputTick(startElapsed, t)
 				if jsonEnc != nil && rampDone == nil {
-					_ = jsonEnc.Encode(t.Snapshot())
+					if err := jsonEnc.Encode(t.Snapshot()); err != nil {
+						log.Warningf(ctx, "histogram: %v", err)
+					}
 				}
 			})
 
@@ -511,7 +522,9 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 					// Note that we're outputting the delta from the last tick. The
 					// cumulative histogram can be computed by merging all of the
 					// per-tick histograms.
-					_ = jsonEnc.Encode(t.Snapshot())
+					if err := jsonEnc.Encode(t.Snapshot()); err != nil {
+						log.Warningf(ctx, "histogram: %v", err)
+					}
 				}
 				if ops.ResultHist == `` || ops.ResultHist == t.Name {
 					if resultTick.Cumulative == nil {


### PR DESCRIPTION
Backport 1/1 commits from #70484.

/cc @cockroachdb/release

---

We are currently observing incomplete histograms being output during
nightly roachperf tpccbench runs.

I don't think the changes here are likely to address the cause, as I
would expect write failures to affect a broader range of roachperf
output. But, it is still good to log any failures we do encounter.

Further, we now sync and close the file explicitly.

Informs #70313

Release note: None
Release justification: Test-only change to improve durability of histogram output.