### PR TITLE
indexrec: add storing column index recommendations

### DIFF
--- a/pkg/sql/opt/indexrec/hypothetical_table_test.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table_test.go
@@ -28,24 +28,23 @@ func TestBuildOptAndHypTableMaps(t *testing.T) {
 		t.Errorf("expected table2 to be %+v,\n got %+v\n", table2, oldTables[table2.ID()])
 	}
 
-	// One index candidate is an existing index.
-	newIndexesTable1 := len(indexCandidates[table1]) - 1
+	// A hypothetical table's index count is equivalent to its number of index
+	// candidates plus 1 for the primary index.
+	indexCountTable1 := len(indexCandidates[table1]) + 1
+	indexCountTable2 := len(indexCandidates[table2]) + 1
 
-	// Two index candidates are existing indexes.
-	newIndexesTable2 := len(indexCandidates[table2]) - 2
-
-	if hypTables[1].IndexCount()-oldTables[1].IndexCount() != newIndexesTable1 {
+	if hypTables[1].IndexCount() != indexCountTable1 {
 		t.Errorf(
 			"expected table1's index count to be %d, got %d\n",
-			hypTables[1].IndexCount()-oldTables[1].IndexCount(),
-			newIndexesTable1,
+			hypTables[1].IndexCount(),
+			indexCountTable1,
 		)
 	}
 
-	if hypTables[2].IndexCount()-oldTables[2].IndexCount() != newIndexesTable2 {
+	if hypTables[2].IndexCount() != indexCountTable2 {
 		t.Errorf("expected table2's index count to be %d, got %d\n",
-			hypTables[2].IndexCount()-oldTables[2].IndexCount(),
-			newIndexesTable2,
+			hypTables[2].IndexCount(),
+			indexCountTable2,
 		)
 	}
 }

--- a/pkg/sql/opt/indexrec/index_candidate_set.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set.go
@@ -98,9 +98,6 @@ func (ics *indexCandidateSet) combineIndexCandidates() {
 
 // categorizeIndexCandidates finds potential index candidates for a given
 // query. See FindIndexCandidateSet for the list of candidate creation rules.
-//
-// TODO(nehageorge): Add information about potential STORING columns to add for
-// indexes where including them could avoid index-joins.
 func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
 	switch expr := expr.(type) {
 	case *memo.SortExpr:

--- a/pkg/sql/opt/indexrec/index_recommendation_set.go
+++ b/pkg/sql/opt/indexrec/index_recommendation_set.go
@@ -21,83 +21,141 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-// FindIndexRecommendationSet finds index candidates that are used in an
+// FindIndexRecommendationSet finds index candidates that are scanned in an
 // expression to determine a statement's index recommendation set.
+//
+// Note that because the index recommendation engine stores all table columns in
+// its hypothetical indexes when optimizing, and then prunes the stored columns
+// after, this may result in the best plan not being chosen. Meaning, a plan
+// might not be recommended because the optimizer includes the overhead of
+// scanning stored columns of an index, which results in plans with hypothetical
+// indexes being more expensive and reduces their likelihood of being
+// recommended. This is a tradeoff we accept in order to recommend STORING
+// columns, as the difference in plan costs is not very significant.
 func FindIndexRecommendationSet(expr opt.Expr, md *opt.Metadata) IndexRecommendationSet {
 	var recommendationSet IndexRecommendationSet
 	recommendationSet.init(md)
 	recommendationSet.createIndexRecommendations(expr)
+	recommendationSet.pruneIndexRecommendations()
 	return recommendationSet
 }
 
-// IndexRecommendationSet stores the hypothetical indexes that are used in a
-// statement's optimal plan (in usedIndexes), as well as the statement's
-// metadata.
+// IndexRecommendationSet stores the hypothetical indexes that are scanned in a
+// statement's optimal plan (in indexRecs), as well as the statement's metadata.
 type IndexRecommendationSet struct {
-	md          *opt.Metadata
-	usedIndexes map[cat.Table]util.FastIntSet
+	md        *opt.Metadata
+	indexRecs map[cat.Table][]indexRecommendation
 }
 
 // init initializes an IndexRecommendationSet by allocating memory for it.
 func (irs *IndexRecommendationSet) init(md *opt.Metadata) {
 	numTables := len(md.AllTables())
 	irs.md = md
-	irs.usedIndexes = make(map[cat.Table]util.FastIntSet, numTables)
+	irs.indexRecs = make(map[cat.Table][]indexRecommendation, numTables)
 }
 
 // createIndexRecommendations recursively walks an expression tree to find
-// hypothetical indexes that are used in it.
+// hypothetical indexes that are scanned in it.
 func (irs *IndexRecommendationSet) createIndexRecommendations(expr opt.Expr) {
 	switch expr := expr.(type) {
 	case *memo.ScanExpr:
-		irs.addIndexToRecommendationSet(expr.Index, expr.Table)
+		irs.addIndexToRecommendationSet(expr.Index, expr.Cols, expr.Table)
 	case *memo.LookupJoinExpr:
-		irs.addIndexToRecommendationSet(expr.Index, expr.Table)
+		irs.addIndexToRecommendationSet(expr.Index, expr.Cols, expr.Table)
 	case *memo.InvertedJoinExpr:
-		irs.addIndexToRecommendationSet(expr.Index, expr.Table)
+		irs.addIndexToRecommendationSet(expr.Index, expr.Cols, expr.Table)
 	case *memo.ZigzagJoinExpr:
-		irs.addIndexToRecommendationSet(expr.LeftIndex, expr.LeftTable)
-		irs.addIndexToRecommendationSet(expr.RightIndex, expr.RightTable)
+		irs.addIndexToRecommendationSet(expr.LeftIndex, expr.Cols, expr.LeftTable)
+		irs.addIndexToRecommendationSet(expr.RightIndex, expr.Cols, expr.RightTable)
 	}
 	for i, n := 0, expr.ChildCount(); i < n; i++ {
 		irs.createIndexRecommendations(expr.Child(i))
 	}
 }
 
-// addIndexToRecommendationSet adds an index to the indexes map if it does not
-// exist already in the map and in the table.
-func (irs *IndexRecommendationSet) addIndexToRecommendationSet(
-	indexOrd cat.IndexOrdinal, tabID opt.TableID,
-) {
-	switch hypTable := irs.md.TableMeta(tabID).Table.(type) {
-	case *hypotheticalTable:
-		// Do not add real table indexes (non-hypothetical indexes).
-		if indexOrd < hypTable.Table.IndexCount() {
-			return
+// pruneIndexRecommendations removes redundant index recommendations from the
+// recommendation set. These are recommendations where the existingIndex field
+// is not nil and no new columns are being stored.
+func (irs *IndexRecommendationSet) pruneIndexRecommendations() {
+	for t, indexRecs := range irs.indexRecs {
+		updatedIndexRecs := make([]indexRecommendation, 0, len(indexRecs))
+		for _, indexRec := range indexRecs {
+			if indexRec.existingIndex == nil || !indexRec.redundantRecommendation() {
+				updatedIndexRecs = append(updatedIndexRecs, indexRec)
+			}
 		}
-		tabUsedIndexes := irs.usedIndexes[hypTable]
-		tabUsedIndexes.Add(indexOrd)
-		irs.usedIndexes[hypTable] = tabUsedIndexes
+		irs.indexRecs[t] = updatedIndexRecs
 	}
 }
 
-// String returns the string index recommendation output that will be displayed
-// below the statement plan in EXPLAIN.
-func (irs *IndexRecommendationSet) String() string {
-	if len(irs.usedIndexes) == 0 {
-		return ""
+// getColOrdSet returns the set of column ordinals within the given table that
+// are contained in cols.
+func (irs *IndexRecommendationSet) getColOrdSet(
+	cols opt.ColSet, tabID opt.TableID,
+) util.FastIntSet {
+	var colsOrdSet util.FastIntSet
+	cols.ForEach(func(col opt.ColumnID) {
+		table := irs.md.ColumnMeta(col).Table
+		// Do not add columns from other tables.
+		if table != tabID {
+			return
+		}
+		colOrd := table.ColumnOrdinal(col)
+		colsOrdSet.Add(colOrd)
+	})
+	return colsOrdSet
+}
+
+// addIndexToRecommendationSet adds an index to the indexes map if it does not
+// exist already in the map and in the table. The scannedCols argument contains
+// the columns of the index that are actually scanned, used to determine which
+// columns should be stored columns in the index recommendation.
+func (irs *IndexRecommendationSet) addIndexToRecommendationSet(
+	indexOrd cat.IndexOrdinal, scannedCols opt.ColSet, tabID opt.TableID,
+) {
+	// Do not recommend the primary index.
+	if indexOrd == cat.PrimaryIndex {
+		return
 	}
+	// Do not add real table indexes (non-hypothetical table indexes).
+	switch hypTable := irs.md.TableMeta(tabID).Table.(type) {
+	case *hypotheticalTable:
+		scannedColOrds := irs.getColOrdSet(scannedCols, tabID)
+		// Try to find an identical existing index recommendation.
+		for _, indexRec := range irs.indexRecs[hypTable] {
+			index := indexRec.index
+			if index.indexOrdinal == indexOrd {
+				// Update newStoredColOrds to include all stored column ordinals that
+				// are in scannedColOrds.
+				indexRec.addStoredColOrds(scannedColOrds)
+				return
+			}
+		}
+		// Create a new index recommendation with pruned stored columns. Only store
+		// columns that are in scannedColOrds.
+		var newIndexRec indexRecommendation
+		newIndexRec.init(indexOrd, hypTable, scannedColOrds)
+		irs.indexRecs[hypTable] = append(irs.indexRecs[hypTable], newIndexRec)
+	}
+}
+
+// String returns the string index recommendation output that will be
+// displayed below the statement plan in EXPLAIN.
+func (irs *IndexRecommendationSet) String() string {
 	indexRecCount := 0
-	for t := range irs.usedIndexes {
-		indexRecCount += irs.usedIndexes[t].Len()
+	for t := range irs.indexRecs {
+		indexRecCount += len(irs.indexRecs[t])
+	}
+	if indexRecCount == 0 {
+		return ""
 	}
 	var sb strings.Builder
 	sb.WriteString(
 		fmt.Sprintf("\n\nindex recommendations: %d\n\n", indexRecCount),
 	)
 
-	sortedTables := make([]cat.Table, 0, len(irs.usedIndexes))
-	for t := range irs.usedIndexes {
+	sortedTables := make([]cat.Table, 0, len(irs.indexRecs))
+	for t := range irs.indexRecs {
 		sortedTables = append(sortedTables, t)
 	}
 	sort.Slice(sortedTables, func(i, j int) bool {
@@ -106,31 +164,147 @@ func (irs *IndexRecommendationSet) String() string {
 
 	indexRecOrd := 1
 	for _, t := range sortedTables {
-		indexes := irs.usedIndexes[t]
-		for _, indexOrd := range indexes.Ordered() {
-			sb.WriteString(fmt.Sprintf("%d. ", indexRecOrd))
-			indexRecOrd++
-			index := t.Index(indexOrd).(*hypotheticalIndex)
-			indexCols := make([]string, len(index.cols))
-
-			for i, n := 0, len(index.cols); i < n; i++ {
-				var indexColSb strings.Builder
-				indexCol := index.Column(i)
-				colName := indexCol.Column.ColName()
-				indexColSb.WriteString(colName.String())
-
-				if indexCol.Descending {
-					indexColSb.WriteString(" DESC")
-				}
-				indexCols[i] = indexColSb.String()
+		indexes := irs.indexRecs[t]
+		for _, indexRec := range indexes {
+			recTypeStr := "index creation"
+			if indexRec.existingIndex != nil {
+				recTypeStr = "index replacement"
 			}
-
-			tableName := t.Name()
-			sqlCmd := fmt.Sprintf(
-				"CREATE INDEX ON %s (%s);\n\n", tableName.String(), strings.Join(indexCols, ", "),
-			)
-			sb.WriteString(sqlCmd)
+			sb.WriteString(fmt.Sprintf("%d. type: %s", indexRecOrd, recTypeStr))
+			indexRecOrd++
+			indexCols := indexRec.indexColsString()
+			storingClause := indexRec.storingClauseString()
+			sb.WriteString(indexRec.indexRecommendationString(indexCols, storingClause))
 		}
 	}
+	return sb.String()
+}
+
+// indexRecommendation stores the information pertaining to a single index
+// recommendation.
+type indexRecommendation struct {
+	// index stores the hypotheticalIndex that is being recommended.
+	index *hypotheticalIndex
+
+	// existingIndex stores an existing index with the same explicit columns, if
+	// one exists.
+	existingIndex cat.Index
+
+	// newStoredColOrds stores the stored column ordinals that are scanned by the
+	// optimizer in the expression tree passed to FindIndexRecommendationSet.
+	newStoredColOrds util.FastIntSet
+
+	// existingStoredColOrds stores the column ordinals of the existingIndex's
+	// stored columns. It is empty if there is no existingIndex.
+	existingStoredColOrds util.FastIntSet
+}
+
+// init initializes an index recommendation. If there is an existingIndex with
+// the same explicit key columns, it is stored here.
+func (ir *indexRecommendation) init(
+	indexOrd int, hypTable *hypotheticalTable, scannedColOrds util.FastIntSet,
+) {
+	index := hypTable.Index(indexOrd).(*hypotheticalIndex)
+	ir.index = index
+	ir.existingIndex = hypTable.existingRedundantIndex(index)
+
+	// Only store columns useful to the statement plan, found in scannedColOrds.
+	ir.newStoredColOrds = index.storedColsOrdSet.Intersection(scannedColOrds)
+
+	// If there is no existing index, return.
+	if ir.existingIndex == nil {
+		return
+	}
+
+	// Iterate through the stored columns of the existing index to set
+	// existingStoredColOrds.
+	var existingStoredOrds util.FastIntSet
+	for i, n := ir.existingIndex.KeyColumnCount(), ir.existingIndex.ColumnCount(); i < n; i++ {
+		existingStoredOrds.Add(ir.existingIndex.Column(i).Ordinal())
+	}
+	ir.existingStoredColOrds = existingStoredOrds
+
+	// Update newStoredColOrds to contain the existingStoredColOrds. We want to
+	// include all existing stored columns in the potential replacement
+	// recommendation.
+	ir.newStoredColOrds.UnionWith(ir.existingStoredColOrds)
+}
+
+// redundantRecommendation compares newStoredColOrds with the existing index's
+// stored columns. It returns true if there are no new columns being stored in
+// newStoredColOrds.
+func (ir *indexRecommendation) redundantRecommendation() bool {
+	return ir.newStoredColOrds.Difference(ir.existingStoredColOrds).Empty()
+}
+
+// addStoredColOrds updates an index recommendation's newStoredColOrds field to
+// also contain the scannedColOrds columns.
+func (ir *indexRecommendation) addStoredColOrds(scannedColOrds util.FastIntSet) {
+	scannedStoredColOrds := ir.index.storedColsOrdSet.Intersection(scannedColOrds)
+	ir.newStoredColOrds.UnionWith(scannedStoredColOrds)
+}
+
+// indexColsString returns a string containing the explicit key columns of the
+// index, used in indexRecommendationString.
+func (ir *indexRecommendation) indexColsString() string {
+	indexCols := make([]string, len(ir.index.cols))
+
+	for i, n := 0, len(ir.index.cols); i < n; i++ {
+		var indexColSb strings.Builder
+		indexCol := ir.index.Column(i)
+		colName := indexCol.Column.ColName()
+		indexColSb.WriteString(colName.String())
+
+		if indexCol.Descending {
+			indexColSb.WriteString(" DESC")
+		}
+
+		indexCols[i] = indexColSb.String()
+	}
+
+	return strings.Join(indexCols, ", ")
+}
+
+// storingClauseString returns the STORING clause string output of an index
+// recommendation.
+func (ir *indexRecommendation) storingClauseString() string {
+	if ir.newStoredColOrds.Len() == 0 {
+		return ""
+	}
+	var storingSb strings.Builder
+	for i, col := range ir.newStoredColOrds.Ordered() {
+		colName := ir.index.tab.Column(col).ColName()
+		if i > 0 {
+			storingSb.WriteString(", ")
+		}
+		storingSb.WriteString(colName.String())
+	}
+	return " STORING (" + storingSb.String() + ")"
+}
+
+// indexRecommendationString returns the string output for an index
+// recommendation, containing the SQL command(s) needed to follow this
+// recommendation.
+func (ir *indexRecommendation) indexRecommendationString(indexCols, storingClause string) string {
+	var sb strings.Builder
+	tableName := ir.index.tab.Name()
+
+	if ir.existingIndex != nil {
+		sb.WriteString("\n   SQL commands: ")
+		indexName := ir.existingIndex.Name()
+		dropCmd := fmt.Sprintf("DROP INDEX %s@%s; ", tableName.String(), indexName.String())
+		sb.WriteString(dropCmd)
+	} else {
+		sb.WriteString("\n   SQL command: ")
+	}
+
+	createCmd := fmt.Sprintf(
+		"CREATE INDEX ON %s (%s)%s;\n\n",
+		tableName.String(),
+		indexCols,
+		storingClause,
+	)
+	sb.WriteString(createCmd)
+
 	return sb.String()
 }

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -14,58 +14,95 @@ CREATE TABLE t3 (k INT, i INT, f FLOAT)
 # index exists.
 
 exec-ddl
-CREATE INDEX existing_t1_k ON t1(k)
+CREATE INDEX existing_t1_k ON t1(k) STORING (s)
+----
+
+exec-ddl
+CREATE INDEX existing_t1_i ON t1(i)
 ----
 
 exec-ddl
 CREATE INDEX existing_t2_k ON t2(k)
 ----
 
+# No recommendations because an identical index exists already.
+index-recommendations
+SELECT i FROM t1 WHERE i >= 3
+----
+No index recommendations.
+--
+Optimal Plan.
+scan t1@_hyp_1
+ ├── columns: i:2!null
+ ├── constraint: /2/5: [/3 - ]
+ └── cost: 367.353333
+
+# No recommendations because an index with the same explicit columns exists
+# already, and no new columns are being stored.
 index-recommendations
 SELECT k FROM t1 WHERE k >= 3
 ----
 No index recommendations.
 --
 Optimal Plan.
-scan t1@existing_t1_k
+scan t1@_hyp_1
  ├── columns: k:1!null
  ├── constraint: /1/5: [/3 - ]
- └── cost: 357.353333
+ └── cost: 367.353333
 
+# There is a replacement recommendation because an index with the same explicit
+# columns exists already and new columns are being stored here. We stored the
+# existing index's stored columns and any new stored columns.
 index-recommendations
-SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE t1.i > 3
+SELECT i FROM t1 WHERE k >= 3
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (k, i);
+1. type: index replacement
+   SQL commands: DROP INDEX t1@existing_t1_k; CREATE INDEX ON t1 (k) STORING (i, s);
+--
+Optimal Plan.
+project
+ ├── columns: i:2
+ ├── cost: 374.04
+ └── scan t1@_hyp_1
+      ├── columns: k:1!null i:2
+      ├── constraint: /1/5: [/3 - ]
+      └── cost: 370.686667
+
+index-recommendations
+SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE t1.i > 3 AND t2.i > 3
+----
+index recommendations: 2
+1. type: index replacement
+   SQL commands: DROP INDEX t1@existing_t1_i; CREATE INDEX ON t1 (i) STORING (k);
+2. type: index creation
+   SQL command: CREATE INDEX ON t2 (i) STORING (k);
 --
 Optimal Plan.
 project
  ├── columns: k:1!null
- ├── cost: 2216.91667
- └── inner-join (merge)
-      ├── columns: t1.k:1!null t1.i:2!null t2.k:8!null
-      ├── left ordering: +8
-      ├── right ordering: +1
-      ├── cost: 2184.22667
+ ├── cost: 770.258392
+ └── inner-join (hash)
+      ├── columns: t1.k:1!null t1.i:2!null t2.k:8!null t2.i:9!null
+      ├── cost: 759.15621
       ├── fd: (1)==(8), (8)==(1)
-      ├── scan t2@existing_t2_k
-      │    ├── columns: t2.k:8
-      │    ├── cost: 1054.32
-      │    └── ordering: +8
-      ├── select
+      ├── scan t1@_hyp_2
       │    ├── columns: t1.k:1 t1.i:2!null
-      │    ├── cost: 1084.55
-      │    ├── ordering: +1
-      │    ├── scan t1@_hyp_3
-      │    │    ├── columns: t1.k:1 t1.i:2
-      │    │    ├── cost: 1074.52
-      │    │    └── ordering: +1
-      │    └── filters
-      │         └── t1.i:2 > 3 [outer=(2), constraints=(/2: [/4 - ]; tight)]
-      └── filters (true)
+      │    ├── constraint: /2/5: [/4 - ]
+      │    └── cost: 370.686667
+      ├── scan t2@_hyp_2
+      │    ├── columns: t2.k:8 t2.i:9!null
+      │    ├── constraint: /9/11: [/4 - ]
+      │    └── cost: 367.353333
+      └── filters
+           └── t1.k:1 = t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 exec-ddl
 DROP INDEX t1@existing_t1_k
+----
+
+exec-ddl
+DROP INDEX t1@existing_t1_i
 ----
 
 exec-ddl
@@ -80,40 +117,133 @@ DROP INDEX t2@existing_t2_k
 # group by candidates.
 
 index-candidates
-SELECT i FROM t1 WHERE i >= 3
+SELECT * FROM t1 WHERE i >= 3
 ----
 t1:
  (i)
 
 index-recommendations
-SELECT i FROM t1 WHERE i >= 3
+SELECT * FROM t1 WHERE i >= 3
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (i);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (i) STORING (k, f, s);
 --
 Optimal Plan.
 scan t1@_hyp_1
- ├── columns: i:2!null
+ ├── columns: k:1 i:2!null f:3 s:4
  ├── constraint: /2/5: [/3 - ]
- └── cost: 357.353333
+ └── cost: 377.353333
+
 
 index-candidates
-SELECT f FROM t1 WHERE f > 2 AND f < 8
+SELECT f, k FROM t1 WHERE f > 2 AND f < 8
 ----
 t1:
  (f)
 
 index-recommendations
-SELECT f FROM t1 WHERE f > 2 AND f < 8
+SELECT f, k FROM t1 WHERE f > 2 AND f < 8
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (f);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (f) STORING (k);
 --
 Optimal Plan.
 scan t1@_hyp_1
- ├── columns: f:3!null
+ ├── columns: f:3!null k:1
  ├── constraint: /3/5: [/2.0000000000000004 - /7.999999999999999]
- └── cost: 128.464444
+ └── cost: 132.908889
+
+index-candidates
+SELECT i FROM t1 WHERE k < 3 AND i > 5
+----
+t1:
+ (i)
+ (k)
+
+index-recommendations
+SELECT i FROM t1 WHERE k < 3 AND i > 5
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k) STORING (i);
+--
+Optimal Plan.
+project
+ ├── columns: i:2!null
+ ├── cost: 377.181111
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── cost: 374.05
+      ├── scan t1@_hyp_1
+      │    ├── columns: k:1!null i:2
+      │    ├── constraint: /1/5: (/NULL - /2]
+      │    └── cost: 370.686667
+      └── filters
+           └── i:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+
+index-candidates
+SELECT i FROM t1 WHERE k < 3 AND i > 5 OR f < 7
+----
+t1:
+ (f)
+ (i)
+ (k)
+
+index-recommendations
+SELECT i FROM t1 WHERE k < 3 AND i > 5 OR f < 7
+----
+index recommendations: 2
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k) STORING (i, f);
+2. type: index creation
+   SQL command: CREATE INDEX ON t1 (f) STORING (k, i);
+--
+Optimal Plan.
+project
+ ├── columns: i:2
+ ├── cost: 816.218448
+ └── project
+      ├── columns: k:1 i:2 f:3
+      ├── cost: 809.754004
+      └── distinct-on
+           ├── columns: k:1 i:2 f:3 rowid:5!null
+           ├── grouping columns: rowid:5!null
+           ├── cost: 803.289559
+           ├── key: (5)
+           ├── fd: (5)-->(1-3)
+           ├── union-all
+           │    ├── columns: k:1 i:2 f:3 rowid:5!null
+           │    ├── left columns: k:8 i:9 f:10 rowid:12
+           │    ├── right columns: k:15 i:16 f:17 rowid:19
+           │    ├── cost: 764.534444
+           │    ├── select
+           │    │    ├── columns: k:8!null i:9!null f:10 rowid:12!null
+           │    │    ├── cost: 380.716667
+           │    │    ├── key: (12)
+           │    │    ├── fd: (12)-->(8-10)
+           │    │    ├── scan t1@_hyp_1
+           │    │    │    ├── columns: k:8!null i:9 f:10 rowid:12!null
+           │    │    │    ├── constraint: /8/12: (/NULL - /2]
+           │    │    │    ├── cost: 377.353333
+           │    │    │    ├── key: (12)
+           │    │    │    └── fd: (12)-->(8-10)
+           │    │    └── filters
+           │    │         └── i:9 > 5 [outer=(9), constraints=(/9: [/6 - ]; tight)]
+           │    └── scan t1@_hyp_3
+           │         ├── columns: k:15 i:16 f:17!null rowid:19!null
+           │         ├── constraint: /17/19: (/NULL - /6.999999999999999]
+           │         ├── cost: 377.353333
+           │         ├── key: (19)
+           │         └── fd: (19)-->(15-17)
+           └── aggregations
+                ├── const-agg [as=k:1, outer=(1)]
+                │    └── k:1
+                ├── const-agg [as=i:2, outer=(2)]
+                │    └── i:2
+                └── const-agg [as=f:3, outer=(3)]
+                     └── f:3
 
 index-candidates
 SELECT s FROM t1 WHERE s = 'NG'
@@ -125,15 +255,15 @@ index-recommendations
 SELECT s FROM t1 WHERE s = 'NG'
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (s);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (s);
 --
 Optimal Plan.
 scan t1@_hyp_1
  ├── columns: s:4!null
  ├── constraint: /4/5: [/'NG' - /'NG']
- ├── cost: 24.32
+ ├── cost: 24.62
  └── fd: ()-->(4)
-
 
 index-candidates
 SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.i
@@ -147,26 +277,28 @@ index-recommendations
 SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.i
 ----
 index recommendations: 2
-1. CREATE INDEX ON t1 (k);
-2. CREATE INDEX ON t2 (i);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k);
+2. type: index creation
+   SQL command: CREATE INDEX ON t2 (i);
 --
 Optimal Plan.
 project
  ├── columns: k:1!null
- ├── cost: 2324.7
+ ├── cost: 2375.2
  └── inner-join (merge)
       ├── columns: t1.k:1!null t2.i:9!null
       ├── left ordering: +1
       ├── right ordering: +9
-      ├── cost: 2226.67
+      ├── cost: 2277.17
       ├── fd: (1)==(9), (9)==(1)
       ├── scan t1@_hyp_1
       │    ├── columns: t1.k:1
-      │    ├── cost: 1054.32
+      │    ├── cost: 1084.62
       │    └── ordering: +1
       ├── scan t2@_hyp_1
       │    ├── columns: t2.i:9
-      │    ├── cost: 1054.32
+      │    ├── cost: 1074.52
       │    └── ordering: +9
       └── filters (true)
 
@@ -178,26 +310,26 @@ t1:
 t2:
  (s)
 
+# See function comment in indexrec.FindIndexRecommendationSet for an explanation
+# as to why there is no recommendation for an index on s.
 index-recommendations
 SELECT t2.s FROM t1 RIGHT JOIN t2 ON t1.s LIKE t2.s
 ----
-index recommendations: 2
-1. CREATE INDEX ON t1 (s);
-2. CREATE INDEX ON t2 (s);
+No index recommendations.
 --
 Optimal Plan.
 project
  ├── columns: s:10
- ├── cost: 15472.1696
+ ├── cost: 15522.6696
  └── left-join (cross)
       ├── columns: t1.s:4 t2.s:10
-      ├── cost: 12138.8163
-      ├── scan t2@_hyp_1
+      ├── cost: 12189.3163
+      ├── scan t2
       │    ├── columns: t2.s:10
-      │    └── cost: 1054.32
-      ├── scan t1@_hyp_1
+      │    └── cost: 1074.52
+      ├── scan t1
       │    ├── columns: t1.s:4
-      │    └── cost: 1054.32
+      │    └── cost: 1084.62
       └── filters
            └── t1.s:4 LIKE t2.s:10 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
 
@@ -211,13 +343,15 @@ index-recommendations
 SELECT i FROM t1 ORDER BY i
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (i);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (i);
 --
 Optimal Plan.
 scan t1@_hyp_1
  ├── columns: i:2
- ├── cost: 1054.32
+ ├── cost: 1084.62
  └── ordering: +2
+
 
 index-candidates
 SELECT k, i FROM t1 ORDER BY k DESC, i ASC
@@ -229,12 +363,13 @@ index-recommendations
 SELECT k, i FROM t1 ORDER BY k DESC, i ASC
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (k, i DESC);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k, i DESC);
 --
 Optimal Plan.
 scan t1@_hyp_1,rev
  ├── columns: k:1 i:2
- ├── cost: 1175.17442
+ ├── cost: 1195.37442
  └── ordering: -1,+2
 
 index-candidates
@@ -247,25 +382,27 @@ index-recommendations
 SELECT count(*) FROM t1 GROUP BY k
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (k);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k);
 --
 Optimal Plan.
 project
  ├── columns: count:8!null
- ├── cost: 1076.37
+ ├── cost: 1106.67
  └── group-by (streaming)
       ├── columns: k:1 count_rows:8!null
       ├── grouping columns: k:1
       ├── internal-ordering: +1
-      ├── cost: 1075.35
+      ├── cost: 1105.65
       ├── key: (1)
       ├── fd: (1)-->(8)
       ├── scan t1@_hyp_1
       │    ├── columns: k:1
-      │    ├── cost: 1054.32
+      │    ├── cost: 1084.62
       │    └── ordering: +1
       └── aggregations
            └── count-rows [as=count_rows:8]
+
 
 index-candidates
 SELECT sum(k) FROM t1 GROUP BY i, f, k
@@ -277,22 +414,23 @@ index-recommendations
 SELECT sum(k) FROM t1 GROUP BY i, f, k
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (k, i, f);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k, i, f);
 --
 Optimal Plan.
 project
  ├── columns: sum:8
- ├── cost: 1154.77
+ ├── cost: 1164.87
  └── group-by (streaming)
       ├── columns: k:1 i:2 f:3 sum:8
       ├── grouping columns: k:1 i:2 f:3
       ├── internal-ordering: +1,+2,+3
-      ├── cost: 1144.75
+      ├── cost: 1154.85
       ├── key: (1-3)
       ├── fd: (1-3)-->(8)
       ├── scan t1@_hyp_1
       │    ├── columns: k:1 i:2 f:3
-      │    ├── cost: 1094.72
+      │    ├── cost: 1104.82
       │    └── ordering: +1,+2,+3
       └── aggregations
            └── sum [as=sum:8, outer=(1)]
@@ -320,21 +458,19 @@ FROM t1 FULL JOIN t2
 ON t2.k IS NULL
 AND t1.f::STRING NOT LIKE t2.i::STRING
 ----
-index recommendations: 2
-1. CREATE INDEX ON t1 (f);
-2. CREATE INDEX ON t2 (k, i);
+No index recommendations.
 --
 Optimal Plan.
 full-join (cross)
  ├── columns: f:3 k:8 i:9
  ├── stable
- ├── cost: 12159.0263
- ├── scan t1@_hyp_1
+ ├── cost: 12199.4263
+ ├── scan t1
  │    ├── columns: f:3
- │    └── cost: 1054.32
- ├── scan t2@_hyp_3
+ │    └── cost: 1084.62
+ ├── scan t2
  │    ├── columns: t2.k:8 t2.i:9
- │    └── cost: 1074.52
+ │    └── cost: 1084.62
  └── filters
       ├── t2.k:8 IS NULL [outer=(8), constraints=(/8: [/NULL - /NULL]; tight), fd=()-->(8)]
       └── f:3::STRING NOT LIKE t2.i:9::STRING [outer=(3,9), stable]
@@ -362,21 +498,21 @@ ON t1.k != t2.k
 AND t1.s IS NOT NULL
 AND t2.i IS NULL
 ----
-index recommendations: 2
-1. CREATE INDEX ON t1 (k, s);
-2. CREATE INDEX ON t2 (i, k);
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t2 (i) STORING (k);
 --
 Optimal Plan.
 left-join (cross)
  ├── columns: k:1 s:4 k:8 i:9
- ├── cost: 1211.755
- ├── scan t1@_hyp_3
+ ├── cost: 1232.055
+ ├── scan t1
  │    ├── columns: t1.k:1 t1.s:4
- │    └── cost: 1074.52
- ├── scan t2@_hyp_3
+ │    └── cost: 1094.72
+ ├── scan t2@_hyp_1
  │    ├── columns: t2.k:8 t2.i:9
- │    ├── constraint: /9/8/11: [/NULL - /NULL]
- │    ├── cost: 24.5200001
+ │    ├── constraint: /9/11: [/NULL - /NULL]
+ │    ├── cost: 24.6200001
  │    └── fd: ()-->(9)
  └── filters
       ├── t1.k:1 != t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
@@ -399,8 +535,10 @@ index-recommendations
 SELECT k, i FROM t1 WHERE k = 1 AND i = 2
 ----
 index recommendations: 2
-1. CREATE INDEX ON t1 (k);
-2. CREATE INDEX ON t1 (i);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k) STORING (i);
+2. type: index creation
+   SQL command: CREATE INDEX ON t1 (i) STORING (k);
 --
 Optimal Plan.
 inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
@@ -408,7 +546,7 @@ inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
  ├── eq columns: [5] = [5]
  ├── left fixed columns: [1] = [1]
  ├── right fixed columns: [2] = [2]
- ├── cost: 11.9435946
+ ├── cost: 11.9982432
  ├── fd: ()-->(1,2)
  └── filters
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
@@ -427,19 +565,15 @@ index-recommendations
 SELECT * FROM t1 WHERE k = 1 AND f > 0
 ----
 index recommendations: 1
-1. CREATE INDEX ON t1 (k, f);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k, f) STORING (i, s);
 --
 Optimal Plan.
-index-join t1
+scan t1@_hyp_3
  ├── columns: k:1!null i:2 f:3!null s:4
- ├── cost: 80.68
- ├── fd: ()-->(1)
- └── scan t1@_hyp_3
-      ├── columns: k:1!null f:3!null rowid:5!null
-      ├── constraint: /1/3/5: [/1/5e-324 - /1]
-      ├── cost: 23.9133333
-      ├── key: (5)
-      └── fd: ()-->(1), (5)-->(3)
+ ├── constraint: /1/3/5: [/1/5e-324 - /1]
+ ├── cost: 24.1933333
+ └── fd: ()-->(1)
 
 # Multi-column combinations used: EQ, EQ + R.
 index-candidates
@@ -455,15 +589,24 @@ t1:
 index-recommendations
 SELECT k, i, f FROM t1 WHERE k = 1 AND i = 2 AND f > 0
 ----
-index recommendations: 1
-1. CREATE INDEX ON t1 (k, i, f);
+index recommendations: 2
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k) STORING (i, f);
+2. type: index creation
+   SQL command: CREATE INDEX ON t1 (i) STORING (k, f);
 --
 Optimal Plan.
-scan t1@_hyp_5
+inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
  ├── columns: k:1!null i:2!null f:3!null
- ├── constraint: /1/2/3/5: [/1/2/5e-324 - /1/2]
- ├── cost: 14.9006775
- └── fd: ()-->(1,2)
+ ├── eq columns: [5] = [5]
+ ├── left fixed columns: [1] = [1]
+ ├── right fixed columns: [2] = [2]
+ ├── cost: 11.8278162
+ ├── fd: ()-->(1,2)
+ └── filters
+      ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      ├── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+      └── f:3 > 0.0 [outer=(3), constraints=(/3: [/5e-324 - ]; tight)]
 
 # Multi-column combinations used: J + R.
 index-candidates
@@ -479,28 +622,24 @@ t2:
 index-recommendations
 SELECT t1.k, t1.f FROM t1 JOIN t2 ON t1.k != t2.k WHERE t1.f > 0
 ----
-index recommendations: 2
-1. CREATE INDEX ON t1 (k, f);
-2. CREATE INDEX ON t2 (k);
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (f) STORING (k);
 --
 Optimal Plan.
 project
  ├── columns: k:1!null f:3!null
- ├── cost: 6579.60069
+ ├── cost: 5885.93736
  └── inner-join (cross)
       ├── columns: t1.k:1!null f:3!null t2.k:8!null
-      ├── cost: 5490.58069
-      ├── scan t2@_hyp_1
+      ├── cost: 4796.91736
+      ├── scan t2
       │    ├── columns: t2.k:8
-      │    └── cost: 1054.32
-      ├── select
+      │    └── cost: 1074.52
+      ├── scan t1@_hyp_1
       │    ├── columns: t1.k:1 f:3!null
-      │    ├── cost: 1084.55
-      │    ├── scan t1@_hyp_3
-      │    │    ├── columns: t1.k:1 f:3
-      │    │    └── cost: 1074.52
-      │    └── filters
-      │         └── f:3 > 0.0 [outer=(3), constraints=(/3: [/5e-324 - ]; tight)]
+      │    ├── constraint: /3/5: [/5e-324 - ]
+      │    └── cost: 370.686667
       └── filters
            └── t1.k:1 != t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
 
@@ -521,26 +660,33 @@ index-recommendations
 SELECT t1.i, t1.s FROM t1 JOIN t2 ON t1.k != t2.k WHERE t1.i = 2 AND t1.s = 'NG'
 ----
 index recommendations: 2
-1. CREATE INDEX ON t1 (i, s, k);
-2. CREATE INDEX ON t2 (k);
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (i) STORING (k, s);
+2. type: index creation
+   SQL command: CREATE INDEX ON t1 (s) STORING (k, i);
 --
 Optimal Plan.
 project
  ├── columns: i:2!null s:4!null
- ├── cost: 1093.96423
+ ├── cost: 1111.17702
  ├── fd: ()-->(2,4)
  └── inner-join (cross)
       ├── columns: t1.k:1!null t1.i:2!null t1.s:4!null t2.k:8!null
-      ├── cost: 1090.96861
+      ├── cost: 1108.1814
       ├── fd: ()-->(2,4)
-      ├── scan t2@_hyp_1
+      ├── scan t2
       │    ├── columns: t2.k:8
-      │    └── cost: 1054.32
-      ├── scan t1@_hyp_5
+      │    └── cost: 1074.52
+      ├── inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
       │    ├── columns: t1.k:1 t1.i:2!null t1.s:4!null
-      │    ├── constraint: /2/4/1/5: [/2/'NG' - /2/'NG']
-      │    ├── cost: 14.9945676
-      │    └── fd: ()-->(2,4)
+      │    ├── eq columns: [5] = [5]
+      │    ├── left fixed columns: [2] = [2]
+      │    ├── right fixed columns: [4] = ['NG']
+      │    ├── cost: 12.0073514
+      │    ├── fd: ()-->(2,4)
+      │    └── filters
+      │         ├── t1.i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+      │         └── t1.s:4 = 'NG' [outer=(4), constraints=(/4: [/'NG' - /'NG']; tight), fd=()-->(4)]
       └── filters
            └── t1.k:1 != t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
 
@@ -589,9 +735,9 @@ FROM (
   AND t1.s = 'NG'
 )
 ----
-index recommendations: 2
-1. CREATE INDEX ON t1 (s);
-2. CREATE INDEX ON t1 (k);
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (s, f) STORING (i);
 --
 Optimal Plan.
 union-all
@@ -599,22 +745,22 @@ union-all
  ├── left columns: count_rows:14
  ├── right columns: count_rows:22
  ├── cardinality: [1 - ]
- ├── cost: 25628.2091
+ ├── cost: 25598.0782
  ├── project
  │    ├── columns: count_rows:14!null
- │    ├── cost: 25532.7458
+ │    ├── cost: 25563.0458
  │    └── group-by (hash)
  │         ├── columns: t2.i:9 t2.s:10 count_rows:14!null
  │         ├── grouping columns: t2.i:9 t2.s:10
- │         ├── cost: 25522.7258
+ │         ├── cost: 25553.0258
  │         ├── key: (9,10)
  │         ├── fd: (9,10)-->(14)
  │         ├── left-join (cross)
  │         │    ├── columns: t1.k:1 t2.k:8 t2.i:9 t2.s:10
- │         │    ├── cost: 12179.2163
- │         │    ├── scan t1@_hyp_4
+ │         │    ├── cost: 12209.5163
+ │         │    ├── scan t1
  │         │    │    ├── columns: t1.k:1
- │         │    │    └── cost: 1054.32
+ │         │    │    └── cost: 1084.62
  │         │    ├── scan t2
  │         │    │    ├── columns: t2.k:8 t2.i:9 t2.s:10
  │         │    │    └── cost: 1094.72
@@ -625,27 +771,23 @@ union-all
  └── scalar-group-by
       ├── columns: count_rows:22!null
       ├── cardinality: [1 - 1]
-      ├── cost: 85.433267
+      ├── cost: 25.002367
       ├── key: ()
       ├── fd: ()-->(22)
       ├── select
       │    ├── columns: t1.i:16!null f:17!null t1.s:18!null
-      │    ├── cost: 85.37
+      │    ├── cost: 24.9391
       │    ├── fd: ()-->(18)
-      │    ├── index-join t1
-      │    │    ├── columns: t1.i:16 f:17 t1.s:18
-      │    │    ├── cost: 85.24
-      │    │    ├── fd: ()-->(18)
-      │    │    └── scan t1@_hyp_1
-      │    │         ├── columns: t1.s:18!null t1.rowid:19!null
-      │    │         ├── constraint: /18/19: [/'NG' - /'NG']
-      │    │         ├── cost: 24.42
-      │    │         ├── key: (19)
-      │    │         └── fd: ()-->(18)
+      │    ├── scan t1@_hyp_5
+      │    │    ├── columns: t1.i:16 f:17!null t1.s:18!null
+      │    │    ├── constraint: /18/17/19: (/'NG'/NULL - /'NG']
+      │    │    ├── cost: 24.8092
+      │    │    └── fd: ()-->(18)
       │    └── filters
       │         └── f:17 > t1.i:16 [outer=(16,17), constraints=(/16: (/NULL - ]; /17: (/NULL - ])]
       └── aggregations
            └── count-rows [as=count_rows:22]
+
 
 # No rule 5 multi-column index combinations.
 index-candidates
@@ -672,78 +814,83 @@ ON t1.k = t2.k
 WHERE EXISTS (SELECT * FROM t3 WHERE t3.f > t3.k)
 ORDER BY t1.k, t2.i, t1.i DESC
 ----
-index recommendations: 1
-1. CREATE INDEX ON t1 (k, i DESC);
+index recommendations: 3
+1. type: index creation
+   SQL command: CREATE INDEX ON t1 (k, i DESC);
+2. type: index creation
+   SQL command: CREATE INDEX ON t2 (k) STORING (i);
+3. type: index creation
+   SQL command: CREATE INDEX ON t3 (f) STORING (k, i);
 --
 Optimal Plan.
 sort (segmented)
  ├── columns: k:1 i:2 i:9
- ├── cost: 2465.1339
+ ├── cost: 2416.02948
  ├── ordering: +1,+9,-2
  └── project
       ├── columns: t1.k:1 t1.i:2 t2.i:9
-      ├── cost: 2312.45257
+      ├── cost: 2263.34815
       ├── ordering: +1
       └── left-join (merge)
            ├── columns: t1.k:1 t1.i:2 t2.k:8 t2.i:9
            ├── left ordering: +1
            ├── right ordering: +8
-           ├── cost: 2301.12537
+           ├── cost: 2252.02095
            ├── ordering: +1
            ├── select
            │    ├── columns: t1.k:1 t1.i:2
-           │    ├── cost: 1101.896
+           │    ├── cost: 1122.06355
            │    ├── ordering: +1
            │    ├── scan t1@_hyp_1
            │    │    ├── columns: t1.k:1 t1.i:2
-           │    │    ├── cost: 1074.52
+           │    │    ├── cost: 1094.72
            │    │    └── ordering: +1
            │    └── filters
            │         └── exists [subquery]
            │              └── limit
            │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
            │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 17.3460033
+           │                   ├── cost: 17.3135466
            │                   ├── key: ()
            │                   ├── fd: ()-->(14-16)
            │                   ├── select
            │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 17.3260033
+           │                   │    ├── cost: 17.2935466
            │                   │    ├── limit hint: 1.00
-           │                   │    ├── scan t3
-           │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16
-           │                   │    │    ├── cost: 17.2656699
-           │                   │    │    └── limit hint: 3.03
+           │                   │    ├── scan t3@_hyp_1
+           │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
+           │                   │    │    ├── constraint: /16/17: (/NULL - ]
+           │                   │    │    ├── cost: 17.2332132
+           │                   │    │    └── limit hint: 3.00
            │                   │    └── filters
            │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │                   └── 1
-           ├── sort
+           ├── select
            │    ├── columns: t2.k:8 t2.i:9
-           │    ├── cost: 1181.23551
+           │    ├── cost: 1111.96355
            │    ├── ordering: +8
-           │    └── select
-           │         ├── columns: t2.k:8 t2.i:9
-           │         ├── cost: 1111.996
-           │         ├── scan t2
-           │         │    ├── columns: t2.k:8 t2.i:9
-           │         │    └── cost: 1084.62
-           │         └── filters
-           │              └── exists [subquery]
-           │                   └── limit
-           │                        ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                        ├── cardinality: [0 - 1]
-           │                        ├── cost: 17.3460033
-           │                        ├── key: ()
-           │                        ├── fd: ()-->(14-16)
-           │                        ├── select
-           │                        │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                        │    ├── cost: 17.3260033
-           │                        │    ├── limit hint: 1.00
-           │                        │    ├── scan t3
-           │                        │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16
-           │                        │    │    ├── cost: 17.2656699
-           │                        │    │    └── limit hint: 3.03
-           │                        │    └── filters
-           │                        │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
-           │                        └── 1
+           │    ├── scan t2@_hyp_2
+           │    │    ├── columns: t2.k:8 t2.i:9
+           │    │    ├── cost: 1084.62
+           │    │    └── ordering: +8
+           │    └── filters
+           │         └── exists [subquery]
+           │              └── limit
+           │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
+           │                   ├── cardinality: [0 - 1]
+           │                   ├── cost: 17.3135466
+           │                   ├── key: ()
+           │                   ├── fd: ()-->(14-16)
+           │                   ├── select
+           │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
+           │                   │    ├── cost: 17.2935466
+           │                   │    ├── limit hint: 1.00
+           │                   │    ├── scan t3@_hyp_1
+           │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
+           │                   │    │    ├── constraint: /16/17: (/NULL - ]
+           │                   │    │    ├── cost: 17.2332132
+           │                   │    │    └── limit hint: 3.00
+           │                   │    └── filters
+           │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
+           │                   └── 1
            └── filters (true)


### PR DESCRIPTION
Previously, we did not support index recommendations including
storing columns. This meant that the provided recommendations
were not always optimal. In this PR, we tentatively store all
non-key columns in each hypothetical index during optimization.
We then prune these stored columns when making the recommendation,
based on which columns are actually used.

Fixes: #73170.

Release note: None

**NOTE:** Only the final commit requires review here, as the other commits are from a previous PR.