### PR TITLE
 sql/schemachanger/scplan: fix minor bugs

### DIFF
--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -186,6 +186,9 @@ func marshalOps(t *testing.T, plan *scplan.Plan) string {
 		var transitionsBuf strings.Builder
 		for i := range stage.Before.Nodes {
 			before, after := stage.Before.Nodes[i], stage.After.Nodes[i]
+			if before == after {
+				continue
+			}
 			_, _ = fmt.Fprintf(&transitionsBuf, "%s -> %s\n",
 				screl.NodeString(before), after.Status)
 		}

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -182,6 +182,15 @@ func marshalOps(t *testing.T, plan *scplan.Plan) string {
 			stages.WriteString(" (non-revertible)")
 		}
 		stages.WriteString("\n")
+		stages.WriteString("  transitions:\n")
+		var transitionsBuf strings.Builder
+		for i := range stage.Before.Nodes {
+			before, after := stage.Before.Nodes[i], stage.After.Nodes[i]
+			_, _ = fmt.Fprintf(&transitionsBuf, "%s -> %s\n",
+				screl.NodeString(before), after.Status)
+		}
+		stages.WriteString(indentText(transitionsBuf.String(), "    "))
+		stages.WriteString("  ops:\n")
 		stageOps := ""
 		for _, op := range stage.Ops.Slice() {
 			opMap, err := scgraphviz.ToMap(op)
@@ -190,7 +199,7 @@ func marshalOps(t *testing.T, plan *scplan.Plan) string {
 			require.NoError(t, err)
 			stageOps += fmt.Sprintf("%T\n%s", op, indentText(string(data), "  "))
 		}
-		stages.WriteString(indentText(stageOps, "  "))
+		stages.WriteString(indentText(stageOps, "    "))
 	}
 	return stages.String()
 }

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -6,378 +6,525 @@ ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT
 ----
 Stage 0
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      ID: 2
-      Name: j
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        ID: 2
+        Name: j
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 1
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 2
-    TableID: 52
-    Unique: true
+          column:
+            id: 2
+            name: j
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 2
+      TableID: 52
+      Unique: true
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 2
+      TableID: 52
 Stage 5 (non-revertible)
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 52
 Stage 6 (non-revertible)
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 52
 
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123
 ----
 Stage 0
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      DefaultExpr: 123:::INT8
-      ID: 2
-      Name: j
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        DefaultExpr: 123:::INT8
+        ID: 2
+        Name: j
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          defaultExpr: 123:::INT8
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 1
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 2
-    TableID: 52
-    Unique: true
+          column:
+            defaultExpr: 123:::INT8
+            id: 2
+            name: j
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 2
+      TableID: 52
+      Unique: true
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 2
+      TableID: 52
 Stage 5 (non-revertible)
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 52
 Stage 6 (non-revertible)
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 52
 
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123;
 ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
 ----
 Stage 0
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      DefaultExpr: 123:::INT8
-      ID: 2
-      Name: j
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        DefaultExpr: 123:::INT8
+        ID: 2
+        Name: j
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          defaultExpr: 123:::INT8
-          id: 2
-          name: j
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      DefaultExpr: 456:::INT8
-      ID: 3
-      Name: k
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+          column:
+            defaultExpr: 123:::INT8
+            id: 2
+            name: j
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        DefaultExpr: 456:::INT8
+        ID: 3
+        Name: k
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          defaultExpr: 456:::INT8
-          id: 3
-          name: k
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN k INT8 DEFAULT 456
-      TargetMetadata:
-        SourceElementID: 1
-        StatementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 1
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 2
-    - 3
-    TableID: 52
-    Unique: true
+          column:
+            defaultExpr: 456:::INT8
+            id: 3
+            name: k
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN k INT8 DEFAULT 456
+        TargetMetadata:
+          SourceElementID: 1
+          StatementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 2
+      - 3
+      TableID: 52
+      Unique: true
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 3
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 3
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 3
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 3
+      TableID: 52
 Stage 5 (non-revertible)
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 52
 Stage 6 (non-revertible)
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 52
 
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
 ----
 Stage 0
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      ComputeExpr: i + 1:::INT8
-      ID: 2
-      Name: a
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        ComputeExpr: i + 1:::INT8
+        ID: 2
+        Name: a
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          computeExpr: i + 1:::INT8
-          id: 2
-          name: a
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8 AS (i + 1) STORED
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 1
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 2
-    TableID: 52
-    Unique: true
+          column:
+            computeExpr: i + 1:::INT8
+            id: 2
+            name: a
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8 AS (i + 1) STORED
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 2
+      TableID: 52
+      Unique: true
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 2
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 2
+      TableID: 52
 Stage 5 (non-revertible)
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 52
 Stage 6 (non-revertible)
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 52
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 52
 
 
 create-table
@@ -389,153 +536,209 @@ ALTER TABLE defaultdb.foo ADD COLUMN a INT;
 ALTER TABLE defaultdb.bar ADD COLUMN b INT;
 ----
 Stage 0
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      ID: 2
-      Name: a
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 1
-    Element:
-      column:
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        ID: 2
+        Name: a
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 1
+      Element:
         column:
-          id: 2
-          name: a
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 52
-    Metadata:
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 1
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 2
-    TableID: 52
-    Unique: true
-  *scop.MakeAddedColumnDeleteOnly
-    Column:
-      ID: 3
-      Name: b
-      Nullable: true
-      Type:
-        family: IntFamily
-        oid: 20
-        width: 64
-    FamilyName: primary
-    TableID: 53
-  *scop.LogEvent
-    DescID: 53
-    Direction: 1
-    Element:
-      column:
+          column:
+            id: 2
+            name: a
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 52
+      Metadata:
+        Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 1
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 2
+      TableID: 52
+      Unique: true
+    *scop.MakeAddedColumnDeleteOnly
+      Column:
+        ID: 3
+        Name: b
+        Nullable: true
+        Type:
+          family: IntFamily
+          oid: 20
+          width: 64
+      FamilyName: primary
+      TableID: 53
+    *scop.LogEvent
+      DescID: 53
+      Direction: 1
+      Element:
         column:
