### PR TITLE
sql/opt: make VALUES type inference handle nested tuples

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -254,6 +254,11 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 			v.err = newQueryNotSupportedErrorf("array %s cannot be executed with distsql", t)
 			return false, expr
 		}
+	case *tree.DTuple:
+		if t.ResolvedType() == types.AnyTuple {
+			v.err = newQueryNotSupportedErrorf("tuple %s cannot be executed with distsql", t)
+			return false, expr
+		}
 	}
 	return true, expr
 }

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1084,3 +1084,41 @@ ORDER BY
 ----
 {}
 {"(1,cat)"}
+
+query T
+SELECT
+  t2.c4
+FROM
+  (
+    VALUES
+      (NULL, (1:::DECIMAL, ARRAY[]:::record[])),
+      (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8)]))
+  )
+    AS t2 (c3, c4)
+----
+(1,{})
+(2,"{""(1,2)""}")
+
+statement error VALUES types tuple\{decimal, tuple\{int, int\}\[\]\} and tuple\{decimal, tuple\{int, int, int\}\[\]\} cannot be matched
+SELECT
+  t2.c4
+FROM
+  (
+    VALUES
+      (NULL, (1:::DECIMAL, ARRAY[]:::record[])),
+      (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8, 3::INT8)])),
+      (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8)]))
+  )
+    AS t2 (c3, c4)
+
+statement error VALUES types tuple\{decimal, tuple\{int, int, int\}\[\]\} and tuple\{decimal, tuple\{int, int\}\[\]\} cannot be matched
+SELECT
+  t2.c4
+FROM
+  (
+    VALUES
+      (NULL, (1:::DECIMAL, ARRAY[]:::record[])),
+      (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8)])),
+      (NULL, (2:::DECIMAL, ARRAY[(1::INT8, 2::INT8, 3::INT8)]))
+  )
+    AS t2 (c3, c4)

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -78,14 +78,10 @@ func (b *Builder) buildValuesClause(
 			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
 				if colTypes[colIdx].Family() == types.UnknownFamily {
 					colTypes[colIdx] = typ
-				} else if colTypes[colIdx].Family() == types.ArrayFamily &&
-					colTypes[colIdx].ArrayContents() == types.AnyTuple &&
-					typ.Family() == types.ArrayFamily &&
-					typ.ArrayContents().Family() == types.TupleFamily &&
-					typ.ArrayContents() != types.AnyTuple {
-					// This more complicated condition handles the case when an earlier
-					// expression in the VALUES clause is an array of AnyTuple, but a
-					// later expression is an array of a more specific tuple type.
+				} else if rightHasMoreSpecificTuple(colTypes[colIdx], typ) {
+					// This condition handles the case when an earlier expression in the
+					// VALUES clause is an array of AnyTuple, but a later expression is an
+					// array of a more specific tuple type.
 					colTypes[colIdx] = typ
 				} else if !typ.Equivalent(colTypes[colIdx]) {
 					panic(pgerror.Newf(pgcode.DatatypeMismatch,
@@ -140,4 +136,39 @@ func reportValuesLenError(expected, actual int) {
 		pgcode.Syntax,
 		"VALUES lists must all be the same length, expected %d columns, found %d",
 		expected, actual))
+}
+
+// rightHasMoreSpecificTuple returns true if the left and right types are
+// equivalent, but the right type is constrained by a more specific nested
+// tuple than the left type.
+func rightHasMoreSpecificTuple(left, right *types.T) bool {
+	if left.Family() != right.Family() {
+		return false
+	}
+	if left.Family() == types.ArrayFamily && right.Family() == types.ArrayFamily {
+		return rightHasMoreSpecificTuple(left.ArrayContents(), right.ArrayContents())
+	}
+	if left.Family() == types.TupleFamily && right.Family() == types.TupleFamily {
+		if right == types.AnyTuple {
+			return false
+		} else if left == types.AnyTuple {
+			return true
+		} else if len(left.TupleContents()) != len(right.TupleContents()) {
+			return false
+		}
+		ret := true
+		for i, leftElem := range left.TupleContents() {
+			rightElem := right.TupleContents()[i]
+			// Only recurse if we are dealing with a container type.
+			if leftElem.Family() == types.ArrayFamily || leftElem.Family() == types.TupleFamily {
+				ret = ret && rightHasMoreSpecificTuple(leftElem, rightElem)
+			} else {
+				ret = ret && leftElem.Equivalent(rightElem)
+			}
+		}
+		return ret
+	}
+	// For non-tuples and non-arrays, we don't want the right type to get
+	// preference over the left type.
+	return false
 }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -780,10 +780,24 @@ func (expr *DTimestamp) Walk(_ Visitor) Expr { return expr }
 func (expr *DTimestampTZ) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
+func (expr *DTuple) Walk(v Visitor) Expr {
+	for _, d := range expr.D {
+		// Datums never get changed by visitors, so we don't need to
+		// look for changed elements.
+		d.Walk(v)
+	}
+	return expr
+}
 
 // Walk implements the Expr interface.
-func (expr *DArray) Walk(_ Visitor) Expr { return expr }
+func (expr *DArray) Walk(v Visitor) Expr {
+	for _, d := range expr.Array {
+		// Datums never get changed by visitors, so we don't need to
+		// look for changed elements.
+		d.Walk(v)
+	}
+	return expr
+}
 
 // Walk implements the Expr interface.
 func (expr *DOid) Walk(_ Visitor) Expr { return expr }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/73197

In 21b124749b1a93621786412bd54b7816a6fb1bf4 this code was enhanced to
handle empty arrays of tuples.

This commit makes it even smarter, so that it handles tuples that
themselves contain arrays of empty tuples (and further levels of nesting
as well).

This fixes internal errors that were caused by queries that used tuples
like this.

Release note: None