### PR TITLE
ui: prevent undefined axis label on custom chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -210,7 +210,7 @@ export class CustomChart extends React.Component<
         history={this.props.history}
       >
         <LineGraph>
-          <Axis units={units}>
+          <Axis units={units} label={AxisUnits[units]}>
             {metrics.map((m, i) => {
               if (m.metric !== "") {
                 if (m.perNode) {


### PR DESCRIPTION
Release note (bug fix): Y-axis labels on custom charts no longer display 'undefined'.

@thtruo, this fix addresses the issue as described in https://github.com/cockroachdb/cockroach/issues/72115.

Now, when the user selects a new unit from the dropdown, the user will experience up to a 10 second delay before the axis label refreshes.  @nathanstilwell and I investigated this last week, and we'd need more time to think of a solution that doesn't create long term maintenance headaches.  The benefit of this PR as it stands is that the Y-axis label is noticeably less broken. FYI.



