### PR TITLE
util/stopper: add newlines to debug/stopper output

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -80,7 +80,7 @@ func HandleDebug(w http.ResponseWriter, r *http.Request) {
 	defer trackedStoppers.Unlock()
 	for _, ss := range trackedStoppers.stoppers {
 		s := ss.s
-		fmt.Fprintf(w, "%p: %d tasks", s, s.NumTasks())
+		fmt.Fprintf(w, "%p: %d tasks\n", s, s.NumTasks())
 	}
 }
 


### PR DESCRIPTION
Previously, lines were simply concatenated, causing a readability issue.

Release note: None