### PR TITLE
sql: refactor internal executor factory to accept init function

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -820,13 +821,14 @@ func backupPlanHook(
 
 		var spans []roachpb.Span
 		var tenants []descpb.TenantInfoWithUsage
+		ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 		if backupStmt.Targets != nil && backupStmt.Targets.Tenant != (roachpb.TenantID{}) {
 			if !p.ExecCfg().Codec.ForSystemTenant() {
 				return pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can backup other tenants")
 			}
 
 			tenantInfo, err := retrieveSingleTenantMetadata(
-				ctx, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn, backupStmt.Targets.Tenant,
+				ctx, ie, p.ExtendedEvalContext().Txn, backupStmt.Targets.Tenant,
 			)
 			if err != nil {
 				return err
@@ -842,7 +844,7 @@ func backupPlanHook(
 			if p.ExecCfg().Codec.ForSystemTenant() && backupStmt.Coverage() == tree.AllDescriptors {
 				// Include all tenants.
 				tenants, err = retrieveAllTenantsMetadata(
-					ctx, p.ExecCfg().InternalExecutor, p.ExtendedEvalContext().Txn,
+					ctx, ie, p.ExtendedEvalContext().Txn,
 				)
 				if err != nil {
 					return err
@@ -1185,7 +1187,7 @@ func getScheduledBackupExecutionArgsFromSchedule(
 	ctx context.Context,
 	env scheduledjobs.JobSchedulerEnv,
 	txn *kv.Txn,
-	ie *sql.InternalExecutor,
+	ie sqlutil.InternalExecutor,
 	scheduleID int64,
 ) (*jobs.ScheduledJob, *ScheduledBackupExecutionArgs, error) {
 	// Load the schedule that has spawned this job.
@@ -1224,8 +1226,9 @@ func planSchedulePTSChaining(
 		return nil
 	}
 
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 	_, args, err := getScheduledBackupExecutionArgsFromSchedule(ctx, env,
-		p.ExtendedEvalContext().Txn, p.ExecCfg().InternalExecutor, backupStmt.CreatedByInfo.ID)
+		p.ExtendedEvalContext().Txn, ie.(*sql.InternalExecutor), backupStmt.CreatedByInfo.ID)
 	if err != nil {
 		return err
 	}
@@ -1244,7 +1247,7 @@ func planSchedulePTSChaining(
 		}
 
 		_, incArgs, err := getScheduledBackupExecutionArgsFromSchedule(ctx, env,
-			p.ExtendedEvalContext().Txn, p.ExecCfg().InternalExecutor, args.DependentScheduleID)
+			p.ExtendedEvalContext().Txn, ie.(*sql.InternalExecutor), args.DependentScheduleID)
 		if err != nil {
 			// If we are unable to resolve the dependent incremental schedule (it
 			// could have been dropped) we do not need to perform any chaining.

--- a/pkg/ccl/backupccl/backup_planning_tenant.go
+++ b/pkg/ccl/backupccl/backup_planning_tenant.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
@@ -76,7 +76,7 @@ func tenantMetadataFromRow(row tree.Datums) (descpb.TenantInfoWithUsage, error) 
 }
 
 func retrieveSingleTenantMetadata(
-	ctx context.Context, ie *sql.InternalExecutor, txn *kv.Txn, tenantID roachpb.TenantID,
+	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, tenantID roachpb.TenantID,
 ) (descpb.TenantInfoWithUsage, error) {
 	row, err := ie.QueryRow(
 		ctx, "backup-lookup-tenant", txn,
@@ -96,7 +96,7 @@ func retrieveSingleTenantMetadata(
 }
 
 func retrieveAllTenantsMetadata(
-	ctx context.Context, ie *sql.InternalExecutor, txn *kv.Txn,
+	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn,
 ) ([]descpb.TenantInfoWithUsage, error) {
 	rows, err := ie.QueryBuffered(
 		ctx, "backup-lookup-tenants", txn,

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
@@ -430,7 +431,7 @@ func doCreateBackupSchedules(
 		return err
 	}
 
-	ex := p.ExecCfg().InternalExecutor
+	ex := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	unpauseOnSuccessID := jobs.InvalidScheduleID
 
@@ -509,7 +510,7 @@ func doCreateBackupSchedules(
 
 func setDependentSchedule(
 	ctx context.Context,
-	ex *sql.InternalExecutor,
+	ex sqlutil.InternalExecutor,
 	scheduleExecutionArgs *ScheduledBackupExecutionArgs,
 	schedule *jobs.ScheduledJob,
 	dependentID int64,
@@ -659,8 +660,8 @@ func emitSchedule(
 func checkScheduleAlreadyExists(
 	ctx context.Context, p sql.PlanHookState, scheduleLabel string,
 ) (bool, error) {
-
-	row, err := p.ExecCfg().InternalExecutor.QueryRowEx(ctx, "check-sched",
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	row, err := ie.QueryRowEx(ctx, "check-sched",
 		p.ExtendedEvalContext().Txn, sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		fmt.Sprintf("SELECT count(schedule_name) FROM %s WHERE schedule_name = '%s'",
 			scheduledjobs.ProdJobSchedulerEnv.ScheduledJobsTableName(), scheduleLabel))

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1803,7 +1803,9 @@ func revalidateIndexes(
 	// since our table is offline.
 	var runner sqlutil.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sqlutil.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV())).(*sql.InternalExecutor)
+			ie := job.MakeSessionBoundInternalExecutor(ctx, func(ie sqlutil.InternalExecutor) {
+				ie.SetSessionData(sql.NewFakeSessionData(execCfg.SV()))
+			})
 			return fn(ctx, txn, ie)
 		})
 	}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1897,7 +1897,8 @@ func insertStats(
 	}
 
 	err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		if err := stats.InsertNewStats(ctx, execCfg.InternalExecutor, txn, latestStats); err != nil {
+		if err := stats.InsertNewStats(ctx, execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}),
+			txn, latestStats); err != nil {
 			return errors.Wrapf(err, "inserting stats from backup")
 		}
 		details.StatsInserted = true
@@ -2121,7 +2122,7 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}
 		if details.DescriptorCoverage == tree.AllDescriptors {
 			// We've dropped defaultdb and postgres in the planning phase, we must
 			// recreate them now if the full cluster restore failed.
-			ie := p.ExecCfg().InternalExecutor
+			ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 			_, err := ie.Exec(ctx, "recreate-defaultdb", txn, "CREATE DATABASE IF NOT EXISTS defaultdb")
 			if err != nil {
 				return err
@@ -2667,7 +2668,7 @@ func (r *restoreResumer) restoreSystemTables(
 }
 
 func (r *restoreResumer) cleanupTempSystemTables(ctx context.Context, txn *kv.Txn) error {
-	executor := r.execCfg.InternalExecutor
+	executor := r.execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 	// Check if the temp system database has already been dropped. This can happen
 	// if the restore job fails after the system database has cleaned up.
 	checkIfDatabaseExists := "SELECT database_name FROM [SHOW DATABASES] WHERE database_name=$1"

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -89,7 +90,7 @@ func defaultSystemTableRestoreFunc(
 	txn *kv.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	executor := execCfg.InternalExecutor
+	executor := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE true", systemTableName)
 	opName := systemTableName + "-data-deletion"
@@ -117,7 +118,7 @@ func defaultSystemTableRestoreFunc(
 func jobsMigrationFunc(
 	ctx context.Context, execCfg *sql.ExecutorConfig, txn *kv.Txn, tempTableName string,
 ) (err error) {
-	executor := execCfg.InternalExecutor
+	executor := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	const statesToRevert = `('` + string(jobs.StatusRunning) + `', ` +
 		`'` + string(jobs.StatusPauseRequested) + `', ` +
@@ -191,7 +192,7 @@ func jobsRestoreFunc(
 	txn *kv.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	executor := execCfg.InternalExecutor
+	executor := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	// When restoring jobs, don't clear the existing table.
 
@@ -212,7 +213,7 @@ func settingsRestoreFunc(
 	txn *kv.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	executor := execCfg.InternalExecutor
+	executor := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	deleteQuery := fmt.Sprintf("DELETE FROM system.%s WHERE name <> 'version'", systemTableName)
 	opName := systemTableName + "-data-deletion"

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -83,13 +83,15 @@ func New(
 	metrics *Metrics,
 ) SchemaFeed {
 	m := &schemaFeed{
-		filter:            schemaChangeEventFilters[events],
-		db:                cfg.DB,
-		clock:             cfg.DB.Clock(),
-		settings:          cfg.Settings,
-		targets:           targets,
-		leaseMgr:          cfg.LeaseManager.(*lease.Manager),
-		ie:                cfg.SessionBoundInternalExecutorFactory(ctx, &sessiondata.SessionData{}),
+		filter:   schemaChangeEventFilters[events],
+		db:       cfg.DB,
+		clock:    cfg.DB.Clock(),
+		settings: cfg.Settings,
+		targets:  targets,
+		leaseMgr: cfg.LeaseManager.(*lease.Manager),
+		ie: cfg.SessionBoundInternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {
+			ie.SetSessionData(&sessiondata.SessionData{})
+		}),
 		collectionFactory: cfg.CollectionFactory,
 		metrics:           metrics,
 	}

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqltelemetry",
+        "//pkg/sql/sqlutil",
         "//pkg/sql/stats",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -723,9 +723,9 @@ func (j *Job) FractionCompleted() float32 {
 // sessionBoundInternalExecutorFactory for a more detailed explanation of why
 // this exists.
 func (j *Job) MakeSessionBoundInternalExecutor(
-	ctx context.Context, sd *sessiondata.SessionData,
+	ctx context.Context, initInternalExecutor func(sqlutil.InternalExecutor),
 ) sqlutil.InternalExecutor {
-	return j.registry.sessionBoundInternalExecutorFactory(ctx, sd)
+	return j.registry.sessionBoundInternalExecutorFactory(ctx, initInternalExecutor)
 }
 
 func (j *Job) runInTxn(

--- a/pkg/migration/migrationjob/migration_job.go
+++ b/pkg/migration/migrationjob/migration_job.go
@@ -61,7 +61,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	execCtx := execCtxI.(sql.JobExecContext)
 	pl := r.j.Payload()
 	cv := *pl.GetMigration().ClusterVersion
-	ie := execCtx.ExecCfg().InternalExecutor
+	ie := execCtx.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 
 	alreadyCompleted, err := CheckIfMigrationCompleted(ctx, nil /* txn */, ie, cv)
 	if alreadyCompleted || err != nil {
@@ -88,7 +88,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 			Settings:          execCtx.ExecCfg().Settings,
 			CollectionFactory: execCtx.ExecCfg().CollectionFactory,
 			LeaseManager:      execCtx.ExecCfg().LeaseManager,
-			InternalExecutor:  execCtx.ExecCfg().InternalExecutor,
+			InternalExecutor:  ie,
 			TestingKnobs:      execCtx.ExecCfg().MigrationTestingKnobs,
 		}, r.j)
 	default:

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -177,7 +178,7 @@ type Node struct {
 	clusterID    *base.ClusterIDContainer // UUID for Cockroach cluster
 	Descriptor   roachpb.NodeDescriptor   // Node ID, network/physical topology
 	storeCfg     kvserver.StoreConfig     // Config to use and pass to stores
-	sqlExec      *sql.InternalExecutor    // For event logging
+	sqlExec      sqlutil.InternalExecutor // For event logging
 	stores       *kvserver.Stores         // Access to node-local stores
 	metrics      nodeMetrics
 	recorder     *status.MetricsRecorder
@@ -311,6 +312,7 @@ func bootstrapCluster(
 // before the ExecutorConfig is initialized). In that case, InitLogger() needs
 // to be called before the Node is used.
 func NewNode(
+	ctx context.Context,
 	cfg kvserver.StoreConfig,
 	recorder *status.MetricsRecorder,
 	reg *metric.Registry,
@@ -324,9 +326,10 @@ func NewNode(
 	tenantUsage multitenant.TenantUsageServer,
 	spanConfigAccessor spanconfig.KVAccessor,
 ) *Node {
-	var sqlExec *sql.InternalExecutor
+	var sqlExec sqlutil.InternalExecutor
 	if execCfg != nil {
-		sqlExec = execCfg.InternalExecutor
+		ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+		sqlExec = ie
 	}
 	n := &Node{
 		storeCfg:            cfg,
@@ -347,8 +350,9 @@ func NewNode(
 }
 
 // InitLogger needs to be called if a nil execCfg was passed to NewNode().
-func (n *Node) InitLogger(execCfg *sql.ExecutorConfig) {
-	n.sqlExec = execCfg.InternalExecutor
+func (n *Node) InitLogger(ctx context.Context, execCfg *sql.ExecutorConfig) {
+	ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	n.sqlExec = ie
 }
 
 // String implements fmt.Stringer.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -806,7 +806,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	*cfg.circularInternalExecutor = sql.MakeInternalExecutor(
 		ctx, pgServer.SQLServer, internalMemMetrics, cfg.Settings,
 	)
-	execCfg.InternalExecutor = cfg.circularInternalExecutor
 	stmtDiagnosticsRegistry := stmtdiagnostics.NewRegistry(
 		cfg.circularInternalExecutor,
 		cfg.db,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -774,7 +774,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// SessionBoundInternalExecutorFactory. The same applies for setting a
 	// SessionBoundInternalExecutor on the job registry.
 	ieFactory := func(
-		ctx context.Context, sessionData *sessiondata.SessionData,
+		ctx context.Context, initInternalExecutor func(ie sqlutil.InternalExecutor),
 	) sqlutil.InternalExecutor {
 		ie := sql.MakeInternalExecutor(
 			ctx,
@@ -782,7 +782,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			internalMemMetrics,
 			cfg.Settings,
 		)
-		ie.SetSessionData(sessionData)
+		initInternalExecutor(&ie)
 		return &ie
 	}
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -616,6 +616,7 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqltestutils",
+        "//pkg/sql/sqlutil",
         "//pkg/sql/stats",
         "//pkg/sql/stmtdiagnostics",
         "//pkg/sql/tests",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -317,7 +317,7 @@ func (p *planner) MemberOfWithAdminOption(
 	return MemberOfWithAdminOption(
 		ctx,
 		p.execCfg,
-		p.ExecCfg().InternalExecutor,
+		p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}),
 		p.Descriptors(),
 		p.Txn(),
 		member,
@@ -492,7 +492,8 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 		return true, nil
 	}
 
-	hasRolePrivilege, err := p.ExecCfg().InternalExecutor.QueryRowEx(
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	hasRolePrivilege, err := ie.QueryRowEx(
 		ctx, "has-role-option", p.Txn(),
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		fmt.Sprintf(

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -217,7 +217,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 			nc,
 			cfgCpy.DB,
 			cfgCpy.Clock,
-			cfgCpy.InternalExecutor,
+			cfgCpy.InternalExecutorFactory(context.Background(), func(ie sqlutil.InternalExecutor) {}),
 			cfgCpy.Settings,
 			cfgCpy.Codec,
 			t.leaseManagerTestingKnobs,

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -44,7 +44,7 @@ func validateCheckExpr(
 	sessionData *sessiondata.SessionData,
 	exprStr string,
 	tableDesc *tabledesc.Mutable,
-	ie *InternalExecutor,
+	ie sqlutil.InternalExecutor,
 	txn *kv.Txn,
 ) error {
 	expr, err := schemaexpr.FormatExprForDisplay(ctx, tableDesc, exprStr, semaCtx, sessionData, tree.FmtParsable)
@@ -237,7 +237,7 @@ func validateForeignKey(
 	ctx context.Context,
 	srcTable *tabledesc.Mutable,
 	fk *descpb.ForeignKeyConstraint,
-	ie *InternalExecutor,
+	ie sqlutil.InternalExecutor,
 	txn *kv.Txn,
 	codec keys.SQLCodec,
 ) error {

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -60,8 +61,9 @@ func (n *commentOnColumnNode) startExec(params runParams) error {
 		return err
 	}
 
+	ie := params.p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx, func(ie sqlutil.InternalExecutor) {})
 	if n.n.Comment != nil {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"set-column-comment",
 			params.p.Txn(),
@@ -75,7 +77,7 @@ func (n *commentOnColumnNode) startExec(params runParams) error {
 			return err
 		}
 	} else {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"delete-column-comment",
 			params.p.Txn(),

--- a/pkg/sql/comment_on_database.go
+++ b/pkg/sql/comment_on_database.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -54,8 +55,9 @@ func (p *planner) CommentOnDatabase(
 }
 
 func (n *commentOnDatabaseNode) startExec(params runParams) error {
+	ie := params.p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx, func(ie sqlutil.InternalExecutor) {})
 	if n.n.Comment != nil {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"set-db-comment",
 			params.p.Txn(),
@@ -68,7 +70,7 @@ func (n *commentOnDatabaseNode) startExec(params runParams) error {
 			return err
 		}
 	} else {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"delete-db-comment",
 			params.p.Txn(),

--- a/pkg/sql/comment_on_index.go
+++ b/pkg/sql/comment_on_index.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -89,7 +90,8 @@ func (n *commentOnIndexNode) startExec(params runParams) error {
 func (p *planner) upsertIndexComment(
 	ctx context.Context, tableID descpb.ID, indexID descpb.IndexID, comment string,
 ) error {
-	_, err := p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+	ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	_, err := ie.ExecEx(
 		ctx,
 		"set-index-comment",
 		p.Txn(),
@@ -106,7 +108,8 @@ func (p *planner) upsertIndexComment(
 func (p *planner) removeIndexComment(
 	ctx context.Context, tableID descpb.ID, indexID descpb.IndexID,
 ) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	_, err := ie.ExecEx(
 		ctx,
 		"delete-index-comment",
 		p.txn,

--- a/pkg/sql/comment_on_schema.go
+++ b/pkg/sql/comment_on_schema.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 )
 
 type commentOnSchemaNode struct {
@@ -67,8 +68,10 @@ func (p *planner) CommentOnSchema(ctx context.Context, n *tree.CommentOnSchema) 
 }
 
 func (n *commentOnSchemaNode) startExec(params runParams) error {
+	ie := params.p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx,
+		func(ie sqlutil.InternalExecutor) {})
 	if n.n.Comment != nil {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"set-schema-comment",
 			params.p.Txn(),

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -53,8 +54,9 @@ func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (p
 }
 
 func (n *commentOnTableNode) startExec(params runParams) error {
+	ie := params.p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx, func(ie sqlutil.InternalExecutor) {})
 	if n.n.Comment != nil {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"set-table-comment",
 			params.p.Txn(),
@@ -67,7 +69,7 @@ func (n *commentOnTableNode) startExec(params runParams) error {
 			return err
 		}
 	} else {
-		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err := ie.ExecEx(
 			params.ctx,
 			"delete-table-comment",
 			params.p.Txn(),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -340,7 +341,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		cfg.SQLStatsTestingKnobs,
 	)
 	reportedSQLStatsController :=
-		reportedSQLStats.GetController(cfg.SQLStatusServer, cfg.DB, cfg.InternalExecutor)
+		reportedSQLStats.GetController(cfg.SQLStatusServer)
 	memSQLStats := sslocal.New(
 		cfg.Settings,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
@@ -2728,7 +2729,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionStartPostCommitJob, timeutil.Now())
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
-			ex.server.cfg.InternalExecutor,
+			ex.server.cfg.InternalExecutorFactory(ex.Ctx(), func(ie sqlutil.InternalExecutor) {}),
 			ex.extraTxnState.jobs); err != nil {
 			handleErr(err)
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
@@ -780,7 +781,7 @@ func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) 
 	retryErr, err := descs.CheckTwoVersionInvariant(
 		ctx,
 		ex.server.cfg.Clock,
-		ex.server.cfg.InternalExecutor,
+		ex.server.cfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}),
 		&ex.extraTxnState.descCollection,
 		ex.state.mu.txn,
 		inRetryBackoff,

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
 )
@@ -151,8 +152,10 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 		hashedPassword = []byte{}
 	}
 
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx, func(ie sqlutil.InternalExecutor) {})
+
 	// Check if the user/role exists.
-	row, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRowEx(
+	row, err := ie.QueryRowEx(
 		params.ctx,
 		opName,
 		params.p.txn,
@@ -172,7 +175,7 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 	}
 
 	// TODO(richardjcai): move hashedPassword column to system.role_options.
-	rowsAffected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
+	rowsAffected, err := ie.Exec(
 		params.ctx,
 		opName,
 		params.p.txn,
@@ -214,7 +217,7 @@ func (n *CreateRoleNode) startExec(params runParams) error {
 			}
 		}
 
-		_, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		_, err = ie.ExecEx(
 			params.ctx,
 			opName,
 			params.p.txn,

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
@@ -306,7 +307,8 @@ func (p *planner) accumulateCascadingViews(
 }
 
 func (p *planner) removeDbComment(ctx context.Context, dbID descpb.ID) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	_, err := ie.ExecEx(
 		ctx,
 		"delete-db-comment",
 		p.txn,
@@ -323,7 +325,8 @@ func (p *planner) removeDbRoleSettings(ctx context.Context, dbID descpb.ID) erro
 	if !p.EvalContext().Settings.Version.IsActive(ctx, clusterversion.DatabaseRoleSettings) {
 		return nil
 	}
-	rowsDeleted, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	rowsDeleted, err := ie.ExecEx(
 		ctx,
 		"delete-db-role-settings",
 		p.txn,

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
 )
@@ -267,7 +268,8 @@ func (p *planner) createDropSchemaJob(
 }
 
 func (p *planner) removeSchemaComment(ctx context.Context, schemaID descpb.ID) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	_, err := ie.ExecEx(
 		ctx,
 		"delete-schema-comment",
 		p.txn,

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -618,7 +619,8 @@ func removeMatchingReferences(
 }
 
 func (p *planner) removeTableComments(ctx context.Context, tableDesc *tabledesc.Mutable) error {
-	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	_, err := ie.ExecEx(
 		ctx,
 		"delete-table-comments",
 		p.txn,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1057,18 +1057,17 @@ type ExecutorConfig struct {
 	NodesStatusServer serverpb.OptionalNodesStatusServer
 	// SQLStatusServer gives access to a subset of the Status service and is
 	// available when not running as a system tenant.
-	SQLStatusServer  serverpb.SQLStatusServer
-	RegionsServer    serverpb.RegionsServer
-	MetricsRecorder  nodeStatusGenerator
-	SessionRegistry  *SessionRegistry
-	SQLLiveness      sqlliveness.Liveness
-	JobRegistry      *jobs.Registry
-	VirtualSchemas   *VirtualSchemaHolder
-	DistSQLPlanner   *DistSQLPlanner
-	TableStatsCache  *stats.TableStatisticsCache
-	StatsRefresher   *stats.Refresher
-	InternalExecutor *InternalExecutor
-	QueryCache       *querycache.C
+	SQLStatusServer serverpb.SQLStatusServer
+	RegionsServer   serverpb.RegionsServer
+	MetricsRecorder nodeStatusGenerator
+	SessionRegistry *SessionRegistry
+	SQLLiveness     sqlliveness.Liveness
+	JobRegistry     *jobs.Registry
+	VirtualSchemas  *VirtualSchemaHolder
+	DistSQLPlanner  *DistSQLPlanner
+	TableStatsCache *stats.TableStatisticsCache
+	StatsRefresher  *stats.Refresher
+	QueryCache      *querycache.C
 
 	SchemaChangerMetrics *SchemaChangerMetrics
 	FeatureFlagMetrics   *featureflag.DenialMetrics
@@ -3062,7 +3061,8 @@ func DescsTxn(
 	execCfg *ExecutorConfig,
 	f func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error,
 ) error {
-	return execCfg.CollectionFactory.Txn(ctx, execCfg.InternalExecutor, execCfg.DB, f)
+	return execCfg.CollectionFactory.Txn(ctx, execCfg.InternalExecutorFactory(ctx,
+		func(ie sqlutil.InternalExecutor) {}), execCfg.DB, f)
 }
 
 // NewRowMetrics creates a row.Metrics struct for either internal or user

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlutil",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -108,7 +109,7 @@ func TestTraceAnalyzer(t *testing.T) {
 	for _, vectorizeMode := range []sessiondatapb.VectorizeExecMode{sessiondatapb.VectorizeOff, sessiondatapb.VectorizeOn} {
 		execCtx, finishAndCollect := tracing.ContextWithRecordingSpan(ctx, execCfg.AmbientCtx.Tracer, t.Name())
 		defer finishAndCollect()
-		ie := execCfg.InternalExecutor
+		ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 		ie.SetSessionData(
 			&sessiondata.SessionData{
 				SessionData: sessiondatapb.SessionData{

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/memzipper"
@@ -115,7 +116,7 @@ type diagnosticsBundle struct {
 func buildStatementBundle(
 	ctx context.Context,
 	db *kv.DB,
-	ie *InternalExecutor,
+	ie sqlutil.InternalExecutor,
 	plan *planTop,
 	planString string,
 	trace tracing.Recording,
@@ -173,7 +174,7 @@ func (bundle *diagnosticsBundle) insert(
 // stmtBundleBuilder is a helper for building a statement bundle.
 type stmtBundleBuilder struct {
 	db *kv.DB
-	ie *InternalExecutor
+	ie sqlutil.InternalExecutor
 
 	plan         *planTop
 	trace        tracing.Recording
@@ -184,7 +185,7 @@ type stmtBundleBuilder struct {
 
 func makeStmtBundleBuilder(
 	db *kv.DB,
-	ie *InternalExecutor,
+	ie sqlutil.InternalExecutor,
 	plan *planTop,
 	trace tracing.Recording,
 	placeholders *tree.PlaceholderInfo,
@@ -424,10 +425,10 @@ func (b *stmtBundleBuilder) finalize() (*bytes.Buffer, error) {
 // schema, table statistics.
 type stmtEnvCollector struct {
 	ctx context.Context
-	ie  *InternalExecutor
+	ie  sqlutil.InternalExecutor
 }
 
-func makeStmtEnvCollector(ctx context.Context, ie *InternalExecutor) stmtEnvCollector {
+func makeStmtEnvCollector(ctx context.Context, ie sqlutil.InternalExecutor) stmtEnvCollector {
 	return stmtEnvCollector{ctx: ctx, ie: ie}
 }
 

--- a/pkg/sql/grant_role.go
+++ b/pkg/sql/grant_role.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -175,9 +176,11 @@ func (n *GrantRoleNode) startExec(params runParams) error {
 	}
 
 	var rowsAffected int
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx,
+		func(ie sqlutil.InternalExecutor) {})
 	for _, r := range n.roles {
 		for _, m := range n.members {
-			affected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			affected, err := ie.ExecEx(
 				params.ctx,
 				opName,
 				params.p.txn,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vtable"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -2586,7 +2587,8 @@ func forEachRole(
 	// logic test fail in 3node-tenant config with 'txn already encountered an
 	// error' (because of the context cancellation), so we buffer all roles
 	// first.
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	rows, err := ie.QueryBuffered(
 		ctx, "read-roles", p.txn, query,
 	)
 	if err != nil {
@@ -2621,7 +2623,8 @@ func forEachRoleMembership(
 	ctx context.Context, p *planner, fn func(role, member security.SQLUsername, isAdmin bool) error,
 ) (retErr error) {
 	query := `SELECT "role", "member", "isAdmin" FROM system.role_members`
-	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	it, err := ie.QueryIterator(
 		ctx, "read-members", p.txn, query,
 	)
 	if err != nil {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -312,7 +313,7 @@ func (ih *instrumentationHelper) Finish(
 
 	var bundle diagnosticsBundle
 	if ih.collectBundle {
-		ie := p.extendedEvalCtx.ExecCfg.InternalExecutor
+		ie := p.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 		phaseTimes := statsCollector.PhaseTimes()
 		if ih.stmtDiagnosticsRecorder.IsExecLatencyConditionMet(
 			ih.diagRequestID, ih.diagRequest, phaseTimes.GetServiceLatencyNoOverhead(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -116,8 +116,8 @@ func MakeInternalExecutor(
 }
 
 // SetSessionData binds the session variables that will be used by queries
-// performed through this executor from now on. This creates a new session stack.
-// It is recommended to use SetSessionDataStack.
+// performed through this executor from now on. This creates a new session
+// stack.
 //
 // SetSessionData cannot be called concurrently with query execution.
 func (ie *InternalExecutor) SetSessionData(sessionData *sessiondata.SessionData) {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -1159,8 +1160,9 @@ func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.N
 
 	ie := ef.planner.extendedEvalCtx.ExecCfg.InternalExecutorFactory(
 		ef.planner.EvalContext().Context,
-		ef.planner.SessionData(),
-	)
+		func(ie sqlutil.InternalExecutor) {
+			ie.SetSessionData(ef.planner.SessionData())
+		})
 	c := makeStmtEnvCollector(ef.planner.EvalContext().Context, ie.(*InternalExecutor))
 
 	// Show the version of Cockroach running.

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqltelemetry",
+        "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/contextutil",

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
@@ -59,7 +60,7 @@ type authOptions struct {
 	identMap *identmap.Conf
 	// ie is the server-wide internal executor, used to
 	// retrieve entries from system.users.
-	ie *sql.InternalExecutor
+	ie sqlutil.InternalExecutor
 
 	// The following fields are only used by tests.
 
@@ -143,7 +144,7 @@ func (c *conn) handleAuthentication(
 		sql.GetUserSessionInitInfo(
 			ctx,
 			execCfg,
-			authOpt.ie,
+			authOpt.ie.(*sql.InternalExecutor),
 			dbUser,
 			c.sessionArgs.SessionDefaults["database"],
 		)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -710,7 +711,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 			connType:        connType,
 			connDetails:     connDetails,
 			insecure:        s.cfg.Insecure,
-			ie:              s.execCfg.InternalExecutor,
+			ie:              s.execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}),
 			auth:            hbaConf,
 			identMap:        identMap,
 			testingAuthHook: testingAuthHook,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -825,7 +826,9 @@ func (p *planner) QueryRowEx(
 	stmt string,
 	qargs ...interface{},
 ) (tree.Datums, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(p.SessionData())
+	})
 	return ie.QueryRowEx(ctx, opName, txn, override, stmt, qargs...)
 }
 
@@ -843,7 +846,9 @@ func (p *planner) QueryIteratorEx(
 	stmt string,
 	qargs ...interface{},
 ) (tree.InternalRows, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(p.SessionData())
+	})
 	rows, err := ie.QueryIteratorEx(ctx, opName, txn, override, stmt, qargs...)
 	return rows.(tree.InternalRows), err
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -421,11 +421,12 @@ func internalExtendedEvalCtx(
 	var indexUsageStats *idxusage.LocalIndexUsageStats
 	var sqlStatsController tree.SQLStatsController
 	var indexUsageStatsController tree.IndexUsageStatsController
-	if execCfg.InternalExecutor != nil {
-		if execCfg.InternalExecutor.s != nil {
-			indexUsageStats = execCfg.InternalExecutor.s.indexUsageStats
-			sqlStatsController = execCfg.InternalExecutor.s.sqlStatsController
-			indexUsageStatsController = execCfg.InternalExecutor.s.indexUsageStatsController
+	if execCfg.InternalExecutorFactory != nil {
+		ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}).(*InternalExecutor)
+		if ie.s != nil {
+			indexUsageStats = ie.s.indexUsageStats
+			sqlStatsController = ie.s.sqlStatsController
+			indexUsageStatsController = ie.s.indexUsageStatsController
 		} else {
 			// If the indexUsageStats is nil from the sql.Server, we create a dummy
 			// index usage stats collector. The sql.Server in the ExecutorConfig

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -29,7 +29,9 @@ import (
 func (p *planner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
 ) (*tree.DOid, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(p.SessionData())
+	})
 	return resolveOID(
 		ctx, p.Txn(),
 		ie,
@@ -41,7 +43,9 @@ func (p *planner) ResolveOIDFromString(
 func (p *planner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
 ) (*tree.DOid, error) {
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+	ie := p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(p.SessionData())
+	})
 	return resolveOID(
 		ctx, p.Txn(),
 		ie,

--- a/pkg/sql/revoke_role.go
+++ b/pkg/sql/revoke_role.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -131,7 +132,9 @@ func (n *RevokeRoleNode) startExec(params runParams) error {
 					"role/user %s cannot be removed from role %s or lose the ADMIN OPTION",
 					security.RootUser, security.AdminRole)
 			}
-			affected, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx,
+				func(ie sqlutil.InternalExecutor) {})
+			affected, err := ie.ExecEx(
 				params.ctx,
 				opName,
 				params.p.txn,

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scsqldeps"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -94,7 +95,7 @@ func (p *planner) WaitForDescriptorSchemaChanges(
 		}
 		blocked := false
 		if err := p.ExecCfg().CollectionFactory.Txn(
-			ctx, p.ExecCfg().InternalExecutor, p.ExecCfg().DB,
+			ctx, p.ExecCfg().InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}), p.ExecCfg().DB,
 			func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
 				if err := txn.SetFixedTimestamp(ctx, now); err != nil {
 					return err

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -130,7 +130,7 @@ func NewSchemaChangerForTesting(
 		ieFactory: func(
 			ctx context.Context, initInternalExecutor func(sqlutil.InternalExecutor),
 		) sqlutil.InternalExecutor {
-			return execCfg.InternalExecutor
+			return execCfg.InternalExecutorFactory(ctx, initInternalExecutor)
 		},
 		metrics:        NewSchemaChangerMetrics(),
 		clock:          db.Clock(),
@@ -586,8 +586,9 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 
 	// If there are any names to drain, then drain them.
 	if len(desc.GetDrainingNames()) > 0 {
+		ie := sc.execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 		if err := drainNamesForDescriptor(
-			ctx, desc.GetID(), sc.execCfg.CollectionFactory, sc.db, sc.execCfg.InternalExecutor,
+			ctx, desc.GetID(), sc.execCfg.CollectionFactory, sc.db, ie,
 			sc.execCfg.Codec, sc.testingKnobs.OldNamesDrainedNotification,
 		); err != nil {
 			return err
@@ -1040,7 +1041,8 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	// descriptor updates are published.
 	var didUpdate bool
 	var depMutationJobs []jobspb.JobID
-	err := sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutor, sc.db, func(
+	ie := sc.execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	err := sc.execCfg.CollectionFactory.Txn(ctx, ie, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
 		var err error
@@ -1338,7 +1340,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	// If any operations was skipped because a mutation was made
 	// redundant due to a column getting dropped later on then we should
 	// wait for those jobs to complete before returning our result back.
-	if err := sc.jobRegistry.WaitForJobs(ctx, sc.execCfg.InternalExecutor, depMutationJobs); err != nil {
+	if err := sc.jobRegistry.WaitForJobs(ctx, ie, depMutationJobs); err != nil {
 		return errors.Wrap(err, "A dependent transaction failed for this schema change")
 	}
 
@@ -1930,7 +1932,8 @@ func (*SchemaChangerTestingKnobs) ModuleTestingKnobs() {}
 func (sc *SchemaChanger) txn(
 	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
 ) error {
-	return sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutor, sc.db, f)
+	return sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutorFactory(ctx,
+		func(ie sqlutil.InternalExecutor) {}), sc.db, f)
 }
 
 // createSchemaChangeEvalCtx creates an extendedEvalContext() to be used for backfills.

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
@@ -98,7 +99,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 		execCfg.NodeID,
 		execCfg.DB,
 		execCfg.Clock,
-		execCfg.InternalExecutor,
+		execCfg.InternalExecutorFactory(context.Background(), func(ie sqlutil.InternalExecutor) {}),
 		execCfg.Settings,
 		execCfg.Codec,
 		lease.ManagerTestingKnobs{},

--- a/pkg/sql/schemachanger/scjob/BUILD.bazel
+++ b/pkg/sql/schemachanger/scjob/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scrun",
         "//pkg/sql/schemachanger/scsqldeps",
+        "//pkg/sql/sqlutil",
         "//pkg/util/log/eventpb",
     ],
 )

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scsqldeps"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -70,7 +71,7 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 	deps := scdeps.NewJobRunDependencies(
 		execCfg.CollectionFactory,
 		execCfg.DB,
-		execCfg.InternalExecutor,
+		execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {}),
 		execCfg.IndexBackfiller,
 		func(ctx context.Context, txn *kv.Txn, depth int, descID descpb.ID, metadata scpb.ElementMetadata, event eventpb.EventPayload) error {
 			return sql.LogEventForSchemaChanger(ctx, execCtx.ExecCfg(), txn, depth, descID, metadata, event)

--- a/pkg/sql/schemachanger/scsqldeps/index_validator.go
+++ b/pkg/sql/schemachanger/scsqldeps/index_validator.go
@@ -75,7 +75,9 @@ func (iv indexValidator) ValidateForwardIndexes(
 		if err != nil {
 			return err
 		}
-		return fn(ctx, validationTxn, iv.ieFactory(ctx, iv.newFakeSessionData(&iv.settings.SV)))
+		return fn(ctx, validationTxn, iv.ieFactory(ctx, func(ie sqlutil.InternalExecutor) {
+			ie.SetSessionData(iv.newFakeSessionData(&iv.settings.SV))
+		}))
 	}
 	return iv.validateForwardIndexes(ctx, tableDesc, indexes, txnRunner, withFirstMutationPublic, gatherAllInvalid, override)
 }
@@ -95,7 +97,9 @@ func (iv indexValidator) ValidateInvertedIndexes(
 		if err != nil {
 			return err
 		}
-		return fn(ctx, validationTxn, iv.ieFactory(ctx, iv.newFakeSessionData(&iv.settings.SV)))
+		return fn(ctx, validationTxn, iv.ieFactory(ctx, func(ie sqlutil.InternalExecutor) {
+			ie.SetSessionData(iv.newFakeSessionData(&iv.settings.SV))
+		}))
 	}
 	return iv.validateInvertedIndexes(ctx, iv.codec, tableDesc, indexes, txnRunner, gatherAllInvalid, override)
 }

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -98,7 +99,8 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 		}
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	rows, err := ie.QueryBuffered(
 		ctx, "check-constraint", params.p.txn, tree.AsStringWithFlags(sel, tree.FmtParsable),
 	)
 	if err != nil {

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -74,7 +75,8 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		return err
 	}
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	rows, err := ie.QueryBuffered(
 		ctx, "scrub-fk", params.p.txn, checkQuery,
 	)
 	if err != nil {
@@ -93,7 +95,7 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		if err != nil {
 			return err
 		}
-		rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
+		rows, err := ie.QueryBuffered(
 			ctx, "scrub-fk", params.p.txn, checkNullsQuery,
 		)
 		if err != nil {

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -116,7 +117,8 @@ func (o *indexCheckOperation) Start(params runParams) error {
 		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.index.GetID(),
 	)
 
-	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	rows, err := ie.QueryBuffered(
 		ctx, "scrub-index", params.p.txn, checkQuery,
 	)
 	if err != nil {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -1085,11 +1086,12 @@ func writeZoneConfig(
 func writeZoneConfigUpdate(
 	ctx context.Context, txn *kv.Txn, execCfg *ExecutorConfig, update *zoneConfigUpdate,
 ) (numAffected int, _ error) {
+	ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
 	if update.value == nil {
-		return execCfg.InternalExecutor.Exec(ctx, "delete-zone", txn,
+		return ie.Exec(ctx, "delete-zone", txn,
 			"DELETE FROM system.zones WHERE id = $1", update.id)
 	}
-	return execCfg.InternalExecutor.Exec(ctx, "update-zone", txn,
+	return ie.Exec(ctx, "update-zone", txn,
 		"UPSERT INTO system.zones (id, config) VALUES ($1, $2)", update.id, update.value)
 }
 

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -48,7 +49,8 @@ func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc 
 	query := fmt.Sprintf("SELECT type, object_id, sub_id, comment FROM system.comments WHERE object_id = %d", tableID)
 
 	txn := p.ExtendedEvalContext().Txn
-	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIterator(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	it, err := ie.QueryIterator(
 		ctx, "show-tables-with-comment", txn, query)
 	if err != nil {
 		log.VEventf(ctx, 1, "%q", err)

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -155,7 +156,9 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 		sql = sql + " AS OF SYSTEM TIME " + ts.AsOfSystemTime()
 	}
 
-	fingerprintCols, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryRowEx(
+	ie := params.extendedEvalCtx.ExecCfg.InternalExecutorFactory(params.ctx,
+		func(ie sqlutil.InternalExecutor) {})
+	fingerprintCols, err := ie.QueryRowEx(
 		params.ctx, "hash-fingerprint",
 		params.p.txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -44,7 +45,8 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 		columns: showHistogramColumns,
 
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			row, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRowEx(
+			ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+			row, err := ie.QueryRowEx(
 				ctx,
 				"read-histogram",
 				p.txn,

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
@@ -67,7 +68,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//    "handle" which can be used with SHOW HISTOGRAM.
 			// TODO(yuzefovich): refactor the code to use the iterator API
 			// (currently it is not possible due to a panic-catcher below).
-			rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
+			ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx,
+				func(ie sqlutil.InternalExecutor) {})
+			rows, err := ie.QueryBuffered(
 				ctx,
 				"read-table-stats",
 				p.txn,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -15,13 +15,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -50,9 +48,7 @@ var _ sqlstats.Provider = &SQLStats{}
 
 // GetController returns a sqlstats.Controller responsible for the current
 // SQLStats.
-func (s *SQLStats) GetController(
-	server serverpb.SQLStatusServer, db *kv.DB, ie sqlutil.InternalExecutor,
-) *Controller {
+func (s *SQLStats) GetController(server serverpb.SQLStatusServer) *Controller {
 	return NewController(s, server)
 }
 

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -158,6 +158,13 @@ type InternalExecutor interface {
 	WithSyntheticDescriptors(
 		descs []catalog.Descriptor, run func() error,
 	) error
+
+	// SetSessionData binds the session variables that will be used by queries
+	// performed through this executor from now on. This creates a new session
+	// stack.
+	//
+	// SetSessionData cannot be called concurrently with query execution.
+	SetSessionData(*sessiondata.SessionData)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal
@@ -194,7 +201,7 @@ type InternalRows interface {
 // SessionBoundInternalExecutorFactory is a function that produces a "session
 // bound" internal executor.
 type SessionBoundInternalExecutorFactory func(
-	context.Context, *sessiondata.SessionData,
+	context.Context, func(InternalExecutor),
 ) InternalExecutor
 
 // InternalExecFn is the type of functions that operates using an internalExecutor.

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -118,6 +118,17 @@ type InternalExecutor interface {
 		qargs ...interface{},
 	) ([]tree.Datums, error)
 
+	// QueryBufferedExWithCols is like QueryBufferedEx, additionally returning the
+	// computed ResultColumns of the input query.
+	QueryBufferedExWithCols(
+		ctx context.Context,
+		opName string,
+		txn *kv.Txn,
+		session sessiondata.InternalExecutorOverride,
+		stmt string,
+		qargs ...interface{},
+	) ([]tree.Datums, colinfo.ResultColumns, error)
+
 	// QueryIterator executes the query, returning an iterator that can be used
 	// to get the results. If the call is successful, the returned iterator
 	// *must* be closed.

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -582,7 +582,9 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 	}
 
 	// Clean up temporary data for inactive sessions.
-	ie := c.makeSessionBoundInternalExecutor(ctx, &sessiondata.SessionData{})
+	ie := c.makeSessionBoundInternalExecutor(ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(&sessiondata.SessionData{})
+	})
 	for sessionID := range sessionIDs {
 		if _, ok := activeSessions[sessionID.Uint128]; !ok {
 			log.Eventf(ctx, "cleaning up temporary object for session %q", sessionID)

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -106,7 +107,9 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 	if n.index.GetID() != n.tableDesc.GetPrimaryIndexID() {
 		indexName = n.index.GetName()
 	}
-	ie := params.p.ExecCfg().InternalExecutorFactory(params.ctx, params.SessionData())
+	ie := params.p.ExecCfg().InternalExecutorFactory(params.ctx, func(ie sqlutil.InternalExecutor) {
+		ie.SetSessionData(params.SessionData())
+	})
 	it, err := ie.QueryIteratorEx(
 		params.ctx, "split points query", params.p.txn, sessiondata.NoSessionDataOverride,
 		statement,

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -379,7 +379,8 @@ var userLoginTimeout = settings.RegisterDurationSetting(
 // GetAllRoles returns a "set" (map) of Roles -> true.
 func (p *planner) GetAllRoles(ctx context.Context) (map[security.SQLUsername]bool, error) {
 	query := `SELECT username FROM system.users`
-	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIteratorEx(
+	ie := p.ExtendedEvalContext().ExecCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	it, err := ie.QueryIteratorEx(
 		ctx, "read-users", p.txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		query)
@@ -410,7 +411,8 @@ func RoleExists(
 	ctx context.Context, execCfg *ExecutorConfig, txn *kv.Txn, role security.SQLUsername,
 ) (bool, error) {
 	query := `SELECT username FROM system.users WHERE username = $1`
-	row, err := execCfg.InternalExecutor.QueryRowEx(
+	ie := execCfg.InternalExecutorFactory(ctx, func(ie sqlutil.InternalExecutor) {})
+	row, err := ie.QueryRowEx(
 		ctx, "read-users", txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		query, role,


### PR DESCRIPTION
This change refactors the InternalExecutorFactory to take in
a closure that allows injecting external state into a new internal
executor.

Release note: None