### PR TITLE
storage: remove leftover logic related to interleaved intents

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6116,7 +6116,6 @@ func TestRangeStatsComputation(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	tc.Start(t, stopper)
-	ctx := context.Background()
 
 	baseStats := tc.repl.GetMVCCStats()
 
@@ -6162,9 +6161,9 @@ func TestRangeStatsComputation(t *testing.T) {
 	}
 	expMS = baseStats
 	expMS.Add(enginepb.MVCCStats{
-		LiveBytes:            101,
+		LiveBytes:            103,
 		KeyBytes:             28,
-		ValBytes:             73,
+		ValBytes:             75,
 		IntentBytes:          23,
 		LiveCount:            2,
 		KeyCount:             2,
@@ -6172,10 +6171,6 @@ func TestRangeStatsComputation(t *testing.T) {
 		IntentCount:          1,
 		SeparatedIntentCount: 1,
 	})
-	if !tc.engine.OverrideTxnDidNotUpdateMetaToFalse(ctx) {
-		expMS.LiveBytes += 2
-		expMS.ValBytes += 2
-	}
 	if err := verifyRangeStats(tc.engine, tc.repl.RangeID, expMS); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -534,12 +534,12 @@ func (s spanSetWriter) ClearUnversioned(key roachpb.Key) error {
 }
 
 func (s spanSetWriter) ClearIntent(
-	key roachpb.Key, state storage.PrecedingIntentState, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
+	key roachpb.Key, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
 ) error {
 	if err := s.checkAllowed(key); err != nil {
 		return err
 	}
-	return s.w.ClearIntent(key, state, txnDidNotUpdateMeta, txnUUID)
+	return s.w.ClearIntent(key, txnDidNotUpdateMeta, txnUUID)
 }
 
 func (s spanSetWriter) ClearEngineKey(key storage.EngineKey) error {
@@ -653,10 +653,6 @@ func (s spanSetWriter) LogLogicalOp(
 	op storage.MVCCLogicalOpType, details storage.MVCCLogicalOpDetails,
 ) {
 	s.w.LogLogicalOp(op, details)
-}
-
-func (s spanSetWriter) OverrideTxnDidNotUpdateMetaToFalse(ctx context.Context) bool {
-	return s.w.OverrideTxnDidNotUpdateMetaToFalse(ctx)
 }
 
 // ReadWriter is used outside of the spanset package internally, in ccl.

--- a/pkg/storage/intent_reader_writer_test.go
+++ b/pkg/storage/intent_reader_writer_test.go
@@ -28,18 +28,6 @@ import (
 	"github.com/cockroachdb/datadriven"
 )
 
-func readPrecedingIntentState(t *testing.T, d *datadriven.TestData) PrecedingIntentState {
-	var str string
-	d.ScanArgs(t, "preceding", &str)
-	switch str {
-	case "separated":
-		return ExistingIntentSeparated
-	case "none":
-		return NoExistingIntent
-	}
-	panic("unknown state")
-}
-
 func readTxnDidNotUpdateMeta(t *testing.T, d *datadriven.TestData) bool {
 	var txnDidNotUpdateMeta bool
 	d.ScanArgs(t, "txn-did-not-update-meta", &txnDidNotUpdateMeta)
@@ -246,9 +234,8 @@ func TestIntentDemuxWriter(t *testing.T) {
 				var txn int
 				d.ScanArgs(t, "txn", &txn)
 				txnUUID := uuid.FromUint128(uint128.FromInts(0, uint64(txn)))
-				state := readPrecedingIntentState(t, d)
 				txnDidNotUpdateMeta := readTxnDidNotUpdateMeta(t, d)
-				scratch, err = w.ClearIntent(key, state, txnDidNotUpdateMeta, txnUUID, scratch)
+				scratch, err = w.ClearIntent(key, txnDidNotUpdateMeta, txnUUID, scratch)
 				if err != nil {
 					return err.Error()
 				}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1048,11 +1048,7 @@ func (b *putBuffer) putInlineMeta(
 var trueValue = true
 
 func (b *putBuffer) putIntentMeta(
-	ctx context.Context,
-	writer Writer,
-	key MVCCKey,
-	helper txnDidNotUpdateMetaHelper,
-	meta *enginepb.MVCCMetadata,
+	ctx context.Context, writer Writer, key MVCCKey, meta *enginepb.MVCCMetadata, alreadyExists bool,
 ) (keyBytes, valBytes int64, err error) {
 	if meta.Txn != nil && meta.Timestamp.ToTimestamp() != meta.Txn.WriteTimestamp {
 		// The timestamps are supposed to be in sync. If they weren't, it wouldn't
@@ -1060,7 +1056,12 @@ func (b *putBuffer) putIntentMeta(
 		return 0, 0, errors.AssertionFailedf(
 			"meta.Timestamp != meta.Txn.WriteTimestamp: %s != %s", meta.Timestamp, meta.Txn.WriteTimestamp)
 	}
-	helper.populateMeta(ctx, meta)
+	if alreadyExists {
+		// Absence represents false.
+		meta.TxnDidNotUpdateMeta = nil
+	} else {
+		meta.TxnDidNotUpdateMeta = &trueValue
+	}
 	bytes, err := b.marshalMeta(meta)
 	if err != nil {
 		return 0, 0, err
@@ -1069,71 +1070,6 @@ func (b *putBuffer) putIntentMeta(
 		return 0, 0, err
 	}
 	return int64(key.EncodedSize()), int64(len(bytes)), nil
-}
-
-// txnDidNotUpdateMetaHelper is used to decide what to put in the MVCCMetadata
-// proto, and what value to pass in the txnDidNotUpdateMeta parameter of
-// PutIntent.
-//
-// Note that separated intents are understood by v21.1 already, though we
-// assume they were never actively written there (the cluster setting defaults
-// to false and there are known bugs). Therefore all nodes in a cluster (v21.1
-// or v21.2) understand separated intents. This understanding by v21.1
-// includes reading and resolving separated intents, and setting
-// MVCCMetadata.TxnDidNotUpdateMeta to true. Note that since v21.1 nodes only
-// write MVCCMetadata to interleaved intents, they can only set
-// MVCCMetadata.TxnDidNotUpdateMeta to true for interleaved intents, which is
-// harmless since interleaved intents do not invoke the SingleDelete
-// optimization.
-//
-// However, when migrating from v21.1 to v21.2, and running in a mixed version
-// cluster, we need to be careful. A v21.1 node can become the leaseholder for
-// a range after a separated intent was written by a v21.2 node. Hence they
-// can resolve separated intents. The logic in v21.1 for using SingleDelete
-// when resolving intents is similarly buggy, and the Pebble code included in
-// v21.1 will not make this buggy usage correct. The solution is for v21.2
-// nodes to never set txnDidNotUpdateMeta=true when writing separated intents,
-// until the cluster version is at the version when the buggy code was fixed
-// in v21.2. So v21.1 code will never use SingleDelete when resolving these
-// separated intents (since the only separated intents being written are by
-// v21.2 nodes).
-//
-// Details about this helper:
-// - The txnDidNotUpdateMeta field is about what happened prior to this Put,
-//   and is intended to be passed through to Writer.PutIntent.
-//   In general it can be true in 2 cases:
-//   - There was no prior intent.
-//   - MVCCMetadata.TxnDidNotUpdateMeta is true: v21.2 nodes will never set
-//     this to true in a mixed version cluster (see next bullet). However,
-//     v21.1 nodes can set it to true.
-//   What saves us is that it is only used by intentDemuxWriter when there was
-//   an existing separated intent that was written once and the writer is
-//   writing interleaved intents, and the true value enables SingleDelete of
-//   the existing separated intent. This transition can happen when an intent
-//   written at a v21.2 node is rewritten on a v21.1 node. So it is irrelevant
-//   for the first case above. And since v21.2 nodes never set
-//   MVCCMetadata.TxnDidNotUpdateMeta to true in a mixed version cluster, the
-//   situation in which this value is used will always be false, which takes
-//   care of case 2 above.
-//
-// - The state field describes the preceding intent state. It is intended to
-//   be used for populating the MVCCMetadata.TxnDidNotUpdateMeta. This is
-//   where we use Writer.OverrideTxnDidNotUpdateMetaToFa
-// TODO(sumeer): We should get rid of txnDidNotUpdateMetaHelper since it's
-// only storing the PrecedingIntentState, and txnDidNotUpdateMetaHelper is
-// too heavyweight for that purpose.
-type txnDidNotUpdateMetaHelper struct {
-	state PrecedingIntentState
-	w     Writer
-}
-
-func (t txnDidNotUpdateMetaHelper) populateMeta(ctx context.Context, meta *enginepb.MVCCMetadata) {
-	if t.state == NoExistingIntent && !t.w.OverrideTxnDidNotUpdateMetaToFalse(ctx) {
-		meta.TxnDidNotUpdateMeta = &trueValue
-	} else {
-		// Absence represents false.
-		meta.TxnDidNotUpdateMeta = nil
-	}
 }
 
 // MVCCPut sets the value for a specified key. It will save the value
@@ -1482,18 +1418,6 @@ func mvccPutInternal(
 		return err
 	}
 
-	// Compute PrecedingIntentState and whether the transaction has previously
-	// updated the intent. This is to prepare for a later Put.
-	var precedingIntentState PrecedingIntentState
-	if !ok || buf.meta.Txn == nil {
-		// !ok represents no meta (no actual intent and no manufactured meta).
-		// buf.meta.Txn==nil represents a manufactured meta, i.e., there is no
-		// intent.
-		precedingIntentState = NoExistingIntent
-	} else {
-		precedingIntentState = ExistingIntentSeparated
-	}
-
 	// Determine the read and write timestamps for the write. For a
 	// non-transactional write, these will be identical. For a transactional
 	// write, we read at the transaction's read timestamp but write intents at its
@@ -1758,12 +1682,15 @@ func mvccPutInternal(
 
 	var metaKeySize, metaValSize int64
 	if newMeta.Txn != nil {
+		// Determine whether the transaction had previously written an intent on
+		// this key and we intend to update that intent, or whether this is the
+		// first time an intent is being written. ok represents the presence of a
+		// meta (an actual intent or a manufactured meta). buf.meta.Txn!=nil
+		// represents a non-manufactured meta, i.e., there is an intent.
+		alreadyExists := ok && buf.meta.Txn != nil
+		// Write the intent metadata key.
 		metaKeySize, metaValSize, err = buf.putIntentMeta(
-			ctx, writer, metaKey,
-			txnDidNotUpdateMetaHelper{
-				state: precedingIntentState,
-				w:     writer,
-			}, newMeta)
+			ctx, writer, metaKey, newMeta, alreadyExists)
 		if err != nil {
 			return err
 		}
@@ -3059,7 +2986,6 @@ func mvccResolveWriteIntent(
 		return false, nil
 	}
 	metaTimestamp := meta.Timestamp.ToTimestamp()
-	precedingIntentState := ExistingIntentSeparated
 	canSingleDelHelper := singleDelOptimizationHelper{
 		_didNotUpdateMeta: meta.TxnDidNotUpdateMeta,
 		_hasIgnoredSeqs:   len(intent.IgnoredSeqNums) > 0,
@@ -3201,16 +3127,10 @@ func mvccResolveWriteIntent(
 			// to do anything to update the intent but to move the timestamp forward,
 			// even if it can.
 			metaKeySize, metaValSize, err = buf.putIntentMeta(
-				ctx, rw, metaKey,
-				txnDidNotUpdateMetaHelper{
-					state: precedingIntentState,
-					w:     rw,
-				},
-				&buf.newMeta)
+				ctx, rw, metaKey, &buf.newMeta, true /* alreadyExists */)
 		} else {
 			metaKeySize = int64(metaKey.EncodedSize())
-			err =
-				rw.ClearIntent(metaKey.Key, precedingIntentState, canSingleDelHelper.onCommitIntent(), meta.Txn.ID)
+			err = rw.ClearIntent(metaKey.Key, canSingleDelHelper.onCommitIntent(), meta.Txn.ID)
 		}
 		if err != nil {
 			return false, err
@@ -3335,8 +3255,7 @@ func mvccResolveWriteIntent(
 
 	if !ok {
 		// If there is no other version, we should just clean up the key entirely.
-		if err =
-			rw.ClearIntent(metaKey.Key, precedingIntentState, canSingleDelHelper.onAbortIntent(), meta.Txn.ID); err != nil {
+		if err = rw.ClearIntent(metaKey.Key, canSingleDelHelper.onAbortIntent(), meta.Txn.ID); err != nil {
 			return false, err
 		}
 		// Clear stat counters attributable to the intent we're aborting.
@@ -3355,8 +3274,7 @@ func mvccResolveWriteIntent(
 		KeyBytes: MVCCVersionTimestampSize,
 		ValBytes: valueSize,
 	}
-	if err =
-		rw.ClearIntent(metaKey.Key, precedingIntentState, canSingleDelHelper.onAbortIntent(), meta.Txn.ID); err != nil {
+	if err = rw.ClearIntent(metaKey.Key, canSingleDelHelper.onAbortIntent(), meta.Txn.ID); err != nil {
 		return false, err
 	}
 	metaKeySize := int64(metaKey.EncodedSize())

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -519,11 +519,11 @@ func (rw intentPrintingReadWriter) PutIntent(
 }
 
 func (rw intentPrintingReadWriter) ClearIntent(
-	key roachpb.Key, state PrecedingIntentState, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
+	key roachpb.Key, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
 ) error {
-	rw.buf.Printf("called ClearIntent(%v, %v, TDNUM(%t), %v)\n",
-		key, state, txnDidNotUpdateMeta, txnUUID)
-	return rw.ReadWriter.ClearIntent(key, state, txnDidNotUpdateMeta, txnUUID)
+	rw.buf.Printf("called ClearIntent(%v, TDNUM(%t), %v)\n",
+		key, txnDidNotUpdateMeta, txnUUID)
+	return rw.ReadWriter.ClearIntent(key, txnDidNotUpdateMeta, txnUUID)
 }
 
 func (e *evalCtx) tryWrapForIntentPrinting(rw ReadWriter) ReadWriter {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -216,7 +216,7 @@ func (fw *SSTWriter) ClearUnversioned(key roachpb.Key) error {
 // the comparator configured during writer creation). `Close` cannot have been
 // called.
 func (fw *SSTWriter) ClearIntent(
-	key roachpb.Key, state PrecedingIntentState, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
+	key roachpb.Key, txnDidNotUpdateMeta bool, txnUUID uuid.UUID,
 ) error {
 	panic("ClearIntent is unsupported")
 }
@@ -232,11 +232,6 @@ func (fw *SSTWriter) ClearEngineKey(key EngineKey) error {
 	fw.scratch = key.EncodeToBuf(fw.scratch[:0])
 	fw.DataSize += int64(len(key.Key))
 	return fw.fw.Delete(fw.scratch)
-}
-
-// OverrideTxnDidNotUpdateMetaToFalse implements the Writer interface.
-func (fw *SSTWriter) OverrideTxnDidNotUpdateMetaToFalse(ctx context.Context) bool {
-	panic("OverrideTxnDidNotUpdateMetaToFalse is unsupported")
 }
 
 // An error is returned if it is not greater than any previous point key

--- a/pkg/storage/testdata/intent_demux_writer
+++ b/pkg/storage/testdata/intent_demux_writer
@@ -1,78 +1,84 @@
-##### Intents written are interleaved. #####
-
 new-writer
 ----
 
-# Go through all combinations of put-intent with
-# preceding={none,separated}
-
-put-intent k=a ts=50 txn=1 preceding=none
+# Put four times. Rewrite every other key.
+put-intent k=a ts=50 txn=1
 ----
 === Calls ===
 PutEngineKey(LT{k: a, strength: Exclusive, uuid:1}, meta{ts: 50.000000000,0, txn: 1})
 === Storage contents ===
 k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
 
-put-intent k=b ts=50 txn=2 preceding=separated
+put-intent k=b ts=55 txn=2
 ----
 === Calls ===
-PutEngineKey(LT{k: b, strength: Exclusive, uuid:2}, meta{ts: 50.000000000,0, txn: 2})
+PutEngineKey(LT{k: b, strength: Exclusive, uuid:2}, meta{ts: 55.000000000,0, txn: 2})
 === Storage contents ===
 k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 50.000000000,0, txn: 2}
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 55.000000000,0, txn: 2}
 
-put-intent k=f ts=50 txn=3 preceding=separated
+# Overwrite intent.
+put-intent k=b ts=60 txn=2
 ----
 === Calls ===
-PutEngineKey(LT{k: f, strength: Exclusive, uuid:3}, meta{ts: 50.000000000,0, txn: 3})
+PutEngineKey(LT{k: b, strength: Exclusive, uuid:2}, meta{ts: 60.000000000,0, txn: 2})
 === Storage contents ===
 k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 50.000000000,0, txn: 2}
-k: LT{k: f, strength: Exclusive, uuid:3}, v: meta{ts: 50.000000000,0, txn: 3}
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 60.000000000,0, txn: 2}
 
-# Go through all combinations of clear-intent with
-# preceding={separated} * txn-did-not-update-meta={true,false}
-clear-intent k=f txn=3 preceding=separated txn-did-not-update-meta=false
+put-intent k=c ts=65 txn=3
 ----
 === Calls ===
-ClearEngineKey(LT{k: f, strength: Exclusive, uuid:3})
+PutEngineKey(LT{k: c, strength: Exclusive, uuid:3}, meta{ts: 65.000000000,0, txn: 3})
 === Storage contents ===
 k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 50.000000000,0, txn: 2}
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 60.000000000,0, txn: 2}
+k: LT{k: c, strength: Exclusive, uuid:3}, v: meta{ts: 65.000000000,0, txn: 3}
 
-clear-intent k=b txn=2 preceding=separated txn-did-not-update-meta=true
+put-intent k=d ts=70 txn=4
+----
+=== Calls ===
+PutEngineKey(LT{k: d, strength: Exclusive, uuid:4}, meta{ts: 70.000000000,0, txn: 4})
+=== Storage contents ===
+k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 60.000000000,0, txn: 2}
+k: LT{k: c, strength: Exclusive, uuid:3}, v: meta{ts: 65.000000000,0, txn: 3}
+k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 70.000000000,0, txn: 4}
+
+# Overwrite intent.
+put-intent k=d ts=75 txn=4
+----
+=== Calls ===
+PutEngineKey(LT{k: d, strength: Exclusive, uuid:4}, meta{ts: 75.000000000,0, txn: 4})
+=== Storage contents ===
+k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 60.000000000,0, txn: 2}
+k: LT{k: c, strength: Exclusive, uuid:3}, v: meta{ts: 65.000000000,0, txn: 3}
+k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 75.000000000,0, txn: 4}
+
+# Clear with txn-did-not-update-meta=false.
+clear-intent k=a txn=1 txn-did-not-update-meta=false
+----
+=== Calls ===
+ClearEngineKey(LT{k: a, strength: Exclusive, uuid:1})
+=== Storage contents ===
+k: LT{k: b, strength: Exclusive, uuid:2}, v: meta{ts: 60.000000000,0, txn: 2}
+k: LT{k: c, strength: Exclusive, uuid:3}, v: meta{ts: 65.000000000,0, txn: 3}
+k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 75.000000000,0, txn: 4}
+
+# Clear with txn-did-not-update-meta=true.
+clear-intent k=b txn=2 txn-did-not-update-meta=true
 ----
 === Calls ===
 SingleClearEngineKey(LT{k: b, strength: Exclusive, uuid:2})
 === Storage contents ===
-k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-
-
-new-writer
-----
-
-put-intent k=d ts=50 txn=4 preceding=none
-----
-=== Calls ===
-PutEngineKey(LT{k: d, strength: Exclusive, uuid:4}, meta{ts: 50.000000000,0, txn: 4})
-=== Storage contents ===
-k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 50.000000000,0, txn: 4}
-
-# Overwrite an existing separated intent
-put-intent k=d ts=60 txn=4 preceding=separated
-----
-=== Calls ===
-PutEngineKey(LT{k: d, strength: Exclusive, uuid:4}, meta{ts: 60.000000000,0, txn: 4})
-=== Storage contents ===
-k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}
-k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 60.000000000,0, txn: 4}
+k: LT{k: c, strength: Exclusive, uuid:3}, v: meta{ts: 65.000000000,0, txn: 3}
+k: LT{k: d, strength: Exclusive, uuid:4}, v: meta{ts: 75.000000000,0, txn: 4}
 
 # Clear range of intents that will clear c and d.
-clear-range start=c end=da
+clear-range start=c end=e
 ----
 === Calls ===
-ClearRawRange(c, da)
-ClearRawRange(LT{c}, LT{da})
+ClearRawRange(c, e)
+ClearRawRange(LT{c}, LT{e})
 === Storage contents ===
-k: LT{k: a, strength: Exclusive, uuid:1}, v: meta{ts: 50.000000000,0, txn: 1}

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -53,6 +53,6 @@ meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=2.000000000,0
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000002)
+called ClearIntent("a", TDNUM(false), 00000000-0000-0000-0000-000000000002)
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -67,7 +67,7 @@ with t=A
   txn_remove
 ----
 >> resolve_intent k=k1 t=A
-called ClearIntent("k1", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+called ClearIntent("k1", TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k2"/3.000000000,0 -> /BYTES/v2
@@ -75,13 +75,13 @@ meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,
 data: "k3"/3.000000000,0 -> /BYTES/v33
 data: "k3"/1.000000000,0 -> /BYTES/v3
 >> resolve_intent k=k2 status=ABORTED t=A
-called ClearIntent("k2", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+called ClearIntent("k2", TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k3"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k3"/3.000000000,0 -> /BYTES/v33
 data: "k3"/1.000000000,0 -> /BYTES/v3
 >> resolve_intent k=k3 status=ABORTED t=A
-called ClearIntent("k3", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+called ClearIntent("k3", TDNUM(false), 00000000-0000-0000-0000-000000000001)
 data: "k1"/3.000000000,0 -> /BYTES/v1
 data: "k3"/1.000000000,0 -> /BYTES/v3
 >> txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -14,7 +14,7 @@ called PutIntent("a", _, 00000000-0000-0000-0000-000000000001)
 meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/22.000000000,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a
-called ClearIntent("a", ExistingIntentSeparated, TDNUM(false), 00000000-0000-0000-0000-000000000001)
+called ClearIntent("a", TDNUM(false), 00000000-0000-0000-0000-000000000001)
 <no data>
 >> txn_remove t=A k=a
 

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -17,7 +17,7 @@ data: "a"/11.000000000,0 -> /BYTES/abc
 >> get k=a t=A
 get: "a" -> /BYTES/abc @11.000000000,0
 >> resolve_intent k=a t=A
-called ClearIntent("a", ExistingIntentSeparated, TDNUM(true), 00000000-0000-0000-0000-000000000001)
+called ClearIntent("a", TDNUM(true), 00000000-0000-0000-0000-000000000001)
 data: "a"/11.000000000,0 -> /BYTES/abc
 
 run ok


### PR DESCRIPTION
This commit is a follow-up to #72536.

It addresses a few of the remaining items left over from removing the bulk of the interleaved intent logic. Specifically, it removes:
- the `PrecedingIntentState` type
- the `PrecedingIntentState` parameter in `Writer.ClearIntent`
- the `Writer.OverrideTxnDidNotUpdateMetaToFalse` method
- the `txnDidNotUpdateMetaHelper` type

The commit does not include any behavioral changes.