### PR TITLE
kvserver: emit `AddSSTable` events via rangefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -108,6 +108,11 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 				); err != nil {
 					return err
 				}
+			case *roachpb.RangeFeedSSTable:
+				// For now, we just error on SST ingestion, since we currently don't
+				// expect SST ingestion into spans with active changefeeds.
+				return errors.Errorf("unexpected SST ingestion: %v", t)
+
 			default:
 				return errors.Errorf("unexpected RangeFeedEvent variant %v", t)
 			}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -175,7 +175,7 @@ func (a *activeRangeFeed) onRangeEvent(
 ) {
 	a.Lock()
 	defer a.Unlock()
-	if event.Val != nil {
+	if event.Val != nil || event.SST != nil {
 		a.LastValueReceived = timeutil.Now()
 	} else if event.Checkpoint != nil {
 		a.Resolved = event.Checkpoint.ResolvedTS

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//build/bazelutil:noop",
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
+        "//pkg/testutils/sstutil",
         "//pkg/testutils/testcluster",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -292,7 +292,8 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 		}
 
 		err := f.processEvents(ctx, frontier, eventCh, errCh)
-		if errors.HasType(err, &roachpb.BatchTimestampBeforeGCError{}) {
+		if errors.HasType(err, &roachpb.BatchTimestampBeforeGCError{}) ||
+			errors.HasType(err, &roachpb.MVCCHistoryMutationError{}) {
 			if errCallback := f.onUnrecoverableError; errCallback != nil {
 				errCallback(ctx, err)
 			}

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -270,7 +271,6 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 	// TODO(ajwerner): Consider adding event buffering. Doing so would require
 	// draining when the rangefeed fails.
 	eventCh := make(chan *roachpb.RangeFeedEvent)
-	errCh := make(chan error)
 
 	for i := 0; r.Next(); i++ {
 		ts := frontier.Frontier()
@@ -280,18 +280,14 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 
 		start := timeutil.Now()
 
-		// Note that the below channel send will not block forever because
-		// processEvents will wait for the worker to send. RunWorker is safe here
-		// because processEvents is guaranteed to consume the error before
-		// returning.
-		if err := f.stopper.RunAsyncTask(ctx, "rangefeed", func(ctx context.Context) {
-			errCh <- f.client.RangeFeed(ctx, f.spans, ts, f.withDiff, eventCh)
-		}); err != nil {
-			log.VEventf(ctx, 1, "exiting rangefeed due to stopper")
-			return
+		rangeFeedTask := func(ctx context.Context) error {
+			return f.client.RangeFeed(ctx, f.spans, ts, f.withDiff, eventCh)
+		}
+		processEventsTask := func(ctx context.Context) error {
+			return f.processEvents(ctx, frontier, eventCh)
 		}
 
-		err := f.processEvents(ctx, frontier, eventCh, errCh)
+		err := ctxgroup.GoAndWait(ctx, rangeFeedTask, processEventsTask)
 		if errors.HasType(err, &roachpb.BatchTimestampBeforeGCError{}) ||
 			errors.HasType(err, &roachpb.MVCCHistoryMutationError{}) {
 			if errCallback := f.onUnrecoverableError; errCallback != nil {
@@ -326,13 +322,9 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 	}
 }
 
-// processEvents processes events sent by the rangefeed on the eventCh. It waits
-// for the rangefeed to signal that it has exited by sending on errCh.
+// processEvents processes events sent by the rangefeed on the eventCh.
 func (f *RangeFeed) processEvents(
-	ctx context.Context,
-	frontier *span.Frontier,
-	eventCh <-chan *roachpb.RangeFeedEvent,
-	errCh <-chan error,
+	ctx context.Context, frontier *span.Frontier, eventCh <-chan *roachpb.RangeFeedEvent,
 ) error {
 	for {
 		select {
@@ -351,16 +343,18 @@ func (f *RangeFeed) processEvents(
 				if advanced && f.onFrontierAdvance != nil {
 					f.onFrontierAdvance(ctx, frontier.Frontier())
 				}
+			case ev.SST != nil:
+				if f.onSSTable == nil {
+					return errors.AssertionFailedf(
+						"received unexpected rangefeed SST event with no OnSSTable handler")
+				}
+				f.onSSTable(ctx, ev.SST)
 			case ev.Error != nil:
 				// Intentionally do nothing, we'll get an error returned from the
 				// call to RangeFeed.
 			}
 		case <-ctx.Done():
-			// Ensure that the RangeFeed goroutine stops.
-			<-errCh
 			return ctx.Err()
-		case err := <-errCh:
-			return err
 		}
 	}
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -15,8 +15,10 @@ import (
 	"runtime/pprof"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -511,6 +513,83 @@ func TestUnrecoverableErrors(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestMVCCHistoryMutationError verifies that applying a MVCC history mutation
+// emits an unrecoverable error.
+func TestMVCCHistoryMutationError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	srv0 := tc.Server(0)
+	db0 := srv0.DB()
+	scratchKey := tc.ScratchRange(t)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+
+	_, err := tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
+	require.NoError(t, err)
+
+	// Set up a rangefeed.
+	f, err := rangefeed.NewFactory(srv0.Stopper(), db0, srv0.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	errC := make(chan error)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, srv0.Clock().Now(),
+		func(context.Context, *roachpb.RangeFeedValue) {},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
+			select {
+			case errC <- err:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case err := <-errC:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Send a ClearRange request that mutates MVCC history.
+	_, pErr := kv.SendWrapped(ctx, db0.NonTransactionalSender(), &roachpb.ClearRangeRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    sp.Key,
+			EndKey: sp.EndKey,
+		},
+	})
+	require.Nil(t, pErr)
+
+	// Wait for the MVCCHistoryMutationError.
+	select {
+	case err := <-errC:
+		var mvccErr *roachpb.MVCCHistoryMutationError
+		require.ErrorAs(t, err, &mvccErr)
+		require.Equal(t, &roachpb.MVCCHistoryMutationError{Span: sp}, err)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for error")
+	}
 }
 
 // TestRangefeedWithLabelsOption verifies go routines started by rangefeed are

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sstutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -452,6 +453,163 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 		require.False(t, v.PrevValue.IsPresent())
 		require.True(t, v.PrevValue.Timestamp.IsEmpty())
 	}
+}
+
+// TestWithOnSSTable tests that the rangefeed emits SST ingestions correctly.
+func TestWithOnSSTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	srv := tc.Server(0)
+	db := srv.DB()
+
+	_, _, err := tc.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	f, err := rangefeed.NewFactory(srv.Stopper(), db, srv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+	// a-f), to ensure the entire SST is emitted even if the registration is
+	// narrower.
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	sstC := make(chan *roachpb.RangeFeedSSTable)
+	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+		func(ctx context.Context, value *roachpb.RangeFeedValue) {},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnSSTable(func(ctx context.Context, sst *roachpb.RangeFeedSSTable) {
+			select {
+			case sstC <- sst:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Ingest an SST.
+	now := db.Clock().Now()
+	now.Logical = 0
+	ts := now.WallTime
+	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
+	sst, sstStart, sstEnd := sstutil.MakeSST(t, sstKVs)
+	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
+		false /* ingestAsWrites */, now)
+	require.Nil(t, pErr)
+
+	// Wait for the SST event and check its contents.
+	var sstEvent *roachpb.RangeFeedSSTable
+	select {
+	case sstEvent = <-sstC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for SST event")
+	}
+
+	require.Equal(t, roachpb.Span{Key: sstStart, EndKey: sstEnd}, sstEvent.Span)
+	require.Equal(t, now, sstEvent.WriteTS)
+	require.Equal(t, sstKVs, sstutil.ScanSST(t, sstEvent.Data))
+}
+
+// TestWithOnSSTableCatchesUpIfNotSet tests that the rangefeed runs a catchup
+// scan if an OnSSTable event is emitted and no OnSSTable event handler is set.
+func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	srv := tc.Server(0)
+	db := srv.DB()
+
+	_, _, err := tc.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	f, err := rangefeed.NewFactory(srv.Stopper(), db, srv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+	// a-f), to ensure only the restricted span is emitted by the catchup scan.
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	rowC := make(chan *roachpb.RangeFeedValue)
+	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+		func(ctx context.Context, value *roachpb.RangeFeedValue) {
+			select {
+			case rowC <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Ingest an SST.
+	now := db.Clock().Now()
+	now.Logical = 0
+	ts := now.WallTime
+	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
+	expectKVs := []sstutil.KV{{"c", ts, "3"}, {"d", ts, "4"}}
+	sst, sstStart, sstEnd := sstutil.MakeSST(t, sstKVs)
+	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
+		false /* ingestAsWrites */, now)
+	require.Nil(t, pErr)
+
+	// Assert that we receive the KV pairs within the rangefeed span.
+	timer := time.NewTimer(3 * time.Second)
+	var seenKVs []sstutil.KV
+	for len(seenKVs) < len(expectKVs) {
+		select {
+		case row := <-rowC:
+			value, err := row.Value.GetBytes()
+			require.NoError(t, err)
+			seenKVs = append(seenKVs, sstutil.KV{
+				KeyString:     string(row.Key),
+				WallTimestamp: row.Value.Timestamp.WallTime,
+				ValueString:   string(value),
+			})
+		case <-timer.C:
+			require.Fail(t, "timed out waiting for catchup scan", "saw entries: %v", seenKVs)
+		}
+	}
+	require.Equal(t, expectKVs, seenKVs)
 }
 
 // TestUnrecoverableErrors verifies that unrecoverable internal errors are surfaced

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/abortspan",
+        "//pkg/kv/kvserver/batcheval/result",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/gc",
         "//pkg/kv/kvserver/readsummary",

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/kv/kvserver/batcheval/result",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/gc",
+        "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/readsummary",
         "//pkg/kv/kvserver/readsummary/rspb",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -144,6 +144,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/testutils/sstutil",
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -251,6 +251,11 @@ func EvalAddSSTable(
 			sstIter.Next()
 		}
 		return result.Result{
+			Replicated: kvserverpb.ReplicatedEvalResult{
+				MVCCHistoryMutation: &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
+					Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
+				},
+			},
 			Local: result.LocalResult{
 				Metrics: &result.Metrics{
 					AddSSTableAsWrites: 1,
@@ -264,6 +269,9 @@ func EvalAddSSTable(
 			AddSSTable: &kvserverpb.ReplicatedEvalResult_AddSSTable{
 				Data:  sst,
 				CRC32: util.CRC32(sst),
+			},
+			MVCCHistoryMutation: &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
+				Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
 			},
 		},
 	}, nil

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -224,6 +224,13 @@ func EvalAddSSTable(
 
 	ms.Add(stats)
 
+	var mvccHistoryMutation *kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation
+	if !args.WriteAtRequestTimestamp {
+		mvccHistoryMutation = &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
+			Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
+		}
+	}
+
 	if args.IngestAsWrites {
 		span.RecordStructured(&types.StringValue{Value: fmt.Sprintf("ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(sst))})
 		log.VEventf(ctx, 2, "ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(sst))
@@ -248,13 +255,22 @@ func EvalAddSSTable(
 					return result.Result{}, err
 				}
 			}
+			// The above MVCC functions do not record logical operations, but we must
+			// use them because e.g. storage.MVCCPut() changes the semantics of the
+			// write by not allowing writing below existing keys, and we want to
+			// retain parity with regular SST ingestion which does allow this. We
+			// therefore record these operations ourselves.
+			if args.WriteAtRequestTimestamp {
+				readWriter.LogLogicalOp(storage.MVCCWriteValueOpType, storage.MVCCLogicalOpDetails{
+					Key:       k.Key,
+					Timestamp: k.Timestamp,
+				})
+			}
 			sstIter.Next()
 		}
 		return result.Result{
 			Replicated: kvserverpb.ReplicatedEvalResult{
-				MVCCHistoryMutation: &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
-					Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
-				},
+				MVCCHistoryMutation: mvccHistoryMutation,
 			},
 			Local: result.LocalResult{
 				Metrics: &result.Metrics{
@@ -267,12 +283,12 @@ func EvalAddSSTable(
 	return result.Result{
 		Replicated: kvserverpb.ReplicatedEvalResult{
 			AddSSTable: &kvserverpb.ReplicatedEvalResult_AddSSTable{
-				Data:  sst,
-				CRC32: util.CRC32(sst),
+				Data:             sst,
+				CRC32:            util.CRC32(sst),
+				Span:             roachpb.Span{Key: start.Key, EndKey: end.Key},
+				AtWriteTimestamp: args.WriteAtRequestTimestamp,
 			},
-			MVCCHistoryMutation: &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
-				Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
-			},
+			MVCCHistoryMutation: mvccHistoryMutation,
 		},
 	}, nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sstutil"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -39,26 +40,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
-
-type mvccKV struct {
-	key   string
-	ts    int64  // 0 for inline
-	value string // "" for nil (tombstone)
-}
-
-func (kv mvccKV) Key() roachpb.Key         { return roachpb.Key(kv.key) }
-func (kv mvccKV) TS() hlc.Timestamp        { return hlc.Timestamp{WallTime: kv.ts} }
-func (kv mvccKV) MVCCKey() storage.MVCCKey { return storage.MVCCKey{Key: kv.Key(), Timestamp: kv.TS()} }
-func (kv mvccKV) ValueBytes() []byte       { return kv.Value().RawBytes }
-
-func (kv mvccKV) Value() roachpb.Value {
-	value := roachpb.MakeValueFromString(kv.value)
-	if kv.value == "" {
-		value = roachpb.Value{}
-	}
-	value.InitChecksum(kv.Key())
-	return value
-}
 
 // TestEvalAddSSTable tests EvalAddSSTable directly, using only an on-disk
 // Pebble engine. This allows precise manipulation of timestamps.
@@ -70,332 +51,333 @@ func TestEvalAddSSTable(t *testing.T) {
 	const intentTS = 100    // values with this timestamp are written as intents
 
 	// These are run with IngestAsWrites both disabled and enabled.
+	// nolint:composites
 	testcases := map[string]struct {
-		data               []mvccKV
-		sst                []mvccKV
+		data               []sstutil.KV
+		sst                []sstutil.KV
 		sstTimestamp       int64 // SSTTimestamp set to given timestamp
 		atReqTS            int64 // WriteAtRequestTimestamp with given timestamp
 		noConflict         bool  // DisallowConflicts
 		noShadow           bool  // DisallowShadowing
 		noShadowBelow      int64 // DisallowShadowingBelow
-		expect             []mvccKV
+		expect             []sstutil.KV
 		expectErr          interface{} // error type, substring, or true (any error)
 		expectErrUnderRace interface{}
 		expectStatsEst     bool // expect MVCCStats.ContainsEstimates, don't check stats
 	}{
 		// Blind writes.
 		"blind writes below existing": {
-			data:           []mvccKV{{"a", 5, "a5"}, {"b", 7, ""}},
-			sst:            []mvccKV{{"a", 3, "sst"}, {"b", 2, "sst"}},
-			expect:         []mvccKV{{"a", 5, "a5"}, {"a", 3, "sst"}, {"b", 7, ""}, {"b", 2, "sst"}},
+			data:           []sstutil.KV{{"a", 5, "a5"}, {"b", 7, ""}},
+			sst:            []sstutil.KV{{"a", 3, "sst"}, {"b", 2, "sst"}},
+			expect:         []sstutil.KV{{"a", 5, "a5"}, {"a", 3, "sst"}, {"b", 7, ""}, {"b", 2, "sst"}},
 			expectStatsEst: true,
 		},
 		"blind replaces existing": {
-			data:           []mvccKV{{"a", 2, "a2"}},
-			sst:            []mvccKV{{"a", 2, "sst"}},
-			expect:         []mvccKV{{"a", 2, "sst"}},
+			data:           []sstutil.KV{{"a", 2, "a2"}},
+			sst:            []sstutil.KV{{"a", 2, "sst"}},
+			expect:         []sstutil.KV{{"a", 2, "sst"}},
 			expectStatsEst: true,
 		},
 		"blind returns WriteIntentError on conflict": {
-			data:      []mvccKV{{"b", intentTS, "b0"}},
-			sst:       []mvccKV{{"b", 1, "sst"}},
+			data:      []sstutil.KV{{"b", intentTS, "b0"}},
+			sst:       []sstutil.KV{{"b", 1, "sst"}},
 			expectErr: &roachpb.WriteIntentError{},
 		},
 		"blind returns WriteIntentError in span": {
-			data:      []mvccKV{{"b", intentTS, "b0"}},
-			sst:       []mvccKV{{"a", 1, "sst"}, {"c", 1, "sst"}},
+			data:      []sstutil.KV{{"b", intentTS, "b0"}},
+			sst:       []sstutil.KV{{"a", 1, "sst"}, {"c", 1, "sst"}},
 			expectErr: &roachpb.WriteIntentError{},
 		},
 		"blind writes tombstones": { // unfortunately, for performance
-			sst:            []mvccKV{{"a", 1, ""}},
-			expect:         []mvccKV{{"a", 1, ""}},
+			sst:            []sstutil.KV{{"a", 1, ""}},
+			expect:         []sstutil.KV{{"a", 1, ""}},
 			expectStatsEst: true,
 		},
 		"blind writes SST inline values": { // unfortunately, for performance
-			sst:            []mvccKV{{"a", 0, "inline"}},
-			expect:         []mvccKV{{"a", 0, "inline"}},
+			sst:            []sstutil.KV{{"a", 0, "inline"}},
+			expect:         []sstutil.KV{{"a", 0, "inline"}},
 			expectStatsEst: true,
 		},
 		"blind writes above existing inline values": { // unfortunately, for performance
-			data:           []mvccKV{{"a", 0, "inline"}},
-			sst:            []mvccKV{{"a", 2, "sst"}},
-			expect:         []mvccKV{{"a", 0, "inline"}, {"a", 2, "sst"}},
+			data:           []sstutil.KV{{"a", 0, "inline"}},
+			sst:            []sstutil.KV{{"a", 2, "sst"}},
+			expect:         []sstutil.KV{{"a", 0, "inline"}, {"a", 2, "sst"}},
 			expectStatsEst: true,
 		},
 
 		// WriteAtRequestTimestamp
 		"WriteAtRequestTimestamp sets timestamp": {
 			atReqTS:        10,
-			sst:            []mvccKV{{"a", 1, "a1"}, {"b", 3, "b3"}},
-			expect:         []mvccKV{{"a", 10, "a1"}, {"b", 10, "b3"}},
+			sst:            []sstutil.KV{{"a", 1, "a1"}, {"b", 3, "b3"}},
+			expect:         []sstutil.KV{{"a", 10, "a1"}, {"b", 10, "b3"}},
 			expectStatsEst: true,
 		},
 		"WriteAtRequestTimestamp rejects tombstones": {
 			atReqTS:   10,
-			sst:       []mvccKV{{"a", 1, ""}},
+			sst:       []sstutil.KV{{"a", 1, ""}},
 			expectErr: "SST values cannot be tombstones",
 		},
 		"WriteAtRequestTimestamp rejects inline values": {
 			atReqTS:   10,
-			sst:       []mvccKV{{"a", 0, "inline"}},
+			sst:       []sstutil.KV{{"a", 0, "inline"}},
 			expectErr: "inline values or intents are not supported",
 		},
 		"WriteAtRequestTimestamp writes below and replaces": {
 			atReqTS:        5,
-			data:           []mvccKV{{"a", 5, "a5"}, {"b", 7, "b7"}},
-			sst:            []mvccKV{{"a", 1, "sst"}, {"b", 1, "sst"}},
-			expect:         []mvccKV{{"a", 5, "sst"}, {"b", 7, "b7"}, {"b", 5, "sst"}},
+			data:           []sstutil.KV{{"a", 5, "a5"}, {"b", 7, "b7"}},
+			sst:            []sstutil.KV{{"a", 1, "sst"}, {"b", 1, "sst"}},
+			expect:         []sstutil.KV{{"a", 5, "sst"}, {"b", 7, "b7"}, {"b", 5, "sst"}},
 			expectStatsEst: true,
 		},
 		"WriteAtRequestTimestamp returns WriteIntentError for intents": {
 			atReqTS:   10,
-			data:      []mvccKV{{"a", intentTS, "intent"}},
-			sst:       []mvccKV{{"a", 1, "a@1"}},
+			data:      []sstutil.KV{{"a", intentTS, "intent"}},
+			sst:       []sstutil.KV{{"a", 1, "a@1"}},
 			expectErr: &roachpb.WriteIntentError{},
 		},
 		"WriteAtRequestTimestamp errors with DisallowConflicts below existing": {
 			atReqTS:    5,
 			noConflict: true,
-			data:       []mvccKV{{"a", 5, "a5"}, {"b", 7, "b7"}},
-			sst:        []mvccKV{{"a", 10, "sst"}, {"b", 10, "sst"}},
+			data:       []sstutil.KV{{"a", 5, "a5"}, {"b", 7, "b7"}},
+			sst:        []sstutil.KV{{"a", 10, "sst"}, {"b", 10, "sst"}},
 			expectErr:  &roachpb.WriteTooOldError{},
 		},
 		"WriteAtRequestTimestamp succeeds with DisallowConflicts above existing": {
 			atReqTS:    8,
 			noConflict: true,
-			data:       []mvccKV{{"a", 5, "a5"}, {"b", 7, "b7"}},
-			sst:        []mvccKV{{"a", 1, "sst"}, {"b", 1, "sst"}},
-			expect:     []mvccKV{{"a", 8, "sst"}, {"a", 5, "a5"}, {"b", 8, "sst"}, {"b", 7, "b7"}},
+			data:       []sstutil.KV{{"a", 5, "a5"}, {"b", 7, "b7"}},
+			sst:        []sstutil.KV{{"a", 1, "sst"}, {"b", 1, "sst"}},
+			expect:     []sstutil.KV{{"a", 8, "sst"}, {"a", 5, "a5"}, {"b", 8, "sst"}, {"b", 7, "b7"}},
 		},
 		"WriteAtRequestTimestamp errors with DisallowShadowing below existing": {
 			atReqTS:   5,
 			noShadow:  true,
-			data:      []mvccKV{{"a", 5, "a5"}, {"b", 7, "b7"}},
-			sst:       []mvccKV{{"a", 10, "sst"}, {"b", 10, "sst"}},
+			data:      []sstutil.KV{{"a", 5, "a5"}, {"b", 7, "b7"}},
+			sst:       []sstutil.KV{{"a", 10, "sst"}, {"b", 10, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"WriteAtRequestTimestamp errors with DisallowShadowing above existing": {
 			atReqTS:   8,
 			noShadow:  true,
-			data:      []mvccKV{{"a", 5, "a5"}, {"b", 7, "b7"}},
-			sst:       []mvccKV{{"a", 1, "sst"}, {"b", 1, "sst"}},
+			data:      []sstutil.KV{{"a", 5, "a5"}, {"b", 7, "b7"}},
+			sst:       []sstutil.KV{{"a", 1, "sst"}, {"b", 1, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"WriteAtRequestTimestamp succeeds with DisallowShadowing above tombstones": {
 			atReqTS:  8,
 			noShadow: true,
-			data:     []mvccKV{{"a", 5, ""}, {"b", 7, ""}},
-			sst:      []mvccKV{{"a", 1, "sst"}, {"b", 1, "sst"}},
-			expect:   []mvccKV{{"a", 8, "sst"}, {"a", 5, ""}, {"b", 8, "sst"}, {"b", 7, ""}},
+			data:     []sstutil.KV{{"a", 5, ""}, {"b", 7, ""}},
+			sst:      []sstutil.KV{{"a", 1, "sst"}, {"b", 1, "sst"}},
+			expect:   []sstutil.KV{{"a", 8, "sst"}, {"a", 5, ""}, {"b", 8, "sst"}, {"b", 7, ""}},
 		},
 		"WriteAtRequestTimestamp succeeds with DisallowShadowing and idempotent writes": {
 			atReqTS:  5,
 			noShadow: true,
-			data:     []mvccKV{{"a", 5, "a5"}, {"b", 5, "b5"}},
-			sst:      []mvccKV{{"a", 1, "a5"}, {"b", 1, "b5"}},
-			expect:   []mvccKV{{"a", 5, "a5"}, {"b", 5, "b5"}},
+			data:     []sstutil.KV{{"a", 5, "a5"}, {"b", 5, "b5"}},
+			sst:      []sstutil.KV{{"a", 1, "a5"}, {"b", 1, "b5"}},
+			expect:   []sstutil.KV{{"a", 5, "a5"}, {"b", 5, "b5"}},
 		},
 		"WriteAtRequestTimestamp errors with DisallowShadowingBelow equal value above existing below limit": {
 			atReqTS:       7,
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 10, "a3"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 10, "a3"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"WriteAtRequestTimestamp errors with DisallowShadowingBelow errors above existing above limit": {
 			atReqTS:       7,
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 6, "a6"}},
-			sst:           []mvccKV{{"a", 10, "sst"}},
+			data:          []sstutil.KV{{"a", 6, "a6"}},
+			sst:           []sstutil.KV{{"a", 10, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"WriteAtRequestTimestamp allows DisallowShadowingBelow equal value above existing above limit": {
 			atReqTS:       7,
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 6, "a6"}},
-			sst:           []mvccKV{{"a", 10, "a6"}},
-			expect:        []mvccKV{{"a", 7, "a6"}, {"a", 6, "a6"}},
+			data:          []sstutil.KV{{"a", 6, "a6"}},
+			sst:           []sstutil.KV{{"a", 10, "a6"}},
+			expect:        []sstutil.KV{{"a", 7, "a6"}, {"a", 6, "a6"}},
 		},
 
 		// DisallowConflicts
 		"DisallowConflicts allows above and beside": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 3, "a3"}, {"b", 1, ""}},
-			sst:        []mvccKV{{"a", 4, "sst"}, {"b", 3, "sst"}, {"c", 1, "sst"}},
-			expect: []mvccKV{
+			data:       []sstutil.KV{{"a", 3, "a3"}, {"b", 1, ""}},
+			sst:        []sstutil.KV{{"a", 4, "sst"}, {"b", 3, "sst"}, {"c", 1, "sst"}},
+			expect: []sstutil.KV{
 				{"a", 4, "sst"}, {"a", 3, "a3"}, {"b", 3, "sst"}, {"b", 1, ""}, {"c", 1, "sst"},
 			},
 		},
 		"DisallowConflicts returns WriteTooOldError below existing": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 3, "a3"}},
-			sst:        []mvccKV{{"a", 2, "sst"}},
+			data:       []sstutil.KV{{"a", 3, "a3"}},
+			sst:        []sstutil.KV{{"a", 2, "sst"}},
 			expectErr:  &roachpb.WriteTooOldError{},
 		},
 		"DisallowConflicts returns WriteTooOldError at existing": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 3, "a3"}},
-			sst:        []mvccKV{{"a", 3, "sst"}},
+			data:       []sstutil.KV{{"a", 3, "a3"}},
+			sst:        []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:  &roachpb.WriteTooOldError{},
 		},
 		"DisallowConflicts returns WriteTooOldError at existing tombstone": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 3, ""}},
-			sst:        []mvccKV{{"a", 3, "sst"}},
+			data:       []sstutil.KV{{"a", 3, ""}},
+			sst:        []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:  &roachpb.WriteTooOldError{},
 		},
 		"DisallowConflicts returns WriteIntentError below intent": {
 			noConflict: true,
-			data:       []mvccKV{{"a", intentTS, "intent"}},
-			sst:        []mvccKV{{"a", 3, "sst"}},
+			data:       []sstutil.KV{{"a", intentTS, "intent"}},
+			sst:        []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:  &roachpb.WriteIntentError{},
 		},
 		"DisallowConflicts ignores intents in span": { // inconsistent with blind writes
 			noConflict: true,
-			data:       []mvccKV{{"b", intentTS, "intent"}},
-			sst:        []mvccKV{{"a", 3, "sst"}, {"c", 3, "sst"}},
-			expect:     []mvccKV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
+			data:       []sstutil.KV{{"b", intentTS, "intent"}},
+			sst:        []sstutil.KV{{"a", 3, "sst"}, {"c", 3, "sst"}},
+			expect:     []sstutil.KV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
 		},
 		"DisallowConflicts is not idempotent": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 3, "a3"}},
-			sst:        []mvccKV{{"a", 3, "a3"}},
+			data:       []sstutil.KV{{"a", 3, "a3"}},
+			sst:        []sstutil.KV{{"a", 3, "a3"}},
 			expectErr:  &roachpb.WriteTooOldError{},
 		},
 		"DisallowConflicts allows new SST tombstones": { // unfortunately, for performance
 			noConflict: true,
-			sst:        []mvccKV{{"a", 3, ""}},
-			expect:     []mvccKV{{"a", 3, ""}},
+			sst:        []sstutil.KV{{"a", 3, ""}},
+			expect:     []sstutil.KV{{"a", 3, ""}},
 		},
 		"DisallowConflicts rejects SST tombstones when shadowing": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 2, "a2"}},
-			sst:        []mvccKV{{"a", 3, ""}},
+			data:       []sstutil.KV{{"a", 2, "a2"}},
+			sst:        []sstutil.KV{{"a", 3, ""}},
 			expectErr:  "SST values cannot be tombstones",
 		},
 		"DisallowConflicts allows new SST inline values": { // unfortunately, for performance
 			noConflict: true,
-			sst:        []mvccKV{{"a", 0, "inline"}},
-			expect:     []mvccKV{{"a", 0, "inline"}},
+			sst:        []sstutil.KV{{"a", 0, "inline"}},
+			expect:     []sstutil.KV{{"a", 0, "inline"}},
 		},
 		"DisallowConflicts rejects SST inline values when shadowing": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 2, "a2"}},
-			sst:        []mvccKV{{"a", 0, ""}},
+			data:       []sstutil.KV{{"a", 2, "a2"}},
+			sst:        []sstutil.KV{{"a", 0, ""}},
 			expectErr:  "SST keys must have timestamps",
 		},
 		"DisallowConflicts rejects existing inline values when shadowing": {
 			noConflict: true,
-			data:       []mvccKV{{"a", 0, "a0"}},
-			sst:        []mvccKV{{"a", 3, "sst"}},
+			data:       []sstutil.KV{{"a", 0, "a0"}},
+			sst:        []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:  "inline values are unsupported",
 		},
 
 		// DisallowShadowing
 		"DisallowShadowing errors above existing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 3, "a3"}},
-			sst:       []mvccKV{{"a", 4, "sst"}},
+			data:      []sstutil.KV{{"a", 3, "a3"}},
+			sst:       []sstutil.KV{{"a", 4, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowing errors below existing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 3, "a3"}},
-			sst:       []mvccKV{{"a", 2, "sst"}},
+			data:      []sstutil.KV{{"a", 3, "a3"}},
+			sst:       []sstutil.KV{{"a", 2, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowing errors at existing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 3, "a3"}},
-			sst:       []mvccKV{{"a", 3, "sst"}},
+			data:      []sstutil.KV{{"a", 3, "a3"}},
+			sst:       []sstutil.KV{{"a", 3, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowing returns WriteTooOldError at existing tombstone": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 3, ""}},
-			sst:       []mvccKV{{"a", 3, "sst"}},
+			data:      []sstutil.KV{{"a", 3, ""}},
+			sst:       []sstutil.KV{{"a", 3, "sst"}},
 			expectErr: &roachpb.WriteTooOldError{},
 		},
 		"DisallowShadowing returns WriteTooOldError below existing tombstone": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 3, ""}},
-			sst:       []mvccKV{{"a", 2, "sst"}},
+			data:      []sstutil.KV{{"a", 3, ""}},
+			sst:       []sstutil.KV{{"a", 2, "sst"}},
 			expectErr: &roachpb.WriteTooOldError{},
 		},
 		"DisallowShadowing allows above existing tombstone": {
 			noShadow: true,
-			data:     []mvccKV{{"a", 3, ""}},
-			sst:      []mvccKV{{"a", 4, "sst"}},
-			expect:   []mvccKV{{"a", 4, "sst"}, {"a", 3, ""}},
+			data:     []sstutil.KV{{"a", 3, ""}},
+			sst:      []sstutil.KV{{"a", 4, "sst"}},
+			expect:   []sstutil.KV{{"a", 4, "sst"}, {"a", 3, ""}},
 		},
 		"DisallowShadowing returns WriteIntentError below intent": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", intentTS, "intent"}},
