### PR TITLE
flowinfra: refactor locking around FlowRegistry

### DIFF
--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -52,24 +52,27 @@ const expectedConnectionTime time.Duration = 500 * time.Millisecond
 
 // InboundStreamInfo represents the endpoint where a data stream from another
 // node connects to a flow. The external node initiates this process through a
-// FlowStream RPC, which uses (*Flow).connectInboundStream() to associate the
-// stream to a receiver to push rows to.
+// FlowStream RPC, which uses FlowRegistry.ConnectInboundStream() to associate
+// the stream to a receiver to push rows to.
 type InboundStreamInfo struct {
+	mu struct {
+		syncutil.Mutex
+		connected bool
+		// if set, indicates that we waited too long for an inbound connection,
+		// or we don't want this stream to connect anymore due to flow
+		// cancellation.
+		canceled bool
+		// finished is set if we have signaled that the stream is done
+		// transferring rows (to the flow's wait group).
+		finished bool
+	}
 	// receiver is the entity that will receive rows from another host, which is
 	// part of a processor (normally an input synchronizer) for row-based
 	// execution and a colrpc.Inbox for vectorized execution.
 	//
 	// During a FlowStream RPC, the stream is handed off to this strategy to
 	// process.
-	receiver  InboundStreamHandler
-	connected bool
-	// if set, indicates that we waited too long for an inbound connection, or
-	// we don't want this stream to connect anymore due to flow cancellation.
-	canceled bool
-	// finished is set if we have signaled that the stream is done transferring
-	// rows (to the flow's wait group).
-	finished bool
-
+	receiver InboundStreamHandler
 	// waitGroup to signal on when finished.
 	waitGroup *sync.WaitGroup
 }
@@ -84,7 +87,69 @@ func NewInboundStreamInfo(
 	}
 }
 
+// connect marks s as connected. It is an error if s was already marked either
+// as connected or canceled. It should be called without holding any mutexes.
+func (s *InboundStreamInfo) connect(
+	flowID execinfrapb.FlowID, streamID execinfrapb.StreamID,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.connected {
+		return errors.Errorf("flow %s: inbound stream %d already connected", flowID, streamID)
+	}
+	if s.mu.canceled {
+		return errors.Errorf("flow %s: inbound stream %d came too late", flowID, streamID)
+	}
+	s.mu.connected = true
+	return nil
+}
+
+// disconnect marks s as not connected. It should be called without holding any
+// mutexes.
+func (s *InboundStreamInfo) disconnect() {
+	s.mu.Lock()
+	s.mu.connected = false
+	s.mu.Unlock()
+}
+
+// finishLocked marks s as finished and notifies the wait group that one stream
+// is done. The mutex of s must be held when calling this method.
+func (s *InboundStreamInfo) finishLocked() {
+	if !s.mu.connected && !s.mu.canceled {
+		panic("finishing inbound stream that didn't connect or time out")
+	}
+	if s.mu.finished {
+		panic("double finish")
+	}
+
+	s.mu.finished = true
+	s.waitGroup.Done()
+}
+
+// cancelIfNotConnected cancels and finishes s if it's not marked as connected,
+// finished, or canceled, and returns the pending receiver if so.
+func (s *InboundStreamInfo) cancelIfNotConnected() InboundStreamHandler {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.connected || s.mu.finished || s.mu.canceled {
+		return nil
+	}
+	s.mu.canceled = true
+	s.finishLocked()
+	return s.receiver
+}
+
+// finish is the same as finishLocked when the mutex of s is not held already.
+func (s *InboundStreamInfo) finish() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.finishLocked()
+}
+
 // flowEntry is a structure associated with a (potential) flow.
