### PR TITLE
kvcoord: make truncate, prev, and next operate on []RequestUnion

### DIFF
--- a/pkg/kv/kvclient/kvcoord/batch_test.go
+++ b/pkg/kv/kvclient/kvcoord/batch_test.go
@@ -169,12 +169,12 @@ func TestBatchPrevNext(t *testing.T) {
 				args.Key, args.EndKey = span.Key, span.EndKey
 				ba.Add(args)
 			}
-			if next, err := next(ba, roachpb.RKey(test.key)); err != nil {
+			if next, err := next(ba.Requests, roachpb.RKey(test.key)); err != nil {
 				t.Error(err)
 			} else if !bytes.Equal(next, roachpb.Key(test.expFW)) {
 				t.Errorf("next: expected %q, got %q", test.expFW, next)
 			}
-			if prev, err := prev(ba, roachpb.RKey(test.key)); err != nil {
+			if prev, err := prev(ba.Requests, roachpb.RKey(test.key)); err != nil {
 				t.Error(err)
 			} else if !bytes.Equal(prev, roachpb.Key(test.expBW)) {
 				t.Errorf("prev: expected %q, got %q", test.expBW, prev)

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1303,7 +1303,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// We use the StartKey of the current descriptor as opposed to the
 			// EndKey of the previous one since that doesn't have bugs when
 			// stale descriptors come into play.
-			seekKey, err = prev(ba, ri.Desc().StartKey)
+			seekKey, err = prev(ba.Requests, ri.Desc().StartKey)
 			nextRS.EndKey = seekKey
 		} else {
 			// In next iteration, query next range.
@@ -1313,7 +1313,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// one, and unless both descriptors are stale, the next descriptor's
 			// StartKey would move us to the beginning of the current range,
 			// resulting in a duplicate scan.
-			seekKey, err = next(ba, ri.Desc().EndKey)
+			seekKey, err = next(ba.Requests, ri.Desc().EndKey)
 			nextRS.Key = seekKey
 		}
 		if err != nil {
@@ -1504,7 +1504,7 @@ func (ds *DistSender) sendPartialBatch(
 		if err != nil {
 			return response{pErr: roachpb.NewError(err)}
 		}
-		ba, positions, err = truncate(ba, rs)
+		ba.Requests, positions, err = truncate(ba.Requests, rs)
 		if len(positions) == 0 && err == nil {
 			// This shouldn't happen in the wild, but some tests exercise it.
 			return response{

--- a/pkg/kv/kvclient/kvcoord/truncate_test.go
+++ b/pkg/kv/kvclient/kvcoord/truncate_test.go
@@ -164,24 +164,24 @@ func TestTruncate(t *testing.T) {
 			t.Errorf("%d: intersection failure: %v", i, err)
 			continue
 		}
-		ba, pos, err := truncate(original, rs)
+		reqs, pos, err := truncate(original.Requests, rs)
 		if err != nil || test.err != "" {
 			if !testutils.IsError(err, test.err) {
 				t.Errorf("%d: %v (expected: %q)", i, err, test.err)
 			}
 			continue
 		}
-		var reqs int
-		for j, arg := range ba.Requests {
+		var numReqs int
+		for j, arg := range reqs {
 			req := arg.GetInner()
 			if h := req.Header(); !bytes.Equal(h.Key, roachpb.Key(test.expKeys[j][0])) || !bytes.Equal(h.EndKey, roachpb.Key(test.expKeys[j][1])) {
 				t.Errorf("%d.%d: range mismatch: actual [%q,%q), wanted [%q,%q)", i, j,
 					h.Key, h.EndKey, test.expKeys[j][0], test.expKeys[j][1])
 			} else if len(h.Key) != 0 {
-				reqs++
+				numReqs++
 			}
 		}
-		if num := len(pos); reqs != num {
+		if num := len(pos); numReqs != num {
 			t.Errorf("%d: counted %d requests, but truncation indicated %d", i, reqs, num)
 		}
 		if !reflect.DeepEqual(original, goldenOriginal) {


### PR DESCRIPTION
Previously, these methods operated on `BatchRequest`s, but the upcoming
`Streamer` work will need to reuse these methods, and there we will only
have `RequestUnion` objects.

Release note: None