-			sst:       []mvccKV{{"a", 3, "sst"}},
+			data:      []sstutil.KV{{"a", intentTS, "intent"}},
+			sst:       []sstutil.KV{{"a", 3, "sst"}},
 			expectErr: &roachpb.WriteIntentError{},
 		},
 		"DisallowShadowing ignores intents in span": { // inconsistent with blind writes
 			noShadow: true,
-			data:     []mvccKV{{"b", intentTS, "intent"}},
-			sst:      []mvccKV{{"a", 3, "sst"}, {"c", 3, "sst"}},
-			expect:   []mvccKV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
+			data:     []sstutil.KV{{"b", intentTS, "intent"}},
+			sst:      []sstutil.KV{{"a", 3, "sst"}, {"c", 3, "sst"}},
+			expect:   []sstutil.KV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
 		},
 		"DisallowShadowing is idempotent": {
 			noShadow: true,
-			data:     []mvccKV{{"a", 3, "a3"}},
-			sst:      []mvccKV{{"a", 3, "a3"}},
-			expect:   []mvccKV{{"a", 3, "a3"}},
+			data:     []sstutil.KV{{"a", 3, "a3"}},
+			sst:      []sstutil.KV{{"a", 3, "a3"}},
+			expect:   []sstutil.KV{{"a", 3, "a3"}},
 		},
 		"DisallowShadowing allows new SST tombstones": { // unfortunately, for performance
 			noShadow: true,
-			sst:      []mvccKV{{"a", 3, ""}},
-			expect:   []mvccKV{{"a", 3, ""}},
+			sst:      []sstutil.KV{{"a", 3, ""}},
+			expect:   []sstutil.KV{{"a", 3, ""}},
 		},
 		"DisallowShadowing rejects SST tombstones when shadowing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, "a2"}},
