### PR TITLE
sem/builtins: introduce crdb_internal.is_at_least_version

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2921,6 +2921,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.is_admin"></a><code>crdb_internal.is_admin() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Retrieves the current user’s admin status.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.is_at_least_version"></a><code>crdb_internal.is_at_least_version(version: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the cluster version is not older than the argument.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.lease_holder"></a><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.list_sql_keys_in_range"></a><code>crdb_internal.list_sql_keys_in_range(range_id: <a href="int.html">int</a>) &rarr; tuple{string AS key, string AS value}</code></td><td><span class="funcdesc"><p>Returns all SQL K/V pairs within the requested range.</p>

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "alter_statement_diagnostics_requests_test.go",
         "alter_table_statistics_avg_size_test.go",
         "alter_web_sessions_create_indexes_test.go",
+        "builtins_test.go",
         "delete_deprecated_namespace_tabledesc_external_test.go",
         "ensure_no_draining_names_external_test.go",
         "fix_descriptor_migration_external_test.go",

--- a/pkg/migration/migrations/builtins_test.go
+++ b/pkg/migration/migrations/builtins_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestIsAtLeastVersionBuiltin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: 1,
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.Start21_2),
+				},
+			},
+		},
+	}
+
+	var (
+		ctx   = context.Background()
+		tc    = testcluster.StartTestCluster(t, 1, clusterArgs)
+		conn  = tc.ServerConn(0)
+		sqlDB = sqlutils.MakeSQLRunner(conn)
+	)
+	defer tc.Stopper().Stop(ctx)
+
+	// Check that the builtin returns false when comparing against 21.2 version
+	// because we are still on 21.1.
+	sqlDB.CheckQueryResults(t, "SELECT crdb_internal.is_at_least_version('21.2')", [][]string{{"false"}})
+
+	// Run the migration.
+	sqlDB.Exec(t, "SET CLUSTER SETTING version = $1", clusterversion.ByKey(clusterversion.V21_2).String())
+
+	// It should now return true.
+	sqlDB.CheckQueryResultsRetry(t, "SELECT crdb_internal.is_at_least_version('21.2')", [][]string{{"true"}})
+}

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/geo",
         "//pkg/geo/geogfn",


### PR DESCRIPTION
This commit introduces `crdb_internal.is_at_least_version` builtin which
returns `true` if the cluster's version is not older than the provided
argument. This allows us to know via SQL whether some migrations must have
already been run.

Release note: None