### PR TITLE
release-21.1: kvserver: remove above-raft closedts assertion

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -1056,7 +1056,9 @@ func (b *replicaAppBatch) assertNoWriteBelowClosedTimestamp(cmd *replicatedCmd) 
 		}
 		return wrapWithNonDeterministicFailure(errors.AssertionFailedf(
 			"command writing below closed timestamp; cmd: %x, write ts: %s, "+
-				"batch state closed: %s, command closed: %s, request: %s, lease: %s",
+				"batch state closed: %s, command closed: %s, request: %s, lease: %s.\n"+
+				"This assertion will fire again on restart; to ignore run with env var\n"+
+				"COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED=false",
 			cmd.idKey, wts,
 			b.state.RaftClosedTimestamp, cmd.raftCmd.ClosedTimestamp,
 			req, b.state.Lease),

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -754,20 +754,19 @@ func (b *propBuf) assignClosedTimestampToProposalLocked(
 		return nil
 	}
 
-	// Sanity check that this command is not violating the closed timestamp. It
-	// must be writing at a timestamp above assignedClosedTimestamp
-	// (assignedClosedTimestamp represents the promise that this replica made
-	// through previous commands to not evaluate requests with lower
-	// timestamps); in other words, assignedClosedTimestamp was not supposed to
-	// have been incremented while requests with lower timestamps were
-	// evaluating (instead, assignedClosedTimestamp was supposed to have bumped
-	// the write timestamp of any request the began evaluating after it was
-	// set).
-	if p.Request.WriteTimestamp().Less(b.assignedClosedTimestamp) && p.Request.IsIntentWrite() {
-		return errors.AssertionFailedf("attempting to propose command writing below closed timestamp. "+
-			"wts: %s < assigned closed: %s; ba: %s",
-			p.Request.WriteTimestamp(), b.assignedClosedTimestamp, p.Request)
-	}
+	// Note that under a steady lease, for requests that leave intents we must
+	// have WriteTimestamp.Less(b.assignedClosedTimestamp) and we used to assert
+	// that here. However, this does not have to be true for proposals that
+	// evaluated under an old lease and which are only entering the proposal
+	// buffer after the lease has returned and in the process of doing so
+	// incremented b.assignedClosedTimestamp. These proposals have no effect (as
+	// they apply as a no-op) but the proposal tracker has no knowledge of the
+	// lease changes and would therefore witness what looks like a violation of
+	// the invariant above. We have an authoritative assertion in
+	// (*replicaAppBatch).assertNoWriteBelowClosedTimestamp that is not
+	// susceptible to the above false positive.
+	//
+	// See https://github.com/cockroachdb/cockroach/issues/72428#issuecomment-976428551.
 
 	lb := b.evalTracker.LowerBound(ctx)
 	if !lb.IsEmpty() {


### PR DESCRIPTION
Backport 2/2 commits from #73114.

/cc @cockroachdb/release

---

This assertion has false positives, and we decided to remove it. An
already-existing below-raft assertion that would catch actual violations
of the invariants remains intact. See #72428 for details.

Fixes #72428.

Release note (bug fix): Fixed a crash with message "attempting to
propose command writing below closed timestamp" that could occur,
typically on overloaded systems experiencing non-cooperative lease
transfers.

