### PR TITLE
tree,spanconfig: s/AvoidCached/AvoidLeased in lookup flags

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -299,7 +299,7 @@ func processTableForMultiRegion(
 	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 		ctx, txn, table.GetParentID(), tree.DatabaseLookupFlags{
 			Required:       true,
-			AvoidCached:    true,
+			AvoidLeased:    true,
 			IncludeOffline: true,
 		})
 	if err != nil {
@@ -1342,7 +1342,7 @@ func createImportingDescriptors(
 				_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 					ctx, txn, table.GetParentID(), tree.DatabaseLookupFlags{
 						Required:       true,
-						AvoidCached:    true,
+						AvoidLeased:    true,
 						IncludeOffline: true,
 					})
 				if err != nil {
@@ -1396,7 +1396,7 @@ func createImportingDescriptors(
 							table.ParentID,
 							tree.DatabaseLookupFlags{
 								Required:       true,
-								AvoidCached:    true,
+								AvoidLeased:    true,
 								IncludeOffline: true,
 							},
 						)
@@ -2307,7 +2307,7 @@ func (r *restoreResumer) dropDescriptors(
 		typDesc := details.TypeDescs[i]
 		mutType, err := descsCol.GetMutableTypeByID(ctx, txn, typDesc.ID, tree.ObjectLookupFlags{
 			CommonLookupFlags: tree.CommonLookupFlags{
-				AvoidCached:    true,
+				AvoidLeased:    true,
 				IncludeOffline: true,
 			},
 		})
@@ -2513,7 +2513,7 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 		_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
 			ctx, txn, tbl.GetParentID(), tree.DatabaseLookupFlags{
 				Required:       true,
-				AvoidCached:    true,
+				AvoidLeased:    true,
 				IncludeOffline: true,
 			})
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -135,7 +135,7 @@ func fetchSpansForTargets(
 		// Note that all targets are currently guaranteed to be tables.
 		for tableID := range targets {
 			flags := tree.ObjectLookupFlagsWithRequired()
-			flags.AvoidCached = true
+			flags.AvoidLeased = true
 			tableDesc, err := descriptors.GetImmutableTableByID(ctx, txn, tableID, flags)
 			if err != nil {
 				return err

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -280,7 +280,7 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 		// Note that all targets are currently guaranteed to be tables.
 		for tableID := range tf.targets {
 			flags := tree.ObjectLookupFlagsWithRequired()
-			flags.AvoidCached = true
+			flags.AvoidLeased = true
 			tableDesc, err := descriptors.GetImmutableTableByID(ctx, txn, tableID, flags)
 			if err != nil {
 				return err

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -738,7 +738,7 @@ func (r *importResumer) parseBundleSchemaIfNeeded(ctx context.Context, phs inter
 			) (err error) {
 				_, dbDesc, err = descriptors.GetImmutableDatabaseByID(ctx, txn, parentID, tree.DatabaseLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				})
 				if err != nil {
 					return err

--- a/pkg/ccl/importccl/import_planning.go
+++ b/pkg/ccl/importccl/import_planning.go
@@ -278,7 +278,7 @@ func resolveUDTsUsedByImportInto(
 		_, dbDesc, err = descriptors.GetImmutableDatabaseByID(ctx, txn, table.GetParentID(),
 			tree.DatabaseLookupFlags{
 				Required:    true,
-				AvoidCached: true,
+				AvoidLeased: true,
 			})
 		if err != nil {
 			return err
@@ -288,7 +288,7 @@ func resolveUDTsUsedByImportInto(
 				immutDesc, err := descriptors.GetImmutableTypeByID(ctx, txn, id, tree.ObjectLookupFlags{
 					CommonLookupFlags: tree.CommonLookupFlags{
 						Required:    true,
-						AvoidCached: true,
+						AvoidLeased: true,
 					},
 				})
 				if err != nil {
@@ -304,7 +304,7 @@ func resolveUDTsUsedByImportInto(
 			immutDesc, err := descriptors.GetImmutableTypeByID(ctx, txn, typeID, tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				},
 			})
 			if err != nil {
@@ -489,7 +489,7 @@ func importPlanHook(
 			// database, so it must exist.
 			txn := p.ExtendedEvalContext().Txn
 			db, err = p.Accessor().GetDatabaseDesc(ctx, txn, p.SessionData().Database, tree.DatabaseLookupFlags{
-				AvoidCached: true,
+				AvoidLeased: true,
 				Required:    true,
 			})
 			if err != nil {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -273,7 +273,7 @@ func createPostgresSchemas(
 		schemaDescs = nil // reset for retries
 		_, dbDesc, err := descriptors.GetImmutableDatabaseByID(ctx, txn, parentID, tree.DatabaseLookupFlags{
 			Required:    true,
-			AvoidCached: true,
+			AvoidLeased: true,
 		})
 		if err != nil {
 			return err

--- a/pkg/migration/migrations/helpers_test.go
+++ b/pkg/migration/migrations/helpers_test.go
@@ -138,7 +138,7 @@ func GetTable(
 		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) (err error) {
 			table, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
-					AvoidCached: true,
+					AvoidLeased: true,
 					Required:    true,
 				},
 			})

--- a/pkg/migration/migrations/schema_changes.go
+++ b/pkg/migration/migrations/schema_changes.go
@@ -152,7 +152,7 @@ func readTableDescriptor(
 	) (err error) {
 		t, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{
 			CommonLookupFlags: tree.CommonLookupFlags{
-				AvoidCached: true,
+				AvoidLeased: true,
 				Required:    true,
 			},
 		})

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -71,7 +71,7 @@ func (p *planner) AlterTableLocality(
 		p.txn,
 		tableDesc.GetParentID(),
 		tree.DatabaseLookupFlags{
-			AvoidCached: true,
+			AvoidLeased: true,
 			Required:    true,
 		},
 	)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -667,7 +667,7 @@ func (sc *SchemaChanger) validateConstraints(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) error {
 		flags := tree.ObjectLookupFlagsWithRequired()
-		flags.AvoidCached = true
+		flags.AvoidLeased = true
 		tableDesc, err = descriptors.GetImmutableTableByID(ctx, txn, sc.descID, flags)
 		return err
 	}); err != nil {
@@ -1385,7 +1385,7 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) (err error) {
 		flags := tree.ObjectLookupFlagsWithRequired()
-		flags.AvoidCached = true
+		flags.AvoidLeased = true
 		tableDesc, err = descriptors.GetImmutableTableByID(ctx, txn, sc.descID, flags)
 		return err
 	}); err != nil {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -288,7 +288,7 @@ func (tc *Collection) GetAllTableDescriptorsInDatabase(
 ) ([]catalog.TableDescriptor, error) {
 	// Ensure the given ID does indeed belong to a database.
 	found, _, err := tc.getDatabaseByID(ctx, txn, dbID, tree.DatabaseLookupFlags{
-		AvoidCached: false,
+		AvoidLeased: false,
 	})
 	if err != nil {
 		return nil, err
@@ -336,7 +336,7 @@ func (tc *Collection) GetObjectNamesAndIDs(
 
 	schemaFlags := tree.SchemaLookupFlags{
 		Required:       flags.Required,
-		AvoidCached:    flags.RequireMutable || flags.AvoidCached,
+		AvoidLeased:    flags.RequireMutable || flags.AvoidLeased,
 		IncludeDropped: flags.IncludeDropped,
 		IncludeOffline: flags.IncludeOffline,
 	}

--- a/pkg/sql/catalog/descs/database.go
+++ b/pkg/sql/catalog/descs/database.go
@@ -61,7 +61,7 @@ func (tc *Collection) getDatabaseByName(
 	ctx context.Context, txn *kv.Txn, name string, flags tree.DatabaseLookupFlags,
 ) (catalog.DatabaseDescriptor, error) {
 	found, desc, err := tc.getByName(
-		ctx, txn, nil, nil, name, flags.AvoidCached, flags.RequireMutable, flags.AvoidSynthetic,
+		ctx, txn, nil, nil, name, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/descs/object.go
+++ b/pkg/sql/catalog/descs/object.go
@@ -68,7 +68,7 @@ func (tc *Collection) getObjectByName(
 		return prefix, nil, err
 	}
 	if desc.Adding() && desc.IsUncommittedVersion() &&
-		(flags.RequireMutable || flags.CommonLookupFlags.AvoidCached) {
+		(flags.RequireMutable || flags.CommonLookupFlags.AvoidLeased) {
 		// Special case: We always return tables in the adding state if they were
 		// created in the same transaction and a descriptor (effectively) read in
 		// the same transaction is requested. What this basically amounts to is
@@ -143,11 +143,11 @@ func (tc *Collection) getObjectByNameIgnoringRequiredAndType(
 	// we should read its parents from the store too to ensure
 	// that subsequent name resolution finds the latest name
 	// in the face of a concurrent rename.
-	avoidCachedForParent := flags.AvoidCached || flags.RequireMutable
+	avoidLeasedForParent := flags.AvoidLeased || flags.RequireMutable
 	// Resolve the database.
 	parentFlags := tree.DatabaseLookupFlags{
 		Required:       flags.Required,
-		AvoidCached:    avoidCachedForParent,
+		AvoidLeased:    avoidLeasedForParent,
 		IncludeDropped: flags.IncludeDropped,
 		IncludeOffline: flags.IncludeOffline,
 	}
@@ -192,7 +192,7 @@ func (tc *Collection) getObjectByNameIgnoringRequiredAndType(
 
 	prefix.Schema = sc
 	found, obj, err := tc.getByName(
-		ctx, txn, db, sc, objectName, flags.AvoidCached, flags.RequireMutable, flags.AvoidSynthetic,
+		ctx, txn, db, sc, objectName, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
 	)
 	if !found || err != nil {
 		return prefix, nil, err

--- a/pkg/sql/catalog/descs/schema.go
+++ b/pkg/sql/catalog/descs/schema.go
@@ -67,7 +67,7 @@ func (tc *Collection) getSchemaByName(
 	flags tree.SchemaLookupFlags,
 ) (catalog.SchemaDescriptor, error) {
 	found, desc, err := tc.getByName(
-		ctx, txn, db, nil, schemaName, flags.AvoidCached, flags.RequireMutable, flags.AvoidSynthetic,
+		ctx, txn, db, nil, schemaName, flags.AvoidLeased, flags.RequireMutable, flags.AvoidSynthetic,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2758,7 +2758,7 @@ CREATE TABLE d1.t2 (name int);
 					Required:       true,
 					RequireMutable: true,
 					IncludeOffline: true,
-					AvoidCached:    true,
+					AvoidLeased:    true,
 				}})
 			if err != nil {
 				return err

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2595,7 +2595,7 @@ func (ex *connExecutor) resetPlanner(
 
 	p.autoCommit = false
 	p.isPreparing = false
-	p.avoidCachedDescriptors = false
+	p.avoidLeasedDescriptors = false
 }
 
 // txnStateTransitionsApplyWrapper is a wrapper on top of Machine built with the

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -605,7 +605,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		// If we're in an explicit txn, we allow AOST but only if it matches with
 		// the transaction's timestamp. This is useful for running AOST statements
 		// using the InternalExecutor inside an external transaction; one might want
-		// to do that to force p.avoidCachedDescriptors to be set below.
+		// to do that to force p.avoidLeasedDescriptors to be set below.
 		asOf, err := p.isAsOf(ctx, ast)
 		if err != nil {
 			return makeErrEvent(err)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3299,7 +3299,7 @@ CREATE TABLE crdb_internal.zones (
 			if zs.Database != "" {
 				_, database, err := p.Descriptors().GetImmutableDatabaseByID(ctx, p.txn, descpb.ID(id), tree.DatabaseLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				})
 				if err != nil {
 					return err

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -78,7 +78,7 @@ func CreateUserDefinedSchemaDescriptor(
 				// Check if the object already exists in a dropped state
 				sc, err := descriptors.GetImmutableSchemaByID(ctx, txn, schemaID, tree.SchemaLookupFlags{
 					Required:       true,
-					AvoidCached:    true,
+					AvoidLeased:    true,
 					IncludeOffline: true,
 					IncludeDropped: true,
 				})

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -203,7 +203,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 
 	case *tree.TableRef:
 		flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
-			AvoidCached: n.p.avoidCachedDescriptors,
+			AvoidLeased: n.p.avoidLeasedDescriptors,
 		}}
 		tableDesc, err = n.p.Descriptors().GetImmutableTableByID(ctx, n.p.txn, descpb.ID(t.TableID), flags)
 		if err != nil {

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -80,7 +80,7 @@ func (n *createTypeNode) startExec(params runParams) error {
 	// Check if a type with the same name exists already.
 	flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
 		Required:    false,
-		AvoidCached: true,
+		AvoidLeased: true,
 	}}
 	found, _, err := params.p.Descriptors().GetImmutableTypeByName(params.ctx, params.p.Txn(), n.typeName, flags)
 	if err != nil {

--- a/pkg/sql/gcjob/index_garbage_collection.go
+++ b/pkg/sql/gcjob/index_garbage_collection.go
@@ -69,7 +69,7 @@ func gcIndexes(
 			freshParentTableDesc, err := descriptors.GetMutableTableByID(
 				ctx, txn, parentID, tree.ObjectLookupFlags{
 					CommonLookupFlags: tree.CommonLookupFlags{
-						AvoidCached:    true,
+						AvoidLeased:    true,
 						Required:       true,
 						IncludeDropped: true,
 						IncludeOffline: true,

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -159,9 +159,9 @@ func (oc *optCatalog) ResolveSchema(
 ) (cat.Schema, cat.SchemaName, error) {
 	if flags.AvoidDescriptorCaches {
 		defer func(prev bool) {
-			oc.planner.avoidCachedDescriptors = prev
-		}(oc.planner.avoidCachedDescriptors)
-		oc.planner.avoidCachedDescriptors = true
+			oc.planner.avoidLeasedDescriptors = prev
+		}(oc.planner.avoidLeasedDescriptors)
+		oc.planner.avoidLeasedDescriptors = true
 	}
 
 	oc.tn.ObjectNamePrefix = *name
@@ -197,9 +197,9 @@ func (oc *optCatalog) ResolveDataSource(
 ) (cat.DataSource, cat.DataSourceName, error) {
 	if flags.AvoidDescriptorCaches {
 		defer func(prev bool) {
-			oc.planner.avoidCachedDescriptors = prev
-		}(oc.planner.avoidCachedDescriptors)
-		oc.planner.avoidCachedDescriptors = true
+			oc.planner.avoidLeasedDescriptors = prev
+		}(oc.planner.avoidLeasedDescriptors)
+		oc.planner.avoidLeasedDescriptors = true
 	}
 
 	oc.tn = *name
@@ -227,9 +227,9 @@ func (oc *optCatalog) ResolveDataSourceByID(
 ) (_ cat.DataSource, isAdding bool, _ error) {
 	if flags.AvoidDescriptorCaches {
 		defer func(prev bool) {
-			oc.planner.avoidCachedDescriptors = prev
-		}(oc.planner.avoidCachedDescriptors)
-		oc.planner.avoidCachedDescriptors = true
+			oc.planner.avoidLeasedDescriptors = prev
+		}(oc.planner.avoidLeasedDescriptors)
+		oc.planner.avoidLeasedDescriptors = true
 	}
 
 	tableLookup, err := oc.planner.LookupTableByID(ctx, descpb.ID(dataSourceID))

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -164,14 +164,14 @@ type planner struct {
 
 	preparedStatements preparedStatementsAccessor
 
-	// avoidCachedDescriptors, when true, instructs all code that
+	// avoidLeasedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to read descriptors
 	// from the store for:
 	// 1. Descriptors that are part of a schema change but are not
 	// modified by the schema change. (reading a table in CREATE VIEW)
 	// 2. Disable the use of the table cache in tests.
-	avoidCachedDescriptors bool
+	avoidLeasedDescriptors bool
 
 	// If set, the planner should skip checking for the SELECT privilege when
 	// initializing plans to read from a table. This should be used with care.

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1128,7 +1128,7 @@ func SynthesizeRegionConfig(
 
 	regionConfig := multiregion.RegionConfig{}
 	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(ctx, txn, dbID, tree.DatabaseLookupFlags{
-		AvoidCached:    !o.useCache,
+		AvoidLeased:    !o.useCache,
 		Required:       true,
 		IncludeOffline: o.includeOffline,
 	})
@@ -1147,7 +1147,7 @@ func SynthesizeRegionConfig(
 		regionEnumID,
 		tree.ObjectLookupFlags{
 			CommonLookupFlags: tree.CommonLookupFlags{
-				AvoidCached:    !o.useCache,
+				AvoidLeased:    !o.useCache,
 				IncludeOffline: o.includeOffline,
 			},
 		},

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -125,7 +125,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	// See #34416.
 	lookupFlags := p.CommonLookupFlags(true /*required*/)
 	// DDL statements bypass the cache.
-	lookupFlags.AvoidCached = true
+	lookupFlags.AvoidLeased = true
 	schemas, err := p.Descriptors().GetSchemasForDatabase(ctx, p.txn, dbDesc.GetID())
 	if err != nil {
 		return err

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -322,7 +322,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				},
 			})
 		if err != nil {
@@ -352,7 +352,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				}})
 		if err != nil {
 			return err
@@ -453,7 +453,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
 					Required:    true,
-					AvoidCached: true,
+					AvoidLeased: true,
 				}})
 		if err != nil {
 			return err

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -674,7 +674,7 @@ func (p *planner) ForceDeleteTableData(ctx context.Context, descID int64) error 
 		tree.ObjectLookupFlags{
 			CommonLookupFlags: tree.CommonLookupFlags{
 				Required:    true,
-				AvoidCached: true,
+				AvoidLeased: true,
 			},
 			DesiredTableDescKind: tree.ResolveRequireTableDesc,
 		})

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -103,7 +103,7 @@ func (p *planner) WaitForDescriptorSchemaChanges(
 					tree.ObjectLookupFlags{
 						CommonLookupFlags: tree.CommonLookupFlags{
 							Required:    true,
-							AvoidCached: true,
+							AvoidLeased: true,
 						},
 					})
 				if err != nil {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -543,7 +543,7 @@ func (sc *SchemaChanger) getTargetDescriptor(ctx context.Context) (catalog.Descr
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) (err error) {
 		flags := tree.CommonLookupFlags{
-			AvoidCached:    true,
+			AvoidLeased:    true,
 			Required:       true,
 			IncludeOffline: true,
 			IncludeDropped: true,
@@ -795,7 +795,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 	return sc.txn(ctx, func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
 		flags := tree.ObjectLookupFlagsWithRequired()
-		flags.AvoidCached = true
+		flags.AvoidLeased = true
 		desc, err := descriptors.GetImmutableTableByID(ctx, txn, sc.descID, flags)
 		if err != nil {
 			return err

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -69,7 +69,7 @@ func (d *buildDeps) MayResolveDatabase(
 	ctx context.Context, name tree.Name,
 ) catalog.DatabaseDescriptor {
 	db, err := d.descsCollection.GetImmutableDatabaseByName(ctx, d.txn, string(name), tree.DatabaseLookupFlags{
-		AvoidCached: true,
+		AvoidLeased: true,
 	})
 	if err != nil {
 		panic(err)
@@ -86,7 +86,7 @@ func (d *buildDeps) MayResolveSchema(
 	}
 	db := d.MayResolveDatabase(ctx, name.CatalogName)
 	schema, err := d.descsCollection.GetSchemaByName(ctx, d.txn, db, name.Schema(), tree.SchemaLookupFlags{
-		AvoidCached: true,
+		AvoidLeased: true,
 	})
 	if err != nil {
 		panic(err)
@@ -100,7 +100,7 @@ func (d *buildDeps) MayResolveTable(
 ) (catalog.ResolvedObjectPrefix, catalog.TableDescriptor) {
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, d.schemaResolver, &name, tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{
-			AvoidCached: true,
+			AvoidLeased: true,
 		},
 		DesiredObjectKind: tree.TableObject,
 	})
@@ -119,7 +119,7 @@ func (d *buildDeps) MayResolveType(
 ) (catalog.ResolvedObjectPrefix, catalog.TypeDescriptor) {
 	desc, prefix, err := resolver.ResolveExistingObject(ctx, d.schemaResolver, &name, tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{
-			AvoidCached: true,
+			AvoidLeased: true,
 		},
 		DesiredObjectKind: tree.TypeObject,
 	})
@@ -140,7 +140,7 @@ func (d *buildDeps) ReadObjectNamesAndIDs(
 		CommonLookupFlags: tree.CommonLookupFlags{
 			Required:       true,
 			RequireMutable: false,
-			AvoidCached:    true,
+			AvoidLeased:    true,
 			IncludeOffline: true,
 			IncludeDropped: true,
 		},
@@ -181,7 +181,7 @@ func (d *buildDeps) MustReadDescriptor(ctx context.Context, id descpb.ID) catalo
 	flags := tree.CommonLookupFlags{
 		Required:       true,
 		RequireMutable: false,
-		AvoidCached:    true,
+		AvoidLeased:    true,
 		IncludeOffline: true,
 		IncludeDropped: true,
 	}

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -88,7 +88,7 @@ func (d *txnDeps) MustReadImmutableDescriptor(
 	flags := tree.CommonLookupFlags{
 		Required:       true,
 		RequireMutable: false,
-		AvoidCached:    true,
+		AvoidLeased:    true,
 		IncludeOffline: true,
 		IncludeDropped: true,
 	}
@@ -270,7 +270,7 @@ func (d *txnDeps) GetResumeSpans(
 	table, err := d.descsCollection.GetImmutableTableByID(ctx, d.txn, tableID, tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{
 			Required:    true,
-			AvoidCached: true,
+			AvoidLeased: true,
 		},
 	})
 	if err != nil {

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -114,13 +114,13 @@ func TestExecutorDescriptorMutationOps(t *testing.T) {
 		CommonLookupFlags: tree.CommonLookupFlags{
 			Required:       true,
 			RequireMutable: true,
-			AvoidCached:    true,
+			AvoidLeased:    true,
 		},
 	}
 	immFlags := tree.ObjectLookupFlags{
 		CommonLookupFlags: tree.CommonLookupFlags{
 			Required:    true,
-			AvoidCached: true,
+			AvoidLeased: true,
 		},
 	}
 	run := func(t *testing.T, c testCase) {

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -226,8 +226,9 @@ type CommonLookupFlags struct {
 	Required bool
 	// RequireMutable specifies whether to return a mutable descriptor.
 	RequireMutable bool
-	// if AvoidCached is set, lookup will avoid the cache (if any).
-	AvoidCached bool
+	// AvoidLeased, if set, avoid the leased (possibly stale) version of the
+	// descriptor. It must be set when callers want consistent reads.
+	AvoidLeased bool
 	// IncludeOffline specifies if offline descriptors should be visible.
 	IncludeOffline bool
 	// IncludeOffline specifies if dropped descriptors should be visible.

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -148,7 +148,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	  FROM [%d AS t]@{FORCE_INDEX=[%d]}
 	`, strings.Join(cols, `,`), n.tableDesc.GetID(), index.GetID())
 	// If were'in in an AOST context, propagate it to the inner statement so that
-	// the inner statement gets planned with planner.avoidCachedDescriptors set,
+	// the inner statement gets planned with planner.avoidLeasedDescriptors set,
 	// like the outter one.
 	if params.p.EvalContext().AsOfSystemTime != nil {
 		ts := params.p.txn.ReadTimestamp()

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -502,7 +502,7 @@ func (e *virtualDefEntry) getPlanInfo(
 		if dbName != "" {
 			dbDesc, err = p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn,
 				dbName, tree.DatabaseLookupFlags{
-					Required: true, AvoidCached: p.avoidCachedDescriptors,
+					Required: true, AvoidLeased: p.avoidLeasedDescriptors,
 				})
 			if err != nil {
 				return nil, err

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -261,7 +261,7 @@ func (v *vTableLookupJoinNode) startExec(params runParams) error {
 		params.p.txn,
 		v.dbName,
 		tree.DatabaseLookupFlags{
-			Required: true, AvoidCached: params.p.avoidCachedDescriptors,
+			Required: true, AvoidLeased: params.p.avoidLeasedDescriptors,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
And add some commentary to hopefully make this clearer. Would've saved
me a few hours of debugging. While here, ensure that the SQLTranslator
uses this flag for consistent reads -- it needs to. This tripped up some
tests in #71994.

Release note: None