### PR TITLE
ui: show per-node series for "Read Amplification" and "SSTables" graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -141,11 +141,14 @@ export default function(props: GraphDashboardProps) {
       tooltip={`The average number of real read operations executed per logical read operation ${tooltipSelection}.`}
     >
       <Axis label="factor">
-        <Metric
-          name="cr.store.rocksdb.read-amplification"
-          title="Read Amplification"
-          aggregateAvg
-        />
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rocksdb.read-amplification"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+          />
+        ))}
       </Axis>
     </LineGraph>,
 
@@ -155,7 +158,14 @@ export default function(props: GraphDashboardProps) {
       tooltip={`The number of SSTables in use ${tooltipSelection}.`}
     >
       <Axis label="sstables">
-        <Metric name="cr.store.rocksdb.num-sstables" title="SSTables" />
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rocksdb.num-sstables"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+          />
+        ))}
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
This commit addresses a longstanding usability issue with the Storage dashboard. Previously, the dashboard would show the average read amplification and the average sstable count across the cluster. When looking at these metrics, we are
specifically interested in the outliers, so this made little sense. As a result, a few of our runbooks (e.g. [RocksDB inverted LSM](https://cockroachlabs.atlassian.net/wiki/spaces/TS/pages/1157890147/RocksDB+inverted+LSM)) require operators to grab custom graphs with the "Per Node" option.

This commit fixes this by splitting these graphs out to show per-node series.

_Example:_

<img width="1132" alt="Screen Shot 2021-12-07 at 10 24 14 PM" src="https://user-images.githubusercontent.com/5438456/145142909-0babdd04-54a6-46d3-9d4e-002a2d375811.png">
