### PR TITLE
kvserver: use and assert non-cancellable Raft scheduler context

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -515,7 +515,14 @@ func (r *Replica) handleRaftReady(
 // non-sensitive cue as to what happened.
 func (r *Replica) handleRaftReadyRaftMuLocked(
 	ctx context.Context, inSnap IncomingSnapshot,
-) (_ handleRaftReadyStats, _ string, foo error) {
+) (handleRaftReadyStats, string, error) {
+	// handleRaftReadyRaftMuLocked is not prepared to handle context cancellation,
+	// so assert that it's given a non-cancellable context.
+	if ctx.Done() != nil {
+		return handleRaftReadyStats{}, "", errors.AssertionFailedf(
+			"handleRaftReadyRaftMuLocked cannot be called with a cancellable context")
+	}
+
 	var stats handleRaftReadyStats
 	if inSnap.Desc != nil {
 		stats.snap.offered = true

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -232,11 +232,11 @@ func TestSchedulerLoop(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(m, p, 1)
+	s := newRaftScheduler(log.AmbientContext{}, m, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
-	s.Start(ctx, stopper)
+	s.Start(stopper)
 	s.EnqueueRaftTicks(1, 2, 3)
 
 	testutils.SucceedsSoon(t, func() error {
@@ -258,11 +258,11 @@ func TestSchedulerBuffering(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(m, p, 1)
+	s := newRaftScheduler(log.AmbientContext{}, m, p, 1)
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
-	s.Start(ctx, stopper)
+	s.Start(stopper)
 
 	testCases := []struct {
 		flag     raftScheduleFlags

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1114,7 +1114,7 @@ func NewStore(
 	s.replRankings = newReplicaRankings()
 
 	s.draining.Store(false)
-	s.scheduler = newRaftScheduler(s.metrics, s, storeSchedulerConcurrency)
+	s.scheduler = newRaftScheduler(cfg.AmbientCtx, s.metrics, s, storeSchedulerConcurrency)
 
 	s.raftEntryCache = raftentry.NewCache(cfg.RaftEntryCacheSize)
 	s.metrics.registry.AddMetricStruct(s.raftEntryCache.Metrics())

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -572,7 +572,7 @@ func (s *Store) processRaft(ctx context.Context) {
 		return
 	}
 
-	s.scheduler.Start(ctx, s.stopper)
+	s.scheduler.Start(s.stopper)
 	// Wait for the scheduler worker goroutines to finish.
 	if err := s.stopper.RunAsyncTask(ctx, "sched-wait", s.scheduler.Wait); err != nil {
 		s.scheduler.Wait(ctx)


### PR DESCRIPTION
`handleRaftReadyRaftMuLocked` is not prepared to handle context
cancellation. It is typically called via the Raft scheduler, which uses
a background context, but can be called via other paths as well (e.g.
snapshot application).

This patch adds an assertion that the given context is not cancellable,
and creates a new background context for the main scheduler code path
instead of using the CLI's cancellable context.

Release note: None

---

Split off from #73484, see previous discussion there.

Turns out that this fails because the Raft scheduler context is in fact cancellable. It's rooted at the CLI context:

https://github.com/cockroachdb/cockroach/blob/c3e8d8568467809c50a8eb8911fd120fe22661bb/pkg/cli/start.go#L407-L408

There's a few different options here, including:

1. Fixing `handleRaftReady` to to handle context cancellation safely.
2. Using a new background context for the Raft scheduler and populating it with necessary data from the passed context.
3. Getting @andreimatei's `contextutil.WithoutCancel()` from #66387 merged, and use it.