-          id: 3
-          name: b
-          nullable: true
-          type:
-            family: IntFamily
-            oid: 20
-            width: 64
-        familyName: primary
-        tableId: 53
-    Metadata:
-      Statement: ALTER TABLE defaultdb.bar ADD COLUMN b INT8
-      TargetMetadata:
-        SourceElementID: 1
-        StatementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: new_primary_key
-    KeyColumnDirections:
-    - 0
-    KeyColumnIDs:
-    - 2
-    ShardedDescriptor: {}
-    StoreColumnIDs:
-    - 1
-    - 3
-    TableID: 53
-    Unique: true
+          column:
+            id: 3
+            name: b
+            nullable: true
+            type:
+              family: IntFamily
+              oid: 20
+              width: 64
+          familyName: primary
+          tableId: 53
+      Metadata:
+        Statement: ALTER TABLE defaultdb.bar ADD COLUMN b INT8
+        TargetMetadata:
+          SourceElementID: 1
+          StatementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: new_primary_key
+      KeyColumnDirections:
+      - 0
+      KeyColumnIDs:
+      - 2
+      ShardedDescriptor: {}
+      StoreColumnIDs:
+      - 1
+      - 3
+      TableID: 53
+      Unique: true
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 2
-    TableID: 52
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 53
-  *scop.MakeAddedColumnDeleteAndWriteOnly
-    ColumnID: 3
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 2
+      TableID: 52
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 53
+    *scop.MakeAddedColumnDeleteAndWriteOnly
+      ColumnID: 3
+      TableID: 53
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 53
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 53
 Stage 4
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 52
-  *scop.MakeColumnPublic
-    ColumnID: 2
-    TableID: 52
-  *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
-    IndexID: 1
-    TableID: 53
-  *scop.MakeAddedPrimaryIndexPublic
-    IndexID: 2
-    TableID: 53
-  *scop.MakeColumnPublic
-    ColumnID: 3
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 52
+    *scop.MakeColumnPublic
+      ColumnID: 2
+      TableID: 52
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 53
+    *scop.MakeAddedPrimaryIndexPublic
+      IndexID: 2
+      TableID: 53
+    *scop.MakeColumnPublic
+      ColumnID: 3
+      TableID: 53
 Stage 5 (non-revertible)
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 52
-  *scop.MakeDroppedIndexDeleteOnly
-    IndexID: 1
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 52
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 53
 Stage 6 (non-revertible)
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 52
-  *scop.MakeIndexAbsent
-    IndexID: 1
-    TableID: 53
+  transitions:
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 52
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 53

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -7,9 +7,9 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT
 ----
 Stage 0
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -57,9 +57,9 @@ Stage 0
       Unique: true
 Stage 1
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -69,27 +69,27 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -104,7 +104,7 @@ Stage 5 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
@@ -113,7 +113,7 @@ Stage 6 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
       IndexID: 1
@@ -124,9 +124,9 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123
 ----
 Stage 0
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -176,9 +176,9 @@ Stage 0
       Unique: true
 Stage 1
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -188,27 +188,27 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -223,7 +223,7 @@ Stage 5 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
@@ -232,7 +232,7 @@ Stage 6 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
       IndexID: 1
@@ -244,10 +244,10 @@ ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
 ----
 Stage 0
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -333,10 +333,10 @@ Stage 0
       Unique: true
 Stage 1
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -349,30 +349,30 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
+    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
+    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -390,7 +390,7 @@ Stage 5 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
   ops:
     *scop.MakeDroppedIndexDeleteOnly
