### PR TITLE
cmpconn,randgen: fixes for ComposeCompare test

### DIFF
--- a/pkg/cmd/cmpconn/compare.go
+++ b/pkg/cmd/cmpconn/compare.go
@@ -115,7 +115,11 @@ var (
 					v = strings.Replace(t, ":00+00:00", ":00+00", 1)
 				case pgtype.Numeric:
 					if t.Status == pgtype.Present {
-						v = apd.NewWithBigInt(t.Int, t.Exp)
+						if t.NaN {
+							v = &apd.Decimal{Form: apd.NaN}
+						} else {
+							v = apd.NewWithBigInt(t.Int, t.Exp)
+						}
 					}
 				case int64:
 					v = apd.New(t, 0)

--- a/pkg/cmd/cmpconn/compare_test.go
+++ b/pkg/cmd/cmpconn/compare_test.go
@@ -72,7 +72,7 @@ func TestCompareVals(t *testing.T) {
 				pgtype.Numeric{
 					Int:    big1,
 					Exp:    -19,
-					Status: 2,
+					Status: pgtype.Present,
 					NaN:    false,
 				},
 			},
@@ -80,8 +80,42 @@ func TestCompareVals(t *testing.T) {
 				pgtype.Numeric{
 					Int:    big2,
 					Exp:    -16,
-					Status: 2,
+					Status: pgtype.Present,
 					NaN:    false,
+				},
+			},
+		},
+		{
+			equal: true,
+			a: []interface{}{
+				pgtype.Numeric{
+					Int:    big.NewInt(0),
+					Exp:    -1,
+					Status: pgtype.Present,
+					NaN:    false,
+				},
+			},
+			b: []interface{}{
+				pgtype.Numeric{
+					Int:    big.NewInt(0),
+					Exp:    6,
+					Status: pgtype.Present,
+					NaN:    false,
+				},
+			},
+		},
+		{
+			equal: true,
+			a: []interface{}{
+				pgtype.Numeric{
+					Status: pgtype.Present,
+					NaN:    true,
+				},
+			},
+			b: []interface{}{
+				pgtype.Numeric{
+					Status: pgtype.Present,
+					NaN:    true,
 				},
 			},
 		},

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -767,6 +767,8 @@ func postgresCreateTableMutator(
 							if colTypeFamily == types.Box2DFamily {
 								isBox2d = true
 							}
+						} else {
+							col.Expr, changed = replaceNonImmutableExpr(rng, col.Expr, colTypes)
 						}
 						if isBox2d {
 							changed = true
@@ -807,34 +809,7 @@ func postgresCreateTableMutator(
 					changed = true
 				case *tree.ColumnTableDef:
 					if def.IsComputed() {
-						// Postgres has different cast volatility for timestamps and OID
-						// types. The substitution here is specific to the output of
-						// testutils.randComputedColumnTableDef.
-						if funcExpr, ok := def.Computed.Expr.(*tree.FuncExpr); ok {
-							if len(funcExpr.Exprs) == 1 {
-								if castExpr, ok := funcExpr.Exprs[0].(*tree.CastExpr); ok {
-									referencedType := colTypes[castExpr.Expr.(*tree.UnresolvedName).String()]
-									isContextDependentType := referencedType.Family() == types.TimestampFamily ||
-										referencedType.Family() == types.OidFamily ||
-										referencedType.Family() == types.DateFamily
-									if isContextDependentType &&
-										tree.MustBeStaticallyKnownType(castExpr.Type) == types.String {
-										def.Computed.Expr = &tree.CaseExpr{
-											Whens: []*tree.When{
-												{
-													Cond: &tree.IsNullExpr{
-														Expr: castExpr.Expr,
-													},
-													Val: RandDatum(rng, types.String, true /* nullOK */),
-												},
-											},
-											Else: RandDatum(rng, types.String, true /* nullOK */),
-										}
-										changed = true
-									}
-								}
-							}
-						}
+						def.Computed.Expr, changed = replaceNonImmutableExpr(rng, def.Computed.Expr, colTypes)
 					}
 					newdefs = append(newdefs, def)
 				default:
@@ -845,6 +820,42 @@ func postgresCreateTableMutator(
 		}
 	}
 	return mutated, changed
+}
+
+// replaceNonImmutableExpr checks if expr has a non-immutable operation in it,
+// and returns an immutable expr if it does. This is needed because Postgres has
+// different cast volatility for timestamps and/OID types. The substitution here
+// is specific to the output of randgen.randExpr, which uses
+// `lower(cast(col as string))`.
+func replaceNonImmutableExpr(
+	rng *rand.Rand, expr tree.Expr, colTypes map[string]*types.T,
+) (newExpr tree.Expr, changed bool) {
+	if funcExpr, ok := expr.(*tree.FuncExpr); ok {
+		if len(funcExpr.Exprs) == 1 {
+			if castExpr, ok := funcExpr.Exprs[0].(*tree.CastExpr); ok {
+				referencedType := colTypes[castExpr.Expr.(*tree.UnresolvedName).String()]
+				isContextDependentType := referencedType.Family() == types.TimestampFamily ||
+					referencedType.Family() == types.OidFamily ||
+					referencedType.Family() == types.DateFamily
+				if isContextDependentType &&
+					tree.MustBeStaticallyKnownType(castExpr.Type) == types.String {
+					newExpr = &tree.CaseExpr{
+						Whens: []*tree.When{
+							{
+								Cond: &tree.IsNullExpr{
+									Expr: castExpr.Expr,
+								},
+								Val: RandDatum(rng, types.String, true /* nullOK */),
+							},
+						},
+						Else: RandDatum(rng, types.String, true /* nullOK */),
+					}
+					return newExpr, true
+				}
+			}
+		}
+	}
+	return expr, false
 }
 
 // columnFamilyMutator is mutations.StatementMutator, but lives here to prevent


### PR DESCRIPTION
Refs https://github.com/cockroachdb/cockroach/issues/67791#issuecomment-988531633

cmpconn: fix comparison of decimal NaNs
randgen: disallow non-immutable expressions in indexes for postgres 