### PR TITLE
scplan: decorate Stage with Phase and other properties

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -8,7 +8,7 @@ CREATE TABLE foo (i INT PRIMARY KEY)
 
 # Declarative is not fully enabled for this statement,
 # so it should error out.
-statement error cannot explain a non-schema change statement
+statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
 EXPLAIN (DDL) ALTER TABLE foo ADD COLUMN j INT
 
 statement ok
@@ -187,7 +187,7 @@ j  b
 statement ok
 SET experimental_use_new_schema_changer = 'unsafe'
 
-statement error pq: cannot explain a non-schema change statement
+statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
 EXPLAIN (DDL) ALTER TABLE bar ALTER COLUMN j TYPE BOOL
 
 statement ok

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -350,7 +350,7 @@ func TestSchemaChanger(t *testing.T) {
 				scop.PreCommitPhase,
 			} {
 				sc := sctestutils.MakePlan(t, nodes, phase)
-				stages := sc.Stages
+				stages := sc.StagesForCurrentPhase()
 				for _, s := range stages {
 					exDeps := ti.newExecDeps(txn, descriptors)
 					require.NoError(t, scgraphviz.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, s.Ops), sc))
@@ -364,7 +364,7 @@ func TestSchemaChanger(t *testing.T) {
 			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 		) error {
 			sc := sctestutils.MakePlan(t, ts, scop.PostCommitPhase)
-			for _, s := range sc.Stages {
+			for _, s := range sc.StagesForCurrentPhase() {
 				exDeps := ti.newExecDeps(txn, descriptors)
 				require.NoError(t, scgraphviz.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, s.Ops), sc))
 				after = s.After
@@ -427,7 +427,7 @@ func TestSchemaChanger(t *testing.T) {
 					scop.PreCommitPhase,
 				} {
 					sc := sctestutils.MakePlan(t, outputNodes, phase)
-					for _, s := range sc.Stages {
+					for _, s := range sc.StagesForCurrentPhase() {
 						exDeps := ti.newExecDeps(txn, descriptors)
 						require.NoError(t, scgraphviz.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, s.Ops), sc))
 						ts = s.After
@@ -440,7 +440,7 @@ func TestSchemaChanger(t *testing.T) {
 			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 		) error {
 			sc := sctestutils.MakePlan(t, ts, scop.PostCommitPhase)
-			for _, s := range sc.Stages {
+			for _, s := range sc.StagesForCurrentPhase() {
 				exDeps := ti.newExecDeps(txn, descriptors)
 				require.NoError(t, scgraphviz.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, s.Ops), sc))
 			}

--- a/pkg/sql/schemachanger/scgraphviz/graphviz.go
+++ b/pkg/sql/schemachanger/scgraphviz/graphviz.go
@@ -91,7 +91,7 @@ func DecorateErrorWithPlanDetails(err error, p scplan.Plan) error {
 
 // DrawStages returns a graphviz string of the stages of the Plan.
 func DrawStages(p scplan.Plan) (string, error) {
-	if p.Stages == nil {
+	if p.StagesForAllPhases() == nil {
 		return "", errors.Errorf("missing stages in plan")
 	}
 	gv, err := drawStages(p)
@@ -152,13 +152,13 @@ func drawStages(p scplan.Plan) (*dot.Graph, error) {
 		e.Label(n.Target.Direction.String())
 		curNodes[i] = tsn
 	}
-	for id, st := range p.Stages {
-		stage := fmt.Sprintf("stage %d of %d", id+1, len(p.Stages))
+	for _, st := range p.StagesForAllPhases() {
+		stage := st.String()
 		sg := stagesSubgraph.Subgraph(stage, dot.ClusterOption{})
 		next := st.After
 		nextNodes := make([]dot.Node, len(curNodes))
 		for i, st := range next.Nodes {
-			cst := sg.Node(fmt.Sprintf("stage %d of %d: %d", id+1, len(p.Stages), i))
+			cst := sg.Node(fmt.Sprintf("%s: %d", stage, i))
 			cst.Attr("label", targetStatusID(i, st.Status))
 			if st != cur.Nodes[i] {
 				ge := curNodes[i].Edge(cst)

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -233,7 +233,7 @@ func TestSchemaChangeWaitsForOtherSchemaChanges(t *testing.T) {
 					}
 
 					// Block job 1 during the backfill.
-					s := p.Stages[idx]
+					s := p.StagesForCurrentPhase()[idx]
 					if stmt != stmt1 || s.Ops.Type() != scop.BackfillType {
 						return nil
 					}
@@ -345,7 +345,7 @@ func TestConcurrentOldSchemaChangesCannotStart(t *testing.T) {
 				for _, m := range table.AllMutations() {
 					assert.LessOrEqual(t, int(m.MutationID()), 2)
 				}
-				s := p.Stages[idx]
+				s := p.StagesForCurrentPhase()[idx]
 				if s.Ops.Type() != scop.BackfillType {
 					return nil
 				}
@@ -451,7 +451,7 @@ func TestInsertDuringAddColumnNotWritingToCurrentPrimaryIndex(t *testing.T) {
 				for _, m := range table.AllMutations() {
 					assert.LessOrEqual(t, int(m.MutationID()), 2)
 				}
-				s := p.Stages[stageIdx]
+				s := p.StagesForCurrentPhase()[stageIdx]
 				if s.Ops.Type() != scop.BackfillType {
 					return nil
 				}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -5,13 +5,12 @@ CREATE TABLE defaultdb.foo (i INT PRIMARY KEY)
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT
 ----
-Stage 1 of 7
+PreCommitPhase stage 1 of 1 with 5 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 2, Name: j}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedColumnDeleteOnly
       ColumnID: 2
@@ -62,14 +61,11 @@ Stage 1 of 7
       IndexID: 2
       Name: new_primary_key
       TableID: 54
-    *scop.SetIndexName
-      IndexID: 1
-      Name: foo_pkey
-      TableID: 54
-Stage 2 of 7
+PostCommitPhase stage 1 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -77,21 +73,25 @@ Stage 2 of 7
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
       TableID: 54
-Stage 3 of 7
+    *scop.SetIndexName
+      IndexID: 1
+      Name: foo_pkey
+      TableID: 54
+PostCommitPhase stage 2 of 6 with 1 BackfillType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 7
+PostCommitPhase stage 3 of 6 with 1 ValidationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 7
+PostCommitPhase stage 4 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
@@ -106,14 +106,14 @@ Stage 5 of 7
     *scop.MakeColumnPublic
       ColumnID: 2
       TableID: 54
-Stage 6 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 5 of 6 with 1 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 54
-Stage 7 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 6 of 6 with 2 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
@@ -127,13 +127,12 @@ Stage 7 of 7 (non-revertible)
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123
 ----
-Stage 1 of 7
+PreCommitPhase stage 1 of 1 with 5 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 2, Name: j}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedColumnDeleteOnly
       ColumnID: 2
@@ -186,14 +185,11 @@ Stage 1 of 7
       IndexID: 2
       Name: new_primary_key
       TableID: 54
-    *scop.SetIndexName
-      IndexID: 1
-      Name: foo_pkey
-      TableID: 54
-Stage 2 of 7
+PostCommitPhase stage 1 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -201,21 +197,25 @@ Stage 2 of 7
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
       TableID: 54
-Stage 3 of 7
+    *scop.SetIndexName
+      IndexID: 1
+      Name: foo_pkey
+      TableID: 54
+PostCommitPhase stage 2 of 6 with 1 BackfillType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 7
+PostCommitPhase stage 3 of 6 with 1 ValidationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 7
+PostCommitPhase stage 4 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
@@ -230,14 +230,14 @@ Stage 5 of 7
     *scop.MakeColumnPublic
       ColumnID: 2
       TableID: 54
-Stage 6 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 5 of 6 with 1 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 54
-Stage 7 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 6 of 6 with 2 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
@@ -252,13 +252,12 @@ ops
 ALTER TABLE defaultdb.foo ADD COLUMN j INT DEFAULT 123;
 ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
 ----
-Stage 1 of 7
+PreCommitPhase stage 1 of 1 with 8 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 2, Name: j}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 54, ColumnID: 3}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 3, Name: k}, ABSENT, ADD] -> PUBLIC
   ops:
@@ -347,18 +346,15 @@ Stage 1 of 7
       IndexID: 2
       Name: new_primary_key
       TableID: 54
-    *scop.SetIndexName
-      IndexID: 1
-      Name: foo_pkey
-      TableID: 54
     *scop.SetColumnName
       ColumnID: 3
       Name: k
       TableID: 54
-Stage 2 of 7
+PostCommitPhase stage 1 of 6 with 4 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 54, ColumnID: 3}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
@@ -367,24 +363,28 @@ Stage 2 of 7
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
       TableID: 54
+    *scop.SetIndexName
+      IndexID: 1
+      Name: foo_pkey
+      TableID: 54
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 3
       TableID: 54
-Stage 3 of 7
+PostCommitPhase stage 2 of 6 with 1 BackfillType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 7
+PostCommitPhase stage 3 of 6 with 1 ValidationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 7
+PostCommitPhase stage 4 of 6 with 4 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
@@ -403,14 +403,14 @@ Stage 5 of 7
     *scop.MakeColumnPublic
       ColumnID: 3
       TableID: 54
-Stage 6 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 5 of 6 with 1 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 54
-Stage 7 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 6 of 6 with 2 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
@@ -424,13 +424,12 @@ Stage 7 of 7 (non-revertible)
 ops
 ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
 ----
-Stage 1 of 7
+PreCommitPhase stage 1 of 1 with 5 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 2, Name: a}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedColumnDeleteOnly
       ColumnID: 2
@@ -483,14 +482,11 @@ Stage 1 of 7
       IndexID: 2
       Name: new_primary_key
       TableID: 54
-    *scop.SetIndexName
-      IndexID: 1
-      Name: foo_pkey
-      TableID: 54
-Stage 2 of 7
+PostCommitPhase stage 1 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -498,21 +494,25 @@ Stage 2 of 7
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
       TableID: 54
-Stage 3 of 7
+    *scop.SetIndexName
+      IndexID: 1
+      Name: foo_pkey
+      TableID: 54
+PostCommitPhase stage 2 of 6 with 1 BackfillType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 7
+PostCommitPhase stage 3 of 6 with 1 ValidationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 7
+PostCommitPhase stage 4 of 6 with 3 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
@@ -527,14 +527,14 @@ Stage 5 of 7
     *scop.MakeColumnPublic
       ColumnID: 2
       TableID: 54
-Stage 6 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 5 of 6 with 1 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
   ops:
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 54
-Stage 7 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 6 of 6 with 2 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
   ops:
@@ -554,18 +554,16 @@ ops
 ALTER TABLE defaultdb.foo ADD COLUMN a INT;
 ALTER TABLE defaultdb.bar ADD COLUMN b INT;
 ----
-Stage 1 of 7
+PreCommitPhase stage 1 of 1 with 10 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 54, ColumnID: 2, Name: a}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 55, ColumnID: 3}, ABSENT, ADD] -> DELETE_ONLY
     [ColumnName:{DescID: 55, ColumnID: 3, Name: b}, ABSENT, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 55, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 55, IndexID: 2, Name: new_primary_key}, ABSENT, ADD] -> PUBLIC
