### PR TITLE
sql: add is_sharded to crdb_internal.table_indexes

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2555,7 +2555,8 @@ CREATE TABLE crdb_internal.table_indexes (
   index_name       STRING NOT NULL,
   index_type       STRING NOT NULL,
   is_unique        BOOL NOT NULL,
-  is_inverted      BOOL NOT NULL
+  is_inverted      BOOL NOT NULL,
+  is_sharded       BOOL NOT NULL
 )
 `,
 	generator: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
@@ -2585,6 +2586,7 @@ CREATE TABLE crdb_internal.table_indexes (
 							idxType,
 							tree.MakeDBool(tree.DBool(idx.IsUnique())),
 							tree.MakeDBool(idx.GetType() == descpb.IndexDescriptor_INVERTED),
+							tree.MakeDBool(tree.DBool(idx.IsSharded())),
 						)
 						return pusher.pushRow(row...)
 					})

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -253,10 +253,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBB colnames
+query ITITTBBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -270,10 +270,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBB colnames
+query ITITTBBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1122,7 +1122,8 @@ CREATE TABLE crdb_internal.table_indexes (
    index_name STRING NOT NULL,
    index_type STRING NOT NULL,
    is_unique BOOL NOT NULL,
-   is_inverted BOOL NOT NULL
+   is_inverted BOOL NOT NULL,
+   is_sharded BOOL NOT NULL
 )  CREATE TABLE crdb_internal.table_indexes (
    descriptor_id INT8 NULL,
    descriptor_name STRING NOT NULL,
@@ -1130,7 +1131,8 @@ CREATE TABLE crdb_internal.table_indexes (
    index_name STRING NOT NULL,
    index_type STRING NOT NULL,
    is_unique BOOL NOT NULL,
-   is_inverted BOOL NOT NULL
+   is_inverted BOOL NOT NULL,
+   is_sharded BOOL NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.table_row_statistics (
    table_id INT8 NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -41,26 +41,26 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 65             test_uwi_child   1          a            family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        true      NULL            false
 65             test_uwi_child   2          rowid        family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false        false     unique_rowid()  true
 
-query ITITTBB colnames
+query ITITTBBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
 ----
-descriptor_id  descriptor_name  index_id  index_name            index_type  is_unique  is_inverted
-56             test_kv          1         test_kv_pkey          primary     true       false
-56             test_kv          2         test_v_idx            secondary   true       false
-56             test_kv          3         test_v_idx2           secondary   false      false
-56             test_kv          4         test_v_idx3           secondary   false      false
-57             test_kvr1        1         test_kvr1_pkey        primary     true       false
-58             test_kvr2        1         test_kvr2_pkey        primary     true       false
-58             test_kvr2        2         test_kvr2_v_key       secondary   true       false
-59             test_kvr3        1         test_kvr3_pkey        primary     true       false
-59             test_kvr3        2         test_kvr3_v_key       secondary   true       false
-60             test_kvi1        1         test_kvi1_pkey        primary     true       false
-61             test_kvi2        1         test_kvi2_pkey        primary     true       false
-61             test_kvi2        2         test_kvi2_idx         secondary   true       false
-62             test_v1          0         ·                     primary     false      false
-63             test_v2          0         ·                     primary     false      false
-64             test_uwi_parent  1         test_uwi_parent_pkey  primary     true       false
-65             test_uwi_child   1         test_uwi_child_pkey   primary     true       false
+descriptor_id  descriptor_name  index_id  index_name            index_type  is_unique  is_inverted  is_sharded
+56             test_kv          1         test_kv_pkey          primary     true       false        false
+56             test_kv          2         test_v_idx            secondary   true       false        false
+56             test_kv          3         test_v_idx2           secondary   false      false        false
+56             test_kv          4         test_v_idx3           secondary   false      false        false
+57             test_kvr1        1         test_kvr1_pkey        primary     true       false        false
+58             test_kvr2        1         test_kvr2_pkey        primary     true       false        false
+58             test_kvr2        2         test_kvr2_v_key       secondary   true       false        false
+59             test_kvr3        1         test_kvr3_pkey        primary     true       false        false
+59             test_kvr3        2         test_kvr3_v_key       secondary   true       false        false
+60             test_kvi1        1         test_kvi1_pkey        primary     true       false        false
+61             test_kvi2        1         test_kvi2_pkey        primary     true       false        false
+61             test_kvi2        2         test_kvi2_idx         secondary   true       false        false
+62             test_v1          0         ·                     primary     false      false        false
+63             test_v2          0         ·                     primary     false      false        false
+64             test_uwi_parent  1         test_uwi_parent_pkey  primary     true       false        false
+65             test_uwi_child   1         test_uwi_child_pkey   primary     true       false        false
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -665,3 +665,18 @@ CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH BUCKET_COUNT = 8
 
 statement ok
 DROP INDEX h1
+
+subtest test_table_indexes
+
+statement ok
+CREATE TABLE poor_t (a INT PRIMARY KEY, b INT, INDEX t_idx_b (b) USING HASH WITH BUCKET_COUNT = 8)
+
+query ITITTBBB colnames
+SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = 'poor_t'
+----
+descriptor_id  descriptor_name  index_id  index_name   index_type  is_unique  is_inverted  is_sharded
+80             poor_t           1         poor_t_pkey  primary     true       false        false
+80             poor_t           2         t_idx_b      secondary   false      false        true
+
+statement ok
+DROP TABLE poor_t


### PR DESCRIPTION
fixes #73057

Release note (bug fix): crdb_internal.table_indexes now shows if an
index is sharded or not.