+//
+// All fields in flowEntry are protected by the FlowRegistry mutex and, thus,
+// must be accessed while holding the lock.
 type flowEntry struct {
 	// waitCh is set if one or more clients are waiting for the flow; the
 	// channel gets closed when the flow is registered.
@@ -97,10 +162,12 @@ type flowEntry struct {
 
 	flow *FlowBase
 
-	// inboundStreams are streams that receive data from other hosts, through the
-	// FlowStream API. All fields in the inboundStreamInfos are protected by the
-	// FlowRegistry mutex (except the receiver, whose methods can be called
-	// freely).
+	// inboundStreams are streams that receive data from other hosts, through
+	// the FlowStream API. This map is set in Flow.Setup(), so it is safe to
+	// lookup into concurrently later.
+	//
+	// Each InboundStreamInfo has its own mutex, separate from the FlowRegistry
+	// mutex. These two mutexes should **not** be held at the same time.
 	inboundStreams map[execinfrapb.StreamID]*InboundStreamInfo
 
 	// streamTimer is a timer that fires after a timeout and verifies that all
@@ -241,13 +308,11 @@ func (fr *FlowRegistry) RegisterFlow(
 	if len(inboundStreams) > 0 {
 		// Set up a function to time out inbound streams after a while.
 		entry.streamTimer = time.AfterFunc(timeout, func() {
-			fr.Lock()
-			// We're giving up waiting for these inbound streams. We will push an
-			// error to its consumer after fr.Unlock; the error will propagate and
-			// eventually drain all the processors.
-			timedOutReceivers := fr.cancelPendingStreamsLocked(id)
-			fr.Unlock()
-			if len(timedOutReceivers) != 0 {
+			// We're giving up waiting for these inbound streams. We will push
+			// an error to its consumer; the error will propagate and eventually
+			// drain all the processors.
+			numTimedOutReceivers := fr.cancelPendingStreams(id, errNoInboundStreamConnection)
+			if numTimedOutReceivers != 0 {
 				// The span in the context might be finished by the time this runs. In
 				// principle, we could ForkSpan() beforehand, but we don't want to
 				// create the extra span every time.
@@ -256,43 +321,48 @@ func (fr *FlowRegistry) RegisterFlow(
 					timeoutCtx,
 					"flow id:%s : %d inbound streams timed out after %s; propagated error throughout flow",
 					id,
-					len(timedOutReceivers),
+					numTimedOutReceivers,
 					timeout,
 				)
-			}
-			for _, r := range timedOutReceivers {
-				go func(r InboundStreamHandler) {
-					r.Timeout(errNoInboundStreamConnection)
-				}(r)
 			}
 		})
 	}
 	return nil
 }
 
-// cancelPendingStreamsLocked cancels all of the streams that haven't been
-// connected yet in this flow, by setting them to finished and ending their
-// wait group. The method returns the list of RowReceivers corresponding to the
-// streams that were canceled. The caller is expected to send those
-// RowReceivers a cancellation message - this method can't do it because sending
-// those messages shouldn't happen under the flow registry's lock.
-func (fr *FlowRegistry) cancelPendingStreamsLocked(id execinfrapb.FlowID) []InboundStreamHandler {
+// cancelPendingStreams cancels all of the streams that haven't been connected
+// yet in this flow, by setting them to finished and ending their wait group.
+// All InboundStreamHandlers of these streams are timed out with the provided
+// error. The number of such timed out receivers is returned.
+//
+// This method should be called without holding the mutex of the FlowRegistry.
+func (fr *FlowRegistry) cancelPendingStreams(
+	id execinfrapb.FlowID, pendingReceiverErr error,
+) (numTimedOutReceivers int) {
+	var inboundStreams map[execinfrapb.StreamID]*InboundStreamInfo
+	fr.Lock()
 	entry := fr.flows[id]
-	if entry == nil || entry.flow == nil {
-		return nil
+	if entry != nil && entry.flow != nil {
+		// It is safe to access the inboundStreams map without holding the
+		// FlowRegistry mutex.
+		inboundStreams = entry.inboundStreams
 	}
-	pendingReceivers := make([]InboundStreamHandler, 0)
-	for streamID, is := range entry.inboundStreams {
-		// Connected, non-finished inbound streams will get an error
-		// returned in ProcessInboundStream(). Non-connected streams
-		// are handled below.
-		if !is.connected && !is.finished && !is.canceled {
-			is.canceled = true
-			pendingReceivers = append(pendingReceivers, is.receiver)
-			fr.finishInboundStreamLocked(id, streamID)
+	fr.Unlock()
+	if inboundStreams == nil {
+		return 0
+	}
+	for _, is := range inboundStreams {
+		// Connected, non-finished inbound streams will get an error returned in
+		// ProcessInboundStream(). Handle non-connected streams here.
+		pendingReceiver := is.cancelIfNotConnected()
+		if pendingReceiver != nil {
+			numTimedOutReceivers++
+			go func(receiver InboundStreamHandler) {
+				receiver.Timeout(pendingReceiverErr)
+			}(pendingReceiver)
 		}
 	}
-	return pendingReceivers
+	return numTimedOutReceivers
 }
 
 // UnregisterFlow removes a flow from the registry. Any subsequent
@@ -308,17 +378,19 @@ func (fr *FlowRegistry) UnregisterFlow(id execinfrapb.FlowID) {
 	fr.Unlock()
 }
 
-// waitForFlowLocked  waits until the flow with the given id gets registered -
-// up to the given timeout - and returns the flowEntry. If the timeout elapses,
-// returns nil. It should only be called while holding the mutex. The mutex is
-// temporarily unlocked if we need to wait.
-// It is illegal to call this if the flow is already connected.
-func (fr *FlowRegistry) waitForFlowLocked(
+// waitForFlow waits until the flow with the given id gets registered - up to
+// the given timeout - and returns the FlowBase. If the timeout elapses, returns
+// nil. It should only be called without holding the mutex.
+func (fr *FlowRegistry) waitForFlow(
 	ctx context.Context, id execinfrapb.FlowID, timeout time.Duration,
-) *flowEntry {
+) *FlowBase {
+	fr.Lock()
+	defer fr.Unlock()
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
-		log.Fatalf(ctx, "waitForFlowLocked called for a flow that's already registered: %d", id)
+		// The flow has just arrived (when the caller temporarily released the
+		// lock to send a handshake message on the gRPC stream).
+		return entry.flow
 	}
 
 	// Flow not registered (at least not yet).
@@ -341,13 +413,8 @@ func (fr *FlowRegistry) waitForFlowLocked(
 	}
 
 	fr.Lock()
-
 	fr.releaseEntryLocked(id)
-	if entry.flow == nil {
-		return nil
-	}
-
-	return entry
+	return entry.flow
 }
 
 // Drain waits at most flowDrainWait for currently running flows to finish and
@@ -476,12 +543,12 @@ func (fr *FlowRegistry) ConnectInboundStream(
 	streamID execinfrapb.StreamID,
 	stream execinfrapb.DistSQL_FlowStreamServer,
 	timeout time.Duration,
-) (_ *FlowBase, _ InboundStreamHandler, _ func(), retErr error) {
+) (*FlowBase, InboundStreamHandler, func(), error) {
 	fr.Lock()
-	defer fr.Unlock()
-
 	entry := fr.getEntryLocked(flowID)
-	if entry.flow == nil {
+	flow := entry.flow
+	fr.Unlock()
+	if flow == nil {
 		// Send the handshake message informing the producer that the consumer has
 		// not been scheduled yet. Another handshake will be sent below once the
 		// consumer has been connected.
@@ -503,33 +570,25 @@ func (fr *FlowRegistry) ConnectInboundStream(
 			// except there we already have the consumer and we can push the error.
 			return nil, nil, nil, err
 		}
-		entry = fr.waitForFlowLocked(ctx, flowID, timeout)
-		if entry == nil {
+		flow = fr.waitForFlow(ctx, flowID, timeout)
+		if flow == nil {
 			return nil, nil, nil, errors.Errorf("flow %s not found", flowID)
 		}
 	}
 
+	// entry.inboundStreams is safe to access without holding the mutex since
+	// the map is not modified after Flow.Setup.
 	s, ok := entry.inboundStreams[streamID]
 	if !ok {
 		return nil, nil, nil, errors.Errorf("flow %s: no inbound stream %d", flowID, streamID)
 	}
-	if s.connected {
-		return nil, nil, nil, errors.Errorf("flow %s: inbound stream %d already connected", flowID, streamID)
-	}
-	if s.canceled {
-		return nil, nil, nil, errors.Errorf("flow %s: inbound stream %d came too late", flowID, streamID)
-	}
-
-	// We now mark the stream as connected but, if an error happens later because
-	// the handshake fails, we reset the state; we want the stream to be
+	// We now mark the stream as connected but, if an error happens later
+	// because the handshake fails, we reset the state; we want the stream to be
 	// considered timed out when the moment comes just as if this connection
 	// attempt never happened.
-	s.connected = true
-	defer func() {
-		if retErr != nil {
-			s.connected = false
-		}
-	}()
+	if err := s.connect(flowID, streamID); err != nil {
+		return nil, nil, nil, err
+	}
 
 	if err := stream.Send(&execinfrapb.ConsumerSignal{
 		Handshake: &execinfrapb.ConsumerHandshake{
@@ -538,30 +597,9 @@ func (fr *FlowRegistry) ConnectInboundStream(
 			MinAcceptedVersion: execinfra.MinAcceptedVersion,
 		},
 	}); err != nil {
+		s.disconnect()
 		return nil, nil, nil, err
 	}
 
-	cleanup := func() {
-		fr.Lock()
-		fr.finishInboundStreamLocked(flowID, streamID)
-		fr.Unlock()
-	}
-	return entry.flow, s.receiver, cleanup, nil
-}
-
-func (fr *FlowRegistry) finishInboundStreamLocked(
-	fid execinfrapb.FlowID, sid execinfrapb.StreamID,
-) {
-	flowEntry := fr.getEntryLocked(fid)
-	streamEntry := flowEntry.inboundStreams[sid]
-
-	if !streamEntry.connected && !streamEntry.canceled {
-		panic("finishing inbound stream that didn't connect or time out")
-	}
-	if streamEntry.finished {
-		panic("double finish")
-	}
-
-	streamEntry.finished = true
-	streamEntry.waitGroup.Done()
+	return flow, s.receiver, s.finish, nil
 }

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -62,8 +62,8 @@ type InboundStreamInfo struct {
 		// or we don't want this stream to connect anymore due to flow
 		// cancellation.
 		canceled bool
-		// finished is set if we have signaled that the stream is done
-		// transferring rows (to the flow's wait group).
+		// finished is set when onFinish has already been called (which signaled
+		// that the stream is done transferring rows to the flow's wait group).
 		finished bool
 	}
 	// receiver is the entity that will receive rows from another host, which is
@@ -73,8 +73,8 @@ type InboundStreamInfo struct {
 	// During a FlowStream RPC, the stream is handed off to this strategy to
 	// process.
 	receiver InboundStreamHandler
-	// waitGroup to signal on when finished.
-	waitGroup *sync.WaitGroup
+	// onFinish will be called when the corresponding inbound stream is done.
+	onFinish func()
 }
 
 // NewInboundStreamInfo returns a new InboundStreamInfo.
@@ -82,8 +82,10 @@ func NewInboundStreamInfo(
 	receiver InboundStreamHandler, waitGroup *sync.WaitGroup,
 ) *InboundStreamInfo {
 	return &InboundStreamInfo{
-		receiver:  receiver,
-		waitGroup: waitGroup,
+		receiver: receiver,
+		// Do not hold onto the whole wait group to limit the coupling of the
+		// InboundStreamInfo with the FlowBase.
+		onFinish: waitGroup.Done,
 	}
 }
 
@@ -112,8 +114,8 @@ func (s *InboundStreamInfo) disconnect() {
 	s.mu.Unlock()
 }
 
-// finishLocked marks s as finished and notifies the wait group that one stream
-// is done. The mutex of s must be held when calling this method.
+// finishLocked marks s as finished and calls onFinish. The mutex of s must be
+// held when calling this method.
 func (s *InboundStreamInfo) finishLocked() {
 	if !s.mu.connected && !s.mu.canceled {
 		panic("finishing inbound stream that didn't connect or time out")
@@ -123,7 +125,7 @@ func (s *InboundStreamInfo) finishLocked() {
 	}
 
 	s.mu.finished = true
-	s.waitGroup.Done()
+	s.onFinish()
 }
 
 // cancelIfNotConnected cancels and finishes s if it's not marked as connected,
@@ -256,9 +258,10 @@ func IsFlowRetryableError(e error) bool {
 // flow. If any of them is not connected within timeout, errors are propagated.
 // The inboundStreams are expected to have been initialized with their
 // WaitGroups (the group should have been incremented). RegisterFlow takes
-// responsibility for calling Done() on that WaitGroup; this responsibility will
-// be forwarded forward by ConnectInboundStream. In case this method returns an
-// error, the WaitGroup will be decremented.
+// responsibility for finishing the inboundStreams (which will call Done() on
+// that WaitGroup); this responsibility will be forwarded forward by
+// ConnectInboundStream. In case this method returns an error, the
+// inboundStreams are finished here.
 func (fr *FlowRegistry) RegisterFlow(
 	ctx context.Context,
 	id execinfrapb.FlowID,
@@ -271,7 +274,7 @@ func (fr *FlowRegistry) RegisterFlow(
 	defer func() {
 		if retErr != nil {
 			for _, stream := range inboundStreams {
-				stream.waitGroup.Done()
+				stream.onFinish()
 			}
 		}
 	}()

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -221,7 +221,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
-		streamID1: {receiver: RowInboundStreamHandler{consumer}, waitGroup: wg},
+		streamID1: {receiver: RowInboundStreamHandler{consumer}, onFinish: wg.Done},
 	}
 	if err := reg.RegisterFlow(
 		context.Background(), id1, f1, inboundStreams, jiffy,
@@ -321,7 +321,7 @@ func TestHandshake(t *testing.T) {
 				wg := &sync.WaitGroup{}
 				wg.Add(1)
 				inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
-					streamID: {receiver: RowInboundStreamHandler{consumer}, waitGroup: wg},
+					streamID: {receiver: RowInboundStreamHandler{consumer}, onFinish: wg.Done},
 				}
 				if err := reg.RegisterFlow(
 					context.Background(), flowID, f1, inboundStreams, time.Hour, /* timeout */
@@ -531,8 +531,8 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 	rc.InitWithBufSizeAndNumSenders(types.OneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver:  RowInboundStreamHandler{rc},
-			waitGroup: &wg,
+			receiver: RowInboundStreamHandler{rc},
+			onFinish: wg.Done,
 		},
 	}
 	wg.Add(1)
@@ -575,8 +575,8 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	wg.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver:  RowInboundStreamHandler{rc},
-			waitGroup: &wg,
+			receiver: RowInboundStreamHandler{rc},
+			onFinish: wg.Done,
 		},
 	}
 
@@ -624,12 +624,12 @@ func TestFlowCancelPartiallyBlocked(t *testing.T) {
 	wgRight.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver:  RowInboundStreamHandler{left},
-			waitGroup: &wgLeft,
+			receiver: RowInboundStreamHandler{left},
+			onFinish: wgLeft.Done,
 		},
 		1: {
-			receiver:  RowInboundStreamHandler{right},
-			waitGroup: &wgRight,
+			receiver: RowInboundStreamHandler{right},
+			onFinish: wgRight.Done,
 		},
 	}
 


### PR DESCRIPTION
**flowinfra: refactor locking around FlowRegistry**

This commit refactors the locking done in `FlowRegistry`. Previously,
the `FlowRegistry`'s mutex (global process-wide) was protecting three
pieces of information:
- `flows` map that stores which flows have already been scheduled on the
node
- `flowEntry` objects (information about each scheduled flow)
- `InboundStreamInfo` objects (information about endpoints to serve
`FlowStream` RPCs).

This commit refactors the `InboundStreamInfo` objects so that each has
its own mutex. This cleans up the things a bit and allows us more
cleanly refactor the code in `ConnectInboundStream` so that we don't
perform any gRPC calls (which might be blocking, rarely) while holding
the `FlowRegistry`'s mutex.

Fixes: #72964.

Release note: None

**flowinfra: remove the reference to waitGroup from InboundStreamInfo**

This limits the coupling of `InboundStreamInfo` and `FlowBase`.

Release note: None