### PR TITLE
colexec: cleanup the handling of memory limit of 1 byte

### DIFF
--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -74,7 +74,11 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
 	ctx context.Context, flowCtx *execinfra.FlowCtx, limit int64, opName string, processorID int32,
 ) (*mon.BoundAccount, string) {
 	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
-		limit = 1
+		if limit != 1 {
+			colexecerror.InternalError(errors.AssertionFailedf(
+				"expected limit of 1 when forcing disk spilling, got %d", limit,
+			))
+		}
 	}
 	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
 	bufferingOpMemMonitor := mon.NewMonitorInheritWithLimit(monitorName, limit, flowCtx.EvalCtx.Mon)

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -474,6 +474,12 @@ func NewHashRouter(
 	// all unblock events preceding it since these *must* be on the channel.
 	unblockEventsChan := make(chan struct{}, 2*len(unlimitedAllocators))
 	memoryLimitPerOutput := memoryLimit / int64(len(unlimitedAllocators))
+	if memoryLimit == 1 {
+		// If total memory limit is 1, we're likely in a "force disk spill"
+		// scenario, so we'll give each output 1 byte too (if we don't override
+		// the value, outputs will end with up "no limit").
+		memoryLimitPerOutput = 1
+	}
 	for i := range unlimitedAllocators {
 		op := newRouterOutputOp(
 			routerOutputOpArgs{

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -1330,7 +1330,7 @@ func BenchmarkHashRouter(b *testing.B) {
 					colexecargs.OpWithMetaInfo{Root: input},
 					typs,
 					[]uint32{0}, /* hashCols */
-					64<<20,      /* memoryLimit */
+					execinfra.DefaultMemoryLimit,
 					queueCfg,
 					&colexecop.TestingSemaphore{},
 					diskAccounts,

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -210,7 +210,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					},
 					typs,
 					[]uint32{0}, /* hashCols */
-					64<<20,      /* memoryLimit */
+					execinfra.DefaultMemoryLimit,
 					queueCfg,
 					&colexecop.TestingSemaphore{},
 					diskAccounts,


### PR DESCRIPTION
For some components (sorters, hash aggregators, hash routers) we divide
up the memory limit into several parts. Previously, if a memory limit of
1 was used, those parts could end up with the limit of zero which could
get treated as "no limit". This is undesirable and is now fixed (note
that other small values of memory limits in theory could still lead to
the old behavior, but it's ok).

The value 1 is special because it is how we implement `ForceDiskSpill`
testing scenario. Still, previously we were exercising the disk spilling
because we would override the zero value to 1 before creating a limited
memory monitor.

In other words, this commit makes several components obey
`distsql_workmem = '1B'` setting (i.e. end to end) and cleans up how the
`ForceDiskSpill` is handled.

Release note: None