### PR TITLE
release-21.1: importccl: truncate row parsing errors

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -69,6 +69,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -7163,6 +7164,42 @@ func TestDetachedImport(t *testing.T) {
 	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
 	sqlDB.QueryRow(t, importIntoQueryDetached, simpleOcf).Scan(&jobID)
 	waitForJobResult(t, tc, jobID, jobs.StatusFailed)
+}
+
+func TestImportRowErrorLargeRows(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			return
+		}
+		_, err := w.Write([]byte("firstrowvalue\nsecondrow,is,notok,"))
+		require.NoError(t, err)
+		// Write 8MB field as the last field of the second
+		// row.
+		bigData := randutil.RandBytes(rng, 8<<20)
+		_, err = w.Write(bigData)
+		require.NoError(t, err)
+		_, err = w.Write([]byte("\n"))
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	connDB := tc.Conns[0]
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(connDB)
+	// Our input file has an 8MB row
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.raft.command.max_size = '4MiB'`)
+	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
+	sqlDB.Exec(t, "CREATE TABLE simple (s string)")
+	defer sqlDB.Exec(t, "DROP table simple")
+
+	importIntoQuery := `IMPORT INTO simple CSV DATA ($1)`
+	// Without truncation this would fail with:
+	// pq: job 715036628973879297: could not mark as reverting: job-update: command is too large: 33561185 bytes (max: 4194304)
+	sqlDB.ExpectErr(t, ".*error parsing row 2: expected 1 fields, got 4.*-- TRUNCATED", importIntoQuery, srv.URL)
 }
 
 func TestImportJobEventLogging(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -405,13 +405,18 @@ const (
 )
 
 func (e *importRowError) Error() string {
-	return fmt.Sprintf("error parsing row %d: %v (row: %q)", e.rowNum, e.err, e.row)
+	// The job system will truncate this error before saving it,
+	// but we will additionally truncate it here since it is
+	// separately written to the log and could easily result in
+	// very large log files.
+	rowForLog := e.row
+	if len(rowForLog) > importRowErrMaxRuneCount {
+		rowForLog = util.TruncateString(rowForLog, importRowErrMaxRuneCount) + importRowErrTruncatedMarker
+	}
+	return fmt.Sprintf("error parsing row %d: %v (row: %s)", e.rowNum, e.err, rowForLog)
 }
 
 func newImportRowError(err error, row string, num int64) error {
-	if len(row) > importRowErrMaxRuneCount {
-		row = util.TruncateString(row, importRowErrMaxRuneCount) + importRowErrTruncatedMarker
-	}
 	return &importRowError{
 		err:    err,
 		row:    row,

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1078,6 +1078,20 @@ func TestJobLifecycle(t *testing.T) {
 				t.Fatalf("unexpected: %v", err)
 			}
 		})
+		t.Run("huge errors are truncated if marking job as failed", func(t *testing.T) {
+			hugeErr := strings.Repeat("a", 2048)
+			truncatedHugeErr := "boom: " + strings.Repeat("a", 1018) + " -- TRUNCATED"
+			err := errors.Errorf("boom: %s", hugeErr)
+			job, exp := createDefaultJob()
+			exp.Error = truncatedHugeErr
+			if err := job.Failed(ctx, err); err != nil {
+				t.Fatal(err)
+			}
+			if err := exp.verify(job.ID(), jobs.StatusFailed); err != nil {
+				t.Fatal(err)
+			}
+		})
+
 	})
 
 	t.Run("cancelable jobs can be paused until finished", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #73303.

/cc @cockroachdb/release

---

Errors encountered when processing rows are persisted to the jobs
table. If the error is too large, the error will be unable to mark
itself as reverting:

    pq: job 715036628973879297: could not mark as reverting: job-update:
    command is too large: 33561185 bytes (max: 4194304)

We now truncate the error to ensure we do not hit this limit.  We
could go further and completely remove the row content from the error
message.

Release note (bug fix): Error messages produced during import are now
truncated. Previously, import could potentially generate large error
messages that could not be persisted to the jobs table, resulting in a
failed import never entering the failed state and instead retrying
repeatedly.

Release justification: Bug fix for a bug that would result in an 
import running forever.
