### PR TITLE
backupccl: ignore ErrDescriptorNotFound on system table lookup

### DIFF
--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -382,18 +383,20 @@ func GetSystemTableIDsToExcludeFromClusterBackup(
 		if backupConfig.shouldIncludeInClusterBackup == optOutOfClusterBackup {
 			err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 				tn := tree.MakeTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(systemTableName))
-				found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
-				if err != nil {
+				found, desc, err := col.GetImmutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
+				isNotFoundErr := errors.Is(err, catalog.ErrDescriptorNotFound)
+				if err != nil && !isNotFoundErr {
 					return err
 				}
+
 				// Some system tables are not present when running inside a secondary
 				// tenant egs: `systemschema.TenantsTable`. In such situations we are
 				// print a warning and move on.
-				if !found {
-					log.Warningf(ctx, "could not find system table descriptor %s", systemTableName)
+				if !found || isNotFoundErr {
+					log.Warningf(ctx, "could not find system table descriptor %q", systemTableName)
 					return nil
 				}
-				systemTableIDsToExclude[desc.ID] = struct{}{}
+				systemTableIDsToExclude[desc.GetID()] = struct{}{}
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
We assumed that in the not-found case GetMutableTableByName would
return a nil error. But, in fact, it returns a non-nil error, causing
us to fail when building our list of optOut system tables.

Now, we look for the DescriptorNotFound error specifically and ignore it.

Release note (enterprise change): BACKUP WITH revision_history would
previously fail on an upgraded but un-finalized cluster. Now, it
should succeed.