### PR TITLE
statusccl: speed up unit tests by sharing test helper

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -41,6 +41,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTenantStatusAPI(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// The liveness session might expire before the stress race can finish.
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+
+	statsIngestionCb, statsIngestionNotifier := idxusage.CreateIndexStatsIngestedCallbackForTest()
+	knobs := tests.CreateTestingKnobs()
+	knobs.IndexUsageStatsKnobs = &idxusage.TestingKnobs{
+		OnIndexUsageStatsProcessedCallback: statsIngestionCb,
+	}
+
+	testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
+	defer testHelper.cleanup(ctx, t)
+
+	t.Run("reset_sql_stats", func(t *testing.T) {
+		testResetSQLStatsRPCForTenant(ctx, t, testHelper)
+	})
+
+	t.Run("reset_index_usage_stats", func(t *testing.T) {
+		testResetIndexUsageStatsRPCForTenant(ctx, t, testHelper, statsIngestionNotifier)
+	})
+
+	t.Run("table_index_stats", func(t *testing.T) {
+		testTableIndexStats(ctx, t, testHelper, statsIngestionNotifier)
+	})
+
+	t.Run("tenant_contention_event", func(t *testing.T) {
+		testContentionEventsForTenant(ctx, t, testHelper)
+	})
+
+	t.Run("tenant_cancel_session", func(t *testing.T) {
+		testTenantStatusCancelSession(t, testHelper)
+	})
+
+	t.Run("tenant_cancel_query", func(t *testing.T) {
+		testTenantStatusCancelQuery(ctx, t, testHelper)
+	})
+
+	t.Run("index_usage_stats", func(t *testing.T) {
+		testIndexUsageForTenants(t, testHelper, statsIngestionNotifier)
+	})
+}
+
 func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -225,22 +272,14 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	})
 }
 
