### PR TITLE
kv: don't consider follower to have pending proposal quota

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -420,7 +420,7 @@ func (r *Replica) hasPendingProposalsRLocked() bool {
 // unquiescing (leading to deadlock). See #46699.
 func (r *Replica) hasPendingProposalQuotaRLocked() bool {
 	if r.mu.proposalQuota == nil {
-		return true
+		return false
 	}
 	return !r.mu.proposalQuota.Full()
 }


### PR DESCRIPTION
`r.mu.proposalQuota` is always nil on a follower, which is enforced in `updateProposalQuotaRaftMuLocked`. Before this change, we were considering a nil `proposalQuota` to have pending proposal quota. As a result, whenever a follower was ticked, it was hitting the `not quiescing: replication quota outstanding` branch in `shouldReplicaQuiesce` and not falling down to the `not quiescing: not leader` branch like we it expected to. This commit fixes this.

The change shouldn't have an impact on behavior, it should just fix the expectations in the code. However, I'm slightly concerned that this could reveal performance issues in `shouldReplicaQuiesce`. For instance, will followers now reaching the call to `raftStatusRLocked` be impactful? Maybe. So I don't want to backport this.