### PR TITLE
ui: save filters on cache for Transactions page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Filters, getFiltersFromQueryString } from "./filter";
+
+describe("Test filter functions", (): void => {
+  describe("Test get filters from query string", (): void => {
+    it("no values on query string", (): void => {
+      const expectedFilters: Filters = {
+        app: "",
+        timeNumber: "0",
+        timeUnit: "seconds",
+        fullScan: false,
+        sqlType: "",
+        database: "",
+        regions: "",
+        nodes: "",
+      };
+      const resultFilters = getFiltersFromQueryString("");
+      expect(resultFilters).toEqual(expectedFilters);
+    });
+  });
+
+  it("different values from default values on query string", (): void => {
+    const expectedFilters: Filters = {
+      app: "$ internal",
+      timeNumber: "1",
+      timeUnit: "milliseconds",
+      fullScan: true,
+      sqlType: "DML",
+      database: "movr",
+      regions: "us-central",
+      nodes: "n1,n2",
+    };
+    const resultFilters = getFiltersFromQueryString(
+      "app=%24+internal&timeNumber=1&timeUnit=milliseconds&fullScan=true&sqlType=DML&database=movr&regions=us-central&nodes=n1,n2",
+    );
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing boolean with full scan = true", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: true,
+      sqlType: "",
+      database: "",
+      regions: "",
+      nodes: "",
+    };
+    const resultFilters = getFiltersFromQueryString("fullScan=true");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing boolean with full scan = false", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: false,
+      sqlType: "",
+      database: "",
+      regions: "",
+      nodes: "",
+    };
+    const resultFilters = getFiltersFromQueryString("fullScan=false");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -11,6 +11,7 @@
 import React from "react";
 import _ from "lodash";
 import * as Long from "long";
+import { History } from "history";
 import { Moment } from "moment";
 import { createSelector } from "reselect";
 
@@ -319,7 +320,7 @@ export class SortedTable<T> extends React.Component<
     return sortData ? sortData.slice(start, end) : data.slice(start, end);
   };
 
-  render() {
+  render(): React.ReactElement {
     const {
       data,
       loading,
@@ -397,7 +398,10 @@ export class SortedTable<T> extends React.Component<
  * @param maxLength the max length to which it should display value
  * and hide the remaining.
  */
-export function longListWithTooltip(value: string, maxLength: number) {
+export function longListWithTooltip(
+  value: string,
+  maxLength: number,
+): React.ReactElement {
   const summary =
     value.length > maxLength ? value.slice(0, maxLength) + "..." : value;
   return (
@@ -411,3 +415,83 @@ export function longListWithTooltip(value: string, maxLength: number) {
     </Tooltip>
   );
 }
+
+/**
+ * Get Sort Setting from Query String and if it's different from current
+ * sortSetting calls the onSortChange function.
+ * @param page the page where the table was added (used for analytics)
+ * @param queryString searchParams
+ * @param sortSetting the current sort Setting on the page
+ * @param onSortingChange function to be called if the values from the search
+ * params are different from the current ones. This function can update
+ * the value stored on localStorage for example.
+ */
+export const handleSortSettingFromQueryString = (
+  page: string,
+  queryString: string,
+  sortSetting: SortSetting,
+  onSortingChange: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void,
+): void => {
+  const searchParams = new URLSearchParams(queryString);
+  const ascending = (searchParams.get("ascending") || undefined) === "true";
+  const columnTitle = searchParams.get("columnTitle") || undefined;
+  if (
+    onSortingChange &&
+    columnTitle &&
+    (sortSetting.columnTitle != columnTitle ||
+      sortSetting.ascending != ascending)
+  ) {
+    onSortingChange(page, columnTitle, ascending);
+  }
+};
+
+/**
+ * Update the query params to the current values of the Sort Setting.
+ * When we change tabs inside the SQL Activity page for example,
+ * the constructor is called only on the first time.
+ * The component update event is called frequently and can be used to
+ * update the query params by using this function that only updates
+ * the query params if the values did change and we're on the correct tab.
+ * @param tab which the query params should update
+ * @param sortSetting the current sort settings
+ * @param defaultSortSetting the default sort settings
+ * @param history
+ */
+export const updateSortSettingQueryParamsOnTab = (
+  tab: string,
+  sortSetting: SortSetting,
+  defaultSortSetting: SortSetting,
+  history: History,
+): void => {
+  const searchParams = new URLSearchParams(history.location.search);
+  const currentTab = searchParams.get("tab") || "";
+  const ascending =
+    (searchParams.get("ascending") ||
+      defaultSortSetting.ascending.toString()) === "true";
+  const columnTitle =
+    searchParams.get("columnTitle") || defaultSortSetting.columnTitle;
+  if (
+    currentTab === tab &&
+    (sortSetting.columnTitle != columnTitle ||
+      sortSetting.ascending != ascending)
+  ) {
+    const params = {
+      ascending: sortSetting.ascending.toString(),
+      columnTitle: sortSetting.columnTitle,
+    };
+    const nextSearchParams = new URLSearchParams(history.location.search);
+    Object.entries(params).forEach(([key, value]) => {
+      if (!value) {
+        nextSearchParams.delete(key);
+      } else {
+        nextSearchParams.set(key, value);
+      }
+    });
+    history.location.search = nextSearchParams.toString();
+    history.replace(history.location);
+  }
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -122,7 +122,7 @@ export const ConnectedStatementsPage = withRouter(
         dispatch(
           localStorageActions.update({
             key: "filters/StatementsPage",
-            value: { filters: value },
+            value: value,
           }),
         );
       },

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -32,6 +32,7 @@ export type LocalStorageState = {
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
   "filters/StatementsPage": Filters;
+  "filters/TransactionsPage": Filters;
 };
 
 type Payload = {
@@ -80,6 +81,9 @@ const initialState: LocalStorageState = {
     defaultSessionsSortSetting,
   "filters/StatementsPage":
     JSON.parse(localStorage.getItem("filters/StatementsPage")) ||
+    defaultFilters,
+  "filters/TransactionsPage":
+    JSON.parse(localStorage.getItem("filters/TransactionsPage")) ||
     defaultFilters,
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -14,6 +14,7 @@ import Long from "long";
 import moment from "moment";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { SortSetting } from "../sortedtable";
+import { Filters } from "../queryFilter";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -40,6 +41,8 @@ export const nodeRegions: { [nodeId: string]: string } = {
   "4": "gcp-europe-west1",
 };
 
+export const columns: string[] = ["all"];
+
 export const dateRange: [moment.Moment, moment.Moment] = [
   moment.utc("2021.08.08"),
   moment.utc("2021.08.12"),
@@ -51,6 +54,14 @@ export const timestamp = new protos.google.protobuf.Timestamp({
 export const sortSetting: SortSetting = {
   ascending: false,
   columnTitle: "executionCount",
+};
+
+export const filters: Filters = {
+  app: "",
+  timeNumber: "0",
+  timeUnit: "seconds",
+  regions: "",
+  nodes: "",
 };
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -45,3 +45,8 @@ export const selectSortSetting = createSelector(
   localStorageSelector,
   localStorage => localStorage["sortSetting/TransactionsPage"],
 );
+
+export const selectFilters = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["filters/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -15,9 +15,11 @@ import { cloneDeep, noop, extend } from "lodash";
 import {
   data,
   nodeRegions,
+  columns,
   routeProps,
   dateRange,
   sortSetting,
+  filters,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -37,10 +39,13 @@ storiesOf("Transactions Page", module)
       data={data}
       dateRange={dateRange}
       nodeRegions={nodeRegions}
+      columns={columns}
       refreshData={noop}
       resetSQLStats={noop}
       sortSetting={sortSetting}
       onSortingChange={noop}
+      filters={filters}
+      onFilterChange={noop}
     />
   ))
   .add("without data", () => {
@@ -50,10 +55,13 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -70,11 +78,14 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         history={history}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -85,10 +96,13 @@ storiesOf("Transactions Page", module)
         data={undefined}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -99,6 +113,7 @@ storiesOf("Transactions Page", module)
         data={undefined}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         error={
           new RequestError(
             "Forbidden",
@@ -110,6 +125,8 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -23,8 +23,10 @@ import { DateRange } from "src/dateRange";
 import { TransactionDetails } from "../transactionDetails";
 import {
   ColumnDescriptor,
+  handleSortSettingFromQueryString,
   ISortedTablePagination,
   SortSetting,
+  updateSortSettingQueryParamsOnTab,
 } from "../sortedtable";
 import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
@@ -39,7 +41,8 @@ import {
   getStatementsByFingerprintIdAndTime,
 } from "./utils";
 import Long from "long";
-import { getSearchParams, unique, syncHistory } from "src/util";
+import { merge } from "lodash";
+import { unique, syncHistory } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
@@ -48,7 +51,8 @@ import {
   Filter,
   Filters,
   defaultFilters,
-  getFiltersFromQueryString,
+  handleFiltersFromQueryString,
+  updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 import { UIConfigState } from "../store";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -87,6 +91,7 @@ export interface TransactionsPageStateProps {
   isTenant?: UIConfigState["isTenant"];
   columns: string[];
   sortSetting: SortSetting;
+  filters: Filters;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -94,6 +99,7 @@ export interface TransactionsPageDispatchProps {
   resetSQLStats: () => void;
   onDateRangeChange?: (start: Moment, end: Moment) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
+  onFilterChange?: (value: Filters) => void;
   onSortingChange?: (
     name: string,
     columnTitle: string,
@@ -120,42 +126,47 @@ export class TransactionsPage extends React.Component<
 > {
   constructor(props: TransactionsPageProps) {
     super(props);
-    const filters = getFiltersFromQueryString(
-      this.props.history.location.search,
-    );
-
-    const trxSearchParams = getSearchParams(this.props.history.location.search);
     this.state = {
       pagination: {
         pageSize: this.props.pageSize || 20,
         current: 1,
       },
-      search: trxSearchParams("q", "").toString(),
-      filters: filters,
+      search: "",
       aggregatedTs: null,
       statementFingerprintIds: null,
       transactionStats: null,
       transactionFingerprintId: null,
     };
-
-    const ascending = trxSearchParams("ascending", false).toString() === "true";
-    const columnTitle = trxSearchParams("columnTitle", undefined);
-    if (
-      this.props.onSortingChange &&
-      columnTitle &&
-      (this.props.sortSetting.columnTitle != columnTitle ||
-        this.props.sortSetting.ascending != ascending)
-    ) {
-      this.props.onSortingChange(
-        "Transactions",
-        columnTitle.toString(),
-        ascending,
-      );
-    }
+    const stateFromHistory = this.getStateFromHistory();
+    this.state = merge(this.state, stateFromHistory);
   }
 
-  static defaultProps: Partial<TransactionsPageProps> = {
-    isTenant: false,
+  getStateFromHistory = (): Partial<TState> => {
+    const { history, sortSetting, filters } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+
+    // Search query.
+    const searchQuery = searchParams.get("q") || undefined;
+
+    // Sort Settings.
+    handleSortSettingFromQueryString(
+      "Transactions",
+      history.location.search,
+      sortSetting,
+      this.props.onSortingChange,
+    );
+
+    // Filters.
+    const latestFilter = handleFiltersFromQueryString(
+      history,
+      filters,
+      this.props.onFilterChange,
+    );
+
+    return {
+      search: searchQuery,
+      filters: latestFilter,
+    };
   };
 
   refreshData = (): void => {
@@ -166,7 +177,27 @@ export class TransactionsPage extends React.Component<
   componentDidMount(): void {
     this.refreshData();
   }
+
+  updateQueryParams(): void {
+    updateFiltersQueryParamsOnTab(
+      "Transactions",
+      this.state.filters,
+      this.props.history,
+    );
+
+    updateSortSettingQueryParamsOnTab(
+      "Transactions",
+      this.props.sortSetting,
+      {
+        ascending: false,
+        columnTitle: "executionCount",
+      },
+      this.props.history,
+    );
+  }
+
   componentDidUpdate(): void {
+    this.updateQueryParams();
     this.refreshData();
   }
 
@@ -221,11 +252,12 @@ export class TransactionsPage extends React.Component<
   };
 
   onSubmitFilters = (filters: Filters): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(filters);
+    }
+
     this.setState({
-      filters: {
-        ...this.state.filters,
-        ...filters,
-      },
+      filters: filters,
     });
     this.resetPagination();
     syncHistory(
@@ -241,6 +273,10 @@ export class TransactionsPage extends React.Component<
   };
 
   onClearFilters = (): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(defaultFilters);
+    }
+
     this.setState({
       filters: {
         ...defaultFilters,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -30,10 +30,13 @@ import {
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
+import {
+  selectDateRange,
+  selectFilters,
+} from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
-import { actions as analyticsActions } from "../store/analytics";
+import { Filters } from "../queryFilter";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -49,6 +52,7 @@ export const TransactionsPageConnected = withRouter(
       dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
       sortSetting: selectSortSetting(state),
+      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -83,6 +87,14 @@ export const TransactionsPageConnected = withRouter(
           localStorageActions.update({
             key: "sortSetting/TransactionsPage",
             value: { columnTitle: columnName, ascending: ascending },
+          }),
+        );
+      },
+      onFilterChange: (value: Filters) => {
+        dispatch(
+          localStorageActions.update({
+            key: "filters/TransactionsPage",
+            value: value,
           }),
         );
       },

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -21,7 +21,11 @@ import { StatementsResponseMessage } from "src/util/api";
 import { TimestampToMoment } from "src/util/convert";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
-import { TransactionsPage } from "@cockroachlabs/cluster-ui";
+import {
+  TransactionsPage,
+  Filters,
+  defaultFilters,
+} from "@cockroachlabs/cluster-ui";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
 import { statementsDateRangeLocalSetting } from "src/redux/statementsDateRange";
 import { setCombinedStatementsDateRangeAction } from "src/redux/statements";
@@ -68,6 +72,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const filtersLocalSetting = new LocalSetting(
+  "filters/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  defaultFilters,
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -85,6 +95,7 @@ const TransactionsPageConnected = withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
       sortSetting: sortSettingLocalSetting.selector(state),
+      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshData: refreshStatements,
@@ -107,6 +118,7 @@ const TransactionsPageConnected = withRouter(
           ascending: ascending,
           columnTitle: columnName,
         }),
+      onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Previously, a sort selection was not maintained when
the page change (e.g. changing tabs/pages).
This commits saves the selected value to be used.

Partially adresses #71851

Release note: None