### PR TITLE
kv: don't set CanForwardReadTimestamp on implicit->explicit EndTxn transition

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -252,7 +252,7 @@ func (tc *txnCommitter) SendLocked(
 	// we transition to an explicitly committed transaction as soon as possible.
 	// This also has the side-effect of kicking off intent resolution.
 	mergedLockSpans, _ := mergeIntoSpans(et.LockSpans, et.InFlightWrites)
-	tc.makeTxnCommitExplicitAsync(ctx, br.Txn, mergedLockSpans, ba.CanForwardReadTimestamp)
+	tc.makeTxnCommitExplicitAsync(ctx, br.Txn, mergedLockSpans)
 
 	// Switch the status on the batch response's transaction to COMMITTED. No
 	// interceptor above this one in the stack should ever need to deal with
@@ -464,7 +464,7 @@ func needTxnRetryAfterStaging(br *roachpb.BatchResponse) *roachpb.Error {
 // written) to explicitly committed (COMMITTED status). It does so by sending a
 // second EndTxnRequest, this time with no InFlightWrites attached.
 func (tc *txnCommitter) makeTxnCommitExplicitAsync(
-	ctx context.Context, txn *roachpb.Transaction, lockSpans []roachpb.Span, canFwdRTS bool,
+	ctx context.Context, txn *roachpb.Transaction, lockSpans []roachpb.Span,
 ) {
 	// TODO(nvanbenschoten): consider adding tracing for this request.
 	// TODO(nvanbenschoten): add a timeout to this request.
@@ -482,7 +482,7 @@ func (tc *txnCommitter) makeTxnCommitExplicitAsync(
 		asyncCtx, "txnCommitter: making txn commit explicit", func(ctx context.Context) {
 			tc.mu.Lock()
 			defer tc.mu.Unlock()
-			if err := makeTxnCommitExplicitLocked(ctx, tc.wrapped, txn, lockSpans, canFwdRTS); err != nil {
+			if err := makeTxnCommitExplicitLocked(ctx, tc.wrapped, txn, lockSpans); err != nil {
 				log.Errorf(ctx, "making txn commit explicit failed for %s: %v", txn, err)
 			}
 		},
@@ -492,18 +492,14 @@ func (tc *txnCommitter) makeTxnCommitExplicitAsync(
 }
 
 func makeTxnCommitExplicitLocked(
-	ctx context.Context,
-	s lockedSender,
-	txn *roachpb.Transaction,
-	lockSpans []roachpb.Span,
-	canFwdRTS bool,
+	ctx context.Context, s lockedSender, txn *roachpb.Transaction, lockSpans []roachpb.Span,
 ) error {
 	// Clone the txn to prevent data races.
 	txn = txn.Clone()
 
 	// Construct a new batch with just an EndTxn request.
 	ba := roachpb.BatchRequest{}
-	ba.Header = roachpb.Header{Txn: txn, CanForwardReadTimestamp: canFwdRTS}
+	ba.Header = roachpb.Header{Txn: txn}
 	et := roachpb.EndTxnRequest{Commit: true}
 	et.Key = txn.Key
 	et.LockSpans = lockSpans

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
@@ -380,7 +380,7 @@ func TestTxnCommitterAsyncExplicitCommitTask(t *testing.T) {
 		mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			defer close(explicitCommitCh)
 			require.Len(t, ba.Requests, 1)
-			require.True(t, ba.CanForwardReadTimestamp)
+			require.False(t, ba.CanForwardReadTimestamp)
 			require.IsType(t, &roachpb.EndTxnRequest{}, ba.Requests[0].GetInner())
 
 			et := ba.Requests[0].GetInner().(*roachpb.EndTxnRequest)


### PR DESCRIPTION
This commit removes logic that was setting the `CanForwardReadTimestamp` flag on the batch header of the EndTxn request in `makeTxnCommitExplicitLocked` to whatever the flag was set to in the batch that implicitly committed the txn. This did not make sense, as we don't expect an implicit->explicit EndTxn to forward the commit timestamp. In fact, such behavior would be a major problem, as the transaction commit timestamp should not change during this transition.

This was not being set for a great reason. It was originally added in cd37f94 when we fixed a bug that was allowing these requests to avoid checking for retryable errors. I checked out that commit and determined that it seems to have been necessary to avoid hitting retryable errors on the implicit->explicit transition in the case when the initial staging record had avoided a txn retry error on [this code path](https://github.com/cockroachdb/cockroach/blob/cd37f94f097abb605907ff4b41b29f2e8e361f01/pkg/storage/batcheval/cmd_end_transaction.go#L407). The use of the flag was necessary because on that path, we weren't telling the client about the refresh. We were just accepting its Txn with a split read timestamp and write timestamp but not returning an updated Transaction proto. This was later rationalized in 901d87f. In that later commit, we consolidated server-side refreshes and ensured that the `BatchResponse.Txn` of a successful `EndTxn` reflected the post-refresh state. So setting the flag in `makeTxnCommitExplicitLocked` has not been necessary since, because this post-refresh proto is what we attach to the implicit->explicit EndTxn request.