### PR TITLE
spanconfig/sqlwatcher: use the right mvcc timestamp

### DIFF
--- a/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
@@ -212,7 +212,7 @@ func (s *SQLWatcher) watchForDescriptorUpdates(
 			return
 		}
 
-		table, database, typ, schema := descpb.FromDescriptorWithMVCCTimestamp(&descriptor, value.Timestamp)
+		table, database, typ, schema := descpb.FromDescriptorWithMVCCTimestamp(&descriptor, ev.Value.Timestamp)
 
 		var id descpb.ID
 		var descType catalog.DescriptorType


### PR DESCRIPTION
When unmarshaling descriptor protos into their specific types, we want
to pass in the MVCC timestamp at which that descriptor was read. Given
we receive these protos through the surrounding rangefeed, we want to
use the rangefeed event timestamp. We we erroneously using the timestamp
found on the rangefeed event's "previous value", which the API
guarantees will be the zero timestamp.

(This tripped us up before; we added some commentary + tests in #71225
for the rangefeed library to make this clearer.)

Release note: None