### PR TITLE
sql: fix "overlapping neighbor spans" error

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -300,7 +300,7 @@ func makeKVBatchFetcher(
 				// Current span's start key is greater than or equal to the last span's
 				// end key - we're good.
 				continue
-			} else if curEndKey.Compare(spans[i-1].Key) < 0 {
+			} else if curEndKey.Compare(spans[i-1].Key) <= 0 {
 				// Current span's end key is less than or equal to the last span's start
 				// key - also good.
 				continue


### PR DESCRIPTION
When testing has race enabled, `makeKVBatchFetcher` checks whether two
neighboring spans overlap. Previously, it would return an error if the
last span's start key was equal to the current span's end key, even
though span end keys are exclusive.

This PR fixes this to check that the current span's end key is less than
or equal to the last span's start key, as per the comments.

Fixes #72785

Release note: None