### PR TITLE
roachprod: allow concurrent creation of clusters

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -27,6 +27,7 @@ import (
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -123,7 +124,7 @@ Local Clusters
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		createVMOpts.ClusterName = args[0]
-		return roachprod.Create(username, numNodes, createVMOpts)
+		return roachprod.Create(username, numNodes, createVMOpts, providerOptsContainer)
 	}),
 }
 
@@ -857,7 +858,7 @@ var versionCmd = &cobra.Command{
 
 func main() {
 	roachprod.InitProviders()
-
+	providerOptsContainer = vm.CreateProviderOptionsContainer()
 	// The commands are displayed in the order they are added to rootCmd. Note
 	// that gcCmd and adminurlCmd contain a trailing \n in their Short help in
 	// order to separate the commands into logical groups.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -97,7 +97,7 @@ func awsMachineSupportsSSD(machineType string) bool {
 	return false
 }
 
-func getAWSOpts(machineType string, zones []string, localSSD bool) aws.ProviderOpts {
+func getAWSOpts(machineType string, zones []string, localSSD bool) vm.ProviderOpts {
 	opts := aws.DefaultProviderOpts()
 	if localSSD {
 		opts.SSDMachineType = machineType
@@ -112,7 +112,7 @@ func getAWSOpts(machineType string, zones []string, localSSD bool) aws.ProviderO
 
 func getGCEOpts(
 	machineType string, zones []string, volumeSize, localSSDCount int, localSSD bool, RAID0 bool,
-) gce.ProviderOpts {
+) vm.ProviderOpts {
 	opts := gce.DefaultProviderOpts()
 	opts.MachineType = machineType
 	if volumeSize != 0 {
@@ -132,7 +132,7 @@ func getGCEOpts(
 	return opts
 }
 
-func getAzureOpts(machineType string, zones []string) azure.ProviderOpts {
+func getAzureOpts(machineType string, zones []string) vm.ProviderOpts {
 	opts := azure.DefaultProviderOpts()
 	opts.MachineType = machineType
 	if len(zones) != 0 {
@@ -145,7 +145,7 @@ func getAzureOpts(machineType string, zones []string) azure.ProviderOpts {
 // in order to create the cluster described in the spec.
 func (s *ClusterSpec) RoachprodOpts(
 	clusterName string, useIOBarrier bool,
-) (vm.CreateOpts, interface{}, error) {
+) (vm.CreateOpts, vm.ProviderOpts, error) {
 
 	createVMOpts := vm.DefaultCreateOpts()
 	createVMOpts.ClusterName = clusterName
@@ -227,7 +227,7 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
-	var providerOpts interface{}
+	var providerOpts vm.ProviderOpts
 	switch s.Cloud {
 	case AWS:
 		providerOpts = getAWSOpts(machineType, zones, createVMOpts.SSDOpts.UseLocalSSD)

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -246,7 +246,9 @@ func ListCloud() (*Cloud, error) {
 }
 
 // CreateCluster TODO(peter): document
-func CreateCluster(nodes int, opts vm.CreateOpts) error {
+func CreateCluster(
+	nodes int, opts vm.CreateOpts, providerOptsContainer vm.ProviderOptionsContainer,
+) error {
 	providerCount := len(opts.VMProviders)
 	if providerCount == 0 {
 		return errors.New("no VMProviders configured")
@@ -263,7 +265,7 @@ func CreateCluster(nodes int, opts vm.CreateOpts) error {
 	}
 
 	return vm.ProvidersParallel(opts.VMProviders, func(p vm.Provider) error {
-		return p.Create(vmLocations[p.Name()], opts)
+		return p.Create(vmLocations[p.Name()], opts, providerOptsContainer[p.Name()])
 	})
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1062,7 +1062,12 @@ func cleanupFailedCreate(clusterName string) error {
 }
 
 // Create TODO
-func Create(username string, numNodes int, createVMOpts vm.CreateOpts) (retErr error) {
+func Create(
+	username string,
+	numNodes int,
+	createVMOpts vm.CreateOpts,
+	providerOptsContainer vm.ProviderOptionsContainer,
+) (retErr error) {
 	if err := LoadClusters(); err != nil {
 		return errors.Wrap(err, "problem loading clusters")
 	}
@@ -1118,7 +1123,7 @@ func Create(username string, numNodes int, createVMOpts vm.CreateOpts) (retErr e
 	}
 
 	fmt.Printf("Creating cluster %s with %d nodes\n", clusterName, numNodes)
-	if createErr := cloud.CreateCluster(numNodes, createVMOpts); createErr != nil {
+	if createErr := cloud.CreateCluster(numNodes, createVMOpts, providerOptsContainer); createErr != nil {
 		return createErr
 	}
 

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -27,7 +27,7 @@ import (
 const sshPublicKeyFile = "${HOME}/.ssh/id_rsa.pub"
 
 // sshKeyExists checks to see if there is a an SSH key with the given name in the given region.
-func (p *Provider) sshKeyExists(keyName string, region string) (bool, error) {
+func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
 	var data struct {
 		KeyPairs []struct {
 			KeyName string
@@ -51,7 +51,7 @@ func (p *Provider) sshKeyExists(keyName string, region string) (bool, error) {
 
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
-func (p *Provider) sshKeyImport(keyName string, region string) error {
+func (p *Provider) sshKeyImport(keyName, region string) error {
 	_, err := os.Stat(os.ExpandEnv(sshPublicKeyFile))
 	if err != nil {
 		if oserror.IsNotExist(err) {

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -180,8 +180,8 @@ func writeStartupScript(extraMountOpts string, useMultiple bool) (string, error)
 // runCommand is used to invoke an AWS command.
 func (p *Provider) runCommand(args []string) ([]byte, error) {
 
-	if p.opts.Profile != "" {
-		args = append(args[:len(args):len(args)], "--profile", p.opts.Profile)
+	if p.Profile != "" {
+		args = append(args[:len(args):len(args)], "--profile", p.Profile)
 	}
 	var stderrBuf bytes.Buffer
 	cmd := exec.Command("aws", args...)

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -13,7 +13,6 @@ package azure
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -22,16 +21,14 @@ import (
 
 // ProviderOpts provides user-configurable, azure-specific create options.
 type ProviderOpts struct {
-	Locations        []string
-	MachineType      string
-	OperationTimeout time.Duration
-	SyncDelete       bool
-	VnetName         string
-	Zone             string
-	NetworkDiskType  string
-	NetworkDiskSize  int32
-	UltraDiskIOPS    int64
-	DiskCaching      string
+	Locations       []string
+	MachineType     string
+	VnetName        string
+	Zone            string
+	NetworkDiskType string
+	NetworkDiskSize int32
+	UltraDiskIOPS   int64
+	DiskCaching     string
 }
 
 var defaultLocations = []string{
@@ -43,26 +40,29 @@ var defaultLocations = []string{
 var defaultZone = "1"
 
 // DefaultProviderOpts returns a new azure.ProviderOpts with default values set.
-func DefaultProviderOpts() ProviderOpts {
-	return ProviderOpts{
-		Locations:        nil,
-		MachineType:      string(compute.VirtualMachineSizeTypesStandardD4V3),
-		OperationTimeout: 10 * time.Minute,
-		SyncDelete:       false,
-		VnetName:         "common",
-		Zone:             "",
-		NetworkDiskType:  "premium-disk",
-		NetworkDiskSize:  500,
-		UltraDiskIOPS:    5000,
-		DiskCaching:      "none",
+func DefaultProviderOpts() *ProviderOpts {
+	return &ProviderOpts{
+		Locations:       nil,
+		MachineType:     string(compute.VirtualMachineSizeTypesStandardD4V3),
+		VnetName:        "common",
+		Zone:            "",
+		NetworkDiskType: "premium-disk",
+		NetworkDiskSize: 500,
+		UltraDiskIOPS:   5000,
+		DiskCaching:     "none",
 	}
+}
+
+// CreateProviderOpts returns a new azure.ProviderOpts with default values set.
+func (p *Provider) CreateProviderOpts() vm.ProviderOpts {
+	return DefaultProviderOpts()
 }
 
 // ConfigureCreateFlags implements vm.ProviderFlags.
 func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
-	flags.DurationVar(&o.OperationTimeout, ProviderName+"-timeout", 10*time.Minute,
+	flags.DurationVar(&providerInstance.OperationTimeout, ProviderName+"-timeout", providerInstance.OperationTimeout,
 		"The maximum amount of time for an Azure API operation to take")
-	flags.BoolVar(&o.SyncDelete, ProviderName+"-sync-delete", false,
+	flags.BoolVar(&providerInstance.SyncDelete, ProviderName+"-sync-delete", providerInstance.SyncDelete,
 		"Wait for deletions to finish before returning")
 	flags.StringVar(&o.MachineType, ProviderName+"-machine-type",
 		string(compute.VirtualMachineSizeTypesStandardD4V3),
@@ -85,12 +85,4 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 
 // ConfigureClusterFlags implements vm.ProviderFlags and is a no-op.
 func (o *ProviderOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
-}
-
-// ConfigureProviderOpts implements vm.ProviderFlags.
-// Usage: create a new struct with default values using DefaultProviderOpts()
-// and update its values then pass it to ConfigureProviderOpts().
-func (o *ProviderOpts) ConfigureProviderOpts(updatedOpts interface{}) {
-	// cast interface to ProviderOpts before assisgning
-	*o = updatedOpts.(ProviderOpts)
 }

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -42,7 +42,7 @@ func (p *provider) ConfigSSH() error {
 }
 
 // Create implements vm.Provider and returns Unimplemented.
-func (p *provider) Create(names []string, opts vm.CreateOpts) error {
+func (p *provider) Create(names []string, opts vm.CreateOpts, providerOpts vm.ProviderOpts) error {
 	return errors.Newf("%s", p.unimplemented)
 }
 
@@ -66,11 +66,6 @@ func (p *provider) FindActiveAccount() (string, error) {
 	return "", nil
 }
 
-// Flags implements vm.Provider and returns the delegate's name.
-func (p *provider) Flags() vm.ProviderFlags {
-	return p.delegate.Flags()
-}
-
 // List implements vm.Provider and returns an empty list.
 func (p *provider) List() (vm.List, error) {
 	return nil, nil
@@ -89,4 +84,9 @@ func (p *provider) Active() bool {
 // ProjectActive is part of the vm.Provider interface.
 func (p *provider) ProjectActive(project string) bool {
 	return false
+}
+
+// CreateProviderFlags is part of the vm.Provider interface.
+func (p *provider) CreateProviderOpts() vm.ProviderOpts {
+	return nil
 }

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -115,19 +115,15 @@ type Provider struct {
 	storage VMStorage
 }
 
-// No-op implementation of ProviderFlags
-type emptyFlags struct{}
+// No-op implementation of vm.ProviderOpts
+type providerOpts struct{}
 
-// ConfigureCreateFlags is part of ProviderFlags.  This implementation is a no-op.
-func (o *emptyFlags) ConfigureCreateFlags(flags *pflag.FlagSet) {
+// ConfigureCreateFlags is part of ProviderOpts.  This implementation is a no-op.
+func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 }
 
-// ConfigureClusterFlags is part of ProviderFlags.  This implementation is a no-op.
-func (o *emptyFlags) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
-}
-
-// ConfigureProviderOpts is part of ProviderFlags.  This implementation is a no-op.
-func (o *emptyFlags) ConfigureProviderOpts(newOpts interface{}) {
+// ConfigureClusterFlags is part of ProviderOpts.  This implementation is a no-op.
+func (o *providerOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
 }
 
 // CleanSSH is part of the vm.Provider interface.  This implementation is a no-op.
@@ -141,7 +137,9 @@ func (p *Provider) ConfigSSH() error {
 }
 
 // Create just creates fake host-info entries in the local filesystem
-func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
+func (p *Provider) Create(
+	names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,
+) error {
 	now := timeutil.Now()
 	c := &cloud.Cluster{
 		Name:      opts.ClusterName,
@@ -228,9 +226,9 @@ func (p *Provider) FindActiveAccount() (string, error) {
 	return "", nil
 }
 
-// Flags is part of the vm.Provider interface. This implementation is a no-op.
-func (p *Provider) Flags() vm.ProviderFlags {
-	return &emptyFlags{}
+// CreateProviderOpts is part of the vm.Provider interface. This implementation is a no-op.
+func (p *Provider) CreateProviderOpts() vm.ProviderOpts {
+	return &providerOpts{}
 }
 
 // List reports all the local cluster "VM" instances.

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -214,36 +214,33 @@ const (
 	AcceptMultipleProjects = true
 )
 
-// ProviderFlags is a hook point for Providers to supply additional,
-// provider-specific flags to various roachprod commands. In general, the flags
+// ProviderOpts is a hook point for Providers to supply additional,
+// provider-specific options to various roachprod commands. In general, the flags
 // should be prefixed with the provider's name to prevent collision between
 // similar options.
 //
 // If a new command is added (perhaps `roachprod enlarge`) that needs
 // additional provider- specific flags, add a similarly-named method
 // `ConfigureEnlargeFlags` to mix in the additional flags.
-type ProviderFlags interface {
+type ProviderOpts interface {
 	// Configures a FlagSet with any options relevant to the `create` command.
 	ConfigureCreateFlags(*pflag.FlagSet)
 	// Configures a FlagSet with any options relevant to cluster manipulation
 	// commands (`create`, `destroy`, `list`, `sync` and `gc`).
 	ConfigureClusterFlags(*pflag.FlagSet, MultipleProjectsOption)
-	// Updates provider opts values to match the passed provider opts struct
-	ConfigureProviderOpts(interface{})
 }
 
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
+	CreateProviderOpts() ProviderOpts
 	CleanSSH() error
 	ConfigSSH() error
-	Create(names []string, opts CreateOpts) error
+	Create(names []string, opts CreateOpts, providerOpts ProviderOpts) error
 	Reset(vms List) error
 	Delete(vms List) error
 	Extend(vms List, lifetime time.Duration) error
 	// Return the account name associated with the provider
 	FindActiveAccount() (string, error)
-	// Returns a hook point for extending top-level roachprod tooling flags
-	Flags() ProviderFlags
 	List() (List, error)
 	// The name of the Provider, which will also surface in the top-level Providers map.
 	Name() string
@@ -269,6 +266,28 @@ type DeleteCluster interface {
 
 // Providers contains all known Provider instances. This is initialized by subpackage init() functions.
 var Providers = map[string]Provider{}
+
+// ProviderOptionsContainer is a container for a collection of provider-specific options.
+type ProviderOptionsContainer map[string]ProviderOpts
+
+// CreateProviderOptionsContainer returns a ProviderOptionsContainer which is
+// populated with options for all registered providers. Only call it after
+// initiliazing providers (populating vm.Providers).
+func CreateProviderOptionsContainer() ProviderOptionsContainer {
+	container := make(ProviderOptionsContainer)
+	for providerName, providerInstance := range Providers {
+		container[providerName] = providerInstance.CreateProviderOpts()
+	}
+	return container
+}
+
+// SetProviderOpts updates the container it operates on with the given
+// provider options for the given provider.
+func (container ProviderOptionsContainer) SetProviderOpts(
+	providerName string, providerOpts ProviderOpts,
+) {
+	container[providerName] = providerOpts
+}
 
 // AllProviderNames returns the names of all known vm Providers.  This is useful with the
 // ProvidersSequential or ProvidersParallel methods.


### PR DESCRIPTION
Previously, we used the roachprod binary
to create clusters concurrently and this
worked fine because every `roachprod verb`
command starts a new seperate process.

Now we use the library so we are overriding
global provider-specific options. This patch
allows us to manage options for multiple clusters
per provider concurrently.

Release note: None