@@ -400,7 +400,7 @@ Stage 6 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
     [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
   ops:
     *scop.MakeIndexAbsent
@@ -412,9 +412,9 @@ ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
 ----
 Stage 0
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -464,9 +464,9 @@ Stage 0
       Unique: true
 Stage 1
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -476,27 +476,27 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -511,7 +511,7 @@ Stage 5 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
@@ -520,7 +520,7 @@ Stage 6 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
       IndexID: 1
@@ -537,12 +537,12 @@ ALTER TABLE defaultdb.bar ADD COLUMN b INT;
 ----
 Stage 0
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -636,12 +636,12 @@ Stage 0
       Unique: true
 Stage 1
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -657,12 +657,12 @@ Stage 1
       TableID: 53
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
@@ -672,12 +672,12 @@ Stage 2
       TableID: 53
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -687,12 +687,12 @@ Stage 3
       TableID: 53
 Stage 4
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
+    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -716,10 +716,10 @@ Stage 5 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
@@ -731,10 +731,10 @@ Stage 6 (non-revertible)
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
     [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, ABSENT, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
       IndexID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -9,7 +9,6 @@ Stage 0
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -59,7 +58,6 @@ Stage 1
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -69,18 +67,14 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -102,8 +96,6 @@ Stage 4
       TableID: 52
 Stage 5 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
@@ -111,8 +103,6 @@ Stage 5 (non-revertible)
       TableID: 52
 Stage 6 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
@@ -126,7 +116,6 @@ Stage 0
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -178,7 +167,6 @@ Stage 1
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -188,18 +176,14 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -221,8 +205,6 @@ Stage 4
       TableID: 52
 Stage 5 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
@@ -230,8 +212,6 @@ Stage 5 (non-revertible)
       TableID: 52
 Stage 6 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
@@ -246,7 +226,6 @@ Stage 0
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
     [Column:{DescID: 52, ColumnID: 3, Name: k}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedColumnDeleteOnly
@@ -335,7 +314,6 @@ Stage 1
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
     [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
@@ -349,20 +327,14 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -388,20 +360,14 @@ Stage 4
       TableID: 52
 Stage 5 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 52
 Stage 6 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: j}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 52, ColumnID: 3, Name: k}, PUBLIC, ADD] -> PUBLIC
   ops:
     *scop.MakeIndexAbsent
       IndexID: 1
@@ -414,7 +380,6 @@ Stage 0
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -466,7 +431,6 @@ Stage 1
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -476,18 +440,14 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -509,8 +469,6 @@ Stage 4
       TableID: 52
 Stage 5 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
@@ -518,8 +476,6 @@ Stage 5 (non-revertible)
       TableID: 52
 Stage 6 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent
@@ -539,10 +495,8 @@ Stage 0
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
     [Column:{DescID: 53, ColumnID: 3, Name: b}, ABSENT, ADD] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedColumnDeleteOnly
       Column:
@@ -638,10 +592,8 @@ Stage 1
   transitions:
     [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
     [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -657,12 +609,8 @@ Stage 1
       TableID: 53
 Stage 2
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.BackfillIndex
       IndexID: 2
@@ -672,12 +620,8 @@ Stage 2
       TableID: 53
 Stage 3
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, DELETE_AND_WRITE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
-    [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -714,11 +658,7 @@ Stage 4
       TableID: 53
 Stage 5 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
@@ -729,11 +669,7 @@ Stage 5 (non-revertible)
       TableID: 53
 Stage 6 (non-revertible)
   transitions:
-    [Column:{DescID: 52, ColumnID: 2, Name: a}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 52, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 52, Name: foo_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 53, ColumnID: 3, Name: b}, PUBLIC, ADD] -> PUBLIC
-    [PrimaryIndex:{DescID: 53, Name: new_primary_key, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 53, Name: bar_pkey, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
     *scop.MakeIndexAbsent

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -7,7 +7,7 @@ CREATE INDEX id1 on defaultdb.t1(id, name) storing (money)
 ----
 Stage 0
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteOnly
       IndexID: 2
@@ -24,28 +24,28 @@ Stage 0
       TableID: 52
 Stage 1
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 52
 Stage 2
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
     *scop.MakeAddedSecondaryIndexPublic
       IndexID: 2
@@ -60,7 +60,7 @@ CREATE INVERTED INDEX concurrently id1 on defaultdb.t1(id, name) storing (money)
 ----
 Stage 0
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteOnly
       Concurrently: true
@@ -79,28 +79,28 @@ Stage 0
       TableID: 52
 Stage 1
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 52
 Stage 2
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 52
 Stage 3
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 52
 Stage 4
   transitions:
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
     *scop.MakeAddedSecondaryIndexPublic
       IndexID: 2
@@ -118,7 +118,7 @@ CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (i
 Stage 0
   transitions:
     [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteOnly
       IndexID: 2
@@ -136,7 +136,7 @@ Stage 0
 Stage 1
   transitions:
     [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -144,7 +144,7 @@ Stage 1
 Stage 2
   transitions:
     [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
@@ -152,7 +152,7 @@ Stage 2
 Stage 3
   transitions:
     [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -160,7 +160,7 @@ Stage 3
 Stage 4
   transitions:
     [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
-    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
     *scop.MakeAddedSecondaryIndexPublic
       IndexID: 2

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -117,7 +117,6 @@ CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (i
 ----
 Stage 0
   transitions:
-    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
     [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteOnly
@@ -135,7 +134,6 @@ Stage 0
       TableID: 52
 Stage 1
   transitions:
-    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
     [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
@@ -143,7 +141,6 @@ Stage 1
       TableID: 52
 Stage 2
   transitions:
-    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
     [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
@@ -151,7 +148,6 @@ Stage 2
       TableID: 52
 Stage 3
   transitions:
-    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
     [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
@@ -159,7 +155,6 @@ Stage 3
       TableID: 52
 Stage 4
   transitions:
-    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
     [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
     *scop.MakeAddedSecondaryIndexPublic

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -6,35 +6,50 @@ ops
 CREATE INDEX id1 on defaultdb.t1(id, name) storing (money)
 ----
 Stage 0
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: id1
-    KeyColumnDirections:
-    - 0
-    - 0
-    KeyColumnIDs:
-    - 1
-    - 2
-    SecondaryIndex: true
-    StoreColumnIDs:
-    - 3
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: id1
+      KeyColumnDirections:
+      - 0
+      - 0
+      KeyColumnIDs:
+      - 1
+      - 2
+      SecondaryIndex: true
+      StoreColumnIDs:
+      - 3
+      TableID: 52
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeAddedSecondaryIndexPublic
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedSecondaryIndexPublic
+      IndexID: 2
+      TableID: 52
 
 deps
 CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
@@ -44,37 +59,52 @@ ops
 CREATE INVERTED INDEX concurrently id1 on defaultdb.t1(id, name) storing (money)
 ----
 Stage 0
-  *scop.MakeAddedIndexDeleteOnly
-    Concurrently: true
-    IndexID: 2
-    IndexName: id1
-    Inverted: true
-    KeyColumnDirections:
-    - 0
-    - 0
-    KeyColumnIDs:
-    - 1
-    - 2
-    SecondaryIndex: true
-    StoreColumnIDs:
-    - 3
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteOnly
+      Concurrently: true
+      IndexID: 2
+      IndexName: id1
+      Inverted: true
+      KeyColumnDirections:
+      - 0
+      - 0
+      KeyColumnIDs:
+      - 1
+      - 2
+      SecondaryIndex: true
+      StoreColumnIDs:
+      - 3
+      TableID: 52
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeAddedSecondaryIndexPublic
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedSecondaryIndexPublic
+      IndexID: 2
+      TableID: 52
 
 deps
 CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
@@ -86,35 +116,55 @@ CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (i
                                                             )
 ----
 Stage 0
-  *scop.MakeAddedIndexDeleteOnly
-    IndexID: 2
-    IndexName: id1
-    KeyColumnDirections:
-    - 0
-    - 0
-    KeyColumnIDs:
-    - 1
-    - 2
-    SecondaryIndex: true
-    StoreColumnIDs:
-    - 3
-    TableID: 52
+  transitions:
+    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteOnly
+      IndexID: 2
+      IndexName: id1
+      KeyColumnDirections:
+      - 0
+      - 0
+      KeyColumnIDs:
+      - 1
+      - 2
+      SecondaryIndex: true
+      StoreColumnIDs:
+      - 3
+      TableID: 52
 Stage 1
-  *scop.MakeAddedIndexDeleteAndWriteOnly
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 2
+      TableID: 52
 Stage 2
-  *scop.BackfillIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      TableID: 52
 Stage 3
-  *scop.ValidateUniqueIndex
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 52
 Stage 4
-  *scop.MakeAddedSecondaryIndexPublic
-    IndexID: 2
-    TableID: 52
+  transitions:
+    [Partitioning:{DescID: 52, IndexID: 2}, ABSENT, ADD] -> ABSENT
+    [SecondaryIndex:{DescID: 52, Name: id1, IndexID: 2}, PUBLIC, ADD] -> PUBLIC
+  ops:
+    *scop.MakeAddedSecondaryIndexPublic
+      IndexID: 2
+      TableID: 52
 
 deps
 CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (id) (

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -52,35 +52,35 @@ DROP DATABASE db1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
+    [Sequence:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
+    [DefaultExpression:{DescID: 57, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 57, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
+    [Table:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
+    [DefaultExpression:{DescID: 56, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
+    [Sequence:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 58}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 60}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 61}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 64}, PUBLIC, DROP] -> TXN_DROPPED
+    [TypeReference:{DescID: 64, ReferencedDescID: 62}, PUBLIC, DROP] -> PUBLIC
+    [TypeReference:{DescID: 64, ReferencedDescID: 63}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 56, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 56, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
+    [Table:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
+    [Type:{DescID: 62}, PUBLIC, DROP] -> TXN_DROPPED
+    [Type:{DescID: 63}, PUBLIC, DROP] -> TXN_DROPPED
+    [Schema:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
+    [Database:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 54
@@ -110,35 +110,35 @@ Stage 0
       DescID: 52
 Stage 1 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
+    [Sequence:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
+    [DefaultExpression:{DescID: 57, ColumnID: 1}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
+    [Table:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
+    [DefaultExpression:{DescID: 56, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
+    [Sequence:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 58}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 59}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 60}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 61}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 64}, TXN_DROPPED, DROP] -> DROPPED
+    [TypeReference:{DescID: 64, ReferencedDescID: 62}, PUBLIC, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 63}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 1}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> ABSENT
+    [Table:{DescID: 56}, TXN_DROPPED, DROP] -> DROPPED
+    [Type:{DescID: 62}, TXN_DROPPED, DROP] -> DROPPED
+    [Type:{DescID: 63}, TXN_DROPPED, DROP] -> DROPPED
+    [Schema:{DescID: 53}, TXN_DROPPED, DROP] -> DROPPED
+    [Database:{DescID: 52}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.MarkDescriptorAsDropped
       DescID: 57
@@ -229,34 +229,34 @@ Stage 1 (non-revertible)
 Stage 2 (non-revertible)
   transitions:
     [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 54}, DROPPED, DROP] -> ABSENT
     [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 57}, DROPPED, DROP] -> ABSENT
     [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 60}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 64}, DROPPED, DROP] -> ABSENT
     [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
     [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 56}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 62}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 63}, DROPPED, DROP] -> ABSENT
+    [Schema:{DescID: 53}, DROPPED, DROP] -> ABSENT
+    [Database:{DescID: 52}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 54

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -52,30 +52,14 @@ DROP DATABASE db1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 57, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
     [Sequence:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
-    [DefaultExpression:{DescID: 57, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 57, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
     [Table:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
-    [DefaultExpression:{DescID: 56, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
     [Sequence:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 58}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 60}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 61}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 64}, PUBLIC, DROP] -> TXN_DROPPED
-    [TypeReference:{DescID: 64, ReferencedDescID: 62}, PUBLIC, DROP] -> PUBLIC
-    [TypeReference:{DescID: 64, ReferencedDescID: 63}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 56, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 56, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
     [Table:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
     [Type:{DescID: 62}, PUBLIC, DROP] -> TXN_DROPPED
     [Type:{DescID: 63}, PUBLIC, DROP] -> TXN_DROPPED
@@ -228,30 +212,14 @@ Stage 1 (non-revertible)
       DescID: 52
 Stage 2 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
     [Sequence:{DescID: 54}, DROPPED, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
     [Table:{DescID: 57}, DROPPED, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
     [Sequence:{DescID: 55}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 58}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 60}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 61}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 64}, DROPPED, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
     [Table:{DescID: 56}, DROPPED, DROP] -> ABSENT
     [Type:{DescID: 62}, DROPPED, DROP] -> ABSENT
     [Type:{DescID: 63}, DROPPED, DROP] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -51,331 +51,424 @@ ops
 DROP DATABASE db1 CASCADE
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 54
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 57
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 55
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 58
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 59
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 60
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 61
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 64
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 56
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 62
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 63
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 53
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 54
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 57
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 55
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 58
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 59
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 60
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 61
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 64
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 56
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 62
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 63
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 53
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 52
 Stage 1 (non-revertible)
-  *scop.MarkDescriptorAsDropped
-    DescID: 57
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 3
-    TableID: 57
-  *scop.UpdateRelationDeps
-    TableID: 57
-  *scop.MarkDescriptorAsDropped
-    DescID: 54
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 57
-    TableID: 54
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 1
-    TableID: 57
-  *scop.UpdateRelationDeps
-    TableID: 57
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 57
-  *scop.UpdateRelationDeps
-    TableID: 57
-  *scop.MarkDescriptorAsDropped
-    DescID: 56
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 3
-    TableID: 56
-  *scop.UpdateRelationDeps
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    DescID: 55
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 56
-    TableID: 55
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 58
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    DescID: 58
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 59
-    TableID: 58
-  *scop.MarkDescriptorAsDropped
-    DescID: 59
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 60
-    TableID: 59
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 61
-    TableID: 59
-  *scop.MarkDescriptorAsDropped
-    DescID: 61
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 64
-    TableID: 61
-  *scop.MarkDescriptorAsDropped
-    DescID: 62
-  *scop.RemoveTypeBackRef
-    DescID: 64
-    TypeID: 62
-  *scop.MarkDescriptorAsDropped
-    DescID: 63
-  *scop.RemoveTypeBackRef
-    DescID: 64
-    TypeID: 63
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 60
-    TableID: 58
-  *scop.MarkDescriptorAsDropped
-    DescID: 60
-  *scop.MarkDescriptorAsDropped
-    DescID: 64
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 1
-    TableID: 56
-  *scop.UpdateRelationDeps
-    TableID: 56
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 56
-  *scop.UpdateRelationDeps
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    DescID: 53
-  *scop.MarkDescriptorAsDropped
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescID: 57
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 57
+    *scop.UpdateRelationDeps
+      TableID: 57
+    *scop.MarkDescriptorAsDropped
+      DescID: 54
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 57
+      TableID: 54
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 57
+    *scop.UpdateRelationDeps
+      TableID: 57
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 57
+    *scop.UpdateRelationDeps
+      TableID: 57
+    *scop.MarkDescriptorAsDropped
+      DescID: 56
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 56
+    *scop.UpdateRelationDeps
+      TableID: 56
+    *scop.MarkDescriptorAsDropped
+      DescID: 55
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 56
+      TableID: 55
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 58
+      TableID: 56
+    *scop.MarkDescriptorAsDropped
+      DescID: 58
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 59
+      TableID: 58
+    *scop.MarkDescriptorAsDropped
+      DescID: 59
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 60
+      TableID: 59
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 61
+      TableID: 59
+    *scop.MarkDescriptorAsDropped
+      DescID: 61
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 64
+      TableID: 61
+    *scop.MarkDescriptorAsDropped
+      DescID: 62
+    *scop.RemoveTypeBackRef
+      DescID: 64
+      TypeID: 62
+    *scop.MarkDescriptorAsDropped
+      DescID: 63
+    *scop.RemoveTypeBackRef
+      DescID: 64
+      TypeID: 63
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 60
+      TableID: 58
+    *scop.MarkDescriptorAsDropped
+      DescID: 60
+    *scop.MarkDescriptorAsDropped
+      DescID: 64
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 56
+    *scop.UpdateRelationDeps
+      TableID: 56
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 56
+    *scop.UpdateRelationDeps
+      TableID: 56
+    *scop.MarkDescriptorAsDropped
+      DescID: 53
+    *scop.MarkDescriptorAsDropped
+      DescID: 52
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 54
-  *scop.LogEvent
-    DescID: 54
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 54
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 3
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 54
-  *scop.DrainDescriptorName
-    TableID: 57
-  *scop.LogEvent
-    DescID: 57
-    Direction: 2
-    Element:
-      table:
-        tableId: 57
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 3
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 57
-  *scop.DrainDescriptorName
-    TableID: 55
-  *scop.LogEvent
-    DescID: 55
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 55
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 5
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.DrainDescriptorName
-    TableID: 60
-  *scop.LogEvent
-    DescID: 60
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 58
-        - 59
-        tableId: 60
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 8
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 60
-  *scop.DrainDescriptorName
-    TableID: 64
-  *scop.LogEvent
-    DescID: 64
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 61
-        tableId: 64
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 10
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 64
-  *scop.DrainDescriptorName
-    TableID: 61
-  *scop.LogEvent
-    DescID: 61
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 64
-        dependsOn:
-        - 59
-        tableId: 61
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 8
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 61
-  *scop.DrainDescriptorName
-    TableID: 59
-  *scop.LogEvent
-    DescID: 59
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 60
-        - 61
-        dependsOn:
-        - 58
-        tableId: 59
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 7
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 59
-  *scop.DrainDescriptorName
-    TableID: 58
-  *scop.LogEvent
-    DescID: 58
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 59
-        - 60
-        dependsOn:
-        - 56
-        tableId: 58
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 6
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 58
-  *scop.DrainDescriptorName
-    TableID: 56
-  *scop.LogEvent
-    DescID: 56
-    Direction: 2
-    Element:
-      table:
-        tableId: 56
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 5
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.DrainDescriptorName
-    TableID: 62
-  *scop.DrainDescriptorName
-    TableID: 63
-  *scop.DrainDescriptorName
-    TableID: 53
-  *scop.LogEvent
-    DescID: 53
-    Direction: 2
-    Element:
-      schema:
-        dependentObjects:
-        - 55
-        - 56
-        - 58
-        - 59
-        - 60
-        - 61
-        - 62
-        - 63
-        - 64
-        schemaId: 53
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.DrainDescriptorName
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 2
-    Element:
-      database:
-        databaseId: 52
-        dependentObjects:
-        - 53
-        - 54
-        - 57
-    Metadata:
-      Statement: DROP DATABASE db1 CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
+  transitions:
+    [DefaultExpression:{DescID: 57, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 57, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 64}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 64}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 62}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 64, ReferencedDescID: 63}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 56, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 62}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 63}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Database:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 54
+    *scop.LogEvent
+      DescID: 54
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 54
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 3
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 54
+    *scop.DrainDescriptorName
+      TableID: 57
+    *scop.LogEvent
+      DescID: 57
+      Direction: 2
+      Element:
+        table:
+          tableId: 57
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 3
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 57
+    *scop.DrainDescriptorName
+      TableID: 55
+    *scop.LogEvent
+      DescID: 55
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 55
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 5
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 55
+    *scop.DrainDescriptorName
+      TableID: 60
+    *scop.LogEvent
+      DescID: 60
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 58
+          - 59
+          tableId: 60
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 8
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 60
+    *scop.DrainDescriptorName
+      TableID: 64
+    *scop.LogEvent
+      DescID: 64
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 61
+          tableId: 64
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 10
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 64
+    *scop.DrainDescriptorName
+      TableID: 61
+    *scop.LogEvent
+      DescID: 61
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 64
+          dependsOn:
+          - 59
+          tableId: 61
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 8
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 61
+    *scop.DrainDescriptorName
+      TableID: 59
+    *scop.LogEvent
+      DescID: 59
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 60
+          - 61
+          dependsOn:
+          - 58
+          tableId: 59
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 7
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 59
+    *scop.DrainDescriptorName
+      TableID: 58
+    *scop.LogEvent
+      DescID: 58
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 59
+          - 60
+          dependsOn:
+          - 56
+          tableId: 58
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 6
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 58
+    *scop.DrainDescriptorName
+      TableID: 56
+    *scop.LogEvent
+      DescID: 56
+      Direction: 2
+      Element:
+        table:
+          tableId: 56
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 5
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 56
+    *scop.DrainDescriptorName
+      TableID: 62
+    *scop.DrainDescriptorName
+      TableID: 63
+    *scop.DrainDescriptorName
+      TableID: 53
+    *scop.LogEvent
+      DescID: 53
+      Direction: 2
+      Element:
+        schema:
+          dependentObjects:
+          - 55
+          - 56
+          - 58
+          - 59
+          - 60
+          - 61
+          - 62
+          - 63
+          - 64
+          schemaId: 53
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.DrainDescriptorName
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 2
+      Element:
+        database:
+          databaseId: 52
+          dependentObjects:
+          - 53
+          - 54
+          - 57
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
 
 deps
 DROP DATABASE db1 CASCADE

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -120,248 +120,320 @@ ops
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 53
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 55
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 56
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 57
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 58
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 61
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 54
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 59
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 60
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 53
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 55
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 56
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 57
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 58
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 61
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 54
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 59
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 60
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 52
 Stage 1 (non-revertible)
-  *scop.MarkDescriptorAsDropped
-    DescID: 54
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 3
-    TableID: 54
-  *scop.UpdateRelationDeps
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    DescID: 53
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 54
-    TableID: 53
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 55
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    DescID: 55
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 56
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    DescID: 56
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 57
-    TableID: 56
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 58
-    TableID: 56
-  *scop.MarkDescriptorAsDropped
-    DescID: 58
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 61
-    TableID: 58
-  *scop.MarkDescriptorAsDropped
-    DescID: 59
-  *scop.RemoveTypeBackRef
-    DescID: 61
-    TypeID: 59
-  *scop.MarkDescriptorAsDropped
-    DescID: 60
-  *scop.RemoveTypeBackRef
-    DescID: 61
-    TypeID: 60
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 57
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    DescID: 57
-  *scop.MarkDescriptorAsDropped
-    DescID: 61
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 1
-    TableID: 54
-  *scop.UpdateRelationDeps
-    TableID: 54
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 54
-  *scop.UpdateRelationDeps
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescID: 54
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 54
+    *scop.UpdateRelationDeps
+      TableID: 54
+    *scop.MarkDescriptorAsDropped
+      DescID: 53
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 54
+      TableID: 53
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 55
+      TableID: 54
+    *scop.MarkDescriptorAsDropped
+      DescID: 55
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 56
+      TableID: 55
+    *scop.MarkDescriptorAsDropped
+      DescID: 56
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 57
+      TableID: 56
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 58
+      TableID: 56
+    *scop.MarkDescriptorAsDropped
+      DescID: 58
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 61
+      TableID: 58
+    *scop.MarkDescriptorAsDropped
+      DescID: 59
+    *scop.RemoveTypeBackRef
+      DescID: 61
+      TypeID: 59
+    *scop.MarkDescriptorAsDropped
+      DescID: 60
+    *scop.RemoveTypeBackRef
+      DescID: 61
+      TypeID: 60
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 57
+      TableID: 55
+    *scop.MarkDescriptorAsDropped
+      DescID: 57
+    *scop.MarkDescriptorAsDropped
+      DescID: 61
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 54
+    *scop.UpdateRelationDeps
+      TableID: 54
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 54
+    *scop.UpdateRelationDeps
+      TableID: 54
+    *scop.MarkDescriptorAsDropped
+      DescID: 52
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 53
-  *scop.LogEvent
-    DescID: 53
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 53
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
-  *scop.DrainDescriptorName
-    TableID: 57
-  *scop.LogEvent
-    DescID: 57
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 55
-        - 56
-        tableId: 57
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 5
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 57
-  *scop.DrainDescriptorName
-    TableID: 61
-  *scop.LogEvent
-    DescID: 61
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 58
-        tableId: 61
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 7
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 61
-  *scop.DrainDescriptorName
-    TableID: 58
-  *scop.LogEvent
-    DescID: 58
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 61
-        dependsOn:
-        - 56
-        tableId: 58
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 5
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 58
-  *scop.DrainDescriptorName
-    TableID: 56
-  *scop.LogEvent
-    DescID: 56
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 57
-        - 58
-        dependsOn:
-        - 55
-        tableId: 56
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 4
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.DrainDescriptorName
-    TableID: 55
-  *scop.LogEvent
-    DescID: 55
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 56
-        - 57
-        dependsOn:
-        - 54
-        tableId: 55
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 3
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.DrainDescriptorName
-    TableID: 54
-  *scop.LogEvent
-    DescID: 54
-    Direction: 2
-    Element:
-      table:
-        tableId: 54
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 54
-  *scop.DrainDescriptorName
-    TableID: 59
-  *scop.DrainDescriptorName
-    TableID: 60
-  *scop.DrainDescriptorName
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 2
-    Element:
-      schema:
-        dependentObjects:
-        - 53
-        - 54
-        - 55
-        - 56
-        - 57
-        - 58
-        - 59
-        - 60
-        - 61
-        schemaId: 52
-    Metadata:
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
+  transitions:
+    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
+    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 53
+    *scop.LogEvent
+      DescID: 53
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 53
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 53
+    *scop.DrainDescriptorName
+      TableID: 57
+    *scop.LogEvent
+      DescID: 57
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 55
+          - 56
+          tableId: 57
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 5
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 57
+    *scop.DrainDescriptorName
+      TableID: 61
+    *scop.LogEvent
+      DescID: 61
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 58
+          tableId: 61
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 7
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 61
+    *scop.DrainDescriptorName
+      TableID: 58
+    *scop.LogEvent
+      DescID: 58
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 61
+          dependsOn:
+          - 56
+          tableId: 58
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 5
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 58
+    *scop.DrainDescriptorName
+      TableID: 56
+    *scop.LogEvent
+      DescID: 56
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 57
+          - 58
+          dependsOn:
+          - 55
+          tableId: 56
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 4
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 56
+    *scop.DrainDescriptorName
+      TableID: 55
+    *scop.LogEvent
+      DescID: 55
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 56
+          - 57
+          dependsOn:
+          - 54
+          tableId: 55
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 3
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 55
+    *scop.DrainDescriptorName
+      TableID: 54
+    *scop.LogEvent
+      DescID: 54
+      Direction: 2
+      Element:
+        table:
+          tableId: 54
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 54
+    *scop.DrainDescriptorName
+      TableID: 59
+    *scop.DrainDescriptorName
+      TableID: 60
+    *scop.DrainDescriptorName
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 2
+      Element:
+        schema:
+          dependentObjects:
+          - 53
+          - 54
+          - 55
+          - 56
+          - 57
+          - 58
+          - 59
+          - 60
+          - 61
+          schemaId: 52
+      Metadata:
+        Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -121,28 +121,28 @@ DROP SCHEMA defaultdb.SC1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
+    [Sequence:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 58}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 61}, PUBLIC, DROP] -> TXN_DROPPED
+    [TypeReference:{DescID: 61, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
+    [TypeReference:{DescID: 61, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 54, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> PUBLIC
+    [Table:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
+    [Type:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
+    [Type:{DescID: 60}, PUBLIC, DROP] -> TXN_DROPPED
+    [Schema:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 53
@@ -166,28 +166,28 @@ Stage 0
       DescID: 52
 Stage 1 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
+    [Sequence:{DescID: 53}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 56}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 58}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 61}, TXN_DROPPED, DROP] -> DROPPED
+    [TypeReference:{DescID: 61, ReferencedDescID: 59}, PUBLIC, DROP] -> ABSENT
+    [TypeReference:{DescID: 61, ReferencedDescID: 60}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 1}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> ABSENT
+    [Table:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
+    [Type:{DescID: 59}, TXN_DROPPED, DROP] -> DROPPED
+    [Type:{DescID: 60}, TXN_DROPPED, DROP] -> DROPPED
+    [Schema:{DescID: 52}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.MarkDescriptorAsDropped
       DescID: 54
@@ -254,27 +254,27 @@ Stage 1 (non-revertible)
 Stage 2 (non-revertible)
   transitions:
     [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 53}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 58}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 58}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 61}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 61}, DROPPED, DROP] -> ABSENT
     [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
     [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 60}, ABSENT, DROP] -> ABSENT
-    [Schema:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 54}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 59}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 60}, DROPPED, DROP] -> ABSENT
+    [Schema:{DescID: 52}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 53

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -121,24 +121,12 @@ DROP SCHEMA defaultdb.SC1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 54, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
     [Sequence:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 58}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 61}, PUBLIC, DROP] -> TXN_DROPPED
-    [TypeReference:{DescID: 61, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
-    [TypeReference:{DescID: 61, ReferencedDescID: 60}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 54, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> PUBLIC
     [Table:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
     [Type:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
     [Type:{DescID: 60}, PUBLIC, DROP] -> TXN_DROPPED
@@ -253,24 +241,12 @@ Stage 1 (non-revertible)
       DescID: 52
 Stage 2 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 54, ColumnID: 3}, ABSENT, DROP] -> ABSENT
     [Sequence:{DescID: 53}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 56}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 57}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 58}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 61}, DROPPED, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 61, ReferencedDescID: 60}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
     [Table:{DescID: 54}, DROPPED, DROP] -> ABSENT
     [Type:{DescID: 59}, DROPPED, DROP] -> ABSENT
     [Type:{DescID: 60}, DROPPED, DROP] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -7,19 +7,19 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 Stage 0
   transitions:
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 52
 Stage 1 (non-revertible)
   transitions:
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.MarkDescriptorAsDropped
       DescID: 52
 Stage 2 (non-revertible)
   transitions:
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 52
@@ -51,17 +51,17 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 53, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [Sequence:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 52
 Stage 1 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 53, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.RemoveColumnDefaultExpression
       ColumnID: 2
@@ -79,7 +79,7 @@ Stage 2 (non-revertible)
   transitions:
     [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 52

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -6,28 +6,37 @@ ops
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 52
+  transitions:
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 52
 Stage 1 (non-revertible)
-  *scop.MarkDescriptorAsDropped
-    DescID: 52
+  transitions:
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescID: 52
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 52
-    Metadata:
-      Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
+  transitions:
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 52
+      Metadata:
+        Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 52
 
 create-table
 CREATE TABLE defaultdb.blog_posts (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
@@ -41,38 +50,53 @@ ops
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 52
 Stage 1 (non-revertible)
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 53
-  *scop.UpdateRelationDeps
-    TableID: 53
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 54
-  *scop.UpdateRelationDeps
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 53
+    *scop.UpdateRelationDeps
+      TableID: 53
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 54
+    *scop.UpdateRelationDeps
+      TableID: 54
+    *scop.MarkDescriptorAsDropped
+      DescID: 52
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 52
-  *scop.LogEvent
-    DescID: 52
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 52
-    Metadata:
-      Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 52
+  transitions:
+    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 52}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 52
+    *scop.LogEvent
+      DescID: 52
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 52
+      Metadata:
+        Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 52
 
 
 deps

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -51,8 +51,6 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 Stage 0
   transitions:
-    [DefaultExpression:{DescID: 53, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
     [Sequence:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
@@ -77,8 +75,6 @@ Stage 1 (non-revertible)
       DescID: 52
 Stage 2 (non-revertible)
   transitions:
-    [DefaultExpression:{DescID: 53, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 54, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [Sequence:{DescID: 52}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -40,20 +40,8 @@ DROP TABLE defaultdb.shipments CASCADE;
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
-    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, PUBLIC, DROP] -> PUBLIC
-    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
-    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
-    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 55, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
     [Sequence:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
-    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 55, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 55, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 55, ColumnID: 4}, PUBLIC, DROP] -> PUBLIC
-    [DefaultExpression:{DescID: 55, ColumnID: 5}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
     [Table:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
@@ -135,20 +123,8 @@ Stage 1 (non-revertible)
       TableID: 54
 Stage 2 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 57}, DROPPED, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
     [Sequence:{DescID: 56}, DROPPED, DROP] -> ABSENT
-    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [Table:{DescID: 55}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -40,21 +40,21 @@ DROP TABLE defaultdb.shipments CASCADE;
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
+    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, PUBLIC, DROP] -> PUBLIC
+    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
+    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 55, ColumnID: 1}, PUBLIC, DROP] -> PUBLIC
+    [Sequence:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
+    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 55, ColumnID: 2}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 55, ColumnID: 3}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 55, ColumnID: 4}, PUBLIC, DROP] -> PUBLIC
+    [DefaultExpression:{DescID: 55, ColumnID: 5}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [Table:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 57
@@ -64,21 +64,21 @@ Stage 0
       DescID: 55
 Stage 1 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
-    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
+    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, PUBLIC, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, PUBLIC, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 1}, PUBLIC, DROP] -> ABSENT
+    [Sequence:{DescID: 56}, TXN_DROPPED, DROP] -> DROPPED
+    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 2}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 4}, PUBLIC, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 5}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [Table:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.MarkDescriptorAsDropped
       DescID: 55
@@ -136,20 +136,20 @@ Stage 1 (non-revertible)
 Stage 2 (non-revertible)
   transitions:
     [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, DROPPED, DROP] -> ABSENT
     [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
     [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
     [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
-    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 56}, DROPPED, DROP] -> ABSENT
     [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
     [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 55}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 57

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -39,118 +39,169 @@ ops
 DROP TABLE defaultdb.shipments CASCADE;
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 57
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 56
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 55
+  transitions:
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 57
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 56
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 55
 Stage 1 (non-revertible)
-  *scop.MarkDescriptorAsDropped
-    DescID: 55
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 57
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    DescID: 57
-  *scop.DropForeignKeyRef
-    Name: fk_customers
-    Outbound: true
-    TableID: 55
-  *scop.DropForeignKeyRef
-    Name: fk_customers
-    TableID: 52
-  *scop.DropForeignKeyRef
-    Name: fk_orders
-    Outbound: true
-    TableID: 55
-  *scop.DropForeignKeyRef
-    Name: fk_orders
-    TableID: 53
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 1
-    TableID: 55
-  *scop.UpdateRelationDeps
-    TableID: 55
-  *scop.MarkDescriptorAsDropped
-    DescID: 56
-  *scop.RemoveSequenceOwnedBy
-    TableID: 56
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 2
-    TableID: 55
-  *scop.UpdateRelationDeps
-    TableID: 55
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 3
-    TableID: 55
-  *scop.UpdateRelationDeps
-    TableID: 55
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 4
-    TableID: 55
-  *scop.UpdateRelationDeps
-    TableID: 55
-  *scop.RemoveColumnDefaultExpression
-    ColumnID: 5
-    TableID: 55
-  *scop.UpdateRelationDeps
-    TableID: 55
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 55
-    TableID: 54
+  transitions:
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescID: 55
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 57
+      TableID: 55
+    *scop.MarkDescriptorAsDropped
+      DescID: 57
+    *scop.DropForeignKeyRef
+      Name: fk_customers
+      Outbound: true
+      TableID: 55
+    *scop.DropForeignKeyRef
+      Name: fk_customers
+      TableID: 52
+    *scop.DropForeignKeyRef
+      Name: fk_orders
+      Outbound: true
+      TableID: 55
+    *scop.DropForeignKeyRef
+      Name: fk_orders
+      TableID: 53
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 55
+    *scop.UpdateRelationDeps
+      TableID: 55
+    *scop.MarkDescriptorAsDropped
+      DescID: 56
+    *scop.RemoveSequenceOwnedBy
+      TableID: 56
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 2
+      TableID: 55
+    *scop.UpdateRelationDeps
+      TableID: 55
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 55
+    *scop.UpdateRelationDeps
+      TableID: 55
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 4
+      TableID: 55
+    *scop.UpdateRelationDeps
+      TableID: 55
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 5
+      TableID: 55
+    *scop.UpdateRelationDeps
+      TableID: 55
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 55
+      TableID: 54
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 57
-  *scop.LogEvent
-    DescID: 57
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 55
-        tableId: 57
-    Metadata:
-      Statement: DROP TABLE defaultdb.shipments CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 57
-  *scop.DrainDescriptorName
-    TableID: 56
-  *scop.LogEvent
-    DescID: 56
-    Direction: 2
-    Element:
-      sequence:
-        sequenceId: 56
-    Metadata:
-      Statement: DROP TABLE defaultdb.shipments CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.DrainDescriptorName
-    TableID: 55
-  *scop.LogEvent
-    DescID: 55
-    Direction: 2
-    Element:
-      table:
-        tableId: 55
-    Metadata:
-      Statement: DROP TABLE defaultdb.shipments CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
+  transitions:
+    [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 57}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_customers, ReferencedDescID: 52}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 52, Name: fk_customers, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [OutboundForeignKey:{DescID: 55, Name: fk_orders, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [InboundForeignKey:{DescID: 53, Name: fk_orders, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 1}, ABSENT, DROP] -> ABSENT
+    [Sequence:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [SequenceOwnedBy:{DescID: 56, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 2}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 3}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 4}, ABSENT, DROP] -> ABSENT
+    [DefaultExpression:{DescID: 55, ColumnID: 5}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [Table:{DescID: 55}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 57
+    *scop.LogEvent
+      DescID: 57
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 55
+          tableId: 57
+      Metadata:
+        Statement: DROP TABLE defaultdb.shipments CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 57
+    *scop.DrainDescriptorName
+      TableID: 56
+    *scop.LogEvent
+      DescID: 56
+      Direction: 2
+      Element:
+        sequence:
+          sequenceId: 56
+      Metadata:
+        Statement: DROP TABLE defaultdb.shipments CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 56
+    *scop.DrainDescriptorName
+      TableID: 55
+    *scop.LogEvent
+      DescID: 55
+      Direction: 2
+      Element:
+        table:
+          tableId: 55
+      Metadata:
+        Statement: DROP TABLE defaultdb.shipments CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 55
 
 deps
 DROP TABLE defaultdb.shipments CASCADE;

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -6,20 +6,32 @@ ops
 DROP TYPE defaultdb.typ
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 52
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 53
+  transitions:
+    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 52
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 53
 Stage 1 (non-revertible)
-  *scop.MarkDescriptorAsDropped
-    DescID: 52
-  *scop.MarkDescriptorAsDropped
-    DescID: 53
+  transitions:
+    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescID: 52
+    *scop.MarkDescriptorAsDropped
+      DescID: 53
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 52
-  *scop.DrainDescriptorName
-    TableID: 53
+  transitions:
+    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 52
+    *scop.DrainDescriptorName
+      TableID: 53
 
 deps
 DROP TYPE defaultdb.typ

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -7,8 +7,8 @@ DROP TYPE defaultdb.typ
 ----
 Stage 0
   transitions:
-    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 52}, PUBLIC, DROP] -> TXN_DROPPED
+    [Type:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 52
@@ -16,8 +16,8 @@ Stage 0
       DescID: 53
 Stage 1 (non-revertible)
   transitions:
-    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 52}, TXN_DROPPED, DROP] -> DROPPED
+    [Type:{DescID: 53}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.MarkDescriptorAsDropped
       DescID: 52
@@ -25,8 +25,8 @@ Stage 1 (non-revertible)
       DescID: 53
 Stage 2 (non-revertible)
   transitions:
-    [Type:{DescID: 52}, ABSENT, DROP] -> ABSENT
-    [Type:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [Type:{DescID: 52}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 53}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 52

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -11,15 +11,15 @@ DROP VIEW defaultdb.v1
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 53
 Stage 1 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 53}, TXN_DROPPED, DROP] -> DROPPED
   ops:
     *scop.RemoveRelationDependedOnBy
       DependedOnBy: 53
@@ -29,7 +29,7 @@ Stage 1 (non-revertible)
 Stage 2 (non-revertible)
   transitions:
     [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 53
@@ -80,19 +80,19 @@ DROP VIEW defaultdb.v1 CASCADE
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
+    [View:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
+    [TypeReference:{DescID: 59, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
+    [TypeReference:{DescID: 59, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 53
@@ -106,19 +106,19 @@ Stage 0
       DescID: 59
 Stage 1 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 53}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 56}, TXN_DROPPED, DROP] -> DROPPED
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, PUBLIC, DROP] -> ABSENT
+    [View:{DescID: 59}, TXN_DROPPED, DROP] -> DROPPED
+    [TypeReference:{DescID: 59, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 58}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.RemoveRelationDependedOnBy
       DependedOnBy: 53
@@ -157,16 +157,16 @@ Stage 1 (non-revertible)
 Stage 2 (non-revertible)
   transitions:
     [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 54}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, DROPPED, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
-    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
     [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
     [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
   ops:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -11,7 +11,6 @@ DROP VIEW defaultdb.v1
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
@@ -28,7 +27,6 @@ Stage 1 (non-revertible)
       DescID: 53
 Stage 2 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 53}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
@@ -80,19 +78,11 @@ DROP VIEW defaultdb.v1 CASCADE
 ----
 Stage 0
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 53}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, PUBLIC, DROP] -> PUBLIC
     [View:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
-    [TypeReference:{DescID: 59, ReferencedDescID: 57}, PUBLIC, DROP] -> PUBLIC
-    [TypeReference:{DescID: 59, ReferencedDescID: 58}, PUBLIC, DROP] -> PUBLIC
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 53
@@ -156,19 +146,11 @@ Stage 1 (non-revertible)
       DescID: 59
 Stage 2 (non-revertible)
   transitions:
-    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 53}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 54}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 56}, DROPPED, DROP] -> ABSENT
-    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
     [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
-    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
   ops:
     *scop.DrainDescriptorName
       TableID: 55

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -10,34 +10,46 @@ ops
 DROP VIEW defaultdb.v1
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 53
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 53
 Stage 1 (non-revertible)
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 53
-    TableID: 52
-  *scop.MarkDescriptorAsDropped
-    DescID: 53
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 53
+      TableID: 52
+    *scop.MarkDescriptorAsDropped
+      DescID: 53
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 53
-  *scop.LogEvent
-    DescID: 53
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 52
-        tableId: 53
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 53
+    *scop.LogEvent
+      DescID: 53
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 52
+          tableId: 53
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 53
 
 deps
 DROP VIEW defaultdb.v1
@@ -67,153 +79,198 @@ ops
 DROP VIEW defaultdb.v1 CASCADE
 ----
 Stage 0
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 53
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 54
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 55
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 56
-  *scop.MarkDescriptorAsDroppedSynthetically
-    DescID: 59
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 53
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 54
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 55
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 56
+    *scop.MarkDescriptorAsDroppedSynthetically
+      DescID: 59
 Stage 1 (non-revertible)
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 53
-    TableID: 52
-  *scop.MarkDescriptorAsDropped
-    DescID: 53
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 54
-    TableID: 53
-  *scop.MarkDescriptorAsDropped
-    DescID: 54
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 55
-    TableID: 54
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 56
-    TableID: 54
-  *scop.MarkDescriptorAsDropped
-    DescID: 56
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 59
-    TableID: 56
-  *scop.RemoveTypeBackRef
-    DescID: 59
-    TypeID: 57
-  *scop.RemoveTypeBackRef
-    DescID: 59
-    TypeID: 58
-  *scop.RemoveRelationDependedOnBy
-    DependedOnBy: 55
-    TableID: 53
-  *scop.MarkDescriptorAsDropped
-    DescID: 55
-  *scop.MarkDescriptorAsDropped
-    DescID: 59
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 53
+      TableID: 52
+    *scop.MarkDescriptorAsDropped
+      DescID: 53
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 54
+      TableID: 53
+    *scop.MarkDescriptorAsDropped
+      DescID: 54
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 55
+      TableID: 54
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 56
+      TableID: 54
+    *scop.MarkDescriptorAsDropped
+      DescID: 56
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 59
+      TableID: 56
+    *scop.RemoveTypeBackRef
+      DescID: 59
+      TypeID: 57
+    *scop.RemoveTypeBackRef
+      DescID: 59
+      TypeID: 58
+    *scop.RemoveRelationDependedOnBy
+      DependedOnBy: 55
+      TableID: 53
+    *scop.MarkDescriptorAsDropped
+      DescID: 55
+    *scop.MarkDescriptorAsDropped
+      DescID: 59
 Stage 2 (non-revertible)
-  *scop.DrainDescriptorName
-    TableID: 55
-  *scop.LogEvent
-    DescID: 55
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 53
-        - 54
-        tableId: 55
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1 CASCADE
-      TargetMetadata:
-        SourceElementID: 3
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 55
-  *scop.DrainDescriptorName
-    TableID: 59
-  *scop.LogEvent
-    DescID: 59
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy: []
-        dependsOn:
-        - 56
-        tableId: 59
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1 CASCADE
-      TargetMetadata:
-        SourceElementID: 5
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 59
-  *scop.DrainDescriptorName
-    TableID: 56
-  *scop.LogEvent
-    DescID: 56
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 59
-        dependsOn:
-        - 54
-        tableId: 56
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1 CASCADE
-      TargetMetadata:
-        SourceElementID: 3
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 56
-  *scop.DrainDescriptorName
-    TableID: 54
-  *scop.LogEvent
-    DescID: 54
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 55
-        - 56
-        dependsOn:
-        - 53
-        tableId: 54
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1 CASCADE
-      TargetMetadata:
-        SourceElementID: 2
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 54
-  *scop.DrainDescriptorName
-    TableID: 53
-  *scop.LogEvent
-    DescID: 53
-    Direction: 2
-    Element:
-      view:
-        dependedOnBy:
-        - 54
-        - 55
-        dependsOn:
-        - 52
-        tableId: 53
-    Metadata:
-      Statement: DROP VIEW defaultdb.v1 CASCADE
-      TargetMetadata:
-        SourceElementID: 1
-        SubWorkID: 1
-      Username: root
-  *scop.CreateGcJobForDescriptor
-    DescID: 53
+  transitions:
+    [RelationDependedOnBy:{DescID: 52, ReferencedDescID: 53}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 53}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 54}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 54}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 53, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 55}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 56}, ABSENT, DROP] -> ABSENT
+    [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 59}, ABSENT, DROP] -> ABSENT
+    [View:{DescID: 59}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 57}, ABSENT, DROP] -> ABSENT
+    [TypeReference:{DescID: 59, ReferencedDescID: 58}, ABSENT, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 55
+    *scop.LogEvent
+      DescID: 55
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 53
+          - 54
+          tableId: 55
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1 CASCADE
+        TargetMetadata:
+          SourceElementID: 3
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 55
+    *scop.DrainDescriptorName
+      TableID: 59
+    *scop.LogEvent
+      DescID: 59
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy: []
+          dependsOn:
+          - 56
+          tableId: 59
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1 CASCADE
+        TargetMetadata:
+          SourceElementID: 5
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 59
+    *scop.DrainDescriptorName
+      TableID: 56
+    *scop.LogEvent
+      DescID: 56
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 59
+          dependsOn:
+          - 54
+          tableId: 56
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1 CASCADE
+        TargetMetadata:
+          SourceElementID: 3
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 56
+    *scop.DrainDescriptorName
+      TableID: 54
+    *scop.LogEvent
+      DescID: 54
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 55
+          - 56
+          dependsOn:
+          - 53
+          tableId: 54
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1 CASCADE
+        TargetMetadata:
+          SourceElementID: 2
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 54
+    *scop.DrainDescriptorName
+      TableID: 53
+    *scop.LogEvent
+      DescID: 53
+      Direction: 2
+      Element:
+        view:
+          dependedOnBy:
+          - 54
+          - 55
+          dependsOn:
+          - 52
+          tableId: 53
+      Metadata:
+        Statement: DROP VIEW defaultdb.v1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+    *scop.CreateGcJobForDescriptor
+      DescID: 53
 
 deps
 DROP VIEW defaultdb.v1 CASCADE


### PR DESCRIPTION
There were two bugs here which, somehow, canceled eachother out. The first
is that we were mutating the slice of the cur node as we went. This meant
that the state transitions were actually bogus and if the job was restated,
we would have been in a world of pain. The second was that we were adding
extra ops when we had more than one op on an opEdge.

Along the way, augment the test format to make these bugs obvious.

Release note: None
