### PR TITLE
kvserver: default kv.rangefeed.catchup_scan_iterator_optimization.enabled to true

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -87,7 +87,7 @@ type cdcTestArgs struct {
 func cdcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	db.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
-	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = true")
+	randomlyRun(t, db, "SET CLUSTER SETTING kv.rangefeed.catchup_scan_iterator_optimization.enabled = false")
 }
 
 const randomSettingPercent = 0.50

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -59,7 +59,7 @@ var RangeFeedRefreshInterval = settings.RegisterDurationSetting(
 var RangefeedTBIEnabled = settings.RegisterBoolSetting(
 	"kv.rangefeed.catchup_scan_iterator_optimization.enabled",
 	"if true, rangefeeds will use time-bound iterators for catchup-scans when possible",
-	util.ConstantWithMetamorphicTestBool("kv.rangefeed.catchup_scan_iterator_optimization.enabled", false),
+	util.ConstantWithMetamorphicTestBool("kv.rangefeed.catchup_scan_iterator_optimization.enabled", true),
 )
 
 // lockedRangefeedStream is an implementation of rangefeed.Stream which provides


### PR DESCRIPTION
We've been testing this at random for some time and, as far as I know,
have not seen any CDC failures caused by this optimization.

This switches the default value to true. Further, I've lowered the
probability that this boolean is flipped in the metamorphic builds
such that the default case gets test more often.

Release note (ops change): The default value of the
kv.rangefeed.catchup_scan_iterator_optimization.enabled cluster
setting is now true.