### PR TITLE
kvserver: include data sizes in snapshot log messages

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -519,6 +520,7 @@ type IncomingSnapshot struct {
 	FromReplica       roachpb.ReplicaDescriptor
 	// The descriptor in the snapshot, never nil.
 	Desc             *roachpb.RangeDescriptor
+	DataSize         int64
 	snapType         SnapshotRequest_Type
 	placeholder      *ReplicaPlaceholder
 	raftAppliedIndex uint64 // logging only
@@ -816,6 +818,7 @@ func (r *Replica) applySnapshot(
 	defer func(start time.Time) {
 		var logDetails redact.StringBuilder
 		logDetails.Printf("total=%0.0fms", timeutil.Since(start).Seconds()*1000)
+		logDetails.Printf(" data=%s", humanizeutil.IBytes(inSnap.DataSize))
 		if len(subsumedRepls) > 0 {
 			logDetails.Printf(" subsumedReplicas=%d@%0.0fms",
 				len(subsumedRepls), stats.subsumedReplicas.Sub(start).Seconds()*1000)

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -165,7 +165,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 
 	msstw, err := newMultiSSTWriter(ctx, scratch, keyRanges, 0)
 	require.NoError(t, err)
-	err = msstw.Finish(ctx)
+	_, err = msstw.Finish(ctx)
 	require.NoError(t, err)
 
 	var actualSSTs [][]byte


### PR DESCRIPTION
Previously, Raft log messages did not include information about the
snapshot size. This patch adds logging of sent bytes on the sender side,
and SST data size on the receiver side. These values may differ.

```
[n3,replicate,s3,r69/3:‹/Table/52/1/-92222461369472…›] 347 streamed INITIAL snapshot 70bcbab5 at applied index 57 to (n1,s1):4LEARNER with 49 MiB in 1.54s @ 32 MiB/s: kv pairs: 48043, rate-limit: 32 MiB/s, queued: 0.00s
[n1,s1,r69/4:{-}] 805 applying INITIAL snapshot 70bcbab5 from (n3,s3):3 at applied index 57
[n1,s1,r69/4:‹/Table/52/1/-92222461369472…›] 806 applied INITIAL snapshot 70bcbab5 from (n3,s3):3 at applied index 57 (total=64ms data=48 MiB ingestion=6@61ms)
```

Release note: None