### PR TITLE
sql: require valid TenantID in start_replication_stream

### DIFF
--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -84,8 +84,10 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-
-				tenantID := int(tree.MustBeDInt(args[0]))
+				tenantID, err := mustBeDIntInTenantRange(args[0])
+				if err != nil {
+					return nil, err
+				}
 				jobID, err := mgr.StartReplicationStream(evalCtx, evalCtx.Txn, uint64(tenantID))
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
MakeTenantID panics if someone tries to use 0 as a tenant ID. Here, we
return an error immediately in this case rather than crashing.

Fixes #71311

Release note: None