### PR TITLE
schemachanger: cleanup sequence owned by back references

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1187,3 +1187,20 @@ CREATE VIEW scdrop3.scdrop3_v1 AS SELECT x FROM scdrop2.scdrop2_v1;
 
 statement ok
 DROP SCHEMA scdrop1, scdrop2, scdrop3 CASCADE
+
+# Validates that if an owned by sequence is dropped, then the back reference
+# inside the table gets cleaned up.
+subtest validate-sequence-owner
+
+statement ok
+CREATE TABLE seqowner(name int);
+
+statement ok
+CREATE SEQUENCE seqowned OWNED BY seqowner.name;
+
+statement ok
+DROP SEQUENCE seqowned;
+
+# Reference to the sequences should have been removed.
+statement ok
+DROP TABLE seqowner;

--- a/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
@@ -309,11 +309,41 @@ func (m *visitor) RemoveRelationDependedOnBy(
 	return nil
 }
 
+func removeOwnedByFromColumn(col *descpb.ColumnDescriptor, seqID descpb.ID) (found bool) {
+	for idx := range col.OwnsSequenceIds {
+		if col.OwnsSequenceIds[idx] == seqID {
+			col.OwnsSequenceIds = append(
+				col.OwnsSequenceIds[:idx],
+				col.OwnsSequenceIds[idx+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
 func (m *visitor) RemoveSequenceOwnedBy(ctx context.Context, op scop.RemoveSequenceOwnedBy) error {
-	tbl, err := m.checkOutTable(ctx, op.TableID)
+	tbl, err := m.checkOutTable(ctx, op.SequenceID)
 	if err != nil {
 		return err
 	}
+	// Clean up the ownership inside the owning table first.
+	sequenceOwner := &tbl.GetSequenceOpts().SequenceOwner
+	ownedByTbl, err := m.checkOutTable(ctx, sequenceOwner.OwnerTableID)
+	if err != nil {
+		return err
+	}
+	col, err := ownedByTbl.FindColumnWithID(sequenceOwner.OwnerColumnID)
+	if err != nil {
+		return err
+	}
+	if found := removeOwnedByFromColumn(col.ColumnDesc(), op.SequenceID); !found {
+		return errors.AssertionFailedf("unable to find sequence (%d) owned by"+
+			" inside table (%d) and column (%d)",
+			op.SequenceID,
+			sequenceOwner.OwnerTableID,
+			sequenceOwner.OwnerColumnID)
+	}
+	// Next, clean the ownership on the sequence.
 	tbl.GetSequenceOpts().SequenceOwner.OwnerTableID = descpb.InvalidID
 	tbl.GetSequenceOpts().SequenceOwner.OwnerColumnID = 0
 	return nil

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -278,7 +278,7 @@ type DropForeignKeyRef struct {
 // reference.
 type RemoveSequenceOwnedBy struct {
 	mutationOp
-	TableID descpb.ID
+	SequenceID descpb.ID
 }
 
 // AddIndexPartitionInfo adds partitoning information into

--- a/pkg/sql/schemachanger/scplan/opgen/opgen_sequence_owned_by.go
+++ b/pkg/sql/schemachanger/scplan/opgen/opgen_sequence_owned_by.go
@@ -30,7 +30,7 @@ func init() {
 				revertible(false),
 				emit(func(this *scpb.SequenceOwnedBy) scop.Op {
 					return &scop.RemoveSequenceOwnedBy{
-						TableID: this.SequenceID,
+						SequenceID: this.SequenceID,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -101,7 +101,7 @@ PreCommitPhase non-revertible stage 1 of 1 with 15 MutationType ops
     *scop.MarkDescriptorAsDropped
       DescID: 58
     *scop.RemoveSequenceOwnedBy
-      TableID: 58
+      SequenceID: 58
     *scop.RemoveColumnDefaultExpression
       ColumnID: 5
       TableID: 57


### PR DESCRIPTION
Previously, the declarative schema changer did not properly clean up
OWNED BY back references for sequences inside tables. This was
inadequate we would incorrectly assume a dependency existed between
a table and sequence after a sequence was dropped for example, which
could lead to errors. To address this, this patch when cleaning up
any OWNED BY inside a table or sequence always cleans up the back
references to the owning column.

Release note: None