### PR TITLE
rpc: add RevertRange to tenant allowlist

### DIFF
--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -145,6 +145,7 @@ var reqMethodAllowlist = [...]bool{
 	roachpb.Delete:         true,
 	roachpb.DeleteRange:    true,
 	roachpb.ClearRange:     true,
+	roachpb.RevertRange:    true,
 	roachpb.Scan:           true,
 	roachpb.ReverseScan:    true,
 	roachpb.EndTxn:         true,


### PR DESCRIPTION
Release note (bug fix): A failed IMPORT INTO to a non-empty would previously be unable to clean up the partially imported data when run in a serverless cluster because the operation to do so was incorrectly denied for tenants.