### PR TITLE
gceworker: install bazelisk

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -75,8 +75,9 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip"
  rm -rf aws awscliv2.zip
 
 # Install Bazelisk as Bazel.
-# NOTE: you should keep this in sync with build/packer/teamcity-agent.sh -- if
-# an update is necessary here, it's probably necessary in the agent as well.
+# NOTE: you should keep this in sync with build/packer/teamcity-agent.sh and
+# build/bootstrap/bootstrap-debian.sh -- if an update is necessary here, it's probably
+# necessary in the agent as well.
 RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 > /tmp/bazelisk \
  && echo '4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd /tmp/bazelisk' | sha256sum -c - \
  && chmod +x /tmp/bazelisk \

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -56,5 +56,15 @@ sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 git clone https://github.com/cockroachdb/cockroach "$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
 git -C "$(go env GOPATH)/src/github.com/cockroachdb/cockroach" submodule update --init
 
+# Install Bazelisk as Bazel.
+# NOTE: you should keep this in sync with build/packer/teamcity-agent.sh and build/bazelbuilder/Dockerfile -- if
+# an update is necessary here, it's probably necessary in the agent as well.
+# Note: `dev` will refuse working if `ccache` is installed. Run `sudo apt remove ccache` to fix the issue.
+curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 > /tmp/bazelisk
+echo '4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd /tmp/bazelisk' | sha256sum -c -
+chmod +x /tmp/bazelisk
+sudo mv /tmp/bazelisk /usr/bin/bazel
+echo "build --config=dev" > ~/.bazelrc
+
 # Install the Unison file-syncer.
 . bootstrap/bootstrap-unison.sh

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -74,7 +74,7 @@ for f in `ls /usr/local/go/bin`; do
 done
 
 # Install Bazelisk.
-# Keep this in sync with `build/bazelbuilder/Dockerfile`.
+# Keep this in sync with `build/bazelbuilder/Dockerfile` and `build/bootstrap/bootstrap-debian.sh`.
 curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 > /tmp/bazelisk
 sha256sum -c - <<EOF
 4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd /tmp/bazelisk


### PR DESCRIPTION
This PR ensures that we install `bazelisk` on the GCE workers as a part
of the bootstrap process.

Release note: None