### PR TITLE
storage: Use prefix iteration for CheckSSTConflicts

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -361,3 +361,23 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 
 	b.StopTimer()
 }
+
+func BenchmarkCheckSSTConflicts(b *testing.B) {
+	for _, numKeys := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
+			for _, numVersions := range []int{8, 64} {
+				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
+					for _, numSstKeys := range []int{1000, 10000} {
+						b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
+							for _, overlap := range []bool{false, true} {
+								b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
+									runCheckSSTConflicts(b, numKeys, numVersions, numSstKeys, overlap)
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1524,3 +1524,55 @@ type noopWriter struct{}
 
 func (noopWriter) Close() error                { return nil }
 func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func runCheckSSTConflicts(b *testing.B, numEngineKeys, numVersions, numSstKeys int, overlap bool) {
+	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
+	value := make([]byte, 128)
+	for i := range value {
+		value[i] = 'a'
+	}
+
+	eng := setupMVCCInMemPebble(b, "")
+	defer eng.Close()
+
+	for i := 0; i < numEngineKeys; i++ {
+		batch := eng.NewBatch()
+		for j := 0; j < numVersions; j++ {
+			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
+			ts := hlc.Timestamp{WallTime: int64(j + 1)}
+			require.NoError(b, batch.PutMVCC(MVCCKey{key, ts}, value))
+		}
+		require.NoError(b, batch.Commit(false))
+	}
+	require.NoError(b, eng.Flush())
+
+	// The engine contains keys numbered key-1, key-2, key-3, etc, while
+	// the SST contains keys numbered key-11, key-21, etc., that fit in
+	// between the engine keys without colliding.
+	sstFile := &MemFile{}
+	sstWriter := MakeIngestionSSTWriter(sstFile)
+	var sstStart, sstEnd MVCCKey
+	for i := 0; i < numSstKeys; i++ {
+		keyNum := int((float64(i) / float64(numSstKeys)) * float64(numEngineKeys))
+		if !overlap {
+			keyNum = i + numEngineKeys
+		}
+		key := roachpb.Key(encoding.EncodeUvarintAscending(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyNum)), 1))
+		mvccKey := MVCCKey{Key: key, Timestamp: hlc.Timestamp{WallTime: int64(numVersions + 3)}}
+		if i == 0 {
+			sstStart.Key = append([]byte(nil), mvccKey.Key...)
+			sstStart.Timestamp = mvccKey.Timestamp
+		} else if i == numSstKeys-1 {
+			sstEnd.Key = append([]byte(nil), mvccKey.Key...)
+			sstEnd.Timestamp = mvccKey.Timestamp
+		}
+		require.NoError(b, sstWriter.Put(mvccKey, value))
+	}
+	sstWriter.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := CheckSSTConflicts(context.Background(), sstFile.Data(), eng, sstStart, sstEnd, false, hlc.Timestamp{}, math.MaxInt64)
+		require.NoError(b, err)
+	}
+}

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -58,9 +58,19 @@ func CheckSSTConflicts(
 			"cannot set both DisallowShadowing and DisallowShadowingBelow")
 	}
 
-	extIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end.Key})
+	// Fast path: there are no keys in the reader between the sstable's start and
+	// end keys. We use a non-prefix iterator for this search, and reopen a prefix
+	// one if there are engine keys in the span.
+	nonPrefixIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end.Key})
+	nonPrefixIter.SeekGE(start)
+	valid, _ := nonPrefixIter.Valid()
+	nonPrefixIter.Close()
+	if !valid {
+		return statsDiff, nil
+	}
+
+	extIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: end.Key, Prefix: true})
 	defer extIter.Close()
