### PR TITLE
changefeedccl: Relax error checking condition in the test.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4541,7 +4541,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 		defer func() {
 			closeFeed(t, foo)
 			if err := g.Wait(); err != nil {
-				require.Truef(t, jobs.HasErrJobCanceled(err), "err=%v", err)
+				require.NotRegexp(t, "unexpected epoch resolved event", err)
 			}
 		}()
 


### PR DESCRIPTION
Closing the feed may return errors other than job termination
(e.g. database closed error). Instead of checking for job termination
error, verify that the error is not one of the disallowed ones.

Fixes #73005
Fixes #72988

Release Notes: none