### PR TITLE
sql: fix AvgSize table stats references for mixed version clusters

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1976,7 +1976,7 @@ func insertStats(
 	}
 
 	err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		if err := stats.InsertNewStats(ctx, execCfg.InternalExecutor, txn, latestStats); err != nil {
+		if err := stats.InsertNewStats(ctx, execCfg.Settings, execCfg.InternalExecutor, txn, latestStats); err != nil {
 			return errors.Wrapf(err, "inserting stats from backup")
 		}
 		details.StatsInserted = true

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -1011,7 +1011,7 @@ func (r *importResumer) writeStubStatisticsForImportedTables(
 					statistic.AvgSize = avgRowSize
 				}
 				// TODO(michae2): parallelize insertion of statistics.
-				err = stats.InsertNewStats(ctx, execCfg.InternalExecutor, nil /* txn */, statistics)
+				err = stats.InsertNewStats(ctx, execCfg.Settings, execCfg.InternalExecutor, nil /* txn */, statistics)
 			}
 			if err != nil {
 				// Failure to create statistics should not fail the entire import.

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -503,6 +503,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 			// Insert the new stat.
 			if err := stats.InsertNewStat(
 				ctx,
+				s.FlowCtx.Cfg.Settings,
 				s.FlowCtx.Cfg.Executor,
 				txn,
 				s.tableID,

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -13,7 +13,9 @@ package sql
 import (
 	"context"
 	encjson "encoding/json"
+	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -25,7 +27,19 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// TODO(harding): Remove use of showTableStatsColumns in 22.2 when AvgSizeColVer
+// is fully integrated.
 var showTableStatsColumns = colinfo.ResultColumns{
+	{Name: "statistics_name", Typ: types.String},
+	{Name: "column_names", Typ: types.StringArray},
+	{Name: "created", Typ: types.Timestamp},
+	{Name: "row_count", Typ: types.Int},
+	{Name: "distinct_count", Typ: types.Int},
+	{Name: "null_count", Typ: types.Int},
+	{Name: "histogram_id", Typ: types.Int},
+}
+
+var showTableStatsColumnsAvgSizeVer = colinfo.ResultColumns{
 	{Name: "statistics_name", Typ: types.String},
 	{Name: "column_names", Typ: types.StringArray},
 	{Name: "created", Typ: types.Timestamp},
@@ -52,7 +66,11 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
 		return nil, err
 	}
-	columns := showTableStatsColumns
+	avgSizeColVerActive := p.ExtendedEvalContext().ExecCfg.Settings.Version.IsActive(ctx, clusterversion.AlterSystemTableStatisticsAddAvgSizeCol)
+	columns := showTableStatsColumnsAvgSizeVer
+	if !avgSizeColVerActive {
+		columns = showTableStatsColumns
+	}
 	if n.UsingJSON {
 		columns = showTableStatsJSONColumns
 	}
@@ -67,22 +85,28 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//    "handle" which can be used with SHOW HISTOGRAM.
 			// TODO(yuzefovich): refactor the code to use the iterator API
 			// (currently it is not possible due to a panic-catcher below).
+			var avgSize string
+			if avgSizeColVerActive {
+				avgSize = `
+					"avgSize",`
+			}
+			stmt := fmt.Sprintf(`SELECT "statisticID",
+																				 name,
+																				 "columnIDs",
+																				 "createdAt",
+																				 "rowCount",
+																				 "distinctCount",
+																				 "nullCount",
+																				 %s
+																				 histogram
+																	FROM system.table_statistics
+																	WHERE "tableID" = $1
+																	ORDER BY "createdAt"`, avgSize)
 			rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 				ctx,
 				"read-table-stats",
 				p.txn,
-				`SELECT "statisticID",
-					      name,
-					      "columnIDs",
-					      "createdAt",
-					      "rowCount",
-					      "distinctCount",
-					      "nullCount",
-					      "avgSize",
-					      histogram
-				 FROM system.table_statistics
-				 WHERE "tableID" = $1
-				 ORDER BY "createdAt"`,
+				stmt,
 				desc.GetID(),
 			)
 			if err != nil {
@@ -101,6 +125,13 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				histogramIdx
 				numCols
 			)
+
+			histIdx := histogramIdx
+			nCols := numCols
+			if !avgSizeColVerActive {
+				histIdx = histogramIdx - 1
+				nCols = numCols - 1
+			}
 
 			// Guard against crashes in the code below (e.g. #56356).
 			defer func() {
@@ -127,7 +158,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					result[i].RowCount = (uint64)(*r[rowCountIdx].(*tree.DInt))
 					result[i].DistinctCount = (uint64)(*r[distinctCountIdx].(*tree.DInt))
 					result[i].NullCount = (uint64)(*r[nullCountIdx].(*tree.DInt))
-					result[i].AvgSize = (uint64)(*r[avgSizeIdx].(*tree.DInt))
+					if avgSizeColVerActive {
+						result[i].AvgSize = (uint64)(*r[avgSizeIdx].(*tree.DInt))
+					}
 					if r[nameIdx] != tree.DNull {
 						result[i].Name = string(*r[nameIdx].(*tree.DString))
 					}
@@ -136,7 +169,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					for j, d := range colIDs {
 						result[i].Columns[j] = statColumnString(desc, d)
 					}
-					if err := result[i].DecodeAndSetHistogram(ctx, &p.semaCtx, r[histogramIdx]); err != nil {
+					if err := result[i].DecodeAndSetHistogram(ctx, &p.semaCtx, r[histIdx]); err != nil {
 						v.Close(ctx)
 						return nil, err
 					}
@@ -159,7 +192,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			}
 
 			for _, r := range rows {
-				if len(r) != numCols {
+				if len(r) != nCols {
 					v.Close(ctx)
 					return nil, errors.Errorf("incorrect columns from internal query")
 				}
@@ -172,20 +205,34 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				}
 
 				histogramID := tree.DNull
-				if r[histogramIdx] != tree.DNull {
+				if r[histIdx] != tree.DNull {
 					histogramID = r[statIDIdx]
 				}
 
-				res := tree.Datums{
-					r[nameIdx],
-					colNames,
-					r[createdAtIdx],
-					r[rowCountIdx],
-					r[distinctCountIdx],
-					r[nullCountIdx],
-					r[avgSizeIdx],
-					histogramID,
+				var res tree.Datums
+				if avgSizeColVerActive {
+					res = tree.Datums{
+						r[nameIdx],
+						colNames,
+						r[createdAtIdx],
+						r[rowCountIdx],
+						r[distinctCountIdx],
+						r[nullCountIdx],
+						r[avgSizeIdx],
+						histogramID,
+					}
+				} else {
+					res = tree.Datums{
+						r[nameIdx],
+						colNames,
+						r[createdAtIdx],
+						r[rowCountIdx],
+						r[distinctCountIdx],
+						r[nullCountIdx],
+						histogramID,
+					}
 				}
+
 				if _, err := v.rows.AddRow(ctx, res); err != nil {
 					v.Close(ctx)
 					return nil, err

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/stats/new_stat.go
+++ b/pkg/sql/stats/new_stat.go
@@ -13,7 +13,9 @@ package stats
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -25,6 +27,7 @@ import (
 // system table.
 func InsertNewStats(
 	ctx context.Context,
+	settings *cluster.Settings,
 	executor sqlutil.InternalExecutor,
 	txn *kv.Txn,
 	tableStats []*TableStatisticProto,
@@ -33,6 +36,7 @@ func InsertNewStats(
 	for _, statistic := range tableStats {
 		err = InsertNewStat(
 			ctx,
+			settings,
 			executor,
 			txn,
 			statistic.TableID,
@@ -57,6 +61,7 @@ func InsertNewStats(
 // stats caches on all other nodes).
 func InsertNewStat(
 	ctx context.Context,
+	settings *cluster.Settings,
 	executor sqlutil.InternalExecutor,
 	txn *kv.Txn,
 	tableID descpb.ID,
@@ -84,7 +89,28 @@ func InsertNewStat(
 			return err
 		}
 	}
-
+	if !settings.Version.IsActive(ctx, clusterversion.AlterSystemTableStatisticsAddAvgSizeCol) {
+		_, err := executor.Exec(
+			ctx, "insert-statistic", txn,
+			`INSERT INTO system.table_statistics (
+					"tableID",
+					"name",
+					"columnIDs",
+					"rowCount",
+					"distinctCount",
+					"nullCount",
+					histogram
+				) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			tableID,
+			nameVal,
+			columnIDsVal,
+			rowCount,
+			distinctCount,
+			nullCount,
+			histogramVal,
+		)
+		return err
+	}
 	_, err := executor.Exec(
 		ctx, "insert-statistic", txn,
 		`INSERT INTO system.table_statistics (


### PR DESCRIPTION
`AvgSize` is a new `system.table_statistics` stat that is not found in
earlier CRDB versions. This led to a bug in multi-version clusters where
the table stats could not be collected or shown because of a reference
to an unknown column, as in the following example:

```
> ANALYZE t;
ERROR: get-table-statistics: column "avgSize" does not exist
> SHOW STATISTICS FOR TABLE t;
ERROR: read-table-stats: column "avgSize" does not exist
```

This change adds version gatekeeping to functions that access or write
to the field `AvgSize` in `system.table_statistics`. If the cluster
settings version is not at cluster version
`AlterSystemTableStatisticsAddAvgSizeCol`, functions such as
`ShowTableStats` and `InsertNewStat`, as well as the
`TableStatisticsCache`, revert to their old behavior without the new
`AvgSize` stat.

Manual testing on a multi-version cluster with nodes at version 21.2.2
and this change result in expected output for `ANALYZE` and
`SHOW STATISTICS`.

Release note: None