### PR TITLE
jobs: clean up a few log messages

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2626,7 +2626,7 @@ func TestChangefeedJobUpdateFailsIfNotClaimed(t *testing.T) {
 			require.Error(t, err)
 			// TODO(ssd): Replace this error in the jobs system with
 			// an error type we can check against.
-			require.Contains(t, err.Error(), fmt.Sprintf("expected session '%s' but found NULL", testSession.ID().String()))
+			require.Contains(t, err.Error(), fmt.Sprintf("expected session \"%s\" but found NULL", testSession.ID().String()))
 		case <-time.After(5 * time.Second):
 			t.Fatal("expected distflow to fail but it hasn't after 5 seconds")
 		}

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -3145,7 +3145,7 @@ func TestLoseLeaseDuringExecution(t *testing.T) {
 	_, err := registry.CreateJobWithTxn(ctx, rec, registry.MakeJobID(), nil)
 	require.NoError(t, err)
 	registry.TestingNudgeAdoptionQueue()
-	require.Regexp(t, `expected session '\w+' but found NULL`, <-resumed)
+	require.Regexp(t, `expected session "\w+" but found NULL`, <-resumed)
 }
 
 func checkBundle(t *testing.T, zipFile string, expectedFiles []string) {


### PR DESCRIPTION
Before we logged the raw strings underlying the SessionID and
Status. Using our custom types means that the String method on these
types is called when printing and ensures the values aren't redacted.

Before:

```
jobs/registry.go:1179 ⋮ [n1] 134 CHANGEFEED job
714787710619222017: stepping through state reverting with error:
job 714787710619222017: with status '‹'running'›': expected
session '5d5195aa8ff74ae58868777451ad8e38' but found '‹V?|Eܤ8i›'
```

After:

```
jobs/registry.go:1179 ⋮ [n1] 92 CHANGEFEED job
714787710619222017: stepping through state reverting with error:
job 714787710619222017: with status 'running': expected session
'858f831075f94d4da9824c01125e1c99' but found
'df3328ed7e6e4a558c7c33b616b28d59'
```

Release note: None