### PR TITLE
sql/logictest: add diff support to expectation output

### DIFF
--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_lib_pq//:pq",
+        "@com_github_pmezard_go_difflib//difflib",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
This adds support for generating a unified diff for expectation
mismatches. This can make it easier to spot the differences between
two results when the result contains many rows.

For example:

```
    ../../sql/logictest/testdata/logic_test/system_namespace:54: SELECT * FROM system.namespace
    expected:
        0   0   defaultdb                        50
        0   0   postgres                         51
        0   0   system                           1
        0   0   test                             52
        1   0   public                           29
        1   29  comments                         24
        1   29  database_role_settings           44
        1   29  descriptor                       3
        1   29  descriptor_id_seq                7
        1   29  eventlog                         12
        1   29  jobs                             15
        1   29  join_tokens                      41
        1   29  lease                            11
        1   29  locations                        21
        1   29  migrations                       40
        1   29  namespace                        30
        1   29  protected_ts_meta                31
        1   29  protected_ts_records             32
        1   29  rangelog                         13
        1   29  replication_constraint_stats     25
        1   29  replication_critical_localities  2
        1   29  replication_stats                27
        1   29  reports_meta                     28
        1   29  role_members                     23
        1   29  role_options                     33
        1   29  scheduled_jobs                   37
        1   29  settings                         6
        1   29  sql_instances                    46
        1   29  sqlliveness                      39
        1   29  statement_bundle_chunks          34
        1   29  statement_diagnostics            36
        1   29  statement_diagnostics_requests   35
        1   29  statement_statistics             42
        1   29  table_statistics                 20
        1   29  transaction_statistics           43
        1   29  ui                               14
        1   29  users                            4
        1   29  web_sessions                     19
        1   29  zones                            5
        50  0   public                           29
        51  0   public                           29
        52  0   public                           29

    but found (query options: "rowsort" -> ignore the following ordering of rows) :
        0   0   defaultdb                        50
        0   0   postgres                         51
        0   0   system                           1
        0   0   test                             52
        1   0   public                           29
        1   29  comments                         24
        1   29  database_role_settings           44
        1   29  descriptor                       3
        1   29  descriptor_id_seq                7
        1   29  eventlog                         12
        1   29  jobs                             15
        1   29  join_tokens                      41
        1   29  lease                            11
        1   29  locations                        21
        1   29  migrations                       40
        1   29  namespace                        30
        1   29  protected_ts_meta                31
        1   29  protected_ts_records             32
        1   29  rangelog                         13
        1   29  replication_constraint_stats     25
        1   29  replication_critical_localities  26
        1   29  replication_stats                27
        1   29  reports_meta                     28
        1   29  role_members                     23
        1   29  role_options                     33
        1   29  scheduled_jobs                   37
        1   29  settings                         6
        1   29  sql_instances                    46
        1   29  sqlliveness                      39
        1   29  statement_bundle_chunks          34
        1   29  statement_diagnostics            36
        1   29  statement_diagnostics_requests   35
        1   29  statement_statistics             42
        1   29  table_statistics                 20
        1   29  transaction_statistics           43
        1   29  ui                               14
        1   29  users                            4
        1   29  web_sessions                     19
        1   29  zones                            5
        50  0   public                           29
        51  0   public                           29
        52  0   public                           29

    Diff:
    --- Expected
    +++ Actual
    @@ -20,3 +20,3 @@
         1   29  replication_constraint_stats     25
    -    1   29  replication_critical_localities  2
    +    1   29  replication_critical_localities  26
         1   29  replication_stats                27
logic.go:3340:
    ../../sql/logictest/testdata/logic_test/system_namespace:100: error while processing
```

The diff output is only added when the `-show-diff` flag is provided
because in some cases it can produce more noise than it is worth.

The diff library used here is the same one already used by the testify
libraries we depend on.

Release note: None