### PR TITLE
changefeedccl: Explicitly set min_resolved_frequency.

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1718,9 +1718,9 @@ func createChangefeed(db *gosql.DB, targets, sinkURL string, args cdcTestArgs) (
 	createStmt := fmt.Sprintf(`CREATE CHANGEFEED FOR %s INTO $1`, targets)
 	extraArgs := []interface{}{sinkURL}
 	if args.whichSink == cloudStorageSink || args.whichSink == webhookSink {
-		createStmt += ` WITH resolved='10s', envelope=wrapped`
+		createStmt += ` WITH resolved='10s', envelope=wrapped, min_checkpoint_frequency='10s'`
 	} else {
-		createStmt += ` WITH resolved`
+		createStmt += ` WITH resolved,  min_checkpoint_frequency='10s'`
 	}
 	if !args.initialScan {
 		createStmt += `, cursor='-1s'`


### PR DESCRIPTION
Previously, the `resolved` was used to control the frequency of
of aggregators emitting checkpoint information to the frontier.
Now, this frequency is controlled via `min_checkpoint_frequency`.
Set checkpoint frequency to 10s, so that checkpoints are emitted
more frequently.  The default of 30s causes latency verifier
to fail at 1 minute since it's now very easy to simply miss
sending frontier updates (so latency can go up to almost 1 minute),
plus the closed timestamp setting of 10 second can exceed
required thresholds.

Fixes #73295
Fixes #73294
Fixes #72806

Release Notes: none