### PR TITLE
roachtest: pass username to cluster create commands

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -755,6 +755,9 @@ type clusterConfig struct {
 	spec spec.ClusterSpec
 	// artifactsDir is the path where log file will be stored.
 	artifactsDir string
+	// username is the username passed via the --username argument
+	// or the ROACHPROD_USER command-line option.
+	username     string
 	localCluster bool
 	useIOBarrier bool
 	alloc        *quotapool.IntAlloc
@@ -934,7 +937,7 @@ func (f *clusterFactory) newCluster(
 
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name
-		err = roachprod.Create("" /* username */, cfg.spec.NodeCount, createVMOpts)
+		err = roachprod.Create(cfg.username, cfg.spec.NodeCount, createVMOpts)
 		if err == nil {
 			if err := f.r.registerCluster(c); err != nil {
 				return nil, err

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -263,6 +263,7 @@ func (r *testRunner) Run(
 		cfg := clusterConfig{
 			spec:         t.Cluster,
 			artifactsDir: artifactsDir,
+			username:     clustersOpt.user,
 			localCluster: clustersOpt.typ == localCluster,
 			alloc:        alloc,
 		}


### PR DESCRIPTION
If a username has been set at the roachtest command line or via the
ROACHPROD_USER environment variable, pass that username to cluster
create command.

When calling roachtest in CI, we are currently seeing errors related to some account 
validation in the roachprod code:

    gce: active account "..." does no belong to domain @cockroachlabs.com

This validation is skipped if the username is explicitly set an before the library-ification, we called roachprod via the command line, which initialized its username option via the ROACHPROD_USER environment variable which it inherited.

I think something like this should solve at least one of the problems we are seeing
in the nightly builds.

Release note: None