### PR TITLE
bazel: don't shard `kvserver` test

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -292,7 +292,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
-    shard_count = 16,
     tags = ["exclusive"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
The `exclusive` tag here prevents the shards from running concurrently.
See #65407, #65582.

Release note: None