### PR TITLE
release-21.1: backupccl: ignore ErrDescriptorNotFound on system table lookup

### DIFF
--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -374,18 +375,20 @@ func GetSystemTableIDsToExcludeFromClusterBackup(
 			err := descs.Txn(ctx, execCfg.Settings, execCfg.LeaseManager, execCfg.InternalExecutor, execCfg.DB,
 				func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 					tn := tree.MakeTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(systemTableName))
-					found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
-					if err != nil {
+					found, desc, err := col.GetImmutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
+					isNotFoundErr := errors.Is(err, catalog.ErrDescriptorNotFound)
+					if err != nil && !isNotFoundErr {
 						return err
 					}
+
 					// Some system tables are not present when running inside a secondary
 					// tenant egs: `systemschema.TenantsTable`. In such situations we are
 					// print a warning and move on.
-					if !found {
+					if !found || isNotFoundErr {
 						log.Warningf(ctx, "could not find system table descriptor %s", systemTableName)
 						return nil
 					}
-					systemTableIDsToExclude[desc.ID] = struct{}{}
+					systemTableIDsToExclude[desc.GetID()] = struct{}{}
 					return nil
 				})
 			if err != nil {

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -21,6 +21,7 @@ func registerTests(r *testRegistry) {
 	registerAlterPK(r)
 	registerAutoUpgrade(r)
 	registerBackup(r)
+	registerBackupMixedVersion(r)
 	registerBackupNodeShutdown(r)
 	registerCancel(r)
 	registerCDC(r)


### PR DESCRIPTION
We assumed that in the not-found case GetMutableTableByName would
return a nil error. But, in fact, it returns a non-nil error, causing
us to fail when building our list of optOut system tables.

Now, we look for the DescriptorNotFound error and ignore it.

We could have alternatively built this list of descriptors using the
package-level vars in the catalog/systemschema package. We opted
against that originally since we wanted to stop writing code that
assumes static system table IDs. I've kept with that same decision
here.

Fixes #73043

Release note (enterprise change): BACKUP WITH revision_history would
previously fail on an upgraded but un-finalized cluster. Now, it
should succeed.

Release justification: Bug fix for critical backup bug.