### PR TITLE
kvserver: remove above-raft closedts assertion

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -981,7 +981,9 @@ func (b *replicaAppBatch) assertNoWriteBelowClosedTimestamp(cmd *replicatedCmd) 
 		}
 		return wrapWithNonDeterministicFailure(errors.AssertionFailedf(
 			"command writing below closed timestamp; cmd: %x, write ts: %s, "+
-				"batch state closed: %s, command closed: %s, request: %s, lease: %s",
+				"batch state closed: %s, command closed: %s, request: %s, lease: %s.\n"+
+				"This assertion will fire again on restart; to ignore run with env var\n"+
+				"COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED=false",
 			cmd.idKey, wts,
 			b.state.RaftClosedTimestamp, cmd.raftCmd.ClosedTimestamp,
 			req, b.state.Lease),


### PR DESCRIPTION
This assertion has false positives, and we decided to remove it. An
already-existing below-raft assertion that would catch actual violations
of the invariants remains intact. See #72428 for details.

Fixes #72428.

Release note (bug fix): Fixed a crash with message "attempting to
propose command writing below closed timestamp" that could occur,
typically on overloaded systems experiencing non-cooperative lease
transfers.
