### PR TITLE
ui: save search query on cache for Transactions page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -15,7 +15,9 @@ type Page =
   | "Statements"
   | "Statement Details"
   | "Sessions"
-  | "Sessions Details";
+  | "Sessions Details"
+  | "Transactions"
+  | "Transaction Details";
 
 type SearchEvent = {
   name: "Keyword Searched";

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -34,6 +34,7 @@ export type LocalStorageState = {
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
   "search/StatementsPage": string;
+  "search/TransactionsPage": string;
 };
 
 type Payload = {
@@ -88,6 +89,8 @@ const initialState: LocalStorageState = {
     defaultFilters,
   "search/StatementsPage":
     JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
+  "search/TransactionsPage":
+    JSON.parse(localStorage.getItem("search/TransactionsPage")) || null,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -43,3 +43,8 @@ export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/TransactionsPage"],
 );
+
+export const selectSearch = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["search/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -36,32 +36,34 @@ storiesOf("Transactions Page", module)
   .add("with data", () => (
     <TransactionsPage
       {...routeProps}
+      columns={columns}
       data={data}
       dateRange={dateRange}
+      filters={filters}
       nodeRegions={nodeRegions}
-      columns={columns}
+      onFilterChange={noop}
+      onSortingChange={noop}
       refreshData={noop}
       resetSQLStats={noop}
+      search={""}
       sortSetting={sortSetting}
-      onSortingChange={noop}
-      filters={filters}
-      onFilterChange={noop}
     />
   ))
   .add("without data", () => {
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={getEmptyData()}
         dateRange={dateRange}
+        filters={filters}
         nodeRegions={nodeRegions}
-        columns={columns}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   })
@@ -75,17 +77,18 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={getEmptyData()}
         dateRange={dateRange}
-        nodeRegions={nodeRegions}
-        columns={columns}
-        refreshData={noop}
-        history={history}
-        resetSQLStats={noop}
-        sortSetting={sortSetting}
-        onSortingChange={noop}
         filters={filters}
+        history={history}
+        nodeRegions={nodeRegions}
         onFilterChange={noop}
+        onSortingChange={noop}
+        refreshData={noop}
+        resetSQLStats={noop}
+        search={""}
+        sortSetting={sortSetting}
       />
     );
   })
@@ -93,16 +96,17 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={undefined}
         dateRange={dateRange}
+        filters={filters}
         nodeRegions={nodeRegions}
-        columns={columns}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   })
@@ -110,10 +114,9 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={undefined}
         dateRange={dateRange}
-        nodeRegions={nodeRegions}
-        columns={columns}
         error={
           new RequestError(
             "Forbidden",
@@ -121,12 +124,14 @@ storiesOf("Transactions Page", module)
             "this operation requires admin privilege",
           )
         }
+        filters={filters}
+        nodeRegions={nodeRegions}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -31,10 +31,12 @@ import { nodeRegionsByIDSelector } from "../store/nodes";
 import {
   selectDateRange,
   selectFilters,
+  selectSearch,
 } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";
+import { actions as analyticsActions } from "../store/analytics";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -43,14 +45,15 @@ export const TransactionsPageConnected = withRouter(
     RouteComponentProps
   >(
     (state: AppState) => ({
-      data: selectTransactionsData(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      error: selectTransactionsLastError(state),
-      isTenant: selectIsTenant(state),
-      dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
-      sortSetting: selectSortSetting(state),
+      data: selectTransactionsData(state),
+      dateRange: selectDateRange(state),
+      error: selectTransactionsLastError(state),
       filters: selectFilters(state),
+      isTenant: selectIsTenant(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: selectSearch(state),
+      sortSetting: selectSortSetting(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -90,9 +93,31 @@ export const TransactionsPageConnected = withRouter(
       },
       onFilterChange: (value: Filters) => {
         dispatch(
+          analyticsActions.track({
+            name: "Filter Clicked",
+            page: "Transactions",
+            filterName: "app",
+            value: value.toString(),
+          }),
+        );
+        dispatch(
           localStorageActions.update({
             key: "filters/TransactionsPage",
             value: value,
+          }),
+        );
+      },
+      onSearchComplete: (query: string) => {
+        dispatch(
+          analyticsActions.track({
+            name: "Keyword Searched",
+            page: "Transactions",
+          }),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "search/TransactionsPage",
+            value: query,
           }),
         );
       },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -122,17 +122,19 @@ export const searchTransactionsData = (
   statements: Statement[],
 ): Transaction[] => {
   return transactions.filter((t: Transaction) =>
-    search.split(" ").every(val =>
-      collectStatementsText(
-        getStatementsByFingerprintIdAndTime(
-          t.stats_data.statement_fingerprint_ids,
-          t.stats_data.aggregated_ts,
-          statements,
-        ),
-      )
-        .toLowerCase()
-        .includes(val.toLowerCase()),
-    ),
+    search
+      ? search.split(" ").every(val =>
+          collectStatementsText(
+            getStatementsByFingerprintIdAndTime(
+              t.stats_data.statement_fingerprint_ids,
+              t.stats_data.aggregated_ts,
+              statements,
+            ),
+          )
+            .toLowerCase()
+            .includes(val.toLowerCase()),
+        )
+      : true,
   );
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -78,6 +78,12 @@ export const filtersLocalSetting = new LocalSetting(
   defaultFilters,
 );
 
+export const searchLocalSetting = new LocalSetting(
+  "search/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -87,15 +93,16 @@ export const transactionColumnsLocalSetting = new LocalSetting(
 const TransactionsPageConnected = withRouter(
   connect(
     (state: AdminUIState) => ({
-      data: selectData(state),
-      statementsError: state.cachedData.statements.lastError,
-      dateRange: selectDateRange(state),
-      lastReset: selectLastReset(state),
-      error: selectLastError(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
-      sortSetting: sortSettingLocalSetting.selector(state),
+      data: selectData(state),
+      dateRange: selectDateRange(state),
+      error: selectLastError(state),
       filters: filtersLocalSetting.selector(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: searchLocalSetting.selector(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
+      statementsError: state.cachedData.statements.lastError,
     }),
     {
       refreshData: refreshStatements,
@@ -119,6 +126,7 @@ const TransactionsPageConnected = withRouter(
           columnTitle: columnName,
         }),
       onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
+      onSearchComplete: (query: string) => searchLocalSetting.set(query),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Previously, a search  was not maintained when
the page change (e.g. coming back from Transaction details).
This commits saves the selected value to be used.

Partially adresses #71851

Release note: None