### PR TITLE
lint: skip TestMisspell

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1296,6 +1296,10 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestMisspell", func(t *testing.T) {
+		skip.IgnoreLint(t, `this lint causes extra rounds through CI for which the cost-
+benefit analysis is not favorable. We could re-instate this as a nightly lint
+instead.
+`)
 		t.Parallel()
 		if pkgSpecified {
 			skip.IgnoreLint(t, "PKG specified")


### PR DESCRIPTION
I think this lint results in a waste of engineering/CI time. The
suggestions I get are usually "misspellings" of words like "dialling"
but these are more often than not [valid] according to popular
dictionaries and even if they weren't, these spellings are not
detrimental to quality in any meaningful way, especially when the loss
of quality of life of engineers resulting from the lint is taken into
account.

Besides, popular IDEs like Goland already have their own spell checkers
built in.

[valid]: https://www.merriam-webster.com/dictionary/dialling

Release note: None