-			sst:       []mvccKV{{"a", 3, ""}},
+			data:      []sstutil.KV{{"a", 2, "a2"}},
+			sst:       []sstutil.KV{{"a", 3, ""}},
 			expectErr: "SST values cannot be tombstones",
 		},
 		"DisallowShadowing allows new SST inline values": { // unfortunately, for performance
 			noShadow: true,
-			sst:      []mvccKV{{"a", 0, "inline"}},
-			expect:   []mvccKV{{"a", 0, "inline"}},
+			sst:      []sstutil.KV{{"a", 0, "inline"}},
+			expect:   []sstutil.KV{{"a", 0, "inline"}},
 		},
 		"DisallowShadowing rejects SST inline values when shadowing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, "a2"}},
-			sst:       []mvccKV{{"a", 0, "inline"}},
+			data:      []sstutil.KV{{"a", 2, "a2"}},
+			sst:       []sstutil.KV{{"a", 0, "inline"}},
 			expectErr: "SST keys must have timestamps",
 		},
 		"DisallowShadowing rejects existing inline values when shadowing": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 0, "a0"}},
-			sst:       []mvccKV{{"a", 3, "sst"}},
+			data:      []sstutil.KV{{"a", 0, "a0"}},
+			sst:       []sstutil.KV{{"a", 3, "sst"}},
 			expectErr: "inline values are unsupported",
 		},
 		"DisallowShadowing collision SST start, existing start, above": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, "a2"}},
-			sst:       []mvccKV{{"a", 7, "sst"}},
+			data:      []sstutil.KV{{"a", 2, "a2"}},
+			sst:       []sstutil.KV{{"a", 7, "sst"}},
 			expectErr: `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowing collision SST start, existing middle, below": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"c", 3, "c3"}},
-			sst:       []mvccKV{{"b", 1, "sst"}},
+			data:      []sstutil.KV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"c", 3, "c3"}},
+			sst:       []sstutil.KV{{"b", 1, "sst"}},
 			expectErr: `ingested key collides with an existing one: "b"`,
 		},
 		"DisallowShadowing collision SST end, existing end, above": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"d", 3, "d3"}},
-			sst:       []mvccKV{{"c", 3, "sst"}, {"d", 4, "sst"}},
+			data:      []sstutil.KV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"d", 3, "d3"}},
+			sst:       []sstutil.KV{{"c", 3, "sst"}, {"d", 4, "sst"}},
 			expectErr: `ingested key collides with an existing one: "d"`,
 		},
 		"DisallowShadowing collision after write above tombstone": {
 			noShadow:  true,
-			data:      []mvccKV{{"a", 2, ""}, {"a", 1, "a1"}, {"b", 2, "b2"}},
-			sst:       []mvccKV{{"a", 3, "sst"}, {"b", 1, "sst"}},
+			data:      []sstutil.KV{{"a", 2, ""}, {"a", 1, "a1"}, {"b", 2, "b2"}},
+			sst:       []sstutil.KV{{"a", 3, "sst"}, {"b", 1, "sst"}},
 			expectErr: `ingested key collides with an existing one: "b"`,
 		},
 
@@ -403,232 +385,232 @@ func TestEvalAddSSTable(t *testing.T) {
 		"DisallowShadowingBelow can be used with DisallowShadowing": {
 			noShadow:      true,
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 5, "123"}},
-			sst:           []mvccKV{{"a", 6, "123"}},
-			expect:        []mvccKV{{"a", 6, "123"}, {"a", 5, "123"}},
+			data:          []sstutil.KV{{"a", 5, "123"}},
+			sst:           []sstutil.KV{{"a", 6, "123"}},
+			expect:        []sstutil.KV{{"a", 6, "123"}, {"a", 5, "123"}},
 		},
 		"DisallowShadowingBelow errors above existing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 4, "sst"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 4, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow errors below existing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 2, "sst"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 2, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow errors at existing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 3, "sst"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow returns WriteTooOldError at existing tombstone": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, ""}},
-			sst:           []mvccKV{{"a", 3, "sst"}},
+			data:          []sstutil.KV{{"a", 3, ""}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:     &roachpb.WriteTooOldError{},
 		},
 		"DisallowShadowingBelow returns WriteTooOldError below existing tombstone": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, ""}},
-			sst:           []mvccKV{{"a", 2, "sst"}},
+			data:          []sstutil.KV{{"a", 3, ""}},
+			sst:           []sstutil.KV{{"a", 2, "sst"}},
 			expectErr:     &roachpb.WriteTooOldError{},
 		},
 		"DisallowShadowingBelow allows above existing tombstone": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, ""}},
-			sst:           []mvccKV{{"a", 4, "sst"}},
-			expect:        []mvccKV{{"a", 4, "sst"}, {"a", 3, ""}},
+			data:          []sstutil.KV{{"a", 3, ""}},
+			sst:           []sstutil.KV{{"a", 4, "sst"}},
+			expect:        []sstutil.KV{{"a", 4, "sst"}, {"a", 3, ""}},
 		},
 		"DisallowShadowingBelow returns WriteIntentError below intent": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", intentTS, "intent"}},
-			sst:           []mvccKV{{"a", 3, "sst"}},
+			data:          []sstutil.KV{{"a", intentTS, "intent"}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:     &roachpb.WriteIntentError{},
 		},
 		"DisallowShadowingBelow ignores intents in span": { // inconsistent with blind writes
 			noShadowBelow: 5,
-			data:          []mvccKV{{"b", intentTS, "intent"}},
-			sst:           []mvccKV{{"a", 3, "sst"}, {"c", 3, "sst"}},
-			expect:        []mvccKV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
+			data:          []sstutil.KV{{"b", intentTS, "intent"}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}, {"c", 3, "sst"}},
+			expect:        []sstutil.KV{{"a", 3, "sst"}, {"b", intentTS, "intent"}, {"c", 3, "sst"}},
 		},
 		"DisallowShadowingBelow is not generally idempotent": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 3, "a3"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 3, "a3"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow allows new SST tombstones": { // unfortunately, for performance
 			noShadowBelow: 5,
-			sst:           []mvccKV{{"a", 3, ""}},
-			expect:        []mvccKV{{"a", 3, ""}},
+			sst:           []sstutil.KV{{"a", 3, ""}},
+			expect:        []sstutil.KV{{"a", 3, ""}},
 		},
 		"DisallowShadowingBelow rejects SST tombstones when shadowing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, "a2"}},
-			sst:           []mvccKV{{"a", 3, ""}},
+			data:          []sstutil.KV{{"a", 2, "a2"}},
+			sst:           []sstutil.KV{{"a", 3, ""}},
 			expectErr:     "SST values cannot be tombstones",
 		},
 		"DisallowShadowingBelow allows new SST inline values": { // unfortunately, for performance
 			noShadowBelow: 5,
-			sst:           []mvccKV{{"a", 0, "inline"}},
-			expect:        []mvccKV{{"a", 0, "inline"}},
+			sst:           []sstutil.KV{{"a", 0, "inline"}},
+			expect:        []sstutil.KV{{"a", 0, "inline"}},
 		},
 		"DisallowShadowingBelow rejects SST inline values when shadowing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, "a2"}},
-			sst:           []mvccKV{{"a", 0, "inline"}},
+			data:          []sstutil.KV{{"a", 2, "a2"}},
+			sst:           []sstutil.KV{{"a", 0, "inline"}},
 			expectErr:     "SST keys must have timestamps",
 		},
 		"DisallowShadowingBelow rejects existing inline values when shadowing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 0, "a0"}},
-			sst:           []mvccKV{{"a", 3, "sst"}},
+			data:          []sstutil.KV{{"a", 0, "a0"}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}},
 			expectErr:     "inline values are unsupported",
 		},
 		"DisallowShadowingBelow collision SST start, existing start, above": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, "a2"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 2, "a2"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow collision SST start, existing middle, below": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"c", 3, "c3"}},
-			sst:           []mvccKV{{"b", 1, "sst"}},
+			data:          []sstutil.KV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"c", 3, "c3"}},
+			sst:           []sstutil.KV{{"b", 1, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "b"`,
 		},
 		"DisallowShadowingBelow collision SST end, existing end, above": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"d", 3, "d3"}},
