### PR TITLE
roachtest: improve artifacts collection on timeout

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/cmd/roachtest/test",
         "//pkg/roachprod/logger",
         "//pkg/testutils",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1674,7 +1674,7 @@ func (c *clusterImpl) PutE(
 
 	c.status("uploading file")
 	defer c.status("")
-	return errors.Wrap(roachprod.Put(ctx, l, c.MakeNodes(nodes...), src, dest, false /* useTreeDist */), "cluster.PutE")
+	return errors.Wrap(roachprod.Put(ctx, l, c.MakeNodes(nodes...), src, dest, true /* useTreeDist */), "cluster.PutE")
 }
 
 // PutLibraries inserts all available library files into all nodes on the cluster

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq" // register postgres driver
@@ -357,7 +358,9 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 	}
 	register(&r)
 	cr := newClusterRegistry()
-	runner := newTestRunner(cr, r.buildVersion)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	runner := newTestRunner(cr, stopper, r.buildVersion)
 
 	filter := registry.NewTestFilter(cfg.args)
 	clusterType := roachprodCluster

--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -53,7 +53,7 @@ func (n NodeListOption) Merge(o NodeListOption) NodeListOption {
 	t := make(NodeListOption, 0, len(n)+len(o))
 	t = append(t, n...)
 	t = append(t, o...)
-	sort.Ints([]int(t))
+	sort.Ints(t)
 	r := t[:1]
 	for i := 1; i < len(t); i++ {
 		if r[len(r)-1] != t[i] {

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -97,18 +97,6 @@ type testImpl struct {
 	versionsBinaryOverride map[string]string
 }
 
-func (t *testImpl) timedOut() bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.mu.timeout
-}
-
-func (t *testImpl) setTimedOut() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.mu.timeout = true
-}
-
 // BuildVersion exposes the build version of the cluster
 // in this test.
 func (t *testImpl) BuildVersion() *version.Version {

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -256,12 +256,14 @@ func (t *testImpl) Skipf(format string, args ...interface{}) {
 // ATTENTION: Since this calls panic(errTestFatal), it should only be called
 // from a test's closure. The test runner itself should never call this.
 func (t *testImpl) Fatal(args ...interface{}) {
-	t.fatalfInner("" /* format */, args...)
+	t.markFailedInner("" /* format */, args...)
+	panic(errTestFatal)
 }
 
 // Fatalf is like Fatal, but takes a format string.
 func (t *testImpl) Fatalf(format string, args ...interface{}) {
-	t.fatalfInner(format, args...)
+	t.markFailedInner(format, args...)
+	panic(errTestFatal)
 }
 
 // FailNow implements the TestingT interface.
@@ -271,17 +273,16 @@ func (t *testImpl) FailNow() {
 
 // Errorf implements the TestingT interface.
 func (t *testImpl) Errorf(format string, args ...interface{}) {
-	t.Fatalf(format, args...)
+	t.markFailedInner(format, args...)
 }
 
-func (t *testImpl) fatalfInner(format string, args ...interface{}) {
+func (t *testImpl) markFailedInner(format string, args ...interface{}) {
 	// Skip two frames: our own and the caller.
 	if format != "" {
 		t.printfAndFail(2 /* skip */, format, args...)
 	} else {
 		t.printAndFail(2 /* skip */, args...)
 	}
-	panic(errTestFatal)
 }
 
 func (t *testImpl) printAndFail(skip int, args ...interface{}) {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -53,6 +53,7 @@ var errTestsFailed = fmt.Errorf("some tests failed")
 
 // testRunner runs tests.
 type testRunner struct {
+	stopper *stop.Stopper
 	// buildVersion is the version of the Cockroach binary that tests will run against.
 	buildVersion version.Version
 
@@ -101,8 +102,11 @@ type testRunner struct {
 //   caller provides this as the caller needs to be able to shut clusters down
 //   on Ctrl+C.
 // buildVersion: The version of the Cockroach binary against which tests will run.
-func newTestRunner(cr *clusterRegistry, buildVersion version.Version) *testRunner {
+func newTestRunner(
+	cr *clusterRegistry, stopper *stop.Stopper, buildVersion version.Version,
+) *testRunner {
 	r := &testRunner{
+		stopper:      stopper,
 		cr:           cr,
 		buildVersion: buildVersion,
 	}
@@ -286,7 +290,6 @@ func (r *testRunner) Run(
 	r.status.skip = make(map[*testImpl]struct{})
 
 	r.work = newWorkPool(tests, count)
-	stopper := stop.NewStopper()
 	errs := &workerErrors{}
 
 	qp := quotapool.NewIntPool("cloud cpu", uint64(clustersOpt.cpuQuota))
@@ -296,12 +299,12 @@ func (r *testRunner) Run(
 	for i := 0; i < parallelism; i++ {
 		i := i // Copy for closure.
 		wg.Add(1)
-		if err := stopper.RunAsyncTask(ctx, "worker", func(ctx context.Context) {
+		if err := r.stopper.RunAsyncTask(ctx, "worker", func(ctx context.Context) {
 			defer wg.Done()
 
 			if err := r.runWorker(
 				ctx, fmt.Sprintf("w%d", i) /* name */, r.work, qp,
-				stopper.ShouldQuiesce(),
+				r.stopper.ShouldQuiesce(),
 				clustersOpt.keepClustersOnTestFailure,
 				lopt.artifactsDir, lopt.literalArtifactsDir, lopt.runnerLogPath, lopt.tee, lopt.stdout,
 				allocateCluster,
@@ -318,7 +321,7 @@ func (r *testRunner) Run(
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					stopper.Stop(ctx)
+					r.stopper.Stop(ctx)
 				}()
 				// Interrupt everybody waiting for resources.
 				if qp != nil {
@@ -501,10 +504,9 @@ func (r *testRunner) runWorker(
 
 		// Now run the test.
 		l.PrintfCtx(ctx, "starting test: %s:%d", testToRun.spec.Name, testToRun.runNum)
-		err = r.runTest(
+		if err := r.runTest(
 			ctx, t, testToRun.runNum, testToRun.runCount, c, testRunnerLogPath, stdout, testL,
-		)
-		if err != nil {
+		); err != nil {
 			shout(ctx, l, stdout, "test returned error: %s: %s", t.Name(), err)
 			// Mark the test as failed if it isn't already.
 			if !t.Failed() {
@@ -643,6 +645,10 @@ func (r *testRunner) runTest(
 
 		// We only have to record panics if the panic'd value is not the sentinel
 		// produced by t.Fatal*().
+		//
+		// TODO(test-eng): we shouldn't be seeing errTestFatal here unless this
+		// goroutine accidentally ends up calling t.Fatal; the test runs in a
+		// different goroutine.
 		if err := recover(); err != nil && err != errTestFatal {
 			t.mu.Lock()
 			t.mu.failed = true
@@ -674,11 +680,7 @@ func (r *testRunner) runTest(
 
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", runID, durationStr, output)
 
-			issueOutput := output
-			if t.timedOut() {
-				issueOutput = "test timed out (see artifacts for details)"
-			}
-			r.maybePostGithubIssue(ctx, l, t, stdout, issueOutput)
+			r.maybePostGithubIssue(ctx, l, t, stdout, output)
 		} else {
 			shout(ctx, l, stdout, "--- PASS: %s (%s)", runID, durationStr)
 			// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
@@ -760,7 +762,6 @@ func (r *testRunner) runTest(
 	// We run the actual test in a different goroutine because it might call
 	// t.Fatal() which kills the goroutine, and also because we want to enforce a
 	// timeout.
-	success := false
 	testReturnedCh := make(chan struct{})
 	go func() {
 		defer close(testReturnedCh) // closed only after we've grabbed the debug info below
@@ -778,10 +779,7 @@ func (r *testRunner) runTest(
 		t.Spec().(*registry.TestSpec).Run(runCtx, t, c)
 	}()
 
-	teardownL, err := c.l.ChildLogger("teardown", logger.QuietStderr, logger.QuietStdout)
-	if err != nil {
-		return err
-	}
+	var timedOut bool
 	select {
 	case <-testReturnedCh:
 		s := "success"
@@ -789,85 +787,87 @@ func (r *testRunner) runTest(
 			s = "failure"
 		}
 		t.L().Printf("tearing down after %s; see teardown.log", s)
-		l, c.l = teardownL, teardownL
-		t.ReplaceL(teardownL)
 	case <-time.After(timeout):
-		t.L().Printf("tearing down after timeout; see teardown.log")
-		l, c.l = teardownL, teardownL
-		t.ReplaceL(teardownL)
-		// Timeouts are often opaque. Improve our changes by dumping the stack
-		// so that at least we can piece together what the test is trying to
-		// do at this very moment.
-		// In large roachtest runs, this will dump everyone else's stack as well,
-		// but this is just hard to avoid. Moving to a worker model in which
-		// each roachtest is spawned off as a separate process would address
-		// this at the expense of ease of communication between the runner and
-		// the test.
-		//
-		// Do this before we cancel the context, which might (hopefully) unblock
-		// the test. We want to see where it got stuck.
-		const stacksFile = "__stacks"
-		if cl, err := t.L().ChildLogger(stacksFile, logger.QuietStderr, logger.QuietStdout); err == nil {
-			cl.PrintfCtx(ctx, "all stacks:\n\n%s\n", allStacks())
-			t.L().PrintfCtx(ctx, "dumped stacks to %s", stacksFile)
-		}
-		// Now kill anything going on in this cluster while collecting stacks
-		// to the logs, to get the server side of the hang.
-		//
-		// Don't use surrounding context, which are likely already canceled.
-		if nodes := c.All(); len(nodes) > 0 { // avoid tests
-			innerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			// Send SIGQUIT to dump stacks (this is how CRDB handles it) followed by SIGKILL.
-			stopOpts := option.DefaultStopOpts()
-			stopOpts.RoachprodOpts.Sig = 3
-			_ = c.StopE(innerCtx, teardownL, stopOpts, c.All())
-			_ = c.StopE(innerCtx, teardownL, option.DefaultStopOpts(), c.All())
-			t.L().PrintfCtx(ctx, "CockroachDB nodes aborted; check the stderr log for goroutine stack traces")
-			cancel()
-		}
-
-		// Mark the test as failed (which will also cancel its context). Then
-		// we'll wait up to 5 minutes in the hope that the test reacts either to
-		// the ctx cancelation or to the fact that it was marked as failed (and
-		// all processes nuked out from under it).
-		// If that happens, great - we return normally and so the cluster can be
-		// reused. It the test does not react to anything, then we return an
-		// error, which will cause the caller to stop everything and destroy
-		// this cluster (as well as all the others). The cluster cannot be
-		// reused since we have a runaway test goroutine that's presumably going
-		// to continue using the cluster.
-		t.printfAndFail(0 /* skip */, "test timed out (%s)", timeout)
-		t.setTimedOut()
-		select {
-		case <-testReturnedCh:
-			if success {
-				panic("expected success=false after a timeout")
-			}
-		case <-time.After(5 * time.Minute):
-			// We really shouldn't get here unless the test code somehow managed
-			// to deadlock without blocking on anything remote - since we killed
-			// everything.
-			const msg = "test timed out and afterwards failed to respond to cancellation"
-			t.L().PrintfCtx(ctx, msg)
-
-			const stacksFile = "__stacks_after_cancellation"
-			if cl, err := t.L().ChildLogger(stacksFile, logger.QuietStderr, logger.QuietStdout); err == nil {
-				cl.PrintfCtx(ctx, "all stacks:\n\n%s\n", allStacks())
-				t.L().PrintfCtx(ctx, "dumped stacks (after cancellation) to %s", stacksFile)
-			}
-			r.collectClusterLogs(ctx, c, t)
-			// We already marked the test as failing, so don't return an error here.
-			// Doing so would shut down the entire roachtest run.
-			return nil
-		}
+		// NB: we're intentionally not failing the test if it hasn't
+		// already. This will be done at the very end of this method,
+		// after we've collected artifacts.
+		t.L().Printf("test timed out after %s; check __stacks.log and CRDB logs for goroutine dumps", timeout)
+		timedOut = true
 	}
 
-	// Detect dead nodes in an inner defer. Note that this will call
-	// t.printfAndFail() when appropriate, which will cause the code below to
-	// enter the t.Failed() branch.
-	c.FailOnDeadNodes(ctx, t)
+	// From now on, all logging goes to teardown.log to give a clear
+	// separation between operations originating from the test vs the
+	// harness.
+	teardownL, err := c.l.ChildLogger("teardown", logger.QuietStderr, logger.QuietStdout)
+	if err != nil {
+		return err
+	}
+	l, c.l = teardownL, teardownL
+	t.ReplaceL(teardownL)
 
-	if !t.Failed() {
+	return r.teardownTest(ctx, t, c, timedOut)
+}
+
+func (r *testRunner) teardownTest(
+	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool,
+) error {
+
+	// We still have to collect artifacts and run post-flight checks, and any of
+	// these might hang. So they go into a goroutine and the main goroutine
+	// abandons them after a timeout. We intentionally don't wait for the
+	// goroutines to return, as this too may hang if something doesn't respond to
+	// ctx cancellation.
+
+	artifactsCollectedCh := make(chan struct{})
+	_ = r.stopper.RunAsyncTask(ctx, "collect-artifacts", func(ctx context.Context) {
+		// TODO(tbg): make `t` and `logger` resilient to use-after-Close to avoid
+		// crashes here in cases where the goroutine leaks but later gets unstuck
+		// and tries to log something.
+		defer close(artifactsCollectedCh)
+		if timedOut {
+			// Timeouts are often opaque. Improve our changes by dumping the stack
+			// so that at least we can piece together what the test is trying to
+			// do at this very moment.
+			//
+			// We're careful here to not fail the test, i.e. we don't call t.Error
+			// here. We want to preserve as much state as possible in the artifacts,
+			// and calling t.{Error,Fatal}{,f} cancels the test's main context.
+			//
+			// We make sure to fail the test later when handling the timedOut variable.
+			const stacksFile = "__stacks"
+			if cl, err := t.L().ChildLogger(stacksFile, logger.QuietStderr, logger.QuietStdout); err == nil {
+				sl := allStacks()
+				if c.Spec().NodeCount == 0 {
+					sl = []byte("<elided during unit test>") // keep test outputs clutter-free
+				}
+				cl.PrintfCtx(ctx, "all stacks:\n\n%s\n", sl)
+				t.L().PrintfCtx(ctx, "dumped stacks to %s", stacksFile)
+			}
+
+			// Send SIGQUIT to ask all processes to dump stacks if requested (without shutting down).
+			// We need to do this before collectClusterArtifacts below, which will download the logs.
+			// Note that the debug.zip will hopefully also contain stacks, but we're just making sure
+			// there's something even if the debug.zip doesn't go through.
+			args := option.DefaultStopOpts()
+			args.RoachprodOpts.Sig = 3
+			err := c.StopE(ctx, t.L(), args, c.All())
+			t.L().PrintfCtx(ctx, "asked CRDB nodes to dump stacks; check their main (DEV) logs: %v", err)
+			// It takes a little moment for the stacks to get flushed to the logs.
+			// Against a real cluster they'll typically be there by the time we fetch
+			// logs but on local clusters this may not be true; either way better to
+			// not take any chances.
+			if c.Spec().NodeCount > 0 { // unit tests
+				time.Sleep(3 * time.Second)
+			}
+		}
+
+		// Detect dead nodes. This will call t.Error() when appropriate. Note that
+		// we do this even if t.Failed() since a down node is often the reason for
+		// the failure, and it's helpful to have the listing in the teardown logs
+		// as well (it is typically already in the main logs if the test used a
+		// monitor).
+		c.assertNoDeadNode(ctx, t)
+
 		// Detect replica divergence (i.e. ranges in which replicas have arrived
 		// at the same log position with different states).
 		//
@@ -880,10 +880,33 @@ func (r *testRunner) runTest(
 		// TODO(testinfra): figure out why this can still get stuck despite the
 		// above.
 		c.FailOnReplicaDivergence(ctx, t)
+
+		if timedOut || t.Failed() {
+			r.collectClusterArtifacts(ctx, c, t)
+		}
+	})
+
+	const artifactsCollectionTimeout = time.Hour
+	select {
+	case <-artifactsCollectedCh:
+	case <-time.After(artifactsCollectionTimeout):
+		// Leak the artifacts collection goroutine. Note that the test may not be
+		// marked as failing here. We intentionally do not trigger it to fail here,
+		// but we could entertain doing so once we have a mechanism that can route
+		// such post-test problems to the test-eng team.
+		t.L().Printf("giving up on artifacts collection after %s", artifactsCollectionTimeout)
 	}
 
-	if t.Failed() {
-		r.collectClusterLogs(ctx, c, t)
+	if timedOut {
+		// Shut down the cluster. We only do this on timeout to help the test terminate;
+		// for regular failures, if the --debug flag is used, we want the cluster to stay
+		// around so someone can poke at it.
+		_ = c.StopE(ctx, t.L(), option.DefaultStopOpts(), c.All())
+
+		// The hung test may, against all odds, still not have reported an error.
+		// We delayed it to improve artifacts collection, and now we ensure the test
+		// is marked as failing.
+		t.Errorf("test timed out (%s)", t.Spec().(*registry.TestSpec).Timeout)
 	}
 	return nil
 }
@@ -964,7 +987,8 @@ func (r *testRunner) maybePostGithubIssue(
 	}
 }
 
-func (r *testRunner) collectClusterLogs(ctx context.Context, c *clusterImpl, t test.Test) {
+// TODO(tbg): nothing in this method should have the `t`; they should have a `Logger` only.
+func (r *testRunner) collectClusterArtifacts(ctx context.Context, c *clusterImpl, t test.Test) {
 	// NB: fetch the logs even when we have a debug zip because
 	// debug zip can't ever get the logs for down nodes.
 	// We only save artifacts for failed tests in CI, so this

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -761,9 +761,9 @@ func (r *testRunner) runTest(
 	// t.Fatal() which kills the goroutine, and also because we want to enforce a
 	// timeout.
 	success := false
-	done := make(chan struct{})
+	testReturnedCh := make(chan struct{})
 	go func() {
-		defer close(done) // closed only after we've grabbed the debug info below
+		defer close(testReturnedCh) // closed only after we've grabbed the debug info below
 
 		// This is the call to actually run the test.
 		defer func() {
@@ -783,7 +783,7 @@ func (r *testRunner) runTest(
 		return err
 	}
 	select {
-	case <-done:
+	case <-testReturnedCh:
 		s := "success"
 		if t.Failed() {
 			s = "failure"
@@ -839,7 +839,7 @@ func (r *testRunner) runTest(
 		t.printfAndFail(0 /* skip */, "test timed out (%s)", timeout)
 		t.setTimedOut()
 		select {
-		case <-done:
+		case <-testReturnedCh:
 			if success {
 				panic("expected success=false after a timeout")
 			}

--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -13,10 +13,13 @@ package tests
 import (
 	"context"
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
 func registerRoachtest(r registry.Registry) {
@@ -37,5 +40,20 @@ func registerRoachtest(r registry.Registry) {
 			}
 		},
 		Cluster: r.MakeClusterSpec(0),
+	})
+	// This test can be run manually to check what happens if a test times out.
+	// In particular, can manually verify that suitable artifacts are created.
+	r.Add(registry.TestSpec{
+		Name:  "roachtest/hang",
+		Tags:  []string{"roachtest"},
+		Owner: registry.OwnerTestEng,
+		Run: func(_ context.Context, t test.Test, c cluster.Cluster) {
+			ctx := context.Background() // intentional
+			c.Put(ctx, t.Cockroach(), "cockroach", c.All())
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+			time.Sleep(time.Hour)
+		},
+		Timeout: 3 * time.Minute,
+		Cluster: r.MakeClusterSpec(3),
 	})
 }


### PR DESCRIPTION
Previously, when a roachtest timed out, we'd be left without many of
the "standard" artifacts. Consequently, investigating timed out tests
was particularly unpleasant.

As of this commit, there is parity between the two. We attempt to
collect the same artifacts, but are careful to bound the time we spend
on this (regardless of whether a timeout occurred). Additionally, we are
very careful to leave the cluster in its original state until the
artifacts collection has finished.

Here's the listing of artifacts for `roachtest/hang`, invoked via

```
./pkg/cmd/roachtest/roachstress.sh -c 1 tag:roachtest -- --debug
```

verifying that all artifacts are present. (I also verified that the
`cockroach.log` files contain a goroutine dump).

```
$ find . -maxdepth 3 -not -path './roachprod_state/*' -type f
./teardown.log
./tsdump.gob.yaml
./run_154437.308025163_n1-3_mkdir.log
./test.log
./debug.zip
./__stacks.log
./logs/2.unredacted/cockroach-pebble.td.tobias.2022-02-02T15_41_35Z.148361.log
./logs/2.unredacted/cockroach.stdout.log
./logs/2.unredacted/cockroach.td.tobias.2022-02-02T15_41_35Z.148361.log
./logs/2.unredacted/roachprod.log
./logs/2.unredacted/cockroach.stderr.log
./logs/2.unredacted/cockroach-stderr.td.tobias.2022-02-02T15_41_35Z.148361.log
./logs/2.unredacted/cockroach-health.td.tobias.2022-02-02T15_41_35Z.148361.log
./logs/3.cockroach.log
./logs/3.unredacted/cockroach-stderr.td.tobias.2022-02-02T15_41_35Z.148436.log
./logs/3.unredacted/cockroach.stdout.log
./logs/3.unredacted/cockroach.td.tobias.2022-02-02T15_41_35Z.148436.log
./logs/3.unredacted/roachprod.log
./logs/3.unredacted/cockroach.stderr.log
./logs/3.unredacted/cockroach-pebble.td.tobias.2022-02-02T15_41_35Z.148436.log
./logs/3.unredacted/cockroach-health.td.tobias.2022-02-02T15_41_35Z.148436.log
./logs/2.cockroach.log
./logs/1.cockroach.log
./logs/1.unredacted/cockroach.stdout.log
./logs/1.unredacted/cockroach-pebble.td.tobias.2022-02-02T15_41_34Z.148215.log
./logs/1.unredacted/roachprod.log
./logs/1.unredacted/cockroach-stderr.td.tobias.2022-02-02T15_41_34Z.148215.log
./logs/1.unredacted/cockroach.stderr.log
./logs/1.unredacted/cockroach.td.tobias.2022-02-02T15_41_34Z.148215.log
./logs/1.unredacted/cockroach-health.td.tobias.2022-02-02T15_41_35Z.148215.log
./logs/1.unredacted/cockroach-sql-schema.td.tobias.2022-02-02T15_41_34Z.148215.log
./run_154437.443860723_n1_cockroach_debug_tsdump.log
./run_154437.673769645_n1-3_cockroach_debug_zip.log
./tsdump.gob
./tsdump.gob-run.sh
```

Release note: None