### PR TITLE
bazel: extend timeouts when running under `race`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ build:with_ui --define cockroach_with_ui=y
 build:test --define crdb_test=y
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
 test:test --test_env=TZ=
+test:race --test_timeout=1200,6000,18000,72000
 query --ui_event_filters=-DEBUG
 
 # CI should always run with `--config=ci`.


### PR DESCRIPTION
According to [documentation](https://go.dev/doc/articles/race_detector),
the race detector can increase execution time by 2-20x. Here we give
tests up to the upper bound (20x) extra time to help prevent timeouts.

Closes #72671.

Release note: None