### PR TITLE
release-21.2: ui: save search query on cache for Statements and Transactions pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -271,6 +271,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount"
   },
+  search: "",
   filters: {
     app: "",
     timeNumber: "0",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -247,3 +247,8 @@ export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/StatementsPage"],
 );
+
+export const selectSearch = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["search/StatementsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -36,9 +36,9 @@ import {
   selectDateRange,
   selectSortSetting,
   selectFilters,
+  selectSearch,
 } from "./statementsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
-import { AggregateStatistics } from "../statementsTable";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
 
@@ -49,18 +49,19 @@ export const ConnectedStatementsPage = withRouter(
     RouteComponentProps
   >(
     (state: AppState, props: StatementsPageProps) => ({
+      apps: selectApps(state),
+      columns: selectColumns(state),
+      databases: selectDatabases(state),
+      dateRange: selectDateRange(state),
+      filters: selectFilters(state),
+      isTenant: selectIsTenant(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
+      search: selectSearch(state),
+      sortSetting: selectSortSetting(state),
       statements: selectStatements(state, props),
       statementsError: selectStatementsLastError(state),
-      apps: selectApps(state),
-      databases: selectDatabases(state),
       totalFingerprints: selectTotalFingerprints(state),
-      lastReset: selectLastReset(state),
-      columns: selectColumns(state),
-      nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
-      dateRange: selectDateRange(state),
-      sortSetting: selectSortSetting(state),
-      isTenant: selectIsTenant(state),
-      filters: selectFilters(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: (req?: StatementsRequest) =>
@@ -103,13 +104,20 @@ export const ConnectedStatementsPage = withRouter(
             action: "Downloaded",
           }),
         ),
-      onSearchComplete: (_results: AggregateStatistics[]) =>
+      onSearchComplete: (query: string) => {
         dispatch(
           analyticsActions.track({
             name: "Keyword Searched",
             page: "Statements",
           }),
-        ),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "search/StatementsPage",
+            value: query,
+          }),
+        );
+      },
       onFilterChange: value => {
         dispatch(
           analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -15,7 +15,9 @@ type Page =
   | "Statements"
   | "Statement Details"
   | "Sessions"
-  | "Sessions Details";
+  | "Sessions Details"
+  | "Transactions"
+  | "Transaction Details";
 
 type SearchEvent = {
   name: "Keyword Searched";

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -34,6 +34,7 @@ export type LocalStorageState = {
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
   "search/StatementsPage": string;
+  "search/TransactionsPage": string;
 };
 
 type Payload = {
@@ -88,6 +89,8 @@ const initialState: LocalStorageState = {
     defaultFilters,
   "search/StatementsPage":
     JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
+  "search/TransactionsPage":
+    JSON.parse(localStorage.getItem("search/TransactionsPage")) || null,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -33,6 +33,7 @@ export type LocalStorageState = {
   "sortSetting/SessionsPage": SortSetting;
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
+  "search/StatementsPage": string;
 };
 
 type Payload = {
@@ -85,6 +86,8 @@ const initialState: LocalStorageState = {
   "filters/TransactionsPage":
     JSON.parse(localStorage.getItem("filters/TransactionsPage")) ||
     defaultFilters,
+  "search/StatementsPage":
+    JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -50,3 +50,8 @@ export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/TransactionsPage"],
 );
+
+export const selectSearch = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["search/TransactionsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -36,32 +36,34 @@ storiesOf("Transactions Page", module)
   .add("with data", () => (
     <TransactionsPage
       {...routeProps}
+      columns={columns}
       data={data}
       dateRange={dateRange}
+      filters={filters}
       nodeRegions={nodeRegions}
-      columns={columns}
+      onFilterChange={noop}
+      onSortingChange={noop}
       refreshData={noop}
       resetSQLStats={noop}
+      search={""}
       sortSetting={sortSetting}
-      onSortingChange={noop}
-      filters={filters}
-      onFilterChange={noop}
     />
   ))
   .add("without data", () => {
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={getEmptyData()}
         dateRange={dateRange}
+        filters={filters}
         nodeRegions={nodeRegions}
-        columns={columns}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   })
@@ -75,17 +77,18 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={getEmptyData()}
         dateRange={dateRange}
-        nodeRegions={nodeRegions}
-        columns={columns}
-        refreshData={noop}
-        history={history}
-        resetSQLStats={noop}
-        sortSetting={sortSetting}
-        onSortingChange={noop}
         filters={filters}
+        history={history}
+        nodeRegions={nodeRegions}
         onFilterChange={noop}
+        onSortingChange={noop}
+        refreshData={noop}
+        resetSQLStats={noop}
+        search={""}
+        sortSetting={sortSetting}
       />
     );
   })
@@ -93,16 +96,17 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={undefined}
         dateRange={dateRange}
+        filters={filters}
         nodeRegions={nodeRegions}
-        columns={columns}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   })
@@ -110,10 +114,9 @@ storiesOf("Transactions Page", module)
     return (
       <TransactionsPage
         {...routeProps}
+        columns={columns}
         data={undefined}
         dateRange={dateRange}
-        nodeRegions={nodeRegions}
-        columns={columns}
         error={
           new RequestError(
             "Forbidden",
@@ -121,12 +124,14 @@ storiesOf("Transactions Page", module)
             "this operation requires admin privilege",
           )
         }
+        filters={filters}
+        nodeRegions={nodeRegions}
+        onFilterChange={noop}
+        onSortingChange={noop}
         refreshData={noop}
         resetSQLStats={noop}
+        search={""}
         sortSetting={sortSetting}
-        onSortingChange={noop}
-        filters={filters}
-        onFilterChange={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -33,10 +33,12 @@ import { nodeRegionsByIDSelector } from "../store/nodes";
 import {
   selectDateRange,
   selectFilters,
+  selectSearch,
 } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";
+import { actions as analyticsActions } from "../store/analytics";
 
 export const TransactionsPageConnected = withRouter(
   connect<
@@ -45,14 +47,15 @@ export const TransactionsPageConnected = withRouter(
     RouteComponentProps
   >(
     (state: AppState) => ({
-      data: selectTransactionsData(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      error: selectTransactionsLastError(state),
-      isTenant: selectIsTenant(state),
-      dateRange: selectDateRange(state),
       columns: selectTxnColumns(state),
-      sortSetting: selectSortSetting(state),
+      data: selectTransactionsData(state),
+      dateRange: selectDateRange(state),
+      error: selectTransactionsLastError(state),
       filters: selectFilters(state),
+      isTenant: selectIsTenant(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: selectSearch(state),
+      sortSetting: selectSortSetting(state),
     }),
     (dispatch: Dispatch) => ({
       refreshData: (req?: StatementsRequest) =>
@@ -92,9 +95,31 @@ export const TransactionsPageConnected = withRouter(
       },
       onFilterChange: (value: Filters) => {
         dispatch(
+          analyticsActions.track({
+            name: "Filter Clicked",
+            page: "Transactions",
+            filterName: "app",
+            value: value.toString(),
+          }),
+        );
+        dispatch(
           localStorageActions.update({
             key: "filters/TransactionsPage",
             value: value,
+          }),
+        );
+      },
+      onSearchComplete: (query: string) => {
+        dispatch(
+          analyticsActions.track({
+            name: "Keyword Searched",
+            page: "Transactions",
+          }),
+        );
+        dispatch(
+          localStorageActions.update({
+            key: "search/TransactionsPage",
+            value: query,
           }),
         );
       },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -105,17 +105,19 @@ export const searchTransactionsData = (
   statements: Statement[],
 ): Transaction[] => {
   return transactions.filter((t: Transaction) =>
-    search.split(" ").every(val =>
-      collectStatementsText(
-        getStatementsByFingerprintIdAndTime(
-          t.stats_data.statement_fingerprint_ids,
-          t.stats_data.aggregated_ts,
-          statements,
-        ),
-      )
-        .toLowerCase()
-        .includes(val.toLowerCase()),
-    ),
+    search
+      ? search.split(" ").every(val =>
+          collectStatementsText(
+            getStatementsByFingerprintIdAndTime(
+              t.stats_data.statement_fingerprint_ids,
+              t.stats_data.aggregated_ts,
+              statements,
+            ),
+          )
+            .toLowerCase()
+            .includes(val.toLowerCase()),
+        )
+      : true,
   );
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.fixture.ts
@@ -184,6 +184,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     ascending: false,
     columnTitle: "executionCount",
   },
+  search: "",
   filters: {
     app: "",
     timeNumber: "0",

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -50,7 +50,6 @@ import {
 import {
   trackDownloadDiagnosticsBundleAction,
   trackStatementsPaginationAction,
-  trackStatementsSearchAction,
 } from "src/redux/analyticsActions";
 import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { LocalSetting } from "src/redux/localsettings";
@@ -248,20 +247,27 @@ export const filtersLocalSetting = new LocalSetting(
   defaultFilters,
 );
 
+export const searchLocalSetting = new LocalSetting(
+  "search/StatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export default withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
+      apps: selectApps(state),
+      columns: statementColumnsLocalSetting.selectorToArray(state),
+      databases: selectDatabases(state),
+      dateRange: selectDateRange(state),
+      filters: filtersLocalSetting.selector(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: searchLocalSetting.selector(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
       statements: selectStatements(state, props),
       statementsError: state.cachedData.statements.lastError,
-      apps: selectApps(state),
-      databases: selectDatabases(state),
       totalFingerprints: selectTotalFingerprints(state),
-      lastReset: selectLastReset(state),
-      columns: statementColumnsLocalSetting.selectorToArray(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      dateRange: selectDateRange(state),
-      sortSetting: sortSettingLocalSetting.selector(state),
-      filters: filtersLocalSetting.selector(state),
     }),
     {
       refreshStatements: refreshStatements,
@@ -272,8 +278,7 @@ export default withRouter(
         createStatementDiagnosticsAlertLocalSetting.set({ show: false }),
       onActivateStatementDiagnostics: createStatementDiagnosticsReportAction,
       onDiagnosticsModalOpen: createOpenDiagnosticsModalAction,
-      onSearchComplete: (results: AggregateStatistics[]) =>
-        trackStatementsSearchAction(results.length),
+      onSearchComplete: (query: string) => searchLocalSetting.set(query),
       onPageChanged: trackStatementsPaginationAction,
       onSortingChange: (
         _tableName: string,

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -78,6 +78,12 @@ export const filtersLocalSetting = new LocalSetting(
   defaultFilters,
 );
 
+export const searchLocalSetting = new LocalSetting(
+  "search/TransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
 export const transactionColumnsLocalSetting = new LocalSetting(
   "showColumns/TransactionPage",
   (state: AdminUIState) => state.localSettings,
@@ -87,15 +93,16 @@ export const transactionColumnsLocalSetting = new LocalSetting(
 const TransactionsPageConnected = withRouter(
   connect(
     (state: AdminUIState) => ({
-      data: selectData(state),
-      statementsError: state.cachedData.statements.lastError,
-      dateRange: selectDateRange(state),
-      lastReset: selectLastReset(state),
-      error: selectLastError(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
       columns: transactionColumnsLocalSetting.selectorToArray(state),
-      sortSetting: sortSettingLocalSetting.selector(state),
+      data: selectData(state),
+      dateRange: selectDateRange(state),
+      error: selectLastError(state),
       filters: filtersLocalSetting.selector(state),
+      lastReset: selectLastReset(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
+      search: searchLocalSetting.selector(state),
+      sortSetting: sortSettingLocalSetting.selector(state),
+      statementsError: state.cachedData.statements.lastError,
     }),
     {
       refreshData: refreshStatements,
@@ -119,6 +126,7 @@ const TransactionsPageConnected = withRouter(
           columnTitle: columnName,
         }),
       onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
+      onSearchComplete: (query: string) => searchLocalSetting.set(query),
     },
   )(TransactionsPage),
 );


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: save search query on cache for Statements page" (#73134)
  * 1/1 commits from "ui: save search query on cache for Transactions page" (#73135)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Low risk, high benefit changes to existing functionality