### PR TITLE
release-21.2: CODEOWNERS: move rttanalysis to sql-schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,7 +116,7 @@
 /pkg/acceptance/             @cockroachdb/sql-experience
 /pkg/base/                   @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries
-/pkg/bench/rttanalysis       @cockroachdb/sql-experience
+/pkg/bench/rttanalysis       @cockroachdb/sql-schema
 /pkg/blobs/                  @cockroachdb/bulk-prs
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/baseccl/            @cockroachdb/cli-prs


### PR DESCRIPTION
Backport 1/1 commits from #73140.

/cc @cockroachdb/release

---

I believe this is more accurate.

Release note: None
