### PR TITLE
roachprod-stress: fix breakage due to changes in `roachprod status`

### DIFF
--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -122,7 +122,7 @@ func run() error {
 		}
 	}
 
-	cmd := exec.Command("roachprod", "status", cluster)
+	cmd := exec.Command("roachprod", "status", "-q", cluster)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "%s", out)


### PR DESCRIPTION
As the `roachprod status` command was recently updated to include a
progress bar, the change to the output broke this command's ability to
count the nodes in a cluster, thus causing errors when iterating through
nodes to remotely run the `stress` command.  This change disables the
use of that progress bar, rectifying the node counting.

Release note: None