### PR TITLE
kvserver: allow read up to GCThreshold when protectedTSCache is not initialized

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -947,7 +947,7 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	// user experience win; it's always safe to allow reads to continue so long
 	// as they are after the GC threshold.
 	c := r.mu.cachedProtectedTS
-	if st.State != kvserverpb.LeaseState_VALID || c.readAt.Less(st.Lease.Start.ToTimestamp()) {
+	if st.State != kvserverpb.LeaseState_VALID || c.readAt.IsEmpty() || c.readAt.Less(st.Lease.Start.ToTimestamp()) {
 		return *r.mu.state.GCThreshold
 	}
 


### PR DESCRIPTION
In the previous code, if `r.mu.cachedProtectedTS.readAt` and
`st.Lease.Start` were zero-valued, then we would reject reads that
could have otherwise proceeded.

While safe, this is unfortunate in the case where the caller has
written a protected timestamp that covers the batch timestamp.

If the caller verifies the protected timestamp, then the problem would
be avoided, but it would be nice to not _require_ verification in this
case.

Here we return the range's GCThreshold in the case that our
cachedProtectedTS is empty.

Release note: None