### PR TITLE
ui: update doc for ui development

### DIFF
--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -11,7 +11,9 @@ To start developing the UI, be sure you're able to build and run a CockroachDB
 node. Instructions for this are located in the top-level README. Every Cockroach
 node serves the UI, by default on port 8080, but you can customize the port with
 the `--http-port` flag. If you've started a node with the default options,
-you'll be able to access the UI at <http://localhost:8080>.
+you'll be able to access the UI at <http://localhost:8080>. If you've started 
+a node using `demo`, the default port is 8081 and you'll be able to access the UI
+at <http://localhost:8081>.
 
 Our UI is compiled using a collection of tools that depends on
 [Node.js](https://nodejs.org/) and are managed with


### PR DESCRIPTION
Previously, running a node with `demo` would use port 8080,
so when developing locally we would use that port to access the UI.
Now with demo using multi-tenant, the default port that should be used
is 8081. This commits add this information to the ui development
documentation.

Fixes #73583

Release note: None