-func TestResetSQLStatsRPCForTenant(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-
+func testResetSQLStatsRPCForTenant(
+	ctx context.Context, t *testing.T, testHelper *tenantTestHelper,
+) {
 	stmts := []string{
 		"SELECT 1",
 		"SELECT 1, 1",
 		"SELECT 1, 1, 1",
 	}
-
-	testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, tests.CreateTestingKnobs())
-	defer testHelper.cleanup(ctx, t)
 
 	testCluster := testHelper.testCluster()
 	controlCluster := testHelper.controlCluster()
@@ -250,6 +289,15 @@ func TestResetSQLStatsRPCForTenant(t *testing.T) {
 		Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled = false")
 	controlCluster.tenantConn(0 /* idx */).
 		Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled = false")
+
+	defer func() {
+		// Cleanup
+		testCluster.tenantConn(0 /* idx */).
+			Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled = true")
+		controlCluster.tenantConn(0 /* idx */).
+			Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled = true")
+
+	}()
 
 	for _, flushed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("flushed=%t", flushed), func(t *testing.T) {
@@ -320,35 +368,27 @@ func TestResetSQLStatsRPCForTenant(t *testing.T) {
 	}
 }
 
-func TestResetIndexUsageStatsRPCForTenant(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-
-	statsIngestionCb, statsIngestionNotifier := idxusage.CreateIndexStatsIngestedCallbackForTest()
-
-	knobs := tests.CreateTestingKnobs()
-	knobs.IndexUsageStatsKnobs = &idxusage.TestingKnobs{
-		OnIndexUsageStatsProcessedCallback: statsIngestionCb,
-	}
-
+func testResetIndexUsageStatsRPCForTenant(
+	ctx context.Context,
+	t *testing.T,
+	testHelper *tenantTestHelper,
+	ingestedNotifier chan roachpb.IndexUsageKey,
+) {
 	testCases := []struct {
-		indexStatsResetter func(helper *tenantTestHelper)
+		name    string
+		resetFn func(helper *tenantTestHelper)
 	}{
 		{
-			func(helper *tenantTestHelper) {
+			name: "sql-cli",
+			resetFn: func(helper *tenantTestHelper) {
 				// Reset index usage stats using SQL shell built-in.
 				testingCluster := helper.testCluster()
-				status := testingCluster.tenantStatusSrv(1 /* idx */)
-				_, err := status.ResetIndexUsageStats(ctx, &serverpb.ResetIndexUsageStatsRequest{})
-				require.NoError(t, err)
+				testingCluster.tenantConn(0).Exec(t, "SELECT crdb_internal.reset_index_usage_stats()")
 			},
 		},
 		{
-			func(helper *tenantTestHelper) {
+			name: "http",
+			resetFn: func(helper *tenantTestHelper) {
 				// Reset index usage stats over HTTP on tenant SQL pod 1.
 				httpPod1 := helper.testCluster().tenantHTTPClient(t, 1)
 				defer httpPod1.Close()
@@ -358,16 +398,14 @@ func TestResetIndexUsageStatsRPCForTenant(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
-		defer testHelper.cleanup(ctx, t)
-
 		testingCluster := testHelper.testCluster()
 		controlCluster := testHelper.controlCluster()
-		var testingTableID, controlTableID string
 
-		for i, cluster := range []tenantCluster{testingCluster, controlCluster} {
-			// Create tables and insert data.
-			cluster.tenantConn(0).Exec(t, `
+		t.Run(testCase.name, func(t *testing.T) {
+			var testingTableID, controlTableID string
+			for i, cluster := range []tenantCluster{testingCluster, controlCluster} {
+				// Create tables and insert data.
+				cluster.tenantConn(0).Exec(t, `
 CREATE TABLE test (
   k INT PRIMARY KEY,
   a INT,
@@ -376,42 +414,42 @@ CREATE TABLE test (
 )
 `)
 
-			cluster.tenantConn(0).Exec(t, `
+				cluster.tenantConn(0).Exec(t, `
 INSERT INTO test
 VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)
 `)
 
-			// Record scan on primary index.
-			cluster.tenantConn(0).Exec(t, "SELECT * FROM test")
+				// Record scan on primary index.
+				cluster.tenantConn(0).Exec(t, "SELECT * FROM test")
 
-			// Record scan on secondary index.
-			cluster.tenantConn(1).Exec(t, "SELECT * FROM test@test_a_idx")
-			testTableIDStr := cluster.tenantConn(2).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
-			testTableID, err := strconv.Atoi(testTableIDStr)
-			require.NoError(t, err)
+				// Record scan on secondary index.
+				cluster.tenantConn(1).Exec(t, "SELECT * FROM test@test_a_idx")
+				testTableIDStr := cluster.tenantConn(2).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
+				testTableID, err := strconv.Atoi(testTableIDStr)
+				require.NoError(t, err)
 
-			// Set table ID outside of loop.
-			if i == 0 {
-				testingTableID = testTableIDStr
-			} else {
-				controlTableID = testTableIDStr
-			}
+				// Set table ID outside of loop.
+				if i == 0 {
+					testingTableID = testTableIDStr
+				} else {
+					controlTableID = testTableIDStr
+				}
 
-			// Wait for the stats to be ingested.
-			require.NoError(t,
-				idxusage.WaitForIndexStatsIngestionForTest(statsIngestionNotifier, map[roachpb.IndexUsageKey]struct{}{
-					{
-						TableID: roachpb.TableID(testTableID),
-						IndexID: 1,
-					}: {},
-					{
-						TableID: roachpb.TableID(testTableID),
-						IndexID: 2,
-					}: {},
-				}, 2 /* expectedEventCnt*/, 5*time.Second /* timeout */),
-			)
+				// Wait for the stats to be ingested.
+				require.NoError(t,
+					idxusage.WaitForIndexStatsIngestionForTest(ingestedNotifier, map[roachpb.IndexUsageKey]struct{}{
+						{
+							TableID: roachpb.TableID(testTableID),
+							IndexID: 1,
+						}: {},
+						{
+							TableID: roachpb.TableID(testTableID),
+							IndexID: 2,
+						}: {},
+					}, 2 /* expectedEventCnt*/, 5*time.Second /* timeout */),
+				)
 
-			query := `
+				query := `
 SELECT
   table_id,
   index_id,
@@ -421,36 +459,36 @@ FROM
   crdb_internal.index_usage_statistics
 WHERE
   table_id = ` + testTableIDStr
-			// Assert index usage data was inserted.
-			expected := [][]string{
-				{testTableIDStr, "1", "1", "true"},
-				{testTableIDStr, "2", "1", "true"},
+				// Assert index usage data was inserted.
+				expected := [][]string{
+					{testTableIDStr, "1", "1", "true"},
+					{testTableIDStr, "2", "1", "true"},
+				}
+				cluster.tenantConn(2).CheckQueryResults(t, query, expected)
 			}
-			cluster.tenantConn(2).CheckQueryResults(t, query, expected)
-		}
 
-		// Reset index usage stats.
-		timePreReset := timeutil.Now()
-		status := testingCluster.tenantStatusSrv(1 /* idx */)
+			// Reset index usage stats.
+			timePreReset := timeutil.Now()
+			status := testingCluster.tenantStatusSrv(1 /* idx */)
 
-		// Reset index usage stats.
-		testCase.indexStatsResetter(testHelper)
+			// Reset index usage stats.
+			testCase.resetFn(testHelper)
 
-		// Check that last reset time was updated for test cluster.
-		resp, err := status.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
-		require.NoError(t, err)
-		require.True(t, resp.LastReset.After(timePreReset))
+			// Check that last reset time was updated for test cluster.
+			resp, err := status.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
+			require.NoError(t, err)
+			require.True(t, resp.LastReset.After(timePreReset))
 
-		// Ensure tenant data isolation.
-		// Check that last reset time was not updated for control cluster.
-		status = controlCluster.tenantStatusSrv(1 /* idx */)
-		resp, err = status.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
-		require.NoError(t, err)
-		require.Equal(t, resp.LastReset, time.Time{})
+			// Ensure tenant data isolation.
+			// Check that last reset time was not updated for control cluster.
+			status = controlCluster.tenantStatusSrv(1 /* idx */)
+			resp, err = status.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
+			require.NoError(t, err)
+			require.Equal(t, resp.LastReset, time.Time{})
 
-		// Query to fetch index usage stats. We do this instead of sending
-		// an RPC request so that we can filter by table id.
-		query := `
+			// Query to fetch index usage stats. We do this instead of sending
+			// an RPC request so that we can filter by table id.
+			query := `
 SELECT
   table_id,
   total_reads,
@@ -461,76 +499,51 @@ WHERE
   table_id = $1
 `
 
-		// Check that index usage stats were reset.
-		rows := testingCluster.tenantConn(2).QueryStr(t, query, testingTableID)
-		require.NotNil(t, rows)
-		for _, row := range rows {
-			require.Equal(t, row[1], "0", "expected total reads for table %s to be reset, but got %s",
-				row[0], row[1])
-			require.Equal(t, row[2], "NULL", "expected last read time for table %s to be reset, but got %s",
-				row[0], row[2])
-		}
+			// Check that index usage stats were reset.
+			rows := testingCluster.tenantConn(2).QueryStr(t, query, testingTableID)
+			require.NotNil(t, rows)
+			for _, row := range rows {
+				require.Equal(t, row[1], "0", "expected total reads for table %s to be reset, but got %s",
+					row[0], row[1])
+				require.Equal(t, row[2], "NULL", "expected last read time for table %s to be reset, but got %s",
+					row[0], row[2])
+			}
 
-		// Ensure tenant data isolation.
-		rows = controlCluster.tenantConn(2).QueryStr(t, query, controlTableID)
-		require.NotNil(t, rows)
-		for _, row := range rows {
-			require.NotEqual(t, row[1], "0", "expected total reads for table %s to not be reset, but got %s", row[0], row[1])
-			require.NotEqual(t, row[2], "NULL", "expected last read time for table %s to not be reset, but got %s", row[0], row[2])
-		}
+			// Ensure tenant data isolation.
+			rows = controlCluster.tenantConn(2).QueryStr(t, query, controlTableID)
+			require.NotNil(t, rows)
+			for _, row := range rows {
+				require.NotEqual(t, row[1], "0", "expected total reads for table %s to not be reset, but got %s", row[0], row[1])
+				require.NotEqual(t, row[2], "NULL", "expected last read time for table %s to not be reset, but got %s", row[0], row[2])
+			}
+
+			// Cleanup.
+			testingCluster.tenantConn(0).Exec(t, "DROP TABLE IF EXISTS test")
+			controlCluster.tenantConn(0).Exec(t, "DROP TABLE IF EXISTS test")
+		})
 	}
 }
 
-func TestTableIndexStats(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-
-	statsIngestionCb, statsIngestionNotifier := idxusage.CreateIndexStatsIngestedCallbackForTest()
-
-	knobs := tests.CreateTestingKnobs()
-	knobs.IndexUsageStatsKnobs = &idxusage.TestingKnobs{
-		OnIndexUsageStatsProcessedCallback: statsIngestionCb,
+func testTableIndexStats(
+	ctx context.Context,
+	t *testing.T,
+	testHelper *tenantTestHelper,
+	ingestedNotifier chan roachpb.IndexUsageKey,
+) {
+	getTableIndexStats := func(helper *tenantTestHelper, db string) *serverpb.TableIndexStatsResponse {
+		// Get index usage stats using function call.
+		cluster := helper.testCluster()
+		status := cluster.tenantStatusSrv(0 /* idx */)
+		req := &serverpb.TableIndexStatsRequest{Table: "test", Database: db}
+		resp, err := status.TableIndexStats(ctx, req)
+		require.NoError(t, err)
+		return resp
 	}
 
-	testCases := []struct {
-		getTableIndexStats func(helper *tenantTestHelper, db string) *serverpb.TableIndexStatsResponse
-	}{
-		{
-			func(helper *tenantTestHelper, db string) *serverpb.TableIndexStatsResponse {
-				// Get index usage stats using function call.
-				cluster := helper.testCluster()
-				status := cluster.tenantStatusSrv(0 /* idx */)
-				req := &serverpb.TableIndexStatsRequest{Table: "test", Database: db}
-				resp, err := status.TableIndexStats(ctx, req)
-				require.NoError(t, err)
-				return resp
-			},
-		},
-		{
-			func(helper *tenantTestHelper, db string) *serverpb.TableIndexStatsResponse {
-				// Get index usage stats using JSON post request.
-				httpPod1 := helper.testCluster().tenantHTTPClient(t, 1)
-				defer httpPod1.Close()
-				resp := &serverpb.TableIndexStatsResponse{}
-				path := fmt.Sprintf("/_status/databases/%s/tables/test/indexstats", db)
-				httpPod1.GetJSON(path, resp)
-				return resp
-			},
-		},
-	}
+	cluster := testHelper.testCluster()
 
-	for _, testCase := range testCases {
-		testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
-		defer testHelper.cleanup(ctx, t)
-
-		cluster := testHelper.testCluster()
-
-		// Create table on a database.
-		cluster.tenantConn(0).Exec(t, `
+	// Create table on a database.
+	cluster.tenantConn(0).Exec(t, `
 CREATE DATABASE test_db1;
 SET DATABASE=test_db1;
 CREATE TABLE test (
@@ -540,8 +553,8 @@ CREATE TABLE test (
   INDEX(a)
 );`)
 
-		// Create second table on different database.
-		cluster.tenantConn(0).Exec(t, `
+	// Create second table on different database.
+	cluster.tenantConn(0).Exec(t, `
 CREATE DATABASE test_db2;
 SET DATABASE=test_db2;
 CREATE TABLE test (
@@ -551,37 +564,36 @@ CREATE TABLE test (
   INDEX(a)
 );`)
 
-		// Record scan on primary index.
-		timePreRead := timeutil.Now()
-		cluster.tenantConn(0).Exec(t, `
+	// Record scan on primary index.
+	timePreRead := timeutil.Now()
+	cluster.tenantConn(0).Exec(t, `
 SET DATABASE=test_db1;
 SELECT * FROM test;
 `)
 
-		// Get Table ID.
-		testTableIDStr := cluster.tenantConn(0).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
-		testTableID, err := strconv.Atoi(testTableIDStr)
-		require.NoError(t, err)
+	// Get Table ID.
+	testTableIDStr := cluster.tenantConn(0).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
+	testTableID, err := strconv.Atoi(testTableIDStr)
+	require.NoError(t, err)
 
-		// Wait for the stats to be ingested.
-		require.NoError(t,
-			idxusage.WaitForIndexStatsIngestionForTest(statsIngestionNotifier, map[roachpb.IndexUsageKey]struct{}{
-				{
-					TableID: roachpb.TableID(testTableID),
-					IndexID: 1,
-				}: {},
-			}, 1 /* expectedEventCnt*/, 5*time.Second /* timeout */),
-		)
+	// Wait for the stats to be ingested.
+	require.NoError(t,
+		idxusage.WaitForIndexStatsIngestionForTest(ingestedNotifier, map[roachpb.IndexUsageKey]struct{}{
+			{
+				TableID: roachpb.TableID(testTableID),
+				IndexID: 1,
+			}: {},
+		}, 1 /* expectedEventCnt*/, 5*time.Second /* timeout */),
+	)
 
-		// Get index usage stats and assert expected results.
-		resp := testCase.getTableIndexStats(testHelper, "test_db1")
-		require.Equal(t, uint64(1), resp.Statistics[0].Statistics.Stats.TotalReadCount)
-		require.True(t, resp.Statistics[0].Statistics.Stats.LastRead.After(timePreRead))
+	// Get index usage stats and assert expected results.
+	resp := getTableIndexStats(testHelper, "test_db1")
+	require.Equal(t, uint64(1), resp.Statistics[0].Statistics.Stats.TotalReadCount)
+	require.True(t, resp.Statistics[0].Statistics.Stats.LastRead.After(timePreRead))
 
-		resp = testCase.getTableIndexStats(testHelper, "test_db2")
-		require.Equal(t, uint64(0), resp.Statistics[0].Statistics.Stats.TotalReadCount)
-		require.Equal(t, resp.Statistics[0].Statistics.Stats.LastRead, time.Time{})
-	}
+	resp = getTableIndexStats(testHelper, "test_db2")
+	require.Equal(t, uint64(0), resp.Statistics[0].Statistics.Stats.TotalReadCount)
+	require.Equal(t, resp.Statistics[0].Statistics.Stats.LastRead, time.Time{})
 }
 
 func ensureExpectedStmtFingerprintExistsInRPCResponse(
@@ -605,18 +617,9 @@ func ensureExpectedStmtFingerprintExistsInRPCResponse(
 	}
 }
 
-func TestContentionEventsForTenant(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-
-	testHelper :=
-		newTestTenantHelper(t, 3 /* tenantClusterSize */, tests.CreateTestingKnobs())
-	defer testHelper.cleanup(ctx, t)
-
+func testContentionEventsForTenant(
+	ctx context.Context, t *testing.T, testHelper *tenantTestHelper,
+) {
 	testingCluster := testHelper.testCluster()
 	controlledCluster := testHelper.controlCluster()
 
@@ -680,28 +683,19 @@ SET TRACING=off;
 	}
 }
 
-func TestIndexUsageForTenants(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-
-	statsIngestionCb, statsIngestionNotifier := idxusage.CreateIndexStatsIngestedCallbackForTest()
-
-	knobs := tests.CreateTestingKnobs()
-	knobs.IndexUsageStatsKnobs = &idxusage.TestingKnobs{
-		OnIndexUsageStatsProcessedCallback: statsIngestionCb,
-	}
-	testHelper := newTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
-	defer testHelper.cleanup(ctx, t)
-
+func testIndexUsageForTenants(
+	t *testing.T, testHelper *tenantTestHelper, ingestNotifier chan roachpb.IndexUsageKey,
+) {
 	testingCluster := testHelper.testCluster()
 	controlledCluster := testHelper.controlCluster()
 
+	testingCluster.tenantConn(0).Exec(t, "USE defaultdb")
+	testingCluster.tenantConn(1).Exec(t, "USE defaultdb")
+	testingCluster.tenantConn(2).Exec(t, "USE defaultdb")
+	testingCluster.tenantConn(0).Exec(t, `CREATE SCHEMA idx_test`)
+
 	testingCluster.tenantConn(0).Exec(t, `
-CREATE TABLE test (
+CREATE TABLE idx_test.test (
   k INT PRIMARY KEY,
   a INT,
   b INT,
@@ -709,23 +703,27 @@ CREATE TABLE test (
 )
 `)
 
+	defer func() {
+		testingCluster.tenantConn(0).Exec(t, "DROP TABLE idx_test.test")
+	}()
+
 	testingCluster.tenantConn(0).Exec(t, `
-INSERT INTO test
+INSERT INTO idx_test.test
 VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)
 `)
 
 	// Record scan on primary index.
-	testingCluster.tenantConn(0).Exec(t, "SELECT * FROM test")
+	testingCluster.tenantConn(0).Exec(t, "SELECT * FROM idx_test.test")
 
 	// Record scan on secondary index.
-	testingCluster.tenantConn(1).Exec(t, "SELECT * FROM test@test_a_idx")
-	testTableIDStr := testingCluster.tenantConn(2).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
+	testingCluster.tenantConn(1).Exec(t, "SELECT * FROM idx_test.test@test_a_idx")
+	testTableIDStr := testingCluster.tenantConn(2).QueryStr(t, "SELECT 'idx_test.test'::regclass::oid")[0][0]
 	testTableID, err := strconv.Atoi(testTableIDStr)
 	require.NoError(t, err)
 
 	// Wait for the stats to be ingested.
 	require.NoError(t,
-		idxusage.WaitForIndexStatsIngestionForTest(statsIngestionNotifier, map[roachpb.IndexUsageKey]struct{}{
+		idxusage.WaitForIndexStatsIngestionForTest(ingestNotifier, map[roachpb.IndexUsageKey]struct{}{
 			{
 				TableID: roachpb.TableID(testTableID),
 				IndexID: 1,
@@ -772,16 +770,7 @@ func selectClusterSessionIDs(t *testing.T, conn *sqlutils.SQLRunner) []string {
 	return sessionIDs
 }
 
-func TestTenantStatusCancelSession(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-	helper := newTestTenantHelper(t, 3, base.TestingKnobs{})
-	defer helper.cleanup(ctx, t)
-
+func testTenantStatusCancelSession(t *testing.T, helper *tenantTestHelper) {
 	// Open a SQL session on tenant SQL pod 0.
 	sqlPod0 := helper.testCluster().tenantConn(0)
 	sqlPod0.Exec(t, "SELECT 1")
@@ -833,16 +822,7 @@ func selectClusterQueryIDs(t *testing.T, conn *sqlutils.SQLRunner) []string {
 	return queryIDs
 }
 
-func TestTenantStatusCancelQuery(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderStressRace(t, "expensive tests")
-
-	ctx := context.Background()
-	helper := newTestTenantHelper(t, 3, base.TestingKnobs{})
-	defer helper.cleanup(ctx, t)
-
+func testTenantStatusCancelQuery(ctx context.Context, t *testing.T, helper *tenantTestHelper) {
 	// Open a SQL session on tenant SQL pod 0 and start a long-running query.
 	sqlPod0 := helper.testCluster().tenantConn(0)
 	resultCh := make(chan struct{})

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -303,21 +303,21 @@ func testResetSQLStatsRPCForTenant(
 		t.Run(fmt.Sprintf("flushed=%t", flushed), func(t *testing.T) {
 			// Clears the SQL Stats at the end of each test via builtin.
 			defer func() {
-				testCluster.tenantConn(0 /* idx */).Exec(t, "SELECT crdb_internal.reset_sql_stats()")
-				controlCluster.tenantConn(0 /* idx */).Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+				testCluster.tenantConn(randomServer).Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+				controlCluster.tenantConn(randomServer).Exec(t, "SELECT crdb_internal.reset_sql_stats()")
 			}()
 
 			for _, stmt := range stmts {
-				testCluster.tenantConn(0 /* idx */).Exec(t, stmt)
-				controlCluster.tenantConn(0 /* idx */).Exec(t, stmt)
+				testCluster.tenantConn(randomServer).Exec(t, stmt)
+				controlCluster.tenantConn(randomServer).Exec(t, stmt)
 			}
 
 			if flushed {
-				testCluster.tenantSQLStats(0 /* idx */).Flush(ctx)
-				controlCluster.tenantSQLStats(0 /* idx */).Flush(ctx)
+				testCluster.tenantSQLStats(randomServer).Flush(ctx)
+				controlCluster.tenantSQLStats(randomServer).Flush(ctx)
 			}
 
-			status := testCluster.tenantStatusSrv(1 /* idx */)
+			status := testCluster.tenantStatusSrv(randomServer)
 
 			statsPreReset, err := status.Statements(ctx, &serverpb.StatementsRequest{
 				Combined: true,
@@ -358,7 +358,7 @@ func testResetSQLStatsRPCForTenant(
 
 			// Ensures that sql stats reset is isolated by tenant boundary.
 			statsFromControlCluster, err :=
-				controlCluster.tenantStatusSrv(1 /* idx */).Statements(ctx, &serverpb.StatementsRequest{
+				controlCluster.tenantStatusSrv(randomServer).Statements(ctx, &serverpb.StatementsRequest{
 					Combined: true,
 				})
 			require.NoError(t, err)
@@ -420,11 +420,14 @@ VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)
 `)
 
 				// Record scan on primary index.
-				cluster.tenantConn(0).Exec(t, "SELECT * FROM test")
+				cluster.tenantConn(randomServer).
+					Exec(t, "SELECT * FROM test")
 
 				// Record scan on secondary index.
-				cluster.tenantConn(1).Exec(t, "SELECT * FROM test@test_a_idx")
-				testTableIDStr := cluster.tenantConn(2).QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
+				cluster.tenantConn(randomServer).
+					Exec(t, "SELECT * FROM test@test_a_idx")
+				testTableIDStr := cluster.tenantConn(randomServer).
+					QueryStr(t, "SELECT 'test'::regclass::oid")[0][0]
 				testTableID, err := strconv.Atoi(testTableIDStr)
 				require.NoError(t, err)
 
@@ -464,12 +467,12 @@ WHERE
 					{testTableIDStr, "1", "1", "true"},
 					{testTableIDStr, "2", "1", "true"},
 				}
-				cluster.tenantConn(2).CheckQueryResults(t, query, expected)
+				cluster.tenantConn(randomServer).CheckQueryResults(t, query, expected)
 			}
 
 			// Reset index usage stats.
 			timePreReset := timeutil.Now()
-			status := testingCluster.tenantStatusSrv(1 /* idx */)
+			status := testingCluster.tenantStatusSrv(randomServer)
 
 			// Reset index usage stats.
 			testCase.resetFn(testHelper)
@@ -481,7 +484,7 @@ WHERE
 
 			// Ensure tenant data isolation.
 			// Check that last reset time was not updated for control cluster.
-			status = controlCluster.tenantStatusSrv(1 /* idx */)
+			status = controlCluster.tenantStatusSrv(randomServer)
 			resp, err = status.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
 			require.NoError(t, err)
 			require.Equal(t, resp.LastReset, time.Time{})
@@ -510,7 +513,7 @@ WHERE
 			}
 
 			// Ensure tenant data isolation.
-			rows = controlCluster.tenantConn(2).QueryStr(t, query, controlTableID)
+			rows = controlCluster.tenantConn(0).QueryStr(t, query, controlTableID)
 			require.NotNil(t, rows)
 			for _, row := range rows {
 				require.NotEqual(t, row[1], "0", "expected total reads for table %s to not be reset, but got %s", row[0], row[1])
@@ -533,7 +536,7 @@ func testTableIndexStats(
 	getTableIndexStats := func(helper *tenantTestHelper, db string) *serverpb.TableIndexStatsResponse {
 		// Get index usage stats using function call.
 		cluster := helper.testCluster()
-		status := cluster.tenantStatusSrv(0 /* idx */)
+		status := cluster.tenantStatusSrv(randomServer)
 		req := &serverpb.TableIndexStatsRequest{Table: "test", Database: db}
 		resp, err := status.TableIndexStats(ctx, req)
 		require.NoError(t, err)
@@ -755,7 +758,7 @@ WHERE
 	require.Equal(t, expected, actual)
 
 	// Ensure tenant data isolation.
-	actual = controlledCluster.tenantConn(2).QueryStr(t, query, testTableID)
+	actual = controlledCluster.tenantConn(0).QueryStr(t, query, testTableID)
 	expected = [][]string{}
 
 	require.Equal(t, expected, actual)


### PR DESCRIPTION
# First Commit

Previously, running statusccl tests was very expensive. This was
because for each unit tests, the test helper set up a host cluster
and two tenant clusters. This resulted in total of 9 nodes being
created and destroyed.

This commit addresses this issue by having all unit tests sharing
a single test helper to avoid unnecessary setup and teardowns of
clusters.

Release note: None

---

# Second Commit 

statusccl: speedup unit test by reducing concurrency

Previously, we spin up 1 host cluster and 2 tenant clusters for testing
tenant status server. Each cluster contains 3 nodes and we effectively
spin up 9 nodes for the test. This is very expensive and can cause
errors like "race: limit on 8128 simultaneously alive goroutines is
exceeded, dying" due to the underyling LLVM limitation.

This commit reduces the total number of nodes that are spinned up.
Host cluster and the second tenant cluster size is now reduced to
1 node to reduce the cost of the tests. Additional special
`randomServerIdx` value is introduced to avoid having the test
rely on the hard-coded server index.

Release note: None