### PR TITLE
server, tracing: Make traces redactable and default to "off"

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -72,6 +73,8 @@ SET tracing = off;
 	tc.Server(0).TracerI().(*tracing.Tracer).SetRedactable(redactable)
 	defer tc.Stopper().Stop(ctx)
 
+	// Queries from the system tenant will receive unredacted traces
+	// since the tracer will not have the redactable flag set.
 	t.Run("system-tenant", func(t *testing.T) {
 		db := tc.ServerConn(0)
 		defer db.Close()
@@ -97,7 +100,6 @@ SET tracing = off;
 		defer tenDB.Close()
 		results := getTrace(t, tenDB)
 
-		const redactedMarkerString = "verbose trace message redacted"
 		var found bool
 		var foundRedactedMarker bool
 		for _, sl := range results {
@@ -111,26 +113,29 @@ SET tracing = off;
 				if strings.Contains(s, visibleString) {
 					found = true
 				}
-				if strings.Contains(s, redactedMarkerString) {
+				if strings.Contains(s, string(server.TraceRedactedMarker)) {
 					foundRedactedMarker = true
 				}
 			}
 		}
 
+		// In both cases we don't expect to see the `TraceRedactedMarker`
+		// since that's only shown when the server is in an inconsistent
+		// state or if there's a version mismatch between client and server.
 		if redactable {
 			// If redaction was on, we expect the tenant to see safe information in its
 			// trace.
 			require.True(t, found, "did not see expected trace message '%q':\n%s",
 				visibleString, sqlutils.MatrixToStr(results))
 			require.False(t, foundRedactedMarker, "unexpectedly found '%q':\n%s",
-				redactedMarkerString, sqlutils.MatrixToStr(results))
+				string(server.TraceRedactedMarker), sqlutils.MatrixToStr(results))
 		} else {
 			// Otherwise, expect the opposite: not even safe information makes it through,
 			// because it gets replaced with foundRedactedMarker.
 			require.False(t, found, "unexpectedly saw message '%q':\n%s",
 				visibleString, sqlutils.MatrixToStr(results))
-			require.True(t, foundRedactedMarker, "not not find expected message '%q':\n%s",
-				redactedMarkerString, sqlutils.MatrixToStr(results))
+			require.False(t, foundRedactedMarker, "unexpectedly found '%q':\n%s",
+				string(server.TraceRedactedMarker), sqlutils.MatrixToStr(results))
 		}
 	})
 }

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -965,7 +965,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 		if err == nil {
 			if !txn.IsCommitted() {
 				err = txn.Commit(ctx)
-				log.Eventf(ctx, "client.Txn did AutoCommit. err: %v\n", err)
+				log.Eventf(ctx, "client.Txn did AutoCommit. err: %v", err)
 				if err != nil {
 					if !errors.HasType(err, (*roachpb.TransactionRetryWithProtoRefreshError)(nil)) {
 						// We can't retry, so let the caller know we tried to

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -68,7 +68,6 @@ func TestTxnVerboseTrace(t *testing.T) {
 		`(?s)`+
 			`.*event:[^:]*:\d+ inside txn\n`+
 			`.*event:[^:]*:\d+ client\.Txn did AutoCommit\. err: <nil>\n`+
-			`.*\n`+
 			`.*event:[^:]*:\d+ txn complete.*`,
 		dump)
 	if err != nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1050,6 +1050,7 @@ func (n *Node) setupSpanForIncomingRPC(
 	// remoteTrace case below.
 	const opName = "/cockroach.roachpb.Internal/Batch"
 	tr := n.storeCfg.AmbientCtx.Tracer
+
 	// newSpan is set if we end up creating a new span.
 	var newSpan *tracing.Span
 	parentSpan := tracing.SpanFromContext(ctx)

--- a/pkg/server/node_tenant.go
+++ b/pkg/server/node_tenant.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-var sRedactedMarker = redact.RedactableString(redact.EscapeBytes(nil))
+const sRedactedMarker = redact.RedactableString("verbose trace message redacted")
 
 // redactRecordingForTenant redacts the sensitive parts of log messages in the
 // recording if the tenant to which this recording is intended is not the system

--- a/pkg/server/node_tenant.go
+++ b/pkg/server/node_tenant.go
@@ -18,7 +18,8 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-const sRedactedMarker = redact.RedactableString("verbose trace message redacted")
+// TraceRedactedMarker is used to replace logs that weren't redacted.
+const TraceRedactedMarker = redact.RedactableString("verbose trace message redacted")
 
 // redactRecordingForTenant redacts the sensitive parts of log messages in the
 // recording if the tenant to which this recording is intended is not the system
@@ -49,7 +50,7 @@ func redactRecordingForTenant(tenID roachpb.TenantID, rec tracing.Recording) err
 				if field.Key != tracingpb.LogMessageField {
 					// We don't have any of these fields, but let's not take any
 					// chances (our dependencies might slip them in).
-					field.Value = sRedactedMarker
+					field.Value = TraceRedactedMarker
 					continue
 				}
 				if !sp.RedactableLogs {
@@ -58,7 +59,7 @@ func redactRecordingForTenant(tenID roachpb.TenantID, rec tracing.Recording) err
 					// stripped. Note that this is not the common path here, as most
 					// information in the trace will be from the local node, which
 					// always creates redactable logs.
-					field.Value = sRedactedMarker
+					field.Value = TraceRedactedMarker
 					continue
 				}
 				field.Value = field.Value.Redact()

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -45,8 +45,9 @@ func TestRedactRecordingForTenant(t *testing.T) {
 			Add("tag_sensitive", tagSensitive).
 			Add("tag_not_sensitive", log.Safe(tagNotSensitive))
 		ctx := logtags.WithTags(context.Background(), tags)
-		ctx, sp := tracing.NewTracer().StartSpanCtx(ctx, "foo", tracing.WithRecording(tracing.RecordingVerbose))
-
+		tracer := tracing.NewTracer()
+		tracer.SetRedactable(true)
+		ctx, sp := tracer.StartSpanCtx(ctx, "foo", tracing.WithRecording(tracing.RecordingVerbose))
 		log.Eventf(ctx, "%s %s", msgSensitive, log.Safe(msgNotSensitive))
 		sp.SetTag("all_span_tags_are_stripped", attribute.StringValue("because_no_redactability"))
 		rec := sp.FinishAndGetRecording(tracing.RecordingVerbose)

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -770,15 +770,20 @@ func BenchmarkLogEntry_String(b *testing.B) {
 }
 
 func BenchmarkEventf_WithVerboseTraceSpan(b *testing.B) {
-	b.ReportAllocs()
-	tagbuf := logtags.SingleTagBuffer("hello", "there")
-	ctx := logtags.WithTags(context.Background(), tagbuf)
-	tracer := tracing.NewTracer()
-	ctx, sp := tracer.StartSpanCtx(ctx, "benchspan", tracing.WithForceRealSpan())
-	b.ResetTimer()
-	defer sp.Finish()
-	sp.SetVerbose(true)
-	for i := 0; i < b.N; i++ {
-		Eventf(ctx, "%s %s %s", "foo", "bar", "baz")
+	for _, redactable := range []bool{false, true} {
+		b.Run(fmt.Sprintf("redactable=%t", redactable), func(b *testing.B) {
+			b.ReportAllocs()
+			tagbuf := logtags.SingleTagBuffer("hello", "there")
+			ctx := logtags.WithTags(context.Background(), tagbuf)
+			tracer := tracing.NewTracer()
+			tracer.SetRedactable(redactable)
+			ctx, sp := tracer.StartSpanCtx(ctx, "benchspan", tracing.WithForceRealSpan())
+			defer sp.Finish()
+			sp.SetVerbose(true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Eventf(ctx, "%s %s %s", "foo", "bar", "baz")
+			}
+		})
 	}
 }

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -97,7 +97,10 @@ func (e *logEntry) SafeFormat(w interfaces.SafePrinter, _ rune) {
 		// with a colon between the line number and the message.
 		// However, some location filter deep inside SQL doesn't
 		// understand a colon after the line number.
-		w.Printf("%s:%d ", redact.Safe(e.file), redact.Safe(e.line))
+		w.SafeString(redact.SafeString(e.file))
+		w.SafeRune(':')
+		w.SafeInt(redact.SafeInt(e.line))
+		w.SafeRune(' ')
 	}
 	if e.tags != nil {
 		w.SafeString("[")
@@ -110,10 +113,10 @@ func (e *logEntry) SafeFormat(w interfaces.SafePrinter, _ rune) {
 			// that the format strings for `log.Infof` etc are const strings.
 			k := redact.SafeString(tag.Key())
 			v := tag.Value()
+			w.SafeString(k)
 			if v != nil {
-				w.Printf("%s=%v", k, tag.Value())
-			} else {
-				w.Printf("%s", k)
+				w.SafeRune('=')
+				w.Print(tag.Value())
 			}
 		}
 		w.SafeString("] ")

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -100,8 +100,13 @@ func getSpanOrEventLog(ctx context.Context) (*tracing.Span, *ctxEventLog, bool) 
 	return nil, nil, false
 }
 
-// eventInternal is the common code for logging an event to trace and/or event
-// logs. All entries passed to this method should be redactable.
+// eventInternal is the common code for logging an event to trace and/or
+// event logs. Entries passed to this method may or may not be
+// redactable (via the `logEntry.redactable` flag). However, if
+// sp.Redactable() is true then they will be printed as redactable by
+// `Recordf`. I the entry is not redactable, the entirety of the message
+// will be marked redactable, otherwise fine-grainer redaction will
+// remain in the result.
 func eventInternal(sp *tracing.Span, el *ctxEventLog, isErr bool, entry *logEntry) {
 	if sp != nil {
 		sp.Recordf("%s", entry)
@@ -162,7 +167,7 @@ func Event(ctx context.Context, msg string) {
 		severity.INFO, /* unused for trace events */
 		channel.DEV,   /* unused for trace events */
 		1,             /* depth */
-		true,          /* redactable */
+		sp.Redactable(),
 		msg)
 	eventInternal(sp, el, false /* isErr */, &entry)
 }
@@ -182,7 +187,7 @@ func Eventf(ctx context.Context, format string, args ...interface{}) {
 		severity.INFO, /* unused for trace events */
 		channel.DEV,   /* unused for trace events */
 		1,             /* depth */
-		true,          /* redactable */
+		sp.Redactable(),
 		format, args...)
 	eventInternal(sp, el, false /* isErr */, &entry)
 }
@@ -207,7 +212,7 @@ func vEventf(
 			severity.INFO, /* unused for trace events */
 			channel.DEV,   /* unused for trace events */
 			depth+1,
-			true, /* redactable */
+			sp.Redactable(),
 			format, args...)
 		eventInternal(sp, el, isErr, &entry)
 	}

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -74,6 +74,14 @@ func (sp *Span) Tracer() *Tracer {
 	return sp.i.Tracer()
 }
 
+// Redactable returns true if this Span's tracer is marked redactable
+func (sp *Span) Redactable() bool {
+	if sp == nil || sp.i.isNoop() {
+		return false
+	}
+	return sp.Tracer().Redactable()
+}
+
 // Finish idempotently marks the Span as completed (at which point it will
 // silently drop any new data added to it). Finishing a nil *Span is a noop.
 func (sp *Span) Finish() {

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -11,6 +11,7 @@
 package tracing
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -181,7 +182,16 @@ func (s *spanInner) Recordf(format string, args ...interface{}) {
 	if !s.hasVerboseSink() {
 		return
 	}
-	str := redact.Sprintf(format, args...)
+	var str redact.RedactableString
+	if s.Tracer().Redactable() {
+		str = redact.Sprintf(format, args...)
+	} else {
+		// `fmt.Sprintf` when called on a logEntry will use the faster
+		// `logEntry.String` method instead of `logEntry.SafeFormat`.
+		// The additional use of `redact.Sprintf("%s",...)` is necessary
+		// to wrap the result in redaction markers.
+		str = redact.Sprintf("%s", fmt.Sprintf(format, args...))
+	}
 	if s.otelSpan != nil {
 		// TODO(obs-inf): depending on the situation it may be more appropriate to
 		// redact the string here.

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -169,6 +169,13 @@ type Tracer struct {
 	// True if tracing to the debug/requests endpoint. Accessed via t.useNetTrace().
 	_useNetTrace int32 // updated atomically
 
+	// True if we would like spans created from this tracer to be marked
+	// as redactable. This will make unstructured events logged to those
+	// spans redactable.
+	// Currently, this is used to mark spans as redactable and to redact
+	// them at the network boundary from KV.
+	_redactable int32 // accessed atomically
+
 	// Pointer to an OpenTelemetry tracer used as a "shadow tracer", if any. If
 	// not nil, the respective *otel.Tracer will be used to create mirror spans
 	// for all spans that the parent Tracer creates.
@@ -302,6 +309,23 @@ type TracerTestingKnobs struct {
 	// UseNetTrace, if set, forces the Traces to always create spans which record
 	// to net.Trace objects.
 	UseNetTrace bool
+}
+
+// Redactable returns true if the tracer is configured to emit
+// redactable logs. This value will affect the redactability of messages
+// from already open Spans.
+func (t *Tracer) Redactable() bool {
+	return atomic.LoadInt32(&t._redactable) != 0
+}
+
+// SetRedactable changes the redactability of the Tracer. This
+// affects any future trace spans created.
+func (t *Tracer) SetRedactable(to bool) {
+	var n int32
+	if to {
+		n = 1
+	}
+	atomic.StoreInt32(&t._redactable, n)
 }
 
 // NewTracer creates a Tracer. It initially tries to run with minimal overhead

--- a/pkg/util/tracing/tracingpb/recorded_span.pb.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.pb.go
@@ -165,8 +165,8 @@ type RecordedSpan struct {
 	// recording.
 	Duration time.Duration `protobuf:"bytes,8,opt,name=duration,proto3,stdduration" json:"duration"`
 	// RedactableLogs determines whether the verbose log messages are redactable.
-	// This field was introduced in the 22.1 cycle. It can be removed in the 22.2
-	// cycle.
+	// This field was introduced in the 22.1 release. It can be removed in the 22.2
+	// release. On 22.1 this is always set to `true`.
 	RedactableLogs bool `protobuf:"varint,15,opt,name=redactable_logs,json=redactableLogs,proto3" json:"redactable_logs,omitempty"`
 	// Events logged in the span.
 	Logs []LogRecord `protobuf:"bytes,9,rep,name=logs,proto3" json:"logs"`

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -72,8 +72,8 @@ message RecordedSpan {
                                          (gogoproto.stdduration) = true];
 
   // RedactableLogs determines whether the verbose log messages are redactable.
-  // This field was introduced in the 22.1 cycle. It can be removed in the 22.2
-  // cycle.
+  // This field was introduced in the 22.1 release. It can be removed in the 22.2
+  // release. On 22.1 this is always set to `true`.
   bool redactable_logs = 15;
   // Events logged in the span.
   repeated LogRecord logs = 9 [(gogoproto.nullable) = false];


### PR DESCRIPTION
Multi-tenant deployments require tracing support
in order to help customers and engineers debug query performance
issues. This requires that trace information recorded on the KV layer
be redacted prior to being transmitted to the tenant in order to
guard against data leakage through the multi-tenant abstractions.

This change makes tracing redactability configurable and adds a cluster
setting to enable fine-grained redactability that we can use for
multi-tenant deployments.

The desired outcome is to preserve redactability for tenant traces while
preserving a non-redactable code path for requests using the system
tenant. This preserves existing functionality in production while
keeping the current performance hit of redaction from propagating to
non-tenant deployments.

This PR brings `master` in parity with changes in `release-21.2` via #73117.

Benchmarking this against master results in the following improvements.
old.txt is using `master` @ 65920cf
new.txt is using this commit @ 7c768ac
Benchmark was run using `gceworker`.

We gain back a significant portion of the performance hit:
```
david@davidh:~/go/src/github.com/cockroachdb/cockroach$ benchstat old.txt new.txt
name                                              old time/op    new time/op    delta
Tracing/1node/scan/trace=100%/threshold=1ms-24      1.20ms ± 4%    1.15ms ± 2%   -4.83%  (p=0.000 n=10+9)
Tracing/1node/insert/trace=100%/threshold=1ms-24    1.51ms ± 3%    1.40ms ± 2%   -6.71%  (p=0.000 n=10+10)
Tracing/3node/scan/trace=100%/threshold=1ms-24      2.17ms ± 3%    2.10ms ± 4%   -3.26%  (p=0.003 n=10+10)
Tracing/3node/insert/trace=100%/threshold=1ms-24    2.41ms ± 3%    2.30ms ± 3%   -4.45%  (p=0.000 n=8+9)

name                                              old alloc/op   new alloc/op   delta
Tracing/1node/scan/trace=100%/threshold=1ms-24       115kB ± 1%     120kB ± 1%   +4.39%  (p=0.000 n=10+10)
Tracing/1node/insert/trace=100%/threshold=1ms-24     149kB ± 1%     152kB ± 0%   +1.92%  (p=0.000 n=10+9)
Tracing/3node/scan/trace=100%/threshold=1ms-24       276kB ± 3%     282kB ± 3%   +2.18%  (p=0.035 n=10+10)
Tracing/3node/insert/trace=100%/threshold=1ms-24     265kB ± 1%     264kB ± 2%     ~     (p=0.963 n=8+9)

name                                              old allocs/op  new allocs/op  delta
Tracing/1node/scan/trace=100%/threshold=1ms-24       1.68k ± 0%     1.47k ± 0%  -12.16%  (p=0.000 n=9+9)
Tracing/1node/insert/trace=100%/threshold=1ms-24     2.05k ± 0%     1.76k ± 0%  -14.46%  (p=0.000 n=10+8)
Tracing/3node/scan/trace=100%/threshold=1ms-24       3.10k ± 0%     2.85k ± 0%   -8.21%  (p=0.000 n=10+10)
Tracing/3node/insert/trace=100%/threshold=1ms-24     3.00k ± 0%     2.66k ± 0%  -11.30%  (p=0.000 n=9+10)
```

Resolves cockroachdb#71694

Release note: None

Resolves #71694

Release note: None