### PR TITLE
kv/kvnemesis: skip TestKVNemesisSingleNode

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -37,6 +37,7 @@ func init() {
 
 func TestKVNemesisSingleNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 73373, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
 


### PR DESCRIPTION
Refs: #73373

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None