### PR TITLE
*: don't mix Tracers in tests 

### DIFF
--- a/pkg/gossip/simulation/BUILD.bazel
+++ b/pkg/gossip/simulation/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/netutil",
         "//pkg/util/stop",
-        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"google.golang.org/grpc"
 )
@@ -72,7 +71,7 @@ func NewNetwork(
 	}
 	n.RPCContext = rpc.NewContext(rpc.ContextOptions{
 		TenantID:   roachpb.SystemTenantID,
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx: log.AmbientContext{Tracer: stopper.Tracer()},
 		Config:     &base.Config{Insecure: true},
 		Clock:      hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 		Stopper:    n.Stopper,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1704,7 +1704,8 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(context.Background())
 
 	n := simulation.NewNetwork(stopper, 3, true, zonepb.DefaultZoneConfigRef())
@@ -1714,7 +1715,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	}
 	n.Start()
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:         log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx:         log.AmbientContext{Tracer: tr},
 		NodeDescs:          n.Nodes[0].Gossip,
 		RPCContext:         n.RPCContext,
 		NodeDialer:         nodedialer.New(n.RPCContext, gossip.AddressResolver(n.Nodes[0].Gossip)),
@@ -2098,7 +2099,8 @@ func TestGetNodeDescriptor(t *testing.T) {
 func TestMultiRangeGapReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(context.Background())
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -2152,16 +2154,13 @@ func TestMultiRangeGapReverse(t *testing.T) {
 	})
 
 	cfg := DistSenderConfig{
-		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx:        log.AmbientContext{Tracer: tr},
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
 		RangeDescriptorDB: rdb,
 		TestingKnobs: ClientTestingKnobs{
-			TransportFactory: SenderTransportFactory(
-				tracing.NewTracer(),
-				sender,
-			),
+			TransportFactory: SenderTransportFactory(tr, sender),
 		},
 		Settings: cluster.MakeTestingClusterSettings(),
 	}
@@ -2391,7 +2390,8 @@ func TestClockUpdateOnResponse(t *testing.T) {
 func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(context.Background())
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -2471,7 +2471,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx: log.AmbientContext{Tracer: tr},
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -2516,7 +2516,8 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(context.Background())
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -2596,7 +2597,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx: log.AmbientContext{Tracer: tr},
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -3249,7 +3250,8 @@ func TestGatewayNodeID(t *testing.T) {
 func TestMultipleErrorsMerged(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(context.Background())
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -3431,7 +3433,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 				}
 
 				cfg := DistSenderConfig{
-					AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+					AmbientCtx: log.AmbientContext{Tracer: tr},
 					Clock:      clock,
 					NodeDescs:  g,
 					RPCContext: rpcContext,
@@ -4186,7 +4188,8 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -4271,7 +4274,7 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx:        log.AmbientContext{Tracer: tr},
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -85,7 +85,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 	}
 
 	// Make a db with a short heartbeat interval.
-	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	ambient := log.AmbientContext{Tracer: s.TracerI().(*tracing.Tracer)}
 	tsf := kvcoord.NewTxnCoordSenderFactory(
 		kvcoord.TxnCoordSenderFactoryConfig{
 			AmbientCtx: ambient,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -168,7 +168,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	}
 
 	// Make a db with a short heartbeat interval.
-	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	ambient := log.AmbientContext{Tracer: s.Cfg.AmbientCtx.Tracer}
 	tsf := NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
 			AmbientCtx: ambient,
@@ -2291,7 +2291,7 @@ func TestTxnCoordSenderPipelining(t *testing.T) {
 		return distSender.Send(ctx, ba)
 	}
 
-	ambientCtx := log.AmbientContext{Tracer: tracing.NewTracer()}
+	ambientCtx := log.AmbientContext{Tracer: s.Cfg.AmbientCtx.Tracer}
 	tsf := NewTxnCoordSenderFactory(TxnCoordSenderFactoryConfig{
 		AmbientCtx: ambientCtx,
 		Settings:   s.Cfg.Settings,

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -38,7 +38,8 @@ func TestRangeFeedIntegration(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Server(0).DB()
+	srv0 := tc.Server(0)
+	db := srv0.DB()
 	scratchKey := tc.ScratchRange(t)
 	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 	mkKey := func(k string) roachpb.Key {
@@ -66,7 +67,7 @@ func TestRangeFeedIntegration(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db, nil)
 	require.NoError(t, err)
 	rows := make(chan *roachpb.RangeFeedValue)
 	initialScanDone := make(chan struct{})
@@ -128,7 +129,8 @@ func TestWithOnFrontierAdvance(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Server(0).DB()
+	srv0 := tc.Server(0)
+	db := srv0.DB()
 	scratchKey := tc.ScratchRange(t)
 	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 	mkKey := func(k string) roachpb.Key {
@@ -155,7 +157,7 @@ func TestWithOnFrontierAdvance(t *testing.T) {
 	_, _, err := tc.SplitRange(mkKey("b"))
 	require.NoError(t, err)
 
-	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db, nil)
 	require.NoError(t, err)
 
 	// mu protects secondWriteTS.
@@ -247,7 +249,8 @@ func TestWithOnCheckpoint(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Server(0).DB()
+	srv0 := tc.Server(0)
+	db := srv0.DB()
 	scratchKey := tc.ScratchRange(t)
 	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 	mkKey := func(k string) roachpb.Key {
@@ -269,7 +272,7 @@ func TestWithOnCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db, nil)
 	require.NoError(t, err)
 
 	var mu syncutil.RWMutex
@@ -345,7 +348,8 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Server(0).DB()
+	srv0 := tc.Server(0)
+	db := srv0.DB()
 	scratchKey := tc.ScratchRange(t)
 	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 	mkKey := func(k string) roachpb.Key {
@@ -367,7 +371,7 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db, nil)
 	require.NoError(t, err)
 
 	rows := make(chan *roachpb.RangeFeedValue)
@@ -456,7 +460,8 @@ func TestUnrecoverableErrors(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
-	db := tc.Server(0).DB()
+	srv0 := tc.Server(0)
+	db0 := srv0.DB()
 	scratchKey := tc.ScratchRange(t)
 	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 
@@ -475,7 +480,7 @@ func TestUnrecoverableErrors(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	f, err := rangefeed.NewFactory(tc.Stopper(), db, nil)
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db0, nil)
 	require.NoError(t, err)
 
 	preGCThresholdTS := hlc.Timestamp{WallTime: 1}

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -306,7 +306,7 @@ func initTestProber(
 		Knobs:    knobs,
 	})
 	p := kvprober.NewProber(kvprober.Opts{
-		Tracer:                  tracing.NewTracer(),
+		Tracer:                  s.TracerI().(*tracing.Tracer),
 		DB:                      kvDB,
 		HistogramWindowInterval: time.Minute, // actual value not important to test
 		Settings:                s.ClusterSettings(),

--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -508,9 +508,10 @@ func setupReplicaRemovalTest(
 			err  *roachpb.Error
 		}
 		resultC := make(chan result)
-		err := tc.Stopper().RunAsyncTask(ctx, "request", func(ctx context.Context) {
+		srv := tc.Servers[0]
+		err := srv.Stopper().RunAsyncTask(ctx, "request", func(ctx context.Context) {
 			reqCtx := context.WithValue(ctx, magicKey{}, struct{}{})
-			resp, pErr := kv.SendWrapped(reqCtx, tc.Servers[0].DistSender(), req)
+			resp, pErr := kv.SendWrapped(reqCtx, srv.DistSender(), req)
 			resultC <- result{resp, pErr}
 		})
 		require.NoError(t, err)

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -44,7 +44,8 @@ func TestBaseQueueConcurrent(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	stopper := stop.NewStopper()
+	tr := tracing.NewTracer()
+	stopper := stop.NewStopper(stop.WithTracer(tr))
 	defer stopper.Stop(ctx)
 
 	// We'll use this many ranges, each of which is added a few times to the
@@ -70,7 +71,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 	store := &Store{
 		cfg: StoreConfig{
 			Clock:             hlc.NewClock(hlc.UnixNano, time.Second),
-			AmbientCtx:        log.AmbientContext{Tracer: tracing.NewTracer()},
+			AmbientCtx:        log.AmbientContext{Tracer: tr},
 			DefaultSpanConfig: roachpb.TestingDefaultSpanConfig(),
 		},
 	}

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -107,14 +107,15 @@ type raftTransportTestContext struct {
 }
 
 func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
+	tr := tracing.NewTracer()
 	rttc := &raftTransportTestContext{
 		t:          t,
-		stopper:    stop.NewStopper(),
+		stopper:    stop.NewStopper(stop.WithTracer(tr)),
 		transports: map[roachpb.NodeID]*kvserver.RaftTransport{},
 	}
 	rttc.nodeRPCContext = rpc.NewContext(rpc.ContextOptions{
 		TenantID:   roachpb.SystemTenantID,
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx: log.AmbientContext{Tracer: tr},
 		Config:     testutils.NewNodeTestBaseContext(),
 		Clock:      hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 		Stopper:    rttc.stopper,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -163,6 +163,7 @@ func createTestStoreWithoutStart(
 		Stopper:    stopper,
 		Settings:   cfg.Settings,
 	})
+	stopper.SetTracer(cfg.AmbientCtx.Tracer)
 	server := rpc.NewServer(rpcContext) // never started
 
 	// Some tests inject their own Gossip and StorePool, via

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"google.golang.org/grpc"
 )
@@ -73,7 +72,7 @@ func NewInsecureTestingContextWithKnobs(
 ) *Context {
 	return NewContext(ContextOptions{
 		TenantID:   roachpb.SystemTenantID,
-		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		AmbientCtx: log.AmbientContext{Tracer: stopper.Tracer()},
 		Config:     &base.Config{Insecure: true},
 		Clock:      clock,
 		Stopper:    stopper,

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -102,7 +102,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -49,6 +48,7 @@ import (
 func TestClusterFlow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 	const numNodes = 3
 	const numRows = 100
 
@@ -90,11 +90,6 @@ func TestClusterFlow(t *testing.T) {
 		//
 		// Note that the ranges won't necessarily be local to the table readers, but
 		// that doesn't matter for the purposes of this test.
-
-		// Start a span (useful to look at spans using Lightstep).
-		sp := tc.ServerTyped(0).Tracer().StartSpan("cluster test")
-		ctx := tracing.ContextWithSpan(context.Background(), sp)
-		defer sp.Finish()
 
 		now := tc.Server(0).Clock().NowAsClockTimestamp()
 		txnProto := roachpb.MakeTransaction(

--- a/pkg/sql/sqlliveness/slstorage/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slstorage/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",

--- a/pkg/sql/sqlliveness/slstorage/slstorage_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -71,7 +72,7 @@ func TestStorage(t *testing.T) {
 			return timeSource.Now().UnixNano()
 		}, base.DefaultMaxClockOffset)
 		settings := cluster.MakeTestingClusterSettings()
-		stopper := stop.NewStopper()
+		stopper := stop.NewStopper(stop.WithTracer(s.TracerI().(*tracing.Tracer)))
 		var ambientCtx log.AmbientContext
 		storage := slstorage.NewTestingStorage(ambientCtx, stopper, clock, kvDB, keys.SystemSQLCodec, settings,
 			tableID, timeSource.NewTimer)
@@ -328,7 +329,7 @@ func TestConcurrentAccessesAndEvictions(t *testing.T) {
 		return timeSource.Now().UnixNano()
 	}, base.DefaultMaxClockOffset)
 	settings := cluster.MakeTestingClusterSettings()
-	stopper := stop.NewStopper()
+	stopper := stop.NewStopper(stop.WithTracer(s.TracerI().(*tracing.Tracer)))
 	defer stopper.Stop(ctx)
 	slstorage.CacheSize.Override(ctx, &settings.SV, 10)
 	var ambientCtx log.AmbientContext

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -673,3 +673,21 @@ span: test
 	rec2 := getRecAndFinish()
 	require.Equal(t, rec1, rec2)
 }
+
+func TestChildNeedsSameTracerAsParent(t *testing.T) {
+	// Check that it is illegal to create a child with a different Tracer than the
+	// parent.
+	tr1 := NewTracer()
+	tr2 := NewTracer()
+	parent := tr1.StartSpan("parent")
+	require.Panics(t, func() {
+		tr2.StartSpan("child", WithParent(parent))
+	})
+
+	// Sterile spans can have children created with a different Tracer (because
+	// they are not really children).
+	parent = tr1.StartSpan("parent", WithSterile())
+	require.NotPanics(t, func() {
+		tr2.StartSpan("child", WithParent(parent))
+	})
+}


### PR DESCRIPTION
Different tests are mixing Tracers within the same trace in various
ways - meaning that a child span is being created with a different
Tracer than the parent. This is not permitted - the Tracer catches it
and panics trying to create the child. The tests were getting away with
it because tracing is usually disabled (i.e. creating no-op spans
doesn't complain about this condition). But if tracing is turned on
(like I'm intending to do generally), these tests freak out.

This patch fixes the tests by ensuring that Tracers are not mixed like
this. One of the common ways in which tests mixing Tracers was by
initiating an operation using a Tracer that the test created (e.g.
through a Stopper), and then calling into a TestServer using that ctx).
In such cases, the solution is to use the Server's Tracer when
initiating the operation.

There is a discussion to be had about whether this practice of mixing
Tracers could be tolerated. The argument for not allowing it goes like
this:
- child spans have links to the parent and vice-versa, and these links
  are used to move spans in and out of the active spans registry when
  they Finish(). For example, a parent will insert all its still-alive
  children into the registry on Finish(). The registries are per-Tracer,
  and things get confusing if a span is created by Tracer A but ends up in
  Tracer B's registry. So actually mixing Tracers in a trace is probably
  indeed a bad idea.
- We could avoid mixing Tracers even if the code attempts to use two of
  them. For example, if one does:

  p := trA.StarSpan()
  c := trB.StartSpan(WithParent(p))

  we could imagine redirecting c's creation from trB to trA
  transparently. So far I've resisted doing so because, even though it'd
  technically work, it would become quite surprising/ambiguous which
  registry a span belongs to (e.g. one would reasonably expect c to be
  found in trB's registry, but it wouldn't).
  So far, I've attempted to avoid these surprises and disallow this
  pattern.

In production there is one Tracer per Server, so these issues are moot
(well, the issues come up in a DemoCluster, where there's multiple
Servers, but I think I've fixed those). For tests, I recognize that they
generally don't care about tracing at all because we haven't really made
background tracing useful for tests (but maybe one day...). So I'll keep
my ears open for pain and, if after this round of cleanup, the issue
keeps popping up, I'll consider adding support for mixing.

Release note: None