### PR TITLE
sql: actually deflake TestSavepoints

### DIFF
--- a/pkg/sql/conn_executor_savepoints_test.go
+++ b/pkg/sql/conn_executor_savepoints_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,7 +28,6 @@ import (
 
 func TestSavepoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 70220, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()

--- a/pkg/sql/conn_executor_savepoints_test.go
+++ b/pkg/sql/conn_executor_savepoints_test.go
@@ -36,26 +36,10 @@ func TestSavepoints(t *testing.T) {
 	datadriven.Walk(t, "testdata/savepoints", func(t *testing.T, path string) {
 
 		params := base.TestServerArgs{}
-		s, db, _ := serverutils.StartServer(t, params)
+		s, origConn, _ := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(ctx)
 
-		sqlConns := make(map[string]*gosql.Conn)
-		getConn := func(name string) *gosql.Conn {
-			conn, ok := sqlConns[name]
-			if ok {
-				return conn
-			}
-			conn, err := db.Conn(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			sqlConns[name] = conn
-			return conn
-		}
-
-		// progressConn is used to manipulate the progress table.
-		progressConn := getConn("progress")
-		if _, err := progressConn.ExecContext(ctx, `CREATE TABLE progress(
+		if _, err := origConn.Exec(`CREATE TABLE progress(
       conn STRING,
     	n INT, 
     	marker BOOL,
@@ -64,21 +48,33 @@ func TestSavepoints(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		const defaultConn = "default"
+		sqlConns := make(map[string]*gosql.DB)
+		sqlConns[defaultConn] = origConn
+
 		datadriven.RunTest(t, path, func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "sql":
 				// Determine which connection to run the SQL statements on. If no
 				// connection specifier is provided, use the "default" conn.
-				connName := "default"
+				connName := defaultConn
+				sqlConn := sqlConns[connName]
 				if td.HasArg("conn") {
 					td.ScanArgs(t, "conn", &connName)
+
+					var ok bool
+					sqlConn, ok = sqlConns[connName]
+					if !ok {
+						sqlConn = serverutils.OpenDBConn(
+							t, s.ServingSQLAddr(), params.UseDatabase, params.Insecure, s.Stopper())
+						sqlConns[connName] = sqlConn
+					}
 				}
-				sqlConn := getConn(connName)
 
 				// Implicitly abort any previously-ongoing txn.
-				_, _ = sqlConn.ExecContext(ctx, "ABORT")
+				_, _ = sqlConn.Exec("ABORT")
 				// Prepare for the next test.
-				if _, err := progressConn.ExecContext(ctx, "DELETE FROM progress WHERE conn = $1", connName); err != nil {
+				if _, err := sqlConn.Exec("DELETE FROM progress WHERE conn = $1", connName); err != nil {
 					td.Fatalf(t, "cleaning up: %v", err)
 				}
 
@@ -108,7 +104,7 @@ func TestSavepoints(t *testing.T) {
 				// updateProgress loads the current set of writes
 				// into the progress bar.
 				updateProgress := func() {
-					rows, err := progressConn.QueryContext(ctx, "SELECT n FROM progress WHERE conn = $1", connName)
+					rows, err := sqlConn.Query("SELECT n FROM progress WHERE conn = $1", connName)
 					if err != nil {
 						t.Logf("%d: reading progress: %v", stepNum, err)
 						// It's OK if we can't read this.
@@ -131,7 +127,7 @@ func TestSavepoints(t *testing.T) {
 				// This is guaranteed to always succeed because SHOW TRANSACTION STATUS
 				// is an observer statement.
 				getTxnStatus := func() string {
-					row := sqlConn.QueryRowContext(ctx, "SHOW TRANSACTION STATUS")
+					row := sqlConn.QueryRow("SHOW TRANSACTION STATUS")
 					var status string
 					if err := row.Scan(&status); err != nil {
 						td.Fatalf(t, "%d: unable to retrieve txn status: %v", stepNum, err)
@@ -141,7 +137,7 @@ func TestSavepoints(t *testing.T) {
 				// showSavepointStatus is like getTxnStatus but retrieves the
 				// savepoint stack.
 				showSavepointStatus := func() {
-					rows, err := sqlConn.QueryContext(ctx, "SHOW SAVEPOINT STATUS")
+					rows, err := sqlConn.Query("SHOW SAVEPOINT STATUS")
 					if err != nil {
 						td.Fatalf(t, "%d: unable to retrieve savepoint status: %v", stepNum, err)
 					}
@@ -188,7 +184,7 @@ func TestSavepoints(t *testing.T) {
 					// Before each statement, mark the progress so far with
 					// a KV write.
 					if isOpenTxn(beforeStatus) {
-						_, err := progressConn.ExecContext(ctx, "INSERT INTO progress(conn, n, marker) VALUES ($1, $2, true)", connName, stepNum)
+						_, err := sqlConn.Exec("INSERT INTO progress(conn, n, marker) VALUES ($1, $2, true)", connName, stepNum)
 						if err != nil {
 							td.Fatalf(t, "%d: before-stmt: %v", stepNum, err)
 						}
@@ -196,7 +192,7 @@ func TestSavepoints(t *testing.T) {
 
 					// Run the statement and report errors/results.
 					fmt.Fprintf(&buf, "%d: %s -- ", stepNum, stmt)
-					execRes, err := sqlConn.ExecContext(ctx, stmt)
+					execRes, err := sqlConn.Exec(stmt)
 					if err != nil {
 						fmt.Fprintf(&buf, "%v\n", err)
 					} else {

--- a/pkg/sql/testdata/savepoints
+++ b/pkg/sql/testdata/savepoints
@@ -263,7 +263,7 @@ INSERT INTO t VALUES (1)
 -- Open        -> Open        ##  (none)
 
 sql
-SET lock_timeout = '1ms'
+SET lock_timeout = '100ms'
 BEGIN
 SAVEPOINT foo
 SELECT * FROM t WHERE x = 1 FOR UPDATE
@@ -272,7 +272,7 @@ SELECT * FROM t WHERE x = 2 FOR UPDATE
 COMMIT
 SET lock_timeout = 0
 ----
-1: SET lock_timeout = '1ms' -- 0 rows
+1: SET lock_timeout = '100ms' -- 0 rows
 -- NoTxn       -> NoTxn       #.......  (none)
 2: BEGIN -- 0 rows
 -- NoTxn       -> Open        ##......  (none)


### PR DESCRIPTION
This PR rolls back #73388 and reworks the fix for #70220. #73388 was an incorrect fix because the test relies on the progress table being updated in the same transaction as the rest of the SQL logic. This ensures that progress updates are rolled back when the rest of the transaction is rolled back. I didn't catch this in the initial PR because I missed the fact that the test had been skipped on `master`, so the test appeared to be passing with the change. When I then tried to backport the change in #73492, CI caught the mistake.

The PR then deflakes `TestSavepoints` by increasing the lock timeout significantly (from 1ms to 100ms) in the `rollback_after_lock_timeout` subtest. The test was flaky because after the transaction hits a lock timeout error, it performs an async rollback. If this async rollback hasn't grabbed latches by the time the next txn retry (with a different txn ID) finishes waiting out the lock_timeout when attempting to write to its progress, a lock timeout error would be thrown. This commit makes this extremely unlikely by increasing the lock timeout from 1ms to 100ms. With this new timeout, I've never seen the test flake under stress.