### PR TITLE
sql/logictests: support conditional skipping of single statements

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -281,13 +281,15 @@ import (
 //  - user <username>
 //    Changes the user for subsequent statements or queries.
 //
-//  - skipif <mysql/mssql/postgresql/cockroachdb>
-//    Skips the following `statement` or `query` if the argument is postgresql
-//    or cockroachdb.
+//  - skipif <mysql/mssql/postgresql/cockroachdb/config CONFIG [ISSUE]>
+//    Skips the following `statement` or `query` if the argument is
+//    postgresql, cockroachdb, or a config matching the currently
+//    running configuration.
 //
-//  - onlyif <mysql/mssql/postgresql/cockroachdb>
-//    Skips the following `statement` or query if the argument is not postgresql
-//    or cockroachdb.
+//  - onlyif <mysql/mssql/postgresql/cockroachdb/config CONFIG [ISSUE]>
+//    Skips the following `statement` or `query` if the argument is not
+//    postgresql, cockroachdb, or a config matching the currently
+//    running configuration.
 //
 //  - traceon <file>
 //    Enables tracing to the given file.
@@ -819,8 +821,22 @@ func findLogicTestConfig(name string) (logicTestConfigIdx, bool) {
 // lineScanner handles reading from input test files.
 type lineScanner struct {
 	*bufio.Scanner
-	line int
-	skip bool
+	line       int
+	skip       bool
+	skipReason string
+}
+
+func (l *lineScanner) SetSkip(reason string) {
+	l.skip = true
+	l.skipReason = reason
+}
+
+func (l *lineScanner) LogAndResetSkip(t *logicTest) {
+	if l.skipReason != "" {
+		t.t().Logf("statement/query skipped with reason: %s", l.skipReason)
+	}
+	l.skipReason = ""
+	l.skip = false
 }
 
 func newLineScanner(r io.Reader) *lineScanner {
@@ -2113,7 +2129,7 @@ func (t *logicTest) processSubtest(subtest subtestDetails, path string) error {
 					}
 				}
 			} else {
-				s.skip = false
+				s.LogAndResetSkip(t)
 			}
 			repeat = 1
 			t.success(path)
@@ -2402,7 +2418,7 @@ func (t *logicTest) processSubtest(subtest subtestDetails, path string) error {
 					}
 				}
 			} else {
-				s.skip = false
+				s.LogAndResetSkip(t)
 			}
 			repeat = 1
 			t.success(path)
@@ -2469,7 +2485,20 @@ func (t *logicTest) processSubtest(subtest subtestDetails, path string) error {
 				return errors.Errorf("skipif command requires a non-blank argument")
 			case "mysql", "mssql":
 			case "postgresql", "cockroachdb":
-				s.skip = true
+				s.SetSkip("")
+				continue
+			case "config":
+				if len(fields) < 3 {
+					return errors.New("skipif config CONFIG [ISSUE] command requires configuration parameter")
+				}
+				configName := fields[2]
+				if t.cfg.name == configName {
+					issue := "no issue given"
+					if len(fields) > 3 {
+						issue = fields[3]
+					}
+					s.SetSkip(fmt.Sprintf("unsupported configuration %s (%s)", configName, issue))
+				}
 				continue
 			default:
 				return errors.Errorf("unimplemented test statement: %s", s.Text())
@@ -2483,11 +2512,21 @@ func (t *logicTest) processSubtest(subtest subtestDetails, path string) error {
 			case "":
 				return errors.New("onlyif command requires a non-blank argument")
 			case "cockroachdb":
-			case "mysql":
-				s.skip = true
+			case "mysql", "mssql":
+				s.SetSkip("")
 				continue
-			case "mssql":
-				s.skip = true
+			case "config":
+				if len(fields) < 3 {
+					return errors.New("onlyif config CONFIG [ISSUE] command requires configuration parameter")
+				}
+				configName := fields[2]
+				if t.cfg.name != configName {
+					issue := "no issue given"
+					if len(fields) > 3 {
+						issue = fields[3]
+					}
+					s.SetSkip(fmt.Sprintf("unsupported configuration %s, statement/query only supports %s (%s)", t.cfg.name, configName, issue))
+				}
 				continue
 			default:
 				return errors.Errorf("unimplemented test statement: %s", s.Text())

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,5 +1,3 @@
-# LogicTest: !3node-tenant(49854)
-
 statement ok
 SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1,4 +1,4 @@
-# LogicTest: local !3node-tenant(52567)
+# LogicTest: local
 
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
@@ -1072,6 +1072,7 @@ t6_expr_idx1       0       (m = 'foo'::public.mytype)  m = 'foo'::public.mytype
 statement ok
 SET DATABASE = system
 
+skipif config 3node-tenant
 query OOIBBBBBBBBBBTTTTTTI colnames
 SELECT *
 FROM pg_catalog.pg_index
@@ -1129,6 +1130,7 @@ indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion  indim
 4225994721  13        2         true         true          false           true          false           true        false         false       true       false           1 7            0 0                        0 0          2 2          NULL      NULL                                                                                                                          2
 
 # From #26504
+skipif config 3node-tenant
 query OOI colnames
 SELECT indexrelid,
        (information_schema._pg_expandarray(indclass)).x AS operator_argument_type_oid,
@@ -4011,6 +4013,7 @@ SET DATABASE = test
 
 # We filter here because 'optimizer' will be different depending on which
 # configuration this logic test is running in, and session ID will vary.
+skipif config 3node-tenant
 query TTTTTT colnames
 SELECT
   name, setting, category, short_desc, extra_desc, vartype
@@ -4116,6 +4119,7 @@ transaction_rows_written_log                          0                   NULL  
 transaction_status                                    NoTxn               NULL      NULL        NULL        string
 vectorize                                             on                  NULL      NULL        NULL        string
 
+skipif config 3node-tenant
 query TTTTTTT colnames
 SELECT
   name, setting, unit, context, enumvals, boot_val, reset_val


### PR DESCRIPTION
This extends the skipif and onlyif directions to allow us to skip
individual statements in certain configurations.

    skipif config 3node-tenant

This allows us to narrow down which tests are broken in a particular
configuration without forcing us to introduce new test files.

Release note: None