### PR TITLE
kvclient: fix span capture in heartbeat interceptor

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -296,21 +296,17 @@ func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) {
 	// (it's zero).
 	h.AmbientContext.AddLogTag("txn-hb", h.mu.txn.Short())
 
-	const taskName = "[async] kv.TxnCoordSender: heartbeat loop"
-
 	// Create a new context so that the heartbeat loop doesn't inherit the
-	// caller's cancelation.
+	// caller's cancelation or span.
 	hbCtx, hbCancel := context.WithCancel(h.AnnotateCtx(context.Background()))
 
 	// Delay spawning the loop goroutine until the first loopInterval passes, to
 	// avoid the associated cost for small write transactions. In benchmarks,
 	// this gave a 3% throughput increase for point writes at high concurrency.
 	timer := time.AfterFunc(h.loopInterval, func() {
-		// We want the loop to run in a span linked to the current one, so we put
-		// our span in the context and fork it.
+		const taskName = "kv.TxnCoordSender: heartbeat loop"
 		var span *tracing.Span
-		hbCtx = tracing.ContextWithSpan(hbCtx, tracing.SpanFromContext(ctx))
-		hbCtx, span = tracing.ForkSpan(hbCtx, taskName)
+		hbCtx, span = h.AmbientContext.Tracer.StartSpanCtx(hbCtx, taskName)
 		defer span.Finish()
 
 		// Only errors on quiesce, which is safe to ignore.


### PR DESCRIPTION
The txnHeartbeater was capturing the tracing span of the first writing
request in a txn, holding on to it for a second, and then using it to
fork a child span. Since the parent span was long closed by then,
creating the child was a use-after-Finish. This has been tolerated, as
all use-after-Finishes have been tolerate, but I'm cracking down on them
because of a tracing agenda. Even if this kind of fork from finishes
span were allowed, it still probably wouldn't be a good idea to hold on
to the parent's memory for so long for very little benefit (the benefits
of the parent-child relationship after a fork are kinda theoretical,
particularly if the parent has finished by the time the child starts).

So, this patch makes the heartbeat loop's span be a root.

Release note: None