### PR TITLE
roachtest: force large snapshot in splits/largerange

### DIFF
--- a/pkg/util/retry/BUILD.bazel
+++ b/pkg/util/retry/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/retry",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -209,7 +209,7 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			maxNumAttempts: 1,
 		},
 		{
-			desc: "errors when max attempts is exhausted",
+			desc: "errors when max_attempts=3 is exhausted",
 			ctx:  context.Background(),
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
@@ -222,6 +222,22 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 
 			minNumAttempts:  3,
 			maxNumAttempts:  3,
+			expectedErrText: expectedErr.Error(),
+		},
+		{
+			desc: "errors when max_attempts=1 is exhausted",
+			ctx:  context.Background(),
+			opts: Options{
+				InitialBackoff: time.Microsecond * 10,
+				MaxBackoff:     time.Microsecond * 20,
+				Multiplier:     2,
+				MaxRetries:     0,
+			},
+			retryFunc:   errWithAttemptsCounterFunc,
+			maxAttempts: 1,
+
+			minNumAttempts:  1,
+			maxNumAttempts:  1,
 			expectedErrText: expectedErr.Error(),
 		},
 		{


### PR DESCRIPTION
This refactors this test such that it always up-replicates using
large snapshots, something that we've seen cause [problems] in the past.

In fact there's a hint at what these problems might be by running this
test now. The upreplication phase takes around 7 minutes (at least in
this particular run; it does vary):

> 13:28:11 split.go:358: bank table replicated after 7m47.730637804s:
r44, {1,6,2}

Based on the transfer speeds alone, we'd expect closer to `2*72.44s`,
i.e. 2-3 minutes:

> I211206 13:22:08.332386 442 kv/kvserver/store_snapshot.go:974 ⋮ [n1,replicate,s1,r44/1:‹/{Table/56-Max}›] 1001  streamed INITIAL snapshot dd4c9be0 at applied index 149418 to (n6,s6):2LEARNER with 16 GiB in 72.44s @ 226 MiB/s: kv pairs: 132152847, rate-limit: 512 MiB/s, queued: 0.02s

What ends up happening is that we send a few of the snapshots in vain as
the `LEARNER` is rolled back before the snapshot completes. This is due
to lease transfers that happen while the snapshot is in flight, where
the new leaseholder proceeds to remove the destination replica (just to
then re-add it under a higher replicaID). I filed this as #73519 but it
shouldn't cause this test to fail, so we'll live with it for now.

It may fail again but since the test has changed substantially:

Fixes #65291.

Release note: None
