### PR TITLE
kv/kvserver/uncertainty: remove observedts_test target from bazel build file

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -149,7 +149,6 @@ ALL_TESTS = [
     "//pkg/kv/kvserver/tscache:tscache_test",
     "//pkg/kv/kvserver/txnrecovery:txnrecovery_test",
     "//pkg/kv/kvserver/txnwait:txnwait_test",
-    "//pkg/kv/kvserver/uncertainty:observedts_test",
     "//pkg/kv/kvserver/uncertainty:uncertainty_test",
     "//pkg/kv/kvserver:kvserver_test",
     "//pkg/kv:kv_test",

--- a/pkg/kv/kvserver/uncertainty/BUILD.bazel
+++ b/pkg/kv/kvserver/uncertainty/BUILD.bazel
@@ -1,39 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "observedts",
-    srcs = [
-        "doc.go",
-        "limit.go",
-        "uncertainty.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/observedts",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/kv/kvserver/kvserverpb",
-        "//pkg/roachpb:with-mocks",
-        "//pkg/util/hlc",
-    ],
-)
-
-go_test(
-    name = "observedts_test",
-    size = "small",
-    srcs = [
-        "limit_test.go",
-        "uncertainty_test.go",
-    ],
-    embed = [":observedts"],
-    deps = [
-        "//pkg/kv/kvserver/kvserverpb",
-        "//pkg/roachpb:with-mocks",
-        "//pkg/util/hlc",
-        "//pkg/util/leaktest",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
     name = "uncertainty",
     srcs = [
         "compute.go",


### PR DESCRIPTION
The test files have been deleted. Leaving observedts_test
target in build file fails CI for some PRs :(