### PR TITLE
importccl: truncate row parsing errors

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -69,6 +69,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -1339,7 +1340,7 @@ func TestImportIntoUserDefinedTypes(t *testing.T) {
 		// Test CSV default and computed column imports.
 		{
 			create: `
-a greeting, b greeting default 'hi', c greeting 
+a greeting, b greeting default 'hi', c greeting
 AS (
 CASE a
 WHEN 'hello' THEN 'hi'
@@ -1364,7 +1365,7 @@ END
 		// Test AVRO default and computed column imports.
 		{
 			create: `
-a greeting, b greeting, c greeting 
+a greeting, b greeting, c greeting
 AS (
 CASE a
 WHEN 'hello' THEN 'hi'
@@ -1389,7 +1390,7 @@ END
 		// Test DELIMITED default and computed column imports.
 		{
 			create: `
-a greeting, b greeting default 'hi', c greeting 
+a greeting, b greeting default 'hi', c greeting
 AS (
 CASE a
 WHEN 'hello' THEN 'hi'
@@ -1414,7 +1415,7 @@ END
 		// Test PGCOPY default and computed column imports.
 		{
 			create: `
-a greeting, b greeting default 'hi', c greeting 
+a greeting, b greeting default 'hi', c greeting
 AS (
 CASE a
 WHEN 'hello' THEN 'hi'
@@ -7006,6 +7007,42 @@ func TestDetachedImport(t *testing.T) {
 	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
 	sqlDB.QueryRow(t, importIntoQueryDetached, simpleOcf).Scan(&jobID)
 	waitForJobResult(t, tc, jobID, jobs.StatusFailed)
+}
+
+func TestImportRowErrorLargeRows(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			return
+		}
+		_, err := w.Write([]byte("firstrowvalue\nsecondrow,is,notok,"))
+		require.NoError(t, err)
+		// Write 8MB field as the last field of the second
+		// row.
+		bigData := randutil.RandBytes(rng, 8<<20)
+		_, err = w.Write(bigData)
+		require.NoError(t, err)
+		_, err = w.Write([]byte("\n"))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	connDB := tc.Conns[0]
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(connDB)
+	// Our input file has an 8MB row
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.raft.command.max_size = '4MiB'`)
+	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
+	sqlDB.Exec(t, "CREATE TABLE simple (s string)")
+	defer sqlDB.Exec(t, "DROP table simple")
+
+	importIntoQuery := `IMPORT INTO simple CSV DATA ($1)`
+	// Without truncation this would fail with:
+	// pq: job 715036628973879297: could not mark as reverting: job-update: command is too large: 33561185 bytes (max: 4194304)
+	sqlDB.ExpectErr(t, ".*error parsing row 2: expected 1 fields, got 4.*-- TRUNCATED", importIntoQuery, srv.URL)
 }
 
 func TestImportJobEventLogging(t *testing.T) {


### PR DESCRIPTION
Errors encountered when processing rows are persisted to the jobs
table. If the error is too large, the error will be unable to mark
itself as reverting:

    pq: job 715036628973879297: could not mark as reverting: job-update:
    command is too large: 33561185 bytes (max: 4194304)

We now truncate the error to ensure we do not hit this limit.  We
could go further and completely remove the row content from the error
message.

Release note (bug fix): Error messages produced during import are now
truncated. Previously, import could potentially generate large error
messages that could not be persisted to the jobs table, resulting in a
failed import never entering the failed state and instead retrying
repeatedly.