### PR TITLE
roachpb: treat GetRequests as non-directional in BatchRequest.Split

### DIFF
--- a/pkg/roachpb/batch_test.go
+++ b/pkg/roachpb/batch_test.go
@@ -93,6 +93,9 @@ func TestBatchSplit(t *testing.T) {
 		{[]Request{get, get, get, put, put, get, get}, []int{3, 2, 2}, true},
 		{[]Request{spl, get, scan, spl, get}, []int{1, 2, 1, 1}, true},
 		{[]Request{spl, spl, get, spl}, []int{1, 1, 1, 1}, true},
+		{[]Request{scan, get, scan, get}, []int{4}, true},
+		{[]Request{rv, get, rv, get}, []int{4}, true},
+		{[]Request{scan, get, rv, get}, []int{2, 2}, true},
 		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 1, 1}, true},
 		// Same one again, but this time don't allow EndTxn to be split.
 		{[]Request{get, scan, get, dr, rv, put, et}, []int{3, 1, 1, 2}, false},

--- a/pkg/sql/logictest/testdata/logic_test/sqllite
+++ b/pkg/sql/logictest/testdata/logic_test/sqllite
@@ -449,3 +449,16 @@ SELECT pk, col0 FROM tab64784 WHERE (col0 IN (SELECT col3 FROM tab64784 WHERE co
 4  216
 1  213
 0  212
+
+# Regression test for crashing when intertwining GetRequests and
+# ReverseScanRequests (which was mistakenly considered illegal).
+statement ok
+CREATE TABLE t73103(pk INT PRIMARY KEY, col0 INT, col1 INT, UNIQUE INDEX idx (col0), UNIQUE INDEX idx_storing (col0) STORING (col1));
+
+query II
+SELECT pk, col0 FROM t73103@idx WHERE col0 <= 63 OR col0 IN (27,11,93,41) ORDER BY 2 DESC
+----
+
+query II
+SELECT pk, col0 FROM t73103@idx_storing WHERE col0 <= 63 OR col0 IN (27,11,93,41) ORDER BY 2 DESC
+----


### PR DESCRIPTION
This commit updates `BatchRequest.Split` to treat `GetRequest`s as
non-directional so that batches with Gets and ReverseScans are not
split. Without this fix currently when reading from a secondary index
in the reverse direction, we might crash. This was exposed recently by
issueing the GetRequests for indexes without STORING clause, but it is
present on 21.2 for index with STORING clause.

Fixes: #73103.

Release note (bug fix): Previously, CockroachDB could crash when reading
of a secondary index with STORING clause in reverse direction (because
of ORDER BY col DESC). The bug was introduced in 21.2.