### PR TITLE
rangefeed: surface unrecoverable errors and don't hopelessly retry 

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5083,7 +5083,7 @@ CREATE TABLE crdb_internal.active_range_feeds (
 					tree.NewDString(rfCtx.CtxTags),
 					tree.NewDString(keys.PrettyPrint(nil /* valDirs */, rfCtx.Span.Key)),
 					tree.NewDString(keys.PrettyPrint(nil /* valDirs */, rfCtx.Span.EndKey)),
-					tree.NewDString(rfCtx.TS.AsOfSystemTime()),
+					tree.NewDString(rfCtx.StartFrom.AsOfSystemTime()),
 					tree.MakeDBool(tree.DBool(rfCtx.WithDiff)),
 					tree.NewDInt(tree.DInt(rf.NodeID)),
 					tree.NewDInt(tree.DInt(rf.RangeID)),


### PR DESCRIPTION
One such error is when the rangefeed falls behind to a point where the
frontier timestamp precedes the GC threshold, and thus will never work.
A new callback lets callers find out about the error, possibly to start
a new rangefeed with an initial scan.