### PR TITLE
scripts: use n2 machines for gceworker instances

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -28,7 +28,7 @@ case "${cmd}" in
 
     gcloud compute instances \
            create "${NAME}" \
-           --machine-type "custom-24-32768" \
+           --machine-type "n2-custom-24-32768" \
            --network "default" \
            --maintenance-policy "MIGRATE" \
            --image-project "ubuntu-os-cloud" \


### PR DESCRIPTION
Previously, we were using n1 machines with 24 cores. GCP also offers instances
with n2 machine types, and based on readings, they offer a ~30% performance
boost. The performance improvement can also be seen when compiling CRDB:
`make clean; time make build`.

On n1:

```
real    3m11.436s
user    40m41.905s
sys     4m1.509s
```

On n2 (~60 seconds faster):

```
real	2m12.232s
user	19m42.405s
sys     2m13.697s
```

Both machines cost roughly the same, though there is a lower sustained use
discount for the n2 machines. Estimated costs for the gceworker instances
are as follows: $0.68/hr (n1), $0.77/hr (n2). Since the costs do not differ
much, but the machines offer a huge performance benefit, we will now create 
new gceworker instances using n2 machines instead of n1 machines.

Note that existing machines won't be bumped to n2. They will need to be
recreated with the new machine types.

Release note: None