### PR TITLE
release-21.2: sql: actually deflake TestSavepoints

### DIFF
--- a/pkg/sql/testdata/savepoints
+++ b/pkg/sql/testdata/savepoints
@@ -263,7 +263,7 @@ INSERT INTO t VALUES (1)
 -- Open        -> Open        ##  (none)
 
 sql
-SET lock_timeout = '1ms'
+SET lock_timeout = '100ms'
 BEGIN
 SAVEPOINT foo
 SELECT * FROM t WHERE x = 1 FOR UPDATE
@@ -272,7 +272,7 @@ SELECT * FROM t WHERE x = 2 FOR UPDATE
 COMMIT
 SET lock_timeout = 0
 ----
-1: SET lock_timeout = '1ms' -- 0 rows
+1: SET lock_timeout = '100ms' -- 0 rows
 -- NoTxn       -> NoTxn       #.......  (none)
 2: BEGIN -- 0 rows
 -- NoTxn       -> Open        ##......  (none)


### PR DESCRIPTION
Backport 1/2 commits from #73494.

/cc @cockroachdb/release

Release justification: testing only

---

This PR rolls back #73388 and reworks the fix for #70220. #73388 was an incorrect fix because the test relies on the progress table being updated in the same transaction as the rest of the SQL logic. This ensures that progress updates are rolled back when the rest of the transaction is rolled back. I didn't catch this in the initial PR because I missed the fact that the test had been skipped on `master`, so the test appeared to be passing with the change. When I then tried to backport the change in #73492, CI caught the mistake.

The PR then deflakes `TestSavepoints` by increasing the lock timeout significantly (from 1ms to 100ms) in the `rollback_after_lock_timeout` subtest. The test was flaky because after the transaction hits a lock timeout error, it performs an async rollback. If this async rollback hasn't grabbed latches by the time the next txn retry (with a different txn ID) finishes waiting out the lock_timeout when attempting to write to its progress, a lock timeout error would be thrown. This commit makes this extremely unlikely by increasing the lock timeout from 1ms to 100ms. With this new timeout, I've never seen the test flake under stress.
