### PR TITLE
sql: make sure session data is initialized properly

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -374,7 +374,7 @@ func TestAvroSchema(t *testing.T) {
 
 			for _, row := range rows {
 				evalCtx := &tree.EvalContext{
-					SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+					SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 				}
 				serialized, err := origSchema.textualFromRow(row)
 				require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -89,7 +89,7 @@ func New(
 		settings:          cfg.Settings,
 		targets:           targets,
 		leaseMgr:          cfg.LeaseManager.(*lease.Manager),
-		ie:                cfg.SessionBoundInternalExecutorFactory(ctx, &sessiondata.SessionData{}),
+		ie:                cfg.SessionBoundInternalExecutorFactory(ctx, sessiondata.NewSessionData()),
 		collectionFactory: cfg.CollectionFactory,
 		metrics:           metrics,
 	}

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -178,7 +178,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 			wc := importccl.NewWorkloadKVConverter(
 				0, tableDesc, t.InitialRows, 0, t.InitialRows.NumBatches, kvCh)
 			evalCtx := &tree.EvalContext{
-				SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+				SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 				Codec:            keys.SystemSQLCodec,
 			}
 			semaCtx := tree.MakeSemaContext()

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -167,7 +167,7 @@ func MakeSimpleTableDescriptor(
 		Context:            ctx,
 		Sequence:           &importSequenceOperators{},
 		Regions:            makeImportRegionOperator(""),
-		SessionDataStack:   sessiondata.NewStack(&sessiondata.SessionData{}),
+		SessionDataStack:   sessiondata.NewStack(sessiondata.NewSessionData()),
 		ClientNoticeSender: &faketreeeval.DummyClientNoticeSender{},
 		Settings:           st,
 	}

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -15,7 +15,6 @@ import (
 	"math"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
@@ -86,14 +85,10 @@ func descForTable(
 }
 
 var testEvalCtx = &tree.EvalContext{
-	SessionDataStack: sessiondata.NewStack(
-		&sessiondata.SessionData{
-			Location: time.UTC,
-		},
-	),
-	StmtTimestamp: timeutil.Unix(100000000, 0),
-	Settings:      cluster.MakeTestingClusterSettings(),
-	Codec:         keys.SystemSQLCodec,
+	SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
+	StmtTimestamp:    timeutil.Unix(100000000, 0),
+	Settings:         cluster.MakeTestingClusterSettings(),
+	Codec:            keys.SystemSQLCodec,
 }
 
 // Value generator represents a value of some data at specified row/col.

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -82,7 +82,7 @@ func ToSSTable(t workload.Table, tableID descpb.ID, ts time.Time) ([]byte, error
 	g.GoCtx(func(ctx context.Context) error {
 		defer close(kvCh)
 		evalCtx := &tree.EvalContext{
-			SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+			SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 			Codec:            keys.SystemSQLCodec,
 		}
 		semaCtx := tree.MakeSemaContext()

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -690,19 +689,12 @@ func (s *Server) GetLocalIndexStatistics() *idxusage.LocalIndexUsageStats {
 
 // newSessionData a SessionData that can be passed to newConnExecutor.
 func (s *Server) newSessionData(args SessionArgs) *sessiondata.SessionData {
-	sd := &sessiondata.SessionData{
-		SessionData: sessiondatapb.SessionData{
-			UserProto: args.User.EncodeProto(),
-		},
-		LocalUnmigratableSessionData: sessiondata.LocalUnmigratableSessionData{
-			RemoteAddr: args.RemoteAddr,
-		},
-		LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
-			ResultsBufferSize: args.ConnResultsBufferSize,
-			IsSuperuser:       args.IsSuperuser,
-			CustomOptions:     make(map[string]string),
-		},
-	}
+	sd := sessiondata.NewSessionData()
+	sd.SessionData.UserProto = args.User.EncodeProto()
+	sd.LocalUnmigratableSessionData.RemoteAddr = args.RemoteAddr
+	sd.LocalOnlySessionData.ResultsBufferSize = args.ConnResultsBufferSize
+	sd.LocalOnlySessionData.IsSuperuser = args.IsSuperuser
+	sd.LocalOnlySessionData.CustomOptions = make(map[string]string)
 	for k, v := range args.CustomOptionSessionDefaults {
 		sd.CustomOptions[k] = v
 	}

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -109,16 +109,11 @@ func TestTraceAnalyzer(t *testing.T) {
 		execCtx, finishAndCollect := tracing.ContextWithRecordingSpan(ctx, execCfg.AmbientCtx.Tracer, t.Name())
 		defer finishAndCollect()
 		ie := execCfg.InternalExecutor
-		ie.SetSessionData(
-			&sessiondata.SessionData{
-				SessionData: sessiondatapb.SessionData{
-					VectorizeMode: vectorizeMode,
-				},
-				LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
-					DistSQLMode: sessiondatapb.DistSQLOn,
-				},
-			},
-		)
+		sd := sessiondata.NewSessionData()
+		sd.SessionData.VectorizeMode = vectorizeMode
+		sd.LocalOnlySessionData.DistSQLMode = sessiondatapb.DistSQLOn
+		ie.SetSessionData(sd)
+
 		_, err := ie.ExecEx(
 			execCtx,
 			t.Name(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -169,9 +169,9 @@ func (ie *InternalExecutor) initConnEx(
 		appStatsBucketName = sd.ApplicationName
 	}
 	applicationStats := ie.s.sqlStats.GetApplicationStats(appStatsBucketName)
-
 	sds := sessiondata.NewStack(sd)
 	sdMutIterator := ie.s.makeSessionDataMutatorIterator(sds, nil /* sessionDefaults */)
+
 	var ex *connExecutor
 	if txn == nil {
 		ex = ie.s.newConnExecutor(

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -298,15 +298,15 @@ func newInternalPlanner(
 	// suitable contexts.
 	ctx := logtags.AddTag(context.Background(), opName, "")
 
-	sd := &sessiondata.SessionData{
-		SessionData:   sessionData,
-		SearchPath:    sessiondata.DefaultSearchPathForUser(user),
-		SequenceState: sessiondata.NewSequenceState(),
-		Location:      time.UTC,
-	}
+	sd := sessiondata.NewSessionData()
+	sd.SessionData = sessionData
+	sd.SearchPath = sessiondata.DefaultSearchPathForUser(user)
+	sd.SequenceState = sessiondata.NewSequenceState()
+	sd.Location = time.UTC
 	sd.SessionData.Database = "system"
 	sd.SessionData.UserProto = user.EncodeProto()
 	sd.SessionData.Internal = true
+
 	sds := sessiondata.NewStack(sd)
 
 	if params.collection == nil {

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -883,9 +883,7 @@ func TestDTimeTZ(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := &tree.EvalContext{
-		SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{
-			Location: time.UTC,
-		}),
+		SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 	}
 
 	maxTime, depOnCtx, err := tree.ParseDTimeTZ(ctx, "24:00:00-1559", time.Microsecond)

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -140,12 +140,9 @@ func TestCompareTimestamps(t *testing.T) {
 			tc.desc,
 			func(t *testing.T) {
 				ctx := &EvalContext{
-					SessionDataStack: sessiondata.NewStack(
-						&sessiondata.SessionData{
-							Location: tc.location,
-						},
-					),
+					SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 				}
+				ctx.SessionData().Location = tc.location
 				res, err := compareTimestamps(ctx, tc.left, tc.right)
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expected, res)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3664,7 +3664,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 	ctx := EvalContext{
 		Codec:            keys.SystemSQLCodec,
 		Txn:              &kv.Txn{},
-		SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+		SessionDataStack: sessiondata.NewStack(sessiondata.NewSessionData()),
 		Settings:         st,
 		NodeID:           base.TestingIDContainer,
 	}

--- a/pkg/sql/sem/tree/role_spec_test.go
+++ b/pkg/sql/sem/tree/role_spec_test.go
@@ -53,7 +53,7 @@ func TestRoleSpecValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		roleSpec := RoleSpec{RoleSpecType: RoleName, Name: tc.username}
-		normalized, err := roleSpec.ToSQLUsername(&sessiondata.SessionData{}, security.UsernameCreation)
+		normalized, err := roleSpec.ToSQLUsername(sessiondata.NewSessionData(), security.UsernameCreation)
 		if !testutils.IsError(err, tc.err) {
 			t.Errorf("%q: expected %q, got %v", tc.username, tc.err, err)
 			continue

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -305,3 +305,12 @@ func (s *Stack) PopAll() {
 func (s *Stack) Elems() []*SessionData {
 	return s.stack
 }
+
+// DefaultSessionData is a session data initialized with sessionVar initializer copied into new sessions.
+var DefaultSessionData SessionData
+
+// NewSessionData create a new session data with defaults populated.   See init in vars.go.
+func NewSessionData() *SessionData {
+	sd := DefaultSessionData
+	return &sd
+}


### PR DESCRIPTION
Previously real connection sessions defaults are installed appropriately
but for internal executor they weren't and most sessionVars were just
set to the the Go default.   Now all sessions are setup with their
sessionVar specified default values.
    
Release note: None