-	extIter.SeekGE(start)
 
 	sstIter, err := NewMemSSTIterator(sst, false)
 	if err != nil {
@@ -69,11 +79,30 @@ func CheckSSTConflicts(
 	defer sstIter.Close()
 	sstIter.SeekGE(start)
 
-	extOK, extErr := extIter.Valid()
+	// extIter is a prefix iterator; it is expected to skip keys that belong
+	// to different prefixes. Only iterate along the sst iterator, and re-seek
+	// extIter each time.
 	sstOK, sstErr := sstIter.Valid()
-	for extErr == nil && sstErr == nil && extOK && sstOK {
+	if sstOK {
+		extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+	}
+	extOK, extErr := extIter.Valid()
+	for sstErr == nil && sstOK {
 		if err := ctx.Err(); err != nil {
 			return enginepb.MVCCStats{}, err
+		}
+		if !extOK {
+			// There is no key in extIter matching this prefix. Check the next
+			// key in sstIter. Note that we can't just use an exhausted extIter
+			// as a sign that we are done; extIter could be skipping keys, so it
+			// must be re-seeked.
+			sstIter.NextKey()
+			sstOK, sstErr = sstIter.Valid()
+			if sstOK {
+				extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+			}
+			extOK, extErr = extIter.Valid()
+			continue
 		}
 
 		extKey, extValue := extIter.UnsafeKey(), extIter.UnsafeValue()
@@ -81,12 +110,19 @@ func CheckSSTConflicts(
 
 		// Keep seeking the iterators until both keys are equal.
 		if cmp := bytes.Compare(extKey.Key, sstKey.Key); cmp < 0 {
+			// sstIter is further ahead. Seek extIter.
 			extIter.SeekGE(MVCCKey{Key: sstKey.Key})
 			extOK, extErr = extIter.Valid()
 			continue
 		} else if cmp > 0 {
-			sstIter.SeekGE(MVCCKey{Key: extKey.Key})
+			// extIter is further ahead. But it could have skipped keys in between,
+			// so re-seek it at the next sst key.
+			sstIter.NextKey()
 			sstOK, sstErr = sstIter.Valid()
+			if sstOK {
+				extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+			}
+			extOK, extErr = extIter.Valid()
 			continue
 		}
 
@@ -118,7 +154,11 @@ func CheckSSTConflicts(
 				if int64(len(intents)) >= maxIntents {
 					return enginepb.MVCCStats{}, &roachpb.WriteIntentError{Intents: intents}
 				}
-				extIter.NextKey()
+				sstIter.NextKey()
+				sstOK, sstErr = sstIter.Valid()
+				if sstOK {
+					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+				}
 				extOK, extErr = extIter.Valid()
 				continue
 			}
@@ -155,7 +195,11 @@ func CheckSSTConflicts(
 			statsDiff.ValBytes -= int64(len(sstValue))
 			statsDiff.ValCount--
 
-			extIter.NextKey()
+			sstIter.NextKey()
+			sstOK, sstErr = sstIter.Valid()
+			if sstOK {
+				extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+			}
 			extOK, extErr = extIter.Valid()
 			continue
 		}
@@ -194,15 +238,19 @@ func CheckSSTConflicts(
 			statsDiff.LiveBytes -= int64(len(extValue)) + MVCCVersionTimestampSize
 		}
 
-		extIter.NextKey()
+		sstIter.NextKey()
+		sstOK, sstErr = sstIter.Valid()
+		if sstOK {
+			extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
+		}
 		extOK, extErr = extIter.Valid()
 	}
 
-	if extErr != nil {
-		return enginepb.MVCCStats{}, extErr
-	}
 	if sstErr != nil {
 		return enginepb.MVCCStats{}, sstErr
+	}
+	if extErr != nil {
+		return enginepb.MVCCStats{}, extErr
 	}
 	if len(intents) > 0 {
 		return enginepb.MVCCStats{}, &roachpb.WriteIntentError{Intents: intents}


### PR DESCRIPTION
Currently we use a regular iterator to iterate on the
reader/engine in CheckSSTConflicts during ingestion,
even though the SST is usually much smaller in size and
sparser in keys than the engine. Given most of the
time we are just re-seeking the engine iterator anyway,
it makes sense to use a prefix iterator to optimize those
seeks to take advantage of bloom filters on any sstables.

Using the microbenchmark added in this PR:

```
name                                                                      old time/op  new time/op  delta
CheckSSTConflicts/keys=1000/versions=8/sstKeys=1000/overlap=false-24      66.7µs ± 1%   2.1µs ± 1%  -96.89%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=8/sstKeys=1000/overlap=true-24       12.0ms ± 0%   0.8ms ± 1%  -93.06%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=8/sstKeys=10000/overlap=false-24     67.8µs ± 1%   2.1µs ± 0%  -96.94%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=8/sstKeys=10000/overlap=true-24      12.3ms ± 1%   1.6ms ± 1%  -86.66%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=64/sstKeys=1000/overlap=false-24     64.2µs ± 0%   2.1µs ± 1%  -96.79%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=64/sstKeys=1000/overlap=true-24      12.8ms ± 1%   0.8ms ± 1%  -93.46%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=64/sstKeys=10000/overlap=false-24    64.9µs ± 0%   2.1µs ± 1%  -96.82%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/versions=64/sstKeys=10000/overlap=true-24     12.9ms ± 1%   1.6ms ± 1%  -87.51%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=8/sstKeys=1000/overlap=false-24     64.3µs ± 1%   2.1µs ± 1%  -96.79%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=8/sstKeys=1000/overlap=true-24      12.6ms ± 1%   0.8ms ± 1%  -93.41%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=8/sstKeys=10000/overlap=false-24    65.2µs ± 1%   2.1µs ± 1%  -96.85%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=8/sstKeys=10000/overlap=true-24      121ms ± 1%     7ms ± 2%  -93.85%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=64/sstKeys=1000/overlap=false-24    62.8µs ± 1%   2.1µs ± 0%  -96.67%  (p=0.016 n=5+4)
CheckSSTConflicts/keys=10000/versions=64/sstKeys=1000/overlap=true-24     13.6ms ± 1%   2.4ms ± 6%  -82.50%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=64/sstKeys=10000/overlap=false-24   63.9µs ± 1%   2.1µs ± 1%  -96.72%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/versions=64/sstKeys=10000/overlap=true-24     132ms ± 1%    26ms ± 1%  -80.22%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=8/sstKeys=1000/overlap=false-24    63.2µs ± 1%   2.1µs ± 1%  -96.75%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=8/sstKeys=1000/overlap=true-24     13.6ms ± 1%   2.2ms ± 4%  -83.87%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=8/sstKeys=10000/overlap=false-24   64.0µs ± 2%   2.0µs ± 1%  -96.81%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=8/sstKeys=10000/overlap=true-24     139ms ± 1%    26ms ± 1%  -81.36%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=64/sstKeys=1000/overlap=false-24   62.4µs ± 2%   2.1µs ± 2%  -96.57%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=64/sstKeys=1000/overlap=true-24    13.9ms ± 1%   2.8ms ± 6%  -79.85%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=64/sstKeys=10000/overlap=false-24  62.6µs ± 2%   2.1µs ± 2%  -96.60%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=100000/versions=64/sstKeys=10000/overlap=true-24    183ms ± 4%    51ms ±37%  -72.11%  (p=0.008 n=5+5)
```

Release note: None.