### PR TITLE
tracing: expand the active spans registry 

### DIFF
--- a/pkg/sql/tests/tracing_sql_test.go
+++ b/pkg/sql/tests/tracing_sql_test.go
@@ -67,16 +67,8 @@ func TestSetTraceSpansVerbosityBuiltin(t *testing.T) {
 	)
 
 	require.True(t, root.IsVerbose())
-	// The children have not been made verbose. This is an artifact of the current
-	// implementation; it might change in the future. Children are only registered
-	// with the parent if the parent is recording at the time when the children
-	// are created (which was not the case here). set_trace_verbose only operates
-	// on spans that are linked to their parent. set_trace_verbose could also go
-	// through the span registry looking for more spans in the trace, but it
-	// doesn't currently do that (and also currently we don't add most spans to
-	// the registry, but that also should change in the future).
-	require.False(t, child.IsVerbose())
-	require.False(t, childChild.IsVerbose())
+	require.True(t, child.IsVerbose())
+	require.True(t, childChild.IsVerbose())
 
 	// New child of verbose child span should also be verbose by default.
 	newChild := tr.StartSpan("root.child.newchild", tracing.WithParent(root))

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -80,6 +80,19 @@ type crdbSpanMu struct {
 	// duration is initialized to -1 and set on Finish().
 	duration time.Duration
 
+	// openChildren maintains the list of currently-open local children. These
+	// children are part of the active spans registry only indirectly, through
+	// this parent. When the parent finishes, any child that's still open will be
+	// inserted into the registry directly.
+	//
+	// If this parent is recording at the time when a child Finish()es, and the
+	// respective childRef indicates that the child is to be included in the
+	// parent's recording, then the child's recording is collected in
+	// recording.finishedChildren.
+	//
+	// The spans are not maintained in a particular order.
+	openChildren []childRef
+
 	recording struct {
 		// recordingType is the recording type of the ongoing recording, if any.
 		// Its 'load' method may be called without holding the surrounding mutex,
@@ -97,12 +110,6 @@ type crdbSpanMu struct {
 		// annotate recordings with the _dropped tag, when applicable.
 		dropped bool
 
-		// openChildren contains the list of local child spans started after this
-		// Span started recording, that haven't been Finish()ed yet. After Finish(),
-		// the respective child moves to finishedChildren.
-		//
-		// The spans are not maintained in a particular order.
-		openChildren []childRef
 		// finishedChildren contains the recordings of finished children (and
 		// grandchildren recursively). This includes remote child span recordings
 		// that were manually imported, as well as recordings from local children
@@ -156,6 +163,7 @@ type sizeLimitedBuffer struct {
 func (s *crdbSpan) finish() bool {
 	var children []*crdbSpan
 	var parent *crdbSpan
+	var needRegistryChange bool
 	{
 		s.mu.Lock()
 		if s.mu.finished {
@@ -164,6 +172,11 @@ func (s *crdbSpan) finish() bool {
 			return false
 		}
 		s.mu.finished = true
+		// If the span is not part of the registry now, it never will be. So, we'll
+		// need to remove it from the registry only if it currently does not have a
+		// parent. We'll also need to manipulate the registry if there are open
+		// children (they'll need to be added to the registry).
+		needRegistryChange = s.mu.parent == nil || len(s.mu.openChildren) > 0
 
 		finishTime := timeutil.Now()
 		duration := finishTime.Sub(s.startTime)
@@ -173,8 +186,8 @@ func (s *crdbSpan) finish() bool {
 		s.mu.duration = duration
 
 		// Shallow-copy the children so they can be processed outside the lock.
-		children = make([]*crdbSpan, len(s.mu.recording.openChildren))
-		for i, c := range s.mu.recording.openChildren {
+		children = make([]*crdbSpan, len(s.mu.openChildren))
+		for i, c := range s.mu.openChildren {
 			children[i] = c.crdbSpan
 		}
 
@@ -192,8 +205,10 @@ func (s *crdbSpan) finish() bool {
 	for _, c := range children {
 		c.parentFinished()
 	}
-	// Atomically replace s in the registry with all of its still-open children.
-	s.tracer.activeSpansRegistry.swap(s.spanID, children)
+	if needRegistryChange {
+		// Atomically replace s in the registry with all of its still-open children.
+		s.tracer.activeSpansRegistry.swap(s.spanID, children)
+	}
 
 	return true
 }
@@ -262,11 +277,11 @@ func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool) Recording {
 	s.mu.Lock()
 	// The capacity here is approximate since we don't know how many
 	// grandchildren there are.
-	result := make(Recording, 0, 1+len(s.mu.recording.openChildren)+len(s.mu.recording.finishedChildren))
+	result := make(Recording, 0, 1+len(s.mu.openChildren)+len(s.mu.recording.finishedChildren))
 	result = append(result, s.getRecordingNoChildrenLocked(RecordingVerbose))
 	result = append(result, s.mu.recording.finishedChildren...)
 
-	for _, child := range s.mu.recording.openChildren {
+	for _, child := range s.mu.openChildren {
 		if child.collectRecording || includeDetachedChildren {
 			result = append(result, child.getVerboseRecording(includeDetachedChildren)...)
 		}
@@ -300,7 +315,7 @@ func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) Recordin
 			buffer = append(buffer, &c.StructuredRecords[i])
 		}
 	}
-	for _, c := range s.mu.recording.openChildren {
+	for _, c := range s.mu.openChildren {
 		if c.collectRecording || includeDetachedChildren {
 			buffer = c.getStructuredEventsRecursively(buffer, includeDetachedChildren)
 		}
@@ -476,7 +491,7 @@ func (s *crdbSpan) getStructuredEventsRecursively(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	buffer = s.getStructuredEventsLocked(buffer)
-	for _, c := range s.mu.recording.openChildren {
+	for _, c := range s.mu.openChildren {
 		if c.collectRecording || includeDetachedChildren {
 			buffer = c.getStructuredEventsRecursively(buffer, includeDetachedChildren)
 		}
@@ -591,24 +606,18 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 //
 // The receiver's lock must be held.
 //
-// The adding fails if the receiver is not recording  (non-recording spans don't
-// accumulate children) or if the reciver has reached the maximum number of
-// spans it can keep track off. Returns false in these cases.
+// The adding fails if the receiver has already Finish()ed. This should never
+// happen, since using a Span after Finish() is illegal. But still, we
+// defensively return false.
 func (s *crdbSpan) addChildLocked(child *crdbSpan, collectChildRec bool) bool {
 	s.mu.AssertHeld()
-	if s.recordingType() == RecordingOff {
-		// We're not recording; there's nothing to do. The caller also checks the
-		// recording status, but we want to also check it here under the lock
-		// (double-checked locking).
+
+	if s.mu.finished {
 		return false
 	}
 
-	if len(s.mu.recording.openChildren) >= maxChildrenPerSpan {
-		return false
-	}
-
-	s.mu.recording.openChildren = append(
-		s.mu.recording.openChildren,
+	s.mu.openChildren = append(
+		s.mu.openChildren,
 		childRef{crdbSpan: child, collectRecording: collectChildRec},
 	)
 	return true
@@ -620,15 +629,12 @@ func (s *crdbSpan) addChildLocked(child *crdbSpan, collectChildRec bool) bool {
 // no longer references it).
 //
 // child is the child span that just finished.
-//
-// This is only called if the respective child had been linked to the parent -
-// i.e. only if the parent was recording when the child started.
 func (s *crdbSpan) childFinished(child *crdbSpan) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var childIdx int
 	found := false
-	for i, c := range s.mu.recording.openChildren {
+	for i, c := range s.mu.openChildren {
 		if c.crdbSpan == child {
 			childIdx = i
 			found = true
@@ -639,13 +645,13 @@ func (s *crdbSpan) childFinished(child *crdbSpan) {
 		panic("child not present in parent")
 	}
 
-	collectChildRec := s.mu.recording.openChildren[childIdx].collectRecording
+	collectChildRec := s.mu.openChildren[childIdx].collectRecording
 
 	// Unlink the child.
-	l := len(s.mu.recording.openChildren)
-	s.mu.recording.openChildren[childIdx] = s.mu.recording.openChildren[l-1]
-	s.mu.recording.openChildren[l-1].crdbSpan = nil // Make the child available to GC.
-	s.mu.recording.openChildren = s.mu.recording.openChildren[:l-1]
+	l := len(s.mu.openChildren)
+	s.mu.openChildren[childIdx] = s.mu.openChildren[l-1]
+	s.mu.openChildren[l-1].crdbSpan = nil // Make the child available to GC.
+	s.mu.openChildren = s.mu.openChildren[:l-1]
 
 	// Collect the child's recording.
 
@@ -698,7 +704,7 @@ func (s *crdbSpan) SetVerbose(to bool) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, child := range s.mu.recording.openChildren {
+	for _, child := range s.mu.openChildren {
 		child.SetVerbose(to)
 	}
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -44,6 +44,9 @@ import (
 )
 
 const (
+	// maxRecordedSpansPerTrace limits the number of spans per recording, keeping
+	// recordings from getting too large.
+	maxRecordedSpansPerTrace = 1000
 	// maxRecordedBytesPerSpan limits the size of logs and structured in a span;
 	// use a comfortable limit.
 	maxLogBytesPerSpan        = 256 * (1 << 10) // 256 KiB

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -48,8 +48,6 @@ const (
 	// use a comfortable limit.
 	maxLogBytesPerSpan        = 256 * (1 << 10) // 256 KiB
 	maxStructuredBytesPerSpan = 10 * (1 << 10)  // 10 KiB
-	// maxChildrenPerSpan limits the number of (direct) child spans in a Span.
-	maxChildrenPerSpan = 1000
 	// maxSpanRegistrySize limits the number of local root spans tracked in
 	// a Tracer's registry.
 	maxSpanRegistrySize = 5000
@@ -721,7 +719,7 @@ func (t *Tracer) startSpanGeneric(
 	helper.crdbSpan.operation = opName
 	helper.crdbSpan.mu.recording.logs = makeSizeLimitedBuffer(maxLogBytesPerSpan, nil /* scratch */)
 	helper.crdbSpan.mu.recording.structured = makeSizeLimitedBuffer(maxStructuredBytesPerSpan, helper.structuredEventsAlloc[:])
-	helper.crdbSpan.mu.recording.openChildren = helper.childrenAlloc[:0]
+	helper.crdbSpan.mu.openChildren = helper.childrenAlloc[:0]
 	if opts.SpanKind != oteltrace.SpanKindUnspecified {
 		helper.crdbSpan.setTagLocked(spanKindTagKey, attribute.StringValue(opts.SpanKind.String()))
 	}
@@ -736,21 +734,24 @@ func (t *Tracer) startSpanGeneric(
 	s := &helper.span
 
 	{
-		// If a parent is specified and the parent is recording, link the newly
-		// created Span to the parent so that the parent will later be able to
-		// collect the child's recording.
+		// If a parent is specified, link the newly created Span to the parent.
+		// While the parent is alive, the child will be part of the
+		// activeSpansRegistry indirectly through this link. If the parent is
+		// recording, it will also use this link to collect the child's recording.
 		if opts.Parent != nil && opts.Parent.i.crdb != nil {
 			parent := opts.Parent.i.crdb
-			if parent.recordingType() != RecordingOff {
-				// We're going to hold the parent's lock while we link both the parent
-				// to the child and the child to the parent.
-				parent.withLock(func() {
-					added := parent.addChildLocked(s.i.crdb, !opts.ParentDoesNotCollectRecording)
-					if added {
-						s.i.crdb.mu.parent = opts.Parent.i.crdb
-					}
-				})
-			}
+			// We're going to hold the parent's lock while we link both the parent
+			// to the child and the child to the parent.
+			parent.withLock(func() {
+				added := parent.addChildLocked(s.i.crdb, !opts.ParentDoesNotCollectRecording)
+				if added {
+					s.i.crdb.mu.parent = opts.Parent.i.crdb
+				} else {
+					// The parent has already finished. Clear it so the would-be child
+					// looks like a root and gets added to the activeSpansRegistry below.
+					opts.Parent = nil
+				}
+			})
 		}
 		s.i.crdb.enableRecording(opts.recordingType())
 	}
@@ -760,13 +761,6 @@ func (t *Tracer) startSpanGeneric(
 	//
 	// NB: (opts.Parent != nil && opts.Parent.i.crdb == nil) is not possible at
 	// the moment, but let's not rely on that.
-	//
-	// TODO(andrei): We should be adding to the registry also if the span has a
-	// local parent but the parent is not recording, since in that case we haven't
-	// linked the span to the parent above. But I don't want to do that before
-	// optimizing the registry code. For now, not adding the span to the registry
-	// in this case doesn't really matter, since the only cases where we're
-	// creating spans is when the parent is recording.
 	if opts.Parent == nil || opts.Parent.i.crdb == nil {
 		t.activeSpansRegistry.addSpan(s.i.crdb)
 	}


### PR DESCRIPTION
Before this patch, the registry only contained (local) roots. A child
span was not part of the registry directly; it was part of it indirectly
if the parent was recording at the moment when the child was opened.

I believe the fact that a child of a non-recording span is not part of
the registry is not principled, just path dependency. This patch makes
child spans indirectly part of the registry even if the parent is not
recording at the moment when the child is created, by having children
always register themselves with the parent, even if the parent is not
recording.

I got rid of the maxChildrenPerSpan limit on the number of open children
that a span keep track off. This limit was fairly non-sensical (it
probably started as more sane but then was refactored into non-sense) as
it applies to open spans but not to recordings of the finished children.
The point of this limit originally was to bound the memory use of
recordings. By acting only on open children, it had no such effect.
Indeed, there's pretty much no reason to bound the number of open
children tracked by a parent, and so this patch removes the limit. In
the next commit we'll get a new limit that refers to sizes of
recordings.

---

This patch also improves the scalability of creating child spans by
avoiding to attempt to remove them from the registry on Finish(). This
attempt was useless because we knew that the child span was not part of
the registry. It was also expensive, since it meant locking (and thus
synchronizing on) the registry. Thus, we now only attempt to remove
roots from the registry.

The scalability increase can be seen in the following:

GOGC=off make bench PKG=./pkg/util/tracing BENCHES=BenchmarkSpanCreation TESTFLAGS="-cpu=1,2,4,8,16,32 -count=5"

SpanCreation/detached-child=false     1.95µs ±28%  2.04µs ±24%     ~     (p=0.278 n=5+5)
SpanCreation/detached-child=false-2   1.32µs ±11%  1.23µs ±15%     ~     (p=0.310 n=5+5)
SpanCreation/detached-child=false-4   1.51µs ± 5%  0.81µs ±11%  -46.49%  (p=0.008 n=5+5)
SpanCreation/detached-child=false-8   1.86µs ± 2%  0.89µs ± 4%  -52.24%  (p=0.008 n=5+5)
SpanCreation/detached-child=false-16  2.08µs ± 5%  0.85µs ± 4%  -59.30%  (p=0.008 n=5+5)
SpanCreation/detached-child=false-32  2.21µs ± 2%  0.85µs ± 2%  -61.71%  (p=0.008 n=5+5)

---

For tactical reasons, this patch also adds protection for creating a
child span in a finished parent. This is illegal, as is any use of a
span after Finish(). Still, almost every other use of a span has
protection against use-after-Finish that makes the respective access
behave reasonably.  This protection will also act as a point where I'll
add an assertion, at least in tests, verifying the absence of such
illegal uses. So, this patch adds similar protection to creating a child
in a Finish()ed span.  In particular, it makes the new would-be child
span act as a root and be registered in the active spans registry.
Before, new span would be added to a finished parent, and so it would
essentially fall by the wayside and not make it to the registry.