### PR TITLE
sql: fix TestRandomSyntaxSelect

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -167,7 +167,10 @@ func (db *verifyFormatDB) execWithTimeout(
 			}
 			// TODO(yuzefovich): allow "no volatility for cast tuple" errors to
 			// fail once #70831 is resolved.
-			if es := err.Error(); (strings.Contains(es, "internal error") && !strings.Contains(es, "no volatility for cast tuple")) ||
+			if es := err.Error(); (strings.Contains(es, "internal error") &&
+				!strings.Contains(es, "no volatility for cast tuple")) ||
+				!strings.Contains(es, "comparison overload not found (ne, tuple, string)") ||
+				!strings.Contains(es, "comparison overload not found (eq, tuple, string)") ||
 				strings.Contains(es, "driver: bad connection") ||
 				strings.Contains(es, "unexpected error inside CockroachDB") {
 				return &crasher{


### PR DESCRIPTION
Ignore the error if the given random query needs comparison between tuple and
string.

Fixes https://github.com/cockroachdb/cockroach/issues/72257

Release note: None