### PR TITLE
tracing: fix a crash

### DIFF
--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -350,13 +350,18 @@ func TestSpanMaxChildren(t *testing.T) {
 	tr := NewTracer()
 	sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 	defer sp.Finish()
-	for i := 0; i < maxChildrenPerSpan+123; i++ {
-		tr.StartSpan(fmt.Sprintf("child %d", i), WithParent(sp))
+	numChildren := maxChildrenPerSpan + 123
+	children := make([]*Span, numChildren)
+	for i := 0; i < numChildren; i++ {
+		children[i] = tr.StartSpan(fmt.Sprintf("child %d", i), WithParent(sp))
 		exp := i + 1
 		if exp > maxChildrenPerSpan {
 			exp = maxChildrenPerSpan
 		}
 		require.Len(t, sp.i.crdb.mu.recording.openChildren, exp)
+	}
+	for _, s := range children {
+		s.Finish()
 	}
 }
 


### PR DESCRIPTION
When a child span finishes, it tries to deregister itself from the
parent. We assert that the parent has a reference to this child. This
assertion fired because there is a case where the parent does not have a
reference to the child - when the parent had too many open children at
the time when the child was created, it will not register the child. In
effect, such a child is a root. This patch makes the child in question
aware of the fact that it is really a root.

Fixes #73351

Release note: None