### PR TITLE
release-21.2: changefeedcc: Do not emit epoch resolved events.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1458,7 +1458,7 @@ func (cf *changeFrontier) maybeProtectTimestamp(
 }
 
 func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
-	if cf.freqEmitResolved == emitNoResolved {
+	if cf.freqEmitResolved == emitNoResolved || newResolved.IsEmpty() {
 		return nil
 	}
 	sinceEmitted := newResolved.GoTime().Sub(cf.lastEmitResolved)


### PR DESCRIPTION
Backport 1/1 commits from #72932.

/cc @cockroachdb/release

---

Do not emit resolved events with unix epoch timestamp.

Fixes #72917

Release Notes: None
