### PR TITLE
roachprod: fix list/sync failure on unrelated aws regions

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
+        "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/flagutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
@@ -143,7 +144,10 @@ if the user would like to update the keys on the remote hosts.
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.SetupSSH(args[0])
+		zonesMap := make(map[string][]string)
+		// Only adding aws zones because only aws.ConfigSSH uses it.
+		zonesMap[aws.ProviderName] = providerOptsContainer[aws.ProviderName].(*aws.ProviderOpts).CreateZones
+		return roachprod.SetupSSH(args[0], zonesMap)
 	}),
 }
 

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -108,9 +108,9 @@ func (p *Provider) CleanSSH() error {
 	return nil
 }
 
-// ConfigSSH implements vm.Provider, is a no-op, and returns nil.
-// On Azure, the SSH public key is set as part of VM instance creation.
-func (p *Provider) ConfigSSH() error {
+// ConfigSSH is part of the vm.Provider interface and is a no-op.
+func (p *Provider) ConfigSSH(zones []string) error {
+	// On Azure, the SSH public key is set as part of VM instance creation.
 	return nil
 }
 

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -37,7 +37,7 @@ func (p *provider) CleanSSH() error {
 }
 
 // ConfigSSH implements vm.Provider and is a no-op.
-func (p *provider) ConfigSSH() error {
+func (p *provider) ConfigSSH(zones []string) error {
 	return nil
 }
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -360,8 +360,9 @@ func (p *Provider) CleanSSH() error {
 	return nil
 }
 
-// ConfigSSH TODO(peter): document
-func (p *Provider) ConfigSSH() error {
+// ConfigSSH is part of the vm.Provider interface
+func (p *Provider) ConfigSSH(zones []string) error {
+	// Populate SSH config files with Host entries from each instance in active projects.
 	for _, prj := range p.GetProjects() {
 		args := []string{"compute", "config-ssh", "--project", prj, "--quiet"}
 		cmd := exec.Command("gcloud", args...)

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -132,7 +132,7 @@ func (p *Provider) CleanSSH() error {
 }
 
 // ConfigSSH is part of the vm.Provider interface.  This implementation is a no-op.
-func (p *Provider) ConfigSSH() error {
+func (p *Provider) ConfigSSH(zones []string) error {
 	return nil
 }
 

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -234,7 +234,10 @@ type ProviderOpts interface {
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
 	CleanSSH() error
-	ConfigSSH() error
+
+	// ConfigSSH takes a list of zones and configures SSH for machines in those
+	// zones for the given provider.
+	ConfigSSH(zones []string) error
 	Create(names []string, opts CreateOpts, providerOpts ProviderOpts) error
 	Reset(vms List) error
 	Delete(vms List) error


### PR DESCRIPTION
`roachprod list` depends on `sync`. When running `roachprod list`,
it should run against all regions and return all the VMs it managed
to get, and print an error for each region failure.

`roachprod sync` should do the same.

We should only run ConfigSSH when `roachprod setup-ssh` is called, or
when a new cluster is created. When we run it, it should run against
the needed regions/zones only.

Release note: None

Fixes #73561