### PR TITLE
ui: Transaction Details page on its own route

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -38,6 +38,7 @@ export * from "./sql";
 export * from "./table";
 export * from "./store";
 export * from "./transactionsPage";
+export * from "./transactionDetails";
 export * from "./text";
 export { util, api };
 export * from "./sessions";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
@@ -9,3 +9,4 @@
 // licenses/APL.txt.
 
 export * from "./transactionDetails";
+export * from "./transactionDetailsConnected";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.fixture.ts
@@ -8,7 +8,36 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { RequestError } from "../util";
+import { RequestError, TimestampToString } from "../util";
+import moment from "moment";
+import { createMemoryHistory } from "history";
+import Long from "long";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+
+const history = createMemoryHistory({ initialEntries: ["/transactions"] });
+const timestamp = new protos.google.protobuf.Timestamp({
+  seconds: new Long(Date.parse("Nov 26 2021 01:00:00 GMT") * 1e-3),
+});
+const timestampString = TimestampToString(timestamp);
+
+export const routeProps = {
+  history,
+  location: {
+    pathname: `/transaction/${timestampString}/3632089240731979669`,
+    search: "",
+    hash: "",
+    state: {},
+  },
+  match: {
+    path: "/transaction/:aggregated_ts/:txn_fingerprint_id",
+    url: `/transaction/${timestampString}/3632089240731979669`,
+    isExact: true,
+    params: {
+      aggregated_ts: timestampString,
+      txn_fingerprint_id: "3632089240731979669",
+    },
+  },
+};
 
 export const transactionDetails = {
   data: {
@@ -554,6 +583,33 @@ export const transactionDetails = {
         },
       },
     ],
+    aggregatedTs: timestampString,
+    transactionFingerprintId: "3632089240731979669",
+    transaction: {
+      stats_data: {
+        statement_fingerprint_ids: [
+          Long.fromString("673bf9d0055bbae332ad497072db9bbf"),
+        ],
+        app: "$ internal-select-running/get-claimed-jobs",
+        aggregated_ts: timestamp,
+        stats: {
+          count: Long.fromInt(93),
+          max_retries: Long.fromInt(0),
+          num_rows: { mean: 0, squared_diffs: 0 },
+          service_lat: {
+            mean: 0.05745331182795698,
+            squared_diffs: 14.213222686585958,
+          },
+          retry_lat: { mean: 0, squared_diffs: 0 },
+          commit_lat: {
+            mean: 0.000010258064516129034,
+            squared_diffs: 3.1277806451612896e-8,
+          },
+        },
+      },
+      node_id: 5,
+      regionNodes: ["gcp-us-east1"],
+    },
   },
   error: new RequestError(
     "Forbidden",
@@ -567,3 +623,8 @@ export const transactionDetails = {
     "4": "gcp-europe-west1",
   },
 };
+
+export const dateRange: [moment.Moment, moment.Moment] = [
+  moment.utc("2021.01.01"),
+  moment.utc("2021.12.31"),
+];

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -11,7 +11,12 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
-import { transactionDetails } from "./transactionDetails.fixture";
+import { noop } from "lodash";
+import {
+  transactionDetails,
+  routeProps,
+  dateRange,
+} from "./transactionDetails.fixture";
 
 import { TransactionDetails } from ".";
 
