### PR TITLE
kvclient: fix bug in batches containing both get and rev scan requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/batch.go
+++ b/pkg/kv/kvclient/kvcoord/batch.go
@@ -144,18 +144,19 @@ func prev(reqs []roachpb.RequestUnion, k roachpb.RKey) (roachpb.RKey, error) {
 		}
 		endKey := h.EndKey
 		if len(endKey) == 0 {
-			// This is unintuitive, but if we have a point request at `x=k` then that request has
-			// already been satisfied (since the batch has already been executed for all keys `>=
-			// k`). We treat `k` as `[k,k)` which does the right thing below. It also does when `x >
-			// k` and `x < k`, so we're good.
+			// If we have a point request for `x < k` then that request has not been
+			// satisfied (since the batch has only been executed for keys `>=k`). We
+			// treat `x` as `[x, x.Next())` which does the right thing below. This
+			// also works when `x > k` or `x=k` as the logic below will skip `x`.
 			//
-			// Note that if `x` is /Local/k/something, then AddrUpperBound below will turn it into
-			// `k\x00`, and so we're looking at the key range `[k, k\x00)`. This is exactly what we
-			// want since otherwise the result would be `k` and so the caller would restrict itself
-			// to `key < k`, but that excludes `k` itself and thus all local keys attached to it.
+			// Note that if the key is /Local/x/something, then instead of using
+			// /Local/x/something.Next() as the end key, we rely on AddrUpperBound to
+			// handle local keys. In particular, AddrUpperBound will turn it into
+			// `x\x00`, so we're looking at the key-range `[x, x.Next())`. This is
+			// exactly what we want as the local key is contained in that range.
 			//
-			// See TestBatchPrevNext for a test case with commentary.
-			endKey = h.Key
+			// See TestBatchPrevNext for test cases with commentary.
+			endKey = h.Key.Next()
 		}
 		eAddr, err := keys.AddrUpperBound(endKey)
 		if err != nil {

--- a/pkg/kv/kvclient/kvcoord/batch_test.go
+++ b/pkg/kv/kvclient/kvcoord/batch_test.go
@@ -49,6 +49,14 @@ func TestBatchPrevNext(t *testing.T) {
 			expFW: max,
 			expBW: min,
 		},
+		{
+			spans: span("a"), key: "a",
+			// Done with `key < a`, so `a <= key` is next.
+			expFW: "a",
+			// Done with `key >= a`, and there's nothing in `[min, a]`, so we return
+			// min here.
+			expBW: min,
+		},
 		{spans: span("a", "b", "c", "d"), key: "c",
 			// Done with `key < c`, so `c <= key` next.
 			expFW: "c",
@@ -87,19 +95,24 @@ func TestBatchPrevNext(t *testing.T) {
 		{spans: abc, key: "b",
 			// We've seen `key < b` so we still need to hit `b`.
 			expFW: "b",
-			// We've seen `key >= b`, so hop over the gap to `a`. Similar to the
-			// first test case.
-			expBW: "a",
+			// We've seen `key >=b`, so hop over the gap to `a`, similar to the first
+			// test case. [`a`] is represented as [`a`,`a.Next()`), so we expect prev
+			// to return a.Next() here..
+			expBW: "a\x00",
 		},
 		{spans: abc, key: "b\x00",
 			// No surprises.
 			expFW: "c",
-			expBW: "b",
+			// Similar to the explanation above, we expect [`b`] = [`b`, `b.Next()`)
+			// here.
+			expBW: "b\x00",
 		},
 		{spans: abc, key: "bb",
 			// Ditto.
 			expFW: "c",
-			expBW: "b",
+			// Similar to the explanation above, we expect [`b`] = [`b`, `b.Next()`)
+			// here.
+			expBW: "b\x00",
 		},
 
 		// Multiple candidates. No surprises, just a sanity check.
@@ -148,6 +161,17 @@ func TestBatchPrevNext(t *testing.T) {
 			// how this doesn't return `b` which would be incorrect as `[KeyMin, b)` does not
 			// contain `loc(b)`.
 			expBW: "b\x00",
+		},
+		{
+			spans: span(loc("a"), "", loc("b"), ""), key: "b",
+			// We've dealt with any key that addresses to `< b`, and `loc(b)` is not
+			// covered by it. `loc(b)` lives between `b` and `b\x00`, so we start at
+			// `b`.
+			expFW: "b",
+			// We've dealt with any key that addresses to `>= b`, which includes
+			// `loc(b)`. The next thing cover is `loc(a)`, which lives between `a`
+			// and `a\x00`, so we return `a\x00` here.
+			expBW: "a\x00",
 		},
 
 		// Multiple candidates. No surprises, just a sanity check.

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -37,7 +37,6 @@ func init() {
 
 func TestKVNemesisSingleNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 73373, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
 
@@ -72,7 +71,6 @@ func TestKVNemesisSingleNode(t *testing.T) {
 
 func TestKVNemesisMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 73370, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
 


### PR DESCRIPTION
This patch fixes a bug which could cause Get requests to be dropped
when:
- They were in the same batch as a ReverseScan request.
- The key referenced in the Get request was to the left of the scan
bounds
- The key referenced in the Get request was on its own range.

This was because of a bug in `prev()`, which the distsender uses to
seek to the next range when scanning keys in reverse. A call to `prev()`
informally means that all requests intersecting with keys `>=k` have
already been executed. Here, we were incorrectly assuming that a point
request for `x` had already been served and skipping over it -- but this
isn't true when `x < k`. This patch ensures we no longer do that by
treating [x] = [x, x.next()) and letting the existing logic take care of the
rest.

Fixes #73370

Release note: None