### PR TITLE
bazel: run `errcheck` checks in `nogo`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -236,6 +236,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_default_library",
         "//pkg/testutils/lint/passes/descriptormarshal",
+        "//pkg/testutils/lint/passes/errcheck",
         "//pkg/testutils/lint/passes/errcmp",
         "//pkg/testutils/lint/passes/fmtsafe",
         "//pkg/testutils/lint/passes/grpcclientconnclose",

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4562,10 +4562,14 @@ def go_deps():
         name = "com_github_kisielk_errcheck",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/kisielk/errcheck",
-        sha256 = "e15bd181a3f384da89fed079dc4ec4d1f431fc20db758fdbe4abb38d7ddee06b",
-        strip_prefix = "github.com/kisielk/errcheck@v1.5.0",
+        patch_args = ["-p1"],
+        patches = [
+            "@cockroach//build/patches:com_github_kisielk_errcheck.patch",
+        ],
+        sha256 = "99d3220891162cb684f8e05d54f3d0dc58abdd496a2f0cfda7fd4a28917a719e",
+        strip_prefix = "github.com/kisielk/errcheck@v1.6.1-0.20210625163953-8ddee489636a",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/kisielk/errcheck/com_github_kisielk_errcheck-v1.5.0.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/kisielk/errcheck/com_github_kisielk_errcheck-v1.6.1-0.20210625163953-8ddee489636a.zip",
         ],
     )
     go_repository(

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -55,7 +55,6 @@ def lint_binary(name, test):
             "@co_honnef_go_tools//cmd/staticcheck",
             "@com_github_client9_misspell//cmd/misspell:misspell",
             "@com_github_cockroachdb_crlfmt//:crlfmt",
-            "@com_github_kisielk_errcheck//:errcheck",
             "@go_sdk//:bin/go",
             "@org_golang_x_lint//golint:golint",
         ],

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -28,7 +28,6 @@ rlocation_ck () {
 test_bin="$(rlocation_ck cockroach/$PACKAGE/${NAME}_/$NAME)"
 go_bin="$(rlocation_ck go_sdk/bin/go)"
 crlfmt_bin="$(rlocation_ck com_github_cockroachdb_crlfmt/crlfmt_/crlfmt)"
-errcheck_bin="$(rlocation_ck com_github_kisielk_errcheck/errcheck_/errcheck)"
 golint_bin="$(rlocation_ck org_golang_x_lint/golint/golint_/golint)"
 misspell_bin="$(rlocation_ck com_github_client9_misspell/cmd/misspell/misspell_/misspell)"
 optfmt_bin="$(rlocation_ck cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
@@ -46,6 +45,6 @@ fi
 cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
 
 TEST_WORKSPACE=cockroach \
-    PATH="$(dirname $go_bin):$(dirname $errcheck_bin):$(dirname $returncheck_bin):$(dirname $staticcheck_bin):$(dirname $crlfmt_bin):$(dirname $misspell_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
+    PATH="$(dirname $go_bin):$(dirname $returncheck_bin):$(dirname $staticcheck_bin):$(dirname $crlfmt_bin):$(dirname $misspell_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
     GOROOT="$(dirname $(dirname $go_bin))" \
     "$test_bin" "$@"

--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -25,6 +25,18 @@
             "_test\\.go$": "tests"
         }
     },
