### PR TITLE
pkg/sql: fix hash-sharded index definition in pg_indexes

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -253,13 +253,13 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		expectedDesc := tabledesc.NewBuilder(expected).BuildImmutableTable()
 		gotDesc := tabledesc.NewBuilder(got).BuildImmutableTable()
 		e, err := catformat.IndexForDisplay(
-			ctx, expectedDesc, tableName, expectedDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx, sd,
+			ctx, expectedDesc, tableName, expectedDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, tree.FmtSimple, &semaCtx, sd, catformat.IndexDisplayDefOnly,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		g, err := catformat.IndexForDisplay(
-			ctx, gotDesc, tableName, gotDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, &semaCtx, sd,
+			ctx, gotDesc, tableName, gotDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, tree.FmtSimple, &semaCtx, sd, catformat.IndexDisplayDefOnly,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -393,7 +393,7 @@ t          new_idx      CREATE INDEX new_idx ON test.public.t USING btree (d ASC
 t          t_a_b_c_idx  CREATE INDEX t_a_b_c_idx ON test.public.t USING btree (a ASC, b ASC, c ASC)
 t          t_b_idx      CREATE INDEX t_b_idx ON test.public.t USING btree (b ASC)
 t          t_c_key      CREATE UNIQUE INDEX t_c_key ON test.public.t USING btree (c ASC)
-t          t_j_idx      CREATE INDEX t_j_idx ON test.public.t USING gin (j ASC)
+t          t_j_idx      CREATE INDEX t_j_idx ON test.public.t USING gin (j)
 t          t_pkey       CREATE UNIQUE INDEX t_pkey ON test.public.t USING btree (pk ASC)
 
 statement error cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -24,6 +24,19 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// IndexDisplayMode influences how an index should be formatted for pretty print
+// in IndexForDisplay function.
+type IndexDisplayMode int
+
+const (
+	// IndexDisplayShowCreate indicates index definition to be printed as a CREATE
+	// INDEX statement.
+	IndexDisplayShowCreate IndexDisplayMode = iota
+	// IndexDisplayDefOnly indicates index definition to be printed as INDEX
+	// definition format within a CREATE TABLE statement.
+	IndexDisplayDefOnly
+)
+
 // IndexForDisplay formats an index descriptor as a SQL string. It converts user
 // defined types in partial index predicate expressions to a human-readable
 // form.
@@ -43,10 +56,23 @@ func IndexForDisplay(
 	tableName *tree.TableName,
 	index catalog.Index,
 	partition string,
+	formatFlags tree.FmtFlags,
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
+	displayMode IndexDisplayMode,
 ) (string, error) {
-	return indexForDisplay(ctx, table, tableName, index.IndexDesc(), index.Primary(), partition, semaCtx, sessionData)
+	return indexForDisplay(
+		ctx,
+		table,
+		tableName,
+		index.IndexDesc(),
+		index.Primary(),
+		partition,
+		formatFlags,
+		semaCtx,
+		sessionData,
+		displayMode,
+	)
 }
 
 func indexForDisplay(
@@ -56,14 +82,26 @@ func indexForDisplay(
 	index *descpb.IndexDescriptor,
 	isPrimary bool,
 	partition string,
+	formatFlags tree.FmtFlags,
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
+	displayMode IndexDisplayMode,
 ) (string, error) {
-	f := tree.NewFmtCtx(tree.FmtSimple)
+	// Please also update CreateIndex's "Format" method in
+	// pkg/sql/sem/tree/create.go if there's any update to index definition
+	// components.
+	if displayMode == IndexDisplayShowCreate && *tableName == descpb.AnonymousTable {
+		return "", errors.New("tableName must be set for IndexDisplayShowCreate mode")
+	}
+
+	f := tree.NewFmtCtx(formatFlags)
+	if displayMode == IndexDisplayShowCreate {
+		f.WriteString("CREATE ")
+	}
 	if index.Unique {
 		f.WriteString("UNIQUE ")
 	}
-	if index.Type == descpb.IndexDescriptor_INVERTED {
+	if !f.HasFlags(tree.FmtPGCatalog) && index.Type == descpb.IndexDescriptor_INVERTED {
 		f.WriteString("INVERTED ")
 	}
 	f.WriteString("INDEX ")
@@ -72,6 +110,16 @@ func indexForDisplay(
 		f.WriteString(" ON ")
 		f.FormatNode(tableName)
 	}
+
+	if f.HasFlags(tree.FmtPGCatalog) {
+		f.WriteString(" USING")
+		if index.Type == descpb.IndexDescriptor_INVERTED {
+			f.WriteString(" gin")
+		} else {
+			f.WriteString(" btree")
+		}
+	}
+
 	f.WriteString(" (")
 	if err := FormatIndexElements(ctx, table, index, f, semaCtx, sessionData); err != nil {
 		return "", err
@@ -96,17 +144,30 @@ func indexForDisplay(
 
 	f.WriteString(partition)
 
-	if err := formatStorageConfigs(table, index, f); err != nil {
-		return "", err
+	if !f.HasFlags(tree.FmtPGCatalog) {
+		if err := formatStorageConfigs(table, index, f); err != nil {
+			return "", err
+		}
 	}
 
 	if index.IsPartial() {
-		f.WriteString(" WHERE ")
-		pred, err := schemaexpr.FormatExprForDisplay(ctx, table, index.Predicate, semaCtx, sessionData, tree.FmtParsable)
+		predFmtFlag := tree.FmtParsable
+		if f.HasFlags(tree.FmtPGCatalog) {
+			predFmtFlag = tree.FmtPGCatalog
+		}
+		pred, err := schemaexpr.FormatExprForDisplay(ctx, table, index.Predicate, semaCtx, sessionData, predFmtFlag)
 		if err != nil {
 			return "", err
 		}
-		f.WriteString(pred)
+
+		f.WriteString(" WHERE ")
+		if f.HasFlags(tree.FmtPGCatalog) {
+			f.WriteString("(")
+			f.WriteString(pred)
+			f.WriteString(")")
+		} else {
+			f.WriteString(pred)
+		}
 	}
 
 	return f.CloseAndGetString(), nil
@@ -125,6 +186,11 @@ func FormatIndexElements(
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
 ) error {
+	elemFmtFlag := tree.FmtParsable
+	if f.HasFlags(tree.FmtPGCatalog) {
+		elemFmtFlag = tree.FmtPGCatalog
+	}
+
 	startIdx := index.ExplicitColumnStartIdx()
 	for i, n := startIdx, len(index.KeyColumnIDs); i < n; i++ {
 		col, err := table.FindColumnWithID(index.KeyColumnIDs[i])
@@ -136,7 +202,7 @@ func FormatIndexElements(
 		}
 		if col.IsExpressionIndexColumn() {
 			expr, err := schemaexpr.FormatExprForExpressionIndexDisplay(
-				ctx, table, col.GetComputeExpr(), semaCtx, sessionData, tree.FmtParsable,
+				ctx, table, col.GetComputeExpr(), semaCtx, sessionData, elemFmtFlag,
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -61,7 +61,7 @@ WHERE tablename = 'sharded_primary'
 ORDER BY 1, 2, 3
 ----
 tablename        indexname  indexdef
-sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC)
+sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC) USING HASH WITH BUCKET_COUNT = 10
 
 query TTB
 SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM sharded_primary]

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4758,7 +4758,7 @@ CREATE INDEX regression_46450_idx ON regression_46450 USING gin(json)
 query T
 select indexdef from pg_indexes where indexname = 'regression_46450_idx'
 ----
-CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json ASC)
+CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json)
 
 # Make sure indexdef uses user-defined schemas.
 
@@ -4817,8 +4817,8 @@ WHERE tablename = 'geospatial_table'
 ----
 indexname              indexdef
 geospatial_table_pkey  CREATE UNIQUE INDEX geospatial_table_pkey ON test.public.geospatial_table USING btree (id ASC)
-idxa                   CREATE INDEX idxa ON test.public.geospatial_table USING gin (a ASC)
-idxb                   CREATE INDEX idxb ON test.public.geospatial_table USING gin (b ASC)
+idxa                   CREATE INDEX idxa ON test.public.geospatial_table USING gin (a)
+idxb                   CREATE INDEX idxb ON test.public.geospatial_table USING gin (b)
 
 subtest partial_index
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -221,11 +221,14 @@ type CreateIndex struct {
 
 // Format implements the NodeFormatter interface.
 func (node *CreateIndex) Format(ctx *FmtCtx) {
+	// Please also update indexForDisplay function in
+	// pkg/sql/catalog/catformat/index.go if there's any update to index
+	// definition components.
 	ctx.WriteString("CREATE ")
 	if node.Unique {
 		ctx.WriteString("UNIQUE ")
 	}
-	if node.Inverted && !ctx.HasFlags(FmtPGCatalog) {
+	if node.Inverted {
 		ctx.WriteString("INVERTED ")
 	}
 	ctx.WriteString("INDEX ")
@@ -241,14 +244,7 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 	}
 	ctx.WriteString("ON ")
 	ctx.FormatNode(&node.Table)
-	if ctx.HasFlags(FmtPGCatalog) {
-		ctx.WriteString(" USING")
-		if node.Inverted {
-			ctx.WriteString(" gin")
-		} else {
-			ctx.WriteString(" btree")
-		}
-	}
+
 	ctx.WriteString(" (")
 	ctx.FormatNode(&node.Columns)
 	ctx.WriteByte(')')
@@ -269,14 +265,8 @@ func (node *CreateIndex) Format(ctx *FmtCtx) {
 		ctx.WriteString(")")
 	}
 	if node.Predicate != nil {
-		if ctx.HasFlags(FmtPGCatalog) {
-			ctx.WriteString(" WHERE (")
-			ctx.FormatNode(node.Predicate)
-			ctx.WriteString(")")
-		} else {
-			ctx.WriteString(" WHERE ")
-			ctx.FormatNode(node.Predicate)
-		}
+		ctx.WriteString(" WHERE ")
+		ctx.FormatNode(node.Predicate)
 	}
 }
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -153,8 +153,10 @@ func ShowCreateTable(
 			&descpb.AnonymousTable,
 			idx,
 			partitionBuf.String(),
+			tree.FmtSimple,
 			p.RunParams(ctx).p.SemaCtx(),
 			p.RunParams(ctx).p.SessionData(),
+			catformat.IndexDisplayDefOnly,
 		)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
fixes #73060

Previously, hash-sharded index's sharding info was not shown
in pg_indexes table because the sharding bucket info was not
copied to the CreateIndex statement object. This pr fixes
this issue by reusing the `IndexForDisplay` function. It also
removes column direction from gin index in pg_indexes.


Release note (bug fix): index create statements in pg_indexes
table now shows hash sharding bucket count if an index is
hash sharded. Column direction is removed from gin/gist index
in pg_indexes.