### PR TITLE
kvserver: introduce sCfg.SlowReplicationThreshold

### DIFF
--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -176,7 +175,7 @@ func (r *Replica) executeWriteBatch(
 	startPropTime := timeutil.Now()
 	slowTimer := timeutil.NewTimer()
 	defer slowTimer.Stop()
-	slowTimer.Reset(base.SlowRequestThreshold)
+	slowTimer.Reset(r.store.cfg.SlowReplicationThreshold)
 	// NOTE: this defer was moved from a case in the select statement to here
 	// because escape analysis does a better job avoiding allocations to the
 	// heap when defers are unconditional. When this was in the slowTimer select

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1016,6 +1016,10 @@ type StoreConfig struct {
 
 	// KVAdmissionController is an optional field used for admission control.
 	KVAdmissionController KVAdmissionController
+
+	// SlowReplicationThreshold is the duration after which an in-flight proposal
+	// is tracked in the requests.slow.raft metric.
+	SlowReplicationThreshold time.Duration
 }
 
 // ConsistencyTestingKnobs is a BatchEvalTestingKnobs struct used to control the
@@ -1061,6 +1065,9 @@ func (sc *StoreConfig) SetDefaults() {
 
 	if sc.TestingKnobs.GossipWhenCapacityDeltaExceedsFraction == 0 {
 		sc.TestingKnobs.GossipWhenCapacityDeltaExceedsFraction = defaultGossipWhenCapacityDeltaExceedsFraction
+	}
+	if sc.SlowReplicationThreshold == 0 {
+		sc.SlowReplicationThreshold = base.SlowRequestThreshold
 	}
 }
 


### PR DESCRIPTION
This defaults to `base.SlowRequestThreshold` but is customizable, which
will be helpful for testing #71806.

Release note: None
