### PR TITLE
release-21.2: sql,jobs: implement redact.SafeValue for JobID and SessionID

### DIFF
--- a/docs/generated/redact_safe.md
+++ b/docs/generated/redact_safe.md
@@ -3,6 +3,7 @@ The following types are considered always safe for reporting:
 File | Type
 --|--
 pkg/cli/exit/exit.go | `Code`
+pkg/jobs/jobspb/wrap.go | `JobID`
 pkg/jobs/jobspb/wrap.go | `Type`
 pkg/kv/kvserver/closedts/ctpb/service.go | `LAI`
 pkg/kv/kvserver/closedts/ctpb/service.go | `SeqNum`
@@ -32,6 +33,7 @@ pkg/sql/catalog/descpb/structured.go | `IndexID`
 pkg/sql/catalog/descpb/structured.go | `MutationID`
 pkg/sql/sem/tree/table_ref.go | `ColumnID`
 pkg/sql/sem/tree/table_ref.go | `ID`
+pkg/sql/sqlliveness/sqlliveness.go | `SessionID`
 pkg/storage/enginepb/mvcc3.go | `*MVCCStats`
 pkg/storage/enginepb/mvcc3.go | `MVCCStatsDelta`
 pkg/util/hlc/timestamp.go | `ClockTimestamp`

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -28,6 +28,9 @@ type JobID int64
 // InvalidJobID is the zero value for JobID corresponding to no job.
 const InvalidJobID JobID = 0
 
+// SafeValue implements the redact.SafeValue interface.
+func (j JobID) SafeValue() {}
+
 // Details is a marker interface for job details proto structs.
 type Details interface{}
 

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -54,6 +54,9 @@ func (s SessionID) String() string {
 	return hex.EncodeToString(encoding.UnsafeConvertStringToBytes(string(s)))
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (s SessionID) SafeValue() {}
+
 // UnsafeBytes returns a byte slice representation of the ID. It is unsafe to
 // modify this byte slice. This method is exposed to ease storing the session
 // ID as bytes in SQL.


### PR DESCRIPTION
Backport 1/1 commits from #71062.

/cc @cockroachdb/release

---

jobspb.JobID is an int64, populated via unique_rowid() at the
point of job creation.

sqlliveness.SessionID is a string but represents an opaque
identifier. In the current implementation, it is the bytes from a V4
UUID.

jobspb.JobIDs currently appear in many log messages and are fairly
valuable when trying to track what happened to a particular job. For
example,

Before:

```
[n1] 60 CHANGEFEED job ‹×›: stepping through state running with error: <nil>
```

After:

```
[n1] 81 CHANGEFEED job 698867169229307905: stepping through state running with error: <nil>
```

SessionID's are not logged in many places currently, but I would like
to include them in error messages in the near future.

Release note (ops change): Job IDs and Session IDs are no longer
redacted. These values do not represent sensitive or identifiable
data, but do aid in debugging problems with the jobs system.

Release justification: Low risk change to improve jobs debugability. 