### PR TITLE
util: fastintset fixes and improvements

### DIFF
--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -326,29 +326,6 @@ func (s FastIntSet) SubsetOf(rhs FastIntSet) bool {
 	return (s.small & rhs.small) == s.small
 }
 
-// Shift generates a new set which contains elements i+delta for elements i in
-// the original set.
-func (s *FastIntSet) Shift(delta int) FastIntSet {
-	if s.large == nil {
-		// Fast path.
-		if delta > 0 {
-			if bits.LeadingZeros64(s.small)-(64-smallCutoff) >= delta {
-				return FastIntSet{small: s.small << uint32(delta)}
-			}
-		} else {
-			if bits.TrailingZeros64(s.small) >= -delta {
-				return FastIntSet{small: s.small >> uint32(-delta)}
-			}
-		}
-	}
-	// Do the slow thing.
-	var result FastIntSet
-	s.ForEach(func(i int) {
-		result.Add(i + delta)
-	})
-	return result
-}
-
 // Encode the set to a Writer using binary.varint byte encoding.  A zero
 // precedes a small int containing s.small.    A non-zero first value is a
 // length and each bit encoded separately follows.

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -139,11 +139,10 @@ func (s FastIntSet) Len() int {
 // Next returns the first value in the set which is >= startVal. If there is no
 // value, the second return value is false.
 func (s FastIntSet) Next(startVal int) (int, bool) {
-	if startVal < smallCutoff {
-		if startVal < 0 {
-			startVal = 0
-		}
-
+	if startVal < 0 && s.large == nil {
+		startVal = 0
+	}
+	if startVal >= 0 && startVal < smallCutoff {
 		if ntz := bits.TrailingZeros64(s.small >> uint64(startVal)); ntz < 64 {
 			return startVal + ntz, true
 		}

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -297,8 +297,11 @@ func (s FastIntSet) Equals(rhs FastIntSet) bool {
 		return false
 	}
 	if s.fitsInSmall() {
+		// We already know that the `small` fields are equal. We just have to make
+		// sure that the other set also has no large elements.
 		return rhs.fitsInSmall()
 	}
+	// We know that s has large elements.
 	return rhs.large != nil && s.large.Equals(rhs.large)
 }
 

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -100,8 +100,8 @@ func TestFastIntSet(t *testing.T) {
 					s3.CopyFrom(s)
 					assertSame(s, s3)
 					// Make sure CopyFrom into a non-empty set still works.
-					s.Shift(100)
-					s.CopyFrom(s3)
+					s3.Add(minVal + rng.Intn(maxVal-minVal))
+					s3.CopyFrom(s)
 					assertSame(s, s3)
 				}
 			})
@@ -147,19 +147,6 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 			for _, num1 := range []int{0, 1, 5, 10, 20} {
 				for _, removed1 := range []int{0, 1, 3, 8} {
 					s1, m1 := genSet(num1, removed1, minVal, num1+removed1+valRange)
-					for _, shift := range []int{-100, -10, -1, 1, 2, 10, 100} {
-						shifted := s1.Shift(shift)
-						failed := false
-						s1.ForEach(func(i int) {
-							failed = failed || !shifted.Contains(i+shift)
-						})
-						shifted.ForEach(func(i int) {
-							failed = failed || !s1.Contains(i-shift)
-						})
-						if failed {
-							t.Errorf("invalid shifted result: %s shifted by %d: %s", &s1, shift, &shifted)
-						}
-					}
 					for _, num2 := range []int{0, 1, 5, 10, 20} {
 						for _, removed2 := range []int{0, 1, 4, 10} {
 							s2, m2 := genSet(num2, removed2, minVal, num2+removed2+valRange)

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -19,83 +19,93 @@ import (
 )
 
 func TestFastIntSet(t *testing.T) {
-	for _, mVal := range []int{1, 8, 30, smallCutoff, 2 * smallCutoff, 4 * smallCutoff} {
-		m := mVal
-		t.Run(fmt.Sprintf("%d", m), func(t *testing.T) {
-			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
-			rng, _ := randutil.NewTestRand()
-			in := make([]bool, m)
-			forEachRes := make([]bool, m)
+	for _, minVal := range []int{-10, -1, 0, 8, smallCutoff, 2 * smallCutoff} {
+		for _, maxVal := range []int{-1, 1, 8, 30, smallCutoff, 2 * smallCutoff, 4 * smallCutoff} {
+			if maxVal <= minVal {
+				continue
+			}
+			// We are using Parallel, we need to make local instances of the loop
+			// variables.
+			minVal := minVal
+			maxVal := maxVal
+			t.Run(fmt.Sprintf("%d_%d", minVal, maxVal), func(t *testing.T) {
+				t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
+				rng, _ := randutil.NewTestRand()
+				in := make(map[int]bool)
+				forEachRes := make(map[int]bool)
 
-			var s FastIntSet
-			for i := 0; i < 1000; i++ {
-				v := rng.Intn(m)
-				if rng.Intn(2) == 0 {
-					in[v] = true
-					s.Add(v)
-				} else {
-					in[v] = false
-					s.Remove(v)
-				}
-				empty := true
-				for j := 0; j < m; j++ {
-					empty = empty && !in[j]
-					if in[j] != s.Contains(j) {
-						t.Fatalf("incorrect result for Contains(%d), expected %t", j, in[j])
+				var s FastIntSet
+				for i := 0; i < 1000; i++ {
+					v := minVal + rng.Intn(maxVal-minVal)
+					if rng.Intn(2) == 0 {
+						in[v] = true
+						s.Add(v)
+					} else {
+						in[v] = false
+						s.Remove(v)
 					}
-				}
-				if empty != s.Empty() {
-					t.Fatalf("incorrect result for Empty(), expected %t", empty)
-				}
-				// Test ForEach
-				for j := range forEachRes {
-					forEachRes[j] = false
-				}
-				s.ForEach(func(j int) {
-					forEachRes[j] = true
-				})
-				for j := 0; j < m; j++ {
-					if in[j] != forEachRes[j] {
-						t.Fatalf("incorrect ForEachResult for %d (%t, expected %t)", j, forEachRes[j], in[j])
-					}
-				}
-				// Cross-check Ordered and Next().
-				var vals []int
-				for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
-					vals = append(vals, i)
-				}
-				if o := s.Ordered(); !reflect.DeepEqual(vals, o) {
-					t.Fatalf("set built with Next doesn't match Ordered: %v vs %v", vals, o)
-				}
-				assertSame := func(orig, copy FastIntSet) {
-					t.Helper()
-					if !orig.Equals(copy) || !copy.Equals(orig) {
-						t.Fatalf("expected equality: %v, %v", orig, copy)
-					}
-					if col, ok := copy.Next(0); ok {
-						copy.Remove(col)
-						if orig.Equals(copy) || copy.Equals(orig) {
-							t.Fatalf("unexpected equality: %v, %v", orig, copy)
+					empty := true
+					for j := minVal; j < maxVal; j++ {
+						empty = empty && !in[j]
+						if in[j] != s.Contains(j) {
+							t.Fatalf("incorrect result for Contains(%d), expected %t", j, in[j])
 						}
-						copy.Add(col)
+					}
+					if empty != s.Empty() {
+						t.Fatalf("incorrect result for Empty(), expected %t", empty)
+					}
+					// Test ForEach
+					for j := range forEachRes {
+						forEachRes[j] = false
+					}
+					s.ForEach(func(j int) {
+						forEachRes[j] = true
+					})
+					for j := minVal; j < maxVal; j++ {
+						if in[j] != forEachRes[j] {
+							t.Fatalf("incorrect ForEachResult for %d (%t, expected %t)", j, forEachRes[j], in[j])
+						}
+					}
+					// Cross-check Ordered and Next().
+					var vals []int
+					// Start at the minimum value, or before.
+					startVal := minVal - rng.Intn(10)
+					for i, ok := s.Next(startVal); ok; i, ok = s.Next(i + 1) {
+						vals = append(vals, i)
+					}
+					if o := s.Ordered(); !reflect.DeepEqual(vals, o) {
+						t.Fatalf("set built with Next doesn't match Ordered: %v vs %v", vals, o)
+					}
+					assertSame := func(orig, copy FastIntSet) {
+						t.Helper()
 						if !orig.Equals(copy) || !copy.Equals(orig) {
 							t.Fatalf("expected equality: %v, %v", orig, copy)
 						}
+						if col, ok := copy.Next(startVal); ok {
+							copy.Remove(col)
+							if orig.Equals(copy) || copy.Equals(orig) {
+								t.Fatalf("unexpected equality: %v, %v", orig, copy)
+							}
+							copy.Add(col)
+							if !orig.Equals(copy) || !copy.Equals(orig) {
+								t.Fatalf("expected equality: %v, %v", orig, copy)
+							}
+						}
 					}
+					// Test Copy.
+					s2 := s.Copy()
+					assertSame(s, s2)
+					// Test CopyFrom.
+					var s3 FastIntSet
+					s3.CopyFrom(s)
+					assertSame(s, s3)
+					// Make sure CopyFrom into a non-empty set still works.
+					s.Shift(100)
+					s.CopyFrom(s3)
+					assertSame(s, s3)
 				}
-				// Test Copy.
-				s2 := s.Copy()
-				assertSame(s, s2)
-				// Test CopyFrom.
-				var s3 FastIntSet
-				s3.CopyFrom(s)
-				assertSame(s, s3)
-				// Make sure CopyFrom into a non-empty set still works.
-				s.Shift(100)
-				s.CopyFrom(s3)
-				assertSame(s, s3)
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -11,6 +11,7 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
@@ -103,6 +104,27 @@ func TestFastIntSet(t *testing.T) {
 					s3.Add(minVal + rng.Intn(maxVal-minVal))
 					s3.CopyFrom(s)
 					assertSame(s, s3)
+
+					// Test Encode/Decode.
+					if minVal >= 0 {
+						var buf bytes.Buffer
+						if err := s.Encode(&buf); err != nil {
+							t.Fatalf("error during Encode: %v", err)
+						}
+						encoded := buf.String()
+						var s2 FastIntSet
+						if err := s2.Decode(bytes.NewReader([]byte(encoded))); err != nil {
+							t.Fatalf("error during Decode: %v", err)
+						}
+						assertSame(s, s2)
+						// Verify that decoding into a non-empty set still works.
+						var s3 FastIntSet
+						s3.Add(minVal + rng.Intn(maxVal-minVal))
+						if err := s3.Decode(bytes.NewReader([]byte(encoded))); err != nil {
+							t.Fatalf("error during Decode: %v", err)
+						}
+						assertSame(s, s3)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
#### util: fix FastIntSet.Next and ForEach with negative numbers

These methods assume that we only insert non-negative elements
(whereas the rest of the API allows that case). This commit fixes this
and improves the test to include negative elements.

Release note: None

#### util: remove FastIntSet.Shift

This method is not used anymore.

Release note: None

#### util: fix FastIntSet.Encode edge case

Encode has an edge case where we incorrectly encode a set that has the
large field set but which is empty. This commit fixes this and adds
tests for Encode/Decode.

Also, before this change Encode could choose either encoding for a
"small" set depending whether `large` was allocated. Although this
doesn't break the documented contract, it is not ideal to leak this
internal detail.

This change also cleans up the code a bit (the semantics of
`largeToSmall` are left over from an earlier implementation).

Release note: None

#### fastintset: reduce allocations from FastIntSet.Encode

The current implementation of Encode causes allocations: the temporary
array escapes to the heap because it is passed through an opaque
interface call.

This change fixes this by passing a `bytes.Buffer` specifically.

`Prepared/ExecBuild` benchmark results:
```
name                                                   old time/op    new time/op    delta
Phases/kv-read/Prepared/ExecBuild                        1.46µs ± 2%    1.40µs ± 2%   -4.04%  (p=0.000 n=10+10)
Phases/kv-read-const/Prepared/ExecBuild                  1.24µs ± 2%    1.14µs ± 2%   -8.03%  (p=0.000 n=10+10)
Phases/tpcc-new-order/Prepared/ExecBuild                 1.79µs ± 2%    1.69µs ± 2%   -5.67%  (p=0.000 n=10+9)
Phases/tpcc-delivery/Prepared/ExecBuild                  33.0µs ± 1%    33.7µs ± 5%   +2.19%  (p=0.001 n=10+10)
Phases/tpcc-stock-level/Prepared/ExecBuild                143µs ± 2%     141µs ± 2%     ~     (p=0.280 n=10+10)
Phases/many-columns-and-indexes-a/Prepared/ExecBuild      511µs ± 1%     515µs ± 2%     ~     (p=0.218 n=10+10)
Phases/many-columns-and-indexes-b/Prepared/ExecBuild      529µs ± 1%     543µs ± 4%   +2.77%  (p=0.004 n=10+10)
Phases/ored-preds-100/Prepared/ExecBuild                  116µs ± 1%     118µs ± 4%   +1.35%  (p=0.029 n=10+10)
Phases/ored-preds-using-params-100/Prepared/ExecBuild    1.41ms ± 2%    1.41ms ± 3%     ~     (p=0.971 n=10+10)
name                                                   old alloc/op   new alloc/op   delta
Phases/kv-read/Prepared/ExecBuild                          704B ± 0%      656B ± 0%   -6.82%  (p=0.000 n=10+10)
Phases/kv-read-const/Prepared/ExecBuild                    520B ± 0%      472B ± 0%   -9.23%  (p=0.000 n=10+10)
Phases/tpcc-new-order/Prepared/ExecBuild                   768B ± 0%      720B ± 0%   -6.25%  (p=0.000 n=10+10)
Phases/tpcc-delivery/Prepared/ExecBuild                  11.1kB ± 0%    11.1kB ± 0%   -0.39%  (p=0.000 n=10+6)
Phases/tpcc-stock-level/Prepared/ExecBuild               39.5kB ± 0%    39.5kB ± 0%   -0.12%  (p=0.000 n=10+10)
Phases/many-columns-and-indexes-a/Prepared/ExecBuild     5.02kB ± 0%    4.98kB ± 0%   -0.80%  (p=0.000 n=10+10)
Phases/many-columns-and-indexes-b/Prepared/ExecBuild     7.46kB ± 0%    7.42kB ± 0%   -0.53%  (p=0.000 n=10+10)
Phases/ored-preds-100/Prepared/ExecBuild                 29.6kB ± 0%    29.6kB ± 0%   -0.16%  (p=0.000 n=10+10)
Phases/ored-preds-using-params-100/Prepared/ExecBuild     765kB ± 0%     765kB ± 0%   -0.01%  (p=0.005 n=10+10)
name                                                   old allocs/op  new allocs/op  delta
Phases/kv-read/Prepared/ExecBuild                          11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.000 n=10+10)
Phases/kv-read-const/Prepared/ExecBuild                    8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.000 n=10+10)
Phases/tpcc-new-order/Prepared/ExecBuild                   11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.000 n=10+10)
Phases/tpcc-delivery/Prepared/ExecBuild                    75.0 ± 0%      73.0 ± 0%   -2.67%  (p=0.000 n=10+10)
Phases/tpcc-stock-level/Prepared/ExecBuild                  249 ± 0%       247 ± 0%   -0.80%  (p=0.000 n=10+10)
Phases/many-columns-and-indexes-a/Prepared/ExecBuild       34.0 ± 0%      32.0 ± 0%   -5.88%  (p=0.000 n=10+10)
Phases/many-columns-and-indexes-b/Prepared/ExecBuild       53.0 ± 0%      51.0 ± 0%   -3.77%  (p=0.000 n=10+10)
Phases/ored-preds-100/Prepared/ExecBuild                    415 ± 0%       413 ± 0%   -0.48%  (p=0.000 n=10+10)
Phases/ored-preds-using-params-100/Prepared/ExecBuild     3.29k ± 0%     3.29k ± 0%   -0.06%  (p=0.000 n=10+10)
```

Release note: None

#### fastintset: fix fast_int_set_small/fast_int_set_large test builds

This commit adds Encode/Decode to the test-only implementation which
unbreaks the test builds with `fast_int_set_small` or
`fast_int_set_large` tags.

Release note: None
