### PR TITLE
cmd/roachprod: disable fancy progress bar when terminal not attached

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/flagutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_term//:term",
     ],
 )
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -81,7 +82,8 @@ var (
 )
 
 func initFlags() {
-	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "disable fancy progress output")
+	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q",
+		false || !term.IsTerminal(int(os.Stdout.Fd())), "disable fancy progress output")
 	rootCmd.PersistentFlags().IntVarP(&config.MaxConcurrency, "max-concurrency", "", 32,
 		"maximum number of operations to execute on nodes concurrently, set to zero for infinite",
 	)


### PR DESCRIPTION
Prior to #72473, `roachprod` would run in "quiet mode" when a terminal
was not attached to stdout (e.g. during a `roachtest`). This avoids
printing each rune of the spinner in a loop (one run every 100ms), which
can result in a very large log file.

Revert to the behavior prior to #72473, which enables quiet mode by
explicitly checking if there is a terminal attached to stdout.

Release note: None