### PR TITLE
release-21.2: tabledesc: forbid computed columns from having DEFAULT expressions

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -92,6 +92,11 @@ type PostDeserializationTableDescriptorChanges struct {
 
 	// UpgradedPrivileges indicates that the PrivilegeDescriptor version was upgraded.
 	UpgradedPrivileges bool
+
+	// RemovedDefaultExprFromComputedColumn indicates that the table had at least
+	// one computed column which also had a DEFAULT expression, which therefore
+	// had to be removed. See issue #72881 for details.
+	RemovedDefaultExprFromComputedColumn bool
 }
 
 // DescriptorType returns the type of this descriptor.

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -625,6 +625,54 @@ func TestDefaultExprNil(t *testing.T) {
 	})
 }
 
+// TestRemoveDefaultExprFromComputedColumn tests that default expressions are
+// correctly removed from descriptors of computed columns as part of the
+// RunPostDeserializationChanges suite.
+func TestRemoveDefaultExprFromComputedColumn(t *testing.T) {
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	const expectedErrRE = `.*: computed column \"b\" cannot also have a DEFAULT expression`
+	// Create a table with a computed column.
+	tdb.Exec(t, `CREATE DATABASE t`)
+	tdb.Exec(t, `CREATE TABLE t.tbl (a INT PRIMARY KEY, b INT AS (1) STORED)`)
+
+	// Get the descriptor for the table.
+	tbl := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "tbl")
+
+	// Setting a default value on the computed column should fail.
+	tdb.ExpectErr(t, expectedErrRE, `ALTER TABLE t.tbl ALTER COLUMN b SET DEFAULT 2`)
+
+	// Copy the descriptor proto for the table and modify it by setting a default
+	// expression.
+	var desc *descpb.TableDescriptor
+	{
+		desc = NewBuilder(tbl.TableDesc()).BuildImmutableTable().TableDesc()
+		defaultExpr := "2"
+		desc.Columns[1].DefaultExpr = &defaultExpr
+	}
+
+	// This modified table descriptor should fail validation.
+	{
+		broken := NewBuilder(desc).BuildImmutableTable()
+		require.Error(t, catalog.ValidateSelf(broken))
+	}
+
+	// This modified table descriptor should be fixed by removing the default
+	// expression.
+	{
+		b := NewBuilder(desc)
+		require.NoError(t, b.RunPostDeserializationChanges(context.Background(), nil /* dg */))
+		fixed := b.BuildImmutableTable()
+		require.NoError(t, catalog.ValidateSelf(fixed))
+		changes, err := GetPostDeserializationChanges(fixed)
+		require.NoError(t, err)
+		require.True(t, changes.RemovedDefaultExprFromComputedColumn)
+		require.False(t, fixed.PublicColumns()[1].HasDefault())
+	}
+}
+
 func TestLogicalColumnID(t *testing.T) {
 	tests := []struct {
 		desc     descpb.TableDescriptor

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -745,11 +745,19 @@ func (desc *wrapper) validateColumns(
 			return errors.Newf("virtual column %q is not computed", column.GetName())
 		}
 
-		if column.HasOnUpdate() && column.IsComputed() {
-			return errors.Newf(
-				"computed column %q cannot also have an ON UPDATE expression",
-				column.GetName(),
-			)
+		if column.IsComputed() {
+			if column.HasDefault() {
+				return pgerror.Newf(pgcode.InvalidTableDefinition,
+					"computed column %q cannot also have a DEFAULT expression",
+					column.GetName(),
+				)
+			}
+			if column.HasOnUpdate() {
+				return pgerror.Newf(pgcode.InvalidTableDefinition,
+					"computed column %q cannot also have an ON UPDATE expression",
+					column.GetName(),
+				)
+			}
 		}
 
 		if column.IsHidden() && column.IsInaccessible() {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1276,6 +1276,22 @@ func TestValidateTableDesc(t *testing.T) {
 				},
 				NextColumnID: 3,
 			}},
+		{`computed column "bar" cannot also have a DEFAULT expression`,
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{
+						ID:          1,
+						Name:        "bar",
+						ComputeExpr: &computedExpr,
+						DefaultExpr: &computedExpr,
+					},
+				},
+				NextColumnID: 2,
+			}},
 	}
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1292,6 +1292,22 @@ func TestValidateTableDesc(t *testing.T) {
 				},
 				NextColumnID: 2,
 			}},
+		{`computed column "bar" cannot also have an ON UPDATE expression`,
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{
+						ID:           1,
+						Name:         "bar",
+						ComputeExpr:  &computedExpr,
+						OnUpdateExpr: &computedExpr,
+					},
+				},
+				NextColumnID: 2,
+			}},
 	}
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -266,20 +266,12 @@ t6  CREATE TABLE public.t6 (
     FAMILY f2 (id2)
 )
 
-# Ensure default expressions are casted correctly.
-statement ok
+# Ensure DEFAULT expression triggers error.
+statement error computed column "x_1" cannot also have a DEFAULT expression
 CREATE TABLE t7 (x INT DEFAULT 1, y INT);
 INSERT INTO t7 (y) VALUES (1), (2), (3);
 ALTER TABLE t7 ALTER COLUMN x TYPE DATE;
 INSERT INTO t7 (y) VALUES (4);
-
-query TI
-SELECT * FROM t7 ORDER BY y
-----
-1970-01-02 00:00:00 +0000 +0000  1
-1970-01-02 00:00:00 +0000 +0000  2
-1970-01-02 00:00:00 +0000 +0000  3
-1970-01-02 00:00:00 +0000 +0000  4
 
 # Ensure a runtime error correctly rolls back and the table is unchanged.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1025,3 +1025,14 @@ SET experimental_computed_column_rewrites = "bad"
 
 statement error invalid column rewrites expression
 SET CLUSTER SETTING sql.defaults.experimental_computed_column_rewrites = "bad"
+
+statement ok
+CREATE TABLE t72881 (
+  c "char",
+  v STRING AS (c) STORED
+);
+INSERT INTO t72881 VALUES ('foo'::STRING)
+
+# Regression test for #72881. Computed columns can't have a DEFAULT expr.
+statement error pgcode 42P16 computed column "v" cannot also have a DEFAULT expression
+ALTER TABLE t72881 ALTER COLUMN v SET DEFAULT 'foo'


### PR DESCRIPTION
Backport 2/2 commits from #73090.

/cc @cockroachdb/release

---

Previously, we didn't have a table descriptor validation check to ensure
that computed columns didn't also have DEFAULT expressions. It is
therefore possible that clusters and cluster backups exist in production
which contain tables with such columns. This commit therefore fixes this
bug by adding the missing validation check, and by removing default
expressions from computed columns when necessary after deserializing
a descriptor protobuf.

Fixes #72881.

Release justification: fixes a descriptor corruption bug

Release note (sql change, bug fix): fixes a bug which allowed computed
columns to also have DEFAULT expressions.
