### PR TITLE
backupccl: ignore ErrDescriptorNotFound on system table lookup

### DIFF
--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -382,18 +383,20 @@ func GetSystemTableIDsToExcludeFromClusterBackup(
 		if backupConfig.shouldIncludeInClusterBackup == optOutOfClusterBackup {
 			err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 				tn := tree.MakeTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(systemTableName))
-				found, desc, err := col.GetMutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
-				if err != nil {
+				found, desc, err := col.GetImmutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlags{})
+				isNotFoundErr := errors.Is(err, catalog.ErrDescriptorNotFound)
+				if err != nil && !isNotFoundErr {
 					return err
 				}
+
 				// Some system tables are not present when running inside a secondary
 				// tenant egs: `systemschema.TenantsTable`. In such situations we are
 				// print a warning and move on.
-				if !found {
-					log.Warningf(ctx, "could not find system table descriptor %s", systemTableName)
+				if !found || isNotFoundErr {
+					log.Warningf(ctx, "could not find system table descriptor %q", systemTableName)
 					return nil
 				}
-				systemTableIDsToExclude[desc.ID] = struct{}{}
+				systemTableIDsToExclude[desc.GetID()] = struct{}{}
 				return nil
 			})
 			if err != nil {

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // The following env variable names match those specified in the TeamCity
@@ -53,16 +54,20 @@ const (
 	rows3GiB   = rows30GiB / 10
 )
 
-func importBankDataSplit(
-	ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster,
-) string {
+func destinationName(c cluster.Cluster) string {
 	dest := c.Name()
-	// Randomize starting with encryption-at-rest enabled.
-	c.EncryptAtRandom(true)
-
 	if c.IsLocal() {
 		dest += fmt.Sprintf("%d", timeutil.Now().UnixNano())
 	}
+	return dest
+}
+
+func importBankDataSplit(
+	ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster,
+) string {
+	dest := destinationName(c)
+	// Randomize starting with encryption-at-rest enabled.
+	c.EncryptAtRandom(true)
 
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -70,17 +75,24 @@ func importBankDataSplit(
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
 	c.Start(ctx)
+	runImportBankDataSplit(ctx, rows, ranges, t, c)
+	return dest
+}
+
+func runImportBankDataSplit(ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster) {
 	c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 	time.Sleep(time.Second) // wait for csv server to open listener
-
 	importArgs := []string{
 		"./workload", "fixtures", "import", "bank",
-		"--db=bank", "--payload-bytes=10240", fmt.Sprintf("--ranges=%d", ranges), "--csv-server", "http://localhost:8081",
-		fmt.Sprintf("--rows=%d", rows), "--seed=1", "{pgurl:1}",
+		"--db=bank",
+		"--payload-bytes=10240",
+		"--csv-server", "http://localhost:8081",
+		"--seed=1",
+		fmt.Sprintf("--ranges=%d", ranges),
+		fmt.Sprintf("--rows=%d", rows),
+		"{pgurl:1}",
 	}
 	c.Run(ctx, c.Node(1), importArgs...)
-
-	return dest
 }
 
 func importBankData(ctx context.Context, rows int, t test.Test, c cluster.Cluster) string {
@@ -143,6 +155,63 @@ func registerBackupNodeShutdown(r registry.Registry) {
 		},
 	})
 
+}
+
+func registerBackupMixedVersion(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:    "backup/mixed-version",
+		Owner:   registry.OwnerBulkIO,
+		Cluster: r.MakeClusterSpec(4),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// An empty string means that the cockroach binary specified by flag
+			// `cockroach` will be used.
+			const mainVersion = ""
+			roachNodes := c.All()
+			predV, err := PredecessorVersion(*t.BuildVersion())
+			require.NoError(t, err)
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
+			loadBackupDataStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+				rows := rows3GiB
+				if c.IsLocal() {
+					rows = 100
+				}
+				runImportBankDataSplit(ctx, rows, 0 /* ranges */, t, u.c)
+			}
+			successfulBackupStep := func(nodeID int, opts ...string) versionStep {
+				return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+					backupOpts := ""
+					if len(opts) > 0 {
+						backupOpts = fmt.Sprintf("WITH %s", strings.Join(opts, ", "))
+					}
+					backupQuery := fmt.Sprintf("BACKUP bank.bank TO 'nodelocal://%d/%s' %s",
+						nodeID, destinationName(c), backupOpts)
+
+					gatewayDB := c.Conn(ctx, nodeID)
+					defer gatewayDB.Close()
+					t.Status("Running: ", backupQuery)
+					_, err := gatewayDB.ExecContext(ctx, backupQuery)
+					require.NoError(t, err)
+				}
+			}
+			u := newVersionUpgradeTest(c,
+				uploadAndStartFromCheckpointFixture(roachNodes, predV),
+				waitForUpgradeStep(roachNodes),
+				preventAutoUpgradeStep(1),
+				loadBackupDataStep,
+				// Upgrade some of the nodes.
+				binaryUpgradeStep(c.Nodes(1, 2), mainVersion),
+				// Backup from new node should succeed.
+				successfulBackupStep(1),
+				// Backup from new node with revision history should succeed.
+				successfulBackupStep(2, "revision_history"),
+				// Backup from old node should succeed.
+				successfulBackupStep(3),
+				// Backup from old node with revision history should succeed.
+				successfulBackupStep(4, "revision_history"),
+			)
+			u.run(ctx, t)
+		},
+	})
 }
 
 // initBulkJobPerfArtifacts registers a histogram, creates a performance

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -21,6 +21,7 @@ func RegisterTests(r registry.Registry) {
 	registerAsyncpg(r)
 	registerAutoUpgrade(r)
 	registerBackup(r)
+	registerBackupMixedVersion(r)
 	registerBackupNodeShutdown(r)
 	registerCancel(r)
 	registerCDC(r)


### PR DESCRIPTION
We assumed that in the not-found case GetMutableTableByName would
return a nil error. But, in fact, it returns a non-nil error, causing
us to fail when building our list of optOut system tables.

Now, we look for the DescriptorNotFound error and ignore it.

We could have alternatively built this list of descriptors using the
package-level vars in the catalog/systemschema package. We opted
against that originally since we wanted to stop writing code that
assumes static system table IDs. I've kept with that same decision
here.

These tests would have additionally caught #72839 and #72839.

This is a forward port of code that has already been applied to 
21.2 in #73050.

Release note: None