### PR TITLE
release-21.1: tabledesc: forbid computed columns from having DEFAULT expressions

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -87,6 +87,11 @@ type PostDeserializationTableDescriptorChanges struct {
 	// UpgradedForeignKeyRepresentation indicates that the foreign key
 	// representation was upgraded.
 	UpgradedForeignKeyRepresentation bool
+
+	// RemovedDefaultExprFromComputedColumn indicates that the table had at least
+	// one computed column which also had a DEFAULT expression, which therefore
+	// had to be removed. See issue #72881 for details.
+	RemovedDefaultExprFromComputedColumn bool
 }
 
 // FindIndexPartitionByName searches this index descriptor for a partition whose name

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -194,6 +194,7 @@ func maybeFillInDescriptor(
 			changes.UpgradedIndexFormatVersion = changes.UpgradedIndexFormatVersion || maybeUpgradeIndexFormatVersion(idx)
 		}
 	}
+	changes.RemovedDefaultExprFromComputedColumn = maybeRemoveDefaultExprFromComputedColumns(desc)
 
 	// Fill in any incorrect privileges that may have been missed due to mixed-versions.
 	// TODO(mberhault): remove this in 2.1 (maybe 2.2) when privilege-fixing migrations have been
@@ -212,6 +213,30 @@ func maybeFillInDescriptor(
 		return PostDeserializationTableDescriptorChanges{}, err
 	}
 	return changes, nil
+}
+
+// maybeRemoveDefaultExprFromComputedColumns removes DEFAULT expressions on
+// computed columns. Although we now have a descriptor validation check to
+// prevent this, this hasn't always been the case, so it's theoretically
+// possible to encounter table descriptors which would fail this validation
+// check. See issue #72881 for details.
+func maybeRemoveDefaultExprFromComputedColumns(desc *descpb.TableDescriptor) (hasChanged bool) {
+	doCol := func(col *descpb.ColumnDescriptor) {
+		if col.IsComputed() && col.HasDefault() {
+			col.DefaultExpr = nil
+			hasChanged = true
+		}
+	}
+
+	for i := range desc.Columns {
+		doCol(&desc.Columns[i])
+	}
+	for _, m := range desc.Mutations {
+		if col := m.GetColumn(); col != nil && m.Direction != descpb.DescriptorMutation_DROP {
+			doCol(col)
+		}
+	}
+	return hasChanged
 }
 
 // maybeUpgradeForeignKeyRepresentation destructively modifies the input table

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -684,6 +684,13 @@ func (desc *wrapper) validateColumns(
 		} else if column.IsVirtual() {
 			return errors.Newf("virtual column %q is not computed", column.GetName())
 		}
+
+		if column.IsComputed() && column.HasDefault() {
+			return pgerror.Newf(pgcode.InvalidTableDefinition,
+				"computed column %q cannot also have a DEFAULT expression",
+				column.GetName(),
+			)
+		}
 	}
 	return nil
 }

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1078,6 +1078,22 @@ func TestValidateTableDesc(t *testing.T) {
 				NextFamilyID: 1,
 				NextIndexID:  3,
 			}},
+		{`computed column "bar" cannot also have a DEFAULT expression`,
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{
+						ID:          1,
+						Name:        "bar",
+						ComputeExpr: &computedExpr,
+						DefaultExpr: &computedExpr,
+					},
+				},
+				NextColumnID: 2,
+			}},
 	}
 	for i, d := range testData {
 		t.Run(d.err, func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -266,20 +266,12 @@ t6  CREATE TABLE public.t6 (
     FAMILY f2 (id2)
 )
 
-# Ensure default expressions are casted correctly.
-statement ok
+# Ensure DEFAULT expression triggers error.
+statement error computed column "x_1" cannot also have a DEFAULT expression
 CREATE TABLE t7 (x INT DEFAULT 1, y INT);
 INSERT INTO t7 (y) VALUES (1), (2), (3);
 ALTER TABLE t7 ALTER COLUMN x TYPE DATE;
 INSERT INTO t7 (y) VALUES (4);
-
-query TI
-SELECT * FROM t7 ORDER BY y
-----
-1970-01-02 00:00:00 +0000 +0000  1
-1970-01-02 00:00:00 +0000 +0000  2
-1970-01-02 00:00:00 +0000 +0000  3
-1970-01-02 00:00:00 +0000 +0000  4
 
 # Ensure a runtime error correctly rolls back and the table is unchanged.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -359,7 +359,7 @@ CREATE TABLE y (
   b INT AS (count(1)) STORED
 )
 
-statement error computed columns cannot have default values
+statement error computed column "a" cannot also have a DEFAULT expression
 CREATE TABLE y (
   a INT AS (3) STORED DEFAULT 4
 )
@@ -976,3 +976,14 @@ DROP TABLE trewrite
 
 statement ok
 DROP TABLE trewrite_copy
+
+statement ok
+CREATE TABLE t72881 (
+  c "char",
+  v STRING AS (c) STORED
+);
+INSERT INTO t72881 VALUES ('foo'::STRING)
+
+# Regression test for #72881. Computed columns can't have a DEFAULT expr.
+statement error pgcode 42P16 computed column "v" cannot also have a DEFAULT expression
+ALTER TABLE t72881 ALTER COLUMN v SET DEFAULT 'foo'


### PR DESCRIPTION
Backport 1/2 commits from #73090.

/cc @cockroachdb/release

---

Previously, we didn't have a table descriptor validation check to ensure
that computed columns didn't also have DEFAULT expressions. It is
therefore possible that clusters and cluster backups exist in production
which contain tables with such columns. This commit therefore fixes this
bug by adding the missing validation check, and by removing default
expressions from computed columns when necessary after deserializing
a descriptor protobuf.

Fixes #72881.

Release justification: fixes a descriptor corruption bug

Release note (sql change, bug fix): fixes a bug which allowed computed
columns to also have DEFAULT expressions.
