### PR TITLE
jobs: truncate all errors before persisting them

### DIFF
--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -364,15 +364,13 @@ func isMultiTableFormat(format roachpb.IOFileFormat_FileFormat) bool {
 	return false
 }
 
-func makeRowErr(_ string, row int64, code pgcode.Code, format string, args ...interface{}) error {
+func makeRowErr(row int64, code pgcode.Code, format string, args ...interface{}) error {
 	err := pgerror.NewWithDepthf(1, code, format, args...)
 	err = errors.WrapWithDepthf(1, err, "row %d", row)
 	return err
 }
 
-func wrapRowErr(
-	err error, _ string, row int64, code pgcode.Code, format string, args ...interface{},
-) error {
+func wrapRowErr(err error, row int64, code pgcode.Code, format string, args ...interface{}) error {
 	if format != "" || len(args) > 0 {
 		err = errors.WrapWithDepthf(1, err, format, args...)
 	}

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -396,13 +396,18 @@ const (
 )
 
 func (e *importRowError) Error() string {
-	return fmt.Sprintf("error parsing row %d: %v (row: %q)", e.rowNum, e.err, e.row)
+	// The job system will truncate this error before saving it,
+	// but we will additionally truncate it here since it is
+	// separately written to the log and could easily result in
+	// very large log files.
+	rowForLog := e.row
+	if len(rowForLog) > importRowErrMaxRuneCount {
+		rowForLog = util.TruncateString(rowForLog, importRowErrMaxRuneCount) + importRowErrTruncatedMarker
+	}
+	return fmt.Sprintf("error parsing row %d: %v (row: %s)", e.rowNum, e.err, rowForLog)
 }
 
 func newImportRowError(err error, row string, num int64) error {
-	if len(row) > importRowErrMaxRuneCount {
-		row = util.TruncateString(row, importRowErrMaxRuneCount) + importRowErrTruncatedMarker
-	}
 	return &importRowError{
 		err:    err,
 		row:    row,

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -1189,7 +1189,7 @@ func (m *pgDumpReader) readFile(
 				row, err := ps.Next()
 				// We expect an explicit copyDone here. io.EOF is unexpected.
 				if err == io.EOF {
-					return makeRowErr("", count, pgcode.ProtocolViolation,
+					return makeRowErr(count, pgcode.ProtocolViolation,
 						"unexpected EOF")
 				}
 				if row == errCopyDone {
@@ -1198,7 +1198,7 @@ func (m *pgDumpReader) readFile(
 				count++
 				tableNameToRowsProcessed[name.String()]++
 				if err != nil {
-					return wrapRowErr(err, "", count, pgcode.Uncategorized, "")
+					return wrapRowErr(err, count, pgcode.Uncategorized, "")
 				}
 				if !importing {
 					continue
@@ -1209,7 +1209,7 @@ func (m *pgDumpReader) readFile(
 				switch row := row.(type) {
 				case copyData:
 					if expected, got := conv.TargetColOrds.Len(), len(row); expected != got {
-						return makeRowErr("", count, pgcode.Syntax,
+						return makeRowErr(count, pgcode.Syntax,
 							"expected %d values, got %d", expected, got)
 					}
 					if rowLimit != 0 && tableNameToRowsProcessed[name.String()] > rowLimit {
@@ -1226,7 +1226,7 @@ func (m *pgDumpReader) readFile(
 							conv.Datums[idx], _, err = tree.ParseAndRequireString(conv.VisibleColTypes[idx], *s, conv.EvalCtx)
 							if err != nil {
 								col := conv.VisibleCols[idx]
-								return wrapRowErr(err, "", count, pgcode.Syntax,
+								return wrapRowErr(err, count, pgcode.Syntax,
 									"parse %q as %s", col.GetName(), col.GetType().SQLString())
 							}
 						}
@@ -1235,7 +1235,7 @@ func (m *pgDumpReader) readFile(
 						return err
 					}
 				default:
-					return makeRowErr("", count, pgcode.Uncategorized,
+					return makeRowErr(count, pgcode.Uncategorized,
 						"unexpected: %v", row)
 				}
 			}
@@ -1362,7 +1362,7 @@ func (m *pgDumpReader) readFile(
 				}
 				key, val, err := sql.MakeSequenceKeyVal(m.evalCtx.Codec, seq, val, isCalled)
 				if err != nil {
-					return wrapRowErr(err, "", count, pgcode.Uncategorized, "")
+					return wrapRowErr(err, count, pgcode.Uncategorized, "")
 				}
 				kv := roachpb.KeyValue{Key: key}
 				kv.Value.SetInt(val)

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -612,7 +613,19 @@ func (j *Job) failed(
 		// a pause-requested job can transition to failed, which may or may not be
 		// acceptable depending on the job.
 		ju.UpdateStatus(StatusFailed)
-		md.Payload.Error = err.Error()
+
+		// Truncate all errors to avoid large rows in the jobs
+		// table.
+		const (
+			jobErrMaxRuneCount    = 1024
+			jobErrTruncatedMarker = " -- TRUNCATED"
+		)
+		errStr := err.Error()
+		if len(errStr) > jobErrMaxRuneCount {
+			errStr = util.TruncateString(errStr, jobErrMaxRuneCount) + jobErrTruncatedMarker
+		}
+		md.Payload.Error = errStr
+
 		md.Payload.FinishedMicros = timeutil.ToUnixMicros(j.registry.clock.Now().GoTime())
 		ju.UpdatePayload(md.Payload)
 		return nil

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1423,6 +1423,20 @@ func TestJobLifecycle(t *testing.T) {
 				t.Fatalf("unexpected: %v", err)
 			}
 		})
+		t.Run("huge errors are truncated if marking job as failed", func(t *testing.T) {
+			hugeErr := strings.Repeat("a", 2048)
+			truncatedHugeErr := "boom: " + strings.Repeat("a", 1018) + " -- TRUNCATED"
+			err := errors.Errorf("boom: %s", hugeErr)
+			job, exp := createDefaultJob()
+			exp.Error = truncatedHugeErr
+			if err := job.Failed(ctx, err); err != nil {
+				t.Fatal(err)
+			}
+			if err := exp.verify(job.ID(), jobs.StatusFailed); err != nil {
+				t.Fatal(err)
+			}
+		})
+
 	})
 
 	t.Run("cancelable jobs can be paused until finished", func(t *testing.T) {


### PR DESCRIPTION
In cockroachdb#73303 we truncated the row data in this error message to prevent
problems with large row data preventing the job status from being
saved.

However, truncating the row means that our
"experimental_save_rejected" option does not work as expected. This
feature previously saved entire rows and now it would have truncated
rows in some case.

Now, we only truncate the error when producing the error
string. Further, we also add truncation to the job system to prevent
other parts of the system from saving too much data to the job system.

Release note: None