### PR TITLE
[DRAFT] bazel: run docker image tests under Bazel

### DIFF
--- a/build/teamcity/cockroach/ci/tests/docker_image.sh
+++ b/build/teamcity/cockroach/ci/tests/docker_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+source "$dir/teamcity-support.sh"
+
+tc_prepare
+
+tc_start_block "Run docker image tests"
+bazel run \
+  //pkg/testutils/docker:docker_test \
+  --config=crosslinux --config=test \
+  --test_timeout=1800
+tc_end_block "Run docker image tests"

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -331,6 +331,7 @@ ALL_TESTS = [
     "//pkg/storage/fs:fs_test",
     "//pkg/storage/metamorphic:metamorphic_test",
     "//pkg/storage:storage_test",
+    "//pkg/testutils/docker:docker_test",
     "//pkg/testutils/floatcmp:floatcmp_test",
     "//pkg/testutils/keysutils:keysutils_test",
     "//pkg/testutils/lint/passes/errwrap:errwrap_test",

--- a/pkg/testutils/docker/BUILD.bazel
+++ b/pkg/testutils/docker/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "testutils_docker",
+    srcs = ["docker_utils.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/docker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_docker_docker//api/types",
+        "@com_github_docker_docker//api/types/container",
+        "@com_github_docker_docker//api/types/filters",
+        "@com_github_docker_docker//client",
+        "@com_github_docker_docker//pkg/stdcopy",
+        "@com_github_docker_go_connections//nat",
+        "@org_golang_x_net//context",
+    ],
+)
+
+go_test(
+    name = "docker_test",
+    size = "enormous",
+    srcs = ["single_node_docker_test.go"],
+    data = glob([
+        "testdata/single-node-test/docker-entrypoint-initdb.d/**",
+    ]) + [
+        "//pkg/testutils/docker:testdata/single-node-test/docker-entrypoint-initdb.d",
+    ],
+    embed = [":testutils_docker"],
+    deps = [
+        "//pkg/util/contextutil",
+        "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_docker_docker//client",
+        "@org_golang_x_net//context",
+    ],
+)

