### PR TITLE
dev: add `go` command to `dev`

### DIFF
--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "dev.go",
         "doctor.go",
         "generate.go",
+        "go.go",
         "lint.go",
         "logic.go",
         "main.go",

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -66,6 +66,7 @@ Dev is the general-purpose dev tool for working on cockroachdb/cockroach. With d
 		makeBuilderCmd(ret.builder),
 		makeDoctorCmd(ret.doctor),
 		makeGenerateCmd(ret.generate),
+		makeGoCmd(ret.gocmd),
 		makeTestLogicCmd(ret.testlogic),
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),

--- a/pkg/cmd/dev/go.go
+++ b/pkg/cmd/dev/go.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import "github.com/spf13/cobra"
+
+func makeGoCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
+	return &cobra.Command{
+		Use:     "go <arguments>",
+		Short:   "Run `go` with the given arguments",
+		Long:    "Run `go` with the given arguments",
+		Example: "dev go mod tidy",
+		Args:    cobra.MinimumNArgs(0),
+		RunE:    runE,
+	}
+}
+
+func (d *dev) gocmd(cmd *cobra.Command, commandLine []string) error {
+	ctx := cmd.Context()
+	args := []string{"run", "@go_sdk//:bin/go", "--ui_event_filters=-DEBUG,-info,-stdout,-stderr", "--noshow_progress", "--"}
+	args = append(args, commandLine...)
+	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+}


### PR DESCRIPTION
Just allows you to run `go` without actually having it installed. Maybe
no one will use this but me, I don't know :)

Release Note: None