### PR TITLE
kvserver: improve Raft ctx handling, fix span use-after-Finish

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 	"go.etcd.io/etcd/raft/v3"
 )
 
@@ -65,7 +66,7 @@ func newUnloadedReplica(
 	ctx context.Context, desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.ReplicaID,
 ) *Replica {
 	if replicaID == 0 {
-		log.Fatalf(context.TODO(), "cannot construct a replica for range %d with a 0 replica ID", desc.RangeID)
+		log.Fatalf(ctx, "cannot construct a replica for range %d with a 0 replica ID", desc.RangeID)
 	}
 	r := &Replica{
 		AmbientContext: store.cfg.AmbientCtx,
@@ -117,6 +118,7 @@ func newUnloadedReplica(
 	r.rangeStr.store(replicaID, &roachpb.RangeDescriptor{RangeID: desc.RangeID})
 	// Add replica log tag - the value is rangeStr.String().
 	r.AmbientContext.AddLogTag("r", &r.rangeStr)
+	r.raftCtx = logtags.AddTag(r.AnnotateCtx(context.Background()), "raft", nil /* value */)
 	// Add replica pointer value. NB: this was historically useful for debugging
 	// replica GC issues, but is a distraction at the moment.
 	// r.AmbientContext.AddLogTag("@", fmt.Sprintf("%x", unsafe.Pointer(r)))

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -482,17 +482,6 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 	})
 }
 
-// raftSchedulerCtx annotates a given Raft scheduler context with information
-// about the replica. The method may return a cached instance of this context.
-func (r *Replica) raftSchedulerCtx(schedulerCtx context.Context) context.Context {
-	if v := r.schedulerCtx.Load(); v != nil {
-		return v.(context.Context)
-	}
-	schedulerCtx = r.AnnotateCtx(schedulerCtx)
-	r.schedulerCtx.Store(schedulerCtx)
-	return schedulerCtx
-}
-
 type handleSnapshotStats struct {
 	offered bool
 	applied bool

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -137,7 +137,10 @@ type raftProcessor interface {
 	// Process a raft.Ready struct containing entries and messages that are
 	// ready to read, be saved to stable storage, committed, or sent to other
 	// peers.
-	processReady(context.Context, roachpb.RangeID)
+	//
+	// This method does not take a ctx; the implementation is expected to use a
+	// ctx annotated with the range information, according to RangeID.
+	processReady(roachpb.RangeID)
 	// Process all queued messages for the specified range.
 	// Return true if the range should be queued for ready processing.
 	processRequestQueue(context.Context, roachpb.RangeID) bool
@@ -299,7 +302,7 @@ func (s *raftScheduler) worker(ctx context.Context) {
 			}
 		}
 		if state.flags&stateRaftReady != 0 {
-			s.processor.processReady(ctx, id)
+			s.processor.processReady(id)
 		}
 
 		s.mu.Lock()

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -176,7 +176,7 @@ func newTestProcessor() *testProcessor {
 	return p
 }
 
-func (p *testProcessor) processReady(_ context.Context, rangeID roachpb.RangeID) {
+func (p *testProcessor) processReady(rangeID roachpb.RangeID) {
 	p.mu.Lock()
 	p.mu.raftReady[rangeID]++
 	p.mu.Unlock()

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -457,9 +457,8 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 	for i := range infos {
 		info := &infos[i]
 		if pErr := s.withReplicaForRequest(
-			ctx, info.req, func(ctx context.Context, r *Replica) *roachpb.Error {
-				ctx = r.raftSchedulerCtx(ctx)
-				return s.processRaftRequestWithReplica(ctx, r, info.req)
+			ctx, info.req, func(_ context.Context, r *Replica) *roachpb.Error {
+				return s.processRaftRequestWithReplica(r.raftCtx, r, info.req)
 			},
 		); pErr != nil {
 			hadError = true
@@ -497,13 +496,13 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 	return true // ready
 }
 
-func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
+func (s *Store) processReady(rangeID roachpb.RangeID) {
 	r, ok := s.mu.replicasByRangeID.Load(rangeID)
 	if !ok {
 		return
 	}
 
-	ctx = r.raftSchedulerCtx(ctx)
+	ctx := r.raftCtx
 	start := timeutil.Now()
 	stats, expl, err := r.handleRaftReady(ctx, noSnap)
 	maybeFatalOnRaftReadyErr(ctx, expl, err)
@@ -520,7 +519,7 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 	}
 }
 
-func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
+func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 	r, ok := s.mu.replicasByRangeID.Load(rangeID)
 	if !ok {
 		return false
@@ -528,7 +527,7 @@ func (s *Store) processTick(ctx context.Context, rangeID roachpb.RangeID) bool {
 	livenessMap, _ := s.livenessMap.Load().(liveness.IsLiveMap)
 
 	start := timeutil.Now()
-	ctx = r.raftSchedulerCtx(ctx)
+	ctx := r.raftCtx
 	exists, err := r.tick(ctx, livenessMap)
 	if err != nil {
 		log.Errorf(ctx, "%v", err)


### PR DESCRIPTION
Code running below Raft in the context of a range had some pretty
bizarre Context management - this code was running inside a memoized
Context (set up by replica.raftSchedulerCtx()). That function was
capturing the context of a random raft worker, and then using it for
operations performed by all other workers. This was broken because it
resulted in use-after-Finish of the tracing Span from the captured
Context, as different workers finish their task (and thus their spans)
at different times. The point of the scheme was probably to save on
allocations when annotating with the range info, but it was too
complicated. This patch replaces it with a statically-initialized
per-replica context to be used by below-Raft work.

Release note: None