### PR TITLE
ui: remove tooltip underline in sorted table headers

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -229,6 +229,7 @@ export class DatabaseTablePage extends React.Component<
     {
       name: "indexes",
       title: "Indexes",
+      hideTitleUnderline: true,
       className: cx("index-stats-table__col-indexes"),
       cell: indexStat => (
         <>
@@ -241,12 +242,14 @@ export class DatabaseTablePage extends React.Component<
     {
       name: "total reads",
       title: "Total Reads",
+      hideTitleUnderline: true,
       cell: indexStat => indexStat.totalReads,
       sort: indexStat => indexStat.totalReads,
     },
     {
       name: "last used",
       title: "Last Used (UTC)",
+      hideTitleUnderline: true,
       className: cx("index-stats-table__col-last-used"),
       cell: indexStat => this.getLastUsedString(indexStat),
       sort: indexStat => indexStat.lastUsed,

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -36,6 +36,9 @@ export interface ISortedTablePagination {
 export interface ColumnDescriptor<T> {
   // Title string that should appear in the header column.
   title: React.ReactNode;
+  // Hides the dashed title underline, which represents that a tooltip exists.
+  // Defaults to false and shows the underline if not defined.
+  hideTitleUnderline?: boolean;
   // Function which generates the contents of an individual cell in this table.
   cell: (obj: T) => React.ReactNode;
   // Function which returns a value that can be used to sort the collection of
@@ -128,6 +131,9 @@ const cx = classNames.bind(styles);
 export interface SortableColumn {
   // Text that will appear in the title header of the table.
   title: React.ReactNode;
+  // Hides the dashed title underline, which represents that a tooltip exists.
+  // Defaults to false and shows the underline if not defined.
+  hideTitleUnderline?: boolean;
   // Function which provides the contents for this column for a given row index
   // in the dataset.
   cell: (rowIndex: number) => React.ReactNode;
@@ -252,6 +258,7 @@ export class SortedTable<T> extends React.Component<
           return {
             name: cd.name,
             title: cd.title,
+            hideTitleUnderline: cd.hideTitleUnderline,
             cell: index => cd.cell(sorted[index]),
             columnTitle: cd.sort ? cd.name : undefined,
             rollup: rollups[ii],

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
@@ -69,7 +69,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
             !sortSetting.ascending && picked && "sorted__cell--descending",
             firstCellBordered && idx === 0 && "cell-header",
           );
-          const titleClasses = cx("column-title");
+          const titleClasses = c.hideTitleUnderline ? "" : cx("column-title");
 
           return (
             <th


### PR DESCRIPTION
Resolves #73280

Previously, all tables headers were expected to have a tooltip; hence
they were default styled with a dashed underline. However, we would like
to reduce the number of tooltips in the UI, as they can be distracting
and take up clutter on the screen.

This commit adds in a new paramter "noHeaderTooltips" which indicates
that the table headers have no tooltips and should have no underline
styling. This also removes the dashed underline for the Index Stats
table, which has no tooltips.

![image](https://user-images.githubusercontent.com/29153209/144677382-3cb040c7-4158-4f88-ae91-2cb5c0fc440a.png)

Release note (ui change): Add ability to remove dashed underline from
sorted table headers for headers with no tooltips. Remove the dashed
underline from the Index Stats table headers.