### PR TITLE
ui: fix db console nits noticed after 21.2 release

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -258,7 +258,6 @@ export class NodeGraphs extends React.Component<
       ? selectedDashboard
       : defaultDashboard;
 
-    const title = dashboards[dashboard].label + " Dashboard";
     const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
     const nodeSources = selectedNode !== "" ? [selectedNode] : null;
 
@@ -327,8 +326,8 @@ export class NodeGraphs extends React.Component<
 
     return (
       <div style={{ paddingBottom }}>
-        <Helmet title={title} />
-        <h3 className="base-heading">{title}</h3>
+        <Helmet title={"Metrics"} />
+        <h3 className="base-heading">Metrics</h3>
         <PageConfig>
           <PageConfigItem>
             <Dropdown

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -465,9 +465,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     return (
       <Fragment>
         <Helmet title="Network Diagnostics | Debug" />
-        <div className="section">
-          <h1 className="base-heading">Network Diagnostics</h1>
-        </div>
+        <h3 className="base-heading">Network Diagnostics</h3>
         <Loading
           loading={!contentAvailable(nodesSummary)}
           error={this.props.nodeSummaryErrors}

--- a/pkg/ui/workspaces/db-console/styl/pages/reports.styl
+++ b/pkg/ui/workspaces/db-console/styl/pages/reports.styl
@@ -182,7 +182,7 @@ $reports-table
     alternating-background white $table-border-color
 
     &&--header
-      background-color green
+      background-color $grey
 
     &&--warning
       color $alert-color


### PR DESCRIPTION
Issues resolved were not introduced by 21.2. Just noticed after the release.

Changes include:
- Removing the old green branding from the problem ranges table
- Making the title of the Metrics page consistent across all metrics dashboards
- Adjusting the font size and alignment of the Network Diagnostics title

Release note (ui change): Visual improvements to db console

Original Report:
https://github.com/cockroachdb/cockroach/issues/72783