### PR TITLE
kvserver: reduce tracing threshold in follower-reads roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -55,7 +55,7 @@ func registerFollowerReads(r registry.Registry) {
 			Owner: registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(
 				6, /* nodeCount */
-				spec.CPU(2),
+				spec.CPU(4),
 				spec.Geo(),
 				spec.Zones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
 			),


### PR DESCRIPTION
The test used to assume that queries taking longer than 25ms were not being
served as follower reads. However, it was only enabling statement tracing for
queries taking longer than 50ms, which was odd.

Release note: None