### PR TITLE
sql: declarative schema changer planning clean up

### DIFF
--- a/pkg/sql/schemachanger/scexec/executor.go
+++ b/pkg/sql/schemachanger/scexec/executor.go
@@ -23,12 +23,6 @@ import (
 
 // ExecuteStage executes the provided ops. The ops must all be of the same type.
 func ExecuteStage(ctx context.Context, deps Dependencies, ops scop.Ops) error {
-	// It is perfectly valid to have empty stage after optimizations /
-	// transformations.
-	if ops == nil {
-		log.Infof(ctx, "skipping execution, no operations in this stage")
-		return nil
-	}
 	log.Infof(ctx, "executing %d ops of type %s", len(ops.Slice()), ops.Type().String())
 	switch typ := ops.Type(); typ {
 	case scop.MutationType:

--- a/pkg/sql/schemachanger/scop/ops.go
+++ b/pkg/sql/schemachanger/scop/ops.go
@@ -28,13 +28,6 @@ type Ops interface {
 // returns an implementation of Ops corresponding to that type. The set of ops
 // must all be the same type, otherwise MakeOps will panic.
 func MakeOps(ops ...Op) Ops {
-	// The type of stage doesn't matter for nil ops.
-	// TODO: (fqazi) Inside planning we need to plan for *multiple* state
-	// transitions now that we can optimize out edges. Once that  is done this
-	// temporary workaround can be fully dropped.
-	if len(ops) == 0 {
-		return nil
-	}
 	var typ Type
 	for i, op := range ops {
 		if i == 0 {

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_column.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_column.go
@@ -72,6 +72,7 @@ func init() {
 		scpb.Target_DROP,
 		scpb.Status_PUBLIC,
 		to(scpb.Status_DELETE_AND_WRITE_ONLY,
+			minPhase(scop.PreCommitPhase),
 			emit(func(this *scpb.Column) scop.Op {
 				return &scop.MakeDroppedColumnDeleteAndWriteOnly{
 					TableID:  this.TableID,
@@ -96,7 +97,6 @@ func init() {
 				}
 			})),
 		to(scpb.Status_ABSENT,
-			minPhase(scop.PostCommitPhase),
 			emit(func(this *scpb.Column) scop.Op {
 				return &scop.MakeColumnAbsent{
 					TableID:  this.TableID,

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_database.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_database.go
@@ -37,8 +37,8 @@ func init() {
 			}),
 		),
 		to(scpb.Status_ABSENT,
-			minPhase(scop.PreCommitPhase),
 			revertible(false),
+			minPhase(scop.PostCommitPhase),
 			emit(func(this *scpb.Database) scop.Op {
 
 				return &scop.DrainDescriptorName{

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_schema.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_schema.go
@@ -37,10 +37,7 @@ func init() {
 			}),
 		),
 		to(scpb.Status_ABSENT,
-			// TODO(ajwerner): The minPhase here feels like it should be PostCommit.
-			// Also, this definitely is not revertible. Leaving to make this commit
-			// a port.
-			minPhase(scop.PreCommitPhase),
+			minPhase(scop.PostCommitPhase),
 			revertible(false),
 			emit(func(this *scpb.Schema) scop.Op {
 				return &scop.DrainDescriptorName{

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_table.go
@@ -39,7 +39,6 @@ func init() {
 		),
 		to(scpb.Status_ABSENT,
 			minPhase(scop.PostCommitPhase),
-			// TODO(fqazi): We need to revisit if at this phase anything is revertible.
 			revertible(false),
 			emit(func(this *scpb.Table, md *scpb.ElementMetadata) scop.Op {
 				return &scop.LogEvent{Metadata: *md,

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_type.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_type.go
@@ -28,8 +28,6 @@ func init() {
 				}
 			})),
 		to(scpb.Status_DROPPED,
-			// TODO(ajwerner): The move to DELETE_ONLY should be marked
-			// non-revertible.
 			minPhase(scop.PreCommitPhase),
 			revertible(false),
 			emit(func(this *scpb.Type) scop.Op {
@@ -39,9 +37,7 @@ func init() {
 			}),
 		),
 		to(scpb.Status_ABSENT,
-			// TODO(ajwerner): The move to DELETE_ONLY should be marked
-			// non-revertible.
-			minPhase(scop.PreCommitPhase),
+			minPhase(scop.PostCommitPhase),
 			revertible(false),
 			emit(func(this *scpb.Type) scop.Op {
 				return &scop.DrainDescriptorName{

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -22,14 +22,15 @@ upsert descriptor #53
   -  version: "1"
   +  state: DROP
   +  version: "2"
-## stage 2 in PreCommitPhase: 2 MutationType ops
-delete schema namespace entry {52 0 sc} -> 53
 create job #1: "Schema change job"
   descriptor IDs: [53]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
+## stage 1 in PostCommitPhase: 2 MutationType ops
+delete schema namespace entry {52 0 sc} -> 53
+update progress of schema change job #1
 commit transaction #2
 # end PostCommitPhase
 
@@ -81,10 +82,6 @@ begin transaction #2
 create job #2: "GC for Dropping descriptors 55 "
   descriptor IDs: [55]
 update progress of schema change job #1
-commit transaction #2
-begin transaction #3
-## stage 2 in PostCommitPhase: is empty
-update progress of schema change job #1
 upsert descriptor #55
   ...
      modificationTime: {}
@@ -93,7 +90,7 @@ upsert descriptor #55
      nextColumnId: 4
      nextFamilyId: 1
   ...
-commit transaction #3
+commit transaction #2
 # end PostCommitPhase
 
 test
@@ -126,16 +123,17 @@ upsert descriptor #57
   -  version: "1"
   +  state: DROP
   +  version: "2"
-## stage 2 in PreCommitPhase: 4 MutationType ops
-delete schema namespace entry {52 0 sc} -> 54
-delete object namespace entry {52 54 e} -> 56
-delete object namespace entry {52 54 _e} -> 57
 create job #1: "Schema change job"
   descriptor IDs: [54 56 57]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
+## stage 1 in PostCommitPhase: 4 MutationType ops
+delete schema namespace entry {52 0 sc} -> 54
+delete object namespace entry {52 54 e} -> 56
+delete object namespace entry {52 54 _e} -> 57
+update progress of schema change job #1
 commit transaction #2
 # end PostCommitPhase
 
@@ -155,14 +153,15 @@ upsert descriptor #52
   -  version: "5"
   +  state: DROP
   +  version: "6"
-## stage 2 in PreCommitPhase: 2 MutationType ops
-delete database namespace entry {0 0 db} -> 52
 create job #1: "Schema change job"
   descriptor IDs: [52]
 # end PreCommitPhase
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
+## stage 1 in PostCommitPhase: 2 MutationType ops
+delete database namespace entry {0 0 db} -> 52
+update progress of schema change job #1
 commit transaction #2
 # end PostCommitPhase
 
@@ -365,9 +364,6 @@ upsert descriptor #70
   -  version: "1"
   +  version: "2"
      viewQuery: (SELECT 'a':::sc1.typ::STRING AS k, n2, n1 FROM db1.sc1.v4)
-## stage 3 in PreCommitPhase: 2 MutationType ops
-delete object namespace entry {58 59 typ} -> 68
-delete object namespace entry {58 59 _typ} -> 69
 create job #1: "Schema change job"
   descriptor IDs: [58 59 60 61 62 63 64 65 66 67 68 69 70]
 upsert descriptor #60
@@ -446,11 +442,13 @@ upsert descriptor #70
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
-## stage 1 in PostCommitPhase: 30 MutationType ops
+## stage 1 in PostCommitPhase: 32 MutationType ops
 create job #2: "GC for Dropping descriptors 60 63 61 62 64 65 66 67 70 "
   descriptor IDs: [60 63 61 62 64 65 66 67 70]
 delete database namespace entry {0 0 db1} -> 58
 delete schema namespace entry {58 0 sc1} -> 59
+delete object namespace entry {58 59 typ} -> 68
+delete object namespace entry {58 59 _typ} -> 69
 upsert descriptor #60
   ...
      createAsOfTime:
@@ -588,10 +586,6 @@ upsert descriptor #70
   +  version: "3"
      viewQuery: (SELECT 'a':::sc1.typ::STRING AS k, n2, n1 FROM db1.sc1.v4)
 update progress of schema change job #1
-commit transaction #2
-begin transaction #3
-## stage 2 in PostCommitPhase: is empty
-update progress of schema change job #1
 upsert descriptor #60
   ...
      modificationTime: {}
@@ -664,5 +658,5 @@ upsert descriptor #70
      nextColumnId: 4
      nextMutationId: 1
   ...
-commit transaction #3
+commit transaction #2
 # end PostCommitPhase


### PR DESCRIPTION
Previously, it was possible to have multiple minimum
phase labels inside the opgen code, which was unnecessary.
Additionally, its possible for empty stages to be created,
which can be safely merged with neighbouring stages. To
address both issues, this patch enforces minimum phases are
only applied progressively and empty stages are merged
together.

Release note: None