### PR TITLE
tracing: improve Tracer scalability by introducing a scalable rand

### DIFF
--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",
         "//pkg/util/json",  # keep
+        "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/colexec/colexechash/hash.go
+++ b/pkg/sql/colexec/colexechash/hash.go
@@ -21,8 +21,9 @@
 package colexechash
 
 import (
-	"math/rand"
 	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 const (
@@ -158,9 +159,7 @@ func f64hash(p unsafe.Pointer, h uintptr) uintptr {
 	case f == 0:
 		return c1 * (c0 ^ h) // +0, -0
 	case f != f:
-		// TODO(asubiotto): fastrand relies on some stack internals.
-		//return c1 * (c0 ^ h ^ uintptr(fastrand())) // any kind of NaN
-		return c1 * (c0 ^ h ^ uintptr(rand.Uint32())) // any kind of NaN
+		return c1 * (c0 ^ h ^ uintptr(randutil.FastUint32())) // any kind of NaN
 	default:
 		return memhash(p, h, 8)
 	}

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/iterutil",
         "//pkg/util/netutil/addr",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/ring",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -13,7 +13,6 @@ package tracing
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -674,9 +674,9 @@ func (t *Tracer) startSpanGeneric(
 
 	traceID := opts.parentTraceID()
 	if traceID == 0 {
-		traceID = tracingpb.TraceID(rand.Int63())
+		traceID = tracingpb.TraceID(randutil.FastInt63())
 	}
-	spanID := tracingpb.SpanID(rand.Int63())
+	spanID := tracingpb.SpanID(randutil.FastInt63())
 	goroutineID := uint64(goid.Get())
 
 	// Now allocate the main *Span and contained crdbSpan.


### PR DESCRIPTION
Each span gets a random span id, and each trace gets a random trace id.
rand.Int63() doesn't scale - it's a mutex around a source. This patch
switches to using the go runtime's fastrand.

The difference is noticeable. I ran the benchmarks with GOGC=off for
more useful numbers because, for this small bench, we're mostly
measuring dynamic memory allocation and GC (particularly since go 1.17
runs benchmarks with a tiny initial heap, so the GC is very frequent).

GOGC=off make bench PKG=./pkg/util/tracing BENCHES=BenchmarkSpanCreation TESTFLAGS="-cpu=1,2,4,8,16,32"

SpanCreation       2.06µs ±25%    1.99µs ±26%     ~     (p=0.310 n=5+5)
SpanCreation-2     1.67µs ±24%    1.30µs ±13%  -22.26%  (p=0.008 n=5+5)
SpanCreation-4     1.94µs ± 5%    1.46µs ± 3%  -24.49%  (p=0.008 n=5+5)
SpanCreation-8     2.12µs ± 4%    1.83µs ± 4%  -13.80%  (p=0.008 n=5+5)
SpanCreation-16    1.94µs ±18%    2.14µs ± 6%     ~     (p=0.222 n=5+5)
SpanCreation-32    2.31µs ± 2%    2.33µs ± 4%     ~     (p=0.690 n=5+5)