### PR TITLE
storage: use BlockPropertyCollector for fine-grained time bound itera…

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -168,4 +168,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-22	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-24	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -173,6 +173,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-22</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-24</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -299,6 +299,11 @@ const (
 	// ValidateGrantOption checks whether the current user granting privileges to
 	// another user holds the grant option for those privileges
 	ValidateGrantOption
+	// PebbleFormatBlockPropertyCollector switches to a backwards incompatible
+	// Pebble version that provides block property collectors that can be used
+	// for fine-grained time bound iteration. See
+	// https://github.com/cockroachdb/pebble/issues/1190 for details.
+	PebbleFormatBlockPropertyCollector
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -523,6 +528,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     ValidateGrantOption,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 22},
+	},
+	{
+		Key:     PebbleFormatBlockPropertyCollector,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 24},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -54,11 +54,12 @@ func _() {
 	_ = x[PublicSchemasWithDescriptors-43]
 	_ = x[UnsplitRangesInAsyncGCJobs-44]
 	_ = x[ValidateGrantOption-45]
+	_ = x[PebbleFormatBlockPropertyCollector-46]
 }
 
-const _Key_name = "V21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDeleteTenantUsageSingleConsumptionColumnSQLStatsTablesSQLStatsCompactionScheduledJobV21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTablePublicSchemasWithDescriptorsUnsplitRangesInAsyncGCJobsValidateGrantOption"
+const _Key_name = "V21_1Start21_1PLUSStart21_2JoinTokensTableAcquisitionTypeInLeaseHistorySerializeViewUDTsExpressionIndexesDeleteDeprecatedNamespaceTableDescriptorMigrationFixDescriptorsDatabaseRoleSettingsTenantUsageTableSQLInstancesTableNewRetryableRangefeedErrorsAlterSystemWebSessionsCreateIndexesSeparatedIntentsMigrationPostSeparatedIntentsMigrationRetryJobsWithExponentialBackoffRecordsBasedRegistryAutoSpanConfigReconciliationJobDefaultPrivilegesZonesTableForSecondaryTenantsUseKeyEncodeForHashShardedIndexesDatabasePlacementPolicyGeneratedAsIdentityOnUpdateExpressionsSpanConfigurationsTableBoundedStalenessDateAndIntervalStylePebbleFormatVersionedMarkerDataKeysRegistryPebbleSetWithDeleteTenantUsageSingleConsumptionColumnSQLStatsTablesSQLStatsCompactionScheduledJobV21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTablePublicSchemasWithDescriptorsUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollector"
 
-var _Key_index = [...]uint16{0, 5, 18, 27, 42, 71, 88, 105, 154, 168, 188, 204, 221, 248, 283, 308, 337, 368, 388, 419, 436, 465, 498, 521, 540, 559, 582, 598, 618, 639, 661, 680, 714, 728, 758, 763, 772, 794, 812, 834, 871, 910, 933, 947, 975, 1001, 1020}
+var _Key_index = [...]uint16{0, 5, 18, 27, 42, 71, 88, 105, 154, 168, 188, 204, 221, 248, 283, 308, 337, 368, 388, 419, 436, 465, 498, 521, 540, 559, 582, 598, 618, 639, 661, 680, 714, 728, 758, 763, 772, 794, 812, 834, 871, 910, 933, 947, 975, 1001, 1020, 1054}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 )
 
