### PR TITLE
ci: remove not included function calls to TC helpers

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -85,9 +85,7 @@ process_test_json() {
       echo "GITHUB_API_TOKEN must be set"
       exit 1
     else
-      tc_start_block "post issues"
       $github_post < "$test_json"
-      tc_end_block "post issues"
     fi
   fi
 


### PR DESCRIPTION
Previously, the nightly CI failed calling to `tc_start_block` and
`tc_end_block`, because they are not available in the current context.

This PR removes their usage.

Release note: None