### PR TITLE
sql: reset indexedTypeFormatter on FmtCtx close

### DIFF
--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -625,12 +625,9 @@ var fmtCtxPool = sync.Pool{
 // recommended for performance-sensitive paths.
 func (ctx *FmtCtx) Close() {
 	ctx.Buffer.Reset()
-	ctx.flags = 0
-	ctx.ann = nil
-	ctx.indexedVarFormat = nil
-	ctx.tableNameFormatter = nil
-	ctx.placeholderFormat = nil
-	ctx.dataConversionConfig = sessiondatapb.DataConversionConfig{}
+	*ctx = FmtCtx{
+		Buffer: ctx.Buffer,
+	}
 	fmtCtxPool.Put(ctx)
 }
 


### PR DESCRIPTION
Previously indexedTypeFormatter wouldn't be reset when
FmtCtx.Close() was called causing the indexedTypeFormatter
function to potentially be reused.

Release note (enterprise change): Fix a bug where restore can sometimes map OIDs
to invalid types in certain circumstances containing UDTs.