### PR TITLE
spanconfig/store: support applying a batch of updates

### DIFF
--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -69,7 +69,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
 	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
 
-	deleted, added := spanConfigStore.Apply(ctx, spanconfig.Update{Span: span, Config: conf}, false /* dryrun */)
+	deleted, added := spanConfigStore.Apply(ctx, false /* dryrun */, spanconfig.Update{Span: span, Config: conf})
 	require.Empty(t, deleted)
 	require.Len(t, added, 1)
 	require.True(t, added[0].Span.Equal(span))

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -96,6 +96,16 @@ func (c ConstraintsConjunction) String() string {
 	return sb.String()
 }
 
+// Equal compares two span config entries.
+func (s *SpanConfigEntry) Equal(o SpanConfigEntry) bool {
+	return s.Span.Equal(o.Span) && s.Config.Equal(o.Config)
+}
+
+// Empty returns true if the span config entry is empty.
+func (s *SpanConfigEntry) Empty() bool {
+	return s.Equal(SpanConfigEntry{})
+}
+
 // TestingDefaultSpanConfig exports the default span config for testing purposes.
 func TestingDefaultSpanConfig() SpanConfig {
 	return SpanConfig{

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -192,10 +192,10 @@ type Store interface {
 
 // StoreWriter is the write-only portion of the Store interface.
 type StoreWriter interface {
-	// Apply applies the given update[1]. It also returns the existing spans that
-	// were deleted and entries that were newly added to make room for the
-	// update. The deleted list can double as a list of overlapping spans in the
-	// Store, provided the update is not a no-op[2].
+	// Apply applies a batch of non-overlapping updates atomically[1] and
+	// returns (i) the existing spans that were deleted, and (ii) the entries
+	// that were newly added to make room for the batch. The deleted list can
+	// also double as a list of overlapping spans in the Store[2].
 	//
 	// Span configs are stored in non-overlapping fashion. When an update
 	// overlaps with existing configs, the existing configs are deleted. If the
@@ -203,7 +203,8 @@ type StoreWriter interface {
 	// configs are re-added. If the update itself is adding an entry, that too
 	// is added. This is best illustrated with the following example:
 	//
-	//                                         [--- X --) is a span with config X
+	//                                        [--- X --) is a span with config X
+	//                                        [xxxxxxxx) is a span being deleted
 	//
 	//  Store    | [--- A ----)[------------- B -----------)[---------- C -----)
 	//  Update   |             [------------------ D -------------)
@@ -211,6 +212,15 @@ type StoreWriter interface {
 	//  Deleted  |             [------------- B -----------)[---------- C -----)
 	//  Added    |             [------------------ D -------------)[--- C -----)
 	//  Store*   | [--- A ----)[------------------ D -------------)[--- C -----)
+	//
+	// Generalizing to multiple updates:
+	//
+	//  Store    | [--- A ----)[------------- B -----------)[---------- C -----)
+	//  Updates  |             [--- D ----)        [xxxxxxxxx)       [--- E ---)
+	//           |
+	//  Deleted  |             [------------- B -----------)[---------- C -----)
+	//  Added    |             [--- D ----)[-- B --)         [-- C -)[--- E ---)
+	//  Store*   | [--- A ----)[--- D ----)[-- B --)         [-- C -)[--- E ---)
 	//
 	// TODO(irfansharif): We'll make use of the dryrun option in a future PR
 	// when wiring up the reconciliation job to use the KVAccessor. Since the
@@ -255,7 +265,7 @@ type StoreWriter interface {
 	//      against a StoreWriter (populated using KVAccessor contents) using
 	//      the descriptor's span config entry would return empty lists,
 	//      indicating a no-op.
-	Apply(ctx context.Context, update Update, dryrun bool) (
+	Apply(ctx context.Context, dryrun bool, updates ...Update) (
 		deleted []roachpb.Span, added []roachpb.SpanConfigEntry,
 	)
 }

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -12,6 +12,7 @@ package spanconfigstore
 
 import (
 	"context"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // EnabledSetting is a hidden cluster setting to enable the use of the span
@@ -130,23 +132,51 @@ func (s *Store) GetSpanConfigForKey(
 
 // Apply is part of the spanconfig.StoreWriter interface.
 func (s *Store) Apply(
-	ctx context.Context, update spanconfig.Update, dryrun bool,
+	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
 ) (deleted []roachpb.Span, added []roachpb.SpanConfigEntry) {
+	deleted, added, err := s.applyInternal(dryrun, updates...)
+	if err != nil {
+		log.Fatalf(ctx, "%v", err)
+	}
+	return deleted, added
+}
+
+func (s *Store) applyInternal(
+	dryrun bool, updates ...spanconfig.Update,
+) (deleted []roachpb.Span, added []roachpb.SpanConfigEntry, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if !update.Span.Valid() || len(update.Span.EndKey) == 0 {
-		log.Fatalf(ctx, "invalid span")
+	for i := range updates {
+		if !updates[i].Span.Valid() || len(updates[i].Span.EndKey) == 0 {
+			return nil, nil, errors.New("invalid span")
+		}
 	}
 
-	entriesToDelete, entriesToAdd := s.accumulateOpsForLocked(update)
+	sorted := make([]spanconfig.Update, len(updates))
+	copy(sorted, updates)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Span.Key.Compare(sorted[j].Span.Key) < 0
+	})
+	updates = sorted // re-use the same variable
+
+	for i := range updates {
+		if i == 0 {
+			continue
+		}
+		if updates[i].Span.Overlaps(updates[i-1].Span) {
+			return nil, nil, errors.Newf("found overlapping updates %s and %s", updates[i-1].Span, updates[i].Span)
+		}
+	}
+
+	entriesToDelete, entriesToAdd := s.accumulateOpsForLocked(updates)
 
 	deleted = make([]roachpb.Span, len(entriesToDelete))
 	for i := range entriesToDelete {
 		entry := &entriesToDelete[i]
 		if !dryrun {
 			if err := s.mu.tree.Delete(entry, false); err != nil {
-				log.Fatalf(ctx, "%v", err)
+				return nil, nil, err
 			}
 		}
 		deleted[i] = entry.Span
@@ -157,101 +187,208 @@ func (s *Store) Apply(
 		entry := &entriesToAdd[i]
 		if !dryrun {
 			if err := s.mu.tree.Insert(entry, false); err != nil {
-				log.Fatalf(ctx, "%v", err)
+				return nil, nil, err
 			}
 		}
 		added[i] = entry.SpanConfigEntry
 	}
 
-	return deleted, added
+	return deleted, added, nil
 }
 
 // accumulateOpsForLocked returns the list of store entries that would be
-// deleted and added if the given update was to be applied. To apply a given
-// update, we want to find all overlapping spans and clear out just the
-// intersections. If the update is adding a new span config, we'll also want to
-// add it store entry after. We do this by deleting all overlapping spans in
-// their entirety and re-adding the non-overlapping portions, if any.
-// Pseudo-code:
+// deleted and added if the given set of updates were to be applied.
 //
-// 	for entry in store.overlapping(update.span):
-// 		union, intersection = union(update.span, entry), intersection(update.span, entry)
-// 		pre, post = span{union.start_key, intersection.start_key}, span{intersection.end_key, union.end_key}
+// To apply a single update, we want to find all overlapping spans and clear out
+// just the intersections. If the update is adding a new span config, we'll also
+// want to add the corresponding store entry after. We do this by deleting all
+// overlapping spans in their entirety and re-adding the non-overlapping
+// segments. Pseudo-code:
 //
-// 		delete entry
-// 		if entry.contains(update.span.start_key):
-// 			add pre=entry.conf
-// 		if entry.contains(update.span.end_key):
-// 			add post=entry.conf
+//   for entry in store.overlapping(update.span):
+//       union, intersection = union(update.span, entry), intersection(update.span, entry)
+//       pre  = span{union.start_key, intersection.start_key}
+//       post = span{intersection.end_key, union.end_key}
+//
+//       delete {span=entry.span, conf=entry.conf}
+//       if entry.contains(update.span.start_key):
+//           # First entry overlapping with update.
+//           add {span=pre, conf=entry.conf} if non-empty
+//       if entry.contains(update.span.end_key):
+//           # Last entry overlapping with update.
+//           add {span=post, conf=entry.conf} if non-empty
 //
 //   if adding:
-//       add update.span=update.conf
+//       add {span=update.span, conf=update.conf} # add ourselves
 //
-func (s *Store) accumulateOpsForLocked(update spanconfig.Update) (toDelete, toAdd []storeEntry) {
-	for _, overlapping := range s.mu.tree.Get(update.Span.AsRange()) {
-		existing := overlapping.(*storeEntry)
-		var (
-			union = existing.Span.Combine(update.Span)
-			inter = existing.Span.Intersect(update.Span)
+// When extending to a set of updates, things are more involved (but only
+// slightly!). Let's assume that the updates are non-overlapping and sorted
+// by start key. As before, we want to delete overlapping entries in their
+// entirety and re-add the non-overlapping segments. With multiple updates, it's
+// possible that a segment being re-added will overlap another update. If
+// processing one update at a time in sorted order, we want to only re-add the
+// gap between the consecutive updates.
+//
+//   keyspace         a  b  c  d  e  f  g  h  i  j
+//   existing state      [--------X--------)
+//   updates          [--A--)           [--B--)
+//
+// When processing [a,c):A, after deleting [b,h):X, it would be incorrect to
+// re-add [c,h):X since we're also looking to apply [g,i):B. Instead of
+// re-adding the trailing segment right away, we carry it forward and process it
+// when iterating over the second, possibly overlapping update. In our example,
+// when iterating over [g,i):B we can subtract the overlap from [c,h):X and only
+// re-add [c,g):X.
+//
+// It's also possible for the segment to extend past the second update. In the
+// example below, when processing [d,f):B and having [b,h):X carried over, we
+// want to re-add [c,d):X and carry forward [f,h):X to the update after (i.e.
+// [g,i):C)).
+//
+//   keyspace         a  b  c  d  e  f  g  h  i  j
+//   existing state      [--------X--------)
+//   updates          [--A--)  [--B--)  [--C--)
+//
+// One final note: we're iterating through the updates without actually applying
+// any mutations. Going back to our first example, when processing [g,i):B,
+// retrieving the set of overlapping spans would (again) retrieve [b,h):X -- an
+// entry we've already encountered when processing [a,c):A. Re-adding
+// non-overlapping segments naively would re-add [b,g):X -- an entry that
+// overlaps with our last update [a,c):A. When retrieving overlapping entries,
+// we need to exclude any that overlap with the segment that was carried over.
+// Pseudo-code:
+//
+//   carry-over = <empty>
+//   for update in updates:
+//       carried-over, carry-over = carry-over, <empty>
+//       if update.overlap(carried-over):
+//           # Fill in the gap between consecutive updates.
+//           add {span=span{carried-over.start_key, update.start_key}, conf=carried-over.conf}
+//           # Consider the trailing span after update; carry it forward if non-empty.
+//           carry-over = {span=span{update.end_key, carried-over.end_key}, conf=carried-over.conf}
+//       else:
+//           add {span=carried-over.span, conf=carried-over.conf} if non-empty
+//
+//       for entry in store.overlapping(update.span):
+//          if entry.overlap(processed):
+//               continue # already processed
+//
+//           union, intersection = union(update.span, entry), intersection(update.span, entry)
+//           pre  = span{union.start_key, intersection.start_key}
+//           post = span{intersection.end_key, union.end_key}
+//
+//           delete {span=entry.span, conf=entry.conf}
+//           if entry.contains(update.span.start_key):
+//               # First entry overlapping with update.
+//               add {span=pre, conf=entry.conf} if non-empty
+//           if entry.contains(update.span.end_key):
+//               # Last entry overlapping with update.
+//               carry-over = {span=post, conf=entry.conf}
+//
+//        if adding:
+//           add {span=update.span, conf=update.conf} # add ourselves
+//
+//   add {span=carry-over.span, conf=carry-over.conf} if non-empty
+//
+func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, toAdd []storeEntry) {
+	var carryOver roachpb.SpanConfigEntry
+	for _, update := range updates {
+		var carriedOver roachpb.SpanConfigEntry
+		carriedOver, carryOver = carryOver, roachpb.SpanConfigEntry{}
+		if update.Span.Overlaps(carriedOver.Span) {
+			gapBetweenUpdates := roachpb.Span{Key: carriedOver.Span.Key, EndKey: update.Span.Key}
+			if gapBetweenUpdates.Valid() {
+				toAdd = append(toAdd, s.makeEntryLocked(gapBetweenUpdates, carriedOver.Config))
+			}
 
-			pre  = roachpb.Span{Key: union.Key, EndKey: inter.Key}
-			post = roachpb.Span{Key: inter.EndKey, EndKey: union.EndKey}
-		)
+			carryOverSpanAfterUpdate := roachpb.Span{Key: update.Span.EndKey, EndKey: carriedOver.Span.EndKey}
+			if carryOverSpanAfterUpdate.Valid() {
+				carryOver = roachpb.SpanConfigEntry{
+					Span:   carryOverSpanAfterUpdate,
+					Config: carriedOver.Config,
+				}
+			}
+		} else if !carriedOver.Empty() {
+			toAdd = append(toAdd, s.makeEntryLocked(carriedOver.Span, carriedOver.Config))
+		}
 
-		// Delete the existing span in its entirety. Below we'll re-add the
-		// non-intersecting parts of the span.
-		toDelete = append(toDelete, *existing)
+		skipAddingSelf := false
+		for _, overlapping := range s.mu.tree.Get(update.Span.AsRange()) {
+			existing := overlapping.(*storeEntry)
+			if existing.Span.Overlaps(carriedOver.Span) {
+				continue // we've already processed this entry above.
+			}
 
-		if existing.Span.ContainsKey(update.Span.Key) { // existing entry contains the update span's start key
-			// ex:     [-----------------)
-			//
-			// up:         [-------)
-			// up:         [-------------)
-			// up:         [--------------
-			// up:     [-------)
-			// up:     [-----------------)
-			// up:     [------------------
+			var (
+				union = existing.Span.Combine(update.Span)
+				inter = existing.Span.Intersect(update.Span)
 
-			// Re-add the non-intersecting span, if any.
-			if pre.Valid() {
-				toAdd = append(toAdd, s.makeEntryLocked(pre, existing.Config))
+				pre  = roachpb.Span{Key: union.Key, EndKey: inter.Key}
+				post = roachpb.Span{Key: inter.EndKey, EndKey: union.EndKey}
+			)
+
+			if update.Addition() {
+				if existing.Span.Equal(update.Span) && existing.Config.Equal(update.Config) {
+					skipAddingSelf = true
+					break // no-op; peep-hole optimization
+				}
+			}
+
+			// Delete the existing span in its entirety. Below we'll re-add the
+			// non-intersecting parts of the span.
+			toDelete = append(toDelete, *existing)
+			if existing.Span.ContainsKey(update.Span.Key) { // existing entry contains the update span's start key
+				// ex:     [-----------------)
+				//
+				// up:         [-------)
+				// up:         [-------------)
+				// up:         [--------------
+				// up:     [-------)
+				// up:     [-----------------)
+				// up:     [------------------
+
+				// Re-add the non-intersecting span, if any.
+				if pre.Valid() {
+					toAdd = append(toAdd, s.makeEntryLocked(pre, existing.Config))
+				}
+			}
+
+			if existing.Span.ContainsKey(update.Span.EndKey) { // existing entry contains the update span's end key
+				// ex:     [-----------------)
+				//
+				// up:     -------------)
+				// up:     [------------)
+				// up:        [---------)
+
+				// Carry over the non-intersecting span.
+				carryOver = roachpb.SpanConfigEntry{
+					Span:   post,
+					Config: existing.Config,
+				}
 			}
 		}
 
-		if existing.Span.ContainsKey(update.Span.EndKey) { // existing entry contains the update span's end key
-			// ex:     [-----------------)
-			//
-			// up:     -------------)
-			// up:     [------------)
-			// up:        [---------)
+		if update.Addition() && !skipAddingSelf {
+			// Add the update itself.
+			toAdd = append(toAdd, s.makeEntryLocked(update.Span, update.Config))
 
-			// Re-add the non-intersecting span.
-			toAdd = append(toAdd, s.makeEntryLocked(post, existing.Config))
+			// TODO(irfansharif): If we're adding an entry, we could inspect the
+			// entries before and after and check whether either of them have
+			// the same config. If they do, we could coalesce them into a single
+			// span. Given that these boundaries determine where we split
+			// ranges, we'd be able to reduce the number of ranges drastically
+			// (think adjacent tables/indexes/partitions with the same config).
+			// This would be especially significant for secondary tenants, where
+			// we'd be able to avoid unconditionally splitting on table
+			// boundaries. We'd still want to split on tenant boundaries, so
+			// certain preconditions would need to hold. For performance
+			// reasons, we'd probably also want to offer a primitive to allow
+			// manually splitting on specific table boundaries.
 		}
 	}
 
-	if update.Addition() {
-		if len(toDelete) == 1 &&
-			toDelete[0].Span.Equal(update.Span) &&
-			toDelete[0].Config.Equal(update.Config) {
-			// We're deleting exactly what we're going to add, this is a no-op.
-			return nil, nil
-		}
-
-		// Add the update itself.
-		toAdd = append(toAdd, s.makeEntryLocked(update.Span, update.Config))
-
-		// TODO(irfansharif): If we're adding an entry, we could inspect the
-		// entries before and after and check whether either of them have the
-		// same config. If they do, we could coalesce them into a single span.
-		// Given that these boundaries determine where we split ranges, we'd be
-		// able to reduce the number of ranges drastically (think adjacent
-		// tables/indexes/partitions with the same config). This would be
-		// especially significant for secondary tenants, where we'd be able to
-		// avoid unconditionally splitting on table boundaries. We'd still want
-		// to split on tenant boundaries, so certain preconditions would need to
-		// hold. For performance reasons, we'd probably also want to offer
-		// a primitive to allow manually splitting on specific table boundaries.
+	if !carryOver.Empty() {
+		toAdd = append(toAdd, s.makeEntryLocked(carryOver.Span, carryOver.Config))
 	}
 
 	return toDelete, toAdd

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/basic
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/basic
@@ -1,0 +1,92 @@
+# Test semantics of batched updates (multiple sets or deletes applied on a snapshot).
+
+# Test that dryruns don't actually mutate anything.
+apply dryrun
+set [b,d):A
+set [f,h):B
+----
+added [b,d):A
+added [f,h):B
+
+get key=b
+----
+conf=FALLBACK
+
+get key=g
+----
+conf=FALLBACK
+
+
+# Add span configs for real.
+apply
+set [b,d):A
+set [f,h):B
+----
+added [b,d):A
+added [f,h):B
+
+get key=a
+----
+conf=FALLBACK
+
+get key=b
+----
+conf=A
+
+get key=g
+----
+conf=B
+
+
+# Check that no-ops shows up as much.
+apply
+set [b,d):A
+set [f,h):B
+----
+
+
+# Check that a delete dryrun does nothing, though emitting the right operations.
+apply dryrun
+delete [f,h)
+delete [c,d)
+----
+deleted [b,d)
+deleted [f,h)
+added [b,c):A
+
+get key=f
+----
+conf=B
+
+
+# Delete a span for real.
+apply
+delete [f,h)
+delete [c,d)
+----
+deleted [b,d)
+deleted [f,h)
+added [b,c):A
+
+# Check for no-ops again.
+apply
+delete [f,g)
+delete [c,d)
+----
+
+# Check that keys are as we'd expect (including the deleted one).
+get key=b
+----
+conf=A
+
+get key=c
+----
+conf=FALLBACK
+
+get key=f
+----
+conf=FALLBACK
+
+get key=g
+----
+conf=FALLBACK

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/encompass
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/encompass
@@ -1,0 +1,79 @@
+# Test semantics of batched updates that overlap with and/or encompass
+# spans already present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-A)  [-B|-C)  [--D--)
+# ====================================
+# result     [-A)  [-B|-C)  [--D--)
+apply
+set [b,c):A
+set [d,e):B
+set [e,f):C
+set [g,i):D
+----
+added [b,c):A
+added [d,e):B
+added [e,f):C
+added [g,i):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--------)
+# ====================================
+# result  [--------X--------|--D--)
+apply dryrun
+set [a,g):X
+----
+deleted [b,c)
+deleted [d,e)
+deleted [e,f)
+added [a,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X--|----Y---)
+# ====================================
+# result  [--------X--|----Y---|-D)
+apply dryrun
+set [a,e):X
+set [e,h):Y
+----
+deleted [b,c)
+deleted [d,e)
+deleted [e,f)
+deleted [g,i)
+added [a,e):X
+added [e,h):Y
+added [h,i):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----------)
+# ====================================
+# result  [--------X-----------|-D)
+apply dryrun
+set [a,h):X
+----
+deleted [b,c)
+deleted [d,e)
+deleted [e,f)
+deleted [g,i)
+added [a,h):X
+added [h,i):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-A)  [-B|-C)  [--D--)
+# set     [--------X-----|xxxxx)
+# ====================================
+# result  [--------X-----)     [-D)
+apply dryrun
+set [a,f):X
+delete [f,h)
+----
+deleted [b,c)
+deleted [d,e)
+deleted [e,f)
+deleted [g,i)
+added [a,f):X
+added [h,i):D

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/errors
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/errors
@@ -1,0 +1,55 @@
+# Ensure we get an error if updates overlap.
+
+apply
+set [a,c):A
+set [a,c):B
+----
+err: found overlapping updates {a-c} and {a-c}
+
+apply
+set [a,c):A
+set [b,c):B
+----
+err: found overlapping updates {a-c} and {b-c}
+
+apply
+set [a,c):A
+set [b,d):B
+----
+err: found overlapping updates {a-c} and {b-d}
+
+apply
+delete [a,c)
+delete [a,c)
+----
+err: found overlapping updates {a-c} and {a-c}
+
+apply
+delete [a,c)
+delete [b,c)
+----
+err: found overlapping updates {a-c} and {b-c}
+
+apply
+delete [a,c)
+delete [b,d)
+----
+err: found overlapping updates {a-c} and {b-d}
+
+apply
+set [a,c):A
+delete [a,c)
+----
+err: found overlapping updates {a-c} and {a-c}
+
+apply
+delete [a,c)
+set [b,c):A
+----
+err: found overlapping updates {a-c} and {b-c}
+
+apply
+set [a,c):A
+delete [b,d)
+----
+err: found overlapping updates {a-c} and {b-d}

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/overlapping
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/overlapping
@@ -1,0 +1,206 @@
+# Test semantics of batched updates that partially overlap with what's already
+# present.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [-----X--------)
+# ====================================
+# result     [-----X--------)
+apply
+set [b,g):X
+----
+added [b,g):X
+
+overlapping span=[a,z)
+----
+[b,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)
+# ====================================
+# result  [--A--)[-----X----)
+apply dryrun
+set [a,c):A
+----
+deleted [b,g)
+added [a,c):A
+added [c,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [--B--)
+# ====================================
+# result  [--A--)[-----X----)  [--B--)
+apply dryrun
+set [a,c):A
+set [h,j):B
+----
+deleted [b,g)
+added [a,c):A
+added [c,g):X
+added [h,j):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [--B--)
+# ====================================
+# result  [--A--)[-X-----|--B--)
+apply dryrun
+set [a,c):A
+set [f,h):B
+----
+deleted [b,g)
+added [a,c):A
+added [c,f):X
+added [f,h):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)     [--B--)
+# ====================================
+# result  [--A--)[-X--|--B--)
+apply dryrun
+set [a,c):A
+set [e,g):B
+----
+deleted [b,g)
+added [a,c):A
+added [c,e):X
+added [e,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [--B--)
+# ====================================
+# result  [--A--)[X|--B--|-X)
+apply dryrun
+set [a,c):A
+set [d,f):B
+----
+deleted [b,g)
+added [a,c):A
+added [c,d):X
+added [d,f):B
+added [f,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set           [--A--|--B--)
+# ====================================
+# result     [-X|--A--|--B--)
+apply dryrun
+set [c,e):A
+set [e,g):B
+----
+deleted [b,g)
+added [b,c):X
+added [c,e):A
+added [e,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [--D--)
+# ====================================
+# set     [--A--|-X|-B|-X|--D--)
+apply dryrun
+set [a,c):A
+set [d,e):B
+set [f,h):D
+----
+deleted [b,g)
+added [a,c):A
+added [c,d):X
+added [d,e):B
+added [e,f):X
+added [f,h):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B)  [-D)
+# ====================================
+# set     [--A--|-X|-B|-X|-D)
+apply dryrun
+set [a,c):A
+set [d,e):B
+set [f,g):D
+----
+deleted [b,g)
+added [a,c):A
+added [c,d):X
+added [d,e):B
+added [e,f):X
+added [f,g):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [-B|-C|--D--)
+# ====================================
+# set     [--A--|-X|-B|-C|--D--)
+apply dryrun
+set [a,c):A
+set [d,e):B
+set [e,f):C
+set [f,h):D
+----
+deleted [b,g)
+added [a,c):A
+added [c,d):X
+added [d,e):B
+added [e,f):C
+added [f,h):D
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)              [xxxxx)
+# ====================================
+# result  [--A--)[-----X----)
+apply dryrun
+set [a,c):A
+delete [h,j)
+----
+deleted [b,g)
+added [a,c):A
+added [c,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)        [xxxxx)
+# ====================================
+# result  [--A--)[-X-----)
+apply dryrun
+set [a,c):A
+delete [f,h)
+----
+deleted [b,g)
+added [a,c):A
+added [c,f):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [xxxxx)     [--B--)
+# ====================================
+# result         [-X--|--B--)
+apply dryrun
+delete [a,c)
+set [e,g):B
+----
+deleted [b,g)
+added [c,e):X
+added [e,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [-----X--------)
+# set     [--A--)  [xx)  [--D--)
+# ====================================
+# set     [--A--|-X)  [-X|--D--)
+apply dryrun
+set [a,c):A
+delete [d,e)
+set [f,h):D
+----
+deleted [b,g)
+added [a,c):A
+added [c,d):X
+added [e,f):X
+added [f,h):D

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/straddle
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/straddle
@@ -1,0 +1,135 @@
+# Test semantics of batched updates that partially overlap with what's already
+# present, possibly straddling multiple existing entries.
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state
+# set        [--A--)  [--B--)
+# ====================================
+# result     [--A--)  [--B--)
+apply
+set [b,d):A
+set [e,g):B
+----
+added [b,d):A
+added [e,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----)
+# ====================================
+# result     [-A|----X---|-B)
+apply dryrun
+set [c,f):X
+----
+deleted [b,d)
+deleted [e,g)
+added [b,c):A
+added [c,f):X
+added [f,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X-------)
+# ====================================
+# result     [-A|----X------)
+apply dryrun
+set [c,g):X
+----
+deleted [b,d)
+deleted [e,g)
+added [b,c):A
+added [c,g):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----|xx)
+# ====================================
+# result     [-A|----X---)
+apply dryrun
+set [c,f):X
+delete [f,g)
+----
+deleted [b,d)
+deleted [e,g)
+added [b,c):A
+added [c,f):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [---X----------)
+# ====================================
+# result     [-A|----X---------)
+apply dryrun
+set [c,h):X
+----
+deleted [b,d)
+deleted [e,g)
+added [b,c):A
+added [c,h):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [---X-------)
+# ====================================
+# result     [-------X---|-B)
+apply dryrun
+set [b,f):X
+----
+deleted [b,d)
+deleted [e,g)
+added [b,f):X
+added [f,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [------X-------)
+# ====================================
+# result  [----------X---|-B)
+apply dryrun
+set [a,f):X
+----
+deleted [b,d)
+deleted [e,g)
+added [a,f):X
+added [f,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set           [xxxxxxxx)
+# ====================================
+# result     [-A)        [-B)
+apply dryrun
+delete [c,f)
+----
+deleted [b,d)
+deleted [e,g)
+added [b,c):A
+added [f,g):B
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set     [xxxxx|---X----------)
+# ====================================
+# result        [----X---------)
+apply dryrun
+delete [a,c)
+set [c,h):X
+----
+deleted [b,d)
+deleted [e,g)
+added [c,h):X
+
+# keys    a  b  c  d  e  f  g  h  i  j
+# state      [--A--)  [--B--)
+# set        [--X--|xxxxx|-Y)
+# ====================================
+# result     [--X--)     [-Y)
+apply dryrun
+set [b,d):X
+delete [d,f)
+set [f,g):Y
+----
+deleted [b,d)
+deleted [e,g)
+added [b,d):X
+added [f,g):Y

--- a/pkg/spanconfig/spanconfigstore/testdata/single/basic
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/basic
@@ -1,6 +1,6 @@
 # Test basic get/set/delete operations where the spans retrieved are identical
 # to the ones being added/deleted, and are non-overlapping with respect to one
-# another.
+# another. Only a single update is applied at a time.
 
 # Check that missing keys fallback to a static config.
 get key=b
@@ -9,7 +9,8 @@ conf=FALLBACK
 
 
 # Test that dryruns don't actually mutate anything.
-set span=[b,d) conf=A dryrun
+apply dryrun
+set [b,d):A
 ----
 added [b,d):A
 
@@ -19,17 +20,20 @@ conf=FALLBACK
 
 
 # Add span configs for real.
-set span=[b,d) conf=A
+apply
+set [b,d):A
 ----
 added [b,d):A
 
-set span=[f,h) conf=B
+apply
+set [f,h):B
 ----
 added [f,h):B
 
 
 # Check that a no-op operation shows up as much.
-set span=[f,h) conf=B
+apply
+set [f,h):B
 ----
 
 
@@ -56,7 +60,8 @@ conf=FALLBACK
 
 
 # Check that a delete dryrun does nothing.
-delete span=[f,h) dryrun
+apply dryrun
+delete [f,h)
 ----
 deleted [f,h)
 
@@ -66,15 +71,18 @@ conf=B
 
 
 # Delete a span for real.
-delete span=[f,h)
+apply
+delete [f,h)
 ----
 deleted [f,h)
 
 # Check that a no-op operation does nothing.
-delete span=[f,g)
+apply
+delete [f,g)
 ----
 
-delete span=[f,h)
+apply
+delete [f,h)
 ----
 
 # Check that keys are as we'd expect (including the deleted one).

--- a/pkg/spanconfig/spanconfigstore/testdata/single/errors
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/errors
@@ -1,0 +1,21 @@
+# Ensure we get an error if updates are over invalid spans.
+
+apply
+set [c,a):A
+----
+err: invalid span
+
+apply
+set [c,c):A
+----
+err: invalid span
+
+apply
+delete [c,a)
+----
+err: invalid span
+
+apply
+delete [c,c)
+----
+err: invalid span

--- a/pkg/spanconfig/spanconfigstore/testdata/single/internal
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/internal
@@ -1,13 +1,16 @@
-# Test the store's internal view of overlapping span configs.
+# Test the store's internal view of overlapping span configs. Only a single
+# update is applied at a time.
 
 overlapping span=[a,z)
 ----
 
-set span=[b,d) conf=A
+apply
+set [b,d):A
 ----
 added [b,d):A
 
-set span=[f,g) conf=B
+apply
+set [f,g):B
 ----
 added [f,g):B
 
@@ -30,7 +33,8 @@ overlapping span=[a,j)
 [b,d):A
 [f,g):B
 
-delete span=[f,g)
+apply
+delete [f,g)
 ----
 deleted [f,g)
 

--- a/pkg/spanconfig/spanconfigstore/testdata/single/overlap
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/overlap
@@ -1,18 +1,21 @@
-# Test operations where the spans overlap with the existing ones.
+# Test operations where the spans overlap with the existing ones. Only a single
+# update is applied at a time.
 
-set span=[b,h) conf=A
+apply
+set [b,h):A
 ----
 added [b,h):A
 
 
 # Check that writing a span with a partial overlap first deletes the existing
 # entry and adds three new ones.
-set span=[d,f) conf=B
+apply
+set [d,f):B
 ----
 deleted [b,h)
 added [b,d):A
-added [f,h):A
 added [d,f):B
+added [f,h):A
 
 overlapping span=[b,h)
 ----
@@ -24,13 +27,14 @@ overlapping span=[b,h)
 # Check that writing a span that partially overlaps with multiple existing
 # entries deletes all of them, and re-adds the right non-overlapping fragments
 # with the right configs.
-set span=[c,e) conf=C
+apply
+set [c,e):C
 ----
 deleted [b,d)
 deleted [d,f)
 added [b,c):A
-added [e,f):B
 added [c,e):C
+added [e,f):B
 
 overlapping span=[b,h)
 ----
@@ -41,7 +45,8 @@ overlapping span=[b,h)
 
 # Check that when a span being written to entirely envelopes an existing entry,
 # that entry is deleted in its entirety.
-delete span=[d,g)
+apply
+delete [d,g)
 ----
 deleted [c,e)
 deleted [e,f)
@@ -64,7 +69,8 @@ compute-split span=[b,h)
 ----
 key=c
 
-set span=[b,g) conf=A
+apply
+set [b,g):A
 ----
 deleted [b,c)
 deleted [c,d)

--- a/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["utils.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/roachpb:with-mocks"],
+    deps = [
+        "//pkg/roachpb:with-mocks",
+        "//pkg/spanconfig",
+    ],
 )
 
 go_test(


### PR DESCRIPTION
We first introduced spanconfig.StoreWriter in #70287. Here we extend the
interface to accept a batch of updates instead of just one.

```go
type StoreWriter interface {
    Apply(ctx context.Context, dryrun bool, updates ...Update) (
        deleted []roachpb.Span, added []roachpb.SpanConfigEntry,
    )
}
```

The implementation is subtle -- we're not processing one update at a
time. The semantics we're after is applying a batch of updates
atomically on a consistent snapshot of the underlying store. This comes
up in the upcoming spanconfig.Reconciler (#71994) -- there, following a
zone config/descriptor change, we want to update KV state in a single
request/RTT instead of an RTT per descendent table. The intended
usage is better captured in the aforementioned PR; let's now talk
about what this entails for the datastructure.

To apply a single update, we want to find all overlapping spans and
clear out just the intersections. If the update is adding a new span
config, we'll also want to add the corresponding store entry after. We
do this by deleting all overlapping spans in their entirety and
re-adding the non-overlapping segments. Pseudo-code:

```python
for entry in store.overlapping(update.span):
  union, intersection = union(update.span, entry), intersection(update.span, entry)
  pre  = span{union.start_key, intersection.start_key}
  post = span{intersection.end_key, union.end_key}

  delete {span=entry.span, conf=entry.conf}
  if entry.contains(update.span.start_key):
    # First entry overlapping with update.
    add {span=pre, conf=entry.conf} if non-empty
  if entry.contains(update.span.end_key):
    # Last entry overlapping with update.
    add {span=post, conf=entry.conf} if non-empty

if adding:
  add {span=update.span, conf=update.conf} # add ourselves
```

When extending to a set of updates, things are more involved. Let's
assume that the updates are non-overlapping and sorted by start key. As
before, we want to delete overlapping entries in their entirety and
re-add the non-overlapping segments. With multiple updates, it's
possible that a segment being re-added will overlap another update.  If
processing one update at a time in sorted order, we want to only re-add
the gap between the consecutive updates.

    keyspace         a  b  c  d  e  f  g  h  i  j
    existing state      [--------X--------)
    updates          [--A--)           [--B--)

When processing [a,c):A, after deleting [b,h):X, it would be incorrect
to re-add [c,h):X since we're also looking to apply [g,i):B. Instead of
re-adding the trailing segment right away, we carry it forward and
process it when iterating over the second, possibly overlapping update.
In our example, when iterating over [g,i):B we can subtract the overlap
from [c,h):X and only re-add [c,g):X.

It's also possible for the segment to extend past the second update. In
the example below, when processing [d,f):B and having [b,h):X carried
over, we want to re-add [c,d):X and carry forward [f,h):X to the update
after (i.e. [g,i):C)).

    keyspace         a  b  c  d  e  f  g  h  i  j
    existing state      [--------X--------)
    updates          [--A--)  [--B--)  [--C--)

One final note: we're iterating through the updates without actually
applying any mutations. Going back to our first example, when processing
[g,i):B, retrieving the set of overlapping spans would (again) retrieve
[b,h):X -- an entry we've already encountered when processing [a,c):A.
Re-adding non-overlapping segments naively would re-add [b,g):X -- an
entry that overlaps with our last update [a,c):A. When retrieving
overlapping entries, we need to exclude any that overlap with the
segment that was carried over. Pseudo-code:

```python
carry-over = <empty>
for update in updates:
  carried-over, carry-over = carry-over, <empty>
  if update.overlap(carried-over):
      # Fill in the gap between consecutive updates.
      add {span=span{carried-over.start_key, update.start_key}, conf=carried-over.conf}
      # Consider the trailing span after update; carry it forward if non-empty.
      carry-over = {span=span{update.end_key, carried-over.end_key}, conf=carried-over.conf}
  else:
      add {span=carried-over.span, conf=carried-over.conf} if non-empty

  for entry in store.overlapping(update.span):
     if entry.overlap(processed):
          continue # already processed

      union, intersection = union(update.span, entry), intersection(update.span, entry)
      pre  = span{union.start_key, intersection.start_key}
      post = span{intersection.end_key, union.end_key}

      delete {span=entry.span, conf=entry.conf}
      if entry.contains(update.span.start_key):
          # First entry overlapping with update.
          add {span=pre, conf=entry.conf} if non-empty
      if entry.contains(update.span.end_key):
          # Last entry overlapping with update.
          carry-over = {span=post, conf=entry.conf}

   if adding:
      add {span=update.span, conf=update.conf} # add ourselves

add {span=carry-over.span, conf=carry-over.conf} if non-empty
```
We've extended the randomized testing suite to generate batches of
updates at a time. We've also added a few illustrated datadriven tests.

Release note: None
