### PR TITLE
row: preliminary changes for streamer work

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -753,7 +753,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 	// Reuse kvs to save allocations.
 	c.kvFetcher.KVs = c.kvFetcher.KVs[:0]
 	c.kvFetcher.KVs = append(c.kvFetcher.KVs, event.KV())
-	if err := rf.StartScanFrom(ctx, &c.kvFetcher); err != nil {
+	if err := rf.StartScanFrom(ctx, &c.kvFetcher, false /* traceKV */); err != nil {
 		return r, err
 	}
 
@@ -804,7 +804,7 @@ func (c *kvEventToRowConsumer) eventToRow(
 		// Reuse kvs to save allocations.
 		c.kvFetcher.KVs = c.kvFetcher.KVs[:0]
 		c.kvFetcher.KVs = append(c.kvFetcher.KVs, prevKV)
-		if err := prevRF.StartScanFrom(ctx, &c.kvFetcher); err != nil {
+		if err := prevRF.StartScanFrom(ctx, &c.kvFetcher, false /* traceKV */); err != nil {
 			return r, err
 		}
 		r.prevDatums, r.prevTableDesc, _, err = prevRF.NextRow(ctx)

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -645,7 +645,7 @@ func processEntryFiles(
 	}
 	kvFetcher := row.MakeBackupSSTKVFetcher(startKeyMVCC, endKeyMVCC, iter, startTime, endTime, debugBackupArgs.withRevisions)
 
-	if err := rf.StartScanFrom(ctx, &kvFetcher); err != nil {
+	if err := rf.StartScanFrom(ctx, &kvFetcher, false /* traceKV */); err != nil {
 		return errors.Wrapf(err, "row fetcher starts scan")
 	}
 

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "inserter.go",
         "kv_batch_fetcher.go",
         "kv_fetcher.go",
+        "locking.go",
         "metrics.go",
         "partial_index.go",
         "row_converter.go",

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -28,13 +28,13 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// singleKVFetcher is a kvBatchFetcher that returns a single kv.
+// singleKVFetcher is a KVBatchFetcher that returns a single kv.
 type singleKVFetcher struct {
 	kvs  [1]roachpb.KeyValue
 	done bool
 }
 
-// nextBatch implements the kvBatchFetcher interface.
+// nextBatch implements the KVBatchFetcher interface.
 func (f *singleKVFetcher) nextBatch(
 	ctx context.Context,
 ) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
@@ -256,7 +256,7 @@ func DecodeRowInfo(
 	}
 	// Use the Fetcher to decode the single kv pair above by passing in
 	// this singleKVFetcher implementation, which doesn't actually hit KV.
-	if err := rf.StartScanFrom(ctx, &f); err != nil {
+	if err := rf.StartScanFrom(ctx, &f, false /* traceKV */); err != nil {
 		return nil, nil, nil, err
 	}
 	datums, _, _, err := rf.NextRowDecoded(ctx)

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -123,7 +123,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 			log.Infof(ctx, "%v %v %v", kv.Key, kv.Value.Timestamp, kv.Value.PrettyPrint())
 		}
 
-		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}); err != nil {
+		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}, false /* traceKV */); err != nil {
 			t.Fatal(err)
 		}
 		var rows []rowWithMVCCMetadata

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -90,10 +90,10 @@ type txnKVFetcher struct {
 
 	reverse bool
 	// lockStrength represents the locking mode to use when fetching KVs.
-	lockStrength descpb.ScanLockingStrength
+	lockStrength lock.Strength
 	// lockWaitPolicy represents the policy to be used for handling conflicting
 	// locks held by other active transactions.
-	lockWaitPolicy descpb.ScanLockingWaitPolicy
+	lockWaitPolicy lock.WaitPolicy
 	// lockTimeout specifies the maximum amount of time that the fetcher will
 	// wait while attempting to acquire a lock on a key or while blocking on an
 	// existing lock in order to perform a non-locking read on a key.
@@ -171,53 +171,6 @@ func (f *txnKVFetcher) getBatchKeyLimitForIdx(batchIdx int) rowinfra.KeyLimit {
 
 	default:
 		return kvBatchSize
-	}
-}
-
-// getKeyLockingStrength returns the configured per-key locking strength to use
-// for key-value scans.
-func (f *txnKVFetcher) getKeyLockingStrength() lock.Strength {
-	switch f.lockStrength {
-	case descpb.ScanLockingStrength_FOR_NONE:
-		return lock.None
-
-	case descpb.ScanLockingStrength_FOR_KEY_SHARE:
-		// Promote to FOR_SHARE.
-		fallthrough
-	case descpb.ScanLockingStrength_FOR_SHARE:
-		// We currently perform no per-key locking when FOR_SHARE is used
-		// because Shared locks have not yet been implemented.
-		return lock.None
-
-	case descpb.ScanLockingStrength_FOR_NO_KEY_UPDATE:
-		// Promote to FOR_UPDATE.
-		fallthrough
-	case descpb.ScanLockingStrength_FOR_UPDATE:
-		// We currently perform exclusive per-key locking when FOR_UPDATE is
-		// used because Upgrade locks have not yet been implemented.
-		return lock.Exclusive
-
-	default:
-		panic(errors.AssertionFailedf("unknown locking strength %s", f.lockStrength))
-	}
-}
-
-// getWaitPolicy returns the configured lock wait policy to use for key-value
-// scans.
-func (f *txnKVFetcher) getWaitPolicy() lock.WaitPolicy {
-	switch f.lockWaitPolicy {
-	case descpb.ScanLockingWaitPolicy_BLOCK:
-		return lock.WaitPolicy_Block
-
-	case descpb.ScanLockingWaitPolicy_SKIP:
-		// Should not get here. Query should be rejected during planning.
-		panic(errors.AssertionFailedf("unsupported wait policy %s", f.lockWaitPolicy))
-
-	case descpb.ScanLockingWaitPolicy_ERROR:
-		return lock.WaitPolicy_Error
-
-	default:
-		panic(errors.AssertionFailedf("unknown wait policy %s", f.lockWaitPolicy))
 	}
 }
 
@@ -317,8 +270,8 @@ func makeKVBatchFetcher(
 		reverse:                    reverse,
 		batchBytesLimit:            batchBytesLimit,
 		firstBatchKeyLimit:         firstBatchKeyLimit,
-		lockStrength:               lockStrength,
-		lockWaitPolicy:             lockWaitPolicy,
+		lockStrength:               getKeyLockingStrength(lockStrength),
+		lockWaitPolicy:             GetWaitPolicy(lockWaitPolicy),
 		lockTimeout:                lockTimeout,
 		acc:                        acc,
 		forceProductionKVBatchSize: forceProductionKVBatchSize,
@@ -359,13 +312,13 @@ func makeKVBatchFetcher(
 // fetch retrieves spans from the kv layer.
 func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	var ba roachpb.BatchRequest
-	ba.Header.WaitPolicy = f.getWaitPolicy()
+	ba.Header.WaitPolicy = f.lockWaitPolicy
 	ba.Header.LockTimeout = f.lockTimeout
 	ba.Header.TargetBytes = int64(f.batchBytesLimit)
 	ba.Header.MaxSpanRequestKeys = int64(f.getBatchKeyLimit())
 	ba.AdmissionHeader = f.requestAdmissionHeader
 	ba.Requests = make([]roachpb.RequestUnion, len(f.spans))
-	keyLocking := f.getKeyLockingStrength()
+	keyLocking := f.lockStrength
 
 	// Detect the number of gets vs scans, so we can batch allocate all of the
 	// requests precisely.

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -122,7 +122,7 @@ type txnKVFetcher struct {
 	responseAdmissionQ     *admission.WorkQueue
 }
 
-var _ kvBatchFetcher = &txnKVFetcher{}
+var _ KVBatchFetcher = &txnKVFetcher{}
 
 // getBatchKeyLimit returns the max size of the next batch. The size is
 // expressed in number of result keys (i.e. this size will be used for
@@ -187,7 +187,7 @@ func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn) sendFunc {
 	}
 }
 
-// makeKVBatchFetcher initializes a kvBatchFetcher for the given spans. If
+// makeKVBatchFetcher initializes a KVBatchFetcher for the given spans. If
 // useBatchLimit is true, the number of result keys per batch is limited; the
 // limit grows between subsequent batches, starting at firstBatchKeyLimit (if not
 // 0) to ProductionKVBatchSize.

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -26,10 +26,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// KVFetcher wraps kvBatchFetcher, providing a NextKV interface that returns the
+// KVFetcher wraps KVBatchFetcher, providing a NextKV interface that returns the
 // next kv from its input.
 type KVFetcher struct {
-	kvBatchFetcher
+	KVBatchFetcher
 
 	kvs []roachpb.KeyValue
 
@@ -108,9 +108,9 @@ func NewKVFetcher(
 	return newKVFetcher(&kvBatchFetcher), err
 }
 
-func newKVFetcher(batchFetcher kvBatchFetcher) *KVFetcher {
+func newKVFetcher(batchFetcher KVBatchFetcher) *KVFetcher {
 	ret := &KVFetcher{
-		kvBatchFetcher: batchFetcher,
+		KVBatchFetcher: batchFetcher,
 	}
 	return ret
 }
@@ -210,15 +210,15 @@ func (f *KVFetcher) NextKV(
 // at the end of execution if the fetcher was provisioned with a memory
 // monitor.
 func (f *KVFetcher) Close(ctx context.Context) {
-	f.kvBatchFetcher.close(ctx)
+	f.KVBatchFetcher.close(ctx)
 }
 
-// SpanKVFetcher is a kvBatchFetcher that returns a set slice of kvs.
+// SpanKVFetcher is a KVBatchFetcher that returns a set slice of kvs.
 type SpanKVFetcher struct {
 	KVs []roachpb.KeyValue
 }
 
-// nextBatch implements the kvBatchFetcher interface.
+// nextBatch implements the KVBatchFetcher interface.
 func (f *SpanKVFetcher) nextBatch(
 	ctx context.Context,
 ) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, err error) {
@@ -232,7 +232,7 @@ func (f *SpanKVFetcher) nextBatch(
 
 func (f *SpanKVFetcher) close(context.Context) {}
 
-// BackupSSTKVFetcher is a kvBatchFetcher that wraps storage.SimpleMVCCIterator
+// BackupSSTKVFetcher is a KVBatchFetcher that wraps storage.SimpleMVCCIterator
 // and returns a batch of kv from backupSST.
 type BackupSSTKVFetcher struct {
 	iter          storage.SimpleMVCCIterator

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package row
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+// getKeyLockingStrength returns the configured per-key locking strength to use
+// for key-value scans.
+func getKeyLockingStrength(lockStrength descpb.ScanLockingStrength) lock.Strength {
+	switch lockStrength {
+	case descpb.ScanLockingStrength_FOR_NONE:
+		return lock.None
+
+	case descpb.ScanLockingStrength_FOR_KEY_SHARE:
+		// Promote to FOR_SHARE.
+		fallthrough
+	case descpb.ScanLockingStrength_FOR_SHARE:
+		// We currently perform no per-key locking when FOR_SHARE is used
+		// because Shared locks have not yet been implemented.
+		return lock.None
+
+	case descpb.ScanLockingStrength_FOR_NO_KEY_UPDATE:
+		// Promote to FOR_UPDATE.
+		fallthrough
+	case descpb.ScanLockingStrength_FOR_UPDATE:
+		// We currently perform exclusive per-key locking when FOR_UPDATE is
+		// used because Upgrade locks have not yet been implemented.
+		return lock.Exclusive
+
+	default:
+		panic(errors.AssertionFailedf("unknown locking strength %s", lockStrength))
+	}
+}
+
+// GetWaitPolicy returns the configured lock wait policy to use for key-value
+// scans.
+func GetWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy {
+	switch lockWaitPolicy {
+	case descpb.ScanLockingWaitPolicy_BLOCK:
+		return lock.WaitPolicy_Block
+
+	case descpb.ScanLockingWaitPolicy_SKIP:
+		// Should not get here. Query should be rejected during planning.
+		panic(errors.AssertionFailedf("unsupported wait policy %s", lockWaitPolicy))
+
+	case descpb.ScanLockingWaitPolicy_ERROR:
+		return lock.WaitPolicy_Error
+
+	default:
+		panic(errors.AssertionFailedf("unknown wait policy %s", lockWaitPolicy))
+	}
+}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -36,6 +36,7 @@ type rowFetcher interface {
 		_ context.Context, _ *kv.Txn, _ roachpb.Spans, batchBytesLimit rowinfra.BytesLimit,
 		rowLimitHint rowinfra.RowLimit, traceKV bool, forceProductionKVBatchSize bool,
 	) error
+	StartScanFrom(_ context.Context, _ row.KVBatchFetcher, traceKV bool) error
 	StartInconsistentScan(
 		_ context.Context,
 		_ *kv.DB,

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -120,6 +120,16 @@ func (c *rowFetcherStatCollector) StartScan(
 	return err
 }
 
+// StartScanFrom is part of the rowFetcher interface.
+func (c *rowFetcherStatCollector) StartScanFrom(
+	ctx context.Context, f row.KVBatchFetcher, traceKV bool,
+) error {
+	start := timeutil.Now()
+	err := c.Fetcher.StartScanFrom(ctx, f, traceKV)
+	c.startScanStallTime += timeutil.Since(start)
+	return err
+}
+
 // StartInconsistentScan is part of the rowFetcher interface.
 func (c *rowFetcherStatCollector) StartInconsistentScan(
 	ctx context.Context,


### PR DESCRIPTION
**row: extract some locking helpers**

These will be used by the Streamer follow-up work.

Release note: None

**row: export KVBatchFetcher and adjust rowFetcher interfaces**

`KVBatchFetcher` interface will be implemented by the new
TxnKVStreamer, and it needs to be exported.

This commit also updates the `rowFetcher` interface (used for stats
collection) to include `StartScanFrom` method. Additionally,
`StartScanFrom` now takes in a `traceKV` parameter (bringing it in
line with other `StartScan.*` methods).

Release note: None