### PR TITLE
roachprod: update host/port flags

### DIFF
--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 # delimiters for the Go text template so that this bash script is valid
 # before template evaluation (so we can use shellcheck).
 LOCAL=#{if .Local#}true#{end#}
-ADVERTISE_FIRST_IP=#{if .AdvertiseFirstIP#}true#{end#}
 LOG_DIR=#{shesc .LogDir#}
 BINARY=#{shesc .Binary#}
 START_CMD=#{shesc .StartCmd#}
@@ -33,10 +32,6 @@ ENV_VARS=(
 )
 
 # End of templated code.
-
-if [[ -n "${ADVERTISE_FIRST_IP}" ]]; then
-  ARGS+=("--advertise-host" "$(hostname -I | awk '{print $1}')")
-fi
 
 if [[ -n "${LOCAL}" ]]; then
   ARGS+=("--background")

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -18,7 +18,6 @@ set -euo pipefail
 # delimiters for the Go text template so that this bash script is valid
 # before template evaluation (so we can use shellcheck).
 LOCAL=true
-ADVERTISE_FIRST_IP=
 LOG_DIR='./path with spaces/logs/$THIS_DOES_NOT_EVER_GET_EXPANDED'
 BINARY=./cockroach
 START_CMD=start-single-node
@@ -35,10 +34,6 @@ ROCKCOACH=17%
 )
 
 # End of templated code.
-
-if [[ -n "${ADVERTISE_FIRST_IP}" ]]; then
-  ARGS+=("--advertise-host" "$(hostname -I | awk '{print $1}')")
-fi
 
 if [[ -n "${LOCAL}" ]]; then
   ARGS+=("--background")


### PR DESCRIPTION
The `--host` and `--port` flags are deprecated. This change switches
`roachprod` to using `listen-addr` and `http-addr` instead.

We also simplify the logic around `advertise-addr`: we can now access
the PrivateIP directly instead of detecting it from inside the start
script.

Release note: None