### PR TITLE
sql: fix IS NAN syntax type-checking

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -139,3 +139,23 @@ query FFF
 SELECT -0.1234567890123456, 123456789012345.6, 1234567.890123456
 ----
 -0.1234567890123457 123456789012345.7 1234567.890123457
+
+# Regression test to make sure `IS NAN` does not coerce NaN to a string.
+statement error unsupported comparison operator: <tuple> = <decimal>
+SELECT ROW() IS NAN
+
+statement error unsupported comparison operator: <tuple> != <decimal>
+SELECT ROW() IS NOT NAN
+
+statement error unsupported comparison operator: <string> = <decimal>
+SELECT 'NaN'::string IS NAN
+
+query BB
+SELECT 'nan'::float IS NAN, 'nan'::float IS NOT NAN
+----
+true  false
+
+query BB
+SELECT 'nan'::decimal IS NAN, 'nan'::decimal IS NOT NAN
+----
+true  false

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -11230,11 +11230,19 @@ a_expr:
   }
 | a_expr IS NAN %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.MakeComparisonOperator(tree.EQ), Left: $1.expr(), Right: tree.NewStrVal("NaN")}
+    $$.val = &tree.ComparisonExpr{
+      Operator: tree.MakeComparisonOperator(tree.EQ),
+      Left: $1.expr(),
+      Right: tree.NewNumVal(constant.MakeFloat64(math.NaN()), "NaN", false /*negative*/),
+    }
   }
 | a_expr IS NOT NAN %prec IS
   {
-    $$.val = &tree.ComparisonExpr{Operator: tree.MakeComparisonOperator(tree.NE), Left: $1.expr(), Right: tree.NewStrVal("NaN")}
+    $$.val = &tree.ComparisonExpr{
+      Operator: tree.MakeComparisonOperator(tree.NE),
+      Left: $1.expr(),
+      Right: tree.NewNumVal(constant.MakeFloat64(math.NaN()), "NaN", false /*negative*/),
+    }
   }
 | a_expr IS NULL %prec IS
   {

--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -1662,7 +1662,7 @@ SELECT a IS NAN
 ----
 SELECT a = 'NaN' -- normalized!
 SELECT ((a) = ('NaN')) -- fully parenthesized
-SELECT a = '_' -- literals removed
+SELECT a = _ -- literals removed
 SELECT _ = 'NaN' -- identifiers removed
 
 parse
@@ -1670,7 +1670,7 @@ SELECT a IS NOT NAN
 ----
 SELECT a != 'NaN' -- normalized!
 SELECT ((a) != ('NaN')) -- fully parenthesized
-SELECT a != '_' -- literals removed
+SELECT a != _ -- literals removed
 SELECT _ != 'NaN' -- identifiers removed
 
 parse


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/63940
fixes https://github.com/cockroachdb/cockroach/issues/72257

Previously using the IS NAN syntax with tuples would cause a
type-checking error. The NAN was treated as a constant string val, which
would be coerced into a tuple. To avoid this, the NAN is now treated as
a constant NumVal.

No release note since this bug was never released. The bug was only
revealed after we started allowing string->tuple casts.

Release note: None