### PR TITLE
sql: do not include inaccessible columns in information_schema.columns

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -425,7 +425,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 		) error {
 			dbNameStr := tree.NewDString(db.GetName())
 			scNameStr := tree.NewDString(scName)
-			for _, column := range table.PublicColumns() {
+			for _, column := range table.AccessibleColumns() {
 				collationCatalog := tree.DNull
 				collationSchema := tree.DNull
 				collationName := tree.DNull

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -27,6 +27,17 @@ CREATE TABLE public.t (
    FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
+query TTBTTTB colnames
+SELECT * FROM [SHOW COLUMNS FROM t] ORDER BY column_name
+----
+column_name  data_type  is_nullable  column_default  generation_expression  indices                                         is_hidden
+a            INT8       true         NULL            ·                      {t_pkey}                                        false
+b            INT8       true         NULL            ·                      {t_pkey}                                        false
+c            STRING     true         NULL            ·                      {t_pkey}                                        false
+comp         INT8       true         NULL            a + 10                 {}                                              false
+j            JSONB      true         NULL            ·                      {t_pkey}                                        false
+k            INT8       false        NULL            ·                      {t_a_plus_b_idx,t_lower_c_a_plus_b_idx,t_pkey}  false
+
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
 statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
 CREATE TABLE err (a INT, INDEX ((a + 10)), CHECK (crdb_internal_idx_expr > 0))

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4794,3 +4794,20 @@ SELECT distinct is_identity FROM information_schema.columns
 is_identity
 NO
 YES
+
+statement ok
+SET DATABASE = test
+
+# Regression test for #70505. Inaccessible columns should not be included in
+# information_schema.columns.
+subtest regression_70505
+
+statement ok
+CREATE TABLE t70505 (k INT PRIMARY KEY, a INT, b INT, INDEX ((a + b), (a + 10)))
+
+query T rowsort
+SELECT column_name FROM information_schema.columns WHERE table_name = 't70505'
+----
+k
+a
+b


### PR DESCRIPTION
This commit omits inaccessible columns from the
`information_schema.columns` table. Inaccessible columns are also
excluded in `SHOW COLUMNS` due to its reliance on
`information_schema.columns`.

Fixes #70505

Release note (bug fix): Internal columns created by the system to
support expression indexes are now omitted from the output of `SHOW
COLUMNS` statements and the `information_schema.columns` table.