### PR TITLE
cli: fix Tracer init for multi-tenant

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -80,6 +80,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer stopper.Stop(ctx)
+	stopper.SetTracer(serverCfg.BaseConfig.AmbientCtx.Tracer)
 
 	st := serverCfg.BaseConfig.Settings
 


### PR DESCRIPTION
Before this patch, a sql pod process ended up using two Tracers:
one created by the Stopper, and another one created by the serverCfg.
These two Tracers were sometimes both used within a single trace, which
is illegal - the multi-tenant process would thus crash if tracing was
enabled. This patch fixes the issue by overriding the Stopper's tracer
early in the sql pod's initialization. This is also how the setup of a
regular server works.

It's messy that we have two Tracers even temporarily, but refactoring
the initialization sufficiently to avoid that seems hard. I'll probably
do something better in the future cause it's itching me, though.

Release note: None