### PR TITLE
release-21.1: sql: reset indexedTypeFormatter on FmtCtx close

### DIFF
--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -451,10 +451,9 @@ var fmtCtxPool = sync.Pool{
 // recommended for performance-sensitive paths.
 func (ctx *FmtCtx) Close() {
 	ctx.Buffer.Reset()
-	ctx.flags = 0
-	ctx.indexedVarFormat = nil
-	ctx.tableNameFormatter = nil
-	ctx.placeholderFormat = nil
+	*ctx = FmtCtx{
+		Buffer: ctx.Buffer,
+	}
 	fmtCtxPool.Put(ctx)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #73095.

/cc @cockroachdb/release

---

Previously indexedTypeFormatter wouldn't be reset when
FmtCtx.Close() was called causing the indexedTypeFormatter
function to potentially be reused.

Release note (enterprise change): Fix a bug where restore can sometimes map OIDs
to invalid types in certain circumstances containing UDTs.
