### PR TITLE
ui: return expectSagas to test runner

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -60,7 +60,7 @@ describe("SQLStats sagas", () => {
 
   describe("refreshSQLStatsSaga", () => {
     it("dispatches request SQLStats action", () => {
-      expectSaga(refreshSQLStatsSaga)
+      return expectSaga(refreshSQLStatsSaga)
         .put(actions.request())
         .run();
     });
@@ -68,7 +68,7 @@ describe("SQLStats sagas", () => {
 
   describe("requestSQLStatsSaga", () => {
     it("successfully requests statements list", () => {
-      expectSaga(requestSQLStatsSaga)
+      return expectSaga(requestSQLStatsSaga)
         .provide(stmtStatsAPIProvider)
         .put(actions.received(nonCombinedSQLStatsResponse))
         .withReducer(reducer)
@@ -81,7 +81,7 @@ describe("SQLStats sagas", () => {
     });
 
     it("requests combined SQL Stats if combined=true in the request message", () => {
-      expectSaga(requestSQLStatsSaga, {
+      return expectSaga(requestSQLStatsSaga, {
         payload: new cockroach.server.serverpb.StatementsRequest({
           combined: true,
         }),
@@ -98,7 +98,7 @@ describe("SQLStats sagas", () => {
     });
 
     it("requests combined SQL Stats if combined=false in the request message", () => {
-      expectSaga(requestSQLStatsSaga, {
+      return expectSaga(requestSQLStatsSaga, {
         payload: new cockroach.server.serverpb.StatementsRequest({
           combined: false,
         }),
@@ -116,7 +116,7 @@ describe("SQLStats sagas", () => {
 
     it("returns error on failed request", () => {
       const error = new Error("Failed request");
-      expectSaga(requestSQLStatsSaga)
+      return expectSaga(requestSQLStatsSaga)
         .provide([[matchers.call.fn(getStatements), throwError(error)]])
         .put(actions.failed(error))
         .withReducer(reducer)
@@ -132,7 +132,7 @@ describe("SQLStats sagas", () => {
   describe("receivedSQLStatsSaga", () => {
     it("sets valid status to false after specified period of time", () => {
       const timeout = 500;
-      expectSaga(receivedSQLStatsSaga, timeout)
+      return expectSaga(receivedSQLStatsSaga, timeout)
         .delay(timeout)
         .put(actions.invalidated())
         .withReducer(reducer, {
@@ -153,7 +153,7 @@ describe("SQLStats sagas", () => {
     const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
 
     it("successfully resets SQL stats", () => {
-      expectSaga(resetSQLStatsSaga)
+      return expectSaga(resetSQLStatsSaga)
         .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(actions.invalidated())
         .put(actions.refresh())
@@ -168,7 +168,7 @@ describe("SQLStats sagas", () => {
 
     it("returns error on failed reset", () => {
       const err = new Error("failed to reset");
-      expectSaga(resetSQLStatsSaga)
+      return expectSaga(resetSQLStatsSaga)
         .provide([[matchers.call.fn(resetSQLStats), throwError(err)]])
         .put(actions.failed(err))
         .withReducer(reducer)

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
@@ -17,7 +17,10 @@ import {
 } from "./sqlStatsActions";
 import { resetSQLStatsSaga } from "./sqlStatsSagas";
 import { resetSQLStats } from "src/util/api";
-import { invalidateStatements, refreshStatements } from "src/redux/apiReducers";
+import {
+  apiReducersReducer,
+  invalidateStatements,
+} from "src/redux/apiReducers";
 import { throwError } from "redux-saga-test-plan/providers";
 
 import { cockroach } from "src/js/protos";
@@ -27,17 +30,19 @@ describe("SQL Stats sagas", () => {
     const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
 
     it("successfully resets SQL stats", () => {
-      expectSaga(resetSQLStatsSaga)
+      // TODO(azhng): validate refreshStatement() actions once we can figure out
+      //  how to get ThunkAction to work with sagas.
+      return expectSaga(resetSQLStatsSaga)
+        .withReducer(apiReducersReducer)
         .provide([[call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(resetSQLStatsCompleteAction())
         .put(invalidateStatements())
-        .put(refreshStatements() as any)
         .run();
     });
 
     it("returns error on failed reset", () => {
       const err = new Error("failed to reset");
-      expectSaga(resetSQLStatsSaga)
+      return expectSaga(resetSQLStatsSaga)
         .provide([[call.fn(resetSQLStats), throwError(err)]])
         .put(resetSQLStatsFailedAction())
         .run();


### PR DESCRIPTION
Previsouly, sqlStatsSaga tests use `expectSaga` function to
verify the saga correctnes. However, the Promise returned by
`expectSaga` function was not returned to the test runner,
this resulted in all the tests be effectively noop.

This commit returned the Promise returend by `expectSaga` to
test runner.

Release note: None