-    [IndexName:{DescID: 55, IndexID: 1, Name: bar_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedColumnDeleteOnly
       ColumnID: 2
@@ -615,10 +613,6 @@ Stage 1 of 7
     *scop.SetIndexName
       IndexID: 2
       Name: new_primary_key
-      TableID: 54
-    *scop.SetIndexName
-      IndexID: 1
-      Name: foo_pkey
       TableID: 54
     *scop.MakeAddedColumnDeleteOnly
       ColumnID: 3
@@ -671,16 +665,14 @@ Stage 1 of 7
       IndexID: 2
       Name: new_primary_key
       TableID: 55
-    *scop.SetIndexName
-      IndexID: 1
-      Name: bar_pkey
-      TableID: 55
-Stage 2 of 7
+PostCommitPhase stage 1 of 6 with 6 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 54, IndexID: 1, Name: foo_pkey}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 55, ColumnID: 3}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 55, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
+    [IndexName:{DescID: 55, IndexID: 1, Name: bar_pkey}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
@@ -688,13 +680,21 @@ Stage 2 of 7
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
       TableID: 54
+    *scop.SetIndexName
+      IndexID: 1
+      Name: foo_pkey
+      TableID: 54
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 55
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 3
       TableID: 55
-Stage 3 of 7
+    *scop.SetIndexName
+      IndexID: 1
+      Name: bar_pkey
+      TableID: 55
+PostCommitPhase stage 2 of 6 with 2 BackfillType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
     [PrimaryIndex:{DescID: 55, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
@@ -705,7 +705,7 @@ Stage 3 of 7
     *scop.BackfillIndex
       IndexID: 2
       TableID: 55
-Stage 4 of 7
+PostCommitPhase stage 3 of 6 with 2 ValidationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
     [PrimaryIndex:{DescID: 55, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
@@ -716,7 +716,7 @@ Stage 4 of 7
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 55
-Stage 5 of 7
+PostCommitPhase stage 4 of 6 with 6 MutationType ops
   transitions:
     [Column:{DescID: 54, ColumnID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> PUBLIC
     [PrimaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
@@ -743,7 +743,7 @@ Stage 5 of 7
     *scop.MakeColumnPublic
       ColumnID: 3
       TableID: 55
-Stage 6 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 5 of 6 with 2 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [PrimaryIndex:{DescID: 55, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
@@ -754,7 +754,7 @@ Stage 6 of 7 (non-revertible)
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 1
       TableID: 55
-Stage 7 of 7 (non-revertible)
+PostCommitPhase non-revertible stage 6 of 6 with 4 MutationType ops
   transitions:
     [PrimaryIndex:{DescID: 54, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
     [PrimaryIndex:{DescID: 55, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -3,9 +3,9 @@ CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, name varchar(256), money int)
 ----
 
 ops
-CREATE INDEX id1 on defaultdb.t1(id, name) storing (money)
+CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
-Stage 1 of 5
+PreCommitPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: id1}, ABSENT, ADD] -> PUBLIC
@@ -26,28 +26,28 @@ Stage 1 of 5
       IndexID: 2
       Name: id1
       TableID: 54
-Stage 2 of 5
+PostCommitPhase stage 1 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 54
-Stage 3 of 5
+PostCommitPhase stage 2 of 4 with 1 BackfillType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 5
+PostCommitPhase stage 3 of 4 with 1 ValidationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 5
+PostCommitPhase stage 4 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
@@ -56,7 +56,7 @@ Stage 5 of 5
       TableID: 54
 
 deps
-CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
+CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
@@ -68,9 +68,9 @@ CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
   rule: index needs a name to be assigned
 
 ops
-CREATE INVERTED INDEX concurrently id1 on defaultdb.t1(id, name) storing (money)
+CREATE INVERTED INDEX CONCURRENTLY id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
-Stage 1 of 5
+PreCommitPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
     [IndexName:{DescID: 54, IndexID: 2, Name: id1}, ABSENT, ADD] -> PUBLIC
@@ -93,28 +93,28 @@ Stage 1 of 5
       IndexID: 2
       Name: id1
       TableID: 54
-Stage 2 of 5
+PostCommitPhase stage 1 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 54
-Stage 3 of 5
+PostCommitPhase stage 2 of 4 with 1 BackfillType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 5
+PostCommitPhase stage 3 of 4 with 1 ValidationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 5
+PostCommitPhase stage 4 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
@@ -123,7 +123,7 @@ Stage 5 of 5
       TableID: 54
 
 deps
-CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
+CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
@@ -135,11 +135,9 @@ CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money)
   rule: index needs a name to be assigned
 
 ops
-CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (id) (
-                                                              PARTITION p1 VALUES IN (1)
-                                                            )
+CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
 ----
-Stage 1 of 5
+PreCommitPhase stage 1 of 1 with 3 MutationType ops
   transitions:
     [Partitioning:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> PUBLIC
     [SecondaryIndex:{DescID: 54, IndexID: 2}, ABSENT, ADD] -> DELETE_ONLY
@@ -171,28 +169,28 @@ Stage 1 of 5
       IndexID: 2
       Name: id1
       TableID: 54
-Stage 2 of 5
+PostCommitPhase stage 1 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY, ADD] -> DELETE_AND_WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 2
       TableID: 54
-Stage 3 of 5
+PostCommitPhase stage 2 of 4 with 1 BackfillType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY, ADD] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
       TableID: 54
-Stage 4 of 5
+PostCommitPhase stage 3 of 4 with 1 ValidationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, BACKFILLED, ADD] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
       TableID: 54
-Stage 5 of 5
+PostCommitPhase stage 4 of 4 with 1 MutationType ops
   transitions:
     [SecondaryIndex:{DescID: 54, IndexID: 2}, VALIDATED, ADD] -> PUBLIC
   ops:
@@ -201,9 +199,7 @@ Stage 5 of 5
       TableID: 54
 
 deps
-CREATE INDEX id1 on  defaultdb.t1(id, name) storing (money) PARTITION BY LIST (id) (
-                                                              PARTITION p1 VALUES IN (1)
-                                                            )
+CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -50,32 +50,24 @@ CREATE VIEW db1.sc1.v5 AS (SELECT 'a'::db1.sc1.typ::string AS k, n2, n1 from db1
 ops
 DROP DATABASE db1 CASCADE
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 14 MutationType ops
   transitions:
     [Sequence:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 57}, PUBLIC, DROP] -> ABSENT
     [Table:{DescID: 60}, PUBLIC, DROP] -> TXN_DROPPED
-    [ColumnName:{DescID: 60, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 60, ColumnID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 60, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 60, ColumnID: 2}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 60, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 60, ColumnID: 3}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 60, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [IndexName:{DescID: 60, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [Locality:{DescID: 60}, PUBLIC, DROP] -> ABSENT
     [Schema:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
     [Sequence:{DescID: 58}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 58}, PUBLIC, DROP] -> ABSENT
     [Table:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
-    [ColumnName:{DescID: 59, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 59, ColumnID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 59, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 59, ColumnID: 2}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 59, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 59, ColumnID: 3}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 59, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [IndexName:{DescID: 59, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [Locality:{DescID: 59}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 61}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 61}, PUBLIC, DROP] -> ABSENT
@@ -120,7 +112,7 @@ Stage 1 of 3
       DescID: 56
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 54
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 2 with 37 MutationType ops
   transitions:
     [Sequence:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 57, Name: sq1}, PUBLIC, DROP] -> ABSENT
@@ -135,11 +127,7 @@ Stage 2 of 3 (non-revertible)
     [UserPrivileges:{DescID: 60, Username: admin}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 60, Username: public}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 60, Username: root}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 60, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 60, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 60, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [DefaultExpression:{DescID: 60, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 60, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [Schema:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
     [Sequence:{DescID: 58}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 58, Name: sq1}, PUBLIC, DROP] -> ABSENT
@@ -154,11 +142,7 @@ Stage 2 of 3 (non-revertible)
     [UserPrivileges:{DescID: 59, Username: admin}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 59, Username: public}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 59, Username: root}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 59, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 59, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 59, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [DefaultExpression:{DescID: 59, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 59, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 61}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 61, Name: v1}, PUBLIC, DROP] -> ABSENT
@@ -288,30 +272,62 @@ Stage 2 of 3 (non-revertible)
       DescID: 56
     *scop.MarkDescriptorAsDropped
       DescID: 54
-Stage 3 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 2 of 2 with 4 MutationType ops
+  transitions:
+    [Type:{DescID: 65}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 66}, DROPPED, DROP] -> ABSENT
+    [Database:{DescID: 54}, DROPPED, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 65
+    *scop.DrainDescriptorName
+      TableID: 66
+    *scop.DrainDescriptorName
+      TableID: 54
+    *scop.LogEvent
+      DescID: 54
+      Direction: 2
+      Element:
+        database:
+          databaseId: 54
+          dependentObjects:
+          - 55
+          - 56
+      Metadata:
+        Statement: DROP DATABASE db1 CASCADE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+        Username: root
+PostCommitPhase non-revertible stage 1 of 1 with 22 MutationType ops
   transitions:
     [Sequence:{DescID: 57}, DROPPED, DROP] -> ABSENT
     [Table:{DescID: 60}, DROPPED, DROP] -> ABSENT
-    [Column:{DescID: 60, ColumnID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 60, ColumnID: 2}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 60, ColumnID: 3}, DELETE_ONLY, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 60, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 60, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 60, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 60, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 60, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 60, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 60, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 60, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [IndexName:{DescID: 60, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [Schema:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [Sequence:{DescID: 58}, DROPPED, DROP] -> ABSENT
     [Table:{DescID: 59}, DROPPED, DROP] -> ABSENT
-    [Column:{DescID: 59, ColumnID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 59, ColumnID: 2}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 59, ColumnID: 3}, DELETE_ONLY, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 59, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 59, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 59, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 59, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 59, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 59, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 59, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 59, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [IndexName:{DescID: 59, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 61}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 62}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 63}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 64}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 67}, DROPPED, DROP] -> ABSENT
-    [Type:{DescID: 65}, DROPPED, DROP] -> ABSENT
-    [Type:{DescID: 66}, DROPPED, DROP] -> ABSENT
     [Schema:{DescID: 56}, DROPPED, DROP] -> ABSENT
-    [Database:{DescID: 54}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.LogEvent
       DescID: 57
@@ -457,10 +473,6 @@ Stage 3 of 3 (non-revertible)
     *scop.CreateGcJobForDescriptor
       DescID: 67
     *scop.DrainDescriptorName
-      TableID: 65
-    *scop.DrainDescriptorName
-      TableID: 66
-    *scop.DrainDescriptorName
       TableID: 56
     *scop.LogEvent
       DescID: 56
@@ -482,23 +494,6 @@ Stage 3 of 3 (non-revertible)
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
           SourceElementID: 2
-          SubWorkID: 1
-        Username: root
-    *scop.DrainDescriptorName
-      TableID: 54
-    *scop.LogEvent
-      DescID: 54
-      Direction: 2
-      Element:
-        database:
-          databaseId: 54
-          dependentObjects:
-          - 55
-          - 56
-      Metadata:
-        Statement: DROP DATABASE db1 CASCADE
-        TargetMetadata:
-          SourceElementID: 1
           SubWorkID: 1
         Username: root
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -7,7 +7,7 @@ CREATE SEQUENCE sc1.SQ1
 ----
 
 create-table
-CREATE TABLE sc1.t1 (id INT PRIMARY KEY, name varchar(256), val int DEFAULT nextval('sc1.sq1'))
+CREATE TABLE sc1.t1 (id INT8 PRIMARY KEY, name VARCHAR(256), val INT8 DEFAULT nextval('sc1.sq1'))
 ----
 
 create-view
@@ -31,7 +31,7 @@ CREATE TYPE sc1.typ AS ENUM('a')
 ----
 
 create-view
-CREATE VIEW sc1.v5 AS (SELECT 'a'::sc1.typ::string AS k, n2, n1 from sc1.v4)
+CREATE VIEW sc1.v5 AS (SELECT 'a'::sc1.typ::STRING AS k, n2, n1 FROM sc1.v4)
 ----
 
 deps
@@ -313,19 +313,15 @@ DROP SCHEMA defaultdb.SC1 CASCADE
 ops
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 10 MutationType ops
   transitions:
     [Sequence:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 55}, PUBLIC, DROP] -> ABSENT
     [Table:{DescID: 56}, PUBLIC, DROP] -> TXN_DROPPED
-    [ColumnName:{DescID: 56, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 56, ColumnID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 56, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 56, ColumnID: 2}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 56, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 56, ColumnID: 3}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 56, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [IndexName:{DescID: 56, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [Locality:{DescID: 56}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 57}, PUBLIC, DROP] -> ABSENT
@@ -361,7 +357,7 @@ Stage 1 of 3
       DescID: 62
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 54
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 2 with 28 MutationType ops
   transitions:
     [Sequence:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 55, Name: sq1}, PUBLIC, DROP] -> ABSENT
@@ -376,11 +372,7 @@ Stage 2 of 3 (non-revertible)
     [UserPrivileges:{DescID: 56, Username: admin}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 56, Username: public}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 56, Username: root}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 56, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 56, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 56, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [DefaultExpression:{DescID: 56, ColumnID: 3}, PUBLIC, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 56, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 57, Name: v1}, PUBLIC, DROP] -> ABSENT
@@ -489,21 +481,32 @@ Stage 2 of 3 (non-revertible)
       TypeID: 62
     *scop.MarkDescriptorAsDropped
       DescID: 54
-Stage 3 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [Type:{DescID: 61}, DROPPED, DROP] -> ABSENT
+    [Type:{DescID: 62}, DROPPED, DROP] -> ABSENT
+  ops:
+    *scop.DrainDescriptorName
+      TableID: 61
+    *scop.DrainDescriptorName
+      TableID: 62
+PostCommitPhase non-revertible stage 1 of 1 with 16 MutationType ops
   transitions:
     [Sequence:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [Table:{DescID: 56}, DROPPED, DROP] -> ABSENT
-    [Column:{DescID: 56, ColumnID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 56, ColumnID: 2}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 56, ColumnID: 3}, DELETE_ONLY, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 56, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 56, ColumnID: 1, Name: id}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 56, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 56, ColumnID: 2, Name: name}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 56, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 56, ColumnID: 3, Name: val}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 56, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 56, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [IndexName:{DescID: 56, IndexID: 1, Name: t1_pkey}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 57}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 58}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 60}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 63}, DROPPED, DROP] -> ABSENT
-    [Type:{DescID: 61}, DROPPED, DROP] -> ABSENT
-    [Type:{DescID: 62}, DROPPED, DROP] -> ABSENT
     [Schema:{DescID: 54}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.LogEvent
@@ -604,10 +607,6 @@ Stage 3 of 3 (non-revertible)
         Username: root
     *scop.CreateGcJobForDescriptor
       DescID: 63
-    *scop.DrainDescriptorName
-      TableID: 61
-    *scop.DrainDescriptorName
-      TableID: 62
     *scop.DrainDescriptorName
       TableID: 54
     *scop.LogEvent

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -5,14 +5,14 @@ CREATE SEQUENCE defaultdb.SQ1
 ops
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 1 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 54}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 54
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 54, Name: sq1}, PUBLIC, DROP] -> ABSENT
@@ -25,7 +25,7 @@ Stage 2 of 3 (non-revertible)
       DescID: 54
     *scop.DrainDescriptorName
       TableID: 54
