### PR TITLE
roachprod: fix node url parsing issue

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2096,6 +2096,9 @@ func (c *clusterImpl) pgURLErr(
 	if err != nil {
 		return nil, err
 	}
+	for i, url := range urls {
+		urls[i] = strings.Trim(url, "'")
+	}
 	return urls, nil
 }
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -218,7 +218,7 @@ func (c *SyncedCluster) NodeURL(host string, port int) string {
 		v.Add("sslmode", "disable")
 	}
 	u.RawQuery = v.Encode()
-	return u.String()
+	return "'" + u.String() + "'"
 }
 
 // NodePort returns the SQL port for the given node.


### PR DESCRIPTION
Passing node url without quoting it causes issues in parsing
it and results in ignoring some parameters.

This patch fixes this by quoting node url.

Release note: None

Fixes #73230 #73229 #73228 #73227 #73211