### PR TITLE
opt: avoid zero row count estimate for inverted index scans

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -577,8 +577,10 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 							if invColStat, ok := stats.ColStats.Add(invCols); ok {
 								invColStat.Histogram = &props.Histogram{}
 								invColStat.Histogram.Init(sb.evalCtx, invCol, stat.Histogram())
-								// Set inverted entry counts from the histogram.
-								invColStat.DistinctCount = invColStat.Histogram.DistinctValuesCount()
+								// Set inverted entry counts from the histogram. Make sure the
+								// distinct count is at least 1, for the same reason as the row
+								// count above.
+								invColStat.DistinctCount = max(invColStat.Histogram.DistinctValuesCount(), 1)
 								// Inverted indexes don't have nulls.
 								invColStat.NullCount = 0
 							}
@@ -747,11 +749,13 @@ func (sb *statisticsBuilder) constrainScan(
 
 			inputStat, _ := sb.colStatFromInput(colSet, scan)
 			if inputHist := inputStat.Histogram; inputHist != nil {
-				// If we have a histogram, set the row count to its total,
-				// unfiltered count. This is needed because s.RowCount is
-				// currently the row count of the table, but should instead
-				// reflect the number of inverted index entries.
-				s.RowCount = inputHist.ValuesCount()
+				// If we have a histogram, set the row count to its total, unfiltered
+				// count. This is needed because s.RowCount is currently the row count
+				// of the table, but should instead reflect the number of inverted index
+				// entries. (Make sure the row count is at least 1. The stats may be
+				// stale, and we can end up with weird and inefficient plans if we
+				// estimate 0 rows.)
+				s.RowCount = max(inputHist.ValuesCount(), 1)
 				if colStat, ok := s.ColStats.Lookup(colSet); ok {
 					colStat.Histogram = inputHist.InvertedFilter(scan.InvertedConstraint)
 					histCols.Add(invertedConstrainedCol)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2094,3 +2094,71 @@ index-join t
       ├── stats: [rows=111.111111, distinct(4)=11.1111111, null(4)=0]
       ├── key: (1)
       └── fd: (1)-->(4)
+
+# Regression test for #73106. Ensure we don't get the error "estimated row count
+# must be non-zero".
+exec-ddl
+CREATE TABLE tab (
+  geom GEOMETRY NOT NULL,
+  INVERTED INDEX (geom ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE tab INJECT STATISTICS '[
+  {
+    "columns": ["geom"],
+    "created_at": "2000-01-01 00:00:00+00:00",
+    "distinct_count": 7673676,
+    "histo_buckets": [
+      {
+        "distinct_range": 0,
+        "num_eq": 0,
+        "num_range": 0,
+        "upper_bound": "\\\\x42fdffffffffffffffff01c1f3f5e7590b574e41f15b57b0682314"
+      }
+    ],
+    "histo_col_type": "BYTES",
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 20000000
+  }
+]'
+----
+
+opt
+SELECT * FROM tab
+WHERE st_coveredby(geom, 'POINT(1 1)':::GEOMETRY)
+----
+select
+ ├── columns: geom:1(geometry!null)
+ ├── immutable
+ ├── stats: [rows=2222222.22, distinct(1)=2222222.22, null(1)=0]
+ ├── index-join tab
+ │    ├── columns: geom:1(geometry!null)
+ │    ├── stats: [rows=1]
+ │    └── inverted-filter
+ │         ├── columns: rowid:2(int!null)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
+ │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │         ├── pre-filterer expression
+ │         │    └── st_covers('0101000000000000000000F03F000000000000F03F', geom:1) [type=bool]
+ │         ├── stats: [rows=1]
+ │         ├── key: (2)
+ │         └── scan tab@tab_geom_idx
+ │              ├── columns: rowid:2(int!null) geom_inverted_key:5(geometry!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
+ │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
+ │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
+ │              ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(5)=1, null(5)=0]
+ │              │   histogram(5)=
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
+ └── filters
+      └── st_coveredby(geom:1, '0101000000000000000000F03F000000000000F03F') [type=bool, outer=(1), immutable, constraints=(/1: (/NULL - ])]


### PR DESCRIPTION
Fixed an edge case where the `statisticsBuilder` could estimate that an
inverted index scan had zero rows. Even if the histogram shows 0 rows,
we now always assume at least one row and one distinct value for an
inverted column, similar to how we handle other columns.

Fixes #73106

Release note (bug fix): Fixed a rare internal error "estimated row count
must be non-zero", which could occur when planning queries using an
inverted index. This error could occur if the histogram on the inverted
index showed that there were no rows.