+    "errcheck": {
+	"exclude_files": {
+            "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",
+            ".*\\.pb\\.go$": "generated code",
+            ".*\\.pb\\.gw\\.go$": "generated code",
+            "github.com/cockroachdb/cockroach/.*_generated\\.go$": "generated code",
+            "github.com/cockroachdb/cockroach/pkg/testutils/lint/lint_test.go": "not really sure why this is failing honestly"
+        },
+        "only_files": {
+            "github.com/cockroachdb/cockroach/.*$": "first-party code"
+        }
+    },
     "errcmp": {
         "exclude_files": {
             "github.com/cockroachdb/cockroach/.*\\.eg\\.go$": "generated code",

--- a/build/patches/com_github_kisielk_errcheck.patch
+++ b/build/patches/com_github_kisielk_errcheck.patch
@@ -1,0 +1,43 @@
+diff -urN a/errcheck/analyzer.go b/errcheck/analyzer.go
+--- a/errcheck/analyzer.go
++++ b/errcheck/analyzer.go
+@@ -6,6 +6,7 @@ import (
+ 	"go/token"
+ 	"reflect"
+ 	"regexp"
++	"strings"
+ 
+ 	"golang.org/x/tools/go/analysis"
+ )
+@@ -21,6 +22,7 @@ var (
+ 	argBlank       bool
+ 	argAsserts     bool
+ 	argExcludeFile string
++	argExcludes    string
+ 	argExcludeOnly bool
+ )
+ 
+@@ -28,6 +30,7 @@ func init() {
+ 	Analyzer.Flags.BoolVar(&argBlank, "blank", false, "if true, check for errors assigned to blank identifier")
+ 	Analyzer.Flags.BoolVar(&argAsserts, "assert", false, "if true, check for ignored type assertion results")
+ 	Analyzer.Flags.StringVar(&argExcludeFile, "exclude", "", "Path to a file containing a list of functions to exclude from checking")
++	Analyzer.Flags.StringVar(&argExcludes, "excludes", "", "Contents of the exclude file as a string (overrides -exclude)")
+ 	Analyzer.Flags.BoolVar(&argExcludeOnly, "excludeonly", false, "Use only excludes from exclude file")
+ }
+ 
+@@ -39,7 +42,14 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
+ 			exclude[name] = true
+ 		}
+ 	}
+-	if argExcludeFile != "" {
++	if argExcludes != "" {
++		for _, name := range strings.Split(argExcludes, "\n") {
++			if strings.HasPrefix(name, "//") || name == "" {
++				continue
++			}
++			exclude[name] = true
++		}
++	} else if argExcludeFile != "" {
+ 		excludes, err := ReadExcludes(argExcludeFile)
+ 		if err != nil {
+ 			return nil, fmt.Errorf("Could not read exclude file: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/jaegertracing/jaeger v1.18.1
 	github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
-	github.com/kisielk/errcheck v1.5.0
+	github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a
 	github.com/kisielk/gotool v1.0.0
 	github.com/knz/go-libedit v1.10.1
 	github.com/knz/strtime v0.0.0-20200318182718-be999391ffa9

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,9 @@ github.com/kevinburke/go-bindata v3.13.0+incompatible h1:hThDhUBH4KjTyhfXfOgacEP
 github.com/kevinburke/go-bindata v3.13.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
-github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a h1:o2feyvFn8r1nJu/iVn89h0kT+CH6pROXZZHQO60NbrI=
+github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/pkg/cmd/dev/go.go
+++ b/pkg/cmd/dev/go.go
@@ -24,8 +24,10 @@ func makeGoCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comman
 }
 
 func (d *dev) gocmd(cmd *cobra.Command, commandLine []string) error {
+	beforeDash, afterDash := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
 	args := []string{"run", "@go_sdk//:bin/go", "--ui_event_filters=-DEBUG,-info,-stdout,-stderr", "--noshow_progress", "--"}
-	args = append(args, commandLine...)
+	args = append(args, beforeDash...)
+	args = append(args, afterDash...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 }

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -1,3 +1,5 @@
+exports_files(["testdata/errcheck_excludes.txt"])
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:build_tags lint

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1593,7 +1593,9 @@ func TestLint(t *testing.T) {
 	// https://github.com/dominikh/go-tools/issues/57 is fixed.
 	t.Run("TestErrCheck", func(t *testing.T) {
 		skip.UnderShort(t)
-		skip.UnderBazelWithIssue(t, 68498, "Generated files not placed in the workspace via Bazel build")
+		if bazel.BuiltWithBazel() {
+			skip.IgnoreLint(t, "the errcheck tests are run during the bazel build")
+		}
 		excludesPath, err := filepath.Abs(filepath.Join("testdata", "errcheck_excludes.txt"))
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/testutils/lint/passes/errcheck/BUILD.bazel
+++ b/pkg/testutils/lint/passes/errcheck/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "errcheck",
+    srcs = ["errcheck.go"],
+    embedsrcs = ["errcheck_excludes.txt"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/errcheck",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_kisielk_errcheck//errcheck",
+    ],
+)
+
+# NB: We want errcheck_excludes.txt in the same logical directory so we can
+# go:embed it, so we just copy it here unchanged.
+genrule(
+    name = "gen-errcheck-excludes",
+    srcs = ["//pkg/testutils/lint:testdata/errcheck_excludes.txt"],
+    outs = ["errcheck_excludes.txt"],
+    cmd = "cp $< $@",
+)

--- a/pkg/testutils/lint/passes/errcheck/errcheck.go
+++ b/pkg/testutils/lint/passes/errcheck/errcheck.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package errcheck defines an Analyzer that is a slightly modified version
+// of the errcheck Analyzer from upstream (github.com/kisielk/errcheck).
+// Specifically, we pass in our own list of excludes.
+
+//go:build bazel
+// +build bazel
+
+package errcheck
+
+import (
+	_ "embed"
+
+	"github.com/kisielk/errcheck/errcheck"
+)
+
+var Analyzer = errcheck.Analyzer
+
+//go:embed errcheck_excludes.txt
+var excludesContent string
+
+func init() {
+	Analyzer.Flags.Set("excludes", excludesContent)
+}


### PR DESCRIPTION
We pull the latest version of `errcheck` which provides an `Analyzer`.
I had to patch it slightly so that it can take the list of `excludes` as
an argument instead of as a file path (we can't find
`errcheck_excludes.txt` during the build).

Closes #68498.

Release note: None