### PR TITLE
sql: declarative schema changer did not detect dropped objects

### DIFF
--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -189,7 +189,7 @@ func MakeIndexDescriptor(
 	}
 
 	// Ensure that the index name does not exist before trying to create the index.
-	if idx, _ := tableDesc.FindIndexWithName(n.Name.String()); idx != nil {
+	if idx, _ := tableDesc.FindIndexWithName(string(n.Name)); idx != nil {
 		if idx.Dropped() {
 			return nil, pgerror.Newf(pgcode.DuplicateRelation, "index with name %q already exists and is being dropped, try again later", n.Name)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -217,3 +217,16 @@ ROLLBACK;
 
 statement ok
 DROP TABLE create_idx_drop_column;
+
+subtest names-with-escaped-chars
+
+# Similarly try using special characters making an index for a new table, we
+# will attempt to recreate it and expect the look up to find the old one.
+statement ok
+CREATE TABLE "'t1-esc'"(name int);
+
+statement ok
+CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)
+
+statement error index with name "'t1-esc-index'" already exists
+CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -705,7 +705,7 @@ user root
 statement ok
 CREATE INDEX foo ON tIndex (b)
 
-statement error relation \"foo\" already exists
+statement error index with name "foo" already exists
 CREATE INDEX foo ON tIndex (a)
 
 statement error column "c" does not exist
@@ -990,14 +990,19 @@ ORDER BY timestamp, info DESC;
 ----
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE fooev ADD COLUMN j INT8", "TableName": "test.public.fooev", "User": "root"}
 
+subtest names-with-escaped-chars
+
+# We are intentionally injecting characters that might get escaped due to
+# incorrect string conversion functions. As a result if descriptors look
+# ups use these incorrectly escaped strings we would be in trouble.
 statement ok
-CREATE DATABASE db1;
+CREATE DATABASE "'db1-a'";
 
 statement ok
-CREATE SCHEMA db1.sc1;
+CREATE SCHEMA "'db1-a'".sc1;
 
 statement ok
-CREATE SCHEMA db1.sc2;
+CREATE SCHEMA "'db1-a'".sc2;
 
 statement ok
 CREATE DATABASE db2;
@@ -1005,11 +1010,22 @@ CREATE DATABASE db2;
 statement ok
 CREATE SCHEMA db2.sc3;
 
+# Similarly try using special characters making an index for a new table, we
+# will attempt to recreate it and expect the look up to find the old one.
+statement ok
+CREATE TABLE "'db1-a'"."'t1-esc'"(name int);
+
+statement ok
+CREATE INDEX "'t1-esc-index'" ON "'db1-a'"."'t1-esc'"(name)
+
+statement error index with name "'t1-esc-index'" already exists
+CREATE INDEX "'t1-esc-index'" ON "'db1-a'"."'t1-esc'"(name)
+
 statement ok
 delete from system.eventlog;
 
 statement ok
-DROP DATABASE db1 cascade;
+DROP DATABASE "'db1-a'" cascade;
 
 statement ok
 DROP DATABASE db2 cascade;
@@ -1019,5 +1035,6 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"DatabaseName": "db1", "DroppedSchemaObjects": ["db1.public", "db1.sc1", "db1.sc2"], "EventType": "drop_database", "Statement": "DROP DATABASE db1 CASCADE", "User": "root"}
+1  {"DatabaseName": "'db1-a'", "DroppedSchemaObjects": ["'db1-a'.sc1", "'db1-a'.sc2"], "EventType": "drop_database", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "User": "root"}
+1  {"EventType": "drop_schema", "SchemaName": "'db1-a'.public", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "User": "root"}
 1  {"DatabaseName": "db2", "DroppedSchemaObjects": ["db2.public", "db2.sc3"], "EventType": "drop_database", "Statement": "DROP DATABASE db2 CASCADE", "User": "root"}

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -391,7 +391,7 @@ CREATE VIEW v4Dep AS (SELECT n2, n1 FROM v2Dep);
 statement ok
 explain (DDL, DEPS) DROP VIEW v1Dep CASCADE;
 
-statement error cannot drop view "test.public.v1dep" because view "test.public.v2dep" depends on it
+statement error pq: cannot drop view "v1dep" because view "v2dep" depends on it
 DROP VIEW v1Dep RESTRICT;
 
 statement error pq: "v1dep" is not a materialized view
@@ -1038,3 +1038,25 @@ ORDER BY timestamp, info DESC;
 1  {"DatabaseName": "'db1-a'", "DroppedSchemaObjects": ["'db1-a'.sc1", "'db1-a'.sc2"], "EventType": "drop_database", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "User": "root"}
 1  {"EventType": "drop_schema", "SchemaName": "'db1-a'.public", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "User": "root"}
 1  {"DatabaseName": "db2", "DroppedSchemaObjects": ["db2.public", "db2.sc3"], "EventType": "drop_database", "Statement": "DROP DATABASE db2 CASCADE", "User": "root"}
+
+# Sanity: Dropping multiple objects in the builder or resolving any dependencies
+# should function fine.
+subtest drop-multiple-in-builder
+
+statement ok
+CREATE TABLE multi_t1 (name INTEGER PRIMARY KEY);
+CREATE TABLE multi_t2 (name INTEGER, other INTEGER, FOREIGN KEY (other) REFERENCES multi_t1(name));
+CREATE VIEW multi_v1 AS (SELECT name FROM multi_t1);
+CREATE VIEW multi_v2 AS (SELECT name FROM multi_v1);
+
+statement ok
+CREATE SEQUENCE multi_sq1
+
+statement ok
+DROP VIEW multi_v1, multi_v2
+
+statement ok
+DROP TABLE multi_t1,multi_t2
+
+statement ok
+DROP SEQUENCE multi_sq1, multi_sq1

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -126,6 +126,7 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/schemachanger/scerrors",
         "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/schemachanger/screl",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -46,7 +46,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"index %q being dropped, try again later", n.Name.String()))
 		}
