### PR TITLE
flowinfra: don't use log scope for tests due to flakiness

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -91,7 +91,6 @@ go_test(
         "//pkg/testutils/buildutil",
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/cancelchecker",

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -24,10 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -68,7 +66,6 @@ func lookupStreamInfo(
 
 func TestFlowRegistry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	reg := NewFlowRegistry()
 
 	id1 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
@@ -208,7 +205,6 @@ func TestFlowRegistry(t *testing.T) {
 // are propagated to their consumers and future attempts to connect them fail.
 func TestStreamConnectionTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 	reg := NewFlowRegistry()
 
 	jiffy := time.Nanosecond
@@ -278,7 +274,6 @@ func TestStreamConnectionTimeout(t *testing.T) {
 // - once the consumer connects, another Handshake message is sent.
 func TestHandshake(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 
 	reg := NewFlowRegistry()
 
@@ -377,7 +372,6 @@ func TestHandshake(t *testing.T) {
 // subtests for more details.
 func TestFlowRegistryDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	reg := NewFlowRegistry()
@@ -553,8 +547,6 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 // error, we are still able to register flows while Pushing the error (#34041).
 func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 73419, "flaky test")
-	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	fr := NewFlowRegistry()
@@ -610,7 +602,6 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 // into a flow even if one of the inbound streams are blocked (#35859).
 func TestFlowCancelPartiallyBlocked(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	fr := NewFlowRegistry()


### PR DESCRIPTION
The tests occasionally fail during the cleanup of the log scope, so
let's remove the scope (possibly temporarily).

Fixes: #73419.
Addresses: #73375.

Release note: None