### PR TITLE
bazel: update `lint` bootstrapping script for bazel

### DIFF
--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -47,12 +47,7 @@ def lint_binary(name, test):
         srcs = [script_name],
         data = [
             test,
-            "//c-deps:libedit_files",
-            "//c-deps:libgeos_files",
-            "//c-deps:libproj_files",
-            "//pkg/cmd/returncheck",
             "//pkg/sql/opt/optgen/cmd/optfmt",
-            "@co_honnef_go_tools//cmd/staticcheck",
             "@com_github_client9_misspell//cmd/misspell:misspell",
             "@com_github_cockroachdb_crlfmt//:crlfmt",
             "@go_sdk//:bin/go",

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -31,8 +31,6 @@ crlfmt_bin="$(rlocation_ck com_github_cockroachdb_crlfmt/crlfmt_/crlfmt)"
 golint_bin="$(rlocation_ck org_golang_x_lint/golint/golint_/golint)"
 misspell_bin="$(rlocation_ck com_github_client9_misspell/cmd/misspell/misspell_/misspell)"
 optfmt_bin="$(rlocation_ck cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
-returncheck_bin="$(rlocation_ck cockroach/pkg/cmd/returncheck/returncheck_/returncheck)"
-staticcheck_bin="$(rlocation_ck co_honnef_go_tools/cmd/staticcheck/staticcheck_/staticcheck)"
 
 # Need to run this so that Go can find the runfiles.
 runfiles_export_envvars
@@ -45,6 +43,6 @@ fi
 cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
 
 TEST_WORKSPACE=cockroach \
-    PATH="$(dirname $go_bin):$(dirname $returncheck_bin):$(dirname $staticcheck_bin):$(dirname $crlfmt_bin):$(dirname $misspell_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
+    PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $misspell_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
     GOROOT="$(dirname $(dirname $go_bin))" \
     "$test_bin" "$@"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -40,26 +40,6 @@ import (
 
 const cockroachDB = "github.com/cockroachdb/cockroach"
 
-func init() {
-	if bazel.BuiltWithBazel() {
-		// We need to explicitly include all the libraries in LDFLAGS.
-		runfiles, err := bazel.RunfilesPath()
-		if err != nil {
-			panic(err)
-		}
-		ldflags := ""
-		for _, dir := range []string{
-			"c-deps/libgeos/lib",
-			"c-deps/libproj/lib",
-			"external/com_github_knz_go_libedit/unix",
-		} {
-			ldflags = ldflags + " -L" + filepath.Join(runfiles, dir)
-		}
-		os.Setenv("CGO_LDFLAGS", ldflags)
-		os.Setenv("LDFLAGS", ldflags)
-	}
-}
-
 func dirCmd(
 	dir string, name string, args ...string,
 ) (*exec.Cmd, *bytes.Buffer, stream.Filter, error) {
@@ -1631,6 +1611,7 @@ func TestLint(t *testing.T) {
 
 	t.Run("TestReturnCheck", func(t *testing.T) {
 		skip.UnderShort(t)
+		skip.UnderBazelWithIssue(t, 73391, "Going to migrate to nogo")
 		// returncheck uses 2GB of ram (as of 2017-07-13), so don't parallelize it.
 		cmd, stderr, filter, err := dirCmd(crdb.Dir, "returncheck", pkgScope)
 		if err != nil {


### PR DESCRIPTION
Now we don't need to build a bunch of extra garbage to run lints. This
makes lints much faster (we still don't have complete feature parity w/
`make lint`, but we have tracking bugs for all the deficiencies). Also
insert a reference to #73391.

Release note: None