### PR TITLE
ci: in bazel roachtest nightlies, symlink `lib` to `lib.docker_amd64`

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -20,4 +20,4 @@ chmod o+rwx lib.docker_amd64
 cp $BAZEL_BIN/c-deps/libgeos/lib/libgeos.so   lib.docker_amd64
 cp $BAZEL_BIN/c-deps/libgeos/lib/libgeos_c.so lib.docker_amd64
 chmod a+w lib.docker_amd64/libgeos.so lib.docker_amd64/libgeos_c.so
-
+ln -s lib.docker_amd64 lib


### PR DESCRIPTION
`build/builder.sh` mounts `lib.docker_amd64` as a volume pointing to the
`lib` directory, so in effect the two directories both exist and have
the same contents. I think that manually setting up this symlink should
quash some "no location to init `GEOS`" errors we
[are seeing](https://teamcity.cockroachdb.com/viewLog.html?buildId=3810253&buildTypeId=Cockroach_Nightlies_RoachtestNightlyGceBazel).