### PR TITLE
ui: use correct selector for CC Console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -25,14 +25,12 @@ import {
   selectTransactionsLastError,
   selectTxnColumns,
   selectSortSetting,
+  selectFilters,
+  selectSearch,
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import {
-  selectDateRange,
-  selectFilters,
-  selectSearch,
-} from "src/statementsPage/statementsPage.selectors";
+import { selectDateRange } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";


### PR DESCRIPTION
Previously, the selector for filters and sort settings
were incorrectly being imported from Statement selectors
instead of Transactions selectors on the Transactions
Connected component.
This commit fixes to the correct import.
We will want to use the same selector for date range on
Statements and Transactions page.

Release note (bug fix): Transaction page now using the correct
selector for sort setting and filters.