### PR TITLE
kv: detect context cancellation in limitBulkIOWrite, avoid log spam

### DIFF
--- a/pkg/kv/kvserver/replica_sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage.go
@@ -180,7 +180,9 @@ func (f *SSTSnapshotStorageFile) Write(contents []byte) (int, error) {
 	if err := f.ensureFile(); err != nil {
 		return 0, err
 	}
-	limitBulkIOWrite(f.ctx, f.scratch.storage.limiter, len(contents))
+	if err := limitBulkIOWrite(f.ctx, f.scratch.storage.limiter, len(contents)); err != nil {
+		return 0, err
+	}
 	return f.file.Write(contents)
 }
 

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -266,7 +266,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 					return noSnap, errors.Wrap(err, "failed to decode mvcc key")
 				}
 				if err := msstw.Put(ctx, key, batchReader.Value()); err != nil {
-					return noSnap, err
+					return noSnap, errors.Wrapf(err, "writing sst for raft snapshot")
 				}
 			}
 		}
@@ -276,7 +276,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			// we must still construct SSTs with range deletion tombstones to remove
 			// the data.
 			if err := msstw.Finish(ctx); err != nil {
-				return noSnap, err
+				return noSnap, errors.Wrapf(err, "finishing sst for raft snapshot")
 			}
 
 			msstw.Close()


### PR DESCRIPTION
This commit adds logic to propagate context cancellation in `limitBulkIOWrite`.
This function is used in two places, 1) when ingesting ssts, and 2) when
receiving a snapshot. The first case uses the Raft scheduler goroutine's
context, so it never gets cancelled. The second case uses the context of the
sender of a Raft snapshot, so it can get cancelled.

In customer clusters, we were seeing Raft snapshots hit their deadline and begin
spamming `error rate limiting bulk io write: context deadline exceeded` errors
messages. This was bad for two reasons. First, it was very noisy. Second, it
meant that a Raft snapshot that was no longer going to succeed was still writing
out full SSTs while holding on to the `snapshotApplySem`. This contributed to
the snapshot starvation we saw in the issue.

With this commit, `limitBulkIOWrite` will eagerly detect context cancellation
and will propagate the cancellation up to the caller, allowing the caller to
quickly release resources.

Release notes (bug fix): Raft snapshots now detect timeouts earlier and avoid
spamming the logs with `context deadline exceeded` errors.