### PR TITLE
roachtest: ensure ssd count is not zero when using local ssd

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -195,6 +195,10 @@ func (s *ClusterSpec) RoachprodOpts(
 		// - if no particular volume size is requested, and,
 		// - on AWS, if the machine type supports it.
 		if s.PreferLocalSSD && s.VolumeSize == 0 && (s.Cloud != AWS || awsMachineSupportsSSD(machineType)) {
+			// Ensure SSD count is at least 1 if UseLocalSSD is true.
+			if s.SSDs == 0 {
+				s.SSDs = 1
+			}
 			createVMOpts.SSDOpts.UseLocalSSD = true
 			createVMOpts.SSDOpts.NoExt4Barrier = !useIOBarrier
 		} else {


### PR DESCRIPTION
Previously (when we used roachprod binary directly), we didn't
pass local ssd count if it's 0 and instead used roachprod's
binary default value (which is 1).

Now we use the library and need to explicitly pass the value.

Release note: None