-			sst:           []mvccKV{{"c", 3, "sst"}, {"d", 4, "sst"}},
+			data:          []sstutil.KV{{"a", 2, "a2"}, {"a", 1, "a1"}, {"b", 2, "b2"}, {"d", 3, "d3"}},
+			sst:           []sstutil.KV{{"c", 3, "sst"}, {"d", 4, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "d"`,
 		},
 		"DisallowShadowingBelow collision after write above tombstone": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 2, ""}, {"a", 1, "a1"}, {"b", 2, "b2"}},
-			sst:           []mvccKV{{"a", 3, "sst"}, {"b", 1, "sst"}},
+			data:          []sstutil.KV{{"a", 2, ""}, {"a", 1, "a1"}, {"b", 2, "b2"}},
+			sst:           []sstutil.KV{{"a", 3, "sst"}, {"b", 1, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "b"`,
 		},
 		"DisallowShadowingBelow at limit writes": {
 			noShadowBelow: 5,
-			sst:           []mvccKV{{"a", 5, "sst"}},
-			expect:        []mvccKV{{"a", 5, "sst"}},
+			sst:           []sstutil.KV{{"a", 5, "sst"}},
+			expect:        []sstutil.KV{{"a", 5, "sst"}},
 		},
 		"DisallowShadowingBelow at limit errors above existing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 5, "sst"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 5, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow at limit errors above existing with same value": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 3, "a3"}},
-			sst:           []mvccKV{{"a", 5, "a3"}},
+			data:          []sstutil.KV{{"a", 3, "a3"}},
+			sst:           []sstutil.KV{{"a", 5, "a3"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow at limit errors on replacing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 5, "a3"}},
-			sst:           []mvccKV{{"a", 5, "sst"}},
+			data:          []sstutil.KV{{"a", 5, "a3"}},
+			sst:           []sstutil.KV{{"a", 5, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow at limit is idempotent": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 5, "a3"}},
-			sst:           []mvccKV{{"a", 5, "a3"}},
-			expect:        []mvccKV{{"a", 5, "a3"}},
+			data:          []sstutil.KV{{"a", 5, "a3"}},
+			sst:           []sstutil.KV{{"a", 5, "a3"}},
+			expect:        []sstutil.KV{{"a", 5, "a3"}},
 		},
 		"DisallowShadowingBelow above limit writes": {
 			noShadowBelow: 5,
-			sst:           []mvccKV{{"a", 7, "sst"}},
-			expect:        []mvccKV{{"a", 7, "sst"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
+			expect:        []sstutil.KV{{"a", 7, "sst"}},
 		},
 		"DisallowShadowingBelow above limit errors on existing below limit": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 4, "a4"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 4, "a4"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit errors on existing below limit with same value": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 4, "a4"}},
-			sst:           []mvccKV{{"a", 7, "a3"}},
+			data:          []sstutil.KV{{"a", 4, "a4"}},
+			sst:           []sstutil.KV{{"a", 7, "a3"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit errors on existing at limit": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 5, "a5"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 5, "a5"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit allows equal value at limit": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 5, "a5"}},
-			sst:           []mvccKV{{"a", 7, "a5"}},
-			expect:        []mvccKV{{"a", 7, "a5"}, {"a", 5, "a5"}},
+			data:          []sstutil.KV{{"a", 5, "a5"}},
+			sst:           []sstutil.KV{{"a", 7, "a5"}},
+			expect:        []sstutil.KV{{"a", 7, "a5"}, {"a", 5, "a5"}},
 		},
 		"DisallowShadowingBelow above limit errors on existing above limit": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 6, "a6"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 6, "a6"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit allows equal value above limit": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 6, "a6"}},
-			sst:           []mvccKV{{"a", 7, "a6"}},
-			expect:        []mvccKV{{"a", 7, "a6"}, {"a", 6, "a6"}},
+			data:          []sstutil.KV{{"a", 6, "a6"}},
+			sst:           []sstutil.KV{{"a", 7, "a6"}},
+			expect:        []sstutil.KV{{"a", 7, "a6"}, {"a", 6, "a6"}},
 		},
 		"DisallowShadowingBelow above limit errors on replacing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 7, "a7"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 7, "a7"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit is idempotent": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 7, "a7"}},
-			sst:           []mvccKV{{"a", 7, "a7"}},
-			expect:        []mvccKV{{"a", 7, "a7"}},
+			data:          []sstutil.KV{{"a", 7, "a7"}},
+			sst:           []sstutil.KV{{"a", 7, "a7"}},
+			expect:        []sstutil.KV{{"a", 7, "a7"}},
 		},
 		"DisallowShadowingBelow above limit errors below existing": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 8, "a8"}},
-			sst:           []mvccKV{{"a", 7, "sst"}},
+			data:          []sstutil.KV{{"a", 8, "a8"}},
+			sst:           []sstutil.KV{{"a", 7, "sst"}},
 			expectErr:     `ingested key collides with an existing one: "a"`,
 		},
 		"DisallowShadowingBelow above limit errors below existing with same value": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 8, "a8"}},
-			sst:           []mvccKV{{"a", 7, "a8"}},
+			data:          []sstutil.KV{{"a", 8, "a8"}},
+			sst:           []sstutil.KV{{"a", 7, "a8"}},
 			expectErr:     &roachpb.WriteTooOldError{},
 		},
 		"DisallowShadowingBelow above limit errors below tombstone": {
 			noShadowBelow: 5,
-			data:          []mvccKV{{"a", 8, ""}},
-			sst:           []mvccKV{{"a", 7, "a8"}},
+			data:          []sstutil.KV{{"a", 8, ""}},
+			sst:           []sstutil.KV{{"a", 7, "a8"}},
 			expectErr:     &roachpb.WriteTooOldError{},
 		},
 
 		// SSTTimestamp
 		"SSTTimestamp works with WriteAtRequestTimestamp": {
 			atReqTS:        7,
-			data:           []mvccKV{{"a", 6, "a6"}},
-			sst:            []mvccKV{{"a", 7, "a7"}},
+			data:           []sstutil.KV{{"a", 6, "a6"}},
+			sst:            []sstutil.KV{{"a", 7, "a7"}},
 			sstTimestamp:   7,
-			expect:         []mvccKV{{"a", 7, "a7"}, {"a", 6, "a6"}},
+			expect:         []sstutil.KV{{"a", 7, "a7"}, {"a", 6, "a6"}},
 			expectStatsEst: true,
 		},
 		"SSTTimestamp doesn't rewrite with incorrect timestamp, but errors under race": {
 			atReqTS:            8,
-			data:               []mvccKV{{"a", 6, "a6"}},
-			sst:                []mvccKV{{"a", 7, "a7"}},
+			data:               []sstutil.KV{{"a", 6, "a6"}},
+			sst:                []sstutil.KV{{"a", 7, "a7"}},
 			sstTimestamp:       8,
-			expect:             []mvccKV{{"a", 7, "a7"}, {"a", 6, "a6"}},
+			expect:             []sstutil.KV{{"a", 7, "a7"}, {"a", 6, "a6"}},
 			expectErrUnderRace: `incorrect timestamp 0.000000007,0 for SST key "a" (expected 0.000000008,0)`,
 			expectStatsEst:     true,
 		},
