### PR TITLE
roachprod: ignore "not found" error for cluster cache files

### DIFF
--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 )
 
 // The code in this file deals with storing cluster metadata in the
@@ -145,6 +146,11 @@ func LoadClusters() error {
 	for _, name := range clusterNames {
 		c, err := loadCluster(name)
 		if err != nil {
+			if oserror.IsNotExist(err) {
+				// It is possible that another process is syncing the cache and just
+				// removed the file. Ignore the error.
+				continue
+			}
 			return errors.Wrapf(err, "could not load info for cluster %s", name)
 		}
 
@@ -170,6 +176,10 @@ func LoadClusters() error {
 // (across all providers, including any local cluster).
 //
 // A file in ClustersDir is created for each cluster; other files are removed.
+//
+// This function assumes the caller took a lock on a file to ensure that
+// multiple processes don't run through this code at the same time. However, it
+// is allowed for LoadClusters to run in another process at the same time.
 func syncClustersCache(cloud *cloud.Cloud) error {
 	// Write all cluster files.
 	for _, c := range cloud.Clusters {


### PR DESCRIPTION
Roachprod processes are allowed to read the clusters cache while
another process is resyncing the cache. We are careful to only make
files visible once they are fully written. But there is a race when we
remove a cluster that was destroyed: the loading process might see the
file when it lists the directory, but then encounter a "file not
found" error. This commit ignores this error.

Fixes #73595.

Release justification: non-production code.

Release note: None