### PR TITLE
sql: include a memory size interface for descriptors for memory monit…

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -138,6 +138,11 @@ func (desc *immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// ByteSize implements the Descriptor interface.
+func (desc *immutable) ByteSize() int64 {
+	return int64(desc.Size())
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 	return NewBuilder(desc.DatabaseDesc())

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -182,6 +182,9 @@ type Descriptor interface {
 	// DescriptorProto prepares this descriptor for serialization.
 	DescriptorProto() *descpb.Descriptor
 
+	//ByteSize returns the memory held by the Descriptor.
+	ByteSize() int64
+
 	// NewBuilder initializes a DescriptorBuilder with this descriptor.
 	NewBuilder() DescriptorBuilder
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -637,6 +637,7 @@ type Manager struct {
 	storage          storage
 	mu               struct {
 		syncutil.Mutex
+		//TODO(james): Track size of leased descriptors in memory.
 		descriptors map[descpb.ID]*descriptorState
 
 		// updatesResolvedTimestamp keeps track of a timestamp before which all

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -15,6 +15,7 @@ package lease
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1208,6 +1209,244 @@ func TestReadOlderVersionForTimestamp(t *testing.T) {
 				retrievedVersions = append([]version{ver}, retrievedVersions...)
 			}
 			require.Equal(t, tc.expected, retrievedVersions)
+		})
+	}
+}
+
+// TestDescriptorByteSizeOrder inserts different amount of data in each
+// descriptor and guarantees the relative order of the Descriptor sizes are
+// correct.
+func TestDescriptorByteSizeOrder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	manager := s.LeaseManager().(*Manager)
+	for _, tc := range []struct {
+		sqlExprs map[string]string
+		expOrder []string
+		name     string
+	}{
+		// Confirm order of TableDescriptors with varying name.
+		{
+			sqlExprs: map[string]string{
+				"s":             "CREATE TABLE s (col1 INT)",
+				"medxx":         "CREATE TABLE medxx (col1 INT)",
+				"largexxxx":     "CREATE TABLE largexxxx (col1 INT)",
+				"largestxxxxxx": "CREATE TABLE largestxxxxxx (col1 INT)",
+			},
+			expOrder: []string{
+				"s",
+				"medxx",
+				"largexxxx",
+				"largestxxxxxx",
+			},
+			name: "tables with varying name",
+		},
+		// Confirm order of TableDescriptors with varying col count.
+		{
+			sqlExprs: map[string]string{
+				"smallxxcol": "CREATE TABLE smallxxcol (col1 INT)",
+				"mediumxcol": "CREATE TABLE mediumxcol (col1 INT, col2 INT)",
+				"largexxcol": "CREATE TABLE largexxcol (col1 INT, col2 INT, col3 UUID)",
+				"largestcol": "CREATE TABLE largestcol (col1 INT, col2 INT, col3 UUID, col4 UUID)",
+			},
+			expOrder: []string{
+				"smallxxcol",
+				"mediumxcol",
+				"largexxcol",
+				"largestcol",
+			},
+			name: "tables with varying col",
+		},
+		// Confirm order of TableDescriptors with varying idx count.
+		{
+			sqlExprs: map[string]string{
+				"smallxx": "CREATE TABLE smallxx (col1 INT, col2 INT, col3 STRING, col4 BOOL, INDEX (col1))",
+				"mediumx": "CREATE TABLE mediumx (col1 INT, col2 INT, col3 STRING, col4 BOOL, INDEX (col1, col2))",
+				"largexx": "CREATE TABLE largexx (col1 INT, col2 INT, col3 STRING, col4 BOOL, INDEX (col1, col2, col3))",
+				"largest": "CREATE TABLE largest (col1 INT, col2 INT, col3 STRING, col4 BOOL, INDEX (col1, col2, col3, col4))",
+			},
+			expOrder: []string{
+				"smallxx",
+				"mediumx",
+				"largexx",
+				"largest",
+			},
+			name: "tables with varying idx",
+		},
+		// Confirm order of DatabaseDescriptors with varying name.
+		{
+			sqlExprs: map[string]string{
+				"sdb":          "CREATE DATABASE sdb",
+				"meddbx":       "CREATE DATABASE meddbx",
+				"largedbxx":    "CREATE DATABASE largedbxx",
+				"largestdbxxx": "CREATE DATABASE largestdbxxx",
+			},
+			expOrder: []string{
+				"sdb",
+				"meddbx",
+				"largedbxx",
+				"largestdbxxx",
+			},
+			name: "databases with varying name",
+		},
+		// Confirm order of SchemaDescriptors with varying name.
+		{
+			sqlExprs: map[string]string{
+				"sschema":          "CREATE SCHEMA sschema",
+				"medschemax":       "CREATE SCHEMA medschemax",
+				"largeschemaxx":    "CREATE SCHEMA largeschemaxx",
+				"largestschemaxxx": "CREATE SCHEMA largestschemaxxx",
+			},
+			expOrder: []string{
+				"sschema",
+				"medschemax",
+				"largeschemaxx",
+				"largestschemaxxx",
+			},
+			name: "schemas with varying name",
+		},
+		// Confirm order of TypeDescriptors with varying name.
+		{
+			sqlExprs: map[string]string{
+				"stype":       "CREATE TYPE stype AS ENUM ('open', 'closed')",
+				"medtype":     "CREATE TYPE medtype AS ENUM ('open', 'closed', 'inactive')",
+				"largetype":   "CREATE TYPE largetype AS ENUM ('open', 'closed', 'inactive', 'active')",
+				"largesttype": "CREATE TYPE largesttype AS ENUM ('open', 'closed', 'inactive', 'active', 'starting')",
+			},
+			expOrder: []string{
+				"stype",
+				"medtype",
+				"largetype",
+				"largesttype",
+			},
+			name: "types with varying name",
+		},
+	} {
+		t.Run(fmt.Sprint(tc.name), func(t *testing.T) {
+			// Create tables and retrieve TableDescriptors.
+			descs := make([]LeasedDescriptor, 0, len(tc.sqlExprs))
+			for size, expr := range tc.sqlExprs {
+				tdb.Exec(t, expr)
+				var tableID descpb.ID
+				tdb.QueryRow(t, "SELECT id FROM system.namespace WHERE name = "+"'"+size+"'").Scan(&tableID)
+				desc, err := manager.Acquire(ctx, s.Clock().Now(), tableID)
+				require.NoError(t, err)
+				descs = append(descs, desc)
+			}
+
+			// Sort the descriptors and confirm is same as expected.
+			sort.Slice(descs, func(i, j int) bool {
+				return descs[i].Underlying().ByteSize() < descs[j].Underlying().ByteSize()
+			})
+			actual := make([]string, len(descs))
+			for i, desc := range descs {
+				actual[i] = desc.GetName()
+			}
+			require.Equalf(t, tc.expOrder, actual, "expected: %v, got: %v", tc.expOrder, actual)
+		})
+	}
+}
+
+// TestLeasedDescriptorByteSizeBaseline ensures each descriptor type has a byte
+// size of at least the baseline approximation, which is the number of bytes
+// from the binary encoded in the descriptor table.
+func TestLeasedDescriptorByteSizeBaseline(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(db)
+	manager := s.LeaseManager().(*Manager)
+
+	getApproxByteSize := func(t *testing.T, descID descpb.ID) int64 {
+		var descBytes *[]byte
+		rows := tdb.Query(t, "SELECT descriptor FROM system.descriptor WHERE id = $1", descID)
+		if rows.Next() {
+			err := rows.Scan(&descBytes)
+			require.NoError(t, err, "error retrieving descriptor from system table")
+		}
+		return int64(len(*descBytes))
+	}
+
+	for _, tc := range []struct {
+		sqlExpr  []string
+		descType string
+		name     string
+	}{
+		{
+			sqlExpr: []string{
+				"CREATE TABLE s (col1 INT)",
+			},
+			descType: "table",
+			name:     "s",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE TABLE ss (col1 INT)",
+				"INSERT INTO s VALUES (1)",
+				"INSERT INTO s VALUES (10)",
+			},
+			descType: "table",
+			name:     "ss",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE DATABASE randomDB",
+			},
+			descType: "db",
+			name:     "randomdb",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE SCHEMA schema_one",
+			},
+			descType: "schema",
+			name:     "schema_one",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE USER max WITH PASSWORD 'roach'",
+				"CREATE SCHEMA schema_two AUTHORIZATION max",
+			},
+			descType: "schema",
+			name:     "schema_two",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE TYPE type_one AS ENUM ('open', 'closed')",
+			},
+			descType: "type",
+			name:     "type_one",
+		},
+		{
+			sqlExpr: []string{
+				"CREATE TYPE type_two AS ENUM ('open', 'closed', 'inactive', 'active', 'starting')",
+			},
+			descType: "type",
+			name:     "type_two",
+		},
+	} {
+		t.Run(fmt.Sprintf("%s descriptor %s", tc.descType, tc.name), func(t *testing.T) {
+			// Execute SQL commands and acquire leases on descriptors.
+			for _, expr := range tc.sqlExpr {
+				tdb.Exec(t, expr)
+			}
+			var descID descpb.ID
+			tdb.QueryRow(t, "SELECT id FROM system.namespace WHERE name ="+
+				"'"+tc.name+"'").Scan(&descID)
+			desc, err := manager.Acquire(ctx, s.Clock().Now(), descID)
+			require.NoError(t, err)
+
+			// Confirm each descriptor byte size is at least the baseline's.
+			approx := getApproxByteSize(t, descID)
+			require.Greaterf(t, desc.Underlying().ByteSize(), approx, "ByteSize of desc "+
+				"%d does not exceed the baseline", desc.GetID())
 		})
 	}
 }

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -150,6 +150,11 @@ func (desc *immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// ByteSize implements the Descriptor interface.
+func (desc *immutable) ByteSize() int64 {
+	return int64(desc.Size())
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 	return NewBuilder(desc.SchemaDesc())

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -81,6 +81,9 @@ func (p synthetic) DescriptorProto() *descpb.Descriptor {
 		"%s schema cannot be encoded", p.kindName())
 	return nil // unreachable
 }
+func (p synthetic) ByteSize() int64 {
+	return 0
+}
 func (p synthetic) NewBuilder() catalog.DescriptorBuilder {
 	log.Fatalf(context.TODO(),
 		"%s schema cannot create a builder", p.kindName())

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -101,6 +101,11 @@ func (desc *wrapper) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// ByteSize implements the Descriptor interface.
+func (desc *wrapper) ByteSize() int64 {
+	return int64(desc.Size())
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *wrapper) NewBuilder() catalog.DescriptorBuilder {
 	return NewBuilder(desc.TableDesc())

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -178,6 +178,18 @@ func (v TableImplicitRecordType) DescriptorProto() *descpb.Descriptor {
 	return nil
 }
 
+// ByteSize implements the Descriptor interface.
+func (v TableImplicitRecordType) ByteSize() int64 {
+	mem := v.desc.ByteSize()
+	if v.typ != nil {
+		mem += int64(v.typ.Size())
+	}
+	if v.privs != nil {
+		mem += int64(v.privs.Size())
+	}
+	return mem
+}
+
 // NewBuilder implements the Descriptor interface.
 func (v TableImplicitRecordType) NewBuilder() catalog.DescriptorBuilder {
 	v.panicNotSupported("NewBuilder")

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -177,6 +177,11 @@ func (desc *immutable) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// ByteSize implements the Descriptor interface.
+func (desc *immutable) ByteSize() int64 {
+	return int64(desc.Size())
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 	return NewBuilder(desc.TypeDesc())


### PR DESCRIPTION
…oring

In order to allow for memory monitoring descriptors and leases (see #67049),
an interface method MemorySize is needed for catalog.Descriptor. This change
allows us to rely on existing protobuf Size() methods.

Release note (sql change): Exposed MemorySize method for a catalog.Descriptor
for memory monitoring purposes.