### PR TITLE
tracing: add options to crash on use-after-Finish 

### DIFF
--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -198,7 +198,6 @@ func TestGRPCInterceptors(t *testing.T) {
 			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
 			var n int
 			finalRecs := sp.FinishAndGetRecording(tracing.RecordingVerbose)
-			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
 				n += len(rec.StructuredRecords)
 				// Remove all of the _unfinished tags. These crop up because

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -159,6 +159,9 @@ func (sp *Span) Meta() SpanMeta {
 // auxiliary trace sink). This does not apply to Spans derived from this one
 // when it was verbose.
 func (sp *Span) SetVerbose(to bool) {
+	if sp.done() {
+		return
+	}
 	// We allow toggling verbosity on and off for a finished span. This shouldn't
 	// matter either way as a finished span drops all new data, but if we
 	// prevented the toggling we could end up in weird states since IsVerbose()

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -136,6 +136,15 @@ func (s *spanInner) Meta() SpanMeta {
 	}
 }
 
+// OperationName returns the span's name. The name was specified at span
+// creation time.
+func (s *spanInner) OperationName() string {
+	if s.isNoop() {
+		return "noop"
+	}
+	return s.crdb.operation
+}
+
 func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
 	if s.isNoop() {
 		return s

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -174,6 +174,11 @@ type parentOption Span
 // wait for the child to Finish(). If this expectation does not hold,
 // WithFollowsFrom should be added to the StartSpan invocation.
 func WithParent(sp *Span) SpanOption {
+	// Panic if the parent has already been finished, if configured to do so. If
+	// the parent has finished and we're configured not to panic, StartSpan() will
+	// deal with it when passed this WithParent option.
+	_ = sp.detectUseAfterFinish()
+
 	// The sp.IsNoop() case is handled in StartSpan, not here, because we want to
 	// assert that the parent's Tracer is the same as the child's. In contrast, in
 	// the IsSterile() case, it is allowed for the "child" to be created with a

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -388,50 +389,91 @@ func (tr *explodyNetTr) Finish() {
 
 // TestSpan_UseAfterFinish finishes a Span multiple times and
 // calls all of its methods multiple times as well. This is
-// to check that `Span.done` is called in the right places,
+// to check that `Span.detectUseAfterFinish` is called in the right places,
 // and serves as a regression test for issues such as:
 //
 // https://github.com/cockroachdb/cockroach/issues/58489#issuecomment-781263005
 func TestSpan_UseAfterFinish(t *testing.T) {
-	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
-	tr._useNetTrace = 1
-	sp := tr.StartSpan("foo")
-	require.NotNil(t, sp.i.netTr)
-	// Set up netTr to reliably explode if Finish'ed twice. We
-	// expect `sp.Finish` to not let it come to that.
-	sp.i.netTr = &explodyNetTr{Trace: sp.i.netTr}
-	sp.Finish()
-	require.True(t, sp.done())
-	sp.Finish()
-	require.EqualValues(t, 2, sp.numFinishCalled)
+	// First, test with a Tracer configured to NOT panic on use-after-Finish.
+	t.Run("production settings", func(t *testing.T) {
+		tr := NewTracerWithOpt(context.Background(),
+			WithTracingMode(TracingModeActiveSpansRegistry),
+			// Mimic production settings, otherwise we crash on span-use-after-Finish in
+			// tests.
+			WithUseAfterFinishOpt(false /* panicOnUseAfterFinish */, false /* debugUseAfterFinish */))
+		require.False(t, tr.PanicOnUseAfterFinish())
+		tr._useNetTrace = 1
+		sp := tr.StartSpan("foo")
+		require.NotNil(t, sp.i.netTr)
+		// Set up netTr to reliably explode if Finish'ed twice. We
+		// expect `sp.Finish` to not let it come to that.
+		sp.i.netTr = &explodyNetTr{Trace: sp.i.netTr}
+		sp.Finish()
+		require.True(t, sp.detectUseAfterFinish())
+		sp.Finish()
+		require.EqualValues(t, 1, atomic.LoadInt32(&sp.finished))
 
-	netTrT := reflect.TypeOf(sp)
-	for i := 0; i < netTrT.NumMethod(); i++ {
-		f := netTrT.Method(i)
-		t.Run(f.Name, func(t *testing.T) {
-			// The receiver is the first argument.
-			args := []reflect.Value{reflect.ValueOf(sp)}
-			for i := 1; i < f.Type.NumIn(); i++ {
-				// Zeroes for the rest. It would be nice to do something
-				// like `quick.Check` here (or even just call quick.Check!)
-				// but that's for another day. It should be doable!
-				args = append(args, reflect.Zero(f.Type.In(i)))
-			}
-			// NB: on an impl of Span that calls through to `trace.Trace.Finish`, and
-			// on my machine, and at the time of writing, `tr.Finish` would reliably
-			// deadlock on exactly the 10th call. This motivates the choice of 20
-			// below.
-			for i := 0; i < 20; i++ {
-				t.Run("invoke", func(t *testing.T) {
-					if i == 9 {
-						f.Func.Call(args)
-					} else {
-						f.Func.Call(args)
-					}
-				})
-			}
+		netTrT := reflect.TypeOf(sp)
+		for i := 0; i < netTrT.NumMethod(); i++ {
+			f := netTrT.Method(i)
+			t.Run(f.Name, func(t *testing.T) {
+				// The receiver is the first argument.
+				args := []reflect.Value{reflect.ValueOf(sp)}
+				for i := 1; i < f.Type.NumIn(); i++ {
+					// Zeroes for the rest. It would be nice to do something
+					// like `quick.Check` here (or even just call quick.Check!)
+					// but that's for another day. It should be doable!
+					args = append(args, reflect.Zero(f.Type.In(i)))
+				}
+				// NB: on an impl of Span that calls through to `trace.Trace.Finish`, and
+				// on my machine, and at the time of writing, `tr.Finish` would reliably
+				// deadlock on exactly the 10th call. This motivates the choice of 20
+				// below.
+				for i := 0; i < 20; i++ {
+					t.Run("invoke", func(t *testing.T) {
+						if i == 9 {
+							f.Func.Call(args)
+						} else {
+							f.Func.Call(args)
+						}
+					})
+				}
+			})
+		}
+
+		// Check that creating a child from a finished parent doesn't crash. The
+		// "child" is expected to really be a root.
+		var parentID tracingpb.SpanID
+		require.NotPanics(t, func() {
+			child := tr.StartSpan("child", WithParent(sp))
+			parentID = child.i.crdb.parentSpanID
+			child.Finish()
 		})
-	}
+		require.Zero(t, parentID)
+	})
+
+	// Second, test with a Tracer configured to panic on use-after-Finish.
+	t.Run("crash settings", func(t *testing.T) {
+		tr := NewTracerWithOpt(context.Background(),
+			WithTracingMode(TracingModeActiveSpansRegistry),
+			WithUseAfterFinishOpt(true /* panicOnUseAfterFinish */, true /* debugUseAfterFinish */))
+		require.True(t, tr.PanicOnUseAfterFinish())
+		sp := tr.StartSpan("foo")
+		sp.Finish()
+		require.Panics(t, func() {
+			sp.Record("boom")
+		})
+		require.Panics(t, func() {
+			sp.GetRecording(RecordingStructured)
+		})
+		require.Panics(t, func() {
+			sp.Finish()
+		})
+		// Check that creating a child from a finished parent crashes.
+		require.Panics(t, func() {
+			tr.StartSpan("child", WithParent(sp))
+		})
+	})
 }
 
 type countingStringer int32

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -799,13 +799,12 @@ func (t *Tracer) startSpanGeneric(
 	}{}
 
 	helper.crdbSpan = crdbSpan{
-		tracer:       t,
-		traceID:      traceID,
-		spanID:       spanID,
-		goroutineID:  goroutineID,
-		startTime:    startTime,
-		parentSpanID: opts.parentSpanID(),
-		logTags:      opts.LogTags,
+		tracer:      t,
+		traceID:     traceID,
+		spanID:      spanID,
+		goroutineID: goroutineID,
+		startTime:   startTime,
+		logTags:     opts.LogTags,
 		mu: crdbSpanMu{
 			duration: -1, // unfinished
 			tags:     helper.tagsAlloc[:0],
@@ -841,6 +840,7 @@ func (t *Tracer) startSpanGeneric(
 				added := parent.addChildLocked(s.i.crdb, !opts.ParentDoesNotCollectRecording)
 				if added {
 					s.i.crdb.mu.parent = opts.Parent.i.crdb
+					s.i.crdb.parentSpanID = opts.parentSpanID()
 				} else {
 					// The parent has already finished. Clear it so the would-be child
 					// looks like a root and gets added to the activeSpansRegistry below.

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -545,13 +545,16 @@ func TestSpanRecordingFinished(t *testing.T) {
 	require.Len(t, spanOpsWithFinished, 0)
 }
 
+// Test that the noop span can be used after finish.
 func TestNoopSpanFinish(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
-	sp := tr.StartSpan("noop")
-	require.Equal(t, tr.noopSpan, sp)
-	require.EqualValues(t, 1, tr.noopSpan.numFinishCalled)
-	sp.Finish()
-	require.EqualValues(t, 1, tr.noopSpan.numFinishCalled)
+	sp1 := tr.StartSpan("noop")
+	sp2 := tr.StartSpan("noop")
+	require.Equal(t, tr.noopSpan, sp1)
+	require.Equal(t, tr.noopSpan, sp2)
+	sp1.Finish()
+	sp2.Record("dummy")
+	sp2.Finish()
 }
 
 // Test that a span constructed with a no-op span behaves like a root span - it


### PR DESCRIPTION
Currently, uses of a Span after it has been Finish()ed are tolerated,
even though they're not supposed to be allowed. In the future, I want to
pool and reuse spans, so not using them after Finish() becomes more
important. The plans is to have such uses lead to trace corruption in
production. This patch adds detection of use-after-Finish() and makes
tests crash on it. Hopefully I've fixed all the bad code.

Release note: None