-Stage 3 of 3 (non-revertible)
+PostCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, DROPPED, DROP] -> ABSENT
   ops:
@@ -45,24 +45,24 @@ Stage 3 of 3 (non-revertible)
       DescID: 54
 
 create-table
-CREATE TABLE defaultdb.blog_posts (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
+CREATE TABLE defaultdb.blog_posts (id INT8 PRIMARY KEY, val INT8 DEFAULT nextval('defaultdb.sq1'), title STRING)
 ----
 
 create-table
-CREATE TABLE defaultdb.blog_posts2 (id INT PRIMARY KEY, val int DEFAULT nextval('defaultdb.sq1'), title text)
+CREATE TABLE defaultdb.blog_posts2 (id INT8 PRIMARY KEY, val INT8 DEFAULT nextval('defaultdb.sq1'), title STRING)
 ----
 
 ops
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 1 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 54}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 54
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 1 with 4 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 54, Name: sq1}, PUBLIC, DROP] -> ABSENT
@@ -83,7 +83,7 @@ Stage 2 of 3 (non-revertible)
     *scop.RemoveRelationDependedOnBy
       DependedOnBy: 56
       TableID: 54
-Stage 3 of 3 (non-revertible)
+PostCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
   transitions:
     [Sequence:{DescID: 54}, DROPPED, DROP] -> ABSENT
   ops:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -32,27 +32,21 @@ CREATE SEQUENCE defaultdb.SQ1 OWNED BY defaultdb.shipments.carrier
 ----
 
 create-view
