### PR TITLE
changefeedccl: Avoid setting flush frequency to 0.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -184,11 +184,10 @@ func newChangeAggregatorProcessor(
 		if err != nil {
 			return nil, err
 		}
-	} else if r == `` {
-		ca.flushFrequency = 0
 	} else {
 		ca.flushFrequency = changefeedbase.DefaultMinCheckpointFrequency
 	}
+
 	return ca, nil
 }
 


### PR DESCRIPTION
Avoid  setting flush frequency to 0 when `min_flush_frequency`
left unspecified.  Doing so results in each frontier update to
be forwarded to the change frontier processor.

Fixes #72808

Release Notes: None