### PR TITLE
spanconfig/sqlwatcher: hide factory pattern, speed up tests, surface no-op checkpoints periodically

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
+++ b/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
@@ -51,33 +51,33 @@ func (t *testServerShim) ServingSQLAddr() string {
 	return t.SQLAddr()
 }
 
-func (t *testServerShim) Stopper() *stop.Stopper                   { panic(unsupportedShimMethod) }
-func (t *testServerShim) Start(context.Context) error              { panic(unsupportedShimMethod) }
-func (t *testServerShim) Node() interface{}                        { panic(unsupportedShimMethod) }
-func (t *testServerShim) NodeID() roachpb.NodeID                   { panic(unsupportedShimMethod) }
-func (t *testServerShim) ClusterID() uuid.UUID                     { panic(unsupportedShimMethod) }
-func (t *testServerShim) ServingRPCAddr() string                   { panic(unsupportedShimMethod) }
-func (t *testServerShim) RPCAddr() string                          { panic(unsupportedShimMethod) }
-func (t *testServerShim) DB() *kv.DB                               { panic(unsupportedShimMethod) }
-func (t *testServerShim) RPCContext() *rpc.Context                 { panic(unsupportedShimMethod) }
-func (t *testServerShim) LeaseManager() interface{}                { panic(unsupportedShimMethod) }
-func (t *testServerShim) InternalExecutor() interface{}            { panic(unsupportedShimMethod) }
-func (t *testServerShim) ExecutorConfig() interface{}              { panic(unsupportedShimMethod) }
-func (t *testServerShim) TracerI() interface{}                     { panic(unsupportedShimMethod) }
-func (t *testServerShim) GossipI() interface{}                     { panic(unsupportedShimMethod) }
-func (t *testServerShim) RangeFeedFactory() interface{}            { panic(unsupportedShimMethod) }
-func (t *testServerShim) Clock() *hlc.Clock                        { panic(unsupportedShimMethod) }
-func (t *testServerShim) DistSenderI() interface{}                 { panic(unsupportedShimMethod) }
-func (t *testServerShim) MigrationServer() interface{}             { panic(unsupportedShimMethod) }
-func (t *testServerShim) SpanConfigAccessor() interface{}          { panic(unsupportedShimMethod) }
-func (t *testServerShim) SpanConfigSQLTranslator() interface{}     { panic(unsupportedShimMethod) }
-func (t *testServerShim) SpanConfigSQLWatcherFactory() interface{} { panic(unsupportedShimMethod) }
-func (t *testServerShim) SQLServer() interface{}                   { panic(unsupportedShimMethod) }
-func (t *testServerShim) SQLLivenessProvider() interface{}         { panic(unsupportedShimMethod) }
-func (t *testServerShim) StartupMigrationsManager() interface{}    { panic(unsupportedShimMethod) }
-func (t *testServerShim) NodeLiveness() interface{}                { panic(unsupportedShimMethod) }
-func (t *testServerShim) HeartbeatNodeLiveness() error             { panic(unsupportedShimMethod) }
-func (t *testServerShim) NodeDialer() interface{}                  { panic(unsupportedShimMethod) }
+func (t *testServerShim) Stopper() *stop.Stopper                { panic(unsupportedShimMethod) }
+func (t *testServerShim) Start(context.Context) error           { panic(unsupportedShimMethod) }
+func (t *testServerShim) Node() interface{}                     { panic(unsupportedShimMethod) }
+func (t *testServerShim) NodeID() roachpb.NodeID                { panic(unsupportedShimMethod) }
+func (t *testServerShim) ClusterID() uuid.UUID                  { panic(unsupportedShimMethod) }
+func (t *testServerShim) ServingRPCAddr() string                { panic(unsupportedShimMethod) }
+func (t *testServerShim) RPCAddr() string                       { panic(unsupportedShimMethod) }
+func (t *testServerShim) DB() *kv.DB                            { panic(unsupportedShimMethod) }
+func (t *testServerShim) RPCContext() *rpc.Context              { panic(unsupportedShimMethod) }
+func (t *testServerShim) LeaseManager() interface{}             { panic(unsupportedShimMethod) }
+func (t *testServerShim) InternalExecutor() interface{}         { panic(unsupportedShimMethod) }
+func (t *testServerShim) ExecutorConfig() interface{}           { panic(unsupportedShimMethod) }
+func (t *testServerShim) TracerI() interface{}                  { panic(unsupportedShimMethod) }
+func (t *testServerShim) GossipI() interface{}                  { panic(unsupportedShimMethod) }
+func (t *testServerShim) RangeFeedFactory() interface{}         { panic(unsupportedShimMethod) }
+func (t *testServerShim) Clock() *hlc.Clock                     { panic(unsupportedShimMethod) }
+func (t *testServerShim) DistSenderI() interface{}              { panic(unsupportedShimMethod) }
+func (t *testServerShim) MigrationServer() interface{}          { panic(unsupportedShimMethod) }
+func (t *testServerShim) SpanConfigAccessor() interface{}       { panic(unsupportedShimMethod) }
+func (t *testServerShim) SpanConfigSQLTranslator() interface{}  { panic(unsupportedShimMethod) }
+func (t *testServerShim) SpanConfigSQLWatcher() interface{}     { panic(unsupportedShimMethod) }
+func (t *testServerShim) SQLServer() interface{}                { panic(unsupportedShimMethod) }
+func (t *testServerShim) SQLLivenessProvider() interface{}      { panic(unsupportedShimMethod) }
+func (t *testServerShim) StartupMigrationsManager() interface{} { panic(unsupportedShimMethod) }
+func (t *testServerShim) NodeLiveness() interface{}             { panic(unsupportedShimMethod) }
+func (t *testServerShim) HeartbeatNodeLiveness() error          { panic(unsupportedShimMethod) }
+func (t *testServerShim) NodeDialer() interface{}               { panic(unsupportedShimMethod) }
 func (t *testServerShim) SetDistSQLSpanResolver(spanResolver interface{}) {
 	panic(unsupportedShimMethod)
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -861,6 +861,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.rangeFeedFactory,
 			1<<20, /* 1 MB bufferMemLimit */
 			cfg.stopper,
+			// TODO(irfansharif): What should this no-op cadence be?
+			30*time.Second, /* checkpointNoopsEvery */
 			spanConfigKnobs,
 		)
 		spanConfigMgr = spanconfigmanager.New(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -855,7 +855,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		// only do it if COCKROACH_EXPERIMENTAL_SPAN_CONFIGS is set.
 		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
 		sqlTranslator := spanconfigsqltranslator.New(execCfg, codec)
-		sqlWatcherFactory := spanconfigsqlwatcher.NewFactory(
+		sqlWatcher := spanconfigsqlwatcher.New(
 			codec,
 			cfg.Settings,
 			cfg.rangeFeedFactory,
@@ -870,7 +870,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.stopper,
 			cfg.Settings,
 			cfg.spanConfigAccessor,
-			sqlWatcherFactory,
+			sqlWatcher,
 			sqlTranslator,
 			spanConfigKnobs,
 		)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -978,14 +978,14 @@ func (ts *TestServer) SpanConfigSQLTranslator() interface{} {
 	return ts.sqlServer.spanconfigMgr.SQLTranslator
 }
 
-// SpanConfigSQLWatcherFactory is part of TestServerInterface.
-func (ts *TestServer) SpanConfigSQLWatcherFactory() interface{} {
+// SpanConfigSQLWatcher is part of TestServerInterface.
+func (ts *TestServer) SpanConfigSQLWatcher() interface{} {
 	if ts.sqlServer.spanconfigMgr == nil {
 		panic(
 			"span config manager uninitialized; see EnableSpanConfigs testing knob to use span configs",
 		)
 	}
-	return ts.sqlServer.spanconfigMgr.SQLWatcherFactory
+	return ts.sqlServer.spanconfigMgr.SQLWatcher
 }
 
 // SQLServer is part of TestServerInterface.

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -60,7 +60,7 @@ type Manager struct {
 	knobs    *spanconfig.TestingKnobs
 
 	spanconfig.KVAccessor
-	spanconfig.SQLWatcherFactory
+	spanconfig.SQLWatcher
 	spanconfig.SQLTranslator
 }
 
@@ -74,7 +74,7 @@ func New(
 	stopper *stop.Stopper,
 	settings *cluster.Settings,
 	kvAccessor spanconfig.KVAccessor,
-	sqlWatcherFactory spanconfig.SQLWatcherFactory,
+	sqlWatcher spanconfig.SQLWatcher,
 	sqlTranslator spanconfig.SQLTranslator,
 	knobs *spanconfig.TestingKnobs,
 ) *Manager {
@@ -82,15 +82,15 @@ func New(
 		knobs = &spanconfig.TestingKnobs{}
 	}
 	return &Manager{
-		db:                db,
-		jr:                jr,
-		ie:                ie,
-		stopper:           stopper,
-		settings:          settings,
-		KVAccessor:        kvAccessor,
-		SQLWatcherFactory: sqlWatcherFactory,
-		SQLTranslator:     sqlTranslator,
-		knobs:             knobs,
+		db:            db,
+		jr:            jr,
+		ie:            ie,
+		stopper:       stopper,
+		settings:      settings,
+		KVAccessor:    kvAccessor,
+		SQLWatcher:    sqlWatcher,
+		SQLTranslator: sqlTranslator,
+		knobs:         knobs,
 	}
 }
 

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -74,7 +74,7 @@ func TestManagerConcurrentJobCreation(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
-		ts.SpanConfigSQLWatcherFactory().(spanconfig.SQLWatcherFactory),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerCreatedJobInterceptor: func(jobI interface{}) {
@@ -163,7 +163,7 @@ func TestManagerStartsJobIfFailed(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
-		ts.SpanConfigSQLWatcherFactory().(spanconfig.SQLWatcherFactory),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerAfterCheckedReconciliationJobExistsInterceptor: func(exists bool) {
@@ -239,7 +239,7 @@ func TestManagerCheckJobConditions(t *testing.T) {
 		ts.Stopper(),
 		ts.ClusterSettings(),
 		ts.SpanConfigAccessor().(spanconfig.KVAccessor),
-		ts.SpanConfigSQLWatcherFactory().(spanconfig.SQLWatcherFactory),
+		ts.SpanConfigSQLWatcher().(spanconfig.SQLWatcher),
 		ts.SpanConfigSQLTranslator().(spanconfig.SQLTranslator),
 		&spanconfig.TestingKnobs{
 			ManagerDisableJobCreation: true,

--- a/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
@@ -22,11 +22,13 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/spanconfig/spanconfigsqlwatcher/buffer.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/buffer.go
@@ -71,11 +71,15 @@ const (
 	numRangefeeds int = iota
 )
 
-// newBuffer constructs and returns a new buffer.
-func newBuffer(limit int) *buffer {
+// newBuffer constructs a new buffer initialized with a starting frontier
+// timestamp.
+func newBuffer(limit int, initialFrontierTS hlc.Timestamp) *buffer {
 	rangefeedBuffer := rangefeedbuffer.New(limit)
 	eventBuffer := &buffer{}
 	eventBuffer.mu.buffer = rangefeedBuffer
+	for i := range eventBuffer.mu.rangefeedFrontiers {
+		eventBuffer.mu.rangefeedFrontiers[i].Forward(initialFrontierTS)
+	}
 	return eventBuffer
 }
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -122,9 +122,9 @@ type TestServerInterface interface {
 	// an interface{}.
 	SpanConfigSQLTranslator() interface{}
 
-	// SpanConfigSQLWatcherFactory returns the underlying
-	// spanconfig.SQLWatcherFactory as an interface{}.
-	SpanConfigSQLWatcherFactory() interface{}
+	// SpanConfigSQLWatcher returns the underlying spanconfig.SQLWatcher as an
+	// interface{}.
+	SpanConfigSQLWatcher() interface{}
 
 	// SQLServer returns the *sql.Server as an interface{}.
 	SQLServer() interface{}


### PR DESCRIPTION
See individual commits.

---

**spanconfig/sqlwatcher: speed up tests**

Using a more aggressive closed timestamp target duration brings the runtime for
TestSQLWatcherReactsToUpdate down from 45s+ to single digits. To speed it up,
we also just re-use the same SQLWatcher instead of creating a new one for every
test case.

Other tests in the package benefit from a similar treatment. Using the default
target duration in fact masked a buggy test; in a future commit we end up
rewrite that test so it's skipped for now.

**spanconfig/sqlwatcher: hide the factory pattern**

The only mutable state across concurrent WatchForSQLUpdate calls was the
internal buffer, which does not need to hang off the surrounding struct.  This
obviates the need for the factory pattern we were using -- callers can set up
multiple SQLWatchers concurrently as is (see TestSQLWatcherMultiple).

This PR first hides the factory under the package boundary; in a later commit
it shed it altogether. This has the benefit of reducing the number of symbols
in pkg/spanconfig and making it symmetric with the other spanconfig
dependencies typically found together (KVAccessor, SQLTranslator). It's also
every-so-slightly less verbose to use in the upcoming spanconfig.Reconciler
(#71994).

**spanconfig/sqlwatcher: checkpoint, even without updates**

If `system.{descriptor,zones}` is static, we would previously discard
all checkpoint events. This is not what we want -- we'd still like to
know how caught up we are, with ongoing updates or otherwise.

MVCC GC, after all, can still happen; if our last checkpoint was when
the last update occurred, we may end up doing a lot of unnecessary work
when finding out our last checkpoint was GC-ed from underneath us. Lack
of periodic checkpoints also makes tests difficult to write -- you'd
have to induce a benign update to flush out all earlier ones. This
latent flakiness was uncovered after speeding up some existing tests in
an earlier commit.

NB: For incremental (possibly noop) checkpoints, we need to ensure that
the sqlwatcher's buffer is initialized with a low watermark. When
flushing events, we take the most conservative timestamp. If not
initialized to a high water, this might be 0 -- violating the
sqlwatcher's monotonically increasing checkpoint ts invariant.

Release note: None
