### PR TITLE
cmpconn: handle pgtypes correctly

### DIFF
--- a/pkg/cmd/cmpconn/BUILD.bazel
+++ b/pkg/cmd/cmpconn/BUILD.bazel
@@ -27,5 +27,8 @@ go_test(
     size = "small",
     srcs = ["compare_test.go"],
     embed = [":cmpconn"],
-    deps = ["@com_github_cockroachdb_apd_v2//:apd"],
+    deps = [
+        "@com_github_cockroachdb_apd_v2//:apd",
+        "@com_github_jackc_pgtype//:pgtype",
+    ],
 )

--- a/pkg/cmd/cmpconn/compare.go
+++ b/pkg/cmd/cmpconn/compare.go
@@ -48,59 +48,59 @@ var (
 			out := make([]interface{}, len(x))
 			for i, v := range x {
 				switch t := v.(type) {
-				case *pgtype.TextArray:
+				case pgtype.TextArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = ""
 					}
-				case *pgtype.BPCharArray:
+				case pgtype.BPCharArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = ""
 					}
-				case *pgtype.VarcharArray:
+				case pgtype.VarcharArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = ""
 					}
-				case *pgtype.Int8Array:
+				case pgtype.Int8Array:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.Int8Array{}
 					}
-				case *pgtype.Float8Array:
+				case pgtype.Float8Array:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.Float8Array{}
 					}
-				case *pgtype.UUIDArray:
+				case pgtype.UUIDArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.UUIDArray{}
 					}
-				case *pgtype.ByteaArray:
+				case pgtype.ByteaArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.ByteaArray{}
 					}
-				case *pgtype.InetArray:
+				case pgtype.InetArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.InetArray{}
 					}
-				case *pgtype.TimestampArray:
+				case pgtype.TimestampArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.TimestampArray{}
 					}
-				case *pgtype.BoolArray:
+				case pgtype.BoolArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.BoolArray{}
 					}
-				case *pgtype.DateArray:
+				case pgtype.DateArray:
 					if t.Status == pgtype.Present && len(t.Elements) == 0 {
 						v = &pgtype.BoolArray{}
 					}
-				case *pgtype.Varbit:
+				case pgtype.Varbit:
 					if t.Status == pgtype.Present {
 						s, _ := t.EncodeText(nil, nil)
 						v = string(s)
 					}
-				case *pgtype.Bit:
-					vb := pgtype.Varbit(*t)
+				case pgtype.Bit:
+					vb := pgtype.Varbit(t)
 					v = &vb
-				case *pgtype.Interval:
+				case pgtype.Interval:
 					if t.Status == pgtype.Present {
 						v = duration.DecodeDuration(int64(t.Months), int64(t.Days), t.Microseconds*1000)
 					}
@@ -113,7 +113,7 @@ var (
 					// non-zero.
 					// See https://github.com/cockroachdb/cockroach/issues/41563
 					v = strings.Replace(t, ":00+00:00", ":00+00", 1)
-				case *pgtype.Numeric:
+				case pgtype.Numeric:
 					if t.Status == pgtype.Present {
 						v = apd.NewWithBigInt(t.Int, t.Exp)
 					}
@@ -135,7 +135,7 @@ var (
 			var a, b, min, sub apd.Decimal
 			a.Abs(x)
 			b.Abs(y)
-			if a.Cmp(&b) > 1 {
+			if a.Cmp(&b) > 0 {
 				min.Set(&b)
 			} else {
 				min.Set(&a)

--- a/pkg/cmd/cmpconn/compare_test.go
+++ b/pkg/cmd/cmpconn/compare_test.go
@@ -11,12 +11,17 @@
 package cmpconn
 
 import (
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/cockroachdb/apd/v2"
+	"github.com/jackc/pgtype"
 )
 
 func TestCompareVals(t *testing.T) {
+	big1, _ := big.NewInt(0).SetString("10986122886681096914", 10)
+	big2, _ := big.NewInt(0).SetString("10986122886681097", 10)
 	for i, tc := range []struct {
 		equal bool
 		a, b  []interface{}
@@ -56,16 +61,55 @@ func TestCompareVals(t *testing.T) {
 			a:     []interface{}{apd.New(2, 0)},
 			b:     []interface{}{apd.New(-2000001, -6)},
 		},
+		{
+			equal: false,
+			a:     []interface{}{apd.New(2, 0)},
+			b:     []interface{}{apd.New(2000001, 20)},
+		},
+		{
+			equal: true,
+			a: []interface{}{
+				pgtype.Numeric{
+					Int:    big1,
+					Exp:    -19,
+					Status: 2,
+					NaN:    false,
+				},
+			},
+			b: []interface{}{
+				pgtype.Numeric{
+					Int:    big2,
+					Exp:    -16,
+					Status: 2,
+					NaN:    false,
+				},
+			},
+		},
 	} {
-		err := CompareVals(tc.a, tc.b)
-		equal := err == nil
-		if equal != tc.equal {
-			t.Log("test index", i)
-			if err != nil {
-				t.Fatal(err)
-			} else {
-				t.Fatal("expected unequal")
+
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			err := CompareVals(tc.a, tc.b)
+			equal := err == nil
+			if equal != tc.equal {
+				t.Log("test index", i)
+				if err != nil {
+					t.Fatal(err)
+				} else {
+					t.Fatal("expected unequal")
+				}
 			}
-		}
+		})
+		t.Run(fmt.Sprintf("test_inverted_%d", i), func(t *testing.T) {
+			err := CompareVals(tc.b, tc.a)
+			equal := err == nil
+			if equal != tc.equal {
+				t.Log("test index", i)
+				if err != nil {
+					t.Fatal(err)
+				} else {
+					t.Fatal("expected unequal")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
The compare options were looking for pointer types, but pgx does not
return pointers. There was also an issue with how decimals were compared
since the min value was computed incorrectly.

refs https://github.com/cockroachdb/cockroach/issues/67791

Release note: None