### PR TITLE
tracing: improve Span.FinishAndGetRecording()

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -231,19 +231,29 @@ func (s *crdbSpan) TraceID() tracingpb.TraceID {
 	return s.traceID
 }
 
-// GetRecording is part of the RegistrySpan interface.
-func (s *crdbSpan) GetRecording(recType RecordingType) Recording {
-	return s.getRecordingImpl(recType, false /* includeDetachedChildren */)
+// GetRecording returns the span's recording.
+//
+// finishing indicates whether s is in the process of finishing. If it isn't,
+// the recording will include an "_unfinished" tag.
+func (s *crdbSpan) GetRecording(recType RecordingType, finishing bool) Recording {
+	return s.getRecordingImpl(recType, false /* includeDetachedChildren */, finishing)
 }
 
+// GetFullRecording is part of the RegistrySpan interface.
 func (s *crdbSpan) GetFullRecording(recType RecordingType) Recording {
-	return s.getRecordingImpl(recType, true /* includeDetachedChildren */)
+	return s.getRecordingImpl(recType, true /* includeDetachedChildren */, false /* finishing */)
 }
 
-func (s *crdbSpan) getRecordingImpl(recType RecordingType, includeDetachedChildren bool) Recording {
+// getRecordingImpl returns the span's recording.
+//
+// finishing indicates whether s is in the process of finishing. If it isn't,
+// the recording will include an "_unfinished" tag.
+func (s *crdbSpan) getRecordingImpl(
+	recType RecordingType, includeDetachedChildren bool, finishing bool,
+) Recording {
 	switch recType {
 	case RecordingVerbose:
-		return s.getVerboseRecording(includeDetachedChildren)
+		return s.getVerboseRecording(includeDetachedChildren, finishing)
 	case RecordingStructured:
 		return s.getStructuredRecording(includeDetachedChildren)
 	case RecordingOff:
@@ -254,7 +264,10 @@ func (s *crdbSpan) getRecordingImpl(recType RecordingType, includeDetachedChildr
 }
 
 // getVerboseRecording returns the Span's recording, including its children.
-func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool) Recording {
+//
+// finishing indicates whether s is in the process of finishing. If it isn't,
+// the recording will include an "_unfinished" tag.
+func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool, finishing bool) Recording {
 	if s == nil {
 		return nil // noop span
 	}
@@ -263,12 +276,12 @@ func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool) Recording {
 	// The capacity here is approximate since we don't know how many
 	// grandchildren there are.
 	result := make(Recording, 0, 1+len(s.mu.recording.openChildren)+len(s.mu.recording.finishedChildren))
-	result = append(result, s.getRecordingNoChildrenLocked(RecordingVerbose))
+	result = append(result, s.getRecordingNoChildrenLocked(RecordingVerbose, finishing))
 	result = append(result, s.mu.recording.finishedChildren...)
 
 	for _, child := range s.mu.recording.openChildren {
 		if child.collectRecording || includeDetachedChildren {
-			result = append(result, child.getVerboseRecording(includeDetachedChildren)...)
+			result = append(result, child.getVerboseRecording(includeDetachedChildren, false /* finishing */)...)
 		}
 	}
 	s.mu.Unlock()
@@ -311,7 +324,10 @@ func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) Recordin
 		return nil
 	}
 
-	res := s.getRecordingNoChildrenLocked(RecordingOff)
+	res := s.getRecordingNoChildrenLocked(
+		RecordingStructured,
+		false, // finishing - since we're only asking for the structured recording, the argument doesn't matter
+	)
 	// If necessary, grow res.StructuredRecords to have space for buffer.
 	var reservedSpace []tracingpb.StructuredRecord
 	if cap(res.StructuredRecords)-len(res.StructuredRecords) < len(buffer) {
@@ -506,8 +522,11 @@ func (s *crdbSpan) getStructuredEventsLocked(
 // The tags are included in the result only if recordingType==RecordingVerbose.
 // This is a performance optimization as stringifying the tag values can be
 // expensive.
+//
+// finishing indicates whether s is in the process of finishing. If it isn't,
+// the recording will include an "_unfinished" tag.
 func (s *crdbSpan) getRecordingNoChildrenLocked(
-	recordingType RecordingType,
+	recordingType RecordingType, finishing bool,
 ) tracingpb.RecordedSpan {
 	rs := tracingpb.RecordedSpan{
 		TraceID:        s.traceID,
@@ -547,7 +566,7 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	// more.
 	wantTags := recordingType == RecordingVerbose
 	if wantTags {
-		if s.mu.duration == -1 {
+		if !finishing && !s.mu.finished {
 			addTag("_unfinished", "1")
 		}
 		addTag("_verbose", "1")
@@ -661,7 +680,7 @@ func (s *crdbSpan) childFinished(child *crdbSpan) {
 		panic("should have been handled above")
 	case RecordingVerbose:
 		verbose = true
-		rec = child.GetRecording(RecordingVerbose)
+		rec = child.GetRecording(RecordingVerbose, false /* finishing - the child is already finished */)
 	case RecordingStructured:
 		events = make([]*tracingpb.StructuredRecord, 0, 3)
 		events = child.getStructuredEventsRecursively(events, false /* includeDetachedChildren */)

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -196,7 +196,6 @@ func TestGRPCInterceptors(t *testing.T) {
 			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
 			var n int
 			finalRecs := sp.FinishAndGetRecording(tracing.RecordingVerbose)
-			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
 				n += len(rec.StructuredRecords)
 				// Remove all of the _unfinished tags. These crop up because

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -117,6 +117,9 @@ func (sp *Span) FinishAndGetRecording(recType RecordingType) Recording {
 // If recType is RecordingStructured, the return value will be nil if the span
 // doesn't have any structured events.
 func (sp *Span) GetRecording(recType RecordingType) Recording {
+	if sp.done() {
+		return nil
+	}
 	return sp.i.GetRecording(recType)
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -155,6 +155,9 @@ func (sp *Span) Meta() SpanMeta {
 // auxiliary trace sink). This does not apply to Spans derived from this one
 // when it was verbose.
 func (sp *Span) SetVerbose(to bool) {
+	if sp.done() {
+		return
+	}
 	// We allow toggling verbosity on and off for a finished span. This shouldn't
 	// matter either way as a finished span drops all new data, but if we
 	// prevented the toggling we could end up in weird states since IsVerbose()

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -89,9 +89,10 @@ func (sp *Span) Finish() {
 // would appear to be unfinished in the recording (it's illegal to collect the
 // recording after the span finishes, except by using this method).
 func (sp *Span) FinishAndGetRecording(recType RecordingType) Recording {
+	// Reach directly into sp.i to pass the finishing argument.
+	rec := sp.i.GetRecording(recType, true /* finishing */)
 	sp.Finish()
-	// Reach directly into sp.i to avoide the done() check in sp.GetRecording().
-	return sp.i.GetRecording(recType)
+	return rec
 }
 
 // GetRecording retrieves the current recording, if the Span has recording
@@ -120,7 +121,7 @@ func (sp *Span) GetRecording(recType RecordingType) Recording {
 	if sp.done() {
 		return nil
 	}
-	return sp.i.GetRecording(recType)
+	return sp.i.GetRecording(recType, false /* finishing */)
 }
 
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -68,11 +68,15 @@ func (s *spanInner) SetVerbose(to bool) {
 	s.crdb.SetVerbose(to)
 }
 
-func (s *spanInner) GetRecording(recType RecordingType) Recording {
+// GetRecording returns the span's recording.
+//
+// finishing indicates whether s is in the process of finishing. If it isn't,
+// the recording will include an "_unfinished" tag.
+func (s *spanInner) GetRecording(recType RecordingType, finishing bool) Recording {
 	if s.isNoop() {
 		return nil
 	}
-	return s.crdb.GetRecording(recType)
+	return s.crdb.GetRecording(recType, finishing)
 }
 
 func (s *spanInner) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {


### PR DESCRIPTION
FinishAndGetRecording() needs to "atomically" finish the span and
collect its recording. The atomic part means that the recording should
not have an "_unfinished" tag in it. Avoiding the presence of that tag
was a bit delicate because, naively, if the recording is collected
before the span is "finished", then the tag would be present and, on the
other hand, the reverse ordering is not easily possible because, if the
span was first finished and then the recording would be collected, that
would be a use-after-Finish() and the recording would not be collected.

Before this patch, FinishAndGetRecording() was cheating a bit by
technically still collecting the recording after finish, but eliding the
use-after-Finish() protection. This shortcut is becoming problematic,
because I need to make Finish() more distructive at lower levels
(working towards the ability to reuse spans), and so even this
"internal" use-after-finish will not work any more. Instead, this patch
moves recording collection before finish, but plumbs down information
about whether a span is in the process of finishing when its recording
is collected, for avoiding the "_unfinished" span.

Release note: None