@@ -24,37 +29,41 @@ storiesOf("Transactions Details", module)
   ))
   .add("with data", () => (
     <TransactionDetails
-      transactionText={data.statements
-        .map(s => s.key.key_data.query)
-        .join("\n")}
+      {...routeProps}
+      aggregatedTs={data.aggregatedTs}
+      dateRange={dateRange}
+      transactionFingerprintId={data.transactionFingerprintId}
+      transaction={data.transaction}
       statements={data.statements as any}
       nodeRegions={nodeRegions}
-      lastReset={Date().toString()}
-      handleDetails={() => {}}
-      resetSQLStats={() => {}}
       isTenant={false}
+      refreshData={noop}
     />
   ))
   .add("with loading indicator", () => (
     <TransactionDetails
-      transactionText={""}
+      {...routeProps}
+      aggregatedTs={data.aggregatedTs}
+      dateRange={dateRange}
+      transactionFingerprintId={data.transactionFingerprintId}
+      transaction={data.transaction}
       statements={undefined}
       nodeRegions={nodeRegions}
-      lastReset={Date().toString()}
-      handleDetails={() => {}}
-      resetSQLStats={() => {}}
       isTenant={false}
+      refreshData={noop}
     />
   ))
   .add("with error alert", () => (
     <TransactionDetails
-      transactionText={""}
+      {...routeProps}
+      aggregatedTs={undefined}
+      dateRange={undefined}
+      transactionFingerprintId={undefined}
+      transaction={undefined}
       statements={undefined}
       nodeRegions={nodeRegions}
       error={error}
-      lastReset={Date().toString()}
-      handleDetails={() => {}}
-      resetSQLStats={() => {}}
       isTenant={false}
+      refreshData={noop}
     />
   ));

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -1,0 +1,89 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "@reduxjs/toolkit";
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Dispatch } from "redux";
+
+import { AppState } from "src/store";
+import { actions as sqlStatsActions } from "src/store/sqlStats";
+import {
+  TransactionDetails,
+  TransactionDetailsDispatchProps,
+  TransactionDetailsProps,
+} from "./transactionDetails";
+import {
+  selectTransactionsData,
+  selectTransactionsLastError,
+} from "../transactionsPage/transactionsPage.selectors";
+import { selectIsTenant } from "../store/uiConfig";
+import { nodeRegionsByIDSelector } from "../store/nodes";
+import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
+import { StatementsRequest } from "src/api/statementsApi";
+import {
+  aggregatedTsAttr,
+  txnFingerprintIdAttr,
+  getMatchParamByName,
+  TimestampToString,
+} from "../util";
+
+export const selectTransaction = createSelector(
+  (state: AppState) => state.adminUI.sqlStats,
+  (_state: AppState, props: RouteComponentProps) => props,
+  (transactionState, props) => {
+    const transactions = transactionState.data?.transactions;
+    if (!transactions) {
+      return null;
+    }
+    const aggregatedTs = getMatchParamByName(props.match, aggregatedTsAttr);
+    const txnFingerprintId = getMatchParamByName(
+      props.match,
+      txnFingerprintIdAttr,
+    );
+
+    return transactions
+      .filter(
+        txn =>
+          txn.stats_data.transaction_fingerprint_id.toString() ==
+          txnFingerprintId,
+      )
+      .filter(
+        txn => TimestampToString(txn.stats_data.aggregated_ts) == aggregatedTs,
+      )[0];
+  },
+);
+
+const mapStateToProps = (state: AppState, props: TransactionDetailsProps) => {
+  return {
+    aggregatedTs: getMatchParamByName(props.match, aggregatedTsAttr),
+    dateRange: selectDateRange(state),
+    error: selectTransactionsLastError(state),
+    isTenant: selectIsTenant(state),
+    nodeRegions: nodeRegionsByIDSelector(state),
+    statements: selectTransactionsData(state)?.statements,
+    transaction: selectTransaction(state, props),
+    transactionFingerprintId: getMatchParamByName(
+      props.match,
+      txnFingerprintIdAttr,
+    ),
+  };
+};
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): TransactionDetailsDispatchProps => ({
+  refreshData: (req?: StatementsRequest) =>
+    dispatch(sqlStatsActions.refresh(req)),
+});
+
+export const TransactionDetailsPageConnected = withRouter<any, any>(
+  connect(mapStateToProps, mapDispatchToProps)(TransactionDetails),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -14,6 +14,7 @@ import {
   getStatementsByFingerprintIdAndTime,
   statementFingerprintIdsToText,
 } from "./utils";
+import { TimestampToString } from "../util";
 import { Filters } from "../queryFilter";
 import { data, nodeRegions, timestamp } from "./transactions.fixture";
 import Long from "long";
@@ -25,7 +26,7 @@ describe("getStatementsByFingerprintIdAndTime", () => {
   it("filters statements by fingerprint id and time", () => {
     const selectedStatements = getStatementsByFingerprintIdAndTime(
       [Long.fromInt(4104049045071304794), Long.fromInt(3334049045071304794)],
-      timestamp,
+      TimestampToString(timestamp),
       [
         {
           id: Long.fromInt(4104049045071304794),
@@ -41,7 +42,7 @@ describe("getStatementsByFingerprintIdAndTime", () => {
   });
 });
 
-const txData = (data.transactions as any) as Transaction[];
+const txData = data.transactions as Transaction[];
 
 describe("Filter transactions", () => {
   it("show non internal if no filters applied", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -9,53 +9,68 @@
 // licenses/APL.txt.
 
 import React from "react";
+import { Link } from "react-router-dom";
 import { getHighlightedText } from "src/highlightedText";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { limitText } from "../utils";
 import classNames from "classnames/bind";
 import statementsStyles from "../../statementsTable/statementsTableContent.module.scss";
 import transactionsCellsStyles from "./transactionsCells.module.scss";
+import { TransactionLinkTarget } from "../transactionsTable";
 
 const statementsCx = classNames.bind(statementsStyles);
 const ownCellStyles = classNames.bind(transactionsCellsStyles);
 const descriptionClassName = statementsCx("cl-table-link__description");
-
 const textWrapper = ownCellStyles("text-wrapper");
 const hoverAreaClassName = ownCellStyles("hover-area");
+
 interface TextCellProps {
   transactionText: string;
   transactionSummary: string;
-  onClick: () => void;
+  aggregatedTs: string;
+  transactionFingerprintId: string;
   search: string;
 }
 
-export const textCell = ({
+export const transactionLink = ({
   transactionText,
   transactionSummary,
-  onClick,
+  aggregatedTs,
+  transactionFingerprintId,
   search,
 }: TextCellProps): React.ReactElement => {
+  const linkProps = {
+    aggregatedTs,
+    transactionFingerprintId,
+  };
+
   return (
-    <div>
-      <Tooltip
-        placement="bottom"
-        content={
-          <pre className={descriptionClassName}>
-            {getHighlightedText(transactionText, search, true /* hasDarkBkg */)}
-          </pre>
-        }
-      >
-        <div className={textWrapper}>
-          <div onClick={onClick} className={hoverAreaClassName}>
-            {getHighlightedText(
-              limitText(transactionSummary, 200),
-              search,
-              false /* hasDarkBkg */,
-              true /* isOriginalText */,
-            )}
+    <Link to={TransactionLinkTarget(linkProps)}>
+      <div>
+        <Tooltip
+          placement="bottom"
+          content={
+            <pre className={descriptionClassName}>
+              {getHighlightedText(
+                transactionText,
+                search,
+                true /* hasDarkBkg */,
+              )}
+            </pre>
+          }
+        >
+          <div className={textWrapper}>
+            <div className={hoverAreaClassName}>
+              {getHighlightedText(
+                limitText(transactionSummary, 200),
+                search,
+                false /* hasDarkBkg */,
+                true /* isOriginalText */,
+              )}
+            </div>
           </div>
-        </div>
-      </Tooltip>
-    </div>
+        </Tooltip>
+      </div>
+    </Link>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -8,20 +8,22 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+export const aggregationIntervalAttr = "aggregation_interval";
+export const aggregatedTsAttr = "aggregated_ts";
 export const appAttr = "app";
 export const dashQueryString = "dash";
 export const dashboardNameAttr = "dashboard_name";
+export const databaseAttr = "database";
 export const databaseNameAttr = "database_name";
 export const implicitTxnAttr = "implicitTxn";
 export const nodeIDAttr = "node_id";
 export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
 export const statementAttr = "statement";
-export const databaseAttr = "database";
-export const tableNameAttr = "table_name";
 export const sessionAttr = "session";
-export const aggregatedTsAttr = "aggregated_ts";
-export const aggregationIntervalAttr = "aggregation_interval";
+export const tabAttr = "tab";
+export const tableNameAttr = "table_name";
+export const txnFingerprintIdAttr = "txn_fingerprint_id";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -66,6 +66,24 @@ export function TimestampToNumber(
 }
 
 /**
+ * TimestampToString converts a Timestamp$Properties object, as seen in wire.proto, to
+ * its unix time and returns that value as a string. If timestamp is null, it returns
+ * the `defaultIfNull` value which is by default is current time.
+ */
+export function TimestampToString(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultIfNull = moment.utc().unix(),
+): string {
+  if (!timestamp) {
+    return defaultIfNull.toString();
+  }
+  return (
+    timestamp.seconds.toNumber() +
+    NanoToMilli(timestamp.nanos) * 1e-3
+  ).toString();
+}
+
+/**
  * LongToMoment converts a Long, representing nanos since the epoch, to a Moment
  * object. If timestamp is null, it returns the current time.
  */

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -30,7 +30,12 @@ import { DatabasesPage } from "src/views/databases/databasesPage";
 import { DatabaseDetailsPage } from "src/views/databases/databaseDetailsPage";
 import { DatabaseTablePage } from "src/views/databases/databaseTablePage";
 import { DataDistributionPage } from "src/views/cluster/containers/dataDistribution";
-import { StatementsPage, StatementDetails } from "@cockroachlabs/cluster-ui";
+import {
+  StatementsPage,
+  StatementDetails,
+  TransactionsPage,
+  TransactionDetails,
+} from "@cockroachlabs/cluster-ui";
 import Debug from "src/views/reports/containers/debug";
 import { ReduxDebug } from "src/views/reports/containers/redux";
 import { CustomChart } from "src/views/reports/containers/customChart";
@@ -353,6 +358,23 @@ describe("Routing to", () => {
     it("routes to <StatementDetails> component", () => {
       navigateToPath("/statement/implicit-attr/statement-attr/");
       assert.lengthOf(appWrapper.find(StatementDetails), 1);
+    });
+  });
+
+  {
+    /* transactions statistics */
+  }
+  describe("'/sql-activity?tab=Transactions' path", () => {
+    it("routes to <TransactionsPage> component", () => {
+      navigateToPath("/sql-activity?tab=Transactions");
+      assert.lengthOf(appWrapper.find(TransactionsPage), 1);
+    });
+  });
+
+  describe("'/transaction/:aggregated_ts/:txn_fingerprint_id' path", () => {
+    it("routes to <TransactionDetails> component", () => {
+      navigateToPath("/transaction/1637877600/4948941983164833719");
+      assert.lengthOf(appWrapper.find(TransactionDetails), 1);
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -20,6 +20,7 @@ import { AdminUIState } from "src/redux/state";
 import { createLoginRoute, createLogoutRoute } from "src/routes/login";
 import visualizationRoutes from "src/routes/visualization";
 import {
+  aggregatedTsAttr,
   appAttr,
   dashboardNameAttr,
   databaseAttr,
@@ -31,6 +32,7 @@ import {
   statementAttr,
   tabAttr,
   tableNameAttr,
+  txnFingerprintIdAttr,
 } from "src/util/constants";
 import NotFound from "src/views/app/components/errorMessage/notFound";
 import Layout from "src/views/app/containers/layout";
@@ -63,6 +65,7 @@ import Stores from "src/views/reports/containers/stores";
 import SQLActivityPage from "src/views/sqlActivity/sqlActivityPage";
 import StatementDetails from "src/views/statements/statementDetails";
 import SessionDetails from "src/views/sessions/sessionDetails";
+import TransactionDetails from "src/views/transactions/transactionDetails";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetails";
 import "styl/app.styl";
@@ -243,6 +246,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   exact
                   from={`/transactions`}
                   to={`/sql-activity?${tabAttr}=Transactions`}
+                />
+                <Route
+                  exact
+                  path={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
+                  component={TransactionDetails}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -8,21 +8,22 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+export const aggregationIntervalAttr = "aggregation_interval";
+export const aggregatedTsAttr = "aggregated_ts";
 export const appAttr = "app";
 export const dashQueryString = "dash";
 export const dashboardNameAttr = "dashboard_name";
+export const databaseAttr = "database";
 export const databaseNameAttr = "database_name";
 export const implicitTxnAttr = "implicitTxn";
 export const nodeIDAttr = "node_id";
 export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
 export const statementAttr = "statement";
-export const databaseAttr = "database";
 export const sessionAttr = "session";
-export const tableNameAttr = "table_name";
-export const aggregatedTsAttr = "aggregated_ts";
 export const tabAttr = "tab";
-export const aggregationIntervalAttr = "aggregation_interval";
+export const tableNameAttr = "table_name";
+export const txnFingerprintIdAttr = "txn_fingerprint_id";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/util/convert.ts
+++ b/pkg/ui/workspaces/db-console/src/util/convert.ts
@@ -77,6 +77,24 @@ export function TimestampToNumber(
 }
 
 /**
+ * TimestampToString converts a Timestamp$Properties object, as seen in wire.proto, to
+ * its unix time and returns that value as a string. If timestamp is null, it returns
+ * the `defaultIfNull` value which is by default is current time.
+ */
+export function TimestampToString(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultIfNull = moment.utc().unix(),
+): string {
+  if (!timestamp) {
+    return defaultIfNull.toString();
+  }
+  return (
+    timestamp.seconds.toNumber() +
+    NanoToMilli(timestamp.nanos) * 1e-3
+  ).toString();
+}
+
+/**
  * LongToMoment converts a Long, representing nanos since the epoch, to a Moment
  * object. If timestamp is null, it returns the current time.
  */

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -1,0 +1,81 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { refreshStatements } from "src/redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
+import { aggregatedTsAttr, txnFingerprintIdAttr } from "src/util/constants";
+import { TimestampToString } from "src/util/convert";
+import { getMatchParamByName } from "src/util/query";
+import { nodeRegionsByIDSelector } from "src/redux/nodes";
+import {
+  selectData,
+  selectDateRange,
+  selectLastError,
+} from "src/views/transactions/transactionsPage";
+import {
+  TransactionDetailsStateProps,
+  TransactionDetailsDispatchProps,
+  TransactionDetailsProps,
+  TransactionDetails,
+} from "@cockroachlabs/cluster-ui";
+
+export const selectTransaction = createSelector(
+  (state: AdminUIState) => state.cachedData.statements,
+  (_state: AdminUIState, props: RouteComponentProps) => props,
+  (transactionState, props) => {
+    const transactions = transactionState.data?.transactions;
+    if (!transactions) {
+      return null;
+    }
+    const aggregatedTs = getMatchParamByName(props.match, aggregatedTsAttr);
+    const txnFingerprintId = getMatchParamByName(
+      props.match,
+      txnFingerprintIdAttr,
+    );
+
+    return transactions
+      .filter(
+        txn =>
+          txn.stats_data.transaction_fingerprint_id.toString() ==
+          txnFingerprintId,
+      )
+      .filter(
+        txn => TimestampToString(txn.stats_data.aggregated_ts) == aggregatedTs,
+      )[0];
+  },
+);
+
+export default withRouter(
+  connect<TransactionDetailsStateProps, TransactionDetailsDispatchProps>(
+    (
+      state: AdminUIState,
+      props: TransactionDetailsProps,
+    ): TransactionDetailsStateProps => {
+      const transaction = selectTransaction(state, props);
+      return {
+        aggregatedTs: getMatchParamByName(props.match, aggregatedTsAttr),
+        dateRange: selectDateRange(state),
+        error: selectLastError(state),
+        isTenant: false,
+        nodeRegions: nodeRegionsByIDSelector(state),
+        statements: selectData(state)?.statements,
+        transaction: transaction,
+        transactionFingerprintId: getMatchParamByName(
+          props.match,
+          txnFingerprintIdAttr,
+        ),
+      };
+    },
+    { refreshData: refreshStatements },
+  )(TransactionDetails),
+);

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -54,7 +54,7 @@ export const selectLastReset = createSelector(
   },
 );
 
-const selectLastError = createSelector(
+export const selectLastError = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
   (state: CachedDataReducerState<StatementsResponseMessage>) => state.lastError,
 );


### PR DESCRIPTION
Previously, transaction details was using the same route
as transactions list, so it wasn't possible to share a link
for a specific transaction details and also only the content
inside the tabs of SQL Activity were being replaced instead
of the entire page.
This commit change Transaction Details to its own route and
separate the creation on a different file from TransactionsPage.

Fixes #73200

Before
https://user-images.githubusercontent.com/1017486/143654072-5180bebd-6c37-4bf0-bf87-9757e29a1783.mov

After
https://user-images.githubusercontent.com/1017486/143655627-485f9768-0671-4a55-9a08-e52a1021deca.mov


Release note: None