### PR TITLE
parser: fix panic when calling .@0 on a tuple

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11634,7 +11634,11 @@ d_expr:
 | '(' a_expr ')' '.' '@' ICONST
   {
     idx, err := $6.numVal().AsInt32()
-    if err != nil || idx <= 0 { return setErr(sqllex, err) }
+    if err != nil { return setErr(sqllex, err) }
+    if idx <= 0 {
+      err := errors.New("invalid numeric tuple index: indexes must be > 0")
+      return setErr(sqllex, err)
+    }
     $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), ByIndex: true, ColIndex: int(idx-1)}
   }
 | '(' a_expr ')'

--- a/pkg/sql/parser/testdata/expr
+++ b/pkg/sql/parser/testdata/expr
@@ -5,3 +5,11 @@ lexical error: invalid UTF-8 byte sequence
 DETAIL: source SQL:
 e'\xad'::string
 ^
+
+error
+SELECT ((1, 2)).@0
+----
+at or near "0": syntax error: invalid numeric tuple index: indexes must be > 0
+DETAIL: source SQL:
+SELECT ((1, 2)).@0
+                 ^


### PR DESCRIPTION
Fixes #73458

The CockroachDB-specific .@n syntax is usable to get the nth field of a
tuple. Previously, the parser would panic when trying to parse .@0. This
parser panic is now corrected.

Release note (bug fix): prevent a panic in the parser when trying to
parse the .@n tuple field deference syntax in the (invalid) n=0 case.