### PR TITLE
release-21.2: save filters on cache for Statement and Transaction pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -27,6 +27,7 @@ export * from "./loading";
 export * from "./modal";
 export * from "./pageConfig";
 export * from "./pagination";
+export * from "./queryFilter";
 export * from "./search";
 export * from "./sortedtable";
 export * from "./statementsDiagnostics";

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.spec.tsx
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Filters, getFiltersFromQueryString } from "./filter";
+
+describe("Test filter functions", (): void => {
+  describe("Test get filters from query string", (): void => {
+    it("no values on query string", (): void => {
+      const expectedFilters: Filters = {
+        app: "",
+        timeNumber: "0",
+        timeUnit: "seconds",
+        fullScan: false,
+        sqlType: "",
+        database: "",
+        regions: "",
+        nodes: "",
+      };
+      const resultFilters = getFiltersFromQueryString("");
+      expect(resultFilters).toEqual(expectedFilters);
+    });
+  });
+
+  it("different values from default values on query string", (): void => {
+    const expectedFilters: Filters = {
+      app: "$ internal",
+      timeNumber: "1",
+      timeUnit: "milliseconds",
+      fullScan: true,
+      sqlType: "DML",
+      database: "movr",
+      regions: "us-central",
+      nodes: "n1,n2",
+    };
+    const resultFilters = getFiltersFromQueryString(
+      "app=%24+internal&timeNumber=1&timeUnit=milliseconds&fullScan=true&sqlType=DML&database=movr&regions=us-central&nodes=n1,n2",
+    );
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing boolean with full scan = true", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: true,
+      sqlType: "",
+      database: "",
+      regions: "",
+      nodes: "",
+    };
+    const resultFilters = getFiltersFromQueryString("fullScan=true");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+
+  it("testing boolean with full scan = false", (): void => {
+    const expectedFilters: Filters = {
+      app: "",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      fullScan: false,
+      sqlType: "",
+      database: "",
+      regions: "",
+      nodes: "",
+    };
+    const resultFilters = getFiltersFromQueryString("fullScan=false");
+    expect(resultFilters).toEqual(expectedFilters);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -11,6 +11,7 @@
 import React from "react";
 import _ from "lodash";
 import * as Long from "long";
+import { History } from "history";
 import { Moment } from "moment";
 import { createSelector } from "reselect";
 
@@ -319,7 +320,7 @@ export class SortedTable<T> extends React.Component<
     return sortData ? sortData.slice(start, end) : data.slice(start, end);
   };
 
-  render() {
+  render(): React.ReactElement {
     const {
       data,
       loading,
@@ -397,7 +398,10 @@ export class SortedTable<T> extends React.Component<
  * @param maxLength the max length to which it should display value
  * and hide the remaining.
  */
-export function longListWithTooltip(value: string, maxLength: number) {
+export function longListWithTooltip(
+  value: string,
+  maxLength: number,
+): React.ReactElement {
   const summary =
     value.length > maxLength ? value.slice(0, maxLength) + "..." : value;
   return (
@@ -411,3 +415,83 @@ export function longListWithTooltip(value: string, maxLength: number) {
     </Tooltip>
   );
 }
+
+/**
+ * Get Sort Setting from Query String and if it's different from current
+ * sortSetting calls the onSortChange function.
+ * @param page the page where the table was added (used for analytics)
+ * @param queryString searchParams
+ * @param sortSetting the current sort Setting on the page
+ * @param onSortingChange function to be called if the values from the search
+ * params are different from the current ones. This function can update
+ * the value stored on localStorage for example.
+ */
+export const handleSortSettingFromQueryString = (
+  page: string,
+  queryString: string,
+  sortSetting: SortSetting,
+  onSortingChange: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void,
+): void => {
+  const searchParams = new URLSearchParams(queryString);
+  const ascending = (searchParams.get("ascending") || undefined) === "true";
+  const columnTitle = searchParams.get("columnTitle") || undefined;
+  if (
+    onSortingChange &&
+    columnTitle &&
+    (sortSetting.columnTitle != columnTitle ||
+      sortSetting.ascending != ascending)
+  ) {
+    onSortingChange(page, columnTitle, ascending);
+  }
+};
+
+/**
+ * Update the query params to the current values of the Sort Setting.
+ * When we change tabs inside the SQL Activity page for example,
+ * the constructor is called only on the first time.
+ * The component update event is called frequently and can be used to
+ * update the query params by using this function that only updates
+ * the query params if the values did change and we're on the correct tab.
+ * @param tab which the query params should update
+ * @param sortSetting the current sort settings
+ * @param defaultSortSetting the default sort settings
+ * @param history
+ */
+export const updateSortSettingQueryParamsOnTab = (
+  tab: string,
+  sortSetting: SortSetting,
+  defaultSortSetting: SortSetting,
+  history: History,
+): void => {
+  const searchParams = new URLSearchParams(history.location.search);
+  const currentTab = searchParams.get("tab") || "";
+  const ascending =
+    (searchParams.get("ascending") ||
+      defaultSortSetting.ascending.toString()) === "true";
+  const columnTitle =
+    searchParams.get("columnTitle") || defaultSortSetting.columnTitle;
+  if (
+    currentTab === tab &&
+    (sortSetting.columnTitle != columnTitle ||
+      sortSetting.ascending != ascending)
+  ) {
+    const params = {
+      ascending: sortSetting.ascending.toString(),
+      columnTitle: sortSetting.columnTitle,
+    };
+    const nextSearchParams = new URLSearchParams(history.location.search);
+    Object.entries(params).forEach(([key, value]) => {
+      if (!value) {
+        nextSearchParams.delete(key);
+      } else {
+        nextSearchParams.set(key, value);
+      }
+    });
+    history.location.search = nextSearchParams.toString();
+    history.replace(history.location);
+  }
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -271,6 +271,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount"
   },
+  filters: {
+    app: "",
+    timeNumber: "0",
+    timeUnit: "seconds",
+    fullScan: false,
+    sqlType: "",
+    database: "",
+    regions: "",
+    nodes: "",
+  },
   statements: [
     {
       label:
@@ -691,6 +701,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onDiagnosticsReportDownload: noop,
   onColumnsChange: noop,
   onSortingChange: noop,
+  onFilterChange: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -242,3 +242,8 @@ export const selectSortSetting = createSelector(
   localStorageSelector,
   localStorage => localStorage["sortSetting/StatementsPage"],
 );
+
+export const selectFilters = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["filters/StatementsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,12 +10,17 @@
 
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { isNil, merge, isEqual } from "lodash";
+import { isNil, merge } from "lodash";
 import moment, { Moment } from "moment";
 import classNames from "classnames/bind";
 import { Loading } from "src/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
-import { ColumnDescriptor, SortSetting } from "src/sortedtable";
+import {
+  ColumnDescriptor,
+  handleSortSettingFromQueryString,
+  SortSetting,
+  updateSortSettingQueryParamsOnTab,
+} from "src/sortedtable";
 import { Search } from "src/search";
 import { Pagination } from "src/pagination";
 import { DateRange } from "src/dateRange";
@@ -25,8 +30,9 @@ import {
   Filters,
   defaultFilters,
   calculateActiveFilters,
-  getFiltersFromQueryString,
   getTimeValueInSeconds,
+  handleFiltersFromQueryString,
+  updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 
 import {
@@ -156,51 +162,19 @@ export class StatementsPage extends React.Component<
     const searchQuery = searchParams.get("q") || undefined;
 
     // Sort Settings.
-    const ascending = (searchParams.get("ascending") || undefined) === "true";
-    const columnTitle = searchParams.get("columnTitle") || undefined;
-    if (
-      this.props.onSortingChange &&
-      columnTitle &&
-      (sortSetting.columnTitle != columnTitle ||
-        sortSetting.ascending != ascending)
-    ) {
-      this.props.onSortingChange("Statements", columnTitle, ascending);
-    }
+    handleSortSettingFromQueryString(
+      "Statements",
+      history.location.search,
+      sortSetting,
+      this.props.onSortingChange,
+    );
 
     // Filters.
-    const filtersQueryString = getFiltersFromQueryString(
-      history.location.search,
+    const latestFilter = handleFiltersFromQueryString(
+      history,
+      filters,
+      this.props.onFilterChange,
     );
-    const hasFilter = searchParams.get("app") || undefined;
-    if (
-      this.props.onFilterChange &&
-      hasFilter &&
-      !isEqual(filtersQueryString, filters)
-    ) {
-      // If we have filters on query string and they're different
-      // from the current filter state on props (localStorage),
-      // we want to update the value on localStorage.
-      this.props.onFilterChange(filtersQueryString);
-    } else if (!isEqual(filters, defaultFilters)) {
-      // If the filters on props (localStorage) are different
-      // from the default values, we want to update the History,
-      // so the url can be easily shared with the filters selected.
-      syncHistory(
-        {
-          app: filters.app,
-          timeNumber: filters.timeNumber,
-          timeUnit: filters.timeUnit,
-          sqlType: filters.sqlType,
-          database: filters.database,
-          regions: filters.regions,
-          nodes: filters.nodes,
-        },
-        this.props.history,
-      );
-    }
-    // If we have a new filter selection on query params, they
-    // take precedent on what is stored on localStorage.
-    const latestFilter = hasFilter ? filtersQueryString : filters;
 
     return {
       search: searchQuery,
@@ -259,47 +233,29 @@ export class StatementsPage extends React.Component<
     }
   }
 
-  // When we change tabs inside the SQL Activity page,
-  // the constructor is called only on the first time.
-  // The component update event is called frequently
-  // and can be used to update the query params by using
-  // this function that makes sure it's only updating
-  // if the values did change and we're on the correct
-  // tab (Statements).
-  updateQueryParamsOnTabSwitch(): void {
-    const { filters } = this.state;
-    const filtersQueryString = getFiltersFromQueryString(
-      this.props.history.location.search,
+  updateQueryParams(): void {
+    updateFiltersQueryParamsOnTab(
+      "Statements",
+      this.state.filters,
+      this.props.history,
     );
-    const searchParams = new URLSearchParams(
-      this.props.history.location.search,
+
+    updateSortSettingQueryParamsOnTab(
+      "Statements",
+      this.props.sortSetting,
+      {
+        ascending: false,
+        columnTitle: "executionCount",
+      },
+      this.props.history,
     );
-    const tab = searchParams.get("tab") || "";
-    if (
-      tab === "Statements" &&
-      !isEqual(filters, defaultFilters) &&
-      !isEqual(filters, filtersQueryString)
-    ) {
-      syncHistory(
-        {
-          app: filters.app,
-          timeNumber: filters.timeNumber,
-          timeUnit: filters.timeUnit,
-          sqlType: filters.sqlType,
-          database: filters.database,
-          regions: filters.regions,
-          nodes: filters.nodes,
-        },
-        this.props.history,
-      );
-    }
   }
 
   componentDidUpdate = (
     __: StatementsPageProps,
     prevState: StatementsPageState,
   ): void => {
-    this.updateQueryParamsOnTabSwitch();
+    this.updateQueryParams();
     if (this.state.search && this.state.search !== prevState.search) {
       this.props.onSearchComplete(this.filteredStatementsData());
     }
@@ -346,6 +302,7 @@ export class StatementsPage extends React.Component<
         app: filters.app,
         timeNumber: filters.timeNumber,
         timeUnit: filters.timeUnit,
+        fullScan: filters.fullScan.toString(),
         sqlType: filters.sqlType,
         database: filters.database,
         regions: filters.regions,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { isNil, merge } from "lodash";
+import { isNil, merge, isEqual } from "lodash";
 import moment, { Moment } from "moment";
 import classNames from "classnames/bind";
 import { Loading } from "src/loading";
@@ -30,11 +30,9 @@ import {
 } from "../queryFilter";
 
 import {
-  appAttr,
   calculateTotalWorkload,
   unique,
   containAny,
-  queryByName,
   syncHistory,
 } from "src/util";
 import {
@@ -89,7 +87,7 @@ export interface StatementsPageDispatchProps {
     ascending: boolean,
   ) => void;
   onDiagnosticsReportDownload?: (report: IStatementDiagnosticsReport) => void;
-  onFilterChange?: (value: string) => void;
+  onFilterChange?: (value: Filters) => void;
   onStatementClick?: (statement: string) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
   onDateRangeChange: (start: Moment, end: Moment) => void;
@@ -106,6 +104,7 @@ export interface StatementsPageStateProps {
   columns: string[];
   nodeRegions: { [key: string]: string };
   sortSetting: SortSetting;
+  filters: Filters;
   isTenant?: UIConfigState["isTenant"];
 }
 
@@ -137,36 +136,28 @@ export class StatementsPage extends React.Component<
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
   constructor(props: StatementsPageProps) {
     super(props);
-    const filters = getFiltersFromQueryString(
-      this.props.history.location.search,
-    );
     const defaultState = {
       pagination: {
         pageSize: 20,
         current: 1,
       },
       search: "",
-      filters: filters,
-      activeFilters: calculateActiveFilters(filters),
     };
-
     const stateFromHistory = this.getStateFromHistory();
     this.state = merge(defaultState, stateFromHistory);
     this.activateDiagnosticsRef = React.createRef();
   }
 
-  static defaultProps: Partial<StatementsPageProps> = {
-    isTenant: false,
-  };
-
   getStateFromHistory = (): Partial<StatementsPageState> => {
-    const { history } = this.props;
+    const { history, sortSetting, filters } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
+
+    // Search query.
     const searchQuery = searchParams.get("q") || undefined;
+
+    // Sort Settings.
     const ascending = (searchParams.get("ascending") || undefined) === "true";
     const columnTitle = searchParams.get("columnTitle") || undefined;
-    const sortSetting = this.props.sortSetting;
-
     if (
       this.props.onSortingChange &&
       columnTitle &&
@@ -176,8 +167,45 @@ export class StatementsPage extends React.Component<
       this.props.onSortingChange("Statements", columnTitle, ascending);
     }
 
+    // Filters.
+    const filtersQueryString = getFiltersFromQueryString(
+      history.location.search,
+    );
+    const hasFilter = searchParams.get("app") || undefined;
+    if (
+      this.props.onFilterChange &&
+      hasFilter &&
+      !isEqual(filtersQueryString, filters)
+    ) {
+      // If we have filters on query string and they're different
+      // from the current filter state on props (localStorage),
+      // we want to update the value on localStorage.
+      this.props.onFilterChange(filtersQueryString);
+    } else if (!isEqual(filters, defaultFilters)) {
+      // If the filters on props (localStorage) are different
+      // from the default values, we want to update the History,
+      // so the url can be easily shared with the filters selected.
+      syncHistory(
+        {
+          app: filters.app,
+          timeNumber: filters.timeNumber,
+          timeUnit: filters.timeUnit,
+          sqlType: filters.sqlType,
+          database: filters.database,
+          regions: filters.regions,
+          nodes: filters.nodes,
+        },
+        this.props.history,
+      );
+    }
+    // If we have a new filter selection on query params, they
+    // take precedent on what is stored on localStorage.
+    const latestFilter = hasFilter ? filtersQueryString : filters;
+
     return {
       search: searchQuery,
+      filters: latestFilter,
+      activeFilters: calculateActiveFilters(latestFilter),
     };
   };
 
@@ -231,10 +259,47 @@ export class StatementsPage extends React.Component<
     }
   }
 
+  // When we change tabs inside the SQL Activity page,
+  // the constructor is called only on the first time.
+  // The component update event is called frequently
+  // and can be used to update the query params by using
+  // this function that makes sure it's only updating
+  // if the values did change and we're on the correct
+  // tab (Statements).
+  updateQueryParamsOnTabSwitch(): void {
+    const { filters } = this.state;
+    const filtersQueryString = getFiltersFromQueryString(
+      this.props.history.location.search,
+    );
+    const searchParams = new URLSearchParams(
+      this.props.history.location.search,
+    );
+    const tab = searchParams.get("tab") || "";
+    if (
+      tab === "Statements" &&
+      !isEqual(filters, defaultFilters) &&
+      !isEqual(filters, filtersQueryString)
+    ) {
+      syncHistory(
+        {
+          app: filters.app,
+          timeNumber: filters.timeNumber,
+          timeUnit: filters.timeUnit,
+          sqlType: filters.sqlType,
+          database: filters.database,
+          regions: filters.regions,
+          nodes: filters.nodes,
+        },
+        this.props.history,
+      );
+    }
+  }
+
   componentDidUpdate = (
     __: StatementsPageProps,
     prevState: StatementsPageState,
   ): void => {
+    this.updateQueryParamsOnTabSwitch();
     if (this.state.search && this.state.search !== prevState.search) {
       this.props.onSearchComplete(this.filteredStatementsData());
     }
@@ -266,11 +331,12 @@ export class StatementsPage extends React.Component<
   };
 
   onSubmitFilters = (filters: Filters): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(filters);
+    }
+
     this.setState({
-      filters: {
-        ...this.state.filters,
-        ...filters,
-      },
+      filters: filters,
       activeFilters: calculateActiveFilters(filters),
     });
 
@@ -300,12 +366,15 @@ export class StatementsPage extends React.Component<
   };
 
   onClearFilters = (): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(defaultFilters);
+    }
+
     this.setState({
-      filters: {
-        ...defaultFilters,
-      },
+      filters: defaultFilters,
       activeFilters: 0,
     });
+
     this.resetPagination();
     syncHistory(
       {
@@ -352,9 +421,7 @@ export class StatementsPage extends React.Component<
         statement =>
           databases.length == 0 || databases.includes(statement.database),
       )
-      .filter(statement =>
-        this.state.filters.fullScan ? statement.fullScan : true,
-      )
+      .filter(statement => (filters.fullScan ? statement.fullScan : true))
       .filter(statement =>
         search
           .split(" ")
@@ -410,7 +477,6 @@ export class StatementsPage extends React.Component<
       statements,
       apps,
       databases,
-      location,
       onDiagnosticsReportDownload,
       onStatementClick,
       resetSQLStats,
@@ -420,8 +486,6 @@ export class StatementsPage extends React.Component<
       isTenant,
       sortSetting,
     } = this.props;
-    const appAttrValue = queryByName(location, appAttr);
-    const selectedApp = appAttrValue || "";
     const data = this.filteredStatementsData();
     const totalWorkload = calculateTotalWorkload(data);
     const totalCount = data.length;
@@ -443,7 +507,7 @@ export class StatementsPage extends React.Component<
     // hiding columns that won't be displayed for tenants.
     const columns = makeStatementsColumns(
       statements,
-      selectedApp,
+      filters.app,
       totalWorkload,
       nodeRegions,
       "statement",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -35,6 +35,7 @@ import {
   selectColumns,
   selectDateRange,
   selectSortSetting,
+  selectFilters,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { AggregateStatistics } from "../statementsTable";
@@ -59,6 +60,7 @@ export const ConnectedStatementsPage = withRouter(
       dateRange: selectDateRange(state),
       sortSetting: selectSortSetting(state),
       isTenant: selectIsTenant(state),
+      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>
@@ -108,15 +110,22 @@ export const ConnectedStatementsPage = withRouter(
             page: "Statements",
           }),
         ),
-      onFilterChange: value =>
+      onFilterChange: value => {
         dispatch(
           analyticsActions.track({
             name: "Filter Clicked",
             page: "Statements",
             filterName: "app",
-            value,
+            value: value.toString(),
           }),
-        ),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "filters/StatementsPage",
+            value: { filters: value },
+          }),
+        );
+      },
       onSortingChange: (
         tableName: string,
         columnName: string,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -122,7 +122,7 @@ export const ConnectedStatementsPage = withRouter(
         dispatch(
           localStorageActions.update({
             key: "filters/StatementsPage",
-            value: { filters: value },
+            value: value,
           }),
         );
       },

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -32,6 +32,7 @@ export type LocalStorageState = {
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
   "filters/StatementsPage": Filters;
+  "filters/TransactionsPage": Filters;
 };
 
 type Payload = {
@@ -80,6 +81,9 @@ const initialState: LocalStorageState = {
     defaultSessionsSortSetting,
   "filters/StatementsPage":
     JSON.parse(localStorage.getItem("filters/StatementsPage")) ||
+    defaultFilters,
+  "filters/TransactionsPage":
+    JSON.parse(localStorage.getItem("filters/TransactionsPage")) ||
     defaultFilters,
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -11,6 +11,7 @@
 import moment from "moment";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../utils";
+import { defaultFilters, Filters } from "../../queryFilter";
 
 type StatementsDateRangeState = {
   start: number;
@@ -30,6 +31,7 @@ export type LocalStorageState = {
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
+  "filters/StatementsPage": Filters;
 };
 
 type Payload = {
@@ -76,6 +78,9 @@ const initialState: LocalStorageState = {
   "sortSetting/SessionsPage":
     JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
     defaultSessionsSortSetting,
+  "filters/StatementsPage":
+    JSON.parse(localStorage.getItem("filters/StatementsPage")) ||
+    defaultFilters,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -14,6 +14,7 @@ import Long from "long";
 import moment from "moment";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { SortSetting } from "../sortedtable";
+import { Filters } from "../queryFilter";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -40,6 +41,8 @@ export const nodeRegions: { [nodeId: string]: string } = {
   "4": "gcp-europe-west1",
 };
 
+export const columns: string[] = ["all"];
+
 export const dateRange: [moment.Moment, moment.Moment] = [
   moment.utc("2021.08.08"),
   moment.utc("2021.08.12"),
@@ -51,6 +54,14 @@ export const timestamp = new protos.google.protobuf.Timestamp({
 export const sortSetting: SortSetting = {
   ascending: false,
   columnTitle: "executionCount",
+};
+
+export const filters: Filters = {
+  app: "",
+  timeNumber: "0",
+  timeUnit: "seconds",
+  regions: "",
+  nodes: "",
 };
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -45,3 +45,8 @@ export const selectSortSetting = createSelector(
   localStorageSelector,
   localStorage => localStorage["sortSetting/TransactionsPage"],
 );
+
+export const selectFilters = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["filters/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -15,9 +15,11 @@ import { cloneDeep, noop, extend } from "lodash";
 import {
   data,
   nodeRegions,
+  columns,
   routeProps,
   dateRange,
   sortSetting,
+  filters,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -37,10 +39,13 @@ storiesOf("Transactions Page", module)
       data={data}
       dateRange={dateRange}
       nodeRegions={nodeRegions}
+      columns={columns}
       refreshData={noop}
       resetSQLStats={noop}
       sortSetting={sortSetting}
       onSortingChange={noop}
+      filters={filters}
+      onFilterChange={noop}
     />
   ))
   .add("without data", () => {
@@ -50,10 +55,13 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -70,11 +78,14 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         history={history}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -85,10 +96,13 @@ storiesOf("Transactions Page", module)
         data={undefined}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         refreshData={noop}
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   })
@@ -99,6 +113,7 @@ storiesOf("Transactions Page", module)
         data={undefined}
         dateRange={dateRange}
         nodeRegions={nodeRegions}
+        columns={columns}
         error={
           new RequestError(
             "Forbidden",
@@ -110,6 +125,8 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         sortSetting={sortSetting}
         onSortingChange={noop}
+        filters={filters}
+        onFilterChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -23,8 +23,10 @@ import { DateRange } from "src/dateRange";
 import { TransactionDetails } from "../transactionDetails";
 import {
   ColumnDescriptor,
+  handleSortSettingFromQueryString,
   ISortedTablePagination,
   SortSetting,
+  updateSortSettingQueryParamsOnTab,
 } from "../sortedtable";
 import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
@@ -39,7 +41,8 @@ import {
   getStatementsByFingerprintIdAndTime,
 } from "./utils";
 import Long from "long";
-import { getSearchParams, unique, syncHistory } from "src/util";
+import { merge } from "lodash";
+import { unique, syncHistory } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
@@ -48,7 +51,8 @@ import {
   Filter,
   Filters,
   defaultFilters,
-  getFiltersFromQueryString,
+  handleFiltersFromQueryString,
+  updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 import { UIConfigState } from "../store";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -86,6 +90,7 @@ export interface TransactionsPageStateProps {
   isTenant?: UIConfigState["isTenant"];
   columns: string[];
   sortSetting: SortSetting;
+  filters: Filters;
 }
 
 export interface TransactionsPageDispatchProps {
@@ -93,6 +98,7 @@ export interface TransactionsPageDispatchProps {
   resetSQLStats: () => void;
   onDateRangeChange?: (start: Moment, end: Moment) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
+  onFilterChange?: (value: Filters) => void;
   onSortingChange?: (
     name: string,
     columnTitle: string,
@@ -119,42 +125,47 @@ export class TransactionsPage extends React.Component<
 > {
   constructor(props: TransactionsPageProps) {
     super(props);
-    const filters = getFiltersFromQueryString(
-      this.props.history.location.search,
-    );
-
-    const trxSearchParams = getSearchParams(this.props.history.location.search);
     this.state = {
       pagination: {
         pageSize: this.props.pageSize || 20,
         current: 1,
       },
-      search: trxSearchParams("q", "").toString(),
-      filters: filters,
+      search: "",
       aggregatedTs: null,
       statementFingerprintIds: null,
       transactionStats: null,
       transactionFingerprintId: null,
     };
-
-    const ascending = trxSearchParams("ascending", false).toString() === "true";
-    const columnTitle = trxSearchParams("columnTitle", undefined);
-    if (
-      this.props.onSortingChange &&
-      columnTitle &&
-      (this.props.sortSetting.columnTitle != columnTitle ||
-        this.props.sortSetting.ascending != ascending)
-    ) {
-      this.props.onSortingChange(
-        "Transactions",
-        columnTitle.toString(),
-        ascending,
-      );
-    }
+    const stateFromHistory = this.getStateFromHistory();
+    this.state = merge(this.state, stateFromHistory);
   }
 
-  static defaultProps: Partial<TransactionsPageProps> = {
-    isTenant: false,
+  getStateFromHistory = (): Partial<TState> => {
+    const { history, sortSetting, filters } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+
+    // Search query.
+    const searchQuery = searchParams.get("q") || undefined;
+
+    // Sort Settings.
+    handleSortSettingFromQueryString(
+      "Transactions",
+      history.location.search,
+      sortSetting,
+      this.props.onSortingChange,
+    );
+
+    // Filters.
+    const latestFilter = handleFiltersFromQueryString(
+      history,
+      filters,
+      this.props.onFilterChange,
+    );
+
+    return {
+      search: searchQuery,
+      filters: latestFilter,
+    };
   };
 
   refreshData = (): void => {
@@ -165,7 +176,27 @@ export class TransactionsPage extends React.Component<
   componentDidMount(): void {
     this.refreshData();
   }
+
+  updateQueryParams(): void {
+    updateFiltersQueryParamsOnTab(
+      "Transactions",
+      this.state.filters,
+      this.props.history,
+    );
+
+    updateSortSettingQueryParamsOnTab(
+      "Transactions",
+      this.props.sortSetting,
+      {
+        ascending: false,
+        columnTitle: "executionCount",
+      },
+      this.props.history,
+    );
+  }
+
   componentDidUpdate(): void {
+    this.updateQueryParams();
     this.refreshData();
   }
 
@@ -220,11 +251,12 @@ export class TransactionsPage extends React.Component<
   };
 
   onSubmitFilters = (filters: Filters): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(filters);
+    }
+
     this.setState({
-      filters: {
-        ...this.state.filters,
-        ...filters,
-      },
+      filters: filters,
     });
     this.resetPagination();
     syncHistory(
@@ -240,6 +272,10 @@ export class TransactionsPage extends React.Component<
   };
 
   onClearFilters = (): void => {
+    if (this.props.onFilterChange) {
+      this.props.onFilterChange(defaultFilters);
+    }
+
     this.setState({
       filters: {
         ...defaultFilters,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -30,10 +30,13 @@ import {
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
+import {
+  selectDateRange,
+  selectFilters,
+} from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
-import { actions as analyticsActions } from "../store/analytics";
+import { Filters } from "../queryFilter";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -49,6 +52,7 @@ export const TransactionsPageConnected = withRouter(
       dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
       sortSetting: selectSortSetting(state),
+      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -83,6 +87,14 @@ export const TransactionsPageConnected = withRouter(
           localStorageActions.update({
             key: "sortSetting/TransactionsPage",
             value: { columnTitle: columnName, ascending: ascending },
+          }),
+        );
+      },
+      onFilterChange: (value: Filters) => {
+        dispatch(
+          localStorageActions.update({
+            key: "filters/TransactionsPage",
+            value: value,
           }),
         );
       },

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -184,6 +184,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount",
   },
+  filters: {
+    app: "",
+    timeNumber: "0",
+    timeUnit: "seconds",
+    fullScan: false,
+    sqlType: "",
+    database: "",
+    regions: "",
+    nodes: "",
+  },
   columns: null,
   match: {
     path: "/statements",

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -36,7 +36,12 @@ import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { statementsDateRangeLocalSetting } from "src/redux/statementsDateRange";
 import { queryByName } from "src/util/query";
 
-import { StatementsPage, AggregateStatistics } from "@cockroachlabs/cluster-ui";
+import {
+  StatementsPage,
+  AggregateStatistics,
+  Filters,
+  defaultFilters,
+} from "@cockroachlabs/cluster-ui";
 import {
   createOpenDiagnosticsModalAction,
   createStatementDiagnosticsReportAction,
@@ -237,6 +242,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const filtersLocalSetting = new LocalSetting(
+  "filters/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  defaultFilters,
+);
+
 export default withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
@@ -250,6 +261,7 @@ export default withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       dateRange: selectDateRange(state),
       sortSetting: sortSettingLocalSetting.selector(state),
+      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshStatements: refreshStatements,
@@ -272,6 +284,7 @@ export default withRouter(
           ascending: ascending,
           columnTitle: columnName,
         }),
+      onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
       onDiagnosticsReportDownload: (report: IStatementDiagnosticsReport) =>
         trackDownloadDiagnosticsBundleAction(report.statement_fingerprint),
       // We use `null` when the value was never set and it will show all columns.

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -21,7 +21,11 @@ import { StatementsResponseMessage } from "src/util/api";
 import { TimestampToMoment } from "src/util/convert";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
-import { TransactionsPage } from "@cockroachlabs/cluster-ui";
+import {
+  TransactionsPage,
+  Filters,
+  defaultFilters,
+} from "@cockroachlabs/cluster-ui";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
 import { statementsDateRangeLocalSetting } from "src/redux/statementsDateRange";
 import { setCombinedStatementsDateRangeAction } from "src/redux/statements";
@@ -68,6 +72,12 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
+export const filtersLocalSetting = new LocalSetting(
+  "filters/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  defaultFilters,
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -85,6 +95,7 @@ const TransactionsPageConnected = withRouter(
       nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
       sortSetting: sortSettingLocalSetting.selector(state),
+      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshData: refreshStatements,
@@ -107,6 +118,7 @@ const TransactionsPageConnected = withRouter(
           ascending: ascending,
           columnTitle: columnName,
         }),
+      onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: save filters on cache for Statements page" (#72946)
  * 1/1 commits from "ui: save filters on cache for Transactions page" (#73003)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Low risk, high benefit changes to existing functionality