@@ -69,6 +70,8 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) {
 }
 
 func BenchmarkCatchUpScan(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	numKeys := 1_000_000
 	valueBytes := 64
 
@@ -185,6 +188,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 	opts.FS = vfs.Default
 	opts.LBaseMaxBytes = lBaseMaxBytes
 	opts.ReadOnly = readOnly
+	opts.FormatMajorVersion = pebble.FormatBlockPropertyCollector
 	peb, err := storage.NewPebble(
 		context.Background(),
 		storage.PebbleConfig{

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -38,6 +38,10 @@ type EngineKey struct {
 	Version []byte
 }
 
+// There are multiple decoding functions in the storage package, optimized for
+// their particular use case, that demultiplex on the various lengths below.
+// If adding another length to this list, remember to search for code
+// referencing these lengths and fix it.
 const (
 	engineKeyNoVersion                             = 0
 	engineKeyVersionWallTimeLen                    = 8

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -124,6 +124,13 @@ func TestSetMinVersion(t *testing.T) {
 	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleSetWithDelete))
 	require.NoError(t, err)
 	require.Equal(t, pebble.FormatSetWithDelete, p.db.FormatMajorVersion())
+
+	// Advancing the store cluster version to PebbleFormatBlockPropertyCollector
+	// should also advance the store's format major version.
+	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.PebbleFormatBlockPropertyCollector))
+	require.NoError(t, err)
+	require.Equal(t, pebble.FormatBlockPropertyCollector, p.db.FormatMajorVersion())
+
 }
 
 func TestMinVersion_IsNotEncrypted(t *testing.T) {


### PR DESCRIPTION
…tion

Adds an implementation of sstable.DataBlockIntervalCollector and
uses that to populate fine-grained per-block time intervals when
the cluster version is at PebbleFormatBlockPropertyCollector.

The original sstable-level pebbleTimeBoundPropCollector is still
in place, and will be useful for files that were written prior to
this use of BlockPropertyCollectors.

Benchmark results: For MVCCIncrementalIterator the ts=480 case is
one where 95% of the versions are irrelevant: new versions are
uniformly written for all keys, and each key on average should
have ~2 blocks. The ts=5 case is where all versions are relevant.

```
name                                            old time/op    new time/op    delta
MVCCIncrementalIterator/useTBI=true/ts=5-16       10.5ms ± 8%    10.7ms ± 7%     ~     (p=0.278 n=9+10)
MVCCIncrementalIterator/useTBI=true/ts=480-16     1.68ms ± 2%    0.38ms ± 2%  -77.44%  (p=0.000 n=9+9)
MVCCIncrementalIterator/useTBI=false/ts=5-16      7.83ms ±11%    8.58ms ± 6%   +9.62%  (p=0.000 n=10+10)
MVCCIncrementalIterator/useTBI=false/ts=480-16     952µs ± 1%     954µs ± 1%     ~     (p=0.549 n=10+9)

name                                            old alloc/op   new alloc/op   delta
MVCCIncrementalIterator/useTBI=true/ts=5-16       24.0kB ± 3%    24.2kB ± 2%     ~     (p=0.370 n=8+9)
MVCCIncrementalIterator/useTBI=true/ts=480-16     23.3kB ± 3%    21.0kB ± 2%  -10.10%  (p=0.000 n=10+9)
MVCCIncrementalIterator/useTBI=false/ts=5-16      11.3kB ±62%    14.0kB ± 3%     ~     (p=0.315 n=10+9)
MVCCIncrementalIterator/useTBI=false/ts=480-16    10.5kB ± 7%    10.5kB ± 7%     ~     (p=0.579 n=10+10)

name                                            old allocs/op  new allocs/op  delta
MVCCIncrementalIterator/useTBI=true/ts=5-16          224 ± 4%       251 ± 2%  +11.84%  (p=0.000 n=8+9)
MVCCIncrementalIterator/useTBI=true/ts=480-16        845 ± 3%       179 ± 1%  -78.87%  (p=0.000 n=10+8)
MVCCIncrementalIterator/useTBI=false/ts=5-16        15.2 ±54%      18.6 ± 3%     ~     (p=0.088 n=10+9)
MVCCIncrementalIterator/useTBI=false/ts=480-16       130 ± 7%       129 ± 7%     ~     (p=0.538 n=10+10)

name                                                               old time/op    new time/op    delta
CatchUpScan/linear-keys/useTBI=true/withDiff=false/perc=0.00-16       602ms ± 3%     600ms ± 5%     ~     (p=0.421 n=5+5)
CatchUpScan/linear-keys/useTBI=true/withDiff=false/perc=50.00-16      296ms ± 2%     290ms ± 2%   -2.05%  (p=0.032 n=5+5)
CatchUpScan/linear-keys/useTBI=true/withDiff=false/perc=75.00-16      145ms ± 3%     139ms ± 2%   -4.22%  (p=0.008 n=5+5)
CatchUpScan/linear-keys/useTBI=true/withDiff=false/perc=95.00-16     26.7ms ± 5%    26.4ms ± 2%     ~     (p=0.421 n=5+5)
CatchUpScan/linear-keys/useTBI=true/withDiff=false/perc=99.00-16     17.6ms ± 1%     5.3ms ± 1%  -70.07%  (p=0.008 n=5+5)
CatchUpScan/linear-keys/useTBI=false/withDiff=false/perc=0.00-16      382ms ± 3%     376ms ± 2%     ~     (p=0.310 n=5+5)
CatchUpScan/linear-keys/useTBI=false/withDiff=false/perc=50.00-16     283ms ± 2%     280ms ± 1%     ~     (p=0.056 n=5+5)
CatchUpScan/linear-keys/useTBI=false/withDiff=false/perc=75.00-16     233ms ± 0%     232ms ± 2%     ~     (p=0.556 n=4+5)
CatchUpScan/linear-keys/useTBI=false/withDiff=false/perc=95.00-16     196ms ± 5%     192ms ± 2%     ~     (p=0.310 n=5+5)
CatchUpScan/linear-keys/useTBI=false/withDiff=false/perc=99.00-16     186ms ± 4%     186ms ± 5%     ~     (p=1.000 n=5+5)
CatchUpScan/random-keys/useTBI=true/withDiff=false/perc=0.00-16       632ms ± 4%     624ms ± 0%     ~     (p=0.151 n=5+5)
CatchUpScan/random-keys/useTBI=true/withDiff=false/perc=50.00-16      518ms ± 1%     516ms ± 1%     ~     (p=0.690 n=5+5)
CatchUpScan/random-keys/useTBI=true/withDiff=false/perc=75.00-16      485ms ± 5%     479ms ± 3%     ~     (p=0.690 n=5+5)
CatchUpScan/random-keys/useTBI=true/withDiff=false/perc=95.00-16      418ms ± 2%     423ms ± 3%     ~     (p=0.548 n=5+5)
CatchUpScan/random-keys/useTBI=true/withDiff=false/perc=99.00-16      404ms ± 1%     400ms ± 2%     ~     (p=0.222 n=5+5)
CatchUpScan/random-keys/useTBI=false/withDiff=false/perc=0.00-16      392ms ± 1%     388ms ± 1%   -1.03%  (p=0.016 n=5+5)
CatchUpScan/random-keys/useTBI=false/withDiff=false/perc=50.00-16     304ms ± 2%     303ms ± 1%     ~     (p=1.000 n=5+5)
CatchUpScan/random-keys/useTBI=false/withDiff=false/perc=75.00-16     247ms ± 2%     247ms ± 2%     ~     (p=1.000 n=5+5)
CatchUpScan/random-keys/useTBI=false/withDiff=false/perc=95.00-16     223ms ±24%     207ms ± 1%     ~     (p=0.222 n=5+5)
CatchUpScan/random-keys/useTBI=false/withDiff=false/perc=99.00-16     198ms ± 2%     201ms ± 4%     ~     (p=0.310 n=5+5)
CatchUpScan/mixed-case/useTBI=true/withDiff=false/perc=0.00-16        620ms ± 1%     624ms ± 1%     ~     (p=0.548 n=5+5)
CatchUpScan/mixed-case/useTBI=true/withDiff=false/perc=50.00-16       519ms ± 2%     509ms ± 1%   -1.90%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/useTBI=true/withDiff=false/perc=75.00-16       460ms ± 3%     452ms ± 1%     ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/useTBI=true/withDiff=false/perc=95.00-16       157ms ± 1%     156ms ± 1%   -1.15%  (p=0.032 n=5+5)
CatchUpScan/mixed-case/useTBI=true/withDiff=false/perc=99.00-16       145ms ± 1%     143ms ± 4%     ~     (p=0.310 n=5+5)
CatchUpScan/mixed-case/useTBI=false/withDiff=false/perc=0.00-16       387ms ± 3%     381ms ± 1%   -1.55%  (p=0.032 n=5+5)
CatchUpScan/mixed-case/useTBI=false/withDiff=false/perc=50.00-16      300ms ± 2%     297ms ± 1%   -1.17%  (p=0.032 n=5+5)
CatchUpScan/mixed-case/useTBI=false/withDiff=false/perc=75.00-16      247ms ± 1%     252ms ± 9%     ~     (p=1.000 n=5+5)
CatchUpScan/mixed-case/useTBI=false/withDiff=false/perc=95.00-16      202ms ± 3%     209ms ±10%     ~     (p=0.421 n=5+5)
CatchUpScan/mixed-case/useTBI=false/withDiff=false/perc=99.00-16      193ms ± 1%     192ms ± 1%     ~     (p=0.151 n=5+5)
```

Allocations are within [-0.10%,+0.10%] for CatchUpScan.

Release note: None