### PR TITLE
release-21.2: jobs: Add jitter to job scheduler.

### DIFF
--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -214,20 +214,22 @@ func TestJobSchedulerDaemonGetWaitPeriod(t *testing.T) {
 	sv, cleanup := getScopedSettings()
 	defer cleanup()
 
+	noJitter := func(d time.Duration) time.Duration { return d }
+
 	schedulerEnabledSetting.Override(ctx, sv, false)
 
 	// When disabled, we wait 5 minutes before rechecking.
-	require.EqualValues(t, 5*time.Minute, getWaitPeriod(sv, nil))
+	require.EqualValues(t, 5*time.Minute, getWaitPeriod(ctx, sv, noJitter, nil))
 	schedulerEnabledSetting.Override(ctx, sv, true)
 
 	// When pace is too low, we use something more reasonable.
 	schedulerPaceSetting.Override(ctx, sv, time.Nanosecond)
-	require.EqualValues(t, minPacePeriod, getWaitPeriod(sv, nil))
+	require.EqualValues(t, minPacePeriod, getWaitPeriod(ctx, sv, noJitter, nil))
 
 	// Otherwise, we use user specified setting.
 	pace := 42 * time.Second
 	schedulerPaceSetting.Override(ctx, sv, pace)
-	require.EqualValues(t, pace, getWaitPeriod(sv, nil))
+	require.EqualValues(t, pace, getWaitPeriod(ctx, sv, noJitter, nil))
 }
 
 type recordScheduleExecutor struct {


### PR DESCRIPTION
Backport 1/1 commits from #73191.

/cc @cockroachdb/release

---

Add jitter to job scheduler loop.
Informs #73133

Release Notes: none
