### PR TITLE
kvserver: fix error wrapping bug in (*replicaAppBatch).Stage

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -475,7 +475,6 @@ func (b *replicaAppBatch) Stage(
 	// b.runPreApplyTriggersAfterStagingWriteBatch and similar for merges? That
 	// way, it would become less of a one-off.
 	if splitMergeUnlock, err := b.r.maybeAcquireSplitMergeLock(ctx, cmd.raftCmd); err != nil {
-		var err error
 		if cmd.raftCmd.ReplicatedEvalResult.Split != nil {
 			err = wrapWithNonDeterministicFailure(err, "unable to acquire split lock")
 		} else {


### PR DESCRIPTION
Previously, this would result in a less-helpful-than-intended error
message since the wrapped error would always be nil and result in a
(caught) panic inside the formatter:

```
F211130 16:23:33.881626 745652 kv/kvserver/store_raft.go:511 ⋮
[n4,s4,r44/4:‹/{Table/Max-Max}›] 503 unable to acquire split lock:
%!v(PANIC=SafeFormatter method: runtime error: invalid memory address
or nil pointer dereference)
```

Release note: None