--- a/pkg/testutils/docker/docker_utils.go
+++ b/pkg/testutils/docker/docker_utils.go
@@ -1,0 +1,338 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package docker
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
+	"golang.org/x/net/context"
+)
+
+const (
+	imageName           = "cockroachdb/cockroach-ci:latest"
+	defaultTimeout      = 10
+	serverStartTimeout  = 80
+	listenUrlFile       = "demoFile"
+	cockroachEntrypoint = "./cockroach"
+	hostPort            = "8080"
+	cockroachPort       = "26275"
+	hostIP              = "127.0.0.1"
+)
+
+type dockerNode struct {
+	cl     client.APIClient
+	contId string
+}
+
+// removeLocalData removes existing database saved in cockroach-data.
+func removeLocalData() error {
+	err := os.RemoveAll("./cockroach-data")
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot remove local data")
+	}
+	return nil
+}
+
+// showContainerLog outputs the container's logs to the logFile and stderr.
+func (dn *dockerNode) showContainerLog(ctx context.Context, logFileName string) error {
+
+	cmdLog, err := os.Create(logFileName)
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot create log file")
+	}
+	out := io.MultiWriter(cmdLog, os.Stderr)
+
+	rc, err := dn.cl.ContainerLogs(ctx, dn.contId, types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot create docker logs")
+	}
+
+	// The docker log output is not quite plaintext: each line has a
+	// prefix consisting of one byte file descriptor (stdout vs stderr),
+	// three bytes padding, four byte length. We could use this to
+	// disentangle stdout and stderr if we wanted to output them into
+	// separate streams, but we don't really care.
+	for {
+		var header uint64
+		if err := binary.Read(rc, binary.BigEndian, &header); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		size := header & math.MaxUint32
+		if _, err := io.CopyN(out, rc, int64(size)); err != nil {
+			return err
+		}
+	}
+
+	if err := rc.Close(); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot close docker log")
+	}
+
+	return nil
+}
+
+// startContainer starts a container with given setting for environment
+// variables, mounted volumes, and command to run.
+func (dn *dockerNode) startContainer(
+	ctx context.Context, containerName string, envSetting []string, volSetting []string, cmd []string,
+) error {
+
+	containerConfig := container.Config{
+		Hostname:     containerName,
+		Image:        imageName,
+		Env:          envSetting,
+		ExposedPorts: nat.PortSet{hostPort: struct{}{}, cockroachPort: struct{}{}},
+		Cmd:          append(cmd, fmt.Sprintf("--listening-url-file=%s", listenUrlFile)),
+	}
+
+	hostConfig := container.HostConfig{
+		Binds: volSetting,
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			nat.Port(hostPort):      {{HostIP: hostIP, HostPort: hostPort}},
+			nat.Port(cockroachPort): {{HostIP: hostIP, HostPort: cockroachPort}},
+		},
+	}
+
+	resp, err := dn.cl.ContainerCreate(
+		ctx,
+		&containerConfig,
+		&hostConfig,
+		nil,
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot create container")
+	}
+
+	dn.contId = resp.ID
+
+	if err := dn.cl.ContainerStart(ctx, dn.contId,
+		types.ContainerStartOptions{}); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot start container")
+	}
+
+	return nil
+}
+
+// removeAllContainers removes all running containers by force.
+func (dn *dockerNode) removeAllContainers(ctx context.Context) error {
+	filter := filters.NewArgs(filters.Arg("ancestor", imageName))
+	conts, err := dn.cl.ContainerList(ctx,
+		types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot list all conts")
+	}
+	for _, cont := range conts {
+		err := dn.cl.ContainerRemove(ctx, cont.ID,
+			types.ContainerRemoveOptions{Force: true})
+		if err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "cannot remove cont %s", cont.Names)
+		}
+	}
+	return nil
+}
+
+type execResult struct {
+	stdOut   string
+	stdErr   string
+	exitCode int
+}
+
+// InspectExecResp inspects the result of a docker command execution, saves its
+// stdout, stderr message and exit code to an execResult, and returns this
+// execResult and a possible error.
+func (dn *dockerNode) InspectExecResp(ctx context.Context, execId string) (execResult, error) {
+	var execRes execResult
+	resp, err := dn.cl.ContainerExecAttach(ctx, execId, types.ExecStartCheck{})
+	if err != nil {
+		return execResult{}, err
+	}
+	defer resp.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	outputDone := make(chan error)
+
+	go func() {
+		_, err = stdcopy.StdCopy(&outBuf, &errBuf, resp.Reader)
+		outputDone <- err
+	}()
+
+	select {
+	case err := <-outputDone:
+		if err != nil {
+			return execRes, err
+		}
+		break
+
+	case <-ctx.Done():
+		return execRes, ctx.Err()
+	}
+
+	stdout, err := ioutil.ReadAll(&outBuf)
+	if err != nil {
+		return execRes, err
+	}
+	stderr, err := ioutil.ReadAll(&errBuf)
+	if err != nil {
+		return execRes, err
+	}
+
+	res, err := dn.cl.ContainerExecInspect(ctx, execId)
+	if err != nil {
+		return execRes, err
+	}
+
+	execRes.exitCode = res.ExitCode
+	execRes.stdOut = string(stdout)
+	execRes.stdErr = string(stderr)
+	return execRes, nil
+}
+
+// execCommand is to execute command in the current container, and returns the
+// execution result and possible error.
+func (dn *dockerNode) execCommand(
+	ctx context.Context, cmd []string, workingDir string,
+) (*execResult, error) {
+	execId, err := dn.cl.ContainerExecCreate(ctx, dn.contId, types.ExecConfig{
+		User:         "root",
+		AttachStderr: true,
+		AttachStdout: true,
+		Tty:          true,
+		Cmd:          cmd,
+		WorkingDir:   workingDir,
+	})
+
+	if err != nil {
+		return nil, errors.NewAssertionErrorWithWrappedErrf(
+			err,
+			"cannot create command \"%s\"",
+			strings.Join(cmd, " "),
+		)
+	}
+
+	res, err := dn.InspectExecResp(ctx, execId.ID)
+	if err != nil {
+		return nil, errors.NewAssertionErrorWithWrappedErrf(
+			err,
+			"cannot execute command \"%s\"",
+			strings.Join(cmd[:], " "),
+		)
+	}
+
+	if res.exitCode != 0 {
+		return &res, errors.NewAssertionErrorWithWrappedErrf(
+			errors.Newf("%s", res.stdErr),
+			"command \"%s\" exit with code %d:\n %+v",
+			strings.Join(cmd[:], " "),
+			res.exitCode,
+			res)
+	}
+
+	return &res, nil
+}
+
+// waitServerStarts waits till the server truly starts or timeout, whichever
+// earlier. It keeps listening to the listenUrlFile till it is closed and
+// written. This is because in #70238, the improved init process for single-node
+// server is to start the server, run the init process, and then restart the
+// server. We mark it as fully started until the server is successfully
+// restarted, and hence write the url to listenUrlFile.
+func (dn *dockerNode) waitServerStarts(ctx context.Context) error {
+	var res *execResult
+	var err error
+
+	// Run the file which listen to the /cockroach folder until ei
+	res, err = dn.execCommand(ctx, []string{
+		"./docker-fsnotify",
+		"/cockroach",
+		listenUrlFile,
+		fmt.Sprint(serverStartTimeout),
+	}, "/cockroach")
+
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot run fsnotify to listen to %s:\nres:%s", listenUrlFile, res)
+	}
+
+	if res.stdOut == "finished\r\n" {
+		return nil
+	} else {
+		return errors.NewAssertionErrorWithWrappedErrf(errors.Newf("%s", res.stdErr), "error in waiting the server to start")
+	}
+}
+
+// execSqlQuery executes the sql query and returns the server's output and
+// possible error.
+func (dn *dockerNode) execSqlQuery(
+	ctx context.Context, sqlQuery string, sqlQueryOpts []string,
+) (*execResult, error) {
+	query := append([]string{cockroachEntrypoint, "sql", "-e", sqlQuery},
+		sqlQueryOpts...,
+	)
+
+	res, err := dn.execCommand(ctx, query, "/cockroach")
+	if err != nil {
+		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error executing query \"%s\"", sqlQuery)
+	}
+
+	return res, nil
+}
+
+//rmContainer performs a forced deletion of the current container.
+func (dn *dockerNode) rmContainer(ctx context.Context) error {
+	if err := dn.cl.ContainerRemove(ctx, dn.contId, types.ContainerRemoveOptions{
+		Force: true,
+	}); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "cannot remove container %s", dn.contId)
+	}
+	dn.contId = ""
+	return nil
+}
+
+// cleanSqlOutput format the output of sql query to be easier to compare
+// with the expected result.
+func cleanSqlOutput(s string) string {
+	trimDash := regexp.MustCompile(`(\n|^)(\-|\+){3,}`)
+	trimNewline := regexp.MustCompile(`(\r|\n){2,}`)
+	trimTime := regexp.MustCompile(`\nTime:(.|\s)+`)
+	trimRow := regexp.MustCompile(`\n\(\d+ rows?\)`)
+	trimSpace := regexp.MustCompile(`\n\s{1,}`)
+
+	var res string
+
+	res = strings.TrimSpace(s)
+	res = trimDash.ReplaceAllString(res, "")
+	res = trimNewline.ReplaceAllString(res, "\n")
+	res = trimTime.ReplaceAllString(res, "")
+	res = trimRow.ReplaceAllString(res, "")
+	res = trimSpace.ReplaceAllString(res, "\n")
+
+	return res
+}

