### PR TITLE
roachprod: add start-tenant command

### DIFF
--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "roachprod",
     srcs = [
         "clusters_cache.go",
+        "multitenant.go",
         "roachprod.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -209,15 +209,6 @@ func (c *SyncedCluster) roachprodEnvRegex(node Node) string {
 	return fmt.Sprintf(`ROACHPROD=%s[ \/]`, escaped)
 }
 
-// StartOpts houses the options needed by Start().
-type StartOpts struct {
-	Encrypt    bool
-	Sequential bool
-	SkipInit   bool
-	StoreCount int
-	ExtraArgs  []string
-}
-
 func (c *SyncedCluster) newSession(node Node) (session, error) {
 	if c.IsLocal() {
 		return newLocalSession(), nil

--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -17,7 +17,6 @@ set -euo pipefail
 LOCAL=#{if .Local#}true#{end#}
 LOG_DIR=#{shesc .LogDir#}
 BINARY=#{shesc .Binary#}
-START_CMD=#{shesc .StartCmd#}
 KEY_CMD=#{.KeyCmd#}
 MEMORY_MAX=#{.MemoryMax#}
 ARGS=(
@@ -46,7 +45,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
   CODE=0
-  "${BINARY}" "${START_CMD}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi

--- a/pkg/roachprod/install/start_template_test.go
+++ b/pkg/roachprod/install/start_template_test.go
@@ -25,8 +25,7 @@ func TestExecStartTemplate(t *testing.T) {
 echo bar $HOME`,
 		EnvVars:   []string{"ROACHPROD=1/tigtag", "COCKROACH=foo", "ROCKCOACH=17%"},
 		Binary:    "./cockroach",
-		StartCmd:  "start-single-node",
-		Args:      []string{`--log "file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}"`},
+		Args:      []string{`start`, `--log`, `file-defaults: {dir: '/path with spaces/logs', exit-on-error: false}`},
 		MemoryMax: "81%",
 		Local:     true,
 	}

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -20,12 +20,13 @@ set -euo pipefail
 LOCAL=true
 LOG_DIR='./path with spaces/logs/$THIS_DOES_NOT_EVER_GET_EXPANDED'
 BINARY=./cockroach
-START_CMD=start-single-node
 KEY_CMD=echo foo && \
 echo bar $HOME
 MEMORY_MAX=81%
 ARGS=(
-'--log "file-defaults: {dir: '"'"'/path with spaces/logs'"'"', exit-on-error: false}"'
+start
+--log
+'file-defaults: {dir: '"'"'/path with spaces/logs'"'"', exit-on-error: false}'
 )
 ENV_VARS=(
 ROACHPROD=1/tigtag
@@ -48,7 +49,7 @@ if [[ -n "${LOCAL}" || "${1-}" == "run" ]]; then
   # NB: ENV_VARS is never empty.
   export "${ENV_VARS[@]}"
   CODE=0
-  "${BINARY}" "${START_CMD}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
+  "${BINARY}" "${ARGS[@]}" >> "${LOG_DIR}/cockroach.stdout.log" 2>> "${LOG_DIR}/cockroach.stderr.log" || CODE="$?"
   if [[ -z "${LOCAL}" || "${CODE}" -ne 0 ]]; then
     echo "cockroach exited with code ${CODE}: $(date)" | tee -a "${LOG_DIR}"/{roachprod,cockroach.{exit,std{out,err}}}.log
   fi

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachprod
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/errors"
+)
+
+// StartTenant starts nodes on a cluster in "tenant" mode (each node is a SQL
+// instance). A tenant cluster needs an existing, running host cluster. The
+// tenant metadata is created on the host cluster if it doesn't exist already.
+//
+// The host and tenant can use the same underlying cluster, as long as different
+// subsets of nodes are selected (e.g. "local:1,2" and "local:3,4").
+func StartTenant(
+	tenantCluster string,
+	hostCluster string,
+	startOpts install.StartOpts,
+	clusterSettingsOpts ...install.ClusterSettingOption,
+) error {
+	tc, err := newCluster(tenantCluster, clusterSettingsOpts...)
+	if err != nil {
+		return err
+	}
+
+	// TODO(radu): do we need separate clusterSettingsOpts for the host cluster?
+	hc, err := newCluster(hostCluster, clusterSettingsOpts...)
+	if err != nil {
+		return err
+	}
+
+	if tc.Name == hc.Name {
+		// We allow using the same cluster, but the node sets must be disjoint.
+		for _, n1 := range tc.Nodes {
+			for _, n2 := range hc.Nodes {
+				if n1 == n2 {
+					return errors.Errorf("host and tenant nodes must be disjoint")
+				}
+			}
+		}
+	}
+
+	if tc.Secure {
+		// TODO(radu): implement secure mode.
+		return errors.Errorf("secure mode not implemented for tenants yet")
+	}
+
+	startOpts.Target = install.StartTenantSQL
+	if startOpts.TenantID < 2 {
+		return errors.Errorf("invalid tenant ID %d (must be 2 or higher)", startOpts.TenantID)
+	}
+
+	// Create tenant, if necessary. We need to run this SQL against a single host,
+	// so temporarily restrict the target nodes to 1.
+	saveNodes := hc.Nodes
+	hc.Nodes = hc.Nodes[:1]
+	fmt.Printf("Creating tenant metadata\n")
+	if err := hc.RunSQL([]string{
+		`-e`,
+		fmt.Sprintf(createTenantIfNotExistsQuery, startOpts.TenantID),
+	}); err != nil {
+		return err
+	}
+	hc.Nodes = saveNodes
+
+	var kvAddrs []string
+	for _, node := range hc.Nodes {
+		kvAddrs = append(kvAddrs, fmt.Sprintf("%s:%d", hc.Host(node), hc.NodePort(node)))
+	}
+	startOpts.KVAddrs = strings.Join(kvAddrs, ",")
+	return tc.Start(startOpts)
+}
+
+// createTenantIfNotExistsQuery is used to initialize the tenant metadata, if
+// it's not initialized already. We set up the tenant with a lot of initial RUs
+// so that we don't encounter throttling by default.
+const createTenantIfNotExistsQuery = `
+SELECT
+  CASE (SELECT 1 FROM system.tenants WHERE id = %[1]d) IS NULL
+  WHEN true
+  THEN (
+    crdb_internal.create_tenant(%[1]d),
+    crdb_internal.update_tenant_resource_limits(%[1]d, 1000000000, 10000, 0, now(), 0)
+  )::STRING
+  ELSE 'already exists'
+  END;`


### PR DESCRIPTION
This commit adds a new `start-tenant` command, which starts a set of
SQL instances for a tenant, against a given host cluster.

For example:
```
roachprod create local-host -n 3
roachprod start local-host
roachprod create local-tenant -n 2
roachprod start-tenant local-tenant --host-cluster local-host
roachprod sql local-tenant
```

Note that non-overlapping subsets of nodes of the same cluster can be
used as well (but it can be more confusing):
```
roachprod create local
roachprod start local:1-2
roachprod start-tenant local:3-4 --host-cluster local:1-2
roachprod sql local:3
```

Multiple tenants can be started by passing different `--tenant-id`
(which defaults to 2).

In future work, we will add the capability of starting a tenant proxy,
as well as higher-level commands for creating and starting an entire
host+tenants deployment.

Note that only insecure clusters are supported for now.

Release note: None