### PR TITLE
stmtdiagnostics: version-gate recent conditional diagnostics

### DIFF
--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -181,6 +182,11 @@ func (r *Registry) poll(ctx context.Context) {
 	}
 }
 
+// TODO(yuzefovich): remove this in 22.2.
+func (r *Registry) isMinExecutionLatencySupported(ctx context.Context) bool {
+	return r.st.Version.IsActive(ctx, clusterversion.AlterSystemStmtDiagReqs)
+}
+
 // RequestID is the ID of a diagnostics request, corresponding to the id
 // column in statement_diagnostics_requests.
 // A zero ID is invalid.
@@ -251,16 +257,29 @@ func (r *Registry) insertRequestInternal(
 		return 0, err
 	}
 
+	if !r.isMinExecutionLatencySupported(ctx) {
+		if minExecutionLatency != 0 || expiresAfter != 0 {
+			return 0, errors.New(
+				"conditional statement diagnostics are only supported " +
+					"after 22.1 version migrations have completed",
+			)
+		}
+	}
+
 	var reqID RequestID
 	var expiresAt time.Time
 	err = r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Check if there's already a pending request for this fingerprint.
+		var extraConditions string
+		if r.isMinExecutionLatencySupported(ctx) {
+			extraConditions = " AND (expires_at IS NULL OR expires_at > now())"
+		}
 		row, err := r.ie.QueryRowEx(ctx, "stmt-diag-check-pending", txn,
 			sessiondata.InternalExecutorOverride{
 				User: security.RootUserName(),
 			},
-			"SELECT count(1) FROM system.statement_diagnostics_requests "+
-				"WHERE completed = false AND statement_fingerprint = $1 AND (expires_at IS NULL OR expires_at > now())",
+			fmt.Sprintf("SELECT count(1) FROM system.statement_diagnostics_requests "+
+				"WHERE completed = false AND statement_fingerprint = $1%s", extraConditions),
 			fprint)
 		if err != nil {
 			return err
@@ -538,18 +557,25 @@ func (r *Registry) InsertStatementDiagnostics(
 // updates r.mu.requests accordingly.
 func (r *Registry) pollRequests(ctx context.Context) error {
 	var rows []tree.Datums
+	isMinExecutionLatencySupported := r.isMinExecutionLatencySupported(ctx)
 	// Loop until we run the query without straddling an epoch increment.
 	for {
 		r.mu.Lock()
 		epoch := r.mu.epoch
 		r.mu.Unlock()
 
+		var extraColumns string
+		var extraConditions string
+		if isMinExecutionLatencySupported {
+			extraColumns = ", min_execution_latency, expires_at"
+			extraConditions = " AND (expires_at IS NULL OR expires_at > now())"
+		}
 		it, err := r.ie.QueryIteratorEx(ctx, "stmt-diag-poll", nil, /* txn */
 			sessiondata.InternalExecutorOverride{
 				User: security.RootUserName(),
 			},
-			"SELECT id, statement_fingerprint, min_execution_latency, expires_at FROM system.statement_diagnostics_requests "+
-				"WHERE completed = false AND (expires_at IS NULL OR expires_at > now())")
+			fmt.Sprintf("SELECT id, statement_fingerprint%s FROM system.statement_diagnostics_requests "+
+				"WHERE completed = false%s", extraColumns, extraConditions))
 		if err != nil {
 			return err
 		}
@@ -580,12 +606,14 @@ func (r *Registry) pollRequests(ctx context.Context) error {
 		id := RequestID(*row[0].(*tree.DInt))
 		fprint := string(*row[1].(*tree.DString))
 		var minExecutionLatency time.Duration
-		if minExecLatency, ok := row[2].(*tree.DInterval); ok {
-			minExecutionLatency = time.Duration(minExecLatency.Nanos())
-		}
 		var expiresAt time.Time
-		if e, ok := row[3].(*tree.DTimestampTZ); ok {
-			expiresAt = e.Time
+		if isMinExecutionLatencySupported {
+			if minExecLatency, ok := row[2].(*tree.DInterval); ok {
+				minExecutionLatency = time.Duration(minExecLatency.Nanos())
+			}
+			if e, ok := row[3].(*tree.DTimestampTZ); ok {
+				expiresAt = e.Time
+			}
 		}
 		ids.Add(int(id))
 		r.addRequestInternalLocked(ctx, id, fprint, minExecutionLatency, expiresAt)


### PR DESCRIPTION
We recently merged a change to support conditional statement diagnostics
which required a migration to the corresponding system table to include
a couple of new columns. However, we forgot to add a version gate for
the queries reading from that table, and as a result in a mixed
21.2-22.1 cluster, before the corresponding migration has completed, the
stmt diagnostics became broken. This is now fixed. I manually tested
that the fix does work and filed an issue to add the corresponding
operations to the mixed version roachtest.

Release note: None (no stable release with this bug)