### PR TITLE
rpc: avoid use-after-Stop via RPC endpoints

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -45,9 +45,11 @@ import (
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -74,6 +76,12 @@ const (
 // GRPC Dialer connection timeout. 20s matches default value that is
 // suppressed when backoff config is provided.
 const minConnectionTimeout = 20 * time.Second
+
+// errDialRejected is returned from client interceptors when the server's
+// stopper is quiescing. The error is constructed to return true in
+// `grpcutil.IsConnectionRejected` which prevents infinite retry loops during
+// cluster shutdown, especially in unit testing.
+var errDialRejected = grpcstatus.Error(codes.PermissionDenied, "refusing to dial; node is quiescing")
 
 // sourceAddr is the environment-provided local address for outgoing
 // connections.
@@ -447,7 +455,7 @@ func NewContext(opts ContextOptions) *Context {
 				// conn. We need to set the error in case we win the race against the
 				// real initialization code.
 				if conn.dialErr == nil {
-					conn.dialErr = &roachpb.NodeUnavailableError{}
+					conn.dialErr = errDialRejected
 				}
 			})
 			ctx.removeConn(conn, k.(connKey))
@@ -1074,6 +1082,12 @@ func (rpcCtx *Context) grpcDialRaw(
 
 	log.Health.Infof(rpcCtx.masterCtx, "dialing n%v: %s (%v)", remoteNodeID, target, class)
 	conn, err := grpc.DialContext(rpcCtx.masterCtx, target, dialOpts...)
+	if err != nil && rpcCtx.masterCtx.Err() != nil {
+		// If the node is draining, discard the error (which is likely gRPC's version
+		// of context.Canceled) and return errDialRejected which instructs callers not
+		// to retry.
+		err = errDialRejected
+	}
 	return conn, dialer.redialChan, err
 }
 
@@ -1161,7 +1175,10 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 					}
 					rpcCtx.removeConn(conn, thisConnKeys...)
 				}); err != nil {
-				conn.dialErr = err
+				// If node is draining (`err` will always equal stop.ErrUnavailable
+				// here), return special error (see its comments).
+				_ = err // ignore this error
+				conn.dialErr = errDialRejected
 			}
 		}
 		if conn.dialErr != nil {

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -62,19 +62,19 @@ import (
 // instead which automates the address resolution.
 //
 // TODO(knz): remove this altogether. Use the dialer in all cases.
-func (ctx *Context) TestingConnHealth(target string, nodeID roachpb.NodeID) error {
-	if ctx.GetLocalInternalClientForAddr(target, nodeID) != nil {
+func (rpcCtx *Context) TestingConnHealth(target string, nodeID roachpb.NodeID) error {
+	if rpcCtx.GetLocalInternalClientForAddr(target, nodeID) != nil {
 		// The local server is always considered healthy.
 		return nil
 	}
-	conn := ctx.GRPCDialNode(target, nodeID, DefaultClass)
+	conn := rpcCtx.GRPCDialNode(target, nodeID, DefaultClass)
 	return conn.Health()
 }
 
 // AddTestingDialOpts adds extra dialing options to the rpc Context. This should
 // be done before GRPCDial is called.
-func (ctx *Context) AddTestingDialOpts(opts ...grpc.DialOption) {
-	ctx.testingDialOpts = append(ctx.testingDialOpts, opts...)
+func (rpcCtx *Context) AddTestingDialOpts(opts ...grpc.DialOption) {
+	rpcCtx.testingDialOpts = append(rpcCtx.testingDialOpts, opts...)
 }
 
 func newTestServer(t testing.TB, ctx *Context, extraOpts ...grpc.ServerOption) *grpc.Server {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1355,6 +1355,8 @@ func (n *Node) GossipSubscription(
 			}
 		case <-ctxDone:
 			return ctx.Err()
+		case <-n.stopper.ShouldQuiesce():
+			return stop.ErrUnavailable
 		}
 	}
 }

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -110,6 +110,13 @@ func IsConnectionRejected(err error) bool {
 
 // IsAuthError returns true if err's Cause is an error produced by
 // gRPC due to an authentication or authorization error for the operation.
+// AuthErrors should generally be considered non-retriable. They indicate
+// that the operation would not succeed even if directed at another node
+// in the cluster.
+//
+// As a special case, an AuthError (PermissionDenied) is returned on outbound
+// dialing when the source node is in the process of terminating (see
+// rpc.errDialRejected).
 func IsAuthError(err error) bool {
 	if s, ok := status.FromError(errors.UnwrapAll(err)); ok {
 		switch s.Code() {


### PR DESCRIPTION
This avoids a class of crashes on shutdown that occur when an RPC is
handled after the stopper has already stopped (and in the process has
stopped the Stores' pebble instances. These crashes are probably very
rare in production but hit with some regularity in unit tests, for an example see:
https://github.com/cockroachdb/cockroach/issues/68395#issuecomment-975545855

I was also able to hit this locally within a few minutes by running

`make stress PKG=./pkg/kv/kvserver/ TESTS=TestStrictGCEnforcement/protected_timestamps_are_respected`.

Fixes #73154.

Release note: None