-CREATE VIEW v1 as (select customer_id, carrier from defaultdb.shipments);
+CREATE VIEW v1 AS (SELECT customer_id, carrier FROM defaultdb.shipments)
 ----
 
 ops
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [Table:{DescID: 57}, PUBLIC, DROP] -> TXN_DROPPED
-    [ColumnName:{DescID: 57, ColumnID: 1, Name: tracking_number}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 57, ColumnID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 57, ColumnID: 2, Name: carrier}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 57, ColumnID: 2}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 57, ColumnID: 3, Name: status}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 57, ColumnID: 3}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 57, ColumnID: 4, Name: customer_id}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 57, ColumnID: 4}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [ColumnName:{DescID: 57, ColumnID: 5, Name: randcol}, PUBLIC, DROP] -> ABSENT
     [Column:{DescID: 57, ColumnID: 5}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
     [PrimaryIndex:{DescID: 57, IndexID: 1}, PUBLIC, DROP] -> DELETE_AND_WRITE_ONLY
-    [IndexName:{DescID: 57, IndexID: 1, Name: shipments_pkey}, PUBLIC, DROP] -> ABSENT
     [Locality:{DescID: 57}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 59}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 59}, PUBLIC, DROP] -> ABSENT
@@ -61,7 +55,7 @@ Stage 1 of 3
       DescID: 57
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 59
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 1 with 11 MutationType ops
   transitions:
     [Table:{DescID: 57}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 57, Name: shipments}, PUBLIC, DROP] -> ABSENT
