### PR TITLE
opt: make better use of FastIntSet fast-path in ColSet

### DIFF
--- a/pkg/sql/catalog/table_col_set_test.go
+++ b/pkg/sql/catalog/table_col_set_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-func BenchmarkColSet(b *testing.B) {
+func BenchmarkTableColSet(b *testing.B) {
 	// Verify that the wrapper doesn't add overhead (as was the case with earlier
 	// go versions which couldn't do mid-stack inlining).
 	const n = 50

--- a/pkg/sql/opt/colset_test.go
+++ b/pkg/sql/opt/colset_test.go
@@ -23,7 +23,7 @@ func BenchmarkColSet(b *testing.B) {
 	b.Run("fastintset", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c util.FastIntSet
-			for j := 0; j < n; j++ {
+			for j := 1; j <= n; j++ {
 				c.Add(j)
 			}
 		}
@@ -31,7 +31,7 @@ func BenchmarkColSet(b *testing.B) {
 	b.Run("colset", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var c ColSet
-			for j := 0; j < n; j++ {
+			for j := 1; j <= n; j++ {
 				c.Add(ColumnID(j))
 			}
 		}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -914,13 +914,19 @@ func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 func (mb *mutationBuilder) mutationColumnIDs() opt.ColSet {
 	cols := opt.ColSet{}
 	for _, col := range mb.insertColIDs {
-		cols.Add(col)
+		if col != 0 {
+			cols.Add(col)
+		}
 	}
 	for _, col := range mb.updateColIDs {
-		cols.Add(col)
+		if col != 0 {
+			cols.Add(col)
+		}
 	}
 	for _, col := range mb.upsertColIDs {
-		cols.Add(col)
+		if col != 0 {
+			cols.Add(col)
+		}
 	}
 	return cols
 }


### PR DESCRIPTION
Previously, a ColSet would use the fast path of its underlying
FastIntSet as long as the set only contained ColumnIDs in the range
[0, 63]. This slightly under-utilized the set's fast path because
ColumnID 0 is reserved as an unknown ColumnID and is never added to a
ColSet.

This commit shifts the ColumnIDs stored in a ColSet by one in the
underlying FastIntSet, so that the set's fast-path can be used for
ColumnIDs in the range [1, 64]. This will prevent falling-back to the
slow-path, which can significantly affect performance (see #72733), in a
few more cases.

Release note: None