### PR TITLE
flowinfra: deflake TestInboundStreamTimeoutIsRetryable

### DIFF
--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -523,7 +523,6 @@ func TestFlowRegistryDrain(t *testing.T) {
 // TODO(asubiotto): This error should also be considered retryable by clients.
 func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 
 	fr := NewFlowRegistry()
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
This test occasionally fails during the cleanup of the log scope, so
let's remove the scope (possibly temporarily).

Addresses: #73375.

Release note: None