--- a/pkg/testutils/docker/single_node_docker_test.go
+++ b/pkg/testutils/docker/single_node_docker_test.go
@@ -1,0 +1,258 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+const upstreamArtifactsPath = "/home/agent/work/.go/src/github.com/cockroachdb/cockroach/upstream_artifacts"
+
+// sqlQuery consists of a sql query and the expected result.
+type sqlQuery struct {
+	query          string
+	expectedResult string
+}
+
+// runContainerArgs are equivalent to arguments passed to a `docker run `
+// command.
+type runContainerArgs struct {
+	// envSetting is to set the environment variables.
+	envSetting []string
+	// volSetting is to set how local directories will be mounted to the container.
+	volSetting []string
+	// cmd is the command to run when starting the container.
+	cmd []string
+}
+
+// singleNodeDockerTest consists of two main parts: start the container with
+// a single-node cockroach server using runContainerArgs,
+// and execute sql queries in this running container.
+type singleNodeDockerTest struct {
+	testName         string
+	runContainerArgs runContainerArgs
+	containerName    string
+	// sqlOpts are arguments passed to a `cockroach sql` command.
+	sqlOpts []string
+	// sqlQueries are queries to run in this container, and their expected results.
+	sqlQueries []sqlQuery
+}
+
+func TestSingleNodeDocker(t *testing.T) {
+
+	ctx := context.Background()
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(errors.NewAssertionErrorWithWrappedErrf(err, "cannot get pwd"))
+	}
+
+	var dockerTests = []singleNodeDockerTest{
+		{
+			testName:      "single-node-insecure-mode",
+			containerName: "roach0",
+			runContainerArgs: runContainerArgs{
+				envSetting: []string{
+					"COCKROACH_DATABASE=mydb",
+				},
+				volSetting: []string{
+					fmt.Sprintf("%s/cockroach-data/roach0:/cockroach/cockroach-data", pwd),
+					fmt.Sprintf("%s/docker-fsnotify/:/cockroach/docker-fsnotify", upstreamArtifactsPath),
+				},
+				cmd: []string{"start-single-node", "--insecure"},
+			},
+			sqlOpts: []string{
+				"--insecure",
+				"--database=mydb",
+			},
+			sqlQueries: []sqlQuery{
+				{"SELECT current_user", "current_user\nroot"},
+				{"SELECT current_database()", "current_database\nmydb"},
+				{"CREATE DATABASE newdb", "CREATE DATABASE"},
+				{"USE newdb", "SET"},
+				{"CREATE TABLE hello (X INT)", "CREATE TABLE"},
+				{"INSERT INTO hello VALUES (1), (2), (3)", "INSERT 3"},
+				{"SELECT * FROM hello", "x\n1\n2\n3"},
+			},
+		},
+
+		{
+			testName:      "single-node-certs-mode",
+			containerName: "roach1",
+			runContainerArgs: runContainerArgs{
+				envSetting: []string{
+					"COCKROACH_DATABASE=mydb",
+					"COCKROACH_USER=myuser",
+					"COCKROACH_PASSWORD=23333",
+				},
+				volSetting: []string{
+					fmt.Sprintf("%s/cockroach-data/roach1:/cockroach/cockroach-data",
+						pwd),
+					fmt.Sprintf("%s/testdata/single-node-test/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d", pwd),
+					fmt.Sprintf("%s/docker-fsnotify/:/cockroach/docker-fsnotify", upstreamArtifactsPath),
+				},
+				cmd: []string{"start-single-node", "--certs-dir=certs"},
+			},
+			sqlOpts: []string{
+				"--certs-dir=certs",
+				"--user=myuser",
+				"--url=postgresql://myuser:23333@127.0.0.1:26257/mydb?sslcert=certs%2Fclient.myuser.crt&sslkey=certs%2Fclient.myuser.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt",
+			},
+			sqlQueries: []sqlQuery{
+				{"SELECT current_user", "current_user\nmyuser"},
+				{"SELECT current_database()", "current_database\nmydb"},
+				{"CREATE TABLE hello (X INT)", "CREATE TABLE"},
+				{"INSERT INTO hello VALUES (1), (2), (3)", "INSERT 3"},
+				{"SELECT * FROM hello", "x\n1\n2\n3"},
+				{"SELECT * FROM bello", "id | name\n1 | a\n2 | b\n3 | c"},
+			},
+		},
+		{
+			testName:      "single-node-insecure-mode-improved",
+			containerName: "roach2",
+			runContainerArgs: runContainerArgs{
+				envSetting: []string{
+					"COCKROACH_DATABASE=mydb",
+				},
+				volSetting: []string{
+					fmt.Sprintf("%s/cockroach-data/roach2:/cockroach/cockroach-data", pwd),
+					fmt.Sprintf("%s/testdata/single-node-test/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d", pwd),
+					fmt.Sprintf("%s/docker-fsnotify/:/cockroach/docker-fsnotify", upstreamArtifactsPath),
+				},
+				cmd: []string{"start-single-node", "--insecure"},
+			},
+			sqlOpts: []string{
+				"--insecure",
+				"--database=mydb",
+			},
+			sqlQueries: []sqlQuery{
+				{"SELECT current_user", "current_user\nroot"},
+				{"SELECT current_database()", "current_database\nmydb"},
+				{"CREATE TABLE hello (X INT)", "CREATE TABLE"},
+				{"INSERT INTO hello VALUES (1), (2), (3)", "INSERT 3"},
+				{"SELECT * FROM hello", "x\n1\n2\n3"},
+				{"SELECT * FROM bello", "id | name\n1 | a\n2 | b\n3 | c"},
+			},
+		},
+	}
+
+	cl, err := client.NewClientWithOpts(client.FromEnv)
+	cl.NegotiateAPIVersion(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	dn := dockerNode{
+		cl: cl,
+	}
+
+	if err := removeLocalData(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := contextutil.RunWithTimeout(
+		ctx,
+		"remove all containers using current image",
+		defaultTimeout*time.Second,
+		func(ctx context.Context) error {
+			return dn.removeAllContainers(ctx)
+		}); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for _, test := range dockerTests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			if err := contextutil.RunWithTimeout(
+				ctx,
+				"start container",
+				defaultTimeout*time.Second,
+				func(ctx context.Context) error {
+					return dn.startContainer(
+						ctx,
+						test.containerName,
+						test.runContainerArgs.envSetting,
+						test.runContainerArgs.volSetting,
+						test.runContainerArgs.cmd,
+					)
+				},
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := contextutil.RunWithTimeout(
+				ctx,
+				"wait for the server to fully start up",
+				serverStartTimeout*time.Second,
+				func(ctx context.Context) error {
+					return dn.waitServerStarts(ctx)
+				},
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := contextutil.RunWithTimeout(
+				ctx,
+				"show log",
+				defaultTimeout*time.Second,
+				func(ctx context.Context) error {
+					return dn.showContainerLog(ctx, fmt.Sprintf("%s.log", test.testName))
+				},
+			); err != nil {
+				log.Warningf(ctx, "cannot show container log: %v", err)
+			}
+
+			for _, qe := range test.sqlQueries {
+				query := qe.query
+				expected := qe.expectedResult
+
+				if err := contextutil.RunWithTimeout(
+					ctx,
+					fmt.Sprintf("execute command \"%s\"", query),
+					defaultTimeout*time.Second,
+					func(ctx context.Context) error {
+						resp, err := dn.execSqlQuery(ctx, query, test.sqlOpts)
+						if err != nil {
+							return err
+						}
+						if cleanSqlOutput(resp.stdOut) != expected {
+							return fmt.Errorf("executing %s, expect:\n%#v\n, got\n%#v\n", query, cleanSqlOutput(resp.stdOut), expected)
+						}
+						return nil
+					},
+				); err != nil {
+					t.Errorf("%v", err)
+				}
+			}
+
+			if err := contextutil.RunWithTimeout(
+				ctx,
+				"remove current container",
+				defaultTimeout*time.Second,
+				func(ctx context.Context) error {
+					return dn.rmContainer(ctx)
+				},
+			); err != nil {
+				t.Errorf("%v", err)
+			}
+
+		})
+	}
+
+}

