### PR TITLE
ui: save search query on cache for Statements page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -271,6 +271,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount"
   },
+  search: "",
   filters: {
     app: "",
     timeNumber: "0",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -241,3 +241,8 @@ export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/StatementsPage"],
 );
+
+export const selectSearch = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["search/StatementsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -35,9 +35,9 @@ import {
   selectDateRange,
   selectSortSetting,
   selectFilters,
+  selectSearch,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
-import { AggregateStatistics } from "../statementsTable";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
 
@@ -48,18 +48,19 @@ export const ConnectedStatementsPage = withRouter(
     RouteComponentProps
   >(
     (state: AppState, props: StatementsPageProps) => ({
+      apps: selectApps(state),
+      columns: selectColumns(state),
+      databases: selectDatabases(state),
+      dateRange: selectDateRange(state),
+      filters: selectFilters(state),
+      isTenant: selectIsTenant(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
+      search: selectSearch(state),
+      sortSetting: selectSortSetting(state),
       statements: selectStatements(state, props),
       statementsError: selectStatementsLastError(state),
-      apps: selectApps(state),
-      databases: selectDatabases(state),
       totalFingerprints: selectTotalFingerprints(state),
-      lastReset: selectLastReset(state),
-      columns: selectColumns(state),
-      nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
-      dateRange: selectDateRange(state),
-      sortSetting: selectSortSetting(state),
-      isTenant: selectIsTenant(state),
-      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>
@@ -102,13 +103,20 @@ export const ConnectedStatementsPage = withRouter(
             action: "Downloaded",
           }),
         ),
-      onSearchComplete: (_results: AggregateStatistics[]) =>
+      onSearchComplete: (query: string) => {
         dispatch(
           analyticsActions.track({
             name: "Keyword Searched",
             page: "Statements",
           }),
-        ),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "search/StatementsPage",
+            value: query,
+          }),
+        );
+      },
       onFilterChange: value => {
         dispatch(
           analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -33,6 +33,7 @@ export type LocalStorageState = {
   "sortSetting/SessionsPage": SortSetting;
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
+  "search/StatementsPage": string;
 };
 
 type Payload = {
@@ -85,6 +86,8 @@ const initialState: LocalStorageState = {
   "filters/TransactionsPage":
     JSON.parse(localStorage.getItem("filters/TransactionsPage")) ||
     defaultFilters,
+  "search/StatementsPage":
+    JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -184,6 +184,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount",
   },
+  search: "",
   filters: {
     app: "",
     timeNumber: "0",

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -50,7 +50,6 @@ import {
 import {
   trackDownloadDiagnosticsBundleAction,
   trackStatementsPaginationAction,
-  trackStatementsSearchAction,
 } from "src/redux/analyticsActions";
 import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { LocalSetting } from "src/redux/localsettings";
@@ -251,20 +250,27 @@ export const filtersLocalSetting = new LocalSetting(
   defaultFilters,
 );
 
+export const searchLocalSetting = new LocalSetting(
+  "search/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export default withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
+      apps: selectApps(state),
+      columns: statementColumnsLocalSetting.selectorToArray(state),
+      databases: selectDatabases(state),
+      dateRange: selectDateRange(state),
+      filters: filtersLocalSetting.selector(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: searchLocalSetting.selector(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
       statements: selectStatements(state, props),
       statementsError: state.cachedData.statements.lastError,
-      apps: selectApps(state),
-      databases: selectDatabases(state),
       totalFingerprints: selectTotalFingerprints(state),
-      lastReset: selectLastReset(state),
-      columns: statementColumnsLocalSetting.selectorToArray(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      dateRange: selectDateRange(state),
-      sortSetting: sortSettingLocalSetting.selector(state),
-      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshStatements: refreshStatements,
@@ -275,8 +281,7 @@ export default withRouter(
         createStatementDiagnosticsAlertLocalSetting.set({ show: false }),
       onActivateStatementDiagnostics: createStatementDiagnosticsReportAction,
       onDiagnosticsModalOpen: createOpenDiagnosticsModalAction,
-      onSearchComplete: (results: AggregateStatistics[]) =>
-        trackStatementsSearchAction(results.length),
+      onSearchComplete: (query: string) => searchLocalSetting.set(query),
       onPageChanged: trackStatementsPaginationAction,
       onSortingChange: (
         _tableName: string,


### PR DESCRIPTION
Previously, a search  was not maintained when
the page change (e.g. coming back from Transaction details).
This commits saves the selected value to be used.

Partially adresses #71851

Release note: None