### PR TITLE
acceptance: remove ballast files

### DIFF
--- a/build/teamcity/cockroach/ci/tests/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests/acceptance.sh
@@ -11,10 +11,18 @@ export ARTIFACTSDIR=$PWD/artifacts/acceptance
 mkdir -p "$ARTIFACTSDIR"
 
 tc_start_block "Run acceptance tests"
+status=0
 bazel run \
   //pkg/acceptance:acceptance_test \
   --config=crosslinux --config=test \
   --test_arg=-l="$ARTIFACTSDIR" \
   --test_env=TZ=America/New_York \
-  --test_timeout=1800
+  --test_timeout=1800 || status=$?
+
+# Some unit tests test automatic ballast creation. These ballasts can be
+# larger than the maximum artifact size. Remove any artifacts with the
+# EMERGENCY_BALLAST filename.
+find "$ARTIFACTSDIR" -name "EMERGENCY_BALLAST" -delete
+
 tc_end_block "Run acceptance tests"
+exit $status


### PR DESCRIPTION
Some acceptance tests create `EMERGENCY_BALLAST` file with size of 1G.
After the tests are done the file is also published as an artifact, what
wastes a lot of disk space.

This patch cleans up the artifacts directory and removes the unnecessary
artifact.

Release note: None

Fixes: DEVINF-282