@@ -650,16 +632,16 @@ func TestEvalAddSSTable(t *testing.T) {
 				for i := len(tc.data) - 1; i >= 0; i-- { // reverse, older timestamps first
 					kv := tc.data[i]
 					var txn *roachpb.Transaction
-					if kv.ts == intentTS {
+					if kv.WallTimestamp == intentTS {
 						txn = &intentTxn
 					}
-					require.NoError(t, storage.MVCCPut(ctx, b, nil, kv.Key(), kv.TS(), kv.Value(), txn))
+					require.NoError(t, storage.MVCCPut(ctx, b, nil, kv.Key(), kv.Timestamp(), kv.Value(), txn))
 				}
 				require.NoError(t, b.Commit(false))
 				stats := engineStats(t, engine)
 
 				// Build and add SST.
-				sst, start, end := makeSST(t, tc.sst)
+				sst, start, end := sstutil.MakeSST(t, tc.sst)
 				reqTS := hlc.Timestamp{WallTime: defaultReqTS}
 				if tc.atReqTS != 0 {
 					reqTS.WallTime = tc.atReqTS
@@ -674,7 +656,7 @@ func TestEvalAddSSTable(t *testing.T) {
 					Args: &roachpb.AddSSTableRequest{
 						RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
 						Data:                    sst,
-						MVCCStats:               sstStats(t, sst),
+						MVCCStats:               sstutil.ComputeStats(t, sst),
 						DisallowConflicts:       tc.noConflict,
 						DisallowShadowing:       tc.noShadow,
 						DisallowShadowingBelow:  hlc.Timestamp{WallTime: tc.noShadowBelow},
@@ -722,7 +704,7 @@ func TestEvalAddSSTable(t *testing.T) {
 				})
 				defer iter.Close()
 				iter.SeekGE(storage.MVCCKey{Key: keys.SystemPrefix})
-				scan := []mvccKV{}
+				scan := []sstutil.KV{}
 				for {
 					ok, err := iter.Valid()
 					require.NoError(t, err)
@@ -748,7 +730,7 @@ func TestEvalAddSSTable(t *testing.T) {
 						value, err = roachpb.Value{RawBytes: meta.RawBytes}.GetBytes()
 						require.NoError(t, err)
 					}
-					scan = append(scan, mvccKV{key: key, ts: ts, value: string(value)})
+					scan = append(scan, sstutil.KV{key, ts, string(value)})
 					iter.Next()
 				}
 				require.Equal(t, tc.expect, scan)
@@ -810,7 +792,7 @@ func runTestDBAddSSTable(
 	var noTS hlc.Timestamp
 
 	{
-		sst, start, end := makeSST(t, []mvccKV{{"bb", 2, "1"}})
+		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bb", 2, "1"}})
 
 		// Key is before the range in the request span.
 		err := db.AddSSTable(
@@ -852,7 +834,7 @@ func runTestDBAddSSTable(
 	// Check that ingesting a key with an earlier mvcc timestamp doesn't affect
 	// the value returned by Get.
 	{
-		sst, start, end := makeSST(t, []mvccKV{{"bb", 1, "2"}})
+		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bb", 1, "2"}})
 		require.NoError(t, db.AddSSTable(
 			ctx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS))
 		r, err := db.Get(ctx, "bb")
@@ -866,7 +848,7 @@ func runTestDBAddSSTable(
 	// Key range in request span is not empty. First time through a different
 	// key is present. Second time through checks the idempotency.
 	{
-		sst, start, end := makeSST(t, []mvccKV{{"bc", 1, "3"}})
+		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bc", 1, "3"}})
 
 		var before int64
 		if store != nil {
@@ -902,7 +884,7 @@ func runTestDBAddSSTable(
 
 	// ... and doing the same thing but via write-batch works the same.
 	{
-		sst, start, end := makeSST(t, []mvccKV{{"bd", 1, "3"}})
+		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bd", 1, "3"}})
 
 		var before int64
 		if store != nil {
@@ -964,7 +946,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	require.NoError(t, err)
 	defer engine.Close()
 
-	for _, kv := range []mvccKV{
+	for _, kv := range []sstutil.KV{
 		{"A", 1, "A"},
 		{"a", 1, "a"},
 		{"a", 6, ""},
@@ -978,7 +960,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		require.NoError(t, engine.PutMVCC(kv.MVCCKey(), kv.ValueBytes()))
 	}
 
-	sst, start, end := makeSST(t, []mvccKV{
+	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{
 		{"a", 4, "aaaaaa"}, // mvcc-shadowed by existing delete.
 		{"a", 2, "aa"},     // mvcc-shadowed within SST.
 		{"c", 6, "ccc"},    // same TS as existing, LSM-shadows existing.
@@ -1030,7 +1012,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	require.Equal(t, engineStats(t, engine), statsEvaled)
 
 	// Check stats for a single KV.
-	sst, start, end = makeSST(t, []mvccKV{{"zzzzzzz", ts.WallTime, "zzz"}})
+	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{{"zzzzzzz", ts.WallTime, "zzz"}})
 	cArgsWithStats := batcheval.CommandArgs{
 		EvalCtx: evalCtx,
 		Header:  roachpb.Header{Timestamp: ts},
@@ -1059,7 +1041,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 	engine := storage.NewDefaultInMemForTesting()
 	defer engine.Close()
 
-	for _, kv := range []mvccKV{
+	for _, kv := range []sstutil.KV{
 		{"a", 2, "aa"},
 		{"b", 1, "bb"},
 		{"b", 6, ""},
@@ -1082,11 +1064,11 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 	// CommandArgs Stats field by using:
 	// cArgs.Stats + ingested_stats - skipped_stats.
 	// Successfully evaluate the first SST as there are no key collisions.
-	kvs := []mvccKV{
+	kvs := []sstutil.KV{
 		{"c", 2, "bb"},
 		{"h", 6, "hh"},
 	}
-	sst, start, end := makeSST(t, kvs)
+	sst, start, end := sstutil.MakeSST(t, kvs)
 
 	// Accumulate stats across SST ingestion.
 	commandStats := enginepb.MVCCStats{}
@@ -1100,7 +1082,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 			RequestHeader:     roachpb.RequestHeader{Key: start, EndKey: end},
 			Data:              sst,
 			DisallowShadowing: true,
-			MVCCStats:         sstStats(t, sst),
+			MVCCStats:         sstutil.ComputeStats(t, sst),
 		},
 		Stats: &commandStats,
 	}
@@ -1117,7 +1099,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 
 	// Evaluate the second SST. Both the KVs are perfectly shadowing and should
 	// not contribute to the stats.
-	sst, start, end = makeSST(t, []mvccKV{
+	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{
 		{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
 		{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
 	})
@@ -1126,7 +1108,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		RequestHeader:     roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:              sst,
 		DisallowShadowing: true,
-		MVCCStats:         sstStats(t, sst),
+		MVCCStats:         sstutil.ComputeStats(t, sst),
 	}
 	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
 	require.NoError(t, err)
@@ -1136,7 +1118,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 
 	// Evaluate the third SST. Two of the three KVs are perfectly shadowing, but
 	// there is one valid KV which should contribute to the stats.
-	sst, start, end = makeSST(t, []mvccKV{
+	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{
 		{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
 		{"e", 2, "ee"},
 		{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
@@ -1146,7 +1128,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		RequestHeader:     roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:              sst,
 		DisallowShadowing: true,
-		MVCCStats:         sstStats(t, sst),
+		MVCCStats:         sstutil.ComputeStats(t, sst),
 	}
 	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
 	require.NoError(t, err)
@@ -1185,7 +1167,7 @@ func TestAddSSTableIntentResolution(t *testing.T) {
 	// Generate an SSTable that covers keys a, b, and c, and submit it with high
 	// priority. This is going to abort the transaction above, encounter its
 	// intent, and resolve it.
-	sst, start, end := makeSST(t, []mvccKV{
+	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{
 		{"a", 1, "1"},
 		{"b", 1, "2"},
 		{"c", 1, "3"},
@@ -1196,7 +1178,7 @@ func TestAddSSTableIntentResolution(t *testing.T) {
 	ba.Add(&roachpb.AddSSTableRequest{
 		RequestHeader:     roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:              sst,
-		MVCCStats:         sstStats(t, sst),
+		MVCCStats:         sstutil.ComputeStats(t, sst),
 		DisallowShadowing: true,
 	})
 	_, pErr := db.NonTransactionalSender().Send(ctx, ba)
@@ -1227,11 +1209,11 @@ func TestAddSSTableWriteAtRequestTimestampRespectsTSCache(t *testing.T) {
 	txnTS := txn.CommitTimestamp()
 
 	// Add an SST writing below the previous write.
-	sst, start, end := makeSST(t, []mvccKV{{"key", 1, "sst"}})
+	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"key", 1, "sst"}})
 	sstReq := &roachpb.AddSSTableRequest{
 		RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:                    sst,
-		MVCCStats:               sstStats(t, sst),
+		MVCCStats:               sstutil.ComputeStats(t, sst),
 		WriteAtRequestTimestamp: true,
 	}
 	ba := roachpb.BatchRequest{
@@ -1287,11 +1269,11 @@ func TestAddSSTableWriteAtRequestTimestampRespectsClosedTS(t *testing.T) {
 
 	// Add an SST writing below the closed timestamp. It should get pushed above it.
 	reqTS := closedTS.Prev()
-	sst, start, end := makeSST(t, []mvccKV{{"key", 1, "sst"}})
+	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"key", 1, "sst"}})
 	sstReq := &roachpb.AddSSTableRequest{
 		RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:                    sst,
-		MVCCStats:               sstStats(t, sst),
+		MVCCStats:               sstutil.ComputeStats(t, sst),
 		WriteAtRequestTimestamp: true,
 	}
 	ba := roachpb.BatchRequest{
@@ -1312,50 +1294,6 @@ func TestAddSSTableWriteAtRequestTimestampRespectsClosedTS(t *testing.T) {
 	v, err := roachpb.Value{RawBytes: kvs[0].Value}.GetBytes()
 	require.NoError(t, err)
 	require.Equal(t, "sst", string(v))
-}
-
-// makeSST builds a binary in-memory SST from the given data.
-func makeSST(t *testing.T, kvs []mvccKV) ([]byte, roachpb.Key, roachpb.Key) {
-	t.Helper()
-
-	sstFile := &storage.MemFile{}
-	writer := storage.MakeBackupSSTWriter(sstFile)
-	defer writer.Close()
-
-	start, end := keys.MaxKey, keys.MinKey
-	for _, kv := range kvs {
-		if kv.key < string(start) {
-			start = roachpb.Key(kv.key)
-		}
-		if kv.key > string(end) {
-			end = roachpb.Key(kv.key)
-		}
-		if kv.ts == 0 {
-			meta := &enginepb.MVCCMetadata{RawBytes: kv.ValueBytes()}
-			metaBytes, err := protoutil.Marshal(meta)
-			require.NoError(t, err)
-			require.NoError(t, writer.PutUnversioned(kv.Key(), metaBytes))
-		} else {
-			require.NoError(t, writer.PutMVCC(kv.MVCCKey(), kv.ValueBytes()))
-		}
-	}
-	require.NoError(t, writer.Finish())
-	writer.Close()
-
-	return sstFile.Data(), start, end.Next()
-}
-
-// sstStats computes the MVCC stats for the given binary SST.
-func sstStats(t *testing.T, sst []byte) *enginepb.MVCCStats {
-	t.Helper()
-
-	iter, err := storage.NewMemSSTIterator(sst, true)
-	require.NoError(t, err)
-	defer iter.Close()
-
-	stats, err := storage.ComputeStatsForRange(iter, keys.MinKey, keys.MaxKey, 0)
-	require.NoError(t, err)
-	return &stats
 }
 
 // engineStats computes the MVCC stats for the given engine.

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -693,6 +693,8 @@ func TestEvalAddSSTable(t *testing.T) {
 					require.NoError(t, engine.WriteFile(sstPath, result.Replicated.AddSSTable.Data))
 					require.NoError(t, engine.IngestExternalFiles(ctx, []string{sstPath}))
 				}
+				require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+				require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans, []roachpb.Span{{Key: start, EndKey: end}})
 
 				// Scan resulting data from engine.
 				iter := storage.NewMVCCIncrementalIterator(engine, storage.MVCCIncrementalIterOptions{

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -693,8 +694,6 @@ func TestEvalAddSSTable(t *testing.T) {
 					require.NoError(t, engine.WriteFile(sstPath, result.Replicated.AddSSTable.Data))
 					require.NoError(t, engine.IngestExternalFiles(ctx, []string{sstPath}))
 				}
-				require.NotNil(t, result.Replicated.MVCCHistoryMutation)
-				require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans, []roachpb.Span{{Key: start, EndKey: end}})
 
 				// Scan resulting data from engine.
 				iter := storage.NewMVCCIncrementalIterator(engine, storage.MVCCIncrementalIterOptions{
@@ -748,6 +747,99 @@ func TestEvalAddSSTable(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestEvalAddSSTableRangefeed tests EvalAddSSTable rangefeed-related
+// behavior.
+func TestEvalAddSSTableRangefeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	reqTS := hlc.Timestamp{WallTime: 10}
+
+	testcases := map[string]struct {
+		sst                   []sstutil.KV
+		atReqTS               bool // WriteAtRequestTimestamp
+		asWrites              bool // IngestAsWrites
+		expectHistoryMutation bool
+		expectLogicalOps      []enginepb.MVCCLogicalOp
+	}{
+		"Default": {
+			sst:                   []sstutil.KV{{"a", 1, "a1"}},
+			expectHistoryMutation: true,
+			expectLogicalOps:      nil,
+		},
+		"WriteAtRequestTimestamp alone": {
+			sst:                   []sstutil.KV{{"a", 1, "a1"}},
+			atReqTS:               true,
+			expectHistoryMutation: false,
+			expectLogicalOps:      nil,
+		},
+		"IngestAsWrites alone": {
+			sst:                   []sstutil.KV{{"a", 1, "a1"}},
+			asWrites:              true,
+			expectHistoryMutation: true,
+			expectLogicalOps:      nil,
+		},
+		"IngestAsWrites and WriteAtRequestTimestamp": {
+			sst:                   []sstutil.KV{{"a", 1, "a1"}, {"b", 2, "b2"}},
+			asWrites:              true,
+			atReqTS:               true,
+			expectHistoryMutation: false,
+			expectLogicalOps: []enginepb.MVCCLogicalOp{
+				// NOTE: Value is populated by the rangefeed processor, not MVCC, so it
+				// won't show up here.
+				{WriteValue: &enginepb.MVCCWriteValueOp{Key: roachpb.Key("a"), Timestamp: reqTS}},
+				{WriteValue: &enginepb.MVCCWriteValueOp{Key: roachpb.Key("b"), Timestamp: reqTS}},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			st := cluster.MakeTestingClusterSettings()
+			ctx := context.Background()
+
+			engine := storage.NewDefaultInMemForTesting()
+			defer engine.Close()
+			opLogger := storage.NewOpLoggerBatch(engine.NewBatch())
+
+			// Build and add SST.
+			sst, start, end := sstutil.MakeSST(t, tc.sst)
+			result, err := batcheval.EvalAddSSTable(ctx, opLogger, batcheval.CommandArgs{
+				EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext(),
+				Header: roachpb.Header{
+					Timestamp: reqTS,
+				},
+				Stats: &enginepb.MVCCStats{},
+				Args: &roachpb.AddSSTableRequest{
+					RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
+					Data:                    sst,
+					MVCCStats:               sstutil.ComputeStats(t, sst),
+					WriteAtRequestTimestamp: tc.atReqTS,
+					IngestAsWrites:          tc.asWrites,
+				},
+			}, &roachpb.AddSSTableResponse{})
+			require.NoError(t, err)
+
+			if tc.asWrites {
+				require.Nil(t, result.Replicated.AddSSTable)
+			} else {
+				require.NotNil(t, result.Replicated.AddSSTable)
+				require.Equal(t, roachpb.Span{Key: start, EndKey: end}, result.Replicated.AddSSTable.Span)
+				require.Equal(t, tc.atReqTS, result.Replicated.AddSSTable.AtWriteTimestamp)
+			}
+			if tc.expectHistoryMutation {
+				require.Equal(t, &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
+					Spans: []roachpb.Span{{Key: start, EndKey: end}},
+				}, result.Replicated.MVCCHistoryMutation)
+				require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+			} else {
+				require.Nil(t, result.Replicated.MVCCHistoryMutation)
+			}
+			require.Equal(t, tc.expectLogicalOps, opLogger.LogicalOps())
+		})
+	}
 }
 
 // TestDBAddSSTable tests application of an SST to a database, both in-memory

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 type wrappedBatch struct {
@@ -133,9 +134,10 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			}
 			cArgs.Stats = &enginepb.MVCCStats{}
 
-			if _, err := ClearRange(ctx, batch, cArgs, &roachpb.ClearRangeResponse{}); err != nil {
-				t.Fatal(err)
-			}
+			result, err := ClearRange(ctx, batch, cArgs, &roachpb.ClearRangeResponse{})
+			require.NoError(t, err)
+			require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+			require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans, []roachpb.Span{{Key: startKey, EndKey: endKey}})
 
 			// Verify cArgs.Stats is equal to the stats we wrote, ignoring some values.
 			newStats := stats

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -75,7 +76,13 @@ func RevertRange(
 
 	args := cArgs.Args.(*roachpb.RevertRangeRequest)
 	reply := resp.(*roachpb.RevertRangeResponse)
-	var pd result.Result
+	pd := result.Result{
+		Replicated: kvserverpb.ReplicatedEvalResult{
+			MVCCHistoryMutation: &kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation{
+				Spans: []roachpb.Span{{Key: args.Key, EndKey: args.EndKey}},
+			},
+		},
+	}
 
 	if empty, err := isEmptyKeyTimeRange(
 		readWriter, args.Key, args.EndKey, args.TargetTime, cArgs.Header.Timestamp,

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []byte {
@@ -160,9 +162,13 @@ func TestCmdRevertRange(t *testing.T) {
 					var resumes int
 					for {
 						var reply roachpb.RevertRangeResponse
-						if _, err := RevertRange(ctx, batch, cArgs, &reply); err != nil {
+						result, err := RevertRange(ctx, batch, cArgs, &reply)
+						if err != nil {
 							t.Fatal(err)
 						}
+						require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+						require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
+							[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
 						if reply.ResumeSpan == nil {
 							break
 						}
@@ -236,10 +242,14 @@ func TestCmdRevertRange(t *testing.T) {
 					var err error
 					for {
 						var reply roachpb.RevertRangeResponse
-						_, err = RevertRange(ctx, batch, cArgs, &reply)
+						var result result.Result
+						result, err = RevertRange(ctx, batch, cArgs, &reply)
 						if err != nil || reply.ResumeSpan == nil {
 							break
 						}
+						require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+						require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
+							[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
 						req.RequestHeader.Key = reply.ResumeSpan.Key
 						resumes++
 					}

--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -290,6 +290,14 @@ func (p *Result) MergeAndDestroy(q Result) error {
 	}
 	q.Replicated.AddSSTable = nil
 
+	if p.Replicated.MVCCHistoryMutation == nil {
+		p.Replicated.MVCCHistoryMutation = q.Replicated.MVCCHistoryMutation
+	} else if q.Replicated.MVCCHistoryMutation != nil {
+		p.Replicated.MVCCHistoryMutation.Spans = append(p.Replicated.MVCCHistoryMutation.Spans,
+			q.Replicated.MVCCHistoryMutation.Spans...)
+	}
+	q.Replicated.MVCCHistoryMutation = nil
+
 	if p.Replicated.PrevLeaseProposal == nil {
 		p.Replicated.PrevLeaseProposal = q.Replicated.PrevLeaseProposal
 	} else if q.Replicated.PrevLeaseProposal != nil {

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -140,6 +140,19 @@ message ReplicatedEvalResult {
   ChangeReplicas change_replicas = 12;
   int64 raft_log_delta = 13;
 
+  // MVCCHistoryMutation describes mutations of MVCC history that may violate
+  // the closed timestamp, timestamp cache, and guarantees that rely on these
+  // (e.g. linearizability and serializability). It is currently used to
+  // disconnect rangefeeds that overlap these spans, as a safeguard -- the
+  // caller is expected to ensure there are no rangefeeds over such spans in the
+  // first place.
+  //
+  // This is a separate message type to keep the base struct comparable in Go.
+  message MVCCHistoryMutation {
+    repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
+  }
+  MVCCHistoryMutation mvcc_history_mutation = 24 [(gogoproto.customname) = "MVCCHistoryMutation"];
+
   // AddSSTable is a side effect that must execute before the Raft application
   // is committed. It must be idempotent to account for an ill-timed crash after
   // applying the side effect, but before committing the batch.

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -164,10 +164,22 @@ message ReplicatedEvalResult {
   // since these Ranges are not user-visible, but it is a general concern assuming
   // other such side effects are added.
   message AddSSTable {
-    option (gogoproto.equal) = true;
-
     bytes data = 1;
     uint32 crc32 = 2 [(gogoproto.customname) = "CRC32"];
+    roachpb.Span span = 3 [(gogoproto.nullable) = false];
+    // If true, all SST MVCC timestamps equal the WriteTimestamp. This is given
+    // by the WriteAtRequestTimestamp request parameter, which was introduced in
+    // 22.1 and only used with the MVCCAddSSTable cluster version.
+    //
+    // TODO(erikgrinaker): This field currently controls whether to emit an
+    // AddSSTable event across the rangefeed. We could equivalently check
+    // MVCCHistoryMutation == nil, but that field was introduced in 22.1,
+    // and so for log entries written by 21.2 or older it will always be nil.
+    // It may be possible to remove this field and check MVCCHistoryMutation
+    // instead in 22.2, but _ONLY_ if a below-Raft cluster migration has also
+    // taken place since 22.1, to make sure all Raft log entries from 21.2 or
+    // older have been applied on all replicas.
+    bool at_write_timestamp = 4;
   }
   AddSSTable add_sstable = 17 [(gogoproto.customname) = "AddSSTable"];
 

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -119,6 +119,7 @@ type Processor struct {
 	filterReqC chan struct{}
 	filterResC chan *Filter
 	eventC     chan *event
+	spanErrC   chan spanErr
 	stopC      chan *roachpb.Error
 	stoppedC   chan struct{}
 }
@@ -155,6 +156,13 @@ type event struct {
 	testRegCatchupSpan roachpb.Span
 }
 
+// spanErr is an error across a key span that will disconnect overlapping
+// registrations.
+type spanErr struct {
+	span roachpb.Span
+	pErr *roachpb.Error
+}
+
 // NewProcessor creates a new rangefeed Processor. The corresponding goroutine
 // should be launched using the Start method.
 func NewProcessor(cfg Config) *Processor {
@@ -172,6 +180,7 @@ func NewProcessor(cfg Config) *Processor {
 		filterReqC: make(chan struct{}),
 		filterResC: make(chan *Filter),
 		eventC:     make(chan *event, cfg.EventChanCap),
+		spanErrC:   make(chan spanErr),
 		stopC:      make(chan *roachpb.Error, 1),
 		stoppedC:   make(chan struct{}),
 	}
@@ -290,6 +299,11 @@ func (p *Processor) run(
 		case r := <-p.unregC:
 			p.reg.Unregister(r)
 
+		// Send errors to registrations overlapping the span and disconnect them.
+		// Requested via DisconnectSpanWithErr().
+		case e := <-p.spanErrC:
+			p.reg.DisconnectWithErr(e.span, e.pErr)
+
 		// Respond to answers about the processor goroutine state.
 		case <-p.lenReqC:
 			p.lenResC <- p.reg.Len()
@@ -377,6 +391,19 @@ func (p *Processor) StopWithErr(pErr *roachpb.Error) {
 	p.syncEventC()
 	// Send the processor a stop signal.
 	p.sendStop(pErr)
+}
+
+// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
+// the given span with the given error.
+func (p *Processor) DisconnectSpanWithErr(span roachpb.Span, pErr *roachpb.Error) {
+	if p == nil {
+		return
+	}
+	select {
+	case p.spanErrC <- spanErr{span: span, pErr: pErr}:
+	case <-p.stoppedC:
+		// Already stopped. Do nothing.
+	}
 }
 
 func (p *Processor) sendStop(pErr *roachpb.Error) {

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -147,6 +147,9 @@ func putPooledEvent(ev *event) {
 type event struct {
 	ops     []enginepb.MVCCLogicalOp
 	ct      hlc.Timestamp
+	sst     []byte
+	sstSpan roachpb.Span
+	sstWTS  hlc.Timestamp
 	initRTS bool
 	syncC   chan struct{}
 	// This setting is used in conjunction with syncC in tests in order to ensure
@@ -506,6 +509,18 @@ func (p *Processor) ConsumeLogicalOps(ops ...enginepb.MVCCLogicalOp) bool {
 	return p.sendEvent(event{ops: ops}, p.EventChanTimeout)
 }
 
+// ConsumeSSTable informs the rangefeed processor of an SSTable that was added
+// via AddSSTable. It returns false if consuming the SSTable hit a timeout, as
+// specified by the EventChanTimeout configuration. If the method returns false,
+// the processor will have been stopped, so calling Stop is not necessary. Safe
+// to call on nil Processor.
+func (p *Processor) ConsumeSSTable(sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp) bool {
+	if p == nil {
+		return true
+	}
+	return p.sendEvent(event{sst: sst, sstSpan: sstSpan, sstWTS: writeTS}, p.EventChanTimeout)
+}
+
 // ForwardClosedTS indicates that the closed timestamp that serves as the basis
 // for the rangefeed processor's resolved timestamp has advanced. It returns
 // false if forwarding the closed timestamp hit a timeout, as specified by the
@@ -583,6 +598,8 @@ func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	switch {
 	case len(e.ops) > 0:
 		p.consumeLogicalOps(ctx, e.ops)
+	case len(e.sst) > 0:
+		p.consumeSSTable(ctx, e.sst, e.sstSpan, e.sstWTS)
 	case !e.ct.IsEmpty():
 		p.forwardClosedTS(ctx, e.ct)
 	case e.initRTS:
@@ -639,6 +656,12 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 	}
 }
 
+func (p *Processor) consumeSSTable(
+	ctx context.Context, sst []byte, sstSpan roachpb.Span, sstWTS hlc.Timestamp,
+) {
+	p.publishSSTable(ctx, sst, sstSpan, sstWTS)
+}
+
 func (p *Processor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
 	if p.rts.ForwardClosedTS(newClosedTS) {
 		p.publishCheckpoint(ctx)
@@ -672,6 +695,24 @@ func (p *Processor) publishValue(
 		PrevValue: prevVal,
 	})
 	p.reg.PublishToOverlapping(roachpb.Span{Key: key}, &event)
+}
+
+func (p *Processor) publishSSTable(
+	ctx context.Context, sst []byte, sstSpan roachpb.Span, sstWTS hlc.Timestamp,
+) {
+	if sstSpan.Equal(roachpb.Span{}) {
+		panic(errors.AssertionFailedf("received SSTable without span"))
+	}
+	if sstWTS.IsEmpty() {
+		panic(errors.AssertionFailedf("received SSTable without write timestamp"))
+	}
+	p.reg.PublishToOverlapping(sstSpan, &roachpb.RangeFeedEvent{
+		SST: &roachpb.RangeFeedSSTable{
+			Data:    sst,
+			Span:    sstSpan,
+			WriteTS: sstWTS,
+		},
+	})
 }
 
 func (p *Processor) publishCheckpoint(ctx context.Context) {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -95,6 +95,8 @@ func clearTrivialReplicatedEvalResultFields(r *kvserverpb.ReplicatedEvalResult) 
 		}
 	}
 	r.Delta = enginepb.MVCCStatsDelta{}
+	// Rangefeeds have been disconnected prior to application.
+	r.MVCCHistoryMutation = nil
 }
 
 // prepareLocalResult is performed after the command has been committed to the

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -626,6 +626,19 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 ) error {
 	res := cmd.replicatedResult()
 
+	// MVCC history mutations violate the closed timestamp, modifying data that
+	// has already been emitted and checkpointed via a rangefeed. Callers are
+	// expected to ensure that no rangefeeds are currently active across such
+	// spans, but as a safeguard we disconnect the overlapping rangefeeds
+	// with a non-retriable error anyway.
+	if res.MVCCHistoryMutation != nil {
+		for _, span := range res.MVCCHistoryMutation.Spans {
+			b.r.disconnectRangefeedSpanWithErr(span, roachpb.NewError(&roachpb.MVCCHistoryMutationError{
+				Span: span,
+			}))
+		}
+	}
+
 	// AddSSTable ingestions run before the actual batch gets written to the
 	// storage engine. This makes sure that when the Raft command is applied,
 	// the ingestion has definitely succeeded. Note that we have taken

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -667,6 +667,10 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 		if added := res.Delta.KeyCount; added > 0 {
 			b.r.writeStats.recordCount(float64(added), 0)
 		}
+		if res.AddSSTable.AtWriteTimestamp {
+			b.r.handleSSTableRaftMuLocked(
+				ctx, res.AddSSTable.Data, res.AddSSTable.Span, res.WriteTimestamp)
+		}
 		res.AddSSTable = nil
 	}
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -585,8 +585,12 @@ func addSSTablePreApply(
 
 	copied := false
 	if eng.InMem() {
+		// Ingest a copy of the SST. Otherwise, Pebble will claim and mutate the
+		// sst.Data byte slice, which will also be used later by e.g. rangefeeds.
+		data := make([]byte, len(sst.Data))
+		copy(data, sst.Data)
 		path = fmt.Sprintf("%x", checksum)
-		if err := eng.WriteFile(path, sst.Data); err != nil {
+		if err := eng.WriteFile(path, data); err != nil {
 			log.Fatalf(ctx, "unable to write sideloaded SSTable at term %d, index %d: %s", term, index, err)
 		}
 	} else {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -452,6 +452,18 @@ func (r *Replica) disconnectRangefeedWithErr(p *rangefeed.Processor, pErr *roach
 	r.unsetRangefeedProcessor(p)
 }
 
+// disconnectRangefeedSpanWithErr broadcasts the provided error to all rangefeed
+// registrations that overlap the given span. Tears down the rangefeed Processor
+// if it has no remaining registrations.
+func (r *Replica) disconnectRangefeedSpanWithErr(span roachpb.Span, pErr *roachpb.Error) {
+	p := r.getRangefeedProcessor()
+	if p == nil {
+		return
+	}
+	p.DisconnectSpanWithErr(span, pErr)
+	r.maybeDisconnectEmptyRangefeed(p)
+}
+
 // disconnectRangefeedWithReason broadcasts the provided rangefeed retry reason
 // to all rangefeed registrations and tears down the active rangefeed Processor.
 // No-op if a rangefeed is not active.

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -786,6 +786,94 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 	})
 }
 
+// TestReplicaRangefeedMVCCHistoryMutationError tests that rangefeeds are
+// disconnected when an MVCC history mutation is applied.
+func TestReplicaRangefeedMVCCHistoryMutationError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	splitKey := roachpb.Key("a")
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+	ts := tc.Servers[0]
+	store, err := ts.Stores().GetStore(ts.GetFirstStoreID())
+	require.NoError(t, err)
+	tc.SplitRangeOrFatal(t, splitKey)
+	tc.AddVotersOrFatal(t, splitKey, tc.Target(1), tc.Target(2))
+	rangeID := store.LookupReplica(roachpb.RKey(splitKey)).RangeID
+
+	// Write to the RHS of the split and wait for all replicas to process it.
+	// This ensures that all replicas have seen the split before we move on.
+	incArgs := incrementArgs(splitKey, 9)
+	_, pErr := kv.SendWrapped(ctx, store.TestSender(), incArgs)
+	require.Nil(t, pErr)
+	tc.WaitForValues(t, splitKey, []int64{9, 9, 9})
+
+	// Set up a rangefeed across a-c.
+	stream := newTestStream()
+	streamErrC := make(chan *roachpb.Error, 1)
+	go func() {
+		req := roachpb.RangeFeedRequest{
+			Header: roachpb.Header{RangeID: rangeID},
+			Span:   roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+		}
+		timer := time.AfterFunc(10*time.Second, stream.Cancel)
+		defer timer.Stop()
+		streamErrC <- store.RangeFeed(&req, stream)
+	}()
+
+	// Wait for a checkpoint.
+	require.Eventually(t, func() bool {
+		if len(streamErrC) > 0 {
+			require.Fail(t, "unexpected rangefeed error", "%v", <-streamErrC)
+		}
+		events := stream.Events()
+		for _, event := range events {
+			require.NotNil(t, event.Checkpoint, "received non-checkpoint event: %v", event)
+		}
+		return len(events) > 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Apply a ClearRange command that mutates MVCC history across c-e.
+	// This does not overlap with the rangefeed registration, and should
+	// not disconnect it.
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), &roachpb.ClearRangeRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    roachpb.Key("c"),
+			EndKey: roachpb.Key("e"),
+		},
+	})
+	require.Nil(t, pErr)
+	if len(streamErrC) > 0 {
+		require.Fail(t, "unexpected rangefeed error", "%v", <-streamErrC)
+	}
+
+	// Apply a ClearRange command that mutates MVCC history across b-e.
+	// This overlaps with the rangefeed, and should disconnect it.
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), &roachpb.ClearRangeRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    roachpb.Key("b"),
+			EndKey: roachpb.Key("e"),
+		},
+	})
+	require.Nil(t, pErr)
+	select {
+	case pErr = <-streamErrC:
+		require.NotNil(t, pErr)
+		var mvccErr *roachpb.MVCCHistoryMutationError
+		require.ErrorAs(t, pErr.GoError(), &mvccErr)
+		require.Equal(t, &roachpb.MVCCHistoryMutationError{
+			Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("e")},
+		}, mvccErr)
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for rangefeed disconnection")
+	}
+}
+
 // TestReplicaRangefeedPushesTransactions tests that rangefeed detects intents
 // that are holding up its resolved timestamp and periodically pushes them to
 // ensure that its resolved timestamp continues to advance.

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -142,8 +143,8 @@ func TestReplicaRangefeed(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		stream := newTestStream()
 		streams[i] = stream
-		ts := tc.Servers[i]
-		store, err := ts.Stores().GetStore(ts.GetFirstStoreID())
+		srv := tc.Servers[i]
+		store, err := srv.Stores().GetStore(srv.GetFirstStoreID())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,6 +165,28 @@ func TestReplicaRangefeed(t *testing.T) {
 
 	checkForExpEvents := func(expEvents []*roachpb.RangeFeedEvent) {
 		t.Helper()
+
+		// SSTs may not be equal byte-for-byte due to AddSSTable rewrites. We nil
+		// out the expected data here for require.Equal comparison, and compare
+		// the actual contents separately.
+		type sstTest struct {
+			expect     []byte
+			expectSpan roachpb.Span
+			expectTS   hlc.Timestamp
+			actual     []byte
+		}
+		var ssts []sstTest
+		for _, e := range expEvents {
+			if e.SST != nil {
+				ssts = append(ssts, sstTest{
+					expect:     e.SST.Data,
+					expectSpan: e.SST.Span,
+					expectTS:   e.SST.WriteTS,
+				})
+				e.SST.Data = nil
+			}
+		}
+
 		for _, stream := range streams {
 			var events []*roachpb.RangeFeedEvent
 			testutils.SucceedsSoon(t, func() error {
@@ -191,7 +214,52 @@ func TestReplicaRangefeed(t *testing.T) {
 			if len(streamErrC) > 0 {
 				t.Fatalf("unexpected error from stream: %v", <-streamErrC)
 			}
+
+			i := 0
+			for _, e := range events {
+				if e.SST != nil && i < len(ssts) {
+					ssts[i].actual = e.SST.Data
+					e.SST.Data = nil
+					i++
+				}
+			}
+
 			require.Equal(t, expEvents, events)
+
+			for _, sst := range ssts {
+				expIter, err := storage.NewMemSSTIterator(sst.expect, false)
+				require.NoError(t, err)
+				defer expIter.Close()
+
+				sstIter, err := storage.NewMemSSTIterator(sst.actual, false)
+				require.NoError(t, err)
+				defer sstIter.Close()
+
+				expIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+				sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+				for {
+					expOK, expErr := expIter.Valid()
+					require.NoError(t, expErr)
+					sstOK, sstErr := sstIter.Valid()
+					require.NoError(t, sstErr)
+					if !expOK {
+						require.False(t, sstOK)
+						break
+					}
+
+					expKey, expValue := expIter.UnsafeKey(), expIter.UnsafeValue()
+					sstKey, sstValue := sstIter.UnsafeKey(), sstIter.UnsafeValue()
+					require.Equal(t, expKey.Key, sstKey.Key)
+					require.Equal(t, expValue, sstValue)
+					// We don't compare expKey.Timestamp and sstKey.Timestamp, because the
+					// SST timestamp may have been rewritten to the request timestamp. We
+					// assert on the write timestamp instead.
+					require.Equal(t, sst.expectTS, sstKey.Timestamp)
+
+					expIter.Next()
+					sstIter.Next()
+				}
+			}
 		}
 	}
 
@@ -257,6 +325,63 @@ func TestReplicaRangefeed(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Ingest an SSTable. We use a new timestamp to avoid getting pushed by the
+	// timestamp cache due to the read above.
+	ts6 := ts.Clock().Now().Add(0, 6)
+
+	expVal6b := roachpb.Value{}
+	expVal6b.SetInt(6)
+	expVal6b.InitChecksum(roachpb.Key("b"))
+
+	expVal6q := roachpb.Value{}
+	expVal6q.SetInt(7)
+	expVal6q.InitChecksum(roachpb.Key("q"))
+
+	sstFile := &storage.MemFile{}
+	sstWriter := storage.MakeIngestionSSTWriter(sstFile)
+	defer sstWriter.Close()
+	require.NoError(t, sstWriter.PutMVCC(
+		storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: ts6},
+		expVal6b.RawBytes))
+	require.NoError(t, sstWriter.PutMVCC(
+		storage.MVCCKey{Key: roachpb.Key("q"), Timestamp: ts6},
+		expVal6q.RawBytes))
+	require.NoError(t, sstWriter.Finish())
+	expSST := sstFile.Data()
+	expSSTSpan := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("r")}
+
+	_, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
+		false /* ingestAsWrites */, ts6)
+	require.Nil(t, pErr)
+
+	// Ingest an SSTable as writes.
+	ts7 := ts.Clock().Now().Add(0, 7)
+
+	expVal7b := roachpb.Value{Timestamp: ts7}
+	expVal7b.SetInt(7)
+	expVal7b.InitChecksum(roachpb.Key("b"))
+
+	expVal7q := roachpb.Value{Timestamp: ts7}
+	expVal7q.SetInt(7)
+	expVal7q.InitChecksum(roachpb.Key("q"))
+
+	sstFile = &storage.MemFile{}
+	sstWriter = storage.MakeIngestionSSTWriter(sstFile)
+	defer sstWriter.Close()
+	require.NoError(t, sstWriter.PutMVCC(
+		storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: ts7},
+		expVal7b.RawBytes))
+	require.NoError(t, sstWriter.PutMVCC(
+		storage.MVCCKey{Key: roachpb.Key("q"), Timestamp: ts7},
+		expVal7q.RawBytes))
+	require.NoError(t, sstWriter.Finish())
+
+	_, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
+		true /* ingestAsWrites */, ts7)
+	require.Nil(t, pErr)
+
 	// Wait for all streams to observe the expected events.
 	expVal2 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val2"), ts2)
 	expVal3 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), ts3)
@@ -281,6 +406,16 @@ func TestReplicaRangefeed(t *testing.T) {
 		}},
 		{Val: &roachpb.RangeFeedValue{
 			Key: roachpb.Key("b"), Value: expVal5, PrevValue: expVal4NoTS,
+		}},
+		{SST: &roachpb.RangeFeedSSTable{
+			// Binary representation of Data may be modified by SST rewrite, see checkForExpEvents.
+			Data: expSST, Span: expSSTSpan, WriteTS: ts6,
+		}},
+		{Val: &roachpb.RangeFeedValue{
+			Key: roachpb.Key("b"), Value: expVal7b, PrevValue: expVal6b,
+		}},
+		{Val: &roachpb.RangeFeedValue{
+			Key: roachpb.Key("q"), Value: expVal7q, PrevValue: expVal6q,
 		}},
 	}...)
 	checkForExpEvents(expEvents)

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1448,6 +1448,9 @@ func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
 	case *RangeFeedCheckpoint:
 		cpyChk := *t
 		cpy.MustSetValue(&cpyChk)
+	case *RangeFeedSSTable:
+		cpySST := *t
+		cpy.MustSetValue(&cpySST)
 	case *RangeFeedError:
 		cpyErr := *t
 		cpy.MustSetValue(&cpyErr)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1596,6 +1596,7 @@ message AdminVerifyProtectedTimestampResponse {
 //
 // * WriteAtRequestTimestamp: ensures compliance with the timestamp cache and
 //   closed timestamp, by rewriting SST timestamps to the request timestamp.
+//   Also emits the SST via the range feed.
 //
 // * DisallowConflicts, DisallowShadowing, or DisallowShadowingBelow: ensures
 //   compliance with MVCC, by checking for conflicting keys in existing data
@@ -1623,7 +1624,9 @@ message AddSSTableRequest {
 
   // WriteAtRequestTimestamp updates all MVCC timestamps in the SST to the
   // request timestamp, even if the request gets pushed. This ensures the writes
-  // comply with the timestamp cache and closed timestamp.
+  // comply with the timestamp cache and closed timestamp. It also causes the
+  // AddSSTable to be emitted via the range feed, since it respects the closed
+  // timestamp.
   //
   // Callers should always set this, except in very special circumstances when
   // the timestamp cache and closed timestamp can safely be ignored (e.g.
@@ -2588,6 +2591,23 @@ message RangeFeedError {
   kv.kvpb.Error error = 1 [(gogoproto.nullable) = false];
 }
 
+// RangeFeedSSTable is a variant of RangeFeedEvent that represents an AddSSTable
+// operation, containing the entire ingested SST. It is only emitted for
+// SSTables written with WriteAtRequestTimestamp enabled, so it is guaranteed to
+// comply with the closed timestamp. The Span and WriteTS fields are advisory,
+// and contain the client-provided SST key span (may be wider than the SST data)
+// and the MVCC timestamp used for all contained entries.
+//
+// The entire SST is emitted even for registrations that have a narrower span,
+// it is up to the caller to prune the SST as appropriate. Catchup scans emit
+// the data as RangeFeedValue events instead (i.e. it reads the ingested KV
+// pairs), but Raft log replay will emit RangeFeedSSTable events.
+message RangeFeedSSTable {
+  bytes              data     = 1;
+  Span               span     = 2 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp write_ts = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "WriteTS"];
+}
+
 // RangeFeedEvent is a union of all event types that may be returned on a
 // RangeFeed response stream.
 message RangeFeedEvent {
@@ -2596,6 +2616,7 @@ message RangeFeedEvent {
   RangeFeedValue      val        = 1;
   RangeFeedCheckpoint checkpoint = 2;
   RangeFeedError      error      = 3;
+  RangeFeedSSTable    sst        = 4 [(gogoproto.customname) = "SST"];
 }
 
 

--- a/pkg/roachpb/batch_generated.go
+++ b/pkg/roachpb/batch_generated.go
@@ -76,6 +76,8 @@ func (ru ErrorDetail) GetInner() error {
 		return t.MinTimestampBoundUnsatisfiable
 	case *ErrorDetail_RefreshFailedError:
 		return t.RefreshFailedError
+	case *ErrorDetail_MVCCHistoryMutation:
+		return t.MVCCHistoryMutation
 	default:
 		return nil
 	}
@@ -352,6 +354,8 @@ func (ru *ErrorDetail) MustSetInner(r error) {
 		union = &ErrorDetail_MinTimestampBoundUnsatisfiable{t}
 	case *RefreshFailedError:
 		union = &ErrorDetail_RefreshFailedError{t}
+	case *MVCCHistoryMutationError:
+		union = &ErrorDetail_MVCCHistoryMutation{t}
 	default:
 		panic(fmt.Sprintf("unsupported type %T for %T", r, ru))
 	}

--- a/pkg/roachpb/errordetailtype_string.go
+++ b/pkg/roachpb/errordetailtype_string.go
@@ -40,6 +40,7 @@ func _() {
 	_ = x[OptimisticEvalConflictsErrType-41]
 	_ = x[MinTimestampBoundUnsatisfiableErrType-42]
 	_ = x[RefreshFailedErrType-43]
+	_ = x[MVCCHistoryMutationErrType-44]
 	_ = x[CommunicationErrType-22]
 	_ = x[InternalErrType-25]
 }
@@ -50,7 +51,7 @@ const (
 	_ErrorDetailType_name_2 = "CommunicationErrType"
 	_ErrorDetailType_name_3 = "InternalErrTypeAmbiguousResultErrTypeStoreNotFoundErrTypeTransactionRetryWithProtoRefreshErrType"
 	_ErrorDetailType_name_4 = "IntegerOverflowErrTypeUnsupportedRequestErrType"
-	_ErrorDetailType_name_5 = "BatchTimestampBeforeGCErrTypeTxnAlreadyEncounteredErrTypeIntentMissingErrTypeMergeInProgressErrTypeRangeFeedRetryErrTypeIndeterminateCommitErrTypeInvalidLeaseErrTypeOptimisticEvalConflictsErrTypeMinTimestampBoundUnsatisfiableErrTypeRefreshFailedErrType"
+	_ErrorDetailType_name_5 = "BatchTimestampBeforeGCErrTypeTxnAlreadyEncounteredErrTypeIntentMissingErrTypeMergeInProgressErrTypeRangeFeedRetryErrTypeIndeterminateCommitErrTypeInvalidLeaseErrTypeOptimisticEvalConflictsErrTypeMinTimestampBoundUnsatisfiableErrTypeRefreshFailedErrTypeMVCCHistoryMutationErrType"
 )
 
 var (
@@ -58,7 +59,7 @@ var (
 	_ErrorDetailType_index_1 = [...]uint8{0, 23, 47, 67}
 	_ErrorDetailType_index_3 = [...]uint8{0, 15, 37, 57, 96}
 	_ErrorDetailType_index_4 = [...]uint8{0, 22, 47}
-	_ErrorDetailType_index_5 = [...]uint8{0, 29, 57, 77, 99, 120, 146, 165, 195, 232, 252}
+	_ErrorDetailType_index_5 = [...]uint16{0, 29, 57, 77, 99, 120, 146, 165, 195, 232, 252, 278}
 )
 
 func (i ErrorDetailType) String() string {
@@ -77,7 +78,7 @@ func (i ErrorDetailType) String() string {
 	case 31 <= i && i <= 32:
 		i -= 31
 		return _ErrorDetailType_name_4[_ErrorDetailType_index_4[i]:_ErrorDetailType_index_4[i+1]]
-	case 34 <= i && i <= 43:
+	case 34 <= i && i <= 44:
 		i -= 34
 		return _ErrorDetailType_name_5[_ErrorDetailType_index_5[i]:_ErrorDetailType_index_5[i+1]]
 	default:

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -323,6 +323,7 @@ const (
 	OptimisticEvalConflictsErrType          ErrorDetailType = 41
 	MinTimestampBoundUnsatisfiableErrType   ErrorDetailType = 42
 	RefreshFailedErrType                    ErrorDetailType = 43
+	MVCCHistoryMutationErrType              ErrorDetailType = 44
 	// When adding new error types, don't forget to update NumErrors below.
 
 	// CommunicationErrType indicates a gRPC error; this is not an ErrorDetail.
@@ -332,7 +333,7 @@ const (
 	// detail. The value 25 is chosen because it's reserved in the errors proto.
 	InternalErrType ErrorDetailType = 25
 
-	NumErrors int = 44
+	NumErrors int = 45
 )
 
 // GoError returns a Go error converted from Error. If the error is a transaction
@@ -1169,6 +1170,21 @@ func (e *BatchTimestampBeforeGCError) Type() ErrorDetailType {
 }
 
 var _ ErrorDetailInterface = &BatchTimestampBeforeGCError{}
+
+func (e *MVCCHistoryMutationError) Error() string {
+	return e.message(nil)
+}
+
+func (e *MVCCHistoryMutationError) message(_ *Error) string {
+	return fmt.Sprintf("unexpected MVCC history mutation in span %s", e.Span)
+}
+
+// Type is part of the ErrorDetailInterface.
+func (e *MVCCHistoryMutationError) Type() ErrorDetailType {
+	return MVCCHistoryMutationErrType
+}
+
+var _ ErrorDetailInterface = &MVCCHistoryMutationError{}
 
 // NewIntentMissingError creates a new IntentMissingError.
 func NewIntentMissingError(key Key, wrongIntent *Intent) *IntentMissingError {

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -480,6 +480,12 @@ message BatchTimestampBeforeGCError {
   optional util.hlc.Timestamp Threshold = 2 [(gogoproto.nullable) = false];
 }
 
+// A MVCCHistoryMutationError indicates that MVCC history was unexpectedly
+// mutated.
+message MVCCHistoryMutationError {
+  optional roachpb.Span span = 1 [(gogoproto.nullable) = false];
+}
+
 // An IntentMissingError indicates that a QueryIntent request expected
 // an intent to be present at its specified key but the intent was
 // not there.
@@ -613,6 +619,8 @@ message ErrorDetail {
     OptimisticEvalConflictsError optimistic_eval_conflicts = 41;
     MinTimestampBoundUnsatisfiableError min_timestamp_bound_unsatisfiable = 42;
     RefreshFailedError refresh_failed_error = 43;
+    MVCCHistoryMutationError mvcc_history_mutation = 44
+      [(gogoproto.customname) = "MVCCHistoryMutation"];
   }
 }
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2114,6 +2114,9 @@ func TestLint(t *testing.T) {
 			`pkg/testutils/.*\.go`,
 			`pkg/workload/.*\.go`,
 		}, "|") + `)`
+		unkeyedLiteralExceptions := `pkg/.*_test\.go:.*(` + strings.Join([]string{
+			`pkg/testutils/sstutil\.KV`,
+		}, "|") + `)`
 		filters := []stream.Filter{
 			// Ignore generated files.
 			stream.GrepNot(`pkg/.*\.pb\.go:`),
@@ -2171,6 +2174,10 @@ func TestLint(t *testing.T) {
 			// pooling, etc, then test code needs to adhere as well.
 			stream.GrepNot(nakedGoroutineExceptions + `:.*Use of go keyword not allowed`),
 			stream.GrepNot(nakedGoroutineExceptions + `:.*Illegal call to Group\.Go\(\)`),
+			// We allow unkeyed struct literals for certain internal test types.
+			// Ideally, go vet should not complain about this for types declared in
+			// the same module: https://github.com/golang/go/issues/43864
+			stream.GrepNot(unkeyedLiteralExceptions + `.*composite literal uses unkeyed fields`),
 		}
 
 		const vetTool = "roachvet"

--- a/pkg/testutils/sstutil/BUILD.bazel
+++ b/pkg/testutils/sstutil/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sstutil",
+    srcs = [
+        "kv.go",
+        "sstutil.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/sstutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/storage",
+        "//pkg/storage/enginepb",
+        "//pkg/util/hlc",
+        "//pkg/util/protoutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/testutils/sstutil/kv.go
+++ b/pkg/testutils/sstutil/kv.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sstutil
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// KV is a simplified representation of an MVCC key/value pair.
+type KV struct {
+	KeyString     string
+	WallTimestamp int64  // 0 for inline
+	ValueString   string // "" for nil (tombstone)
+}
+
+// Key returns the roachpb.Key representation of the key.
+func (kv KV) Key() roachpb.Key {
+	return roachpb.Key(kv.KeyString)
+}
+
+// Timestamp returns the hlc.Timestamp representation of the timestamp.
+func (kv KV) Timestamp() hlc.Timestamp {
+	return hlc.Timestamp{WallTime: kv.WallTimestamp}
+}
+
+// MVCCKey returns the storage.MVCCKey representation of the key and timestamp.
+func (kv KV) MVCCKey() storage.MVCCKey {
+	return storage.MVCCKey{
+		Key:       kv.Key(),
+		Timestamp: kv.Timestamp(),
+	}
+}
+
+// Value returns the roachpb.Value representation of the value.
+func (kv KV) Value() roachpb.Value {
+	value := roachpb.MakeValueFromString(kv.ValueString)
+	if kv.ValueString == "" {
+		value = roachpb.Value{}
+	}
+	value.InitChecksum(kv.Key())
+	return value
+}
+
+// ValueBytes returns the roachpb.Value byte-representation of the value.
+func (kv KV) ValueBytes() []byte {
+	return kv.Value().RawBytes
+}

--- a/pkg/testutils/sstutil/sstutil.go
+++ b/pkg/testutils/sstutil/sstutil.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sstutil
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// MakeSST builds a binary in-memory SST from the given tests data. It returns
+// the binary SST data as well as the start and end (exclusive) keys of the SST.
+func MakeSST(t *testing.T, kvs []KV) ([]byte, roachpb.Key, roachpb.Key) {
+	t.Helper()
+
+	sstFile := &storage.MemFile{}
+	writer := storage.MakeIngestionSSTWriter(sstFile)
+	defer writer.Close()
+
+	start, end := keys.MaxKey, keys.MinKey
+	for _, kv := range kvs {
+		if kv.Key().Compare(start) < 0 {
+			start = kv.Key()
+		}
+		if kv.Key().Compare(end) > 0 {
+			end = kv.Key()
+		}
+		if kv.Timestamp().IsEmpty() {
+			meta := &enginepb.MVCCMetadata{RawBytes: kv.ValueBytes()}
+			metaBytes, err := protoutil.Marshal(meta)
+			require.NoError(t, err)
+			require.NoError(t, writer.PutUnversioned(kv.Key(), metaBytes))
+		} else {
+			require.NoError(t, writer.PutMVCC(kv.MVCCKey(), kv.ValueBytes()))
+		}
+	}
+	require.NoError(t, writer.Finish())
+	writer.Close()
+
+	return sstFile.Data(), start, end.Next()
+}
+
+// ScanSST scans a binary in-memory SST for KV pairs.
+func ScanSST(t *testing.T, sst []byte) []KV {
+	t.Helper()
+
+	var kvs []KV
+	iter, err := storage.NewMemSSTIterator(sst, true)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	iter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+	for {
+		ok, err := iter.Valid()
+		require.NoError(t, err)
+		if !ok {
+			break
+		}
+
+		k := iter.UnsafeKey()
+		v := roachpb.Value{RawBytes: iter.UnsafeValue()}
+		value, err := v.GetBytes()
+		require.NoError(t, err)
+		kvs = append(kvs, KV{
+			KeyString:     string(k.Key),
+			WallTimestamp: k.Timestamp.WallTime,
+			ValueString:   string(value),
+		})
+		iter.Next()
+	}
+	return kvs
+}
+
+// ComputeStats computes the MVCC stats for the given binary SST.
+func ComputeStats(t *testing.T, sst []byte) *enginepb.MVCCStats {
+	t.Helper()
+
+	iter, err := storage.NewMemSSTIterator(sst, true)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	stats, err := storage.ComputeStatsForRange(iter, keys.MinKey, keys.MaxKey, 0)
+	require.NoError(t, err)
+	return &stats
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -423,6 +423,7 @@ var charts = []sectionDescription{
 					"distsender.rpc.err.leaserejectederrtype",
 					"distsender.rpc.err.mergeinprogresserrtype",
 					"distsender.rpc.err.mintimestampboundunsatisfiableerrtype",
+					"distsender.rpc.err.mvcchistorymutationerrtype",
 					"distsender.rpc.err.nodeunavailableerrtype",
 					"distsender.rpc.err.notleaseholdererrtype",
 					"distsender.rpc.err.oprequirestxnerrtype",


### PR DESCRIPTION
**testutils: add sstutil package**

This patch adds a `testutils/sstutil` package with SST-related test
utilities.

Release note: None

**kvserver: disconnect rangefeeds on MVCC history mutations**

This patch adds a field `MVCCHistoryMutation` to `ReplicatedEvalResult`,
which disconnects any rangefeeds that overlap with the command span.
Callers are expected to ensure there are no rangefeeds over such spans,
but if they fail to do so it is better to error out rather than silently
pretend like nothing happened. The field is set for `AddSSTable`,
`ClearRange`, and `RevertRange` requests.

This error is exposed via the `OnInternalError` callback for
`rangefeed.Factory`-based rangefeed clients. However, if this callback
is not set, these clients will silently stop processing events. This is
unfortunate, but follows from the API design. Most callers do not appear
to set such a callback, and it is left for the owning teams to update
the usage of the library with appropriate error handling. Furthermore,
this error detection requires knowledge about the new
`MVCCHistoryMutationError` error type, so older nodes in mixed-version
clusters will simply treat this as a retryable error.

Touches #70434.

Release note: None

**kvserver: emit AddSSTable events via rangefeeds**

This patch emits `AddSSTable` events across rangefeeds when the
ingestion was done with `WriteAtRequestTimestamp` enabled (since this
ensures they respect the closed timestamp). This setting is introduced
with 22.1, and callers must check the `MVCCAddSStable` version gate
before using it, so by extension this event is only emitted once the
entire cluster runs 22.1.

Clients built via `rangefeed.Factory` have a new `WithOnSSTable` option
that can be used to register a callback for these events. If such a
callback is not set, the rangefeed will run a catchup scan that includes
the values written by the `AddSSTable` request.

The entire SST is emitted in binary form, regardless of how the
registration span overlaps it -- it is up to callers to prune the SST
contents as appropriate. Previous values are not included for keys
replaced by the SST.

Resolves #70434.

Release note: None

---

Initial draft. A few outstanding questions:

1. ~~Changefeeds will error on these SST events. We currently do not expect to ingest SSTs into online tables, and thus we do not expect changefeeds to see these events. Now that we have MVCC-compliant `AddSSTable` we _could_ begin to use `AddSSTable` into online tables, and thus the changefeeds would need to handle this (note here that the SST events do not contain previous value diffs), but I figure we can cross that bridge when we get there. Does this make sense?~~

2. ~~Internal consumers that subscribe via `rangefeed.Factory` must register an `OnSSTable` handler, otherwise they will not be notified about such events. I'm not sure if we ever expect to ingest SSTs into e.g. online system spans and such, but we may want to consider sending such subscribers an error if they haven't registered `OnSSTable` rather than silently ignoring them.~~

3. These events are likely to be much larger than regular key/value events, and thus there is a greater risk of excessive memory usage since the buffer size per replica is 4096 events. The SSTs are already in memory due to Raft application, but buffering them here can cause them to stick around and pile up. We should consider adding memory accounting here, and use a store-wide memory limit rather than a per-replica fixed-size queue. See: #73616.