### PR TITLE
opt: fix internal error due to DEFAULT in PARTITION BY LIST clause

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_constrained_scans
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_constrained_scans
@@ -260,3 +260,60 @@ select
 query BB
 SELECT * FROM t0 WHERE t0.c0 AND (c1 OR (c0 > false AND c0 < false))
 ----
+
+# Regression test for #73629. A default partition should not cause SELECT
+# queries to fail with an internal error.
+statement ok
+CREATE TABLE abcd (
+  a STRING NOT NULL,
+  b STRING NOT NULL,
+  c INT,
+  d INT,
+  PRIMARY KEY (a, b)
+) PARTITION BY LIST (a) (
+  PARTITION p1 VALUES IN ('foo', 'bar'),
+  PARTITION p2 VALUES IN ('baz'),
+  PARTITION default VALUES IN (DEFAULT)
+)
+
+query T
+EXPLAIN (OPT) SELECT * FROM abcd WHERE b = 'foobar'
+----
+select
+ ├── scan abcd
+ │    └── constraint: /1/2
+ │         ├── [ - /'bar')
+ │         ├── [/'bar'/'foobar' - /'bar'/'foobar']
+ │         ├── [/e'bar\x00'/'foobar' - /'baz')
+ │         ├── [/'baz'/'foobar' - /'baz'/'foobar']
+ │         ├── [/e'baz\x00'/'foobar' - /'foo')
+ │         ├── [/'foo'/'foobar' - /'foo'/'foobar']
+ │         └── [/e'foo\x00'/'foobar' - ]
+ └── filters
+      └── b = 'foobar'
+
+statement ok
+CREATE TABLE abcde (
+  a STRING NOT NULL,
+  b STRING NOT NULL,
+  c INT NOT NULL,
+  d INT,
+  e INT,
+  PRIMARY KEY (a, b, c)
+) PARTITION BY LIST (a, b) (
+  PARTITION p1 VALUES IN (('foo', 'bar')),
+  PARTITION p2 VALUES IN (('baz', DEFAULT)),
+  PARTITION DEFAULT VALUES IN ((DEFAULT, DEFAULT))
+)
+
+query T
+EXPLAIN (OPT) SELECT * FROM abcde WHERE c = 5
+----
+select
+ ├── scan abcde
+ │    └── constraint: /1/2/3
+ │         ├── [ - /'foo'/'bar')
+ │         ├── [/'foo'/'bar'/5 - /'foo'/'bar'/5]
+ │         └── [/'foo'/e'bar\x00'/5 - ]
+ └── filters
+      └── c = 5

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -706,10 +706,15 @@ func (c *CustomFuncs) partitionValuesFilters(
 	tabID opt.TableID, index cat.Index,
 ) (partitionFilter, inBetweenFilter memo.FiltersExpr) {
 
-	// Find all the partition values
+	// Find all the partition values.
 	partitionValues := make([]tree.Datums, 0, index.PartitionCount())
 	for i, n := 0, index.PartitionCount(); i < n; i++ {
-		partitionValues = append(partitionValues, index.Partition(i).PartitionByListPrefixes()...)
+		for _, datums := range index.Partition(i).PartitionByListPrefixes() {
+			// Ignore the DEFAULT case, where there is no value.
+			if len(datums) > 0 {
+				partitionValues = append(partitionValues, datums)
+			}
+		}
 	}
 	if len(partitionValues) == 0 {
 		return partitionFilter, inBetweenFilter


### PR DESCRIPTION
This commit fixes an internal error that could occur during optimization
of some `SELECT` queries due to the presence of a `DEFAULT` partition in a
`PARTITION BY LIST` clause. The error was caused by the fact that the
optimizer sorts the list of `PARTITION BY LIST` prefixes, and the Datums
of length 0 from the `DEFAULT` partition caused the sorting code to panic.
In 20.2.x and earlier, the `DEFAULT` Datums of length 0 was removed before
the prefixes were sent to the optimizer, so this was not a problem until
21.1.0.

This commit fixes the problem by filtering out the Datums of length 0
before sorting.

Fixes #73629

Release note (bug fix): Fixed an internal error, "empty Datums being
compared to other", that could occur during planning for some `SELECT`
queries over tables that included a `DEFAULT` partition value in a
`PARTITION BY LIST` clause. This bug was present since 21.1.0 and has
now been fixed. The bug does not exist on versions 20.2.x and earlier.