### PR TITLE
release-21.2: changefeedccl: don't warn when Timestamp() is called on flush event

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -149,6 +149,8 @@ func (b *Event) Timestamp() hlc.Timestamp {
 			return b.backfillTimestamp
 		}
 		return b.kv.Value.Timestamp
+	case TypeFlush:
+		return hlc.Timestamp{}
 	default:
 		log.Warningf(context.TODO(),
 			"setting empty timestamp for unknown event type")
@@ -165,6 +167,8 @@ func (b *Event) MVCCTimestamp() hlc.Timestamp {
 		return b.resolved.Timestamp
 	case TypeKV:
 		return b.kv.Value.Timestamp
+	case TypeFlush:
+		return hlc.Timestamp{}
 	default:
 		log.Warningf(context.TODO(),
 			"setting empty timestamp for unknown event type")

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -461,6 +461,12 @@ func copyFromSourceToDestUntilTableEvent(
 					return false, false, err
 				}
 				return true, frontier.Frontier().EqOrdering(boundaryResolvedTimestamp), nil
+			case kvevent.TypeFlush:
+				// TypeFlush events have a timestamp of zero and should have already
+				// been processed by the timestamp check above. We include this here
+				// for completeness.
+				return false, false, nil
+
 			default:
 				return false, false, &errUnknownEvent{e}
 			}


### PR DESCRIPTION
Backport 1/1 commits from #71265.

/cc @cockroachdb/release

---

When investigating a recent test failure, I noticed the following log
messages:

    ccl/changefeedccl/kvevent/event.go:153 ⋮ [-] 1830  setting empty timestamp for unknown event type
    ccl/changefeedccl/kvevent/event.go:153 ⋮ [-] 1831  setting empty timestamp for unknown event type
    ccl/changefeedccl/kvevent/event.go:153 ⋮ [-] 1832  setting empty timestamp for unknown event type
    ccl/changefeedccl/kvevent/event.go:153 ⋮ [-] 1833  setting empty timestamp for unknown event type
    ccl/changefeedccl/kvevent/event.go:153 ⋮ [-] 1834  setting empty timestamp for unknown event type

One possibility is that these were generated by our new Flush event,
which is an in-band signal between the kvFeed and the changeAggregator
and has no associated timestamp.

This PR adds handling for TypeFlush to cut down on the log spam.

Not however, this raises the question of why we were hitting the
condition that forces a flush so often.

One possibility is that we were unable to allocate resources to add
items to the queue because of some other user of our memory monitor
and thus while we kept trying to flush, these flushes had no
effect. We may consider tracking whether there has been a successful
resource acquisition since the last flush and only resending a flush
if there has been.

Release note: None
Release justification: Low risk change to reduce log spam from changefeeds.