### PR TITLE
sql: add merging, remove conditional puts for delete-preserving indexes

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -123,6 +123,7 @@ go_library(
         "lookup_join.go",
         "max_one_row.go",
         "mem_metrics.go",
+        "mvcc_backfiller.go",
         "name_util.go",
         "notice.go",
         "opaque.go",

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -17,21 +17,33 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/rowencpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/startupmigrations"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // This tests the delete-preserving index encoding for SQL writes on an index
@@ -119,12 +131,6 @@ func TestDeletePreservingIndexEncoding(t *testing.T) {
 		}
 		end := kvDB.Clock().Now()
 
-		startBackfill <- true
-		finishedSchemaChange.Wait()
-		if err := <-errorChan; err != nil {
-			t.Fatalf("Schema change encountered an error: %s", err)
-		}
-
 		// Grab the revision histories for both indices.
 		prefix := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec, tableDesc.GetID(), index.ID)
 		prefixEnd := append(prefix, []byte("\xff")...)
@@ -132,6 +138,12 @@ func TestDeletePreservingIndexEncoding(t *testing.T) {
 		revisions, err := kvclient.GetAllRevisions(context.Background(), kvDB, prefix, prefixEnd, now, end)
 		if err != nil {
 			return nil, nil, err
+		}
+
+		startBackfill <- true
+		finishedSchemaChange.Wait()
+		if err := <-errorChan; err != nil {
+			t.Logf("Schema change with delete_preserving=%v encountered an error: %s, continuing...", deletePreservingEncoding, err)
 		}
 
 		return revisions, prefix, nil
@@ -153,27 +165,51 @@ func TestDeletePreservingIndexEncoding(t *testing.T) {
 	}{
 		{"secondary_index_encoding_test",
 			`CREATE DATABASE d;
-			CREATE TABLE d.t (
-				k INT NOT NULL PRIMARY KEY,
-				a INT NOT NULL,
-				b INT
-			);`,
+					CREATE TABLE d.t (
+						k INT NOT NULL PRIMARY KEY,
+						a INT NOT NULL,
+						b INT
+					);`,
 			`CREATE INDEX ON d.t (a) STORING (b);`,
 			`INSERT INTO d.t (k, a, b) VALUES (1234, 101, 10001), (1235, 102, 10002), (1236, 103, 10003);
-DELETE FROM d.t WHERE k = 1;
-UPDATE d.t SET b = 10004 WHERE k = 2;`,
+		DELETE FROM d.t WHERE k = 1;
+		UPDATE d.t SET b = 10004 WHERE k = 2;`,
 		},
 		{"primary_encoding_test",
 			`CREATE DATABASE d;
-			CREATE TABLE d.t (
-				k INT NOT NULL PRIMARY KEY,
-				a INT NOT NULL,
-				b INT
-			);`,
+					CREATE TABLE d.t (
+						k INT NOT NULL PRIMARY KEY,
+						a INT NOT NULL,
+						b INT
+					);`,
 			`ALTER TABLE d.t ALTER PRIMARY KEY USING COLUMNS (k, a);`,
 			`INSERT INTO d.t (k, a, b) VALUES (1234, 101, 10001), (1235, 102, 10002), (1236, 103, 10003);
-DELETE FROM d.t WHERE k = 1;
-UPDATE d.t SET b = 10004 WHERE k = 2;`,
+		DELETE FROM d.t WHERE k = 1;
+		UPDATE d.t SET b = 10004 WHERE k = 2;`,
+		},
+		{"unique_index_test",
+			`CREATE DATABASE d;
+					CREATE TABLE d.t (
+						k INT NOT NULL PRIMARY KEY,
+						a INT NOT NULL,
+						b INT
+					);`,
+			`CREATE UNIQUE INDEX ON d.t (a);`,
+			`INSERT INTO d.t (k, a, b) VALUES (1234, 101, 10001), (1235, 102, 10002), (1236, 103, 10003);
+		DELETE FROM d.t WHERE k = 1234;
+	INSERT INTO d.t (k, a, b) VALUES (1237, 101, 10004);`,
+		},
+		{"primary_encoding_test_same_key",
+			`CREATE DATABASE d;
+					CREATE TABLE d.t (
+						k INT NOT NULL PRIMARY KEY,
+						a INT NOT NULL,
+						b INT
+					);`,
+			`ALTER TABLE d.t ALTER PRIMARY KEY USING COLUMNS (k, a);`,
+			`INSERT INTO d.t (k, a, b) VALUES (1234, 101, 10001), (1235, 102, 10002), (1236, 103, 10003);
+		DELETE FROM d.t WHERE k = 1234;
+		INSERT INTO d.t (k, a, b) VALUES (1234, 104, 10004);`,
 		},
 	}
 
@@ -278,7 +314,6 @@ func compareVersionedValueWrappers(
 	actual []WrappedVersionedValues,
 	actualPrefixLength int,
 ) error {
-
 	if len(expected) != len(actual) {
 		return errors.Newf("expected %d values, got %d", len(expected), len(actual))
 	}
@@ -306,4 +341,314 @@ func compareVersionedValueWrappers(
 	}
 
 	return nil
+}
+
+// This test tests that the schema changer is able to merge entries from a
+// delete-preserving index into a regular index.
+func TestMergeProcess(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	defer lease.TestingDisableTableLeases()()
+
+	params, _ := tests.CreateTestServerParams()
+
+	type TestCase struct {
+		name                   string
+		setupSQL               string
+		srcIndex               string
+		dstIndex               string
+		dstDataSQL             string
+		srcDataSQL             string
+		dstDataSQL2            string
+		dstContentsBeforeMerge [][]string
+		dstContentsAfterMerge  [][]string
+	}
+
+	testCases := []TestCase{
+		{
+			name: "unique index",
+			setupSQL: `CREATE DATABASE d;
+   CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
+		UNIQUE INDEX idx (b),
+		UNIQUE INDEX idx_temp (b)
+);`,
+			srcIndex: "idx_temp",
+			dstIndex: "idx",
+			// Populate dstIndex with some 1000/1, 2000/2 entries. Populate srcIndex
+			// with 3000/3, 4000/4 entries, and a delete for the 2000/2 entry.
+			dstDataSQL: `INSERT INTO d.t (k, a, b) VALUES (1, 100, 1000), (2, 200, 2000)`,
+			srcDataSQL: `INSERT INTO d.t (k, a, b) VALUES (3, 300, 3000), (4, 400, 4000);
+   								 DELETE FROM d.t WHERE k = 2`,
+			// Insert another row for the 2000/2 entry just so that there's a primary
+			// index row for the index to return when we read it.
+			dstDataSQL2: `INSERT INTO d.t (k, a, b) VALUES (2, 201, 2000)`,
+			dstContentsBeforeMerge: [][]string{
+				{"1", "1000"},
+				{"2", "2000"},
+			},
+			// After merge dstIndex has 1000/1, 3000/3, 4000/4 entries. Its 2000/2 entry was
+			// deleted by the srcIndex delete.
+			dstContentsAfterMerge: [][]string{
+				{"1", "1000"},
+				{"3", "3000"},
+				{"4", "4000"},
+			},
+		},
+		{
+			name: "unique index noop delete",
+			setupSQL: `
+				CREATE DATABASE d;
+				CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
+					UNIQUE INDEX idx (b),
+					UNIQUE INDEX idx_temp (b)
+  			);`,
+			srcIndex: "idx_temp",
+			dstIndex: "idx",
+			// Populate dstIndex with some 1000/1, 2000/2 entries. Populate srcIndex
+			// with 3000/3, 4000/4 entries, and a delete for a nonexistent key.
+			dstDataSQL: `INSERT INTO d.t (k, a, b) VALUES (1, 100, 1000), (2, 200, 2000)`,
+			srcDataSQL: `INSERT INTO d.t (k, a, b) VALUES (3, 300, 3000), (4, 400, 4000);
+   								 DELETE FROM d.t WHERE k = 5`,
+			dstContentsBeforeMerge: [][]string{
+				{"1", "1000"},
+				{"2", "2000"},
+			},
+			// After merge dstIndex has entries from both indexes.
+			dstContentsAfterMerge: [][]string{
+				{"1", "1000"},
+				{"2", "2000"},
+				{"3", "3000"},
+				{"4", "4000"},
+			},
+		},
+		{
+			name: "index with overriding values",
+			setupSQL: `
+				CREATE DATABASE d;
+   			CREATE TABLE d.t (k INT PRIMARY KEY, a INT, b INT,
+					UNIQUE INDEX idx (b),
+					UNIQUE INDEX idx_temp (b)
+				);`,
+			srcIndex:   "idx_temp",
+			dstIndex:   "idx",
+			dstDataSQL: `INSERT INTO d.t (k, a, b) VALUES (1, 100, 1000), (2, 200, 2000)`,
+			srcDataSQL: `INSERT INTO d.t (k, a, b) VALUES (3, 300, 1000), (4, 400, 2000)`,
+			dstContentsBeforeMerge: [][]string{
+				{"1", "1000"},
+				{"2", "2000"},
+			},
+			// After merge dstIndex should have same entries as srcIndex.
+			dstContentsAfterMerge: [][]string{
+				{"3", "1000"},
+				{"4", "2000"},
+			},
+		},
+	}
+
+	run := func(t *testing.T, test TestCase) {
+		server, tdb, kvDB := serverutils.StartServer(t, params)
+		defer server.Stopper().Stop(context.Background())
+
+		// Run the initial setupSQL.
+		if _, err := tdb.Exec(test.setupSQL); err != nil {
+			t.Fatal(err)
+		}
+
+		codec := keys.SystemSQLCodec
+		tableDesc := catalogkv.TestingGetMutableExistingTableDescriptor(kvDB, codec, "d", "t")
+		lm := server.LeaseManager().(*lease.Manager)
+		settings := server.ClusterSettings()
+		execCfg := server.ExecutorConfig().(sql.ExecutorConfig)
+		jr := server.JobRegistry().(*jobs.Registry)
+
+		changer := sql.NewSchemaChangerForTesting(
+			tableDesc.GetID(), 1, execCfg.NodeID.SQLInstanceID(), kvDB, lm, jr, &execCfg, settings)
+
+		// Here want to have different entries for the two indices, so we manipulate
+		// the index to DELETE_ONLY when we don't want to write to it, and
+		// DELETE_AND_WRITE_ONLY when we write to it.
+		mTest := makeMutationTest(t, kvDB, tdb, tableDesc)
+
+		mTest.writeIndexMutation(ctx, test.dstIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY})
+		mTest.updateIndexMutation(ctx, test.srcIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_ONLY}, true)
+
+		if _, err := tdb.Exec(test.dstDataSQL); err != nil {
+			t.Fatal(err)
+		}
+
+		mTest.makeMutationsActive(ctx)
+		mTest.writeIndexMutation(ctx, test.dstIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_ONLY})
+		mTest.writeIndexMutation(ctx, test.srcIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY})
+
+		if _, err := tdb.Exec(test.srcDataSQL); err != nil {
+			t.Fatal(err)
+		}
+
+		mTest.makeMutationsActive(ctx)
+		mTest.writeIndexMutation(ctx, test.dstIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY})
+		mTest.writeIndexMutation(ctx, test.srcIndex, descpb.DescriptorMutation{State: descpb.DescriptorMutation_DELETE_ONLY})
+
+		if _, err := tdb.Exec(test.dstDataSQL2); err != nil {
+			t.Fatal(err)
+		}
+
+		mTest.makeMutationsActive(ctx)
+		tableDesc = catalogkv.TestingGetMutableExistingTableDescriptor(kvDB, codec, "d", "t")
+
+		dstIndex, err := tableDesc.FindIndexWithName(test.dstIndex)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		srcIndex, err := tableDesc.FindIndexWithName(test.srcIndex)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			mut, err := descriptors.GetMutableTableByID(ctx, txn, tableDesc.GetID(), tree.ObjectLookupFlags{})
+			if err != nil {
+				return err
+			}
+
+			require.Equal(t, test.dstContentsBeforeMerge,
+				datumSliceToStrMatrix(fetchIndex(ctx, t, txn, mut, test.dstIndex)))
+
+			return nil
+		}))
+
+		if err := changer.Merge(context.Background(),
+			codec,
+			tableDesc,
+			srcIndex.GetID(),
+			dstIndex.GetID(),
+			tableDesc.IndexSpan(codec, srcIndex.GetID())); err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			mut, err := descriptors.GetMutableTableByID(ctx, txn, tableDesc.GetID(), tree.ObjectLookupFlags{})
+			if err != nil {
+				return err
+			}
+
+			require.Equal(t, test.dstContentsAfterMerge,
+				datumSliceToStrMatrix(fetchIndex(ctx, t, txn, mut, test.dstIndex)))
+			return nil
+		}))
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			run(t, test)
+		})
+	}
+}
+
+func (mt mutationTest) updateIndexMutation(
+	ctx context.Context, index string, m descpb.DescriptorMutation, preserveDeletes bool,
+) {
+	tableDesc := mt.tableDesc
+	idx, err := tableDesc.FindIndexWithName(index)
+	if err != nil {
+		mt.Fatal(err)
+	}
+	// The rewrite below potentially invalidates the original object with an overwrite.
+	// Clarify what's going on.
+	idxCopy := *idx.IndexDesc()
+	idxCopy.UseDeletePreservingEncoding = preserveDeletes
+	tableDesc.RemovePublicNonPrimaryIndex(idx.Ordinal())
+	m.Descriptor_ = &descpb.DescriptorMutation_Index{Index: &idxCopy}
+	mt.writeMutation(ctx, m)
+}
+
+// fetchIndex fetches the contents of an a table index returning the results
+// as datums. The datums will correspond to each of the columns stored in the
+// index, ordered by column ID.
+func fetchIndex(
+	ctx context.Context, t *testing.T, txn *kv.Txn, table *tabledesc.Mutable, indexName string,
+) []tree.Datums {
+	t.Helper()
+	var fetcher row.Fetcher
+	var alloc tree.DatumAlloc
+
+	mm := mon.MakeStandaloneBudget(1 << 30)
+	idx, err := table.FindIndexWithName(indexName)
+	colIdxMap := catalog.ColumnIDToOrdinalMap(table.PublicColumns())
+	var valsNeeded util.FastIntSet
+	{
+		colIDsNeeded := idx.CollectKeyColumnIDs()
+		if idx.Primary() {
+			for _, column := range table.PublicColumns() {
+				if !column.IsVirtual() {
+					colIDsNeeded.Add(column.GetID())
+				}
+			}
+		} else {
+			colIDsNeeded.UnionWith(idx.CollectSecondaryStoredColumnIDs())
+			colIDsNeeded.UnionWith(idx.CollectKeySuffixColumnIDs())
+		}
+
+		colIDsNeeded.ForEach(func(colID descpb.ColumnID) {
+			valsNeeded.Add(colIdxMap.GetDefault(colID))
+		})
+	}
+	require.NoError(t, err)
+	spans := []roachpb.Span{table.IndexSpan(keys.SystemSQLCodec, idx.GetID())}
+	const reverse = false
+	require.NoError(t, fetcher.Init(
+		ctx,
+		keys.SystemSQLCodec,
+		reverse,
+		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
+		0,
+		&alloc,
+		mm.Monitor(),
+		row.FetcherTableArgs{
+			Desc:             table,
+			Index:            idx,
+			ColIdxMap:        colIdxMap,
+			Cols:             table.PublicColumns(),
+			ValNeededForCol:  valsNeeded,
+			IsSecondaryIndex: !idx.Primary(),
+		},
+	))
+
+	require.NoError(t, fetcher.StartScan(
+		ctx, txn, spans, rowinfra.NoBytesLimit, 0, true, false, /* forceProductionBatchSize */
+	))
+	var rows []tree.Datums
+	for {
+		datums, err := fetcher.NextRowDecoded(ctx)
+		require.NoError(t, err)
+		if datums == nil {
+			break
+		}
+		// Copy the datums out as the slice is reused internally.
+		row := make(tree.Datums, 0, valsNeeded.Len())
+		for i := range datums {
+			if valsNeeded.Contains(i) {
+				row = append(row, datums[i])
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func datumSliceToStrMatrix(rows []tree.Datums) [][]string {
+	res := make([][]string, len(rows))
+	for i, row := range rows {
+		rowStrs := make([]string, len(row))
+		for j, d := range row {
+			rowStrs[j] = d.String()
+		}
+		res[i] = rowStrs
+	}
+	return res
 }

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -1,0 +1,126 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/errors"
+)
+
+// Merge merges the entries in the provide span sourceSpan from the index with
+// sourceID into the index with destinationID.
+func (sc *SchemaChanger) Merge(
+	ctx context.Context,
+	codec keys.SQLCodec,
+	table catalog.TableDescriptor,
+	sourceID descpb.IndexID,
+	destinationID descpb.IndexID,
+	sourceSpan roachpb.Span,
+) error {
+	sourcePrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), sourceID)
+	prefixLen := len(sourcePrefix)
+	destPrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), destinationID)
+
+	const pageSize = 1000
+	key := sourceSpan.Key
+	destKey := make([]byte, len(destPrefix))
+
+	for key != nil {
+		err := sc.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// For now just grab all of the destination KVs and merge the corresponding entries.
+			kvs, err := txn.Scan(ctx, key, sourceSpan.EndKey, int64(pageSize))
+			if err != nil {
+				return err
+			}
+
+			if len(kvs) == 0 {
+				key = nil
+				return nil
+			}
+
+			destKeys := make([]roachpb.Key, len(kvs))
+			for i := range kvs {
+				sourceKV := &kvs[i]
+
+				if len(sourceKV.Key) < prefixLen {
+					return errors.Errorf("Key for index entry %v does not start with prefix %v", sourceKV, sourceSpan.Key)
+				}
+
+				destKey = destKey[:0]
+				destKey = append(destKey, destPrefix...)
+				destKey = append(destKey, sourceKV.Key[prefixLen:]...)
+				destKeys[i] = make([]byte, len(destKey))
+				copy(destKeys[i], destKey)
+			}
+
+			wb := txn.NewBatch()
+			for i := range kvs {
+				mergedEntry, deleted, err := mergeEntry(&kvs[i], destKeys[i])
+				if err != nil {
+					return err
+				}
+
+				// We can blindly put and delete values during the merge since any
+				// uniqueness variations in the merged index will be caught by
+				// ValidateForwardIndexes and ValidateInvertedIndexes during validation.
+				if deleted {
+					wb.Del(mergedEntry.Key)
+				} else {
+					wb.Put(mergedEntry.Key, mergedEntry.Value)
+				}
+			}
+
+			if err := txn.Run(ctx, wb); err != nil {
+				return err
+			}
+
+			key = kvs[len(kvs)-1].Key.Next()
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeEntry(sourceKV *kv.KeyValue, destKey roachpb.Key) (*kv.KeyValue, bool, error) {
+	var destTagAndData []byte
+	var deleted bool
+
+	tempWrapper, err := rowenc.DecodeWrapper(sourceKV.Value)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if tempWrapper.Deleted {
+		deleted = true
+	} else {
+		destTagAndData = tempWrapper.Value
+	}
+
+	value := &roachpb.Value{}
+	value.SetTagAndData(destTagAndData)
+
+	return &kv.KeyValue{
+		Key:   destKey,
+		Value: value,
+	}, deleted, nil
+}

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete_preserving_unique_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete_preserving_unique_index
@@ -1,0 +1,79 @@
+# LogicTest: local !metamorphic
+
+# ---------------------------------------------------------
+# Ensure Unique Indexes Work With Delete Preserving Encoding
+# ---------------------------------------------------------
+statement ok
+CREATE TABLE ti (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    FAMILY (a, b, c),
+    UNIQUE INDEX (b, c) WHERE c > b
+);
+
+let $t_id
+SELECT id FROM system.namespace WHERE name = 'ti'
+
+let $updated_t_jsonb
+WITH
+  descs
+    AS (
+      SELECT
+        id,
+        crdb_internal.pb_to_json(
+          'cockroach.sql.sqlbase.Descriptor',
+          descriptor
+        )
+          AS descriptor
+      FROM
+        system.descriptor
+    )
+SELECT
+  CAST (json_set(descriptor, ARRAY['table', 'indexes', '0', 'useDeletePreservingEncoding'], 'true') AS STRING)
+FROM
+  descs WHERE id = $t_id;
+
+statement ok
+SELECT * FROM crdb_internal.unsafe_upsert_descriptor($t_id, crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor',$$ $updated_t_jsonb $$), true)
+
+statement ok
+INSERT INTO ti VALUES (1, 1, 100), (2, 2, 1)
+
+# Test that it's okay to delete and insert the same entry back into the unique
+# delete-preserving index.
+query T kvtrace
+DELETE FROM ti WHERE a = 1
+----
+Scan /Table/56/1/1/0
+Put (delete) /Table/56/2/1/100/0
+Del /Table/56/1/1/0
+
+query T kvtrace
+INSERT INTO ti VALUES (1, 1, 100)
+----
+CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Int/100
+Put /Table/56/2/1/100/0 -> /BYTES/0x0a020389
+
+# Update a row between not matching the partial index and matching the partial
+# index, thus testing the index deletes that are triggered by this update path.
+query T kvtrace
+UPDATE ti SET c = 200 WHERE a = 2
+----
+Scan /Table/56/1/2/0
+Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/200
+Put /Table/56/2/2/200/0 -> /BYTES/0x0a02038a
+
+query T kvtrace
+UPDATE ti SET c = 1 WHERE a = 2
+----
+Scan /Table/56/1/2/0
+Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/1
+Put (delete) /Table/56/2/2/200/0
+
+query T kvtrace
+UPDATE ti SET c = 200 WHERE a = 2
+----
+Scan /Table/56/1/2/0
+Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/200
+Put /Table/56/2/2/200/0 -> /BYTES/0x0a02038a

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_nonmetamorphic
@@ -144,7 +144,7 @@ UPDATE ti SET b = b + 1, c = c + 1
 Scan /Table/57/{1-2}
 Put /Table/57/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
 Put (delete) /Table/57/2/2/100/1/0
-CPut /Table/57/2/3/101/1/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/57/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Partial Index With Delete Preserving Encoding
@@ -199,7 +199,7 @@ UPDATE tpi SET b = b - 3, c = 'foo'
 ----
 Scan /Table/58/{1-2}
 Put /Table/58/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
-CPut /Table/58/2/"foo"/3/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/58/2/"foo"/3/0 -> /BYTES/0x0a0103
 
 # Update a row that matches the partial index before and after, but the index
 # entry doesn't change.
@@ -217,7 +217,7 @@ UPDATE tpi SET b = b + 1, c = 'foobar'
 Scan /Table/58/{1-2}
 Put /Table/58/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
 Put (delete) /Table/58/2/"foo"/3/0
-CPut /Table/58/2/"foobar"/3/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/58/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Update a row that matches the partial index before but not after.
 query T kvtrace
@@ -279,7 +279,7 @@ UPDATE tei SET a = a + 1, b = b + 100
 Scan /Table/59/{1-2}
 Put /Table/59/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Put (delete) /Table/59/2/102/1/0
-CPut /Table/59/2/203/1/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/59/2/203/1/0 -> /BYTES/0x0a0103
 
 # Update a row with different values without changing the index entry.
 query T kvtrace
@@ -340,7 +340,7 @@ UPDATE tii SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 Scan /Table/60/{1-2}
 Put /Table/60/1/1/0 -> /TUPLE/
 Put (delete) /Table/60/2/3/1/0
-InitPut /Table/60/2/4/1/0 -> /BYTES/0x0a0103
+Put /Table/60/2/4/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Multicolumn Inverted Index With Delete Preserving Encoding
@@ -395,5 +395,5 @@ Scan /Table/61/{1-2}
 Put /Table/61/1/1/0 -> /TUPLE/2:2:Int/3/
 Put (delete) /Table/61/2/2/"a"/"foo"/1/0
 Put (delete) /Table/61/2/2/"b"/"bar"/1/0
-InitPut /Table/61/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
-InitPut /Table/61/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103
+Put /Table/61/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
+Put /Table/61/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -118,7 +118,7 @@ UPSERT INTO ti VALUES (1, 3, 101)
 Scan /Table/60/1/1/0
 Put /Table/60/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
 Put (delete) /Table/60/2/2/100/1/0
-CPut /Table/60/2/3/101/1/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/60/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Partial Index With Delete Preserving Encoding
@@ -173,7 +173,7 @@ UPSERT INTO tpi VALUES (3, 2, 'foo')
 ----
 Scan /Table/61/1/3/0
 Put /Table/61/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
-CPut /Table/61/2/"foo"/3/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/61/2/"foo"/3/0 -> /BYTES/0x0a0103
 
 # Upsert a row that matches the partial index before and after, but the index
 # entry doesn't change.
@@ -191,7 +191,7 @@ UPSERT INTO tpi VALUES (3, 2, 'foobar')
 Scan /Table/61/1/3/0
 Put /Table/61/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
 Put (delete) /Table/61/2/"foo"/3/0
-CPut /Table/61/2/"foobar"/3/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/61/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Upsert a row that matches the partial index before but not after.
 query T kvtrace
@@ -253,7 +253,7 @@ UPSERT INTO tei VALUES (1, 3, 500)
 Scan /Table/62/1/1/0
 Put /Table/62/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/500
 Put (delete) /Table/62/2/102/1/0
-CPut /Table/62/2/503/1/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/62/2/503/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row with different values without changing the index entry.
 query T kvtrace
@@ -269,7 +269,7 @@ UPSERT INTO tei VALUES (2, 4, 499)
 Scan /Table/62/1/2/0
 Put /Table/62/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/499
 Put (delete) /Table/62/2/203/2/0
-CPut /Table/62/2/503/2/0 -> /BYTES/0x0a0103 (expecting does not exist)
+Put /Table/62/2/503/2/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Inverted Index With Delete Preserving Encoding
@@ -323,7 +323,7 @@ UPSERT INTO tii VALUES (1, ARRAY[1, 2, 2, NULL, 4, 4])
 Scan /Table/63/1/1/0
 Put /Table/63/1/1/0 -> /TUPLE/
 Put (delete) /Table/63/2/3/1/0
-InitPut /Table/63/2/4/1/0 -> /BYTES/0x0a0103
+Put /Table/63/2/4/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Multicolumn Inverted Index With Delete Preserving Encoding
@@ -378,5 +378,56 @@ Scan /Table/64/1/1/0
 Put /Table/64/1/1/0 -> /TUPLE/2:2:Int/3/
 Put (delete) /Table/64/2/2/"a"/"foo"/1/0
 Put (delete) /Table/64/2/2/"b"/"bar"/1/0
-InitPut /Table/64/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
-InitPut /Table/64/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103
+Put /Table/64/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
+Put /Table/64/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103
+
+# ---------------------------------------------------------
+# Unique Index With Delete Preserving Encoding
+# ---------------------------------------------------------
+statement ok
+CREATE TABLE tui (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    FAMILY (a, b, c),
+    UNIQUE INDEX (b, c)
+);
+
+let $t_id
+SELECT id FROM system.namespace WHERE name = 'tui'
+
+let $updated_t_jsonb
+WITH
+  descs
+    AS (
+      SELECT
+        id,
+        crdb_internal.pb_to_json(
+          'cockroach.sql.sqlbase.Descriptor',
+          descriptor
+        )
+          AS descriptor
+      FROM
+        system.descriptor
+    )
+SELECT
+  CAST (json_set(descriptor, ARRAY['table', 'indexes', '0', 'useDeletePreservingEncoding'], 'true') AS STRING)
+FROM
+  descs WHERE id = $t_id;
+
+statement ok
+SELECT * FROM crdb_internal.unsafe_upsert_descriptor($t_id, crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor',$$ $updated_t_jsonb $$), true)
+
+statement ok
+INSERT INTO tui VALUES (1, 2, 100), (2, 3, 200), (3, 4, 300)
+
+statement ok
+DELETE FROM tui WHERE a = 2
+
+query T kvtrace
+UPSERT INTO tui VALUES (1, 3, 200)
+----
+Scan /Table/65/1/1/0
+Put /Table/65/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
+Put (delete) /Table/65/2/2/100/0
+Put /Table/65/2/3/200/0 -> /BYTES/0x0a020389

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -191,7 +191,13 @@ func (ri *Inserter) InsertRow(
 		if ok {
 			for i := range entries {
 				e := &entries[i]
-				putFn(ctx, b, &e.Key, &e.Value, traceKV)
+
+				// We don't want to check any conflicts when trying to preserve deletes.
+				if ri.Helper.Indexes[idx].UseDeletePreservingEncoding() {
+					insertPutFn(ctx, b, &e.Key, &e.Value, traceKV)
+				} else {
+					putFn(ctx, b, &e.Key, &e.Value, traceKV)
+				}
 			}
 		}
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -420,16 +420,24 @@ func (ru *Updater) UpdateRow(
 					} else {
 						continue
 					}
-					if traceKV {
-						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-						v := newEntry.Value.PrettyPrint()
-						if expValue != nil {
-							log.VEventf(ctx, 2, "CPut %s -> %v (replacing %v, if exists)", k, v, expValue)
-						} else {
-							log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+
+					if index.UseDeletePreservingEncoding() {
+						// Delete preserving encoding indexes are used only as a log of
+						// index writes during backfill, thus we can blindly put values into
+						// them.
+						insertPutFn(ctx, batch, &newEntry.Key, &newEntry.Value, traceKV)
+					} else {
+						if traceKV {
+							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
+							v := newEntry.Value.PrettyPrint()
+							if expValue != nil {
+								log.VEventf(ctx, 2, "CPut %s -> %v (replacing %v, if exists)", k, v, expValue)
+							} else {
+								log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+							}
 						}
+						batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, expValue)
 					}
-					batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, expValue)
 				} else if oldEntry.Family < newEntry.Family {
 					if oldEntry.Family == descpb.FamilyID(0) {
 						return nil, errors.AssertionFailedf(
@@ -450,15 +458,23 @@ func (ru *Updater) UpdateRow(
 							ru.Helper.TableDesc.GetName(), index.GetName(),
 						)
 					}
-					// In this case, the index now has a k/v that did not exist in the
-					// old row, so we should expect to not see a value for the new
-					// key, and put the new key in place.
-					if traceKV {
-						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-						v := newEntry.Value.PrettyPrint()
-						log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+
+					if index.UseDeletePreservingEncoding() {
+						// Delete preserving encoding indexes are used only as a log of
+						// index writes during backfill, thus we can blindly put values into
+						// them.
+						insertPutFn(ctx, batch, &newEntry.Key, &newEntry.Value, traceKV)
+					} else {
+						// In this case, the index now has a k/v that did not exist in the
+						// old row, so we should expect to not see a value for the new key,
+						// and put the new key in place.
+						if traceKV {
+							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
+							v := newEntry.Value.PrettyPrint()
+							log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+						}
+						batch.CPut(newEntry.Key, &newEntry.Value, nil)
 					}
-					batch.CPut(newEntry.Key, &newEntry.Value, nil)
 					newIdx++
 				}
 			}
@@ -481,12 +497,16 @@ func (ru *Updater) UpdateRow(
 				// and the old row values do not match the partial index
 				// predicate.
 				newEntry := &newEntries[newIdx]
-				if traceKV {
-					k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-					v := newEntry.Value.PrettyPrint()
-					log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+				if index.UseDeletePreservingEncoding() {
+					insertPutFn(ctx, batch, &newEntry.Key, &newEntry.Value, traceKV)
+				} else {
+					if traceKV {
+						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
+						v := newEntry.Value.PrettyPrint()
+						log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+					}
+					batch.CPut(newEntry.Key, &newEntry.Value, nil)
 				}
-				batch.CPut(newEntry.Key, &newEntry.Value, nil)
 				newIdx++
 			}
 		} else {
@@ -496,10 +516,15 @@ func (ru *Updater) UpdateRow(
 					return nil, err
 				}
 			}
-			putFn := insertInvertedPutFn
 			// We're adding all of the inverted index entries from the row being updated.
 			for j := range ru.newIndexEntries[i] {
-				putFn(ctx, batch, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+				if index.UseDeletePreservingEncoding() {
+					// Delete preserving encoding indexes are used only as a log of index
+					// writes during backfill, thus we can blindly put values into them.
+					insertPutFn(ctx, batch, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+				} else {
+					insertInvertedPutFn(ctx, batch, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This change adds functionality to allow the schema changer to merge entries
from a delete-preserving index to another index.

This change also modifies the write path for delete-preserving indexes to
use Put instead of CPut or InitPut as we don't need these types of checks
for the delete-preserving indexes. The delete-preserving index will only
be used as a log of writes during the new index backfilling process. Any
constraints will be resolved when these entries are merged back into the main
index.

This change is part of a rewrite of the index backfiller:
https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20211004_incremental_index_backfiller.md#new-index-encoding-for-deletions-vs-mvcc

Release note: None