--- a/pkg/testutils/docker/testdata/single-node-test/docker-entrypoint-initdb.d/hello.sql
+++ b/pkg/testutils/docker/testdata/single-node-test/docker-entrypoint-initdb.d/hello.sql
@@ -1,0 +1,8 @@
+USE mydb;
+
+CREATE TABLE bello (
+                      id INT UNIQUE,
+                      name varchar(12)
+);
+
+INSERT INTO bello (id, name) values (1, 'a'), (2, 'b'), (3, 'c');

--- a/pkg/testutils/docker/testdata/single-node-test/docker-entrypoint-initdb.d/yes.sql
+++ b/pkg/testutils/docker/testdata/single-node-test/docker-entrypoint-initdb.d/yes.sql
@@ -1,0 +1,10 @@
+-- tables
+-- Table: call
+CREATE TABLE donut (
+    id INT UNIQUE,
+    name varchar(12)
+);
+
+
+INSERT INTO donut (id, name) values (1, 'a'), (2, 'b'), (3, 'c');
+


### PR DESCRIPTION
**This is a draft commit to test the teamcity ci. Should never be merged.**

This commit is to add a test infrastructure for docker image in TeamCity using
bazel.
It downloads the docker image tar from an upstream build configuration
(not fully implemented yet, #72394 ), loads the docker image from the tar,
builds a docker container based on it, and runs SQL queries inside that
container.

Release note: None