### PR TITLE
workflow: add a stale checker for backports

### DIFF
--- a/.github/workflows/backport-stale.yml
+++ b/.github/workflows/backport-stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale backport requests
+
+on:
+  schedule:
+  - cron: "0 10 * * 1-4"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v3
+      with:
+        operations-per-run: 1000
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Blah'
+        stale-pr-message: 'Reminder: it has been 3 weeks please merge or close your backport!'
+        stale-issue-label: 'no-backport-issue-activity'
+        stale-pr-label: 'no-backport-pr-activity'
+        close-issue-label: 'X-stale'
+        close-pr-label: 'X-stale'
+        days-before-pr-stale: 21
+        # Disable this for issues, by setting a very high bar
+        days-before-issue-stale: 99999
+        days-before-close: 99999
+        any-of-labels: 'blathers-backport'


### PR DESCRIPTION
Ping a backport PR after 3 weeks to nudge the author
to merge or close. This will not auto-close prs, just a single nudge. 

Release note: None