### PR TITLE
dev: fix `/...` expansion in `dev`

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -334,13 +334,15 @@ func (d *dev) getBasicBuildArgs(
 				err = fmt.Errorf("could not run `bazel %s` (%w)", shellescape.QuoteCommand(queryArgs), queryErr)
 				return
 			}
-			fields := strings.Fields(strings.TrimSpace(string(labelKind)))
-			fullTargetName := fields[len(fields)-1]
-			typ := fields[0]
-			args = append(args, fullTargetName)
-			buildTargets = append(buildTargets, buildTarget{fullName: fullTargetName, isGoBinary: typ == "go_binary"})
-			if typ == "go_test" {
-				shouldBuildWithTestConfig = true
+			for _, line := range strings.Split(strings.TrimSpace(string(labelKind)), "\n") {
+				fields := strings.Fields(line)
+				fullTargetName := fields[len(fields)-1]
+				typ := fields[0]
+				args = append(args, fullTargetName)
+				buildTargets = append(buildTargets, buildTarget{fullName: fullTargetName, isGoBinary: typ == "go_binary"})
+				if typ == "go_test" {
+					shouldBuildWithTestConfig = true
+				}
 			}
 			continue
 		}

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -86,3 +86,13 @@ bazel build //pkg/roachpb:roachpb_test --config=test
 bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
+
+dev build pkg/foo/...
+----
+bazel query pkg/foo/... --output=label_kind
+bazel build //pkg/foo:bar //pkg/foo:baz --config=test
+bazel info workspace --color=no
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+bazel info bazel-bin --color=no
+rm go/src/github.com/cockroachdb/cockroach/bin/bar
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/foo/bar_/bar go/src/github.com/cockroachdb/cockroach/bin/bar

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -228,3 +228,31 @@ mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 ----
 /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+bazel query pkg/foo/... --output=label_kind
+----
+----
+go_binary rule //pkg/foo:bar
+go_test rule //pkg/foo:baz
+----
+----
+
+bazel build //pkg/foo:bar //pkg/foo:baz --config=test
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+mkdir go/src/github.com/cockroachdb/cockroach/bin
+----
+
+bazel info bazel-bin --color=no
+----
+/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin
+
+rm go/src/github.com/cockroachdb/cockroach/bin/bar
+----
+
+ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/foo/bar_/bar go/src/github.com/cockroachdb/cockroach/bin/bar
+----


### PR DESCRIPTION
The `bazel query` output can return many outputs; instead of keeping the
first and throwing the rest of them away like we used to, we make sure
to keep all of them.

Closes #73083

Release note: None