@@ -69,16 +63,10 @@ Stage 2 of 3 (non-revertible)
     [UserPrivileges:{DescID: 57, Username: admin}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 57, Username: public}, PUBLIC, DROP] -> ABSENT
     [UserPrivileges:{DescID: 57, Username: root}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [DefaultExpression:{DescID: 57, ColumnID: 1}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [SequenceOwnedBy:{DescID: 58, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 57, ColumnID: 4}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
-    [Column:{DescID: 57, ColumnID: 5}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [DefaultExpression:{DescID: 57, ColumnID: 5}, PUBLIC, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, PUBLIC, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 57, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> DELETE_ONLY
     [ForeignKey:{DescID: 57, ReferencedDescID: 54, Name: fk_customers}, PUBLIC, DROP] -> ABSENT
     [ForeignKey:{DescID: 57, ReferencedDescID: 55, Name: fk_orders}, PUBLIC, DROP] -> ABSENT
     [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, PUBLIC, DROP] -> ABSENT
@@ -115,15 +103,21 @@ Stage 2 of 3 (non-revertible)
       TableID: 57
     *scop.DrainDescriptorName
       TableID: 59
-Stage 3 of 3 (non-revertible)
+PostCommitPhase non-revertible stage 1 of 1 with 4 MutationType ops
   transitions:
     [Table:{DescID: 57}, DROPPED, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 1}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 2}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 3}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 4}, DELETE_ONLY, DROP] -> ABSENT
-    [Column:{DescID: 57, ColumnID: 5}, DELETE_ONLY, DROP] -> ABSENT
-    [PrimaryIndex:{DescID: 57, IndexID: 1}, DELETE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 57, ColumnID: 1, Name: tracking_number}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 57, ColumnID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 57, ColumnID: 2, Name: carrier}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 57, ColumnID: 2}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 57, ColumnID: 3, Name: status}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 57, ColumnID: 3}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 57, ColumnID: 4, Name: customer_id}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 57, ColumnID: 4}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [ColumnName:{DescID: 57, ColumnID: 5, Name: randcol}, PUBLIC, DROP] -> ABSENT
+    [Column:{DescID: 57, ColumnID: 5}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [PrimaryIndex:{DescID: 57, IndexID: 1}, DELETE_AND_WRITE_ONLY, DROP] -> ABSENT
+    [IndexName:{DescID: 57, IndexID: 1, Name: shipments_pkey}, PUBLIC, DROP] -> ABSENT
     [View:{DescID: 59}, DROPPED, DROP] -> ABSENT
   ops:
     *scop.LogEvent

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -5,7 +5,7 @@ CREATE TYPE defaultdb.typ AS ENUM('a')
 ops
 DROP TYPE defaultdb.typ
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [Type:{DescID: 54}, PUBLIC, DROP] -> TXN_DROPPED
     [Type:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
@@ -14,7 +14,7 @@ Stage 1 of 3
       DescID: 54
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 55
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 2 with 2 MutationType ops
   transitions:
     [Type:{DescID: 54}, TXN_DROPPED, DROP] -> DROPPED
     [Type:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
@@ -23,7 +23,7 @@ Stage 2 of 3 (non-revertible)
       DescID: 54
     *scop.MarkDescriptorAsDropped
       DescID: 55
-Stage 3 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 2 of 2 with 2 MutationType ops
   transitions:
     [Type:{DescID: 54}, DROPPED, DROP] -> ABSENT
     [Type:{DescID: 55}, DROPPED, DROP] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -9,14 +9,14 @@ CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1)
 ops
 DROP VIEW defaultdb.v1
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 1 MutationType ops
   transitions:
     [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 55}, PUBLIC, DROP] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 55
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 1 with 3 MutationType ops
   transitions:
     [View:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 55, Name: v1}, PUBLIC, DROP] -> ABSENT
