### PR TITLE
opt: prevent creation of invalid streaming set operations

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -276,3 +276,46 @@ memo (optimized, ~8KB, required=[presentation: k:13,u:14,v:15,w:16])
       └── []
            ├── best: (scan kuvw,cols=(7-10))
            └── cost: 1104.82
+
+# Regression test for #73084. Ensure that we do not create empty streaming set
+# op orderings.
+exec-ddl
+CREATE TABLE table1 (
+	id INT64 PRIMARY KEY,
+	date TIMESTAMP DEFAULT now()
+)
+----
+
+opt expect-not=GenerateStreamingSetOp
+(SELECT id FROM table1 ORDER BY date ASC LIMIT 1)
+UNION
+(SELECT id FROM table1 ORDER BY date DESC LIMIT 1)
+----
+union
+ ├── columns: id:9!null
+ ├── left columns: table1.id:1
+ ├── right columns: table1.id:5
+ ├── cardinality: [0 - 2]
+ ├── key: (9)
+ ├── top-k
+ │    ├── columns: table1.id:1!null date:2
+ │    ├── internal-ordering: +2
+ │    ├── k: 1
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2)
+ │    └── scan table1
+ │         ├── columns: table1.id:1!null date:2
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2)
+ └── top-k
+      ├── columns: table1.id:5!null date:6
+      ├── internal-ordering: -6
+      ├── k: 1
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(5,6)
+      └── scan table1
+           ├── columns: table1.id:5!null date:6
+           ├── key: (5)
+           └── fd: (5)-->(6)


### PR DESCRIPTION
Prior to this commit, it was possible to generate a streaming
set operation with an empty ordering, due to using interesting
orderings involving input columns that were not output by the
set operation. This commit fixes the problem by removing those
orderings from consideration.

Fixes #73084

Release note (bug fix): Fixed an internal error that could occur
during planning for some set operations (e.g., UNION, INTERSECT or
EXCEPT) when at least one side of the set operation was ordered on
a column that was not output by the set operation. This bug was
first introduced in 21.2.0 and does not exist in prior versions.