### PR TITLE
roachpb: move recent TestSpansString into roachpb_test package

### DIFF
--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -2094,25 +2094,3 @@ func TestAddIgnoredSeqNumRange(t *testing.T) {
 		require.Equal(t, tc.exp, txn.IgnoredSeqNums)
 	}
 }
-
-func TestSpansString(t *testing.T) {
-	for _, tc := range []struct {
-		spans    Spans
-		expected string
-	}{
-		{
-			spans:    Spans{},
-			expected: "",
-		},
-		{
-			spans:    Spans{{Key: Key("a"), EndKey: Key("b")}},
-			expected: "{a-b}",
-		},
-		{
-			spans:    Spans{{Key: Key("a")}, {Key: Key("c"), EndKey: Key("d")}},
-			expected: "a, {c-d}",
-		},
-	} {
-		require.Equal(t, tc.expected, tc.spans.String())
-	}
-}

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -119,3 +119,25 @@ func TestRangeDescriptorStringRedact(t *testing.T) {
 		redact.Sprint(desc),
 	)
 }
+
+func TestSpansString(t *testing.T) {
+	for _, tc := range []struct {
+		spans    roachpb.Spans
+		expected string
+	}{
+		{
+			spans:    roachpb.Spans{},
+			expected: "",
+		},
+		{
+			spans:    roachpb.Spans{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+			expected: "{a-b}",
+		},
+		{
+			spans:    roachpb.Spans{{Key: roachpb.Key("a")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			expected: "a, {c-d}",
+		},
+	} {
+		require.Equal(t, tc.expected, tc.spans.String())
+	}
+}


### PR DESCRIPTION
The test depends on `pkg/keys` (via `PrettyPrint` dependency), so it has
to be in `roachpb_test` package (which is correctly setup for Bazel to
avoid the cyclical dependencies).

Release note: None