### PR TITLE
kvserver: de-flake TestStrictGCEnforcement

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3142,7 +3142,6 @@ func TestTransferLeaseBlocksWrites(t *testing.T) {
 // to the zone configs.
 func TestStrictGCEnforcement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 73123, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// The unfortunate thing about this test is that the gcttl is in seconds and


### PR DESCRIPTION
PR #72978 unintentionally introduced a small change: on a follower read,
we would pass the lease status to `checkTSAboveGCThreshold`. If this
lease status was `VALID` but not owned by the recipient replica (i.e.
this was a follower read), `checkTSAboveGCThreshold` could return the
implied GCThreshold (i.e. `now()-gcttl`) instead of the lowest possible
TTL. This made `TestStrictGCEnforcement` flaky since that test verifies
that a historical read goes through on the recent recipient of a lease
(which may not have applied the lease yet), who would serve it via a
follower read and would thus error out a read that the test expected to
go through.

Fixes #73123.

Release note: None
