### PR TITLE
kv,sql: fix some nilness lint errors

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -521,9 +521,7 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 		// only after performing necessary bookkeeping.
 		if filter := b.testing.submitProposalFilter; filter != nil {
 			if drop, err := filter(p); drop || err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
+				firstErr = err
 				continue
 			}
 		}

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -172,11 +172,6 @@ func (c *conn) handleAuthentication(
 		))
 	}
 
-	if err != nil {
-		ac.LogAuthFailed(ctx, eventpb.AuthFailReason_METHOD_NOT_FOUND, err)
-		return connClose, sendError(pgerror.WithCandidateCode(err, pgcode.InvalidAuthorizationSpecification))
-	}
-
 	// Set up lazy provider for password or cert-password methods.
 	pwDataFn := func(ctx context.Context) ([]byte, *tree.DTimestamp, error) {
 		pwHash, err := pwRetrievalFn(ctx)

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -233,7 +233,7 @@ func (s *serialOrderedSynchronizer) consumeMetadata(
 			src.row = row
 			return nil
 		}
-		if row == nil && meta == nil {
+		if row == nil {
 			return nil
 		}
 	}

--- a/pkg/util/timeutil/time_zone_util.go
+++ b/pkg/util/timeutil/time_zone_util.go
@@ -138,10 +138,6 @@ func ParseTimeZoneOffset(
 		offset = hoursMinutesSecondsToSeconds(origRepr)
 		offset *= offsetMultiplier
 
-		if err != nil {
-			return 0, "", false
-		}
-
 		return offset, location, true
 	}
 


### PR DESCRIPTION
The `nilness` linter caught these cases. We remove some unnecessary
nilness checks.

Release note: None