@@ -33,7 +33,7 @@ Stage 2 of 3 (non-revertible)
     *scop.RemoveRelationDependedOnBy
       DependedOnBy: 55
       TableID: 54
-Stage 3 of 3 (non-revertible)
+PostCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
   transitions:
     [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
   ops:
@@ -107,7 +107,7 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 ops
 DROP VIEW defaultdb.v1 CASCADE
 ----
-Stage 1 of 3
+StatementPhase stage 1 of 1 with 5 MutationType ops
   transitions:
     [View:{DescID: 55}, PUBLIC, DROP] -> TXN_DROPPED
     [Locality:{DescID: 55}, PUBLIC, DROP] -> ABSENT
@@ -130,7 +130,7 @@ Stage 1 of 3
       DescID: 58
     *scop.MarkDescriptorAsDroppedSynthetically
       DescID: 61
-Stage 2 of 3 (non-revertible)
+PreCommitPhase non-revertible stage 1 of 1 with 18 MutationType ops
   transitions:
     [View:{DescID: 55}, TXN_DROPPED, DROP] -> DROPPED
     [Namespace:{DescID: 55, Name: v1}, PUBLIC, DROP] -> ABSENT
@@ -215,7 +215,7 @@ Stage 2 of 3 (non-revertible)
     *scop.RemoveTypeBackRef
       DescID: 61
       TypeID: 60
-Stage 3 of 3 (non-revertible)
+PostCommitPhase non-revertible stage 1 of 1 with 10 MutationType ops
   transitions:
     [View:{DescID: 55}, DROPPED, DROP] -> ABSENT
     [View:{DescID: 56}, DROPPED, DROP] -> ABSENT

--- a/pkg/sql/schemachanger/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/testdata/alter_table_add_column
@@ -14,7 +14,7 @@ begin transaction #1
 # begin StatementPhase
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 5 MutationType ops
+## PreCommitPhase stage 1 of 1 with 5 MutationType ops
 upsert descriptor #56
   ...
      - columnIds:
@@ -94,7 +94,7 @@ upsert descriptor #56
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
-## stage 1 in PostCommitPhase: 3 MutationType ops
+## PostCommitPhase stage 1 of 6 with 3 MutationType ops
 upsert descriptor #56
   ...
        direction: ADD
@@ -118,15 +118,15 @@ upsert descriptor #56
 update progress of schema change job #1
 commit transaction #2
 begin transaction #3
-## stage 2 in PostCommitPhase: 1 BackfillType ops
+## PostCommitPhase stage 2 of 6 with 1 BackfillType ops
 update progress of schema change job #1
 commit transaction #3
 begin transaction #4
-## stage 3 in PostCommitPhase: 1 ValidationType ops
+## PostCommitPhase stage 3 of 6 with 1 ValidationType ops
 update progress of schema change job #1
 commit transaction #4
 begin transaction #5
-## stage 4 in PostCommitPhase: 3 MutationType ops
+## PostCommitPhase stage 4 of 6 with 3 MutationType ops
 upsert descriptor #56
   ...
          oid: 20
@@ -220,7 +220,7 @@ upsert descriptor #56
 update progress of schema change job #1
 commit transaction #5
 begin transaction #6
-## stage 5 in PostCommitPhase: 1 MutationType ops
+## PostCommitPhase non-revertible stage 5 of 6 with 1 MutationType ops
 upsert descriptor #56
   ...
          version: 4
@@ -237,7 +237,7 @@ upsert descriptor #56
 update progress of schema change job #1
 commit transaction #6
 begin transaction #7
-## stage 6 in PostCommitPhase: 2 MutationType ops
+## PostCommitPhase non-revertible stage 6 of 6 with 2 MutationType ops
 create job #2: "GC for dropping table 56 index 1"
   descriptor IDs: [56]
 upsert descriptor #56

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -12,10 +12,10 @@ DROP SCHEMA db.sc;
 ----
 begin transaction #1
 # begin StatementPhase
-## stage 1 in StatementPhase: 1 MutationType ops
+## StatementPhase stage 1 of 1 with 1 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 1 MutationType ops
+## PreCommitPhase non-revertible stage 1 of 2 with 1 MutationType ops
 upsert descriptor #56
   ...
          userProto: root
@@ -23,7 +23,7 @@ upsert descriptor #56
   -  version: "1"
   +  state: DROP
   +  version: "2"
-## stage 2 in PreCommitPhase: 2 MutationType ops
+## PreCommitPhase non-revertible stage 2 of 2 with 2 MutationType ops
 delete schema namespace entry {54 0 sc} -> 56
 create job #1: "Schema change job"
   descriptor IDs: [56]
@@ -50,10 +50,10 @@ DROP TABLE db.sc.t;
 ----
 begin transaction #1
 # begin StatementPhase
-## stage 1 in StatementPhase: 1 MutationType ops
+## StatementPhase stage 1 of 1 with 1 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 2 MutationType ops
+## PreCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
 delete object namespace entry {54 57 t} -> 58
 upsert descriptor #58
   ...
@@ -77,13 +77,9 @@ upsert descriptor #58
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
-## stage 1 in PostCommitPhase: 2 MutationType ops
+## PostCommitPhase non-revertible stage 1 of 1 with 2 MutationType ops
 create job #2: "GC for dropping descriptor 58"
   descriptor IDs: [58]
-update progress of schema change job #1
-commit transaction #2
-begin transaction #3
-## stage 2 in PostCommitPhase: is empty
 update progress of schema change job #1
 upsert descriptor #58
   ...
@@ -93,7 +89,7 @@ upsert descriptor #58
      nextColumnId: 4
      nextFamilyId: 1
   ...
-commit transaction #3
+commit transaction #2
 # end PostCommitPhase
 
 test
@@ -101,10 +97,10 @@ DROP SCHEMA db.sc CASCADE;
 ----
 begin transaction #1
 # begin StatementPhase
-## stage 1 in StatementPhase: 3 MutationType ops
+## StatementPhase stage 1 of 1 with 3 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 3 MutationType ops
+## PreCommitPhase non-revertible stage 1 of 2 with 3 MutationType ops
 upsert descriptor #57
   ...
          userProto: root
@@ -126,7 +122,7 @@ upsert descriptor #60
   -  version: "1"
   +  state: DROP
   +  version: "2"
-## stage 2 in PreCommitPhase: 4 MutationType ops
+## PreCommitPhase non-revertible stage 2 of 2 with 4 MutationType ops
 delete schema namespace entry {54 0 sc} -> 57
 delete object namespace entry {54 57 e} -> 59
 delete object namespace entry {54 57 _e} -> 60
@@ -144,10 +140,10 @@ DROP DATABASE db CASCADE;
 ----
 begin transaction #1
 # begin StatementPhase
-## stage 1 in StatementPhase: 2 MutationType ops
+## StatementPhase stage 1 of 1 with 2 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 2 MutationType ops
+## PreCommitPhase non-revertible stage 1 of 2 with 2 MutationType ops
 upsert descriptor #54
   ...
        public:
@@ -162,7 +158,7 @@ upsert descriptor #55
   -  version: "1"
   +  state: DROP
   +  version: "2"
-## stage 2 in PreCommitPhase: 4 MutationType ops
+## PreCommitPhase non-revertible stage 2 of 2 with 4 MutationType ops
 delete database namespace entry {0 0 db} -> 54
 delete schema namespace entry {54 0 public} -> 55
 create job #1: "Schema change job"
@@ -209,10 +205,10 @@ DROP DATABASE db1 CASCADE
 ----
 begin transaction #1
 # begin StatementPhase
-## stage 1 in StatementPhase: 14 MutationType ops
+## StatementPhase stage 1 of 1 with 14 MutationType ops
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 37 MutationType ops
+## PreCommitPhase non-revertible stage 1 of 2 with 37 MutationType ops
 delete object namespace entry {61 62 sq1} -> 64
 delete object namespace entry {61 63 sq1} -> 65
 delete object namespace entry {61 63 t1} -> 66
@@ -457,7 +453,7 @@ upsert descriptor #74
   -  version: "1"
   +  version: "2"
      viewQuery: (SELECT 'a':::sc1.typ::STRING AS k, n2, n1 FROM db1.sc1.v4)
-## stage 2 in PreCommitPhase: 4 MutationType ops
+## PreCommitPhase non-revertible stage 2 of 2 with 4 MutationType ops
 delete database namespace entry {0 0 db1} -> 61
 delete object namespace entry {61 63 typ} -> 72
 delete object namespace entry {61 63 _typ} -> 73
@@ -539,15 +535,11 @@ upsert descriptor #74
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
-## stage 1 in PostCommitPhase: 22 MutationType ops
+## PostCommitPhase non-revertible stage 1 of 1 with 22 MutationType ops
 create job #2: "GC for dropping descriptors 64 67 65 66 68 69 70 71 74"
   descriptor IDs: [64 67 65 66 68 69 70 71 74]
 delete schema namespace entry {61 0 public} -> 62
 delete schema namespace entry {61 0 sc1} -> 63
-update progress of schema change job #1
-commit transaction #2
-begin transaction #3
-## stage 2 in PostCommitPhase: is empty
 update progress of schema change job #1
 upsert descriptor #64
   ...
@@ -621,5 +613,5 @@ upsert descriptor #74
      nextColumnId: 4
      nextMutationId: 1
   ...
-commit transaction #3
+commit transaction #2
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/index
+++ b/pkg/sql/schemachanger/testdata/index
@@ -11,7 +11,7 @@ begin transaction #1
 # begin StatementPhase
 # end StatementPhase
 # begin PreCommitPhase
-## stage 1 in PreCommitPhase: 2 MutationType ops
+## PreCommitPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #54
   ...
      id: 54
@@ -68,7 +68,7 @@ upsert descriptor #54
 commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
-## stage 1 in PostCommitPhase: 1 MutationType ops
+## PostCommitPhase stage 1 of 4 with 1 MutationType ops
 upsert descriptor #54
   ...
          version: 3
@@ -85,15 +85,15 @@ upsert descriptor #54
 update progress of schema change job #1
 commit transaction #2
 begin transaction #3
-## stage 2 in PostCommitPhase: 1 BackfillType ops
+## PostCommitPhase stage 2 of 4 with 1 BackfillType ops
 update progress of schema change job #1
 commit transaction #3
 begin transaction #4
-## stage 3 in PostCommitPhase: 1 ValidationType ops
+## PostCommitPhase stage 3 of 4 with 1 ValidationType ops
 update progress of schema change job #1
 commit transaction #4
 begin transaction #5
-## stage 4 in PostCommitPhase: 1 MutationType ops
+## PostCommitPhase stage 4 of 4 with 1 MutationType ops
 upsert descriptor #54
   ...
      formatVersion: 3


### PR DESCRIPTION
This commit makes scplan.Stage aware of the phase it's in, and where in
the phase it's in. This makes for convenient string representations.

This commit also builds stages for all phases after the current
execution phase in addition to the stages at the current execution phase.
This results in a more useful graphviz representation.

This commit also has the planner get rid of no-op stages (possible due
to being optimized out) by greedily collapsing them into neighbouring
stages, following certain rules.

Fixes #66609.

Release note: None