### PR TITLE
server: use a shared ID container + guarantee log tag

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -23,14 +23,21 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// NodeIDContainer is used to share a single roachpb.NodeID instance between
-// multiple layers. It allows setting and getting the value. Once a value is
-// set, the value cannot change.
+// NodeIDContainer is used to share a single roachpb.NodeID or
+// SQLInstanceID instance between multiple layers. It allows setting
+// and getting the value. Once a value is set, the value cannot
+// change.
+// Note: we plan to rename it to denote its generic nature, see
+// https://github.com/cockroachdb/cockroach/pull/73309
 type NodeIDContainer struct {
 	_ util.NoCopy
 
-	// nodeID is accessed atomically.
+	// nodeID represents either a NodeID or a SQLInstanceID (if
+	// sqlInstance is set). It is accessed atomically.
 	nodeID int32
+
+	// sqlInstance is set to true when the node is a SQL instance.
+	sqlInstance bool
 
 	// If nodeID has been set, str represents nodeID converted to string. We
 	// precompute this value to speed up String() and keep it from allocating
@@ -42,6 +49,9 @@ type NodeIDContainer struct {
 func (n *NodeIDContainer) String() string {
 	s := n.str.Load()
 	if s == nil {
+		if n.sqlInstance {
+			return "sql?"
+		}
 		return "?"
 	}
 	return s.(string)
@@ -53,24 +63,45 @@ var _ redact.SafeValue = &NodeIDContainer{}
 func (n *NodeIDContainer) SafeValue() {}
 
 // Get returns the current node ID; 0 if it is unset.
+//
+// Note that Get() returns a value of type roachpb.NodeID even though
+// the container is configured to store SQL instance IDs. This is
+// because components that call Get() do so in a context where the
+// type distinction between NodeID and SQLInstanceID does not matter,
+// and we benefit from using a single type instead of duplicating the
+// code. See for example the `rpc` package, where server-to-server
+// RPCs get addressed with server IDs regardless of whether they are
+// KV nodes or SQL instances.
+// See also: https://github.com/cockroachdb/cockroach/pull/73309
 func (n *NodeIDContainer) Get() roachpb.NodeID {
 	return roachpb.NodeID(atomic.LoadInt32(&n.nodeID))
 }
 
 // Set sets the current node ID. If it is already set, the value must match.
 func (n *NodeIDContainer) Set(ctx context.Context, val roachpb.NodeID) {
+	n.setInternal(ctx, int32(val), false)
+}
+
+func (n *NodeIDContainer) setInternal(ctx context.Context, val int32, sqlInstance bool) {
 	if val <= 0 {
 		log.Fatalf(ctx, "trying to set invalid NodeID: %d", val)
 	}
-	oldVal := atomic.SwapInt32(&n.nodeID, int32(val))
+	oldVal := atomic.SwapInt32(&n.nodeID, val)
 	if oldVal == 0 {
 		if log.V(2) {
-			log.Infof(ctx, "NodeID set to %d", val)
+			log.Infof(ctx, "ID set to %d", val)
 		}
-	} else if oldVal != int32(val) {
-		log.Fatalf(ctx, "different NodeIDs set: %d, then %d", oldVal, val)
+	} else if n.sqlInstance != sqlInstance {
+		serverIs := map[bool]redact.SafeString{false: "SQL instance", true: "node"}
+		log.Fatalf(ctx, "server is a %v, cannot set %v ID", serverIs[!n.sqlInstance], serverIs[sqlInstance])
+	} else if oldVal != val {
+		log.Fatalf(ctx, "different IDs set: %d, then %d", oldVal, val)
 	}
-	n.str.Store(strconv.Itoa(int(val)))
+	prefix := ""
+	if sqlInstance {
+		prefix = "sql"
+	}
+	n.str.Store(prefix + strconv.Itoa(int(val)))
 }
 
 // Reset changes the NodeID regardless of the old value.
@@ -153,12 +184,6 @@ func (s *StoreIDContainer) Set(ctx context.Context, val int32) {
 // process ID from the unix world: an integer assigned to the SQL server
 // on process start which is unique across all SQL server processes running
 // on behalf of the tenant, while the SQL server is running.
-//
-// NB: until https://github.com/cockroachdb/cockroach/issues/47899 is addressed,
-// the properties of the SQLInstanceID hold trivially due to the constraint that
-// only one SQL server must be running on behalf of the tenant at any given
-// time. After that, it's likely that we'll allocate these IDs off a counter,
-// so they will be completely unique (per tenant).
 type SQLInstanceID int32
 
 func (s SQLInstanceID) String() string {
@@ -168,132 +193,78 @@ func (s SQLInstanceID) String() string {
 	return strconv.Itoa(int(s))
 }
 
-// SQLIDContainer wraps a SQLInstanceID and optionally a NodeID.
-type SQLIDContainer struct {
-	w             errorutil.TenantSQLDeprecatedWrapper // NodeID
-	sqlInstanceID SQLInstanceID
+// SQLIDContainer is a variant of NodeIDContainer that contains SQL instance IDs.
+type SQLIDContainer NodeIDContainer
 
-	// If the value has been set, str represents the instance ID
-	// converted to string. We precompute this value to speed up
-	// String() and keep it from allocating memory dynamically.
-	str atomic.Value
+// NewSQLIDContainerForNode sets up a SQLIDContainer which serves the underlying
+// NodeID as the SQL instance ID.
+func NewSQLIDContainerForNode(nodeID *NodeIDContainer) *SQLIDContainer {
+	if nodeID.sqlInstance {
+		// This assertion exists to prevent misuse of the API, where a
+		// caller would call NewSQLIDContainerForNode() once, cast the
+		// result type to `*NodeIDContainer`, then mistakenly call
+		// NewSQLIDContainerForNode() again.
+		log.Fatalf(context.Background(), "programming error: container is already for a SQL instance")
+	}
+	return (*SQLIDContainer)(nodeID)
 }
 
-// NewSQLIDContainer sets up an SQLIDContainer. It is handed either a positive SQLInstanceID
-// (on tenants) or a positive NodeID, but not both.
-//
-// A zero sqlInstanceID falls back to the NodeID in SQLInstanceID().
-// This is used in single-tenant deployments.
-//
-// In a multi-tenant deployment, we could initialize the SQLIDContainer with
-// a nil nodeIDContainer and 0 as the instance ID. This is to aid bootstrapping.
-// In such a case, SetSQLInstanceID needs to be invoked prior to the SQLIDContainer
-// being used.
-func NewSQLIDContainer(sqlInstanceID SQLInstanceID, nodeID *NodeIDContainer) *SQLIDContainer {
-	return &SQLIDContainer{
-		w:             errorutil.MakeTenantSQLDeprecatedWrapper(nodeID, nodeID != nil),
-		sqlInstanceID: sqlInstanceID,
-	}
+// SwitchToSQLIDContainer changes a NodeIDContainer to become able to
+// store SQL instance IDs. After it has been switched, the original
+// container will report the SQL instance ID value as NodeID via
+// its Get() method.
+func (n *NodeIDContainer) SwitchToSQLIDContainer() *SQLIDContainer {
+	sc := NewSQLIDContainerForNode(n)
+	sc.sqlInstance = true
+	return sc
 }
 
 // SetSQLInstanceID sets the SQL instance ID. It returns an error if
 // we attempt to set an instance ID when the nodeID has already been
 // initialized.
 func (c *SQLIDContainer) SetSQLInstanceID(ctx context.Context, sqlInstanceID SQLInstanceID) error {
-	if _, ok := c.OptionalNodeID(); ok {
+	if !c.sqlInstance {
 		return errors.New("attempting to initialize instance ID when node ID is set")
 	}
 
-	// Use the same logic to set the instance ID as for the node ID.
-	//
-	// TODO(knz): All this could be advantageously simplified if we agreed
-	// to use the same type for NodeIDContainer and SQLIDContainer.
-	if sqlInstanceID <= 0 {
-		log.Fatalf(ctx, "trying to set invalid SQLInstanceID: %d", sqlInstanceID)
-	}
-	oldVal := atomic.SwapInt32((*int32)(&c.sqlInstanceID), int32(sqlInstanceID))
-	if oldVal == 0 {
-		if log.V(2) {
-			log.Infof(ctx, "SQLInstanceID set to %d", sqlInstanceID)
-		}
-	} else if oldVal != int32(sqlInstanceID) {
-		log.Fatalf(ctx, "different SQLInstanceIDs set: %d, then %d", oldVal, sqlInstanceID)
-	}
-
-	c.str.Store(strconv.Itoa(int(sqlInstanceID)))
+	(*NodeIDContainer)(c).setInternal(ctx, int32(sqlInstanceID), true)
 	return nil
 }
 
 // OptionalNodeID returns the NodeID and true, if the former is exposed.
 // Otherwise, returns zero and false.
 func (c *SQLIDContainer) OptionalNodeID() (roachpb.NodeID, bool) {
-	v, ok := c.w.Optional()
-	if !ok {
+	if (*NodeIDContainer)(c).sqlInstance {
 		return 0, false
 	}
-	return v.(*NodeIDContainer).Get(), true
+	return (*NodeIDContainer)(c).Get(), true
 }
 
 // OptionalNodeIDErr is like OptionalNodeID, but returns an error (referring to
 // the optionally supplied GitHub issues) if the ID is not present.
 func (c *SQLIDContainer) OptionalNodeIDErr(issue int) (roachpb.NodeID, error) {
-	v, err := c.w.OptionalErr(issue)
-	if err != nil {
-		return 0, err
+	if (*NodeIDContainer)(c).sqlInstance {
+		return 0, errorutil.UnsupportedWithMultiTenancy(issue)
 	}
-	return v.(*NodeIDContainer).Get(), nil
+	return (*NodeIDContainer)(c).Get(), nil
 }
 
 // SQLInstanceID returns the wrapped SQLInstanceID.
 func (c *SQLIDContainer) SQLInstanceID() SQLInstanceID {
-	if n, ok := c.OptionalNodeID(); ok {
-		return SQLInstanceID(n)
-	}
-	return c.sqlInstanceID
+	return SQLInstanceID((*NodeIDContainer)(c).Get())
 }
 
 // SafeValue implements the redact.SafeValue interface.
 func (c *SQLIDContainer) SafeValue() {}
 
-func (c *SQLIDContainer) String() string {
-	st := c.str.Load()
-	if st == nil {
-		// This can mean either that:
-		// - neither the instance ID nor the node ID has been set.
-		// - only the node ID has been set.
-		//
-		// In the latter case, we don't want to return "?" here, as in the
-		// NodeIDContainer case above: we want to return the node ID
-		// representation instead. Alas, there is no way to know
-		// but to open the node ID container box.
-		//
-		// TODO(knz): This could be greatly simplified if we accepted to
-		// use the same data type for both SQL instance ID and node ID
-		// containers.
-		v, ok := c.w.Optional()
-		if !ok {
-			// This is definitely not a node ID, and since we're in this
-			// branch of the conditional above, we don't have SQL instance
-			// ID either (yet).
-			return "?"
-		}
-		nc := v.(*NodeIDContainer)
-		st = nc.str.Load()
-		if st == nil {
-			// We're designating a Node ID, but it was not set yet.
-			return "?"
-		}
-		// Node ID was set. Keep its representation for the instance ID as
-		// well.
-		c.str.Store(st)
-	}
-	return st.(string)
-}
+func (c *SQLIDContainer) String() string { return (*NodeIDContainer)(c).String() }
 
-// TestingIDContainer is an SQLIDContainer with hard-coded SQLInstanceID of 10 and
-// NodeID of 1.
+// TestingIDContainer is an SQLIDContainer with hard-coded SQLInstanceID of 10.
 var TestingIDContainer = func() *SQLIDContainer {
 	var c NodeIDContainer
-	c.Set(context.Background(), 1)
-	return NewSQLIDContainer(10, &c)
+	sc := c.SwitchToSQLIDContainer()
+	if err := sc.SetSQLInstanceID(context.Background(), 10); err != nil {
+		panic(err)
+	}
+	return sc
 }()

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -916,7 +916,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 		if nodeID != 0 {
 			c.Set(context.Background(), nodeID)
 		}
-		dbCtx.NodeID = base.NewSQLIDContainer(0, &c)
+		dbCtx.NodeID = base.NewSQLIDContainerForNode(&c)
 
 		db := kv.NewDBWithContext(testutils.MakeAmbientCtx(), factory, clock, dbCtx)
 		return db

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -190,7 +190,7 @@ func DefaultDBContext(stopper *stop.Stopper) DBContext {
 	return DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		// TODO(tbg): this is ugly. Force callers to pass in an SQLIDContainer.
-		NodeID:  base.NewSQLIDContainer(0, &c),
+		NodeID:  base.NewSQLIDContainerForNode(&c),
 		Stopper: stopper,
 	}
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -116,6 +116,11 @@ type BaseConfig struct {
 	*base.Config
 
 	Tracer *tracing.Tracer
+
+	// IDContainer is the Node ID / SQL Instance ID container
+	// that will contain the ID for the server to instantiate.
+	IDContainer *base.NodeIDContainer
+
 	// AmbientCtx is used to annotate contexts used inside the server.
 	AmbientCtx log.AmbientContext
 
@@ -170,6 +175,7 @@ func MakeBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 	}
 	baseCfg := BaseConfig{
 		Tracer:            tr,
+		IDContainer:       &base.NodeIDContainer{},
 		AmbientCtx:        log.AmbientContext{Tracer: tr},
 		Config:            new(base.Config),
 		Settings:          st,
@@ -177,6 +183,11 @@ func MakeBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 		DefaultZoneConfig: zonepb.DefaultZoneConfig(),
 		StorageEngine:     storage.DefaultStorageEngine,
 	}
+	// We use the tag "n" here for both KV nodes and SQL instances,
+	// using the knowledge that the value part of a SQL instance ID
+	// container will prefix the value with the string "sql", resulting
+	// in a tag that is prefixed with "nsql".
+	baseCfg.AmbientCtx.AddLogTag("n", baseCfg.IDContainer)
 	baseCfg.InitDefaults()
 	return baseCfg
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,7 +110,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -293,8 +293,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// bootstrapped; otherwise a new one is allocated in Node.
 	nodeIDContainer := &base.NodeIDContainer{}
 	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
-	const sqlInstanceID = base.SQLInstanceID(0)
-	idContainer := base.NewSQLIDContainer(sqlInstanceID, nodeIDContainer)
+	idContainer := base.NewSQLIDContainerForNode(nodeIDContainer)
 
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -291,8 +291,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// regular tag since it's just doing an (atomic) load when a log/trace message
 	// is constructed. The node ID is set by the Store if this host was
 	// bootstrapped; otherwise a new one is allocated in Node.
-	nodeIDContainer := &base.NodeIDContainer{}
-	cfg.AmbientCtx.AddLogTag("n", nodeIDContainer)
+	nodeIDContainer := cfg.IDContainer
 	idContainer := base.NewSQLIDContainerForNode(nodeIDContainer)
 
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -168,13 +168,14 @@ func StartTenant(
 	// Also add the SQL instance tag to the tenant status server's
 	// ambient context.
 	//
-	// We use the tag "sqli" instead of just "sql" because the latter is
-	// too generic and would be hard to search if someone was looking at
-	// a log message and wondering what it stands for.
+	// We use the tag "n" here like for KV nodes, using the knowledge
+	// that the value part of a SQL instance ID container will prefix
+	// the value with the string "sql", resulting in a tag that is prefixed
+	// with "nsql".
 	//
 	// TODO(knz): find a way to share common logging tags between
 	// multiple AmbientContext instances.
-	tenantStatusServer.AmbientContext.AddLogTag("sqli", s.sqlIDContainer)
+	tenantStatusServer.AmbientContext.AddLogTag("n", s.sqlIDContainer)
 
 	if err != nil {
 		return nil, "", "", err
@@ -369,11 +370,13 @@ func makeTenantSQLServerArgs(
 
 	// We want all log messages issued on behalf of this SQL instance to report
 	// the instance ID (once known) as a tag.
-	instanceIDContainer := base.NewSQLIDContainer(0, nil)
-	// We use the tag "sqli" instead of just "sql" because the latter is
-	// too generic and would be hard to search if someone was looking at
-	// a log message and wondering what it stands for.
-	baseCfg.AmbientCtx.AddLogTag("sqli", instanceIDContainer)
+	var c base.NodeIDContainer
+	instanceIDContainer := c.SwitchToSQLIDContainer()
+	// We use the tag "n" here like for KV nodes, using the knowledge
+	// that the value part of a SQL instance ID container will prefix
+	// the value with the string "sql", resulting in a tag that is prefixed
+	// with "nsql".
+	baseCfg.AmbientCtx.AddLogTag("n", instanceIDContainer)
 	startupCtx = baseCfg.AmbientCtx.AnnotateCtx(startupCtx)
 
 	// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -165,17 +165,6 @@ func StartTenant(
 	args.sqlStatusServer = tenantStatusServer
 	s, err := newSQLServer(ctx, args)
 	tenantStatusServer.sqlServer = s
-	// Also add the SQL instance tag to the tenant status server's
-	// ambient context.
-	//
-	// We use the tag "n" here like for KV nodes, using the knowledge
-	// that the value part of a SQL instance ID container will prefix
-	// the value with the string "sql", resulting in a tag that is prefixed
-	// with "nsql".
-	//
-	// TODO(knz): find a way to share common logging tags between
-	// multiple AmbientContext instances.
-	tenantStatusServer.AmbientContext.AddLogTag("n", s.sqlIDContainer)
 
 	if err != nil {
 		return nil, "", "", err
@@ -370,13 +359,7 @@ func makeTenantSQLServerArgs(
 
 	// We want all log messages issued on behalf of this SQL instance to report
 	// the instance ID (once known) as a tag.
-	var c base.NodeIDContainer
-	instanceIDContainer := c.SwitchToSQLIDContainer()
-	// We use the tag "n" here like for KV nodes, using the knowledge
-	// that the value part of a SQL instance ID container will prefix
-	// the value with the string "sql", resulting in a tag that is prefixed
-	// with "nsql".
-	baseCfg.AmbientCtx.AddLogTag("n", instanceIDContainer)
+	instanceIDContainer := baseCfg.IDContainer.SwitchToSQLIDContainer()
 	startupCtx = baseCfg.AmbientCtx.AnnotateCtx(startupCtx)
 
 	// TODO(tbg): this is needed so that the RPC heartbeats between the testcluster

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -99,7 +99,6 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -207,7 +207,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 	if mgr == nil {
 		var c base.NodeIDContainer
 		c.Set(context.Background(), roachpb.NodeID(nodeID))
-		nc := base.NewSQLIDContainer(0, &c)
+		nc := base.NewSQLIDContainerForNode(&c)
 		// Hack the ExecutorConfig that we pass to the Manager to have a
 		// different node id.
 		cfgCpy := t.server.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -158,7 +158,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	ltc.dbContext = &kv.DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		Stopper:      ltc.stopper,
-		NodeID:       base.NewSQLIDContainer(0, &nodeIDContainer),
+		NodeID:       base.NewSQLIDContainerForNode(&nodeIDContainer),
 	}
 	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.dbContext)
 	transport := kvserver.NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)


### PR DESCRIPTION
All commits but the last from #73158 and prior PRs.
(Reviewers: focus on the last commit)

Uses the infra set up in #73156, as recommended by Radu in [this comment](https://github.com/cockroachdb/cockroach/pull/72702#pullrequestreview-810672898).

Informs #58938.
Fixes #72815.
Supersedes #72702.

Prior to this commit, certain components were initialized from the
base server config `(BaseConfig).AmbientContext` before the node ID /
SQL instance ID container was attached to it via `AddLogTag`.

This commit fixes that by instantiating the node ID / SQL instance ID
container once in the `BaseConfig`, together with the
`AmbientContext`, and binding them together before the config is used
as input to initialize other components.
