### PR TITLE
sql/flowinfra: skip TestTimeoutPushDoesntBlockRegister

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "//pkg/testutils/buildutil",
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/cancelchecker",

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -552,6 +553,7 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 // error, we are still able to register flows while Pushing the error (#34041).
 func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 73419, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #73419

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None