-		panic(sqlerrors.NewRelationAlreadyExistsError(n.Name.String()))
+		panic(pgerror.Newf(pgcode.DuplicateRelation, "index with name %q already exists", n.Name))
 	}
 
 	if rel.MaterializedView() {
@@ -197,7 +197,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 	secondaryIndexName := &scpb.IndexName{
 		TableID: secondaryIndex.TableID,
 		IndexID: secondaryIndex.IndexID,
-		Name:    n.Name.String(),
+		Name:    string(n.Name),
 	}
 	// Convert partitioning information for the execution
 	// side of things.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
@@ -34,6 +34,10 @@ func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
 	{
 		c := b.WithNewSourceElementID()
 		doSchema := func(schema catalog.SchemaDescriptor) {
+			// Sanity: Check if the descriptor is already dropped.
+			if checkIfDescOrElementAreDropped(b, schema.GetID()) {
+				return
+			}
 			// For public and temporary schemas the drop logic
 			// will only drop the underlying objects and return
 			// if that no drop schema node was added (nodeAdded).
@@ -51,7 +55,6 @@ func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
 				schemaDroppedIDs.ForEach(dropIDs.Add)
 			}
 		}
-
 		var schemaIDs catalog.DescriptorIDSet
 		schemaIDs.Add(db.GetSchemaID(tree.PublicSchema))
 		_ = db.ForEachSchemaInfo(func(id descpb.ID, _ string, isDropped bool) error {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
@@ -48,7 +48,10 @@ func dropSchema(
 	}
 	_, objectIDs := b.CatalogReader().ReadObjectNamesAndIDs(b, db, sc)
 	for _, id := range objectIDs {
-		dropIDs.Add(id)
+		// If the object is already dropped, nothing to do here.
+		if !checkIfDescOrElementAreDropped(b, id) {
+			dropIDs.Add(id)
+		}
 	}
 	if behavior != tree.DropCascade && !dropIDs.Empty() {
 		panic(pgerror.Newf(pgcode.DependentObjectsStillExist,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
@@ -47,7 +47,8 @@ func dropSequence(b BuildCtx, seq catalog.TableDescriptor, cascade tree.DropBeha
 		if dep.TableID != seq.GetID() {
 			return
 		}
-		if cascade != tree.DropCascade {
+		if cascade != tree.DropCascade &&
+			!checkIfDescOrElementAreDropped(b, dep.DependedOnBy) {
 			panic(pgerror.Newf(
 				pgcode.DependentObjectsStillExist,
 				"cannot drop sequence %s because other objects depend on it",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
@@ -38,6 +38,10 @@ func DropType(b BuildCtx, n *tree.DropType) {
 		if typ == nil {
 			continue
 		}
+		// If the descriptor is already being dropped, nothing to do.
+		if checkIfDescOrElementAreDropped(b, typ.GetID()) {
+			return
+		}
 		dropType(b, typ, n.DropBehavior)
 		b.IncrementSubWorkID()
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
@@ -23,6 +23,11 @@ import (
 
 // DropView implements DROP VIEW.
 func DropView(b BuildCtx, n *tree.DropView) {
+	type viewDropCtx struct {
+		view     catalog.TableDescriptor
+		buildCtx BuildCtx
+	}
+	views := make([]viewDropCtx, 0, len(n.Names))
 	for _, name := range n.Names {
 		_, view := b.ResolveView(name.ToUnresolvedObjectName(), ResolveParams{
 			IsExistenceOptional: n.IfExists,
@@ -38,44 +43,68 @@ func DropView(b BuildCtx, n *tree.DropView) {
 		if !view.MaterializedView() && n.IsMaterialized {
 			panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a materialized view", view.GetName()))
 		}
-		dropView(b, view, n.DropBehavior)
+		newCtx := dropViewBasic(b, view)
+		views = append(views, viewDropCtx{
+			view:     view,
+			buildCtx: newCtx,
+		})
 		b.IncrementSubWorkID()
+	}
+	// Validate if the dependent objects need to be dropped, if necessary
+	// this will cascade.
+	for _, viewCtx := range views {
+		dropViewDependents(viewCtx.buildCtx, viewCtx.view, n.DropBehavior)
 	}
 }
 
+// dropTable drops a view and its dependencies, if the cascade behavior is not
+// specified the appropriate error will be generated.
 func dropView(b BuildCtx, view catalog.TableDescriptor, behavior tree.DropBehavior) {
-	// Convert the table descriptor into elements.	b.EnqueueDropIfNotExists(viewNode)
-	decomposeTableDescToElements(b, view, scpb.Target_DROP)
-	// Use the c BuildCtx again.
-	{
-		c := b.WithNewSourceElementID()
-		// Go over the dependencies and generate drop targets
-		// for them. In our case they should only be views.
-		scpb.ForEachRelationDependedOnBy(b,
-			func(_ scpb.Status,
-				_ scpb.Target_Direction,
-				dep *scpb.RelationDependedOnBy) {
-				if dep.TableID != view.GetID() {
-					return
-				}
-				dependentDesc := c.MustReadTable(dep.DependedOnBy)
-				if !dependentDesc.IsView() {
-					panic(errors.AssertionFailedf("descriptor :%s is not a view", dependentDesc.GetName()))
-				}
-				if behavior != tree.DropCascade {
-					name, err := b.CatalogReader().GetQualifiedTableNameByID(b.EvalCtx().Context, int64(view.GetID()), tree.ResolveRequireViewDesc)
-					onErrPanic(err)
+	dropViewDependents(dropViewBasic(b, view), view, behavior)
+}
 
-					depViewName, err := b.CatalogReader().GetQualifiedTableNameByID(b.EvalCtx().Context, int64(dep.DependedOnBy), tree.ResolveRequireViewDesc)
-					onErrPanic(err)
+// dropTableBasic drops the view and does not validate or deal with
+// any objects that may need to be dealt with when cascading. The BuildCtx for
+// cascaded drops is returned.
+func dropViewBasic(b BuildCtx, view catalog.TableDescriptor) BuildCtx {
+	decomposeTableDescToElements(b, view, scpb.Target_DROP)
+	return b.WithNewSourceElementID()
+}
+
+// dropTableDependents drops any dependent objects for the view if possible,
+// if a cascade is not specified an appropriate error is returned.
+func dropViewDependents(b BuildCtx, view catalog.TableDescriptor, behavior tree.DropBehavior) {
+	// Go over the dependencies and generate drop targets
+	// for them. In our case they should only be views.
+	scpb.ForEachRelationDependedOnBy(b,
+		func(_ scpb.Status,
+			_ scpb.Target_Direction,
+			dep *scpb.RelationDependedOnBy) {
+			if dep.TableID != view.GetID() {
+				return
+			}
+			dependentDesc := b.MustReadTable(dep.DependedOnBy)
+			if !dependentDesc.IsView() {
+				panic(errors.AssertionFailedf("descriptor :%s is not a view", dependentDesc.GetName()))
+			}
+			if behavior != tree.DropCascade &&
+				!checkIfDescOrElementAreDropped(b, dep.DependedOnBy) {
+				name, err := b.CatalogReader().GetQualifiedTableNameByID(b, int64(view.GetID()), tree.ResolveRequireViewDesc)
+				onErrPanic(err)
+
+				depViewName, err := b.CatalogReader().GetQualifiedTableNameByID(b, int64(dep.DependedOnBy), tree.ResolveRequireViewDesc)
+				onErrPanic(err)
+				if dependentDesc.GetParentID() != view.GetParentID() {
+					panic(sqlerrors.NewDependentObjectErrorf("cannot drop view %q because view %q depends on it",
+						name.FQString(), depViewName.FQString()))
+				} else {
 					panic(errors.WithHintf(
 						sqlerrors.NewDependentObjectErrorf("cannot drop view %q because view %q depends on it",
-							name, depViewName.FQString()),
-						"you can drop %s instead.", depViewName.FQString()))
+							name.Object(), depViewName.Object()),
+						"you can drop %s instead.", depViewName.Object()))
 				}
-				// Decompose and recursively attempt to drop
-				dropView(b, dependentDesc, behavior)
-			})
-
-	}
+			}
+			// Decompose and recursively attempt to drop.
+			dropView(b, dependentDesc, behavior)
+		})
 }

--- a/pkg/sql/schemachanger/scbuild/name_resolver.go
+++ b/pkg/sql/schemachanger/scbuild/name_resolver.go
@@ -170,7 +170,7 @@ func (b buildCtx) ResolveIndex(
 	if !rel.IsPhysicalTable() || rel.IsSequence() {
 		panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not an indexable table or a materialized view", rel.GetName()))
 	}
-	idx, _ := rel.FindIndexWithName(indexName.String())
+	idx, _ := rel.FindIndexWithName(string(indexName))
 	if idx == nil {
 		if indexName == "" || indexName == tabledesc.LegacyPrimaryKeyIndexName {
 			// Fallback to primary index

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -68,7 +68,7 @@ var _ scbuild.CatalogReader = (*buildDeps)(nil)
 func (d *buildDeps) MayResolveDatabase(
 	ctx context.Context, name tree.Name,
 ) catalog.DatabaseDescriptor {
-	db, err := d.descsCollection.GetImmutableDatabaseByName(ctx, d.txn, name.String(), tree.DatabaseLookupFlags{
+	db, err := d.descsCollection.GetImmutableDatabaseByName(ctx, d.txn, string(name), tree.DatabaseLookupFlags{
 		AvoidCached: true,
 	})
 	if err != nil {

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -367,7 +367,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 5
+          SourceElementID: 6
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -381,7 +381,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 5
+          SourceElementID: 6
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -395,7 +395,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 6
+          SourceElementID: 8
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -409,7 +409,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 6
+          SourceElementID: 9
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -423,7 +423,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 6
+          SourceElementID: 10
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -437,7 +437,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 6
+          SourceElementID: 10
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -451,7 +451,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP DATABASE db1 CASCADE
         TargetMetadata:
-          SourceElementID: 6
+          SourceElementID: 12
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -543,7 +543,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP SCHEMA defaultdb.sc1 CASCADE
         TargetMetadata:
-          SourceElementID: 3
+          SourceElementID: 4
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -557,7 +557,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP SCHEMA defaultdb.sc1 CASCADE
         TargetMetadata:
-          SourceElementID: 3
+          SourceElementID: 5
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -571,7 +571,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP SCHEMA defaultdb.sc1 CASCADE
         TargetMetadata:
-          SourceElementID: 3
+          SourceElementID: 6
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -585,7 +585,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP SCHEMA defaultdb.sc1 CASCADE
         TargetMetadata:
-          SourceElementID: 3
+          SourceElementID: 6
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -599,7 +599,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP SCHEMA defaultdb.sc1 CASCADE
         TargetMetadata:
-          SourceElementID: 3
+          SourceElementID: 8
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -149,7 +149,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP TABLE defaultdb.shipments CASCADE
         TargetMetadata:
-          SourceElementID: 2
+          SourceElementID: 3
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -246,7 +246,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP VIEW defaultdb.v1 CASCADE
         TargetMetadata:
-          SourceElementID: 1
+          SourceElementID: 2
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -260,7 +260,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP VIEW defaultdb.v1 CASCADE
         TargetMetadata:
-          SourceElementID: 1
+          SourceElementID: 3
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -274,7 +274,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP VIEW defaultdb.v1 CASCADE
         TargetMetadata:
-          SourceElementID: 1
+          SourceElementID: 3
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor
@@ -288,7 +288,7 @@ Stage 3 of 3 (non-revertible)
       Metadata:
         Statement: DROP VIEW defaultdb.v1 CASCADE
         TargetMetadata:
-          SourceElementID: 1
+          SourceElementID: 5
           SubWorkID: 1
         Username: root
     *scop.CreateGcJobForDescriptor


### PR DESCRIPTION
Previously, the declarative schema changer was incorrectly
converting index and database names. This was inadequate because
object looks up would fail due to certain being characters
being converted to be SQL friendly. To address this, this
patch correctly fixes uses the correct string conversion functions.


Release Note: None

