### PR TITLE
tracing: introduce a minimal tracing mode and enable in tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -131,7 +131,11 @@ type TestServerArgs struct {
 	// IF set, the demo login endpoint will be enabled.
 	EnableDemoLoginEndpoint bool
 
+	// Tracer, if set, will be used by the Server for creating Spans.
 	Tracer *tracing.Tracer
+	// TracingDefault kicks in if Tracer is not set. It is passed to the Tracer
+	// that will be created for the server.
+	TracingDefault tracing.TracingMode
 	// If set, a TraceDir is initialized at the provided path.
 	TraceDir string
 
@@ -297,4 +301,7 @@ type TestTenantArgs struct {
 	// StartingHTTPPort, if it is non-zero, is added to the tenant ID in order to
 	// determine the tenant's HTTP port.
 	StartingHTTPPort int
+
+	// TracingDefault controls whether the tracing will be on or off by default.
+	TracingDefault tracing.TracingMode
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -140,7 +140,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	st.ExternalIODir = params.ExternalIODir
 	tr := params.Tracer
 	if params.Tracer == nil {
-		tr = tracing.NewTracerWithOpt(context.TODO(), tracing.WithClusterSettings(&st.SV))
+		tr = tracing.NewTracerWithOpt(context.TODO(), tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
 	}
 	cfg := makeTestConfig(st, tr)
 	cfg.TestingKnobs = params.Knobs
@@ -644,12 +644,12 @@ func (ts *TestServer) StartTenant(
 	if stopper == nil {
 		// We don't share the stopper with the server because we want their Tracers
 		// to be different, to simulate them being different processes.
-		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
 		stopper = stop.NewStopper(stop.WithTracer(tr))
 		// The server's stopper stops the tenant, for convenience.
 		ts.Stopper().AddCloser(stop.CloserFn(func() { stopper.Stop(context.Background()) }))
 	} else if stopper.Tracer() == nil {
-		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
+		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
 		stopper.SetTracer(tr)
 	}
 

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_lib_pq//:pq",

--- a/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
+++ b/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
@@ -1,6 +1,11 @@
 # Verify that the crdb_internal.node_inflight_trace_spans vtable populates
 # correctly.
 
+# This test wants tracing to be generally off across the cluster, otherwise it
+# picks up more spans than it wants.
+# TODO(andrei): Figure out a replacement for this test that is more robust.
+# cluster-opt: tracing-off
+
 statement ok
 GRANT ADMIN TO testuser
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1654,10 +1654,12 @@ func TestLint(t *testing.T) {
 				stream.GrepNot("pkg/sql/types/types.go.* var Uuid should be UUID"),
 				stream.GrepNot("pkg/sql/oidext/oidext.go.*don't use underscores in Go names; const T_"),
 				stream.GrepNot("server/api_v2.go.*package comment should be of the form"),
-				stream.GrepNot("type name will be used as row.RowLimit by other packages, and that stutters; consider calling this Limit"),
 				stream.GrepNot("pkg/util/timeutil/time_zone_util.go.*error strings should not be capitalized or end with punctuation or a newline"),
 				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method ExtendedEvalContext returns unexported type"),
 				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method SessionDataMutatorIterator returns unexported type"),
+
+				stream.GrepNot("type name will be used as row.RowLimit by other packages, and that stutters; consider calling this Limit"),
+				stream.GrepNot("type name will be used as tracing.TracingMode by other packages, and that stutters; consider calling this Mode"),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -687,12 +687,7 @@ func (cf closerFunc) Close() { cf() }
 // the ChildSpan option.
 func TestStopperRunAsyncTaskTracing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tr := tracing.NewTracerWithOpt(context.Background(), tracing.WithTestingKnobs(
-		tracing.TracerTestingKnobs{
-			// We want the tracer to generate real spans so that we can test that the
-			// RootSpan option produces a root span.
-			ForceRealSpans: true,
-		}))
+	tr := tracing.NewTracerWithOpt(context.Background(), tracing.WithTracingMode(tracing.TracingModeActiveSpansRegistry))
 	s := stop.NewStopper(stop.WithTracer(tr))
 
 	ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(context.Background(), tr, "parent")

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/settings",
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/iterutil",
         "//pkg/util/netutil/addr",

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -67,7 +67,6 @@ go_test(
     ],
     embed = [":tracing"],
     deps = [
-        "//pkg/settings",
         "//pkg/testutils",
         "//pkg/testutils/grpcutils",
         "//pkg/util",

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -102,8 +102,7 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 }
 
 func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
-	tr := NewTracerWithOpt(context.Background(),
-		WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 
 	ev := &types.Int32Value{Value: 5}
 	b.ReportAllocs()
@@ -119,9 +118,7 @@ func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
 
 // BenchmarkSpanCreation creates traces with a couple of spans in them.
 func BenchmarkSpanCreation(b *testing.B) {
-	tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{
-		ForceRealSpans: true,
-	}))
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	const numChildren = 5
 	childNames := make([]string, numChildren)
 	for i := 0; i < numChildren; i++ {

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/types"
 )
@@ -28,37 +27,31 @@ import (
 func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 	ctx := context.Background()
 
-	tr := NewTracer()
-	sv := settings.Values{}
-	tr.Configure(ctx, &sv)
-
 	staticLogTags := logtags.Buffer{}
 	staticLogTags.Add("foo", "bar")
 
-	b.ResetTimer()
-
-	parSp := tr.StartSpan("one-off", WithForceRealSpan())
-	defer parSp.Finish()
-
 	for _, tc := range []struct {
-		name string
-		opts []SpanOption
+		name        string
+		defaultMode TracingMode
+		parent      bool
+		opts        []SpanOption
 	}{
-		{"none", nil},
-		{"real", []SpanOption{
-			WithForceRealSpan(),
-		}},
-		{"real,logtag", []SpanOption{
-			WithForceRealSpan(), WithLogTags(&staticLogTags),
-		}},
-		{"real,autoparent", []SpanOption{
-			WithForceRealSpan(), WithParent(parSp),
-		}},
-		{"real,manualparent", []SpanOption{
-			WithForceRealSpan(), WithParent(parSp), WithDetachedRecording(),
-		}},
+		{"none", TracingModeOnDemand, false, nil},
+		{"real", TracingModeActiveSpansRegistry, false, nil},
+		{"real,logtag", TracingModeActiveSpansRegistry, false, []SpanOption{WithLogTags(&staticLogTags)}},
+		{"real,autoparent", TracingModeActiveSpansRegistry, true, nil},
+		{"real,manualparent", TracingModeActiveSpansRegistry, true, []SpanOption{WithDetachedRecording()}},
 	} {
 		b.Run(fmt.Sprintf("opts=%s", tc.name), func(b *testing.B) {
+			tr := NewTracerWithOpt(ctx, WithTracingMode(TracingModeActiveSpansRegistry))
+			b.ResetTimer()
+
+			if tc.parent {
+				parSp := tr.StartSpan("one-off")
+				defer parSp.Finish()
+				tc.opts = append(tc.opts, WithParent(parSp))
+			}
+
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				newCtx, sp := tr.StartSpanCtx(ctx, "benching", tc.opts...)
@@ -73,11 +66,9 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 // BenchmarkSpan_GetRecording microbenchmarks GetRecording.
 func BenchmarkSpan_GetRecording(b *testing.B) {
 	ctx := context.Background()
-	var sv settings.Values
-	tr := NewTracer()
-	tr.Configure(ctx, &sv)
+	tr := NewTracerWithOpt(ctx, WithTracingMode(TracingModeActiveSpansRegistry))
 
-	sp := tr.StartSpan("foo", WithForceRealSpan())
+	sp := tr.StartSpan("foo")
 
 	run := func(b *testing.B, sp *Span) {
 		b.ReportAllocs()
@@ -91,7 +82,7 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 		run(b, sp)
 	})
 
-	child := tr.StartSpan("bar", WithParent(sp), WithForceRealSpan())
+	child := tr.StartSpan("bar", WithParent(sp))
 	b.Run("child-only", func(b *testing.B) {
 		run(b, child)
 	})

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -297,8 +297,8 @@ type forceRealSpanOption struct{}
 
 var forceRealSpanSingleton = SpanOption(forceRealSpanOption{})
 
-// WithForceRealSpan forces StartSpan to create of a real Span instead of
-// a low-overhead non-recordable noop span.
+// WithForceRealSpan forces StartSpan to create of a real Span regardless of the
+// Tracer's tracing mode (instead of a low-overhead non-recordable noop span).
 //
 // When tracing is disabled all spans are noopSpans; these spans aren't
 // capable of recording, so this option should be passed to StartSpan if the

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestStartSpan(t *testing.T) {
-	tr := NewTracer()
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
 	sp := tr.StartSpan("test")
 	defer sp.Finish()
 	require.Equal(t, "noop", sp.OperationName())
@@ -487,7 +487,7 @@ func TestStructureRecording(t *testing.T) {
 		t.Run(fmt.Sprintf("finish1=%t", finishCh1), func(t *testing.T) {
 			for _, finishCh2 := range []bool{true, false} {
 				t.Run(fmt.Sprintf("finish2=%t", finishCh2), func(t *testing.T) {
-					tr := NewTracerWithOpt(context.Background(), WithTestingKnobs(TracerTestingKnobs{ForceRealSpans: true}))
+					tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 					sp := tr.StartSpan("root", WithRecording(RecordingStructured))
 					ch1 := tr.StartSpan("child", WithParent(sp))
 					ch2 := tr.StartSpan("grandchild", WithParent(ch1))

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -393,9 +393,9 @@ func (tr *explodyNetTr) Finish() {
 //
 // https://github.com/cockroachdb/cockroach/issues/58489#issuecomment-781263005
 func TestSpan_UseAfterFinish(t *testing.T) {
-	tr := NewTracer()
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	tr._useNetTrace = 1
-	sp := tr.StartSpan("foo", WithForceRealSpan())
+	sp := tr.StartSpan("foo")
 	require.NotNil(t, sp.i.netTr)
 	// Set up netTr to reliably explode if Finish'ed twice. We
 	// expect `sp.Finish` to not let it come to that.
@@ -444,12 +444,11 @@ func (i *countingStringer) String() string {
 // TestSpanTagsInRecordings verifies that tags added before a recording started
 // are part of the recording.
 func TestSpanTagsInRecordings(t *testing.T) {
-	tr := NewTracer()
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	var counter countingStringer
 	logTags := logtags.SingleTagBuffer("foo", "tagbar")
 	logTags = logTags.Add("foo1", &counter)
 	sp := tr.StartSpan("root",
-		WithForceRealSpan(),
 		WithLogTags(logTags),
 	)
 	defer sp.Finish()

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -11,6 +11,7 @@
 package tracing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/logtags"
@@ -21,14 +22,14 @@ import (
 )
 
 func TestLogTags(t *testing.T) {
-	tr := NewTracer()
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	sr := tracetest.NewSpanRecorder()
 	otelTr := otelsdk.NewTracerProvider(otelsdk.WithSpanProcessor(sr)).Tracer("test")
 	tr.SetOpenTelemetryTracer(otelTr)
 
 	l := logtags.SingleTagBuffer("tag1", "val1")
 	l = l.Add("tag2", "val2")
-	sp1 := tr.StartSpan("foo", WithForceRealSpan(), WithLogTags(l))
+	sp1 := tr.StartSpan("foo", WithLogTags(l))
 	sp1.SetVerbose(true)
 	require.NoError(t, CheckRecordedSpans(sp1.FinishAndGetRecording(RecordingVerbose), `
 		span: foo
@@ -47,7 +48,7 @@ func TestLogTags(t *testing.T) {
 	RegisterTagRemapping("tag1", "one")
 	RegisterTagRemapping("tag2", "two")
 
-	sp2 := tr.StartSpan("bar", WithForceRealSpan(), WithLogTags(l))
+	sp2 := tr.StartSpan("bar", WithLogTags(l))
 	sp2.SetVerbose(true)
 	require.NoError(t, CheckRecordedSpans(sp2.FinishAndGetRecording(RecordingVerbose), `
 		span: bar
@@ -64,7 +65,7 @@ func TestLogTags(t *testing.T) {
 		require.Equal(t, exp, otelSpan.Attributes())
 	}
 
-	sp3 := tr.StartSpan("baz", WithLogTags(l), WithForceRealSpan())
+	sp3 := tr.StartSpan("baz", WithLogTags(l))
 	sp3.SetVerbose(true)
 	require.NoError(t, CheckRecordedSpans(sp3.FinishAndGetRecording(RecordingVerbose), `
 		span: baz

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
@@ -150,6 +151,32 @@ var ZipkinCollector = settings.RegisterValidatedStringSetting(
 	},
 ).WithPublic()
 
+// enableTracingByDefault controls whether Tracers configured with
+// WithTracingMode(TracingModeFromEnv) generally create spans or not.
+var enableTracingByDefault = envutil.EnvOrDefaultBool("COCKROACH_REAL_SPANS", false) || buildutil.CrdbTestBuild
+
+// TracingMode specifies whether span creation is enabled or disabled by
+// default, when other conditions that don't explicitly turn tracing on don't
+// apply.
+type TracingMode int
+
+const (
+	// TracingModeFromEnv configures tracing according to enableTracingByDefault.
+	TracingModeFromEnv TracingMode = iota
+	// TracingModeOnDemand means that Spans will no be created unless there's a
+	// particular reason to create them (i.e. a span being created with
+	// WithForceRealSpan(), a net.Trace or OpenTelemetry tracers attached).
+	TracingModeOnDemand
+	// TracingModeActiveSpansRegistry means that Spans are always created.
+	// Currently-open spans are accessible through the active spans registry.
+	//
+	// If no net.Trace/OpenTelemetry tracer is attached, spans do not record
+	// events by default (i.e. do not accumulate log messages via Span.Record() or
+	// a history of finished child spans). In order for a span to record events,
+	// it must be started with the WithRecording() option).
+	TracingModeActiveSpansRegistry
+)
+
 // Tracer implements tracing requests. It supports:
 //
 //  - forwarding events to x/net/trace instances
@@ -171,6 +198,8 @@ type Tracer struct {
 	// x/net/trace or OpenTelemetry and we are not recording.
 	noopSpan        *Span
 	sterileNoopSpan *Span
+
+	tracingDefault TracingMode
 
 	// backardsCompatibilityWith211, if set, makes the Tracer
 	// work with 21.1 remote nodes.
@@ -315,9 +344,6 @@ func (r *spanRegistry) swap(parentID tracingpb.SpanID, children []*crdbSpan) {
 type TracerTestingKnobs struct {
 	// Clock allows the time source for spans to be controlled.
 	Clock timeutil.TimeSource
-	// ForceRealSpans, if set, forces the Tracer to create spans even when tracing
-	// is otherwise disabled.
-	ForceRealSpans bool
 	// UseNetTrace, if set, forces the Traces to always create spans which record
 	// to net.Trace objects.
 	UseNetTrace bool
@@ -367,13 +393,15 @@ func NewTracerWithOpt(ctx context.Context, opts ...TracerOption) *Tracer {
 		t.Configure(ctx, o.sv)
 	}
 	t.testing = o.knobs
+	t.tracingDefault = TracingMode(o.tracingDefault)
 	return t
 }
 
 // tracerOptions groups configuration for Tracer construction.
 type tracerOptions struct {
-	sv    *settings.Values
-	knobs TracerTestingKnobs
+	sv             *settings.Values
+	knobs          TracerTestingKnobs
+	tracingDefault tracingModeOpt
 }
 
 // TracerOption is implemented by the arguments to the Tracer constructor.
@@ -410,6 +438,19 @@ var _ TracerOption = knobsOpt{}
 // WithTestingKnobs configures the Tracer with the specified knobs.
 func WithTestingKnobs(knobs TracerTestingKnobs) TracerOption {
 	return knobsOpt{knobs: knobs}
+}
+
+type tracingModeOpt TracingMode
+
+var _ TracerOption = tracingModeOpt(TracingModeFromEnv)
+
+func (o tracingModeOpt) apply(opt *tracerOptions) {
+	opt.tracingDefault = o
+}
+
+// WithTracingMode configures the Tracer's tracing mode.
+func WithTracingMode(opt TracingMode) TracerOption {
+	return tracingModeOpt(opt)
 }
 
 // Configure sets up the Tracer according to the cluster settings (and keeps
@@ -627,8 +668,16 @@ func (t *Tracer) StartSpanCtx(
 // AlwaysTrace returns true if operations should be traced regardless of the
 // context.
 func (t *Tracer) AlwaysTrace() bool {
-	if t.testing.ForceRealSpans {
+	switch t.tracingDefault {
+	case TracingModeFromEnv:
+		if enableTracingByDefault {
+			return true
+		}
+	case TracingModeActiveSpansRegistry:
 		return true
+	case TracingModeOnDemand:
+	default:
+		panic(fmt.Sprintf("unrecognized tracing option: %v", t.tracingDefault))
 	}
 	otelTracer := t.getOtelTracer()
 	return t.useNetTrace() || otelTracer != nil

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -329,8 +329,8 @@ func TestTracer_PropagateNonRecordingRealSpanAcrossRPCBoundaries(t *testing.T) {
 	// Verify that when a span is put on the wire on one end, and is checked
 	// against the span inclusion functions both on the client and server, a real
 	// span results in a real span.
-	tr1 := NewTracer()
-	sp1 := tr1.StartSpan("tr1.root", WithForceRealSpan())
+	tr1 := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
+	sp1 := tr1.StartSpan("tr1.root")
 	defer sp1.Finish()
 	carrier := metadataCarrier{MD: metadata.MD{}}
 	require.True(t, spanInclusionFuncForClient(sp1))
@@ -384,9 +384,9 @@ func TestOtelTracer(t *testing.T) {
 }
 
 func TestTracer_RegistryMaxSize(t *testing.T) {
-	tr := NewTracer()
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	for i := 0; i < maxSpanRegistrySize+10; i++ {
-		_ = tr.StartSpan("foo", WithForceRealSpan()) // intentionally not closed
+		_ = tr.StartSpan("foo") // intentionally not closed
 		exp := i + 1
 		if exp > maxSpanRegistrySize {
 			exp = maxSpanRegistrySize
@@ -399,8 +399,8 @@ func TestTracer_RegistryMaxSize(t *testing.T) {
 // activeSpans registry gracefully exits upon receiving a sentinel error from
 // `iterutil.StopIteration()`.
 func TestActiveSpanVisitorErrors(t *testing.T) {
-	tr := NewTracer()
-	root := tr.StartSpan("root", WithForceRealSpan())
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
+	root := tr.StartSpan("root")
 	defer root.Finish()
 
 	child := tr.StartSpan("root.child", WithParent(root))


### PR DESCRIPTION
This patch makes the Tracer's behavior more configurable. Before, the
Tracer would generally not create spans when there was no explicit
reason to do so, unless a testing knob option was passed to the Tracer
creation (TracerTestingKnobs{ForceRealSpans: true}). This patch elevates
this configuration to a proper tracer option. The Tracer can be
configured to always create spans (useful for having all the in-flight
operations represented in the active spans registry), to not do that
(the old behavior), or to read the configuration from an env var. This
env var is useful while I test various things with the goal of
eventually enabling this tracing mode everywhere. For now the env var
defaults to tracing being off, except in CrdbTestBuild's (i.e. unit
tests), where it's on.

Some tests are changed to explicitly request tracing to be off, so that
they retain the old behavior, as they were relying on it. Among them, a
logic tests needs it, so a new cluster configuration option is added to
logic tests and test clusters.

After this patch, I think we're pretty close to enabling this new
tracing mode in production. Before that though, there's a couple more
performance optimizations to make, and more testing against
span-use-after-Finish.

Release note: None