### PR TITLE
backup: support restoring to system from backups made by tenants

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7021,8 +7021,8 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 			})
 			t.Run("into-system-tenant-id", func(t *testing.T) {
 				systemDB.Exec(t, `CREATE DATABASE foo2`)
-				systemDB.ExpectErr(t, `cannot restore tenant backups into system tenant`,
-					`RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
+				systemDB.Exec(t, `RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
+				systemDB.CheckQueryResults(t, `SELECT * FROM foo2.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
 			})
 		})
 	})

--- a/pkg/ccl/backupccl/key_rewriter.go
+++ b/pkg/ccl/backupccl/key_rewriter.go
@@ -84,16 +84,27 @@ type KeyRewriter struct {
 		prefix []byte
 	}
 
+	// fromSystemTenant is true if the backup was produced by a system tenant,
+	// which is important in that it means any tenant prefixed keys belong to a
+	// backup of that tenant.
+	fromSystemTenant bool
+
 	prefixes prefixRewriter
+	tenants  prefixRewriter
 	descs    map[descpb.ID]catalog.TableDescriptor
 }
 
 // makeKeyRewriterFromRekeys makes a KeyRewriter from Rekey protos.
 func makeKeyRewriterFromRekeys(
-	codec keys.SQLCodec, rekeys []execinfrapb.TableRekey,
+	codec keys.SQLCodec, tableRekeys []execinfrapb.TableRekey, tenantRekeys []execinfrapb.TenantRekey,
 ) (*KeyRewriter, error) {
 	descs := make(map[descpb.ID]catalog.TableDescriptor)
-	for _, rekey := range rekeys {
+	for _, rekey := range tableRekeys {
+		// Ignore the coordinator's poison-pill, rekey, added in restore_job.go, as
+		// we will correctly handle tenant keys below.
+		if rekey.OldID == 0 {
+			continue
+		}
 		var desc descpb.Descriptor
 		if err := protoutil.Unmarshal(rekey.NewDesc, &desc); err != nil {
 			return nil, errors.Wrapf(err, "unmarshalling rekey descriptor for old table id %d", rekey.OldID)
@@ -104,14 +115,30 @@ func makeKeyRewriterFromRekeys(
 		}
 		descs[descpb.ID(rekey.OldID)] = tabledesc.NewBuilder(table).BuildImmutableTable()
 	}
-	return makeKeyRewriter(codec, descs)
+
+	return makeKeyRewriter(codec, descs, tenantRekeys)
 }
+
+var (
+	// isBackupFromSystemTenantRekey is added when the back was made by a system
+	// tenant to indicate that keys in that backup with other tenant prefixes are
+	// backing up those tenants and should not be decoded as table keys.
+	isBackupFromSystemTenantRekey = execinfrapb.TenantRekey{
+		OldID: roachpb.SystemTenantID,
+		NewID: roachpb.SystemTenantID,
+	}
+)
 
 // makeKeyRewriter makes a KeyRewriter from a map of descs keyed by original ID.
 func makeKeyRewriter(
-	codec keys.SQLCodec, descs map[descpb.ID]catalog.TableDescriptor,
+	codec keys.SQLCodec,
+	descs map[descpb.ID]catalog.TableDescriptor,
+	tenants []execinfrapb.TenantRekey,
 ) (*KeyRewriter, error) {
 	var prefixes prefixRewriter
+	var tenantPrefixes prefixRewriter
+	tenantPrefixes.rewrites = make([]prefixRewrite, len(tenants))
+
 	seenPrefixes := make(map[string]bool)
 	for oldID, desc := range descs {
 		// The PrefixEnd() of index 1 is the same as the prefix of index 2, so use a
@@ -146,10 +173,29 @@ func makeKeyRewriter(
 	sort.Slice(prefixes.rewrites, func(i, j int) bool {
 		return bytes.Compare(prefixes.rewrites[i].OldPrefix, prefixes.rewrites[j].OldPrefix) < 0
 	})
+	fromSystemTenant := false
+	for i := range tenants {
+		if tenants[i] == isBackupFromSystemTenantRekey {
+			fromSystemTenant = true
+			continue
+		}
+		tenantPrefixes.rewrites[i] = prefixRewrite{
+			OldPrefix: keys.MakeSQLCodec(tenants[i].OldID).TenantPrefix(),
+			NewPrefix: keys.MakeSQLCodec(tenants[i].NewID).TenantPrefix(),
+		}
+		tenantPrefixes.rewrites[i].noop = bytes.Equal(
+			tenantPrefixes.rewrites[i].OldPrefix, tenantPrefixes.rewrites[i].NewPrefix,
+		)
+	}
+	sort.Slice(tenantPrefixes.rewrites, func(i, j int) bool {
+		return bytes.Compare(tenantPrefixes.rewrites[i].OldPrefix, tenantPrefixes.rewrites[j].OldPrefix) < 0
+	})
 	return &KeyRewriter{
-		codec:    codec,
-		prefixes: prefixes,
-		descs:    descs,
+		codec:            codec,
+		prefixes:         prefixes,
+		descs:            descs,
+		tenants:          tenantPrefixes,
+		fromSystemTenant: fromSystemTenant,
 	}, nil
 }
 
@@ -164,12 +210,18 @@ func MakeKeyRewriterPrefixIgnoringInterleaved(tableID descpb.ID, indexID descpb.
 // RewriteKey modifies key (possibly in place), changing all table IDs to their
 // new value.
 func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
-	if kr.codec.ForSystemTenant() && bytes.HasPrefix(key, keys.TenantPrefix) {
-		// If we're rewriting from the system tenant, we don't rewrite tenant keys
-		// at all since we assume that we're restoring an entire tenant.
-		return key, true, nil
+	// If we are reading a system tenant backup and this is a tenant key then it
+	// is part of a backup *of* that tenant, so we we only restore it if we have a
+	// tenant rekey for it, i.e. we're restoring that tenant.
+	if kr.fromSystemTenant && bytes.HasPrefix(key, keys.TenantPrefix) {
+		k, ok := kr.tenants.rewriteKey(key)
+		return k, ok, nil
 	}
 
+	// At this point we know we're not restoring a tenant, however the keys we're
+	// restoring from could still have tenant prefixes if they were backed up _by_
+	// a tenant, so we'll remove the prefix if any, rekey, and then encode with
+	// our own tenant prefix, if any.
 	noTenantPrefix, oldTenantID, err := keys.DecodeTenantPrefix(key)
 	if err != nil {
 		return nil, false, err

--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -74,7 +74,7 @@ func TestKeyRewriter(t *testing.T) {
 		},
 	}
 
-	kr, err := makeKeyRewriterFromRekeys(keys.SystemSQLCodec, rekeys)
+	kr, err := makeKeyRewriterFromRekeys(keys.SystemSQLCodec, rekeys, nil /* tenantRekeys */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestKeyRewriter(t *testing.T) {
 		newKr, err := makeKeyRewriterFromRekeys(keys.SystemSQLCodec, []execinfrapb.TableRekey{
 			{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
 			{OldID: uint32(desc.ID), NewDesc: mustMarshalDesc(t, desc2.TableDesc())},
-		})
+		}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +153,7 @@ func TestKeyRewriter(t *testing.T) {
 			destCodec := keys.MakeSQLCodec(destTenant)
 			newKr, err := makeKeyRewriterFromRekeys(destCodec, []execinfrapb.TableRekey{
 				{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
-			})
+			}, nil)
 			require.NoError(t, err)
 
 			key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())

--- a/pkg/ccl/backupccl/restoration_data.go
+++ b/pkg/ccl/backupccl/restoration_data.go
@@ -34,10 +34,11 @@ type restorationData interface {
 	// Peripheral data that is needed in the restoration flow relating to the data
 	// included in this bundle.
 	getRekeys() []execinfrapb.TableRekey
+	getTenantRekeys() []execinfrapb.TenantRekey
 	getPKIDs() map[uint64]bool
 
 	// addTenant extends the set of data needed to restore to include a new tenant.
-	addTenant(roachpb.TenantID)
+	addTenant(fromID, toID roachpb.TenantID)
 
 	// isEmpty returns true iff there is any data to be restored.
 	isEmpty() bool
@@ -63,7 +64,9 @@ type restorationDataBase struct {
 	// spans is the spans included in this bundle.
 	spans []roachpb.Span
 	// rekeys maps old table IDs to their new table descriptor.
-	rekeys []execinfrapb.TableRekey
+	tableRekeys []execinfrapb.TableRekey
+	// tenantRekeys maps tenants being restored to their new ID.
+	tenantRekeys []execinfrapb.TenantRekey
 	// pkIDs stores the ID of the primary keys for all of the tables that we're
 	// restoring for RowCount calculation.
 	pkIDs map[uint64]bool
@@ -78,7 +81,12 @@ var _ restorationData = &restorationDataBase{}
 
 // getRekeys implements restorationData.
 func (b *restorationDataBase) getRekeys() []execinfrapb.TableRekey {
-	return b.rekeys
+	return b.tableRekeys
+}
+
+// getRekeys implements restorationData.
+func (b *restorationDataBase) getTenantRekeys() []execinfrapb.TenantRekey {
+	return b.tenantRekeys
 }
 
 // getPKIDs implements restorationData.
@@ -97,9 +105,13 @@ func (b *restorationDataBase) getSystemTables() []catalog.TableDescriptor {
 }
 
 // addTenant implements restorationData.
-func (b *restorationDataBase) addTenant(tenantID roachpb.TenantID) {
-	prefix := keys.MakeTenantPrefix(tenantID)
+func (b *restorationDataBase) addTenant(fromTenantID, toTenantID roachpb.TenantID) {
+	prefix := keys.MakeTenantPrefix(fromTenantID)
 	b.spans = append(b.spans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	b.tenantRekeys = append(b.tenantRekeys, execinfrapb.TenantRekey{
+		OldID: fromTenantID,
+		NewID: toTenantID,
+	})
 }
 
 // isEmpty implements restorationData.

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -331,7 +331,7 @@ func (rd *restoreDataProcessor) openSSTs(
 
 func (rd *restoreDataProcessor) runRestoreWorkers(ctx context.Context, ssts chan mergedSST) error {
 	return ctxgroup.GroupWorkers(ctx, rd.numWorkers, func(ctx context.Context, _ int) error {
-		kr, err := makeKeyRewriterFromRekeys(rd.FlowCtx.Codec(), rd.spec.Rekeys)
+		kr, err := makeKeyRewriterFromRekeys(rd.FlowCtx.Codec(), rd.spec.TableRekeys, rd.spec.TenantRekeys)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -371,7 +371,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			atomic.StoreInt64(&remainingAmbiguousSubReqs, initialAmbiguousSubReqs)
 
 			mockRestoreDataSpec := execinfrapb.RestoreDataSpec{
-				Rekeys: rekeys,
+				TableRekeys: rekeys,
 			}
 			restoreSpanEntry := execinfrapb.RestoreSpanEntry{
 				Span: roachpb.Span{Key: first, EndKey: last.PrefixEnd()},
@@ -392,7 +392,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			require.NoError(t, mockRestoreDataProcessor.openSSTs(ctx, restoreSpanEntry, ssts))
 			close(ssts)
 			sst := <-ssts
-			rewriter, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), mockRestoreDataSpec.Rekeys)
+			rewriter, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), mockRestoreDataSpec.TableRekeys, mockRestoreDataSpec.TenantRekeys)
 			require.NoError(t, err)
 			_, err = mockRestoreDataProcessor.processRestoreSpanEntry(ctx, rewriter, sst)
 			require.NoError(t, err)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -535,6 +535,7 @@ func restore(
 			dataToRestore.getPKIDs(),
 			encryption,
 			dataToRestore.getRekeys(),
+			dataToRestore.getTenantRekeys(),
 			endTime,
 			progCh,
 		)
@@ -1271,16 +1272,16 @@ func createImportingDescriptors(
 	}
 
 	dataToPreRestore := &restorationDataBase{
-		spans:  preRestoreSpans,
-		rekeys: rekeys,
-		pkIDs:  pkIDs,
+		spans:       preRestoreSpans,
+		tableRekeys: rekeys,
+		pkIDs:       pkIDs,
 	}
 
 	dataToRestore := &mainRestorationData{
 		restorationDataBase{
-			spans:  postRestoreSpans,
-			rekeys: rekeys,
-			pkIDs:  pkIDs,
+			spans:       postRestoreSpans,
+			tableRekeys: rekeys,
+			pkIDs:       pkIDs,
 		},
 	}
 
@@ -1409,29 +1410,17 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	// backupCodec is the codec that was used to encode the keys in the backup. It
 	// is the tenant in which the backup was taken.
 	backupCodec := keys.SystemSQLCodec
+	backupTenantID := roachpb.SystemTenantID
+
 	if len(sqlDescs) != 0 {
 		if len(latestBackupManifest.Spans) != 0 && !latestBackupManifest.HasTenants() {
 			// If there are no tenant targets, then the entire keyspace covered by
 			// Spans must lie in 1 tenant.
-			_, backupTenantID, err := keys.DecodeTenantPrefix(latestBackupManifest.Spans[0].Key)
+			_, backupTenantID, err = keys.DecodeTenantPrefix(latestBackupManifest.Spans[0].Key)
 			if err != nil {
 				return err
 			}
 			backupCodec = keys.MakeSQLCodec(backupTenantID)
-			// Disallow cluster restores, unless the tenant IDs match.
-			if details.DescriptorCoverage == tree.AllDescriptors {
-				if !backupCodec.TenantPrefix().Equal(p.ExecCfg().Codec.TenantPrefix()) {
-					return unimplemented.NewWithIssuef(62277,
-						"cannot cluster RESTORE backups taken from different tenant: %s",
-						backupTenantID.String())
-				}
-			}
-			if backupTenantID != roachpb.SystemTenantID && p.ExecCfg().Codec.ForSystemTenant() {
-				// TODO(pbardea): This is unsupported for now because the key-rewriter
-				// cannot distinguish between RESTORE TENANT and table restore from a
-				// backup taken in a tenant, into the system tenant.
-				return errors.New("cannot restore tenant backups into system tenant")
-			}
 		}
 	}
 
@@ -1452,6 +1441,45 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err != nil {
 		return err
 	}
+
+	if !backupCodec.TenantPrefix().Equal(p.ExecCfg().Codec.TenantPrefix()) {
+		// Disallow cluster restores until values like jobs are relocatable.
+		if details.DescriptorCoverage == tree.AllDescriptors {
+			return unimplemented.NewWithIssuef(62277,
+				"cannot cluster RESTORE backups taken from different tenant: %s",
+				backupTenantID.String())
+		}
+
+		// Ensure old processors fail if this is a previously unsupported restore of
+		// a tenant backup by the system tenant, which the old rekey processor would
+		// mishandle since it assumed the system tenant always restored tenant keys
+		// to tenant prefixes, i.e. as tenant restore.
+		if backupTenantID != roachpb.SystemTenantID && p.ExecCfg().Codec.ForSystemTenant() {
+			// This empty table rekey acts as a poison-pill, which will be ignored by
+			// a current processor but reliably cause an older processor, which would
+			// otherwise mishandle tenant-made backup keys, to fail as it will be
+			// unable to decode the zero ID table desc.
+			preData.tableRekeys = append(preData.tableRekeys, execinfrapb.TableRekey{})
+			mainData.tableRekeys = append(preData.tableRekeys, execinfrapb.TableRekey{})
+		}
+	}
+
+	// If, and only if, the backup was made by a system tenant, can it contain
+	// backed up tenants, which the processor needs to know when is rekeying -- if
+	// the backup contains tenants, then a key with a tenant prefix should be
+	// restored if, and only if, we're restoring that tenant, and restored to a
+	// tenant. Otherwise, if this backup was not made by a system tenant, it does
+	// not contain tenants, so the rekey will assume if a key has a tenant prefix,
+	// it is because the tenant produced the backup, and it should be removed to
+	// then decode the remainder of the key. We communicate this distinction to
+	// the processor with a special tenant rekey _into_ the system tenant, which
+	// would never otherwise be valid. It will discard this rekey but it signals
+	// to it that we're rekeying a system-made backup.
+	if backupTenantID == roachpb.SystemTenantID {
+		preData.tenantRekeys = append(preData.tenantRekeys, isBackupFromSystemTenantRekey)
+		mainData.tenantRekeys = append(preData.tenantRekeys, isBackupFromSystemTenantRekey)
+	}
+
 	// Refresh the job details since they may have been updated when creating the
 	// importing descriptors.
 	details = r.job.Details().(jobspb.RestoreDetails)
@@ -1502,7 +1530,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	for _, tenant := range details.Tenants {
-		mainData.addTenant(roachpb.MakeTenantID(tenant.ID))
+		// TODO(dt): extend the job to keep track of new ID.
+		id := roachpb.MakeTenantID(tenant.ID)
+		mainData.addTenant(id, id)
 	}
 
 	numNodes, err := clusterNodeCount(p.ExecCfg().Gossip)

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -214,7 +214,7 @@ func newSplitAndScatterProcessor(
 	}
 
 	db := flowCtx.Cfg.DB
-	kr, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), spec.Rekeys)
+	kr, err := makeKeyRewriterFromRekeys(flowCtx.Codec(), spec.TableRekeys, spec.TenantRekeys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -73,6 +73,11 @@ func (t TenantID) IsSet() bool {
 	return t.InternalValue != 0
 }
 
+// IsSystem returns whether this ID is that of the system tenant.
+func (t TenantID) IsSystem() bool {
+	return IsSystemTenantID(t.InternalValue)
+}
+
 // IsSystemTenantID returns whether the provided ID corresponds to that of the
 // system tenant.
 func IsSystemTenantID(id uint64) bool {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -227,6 +227,13 @@ message TableRekey {
   optional bytes new_desc = 2;
 }
 
+message TenantRekey {
+  // OldID is a previous tenant ID.
+  optional roachpb.TenantID old_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "OldID"];
+  // NewID is the ID with which to replace OldID.
+  optional roachpb.TenantID new_id = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "NewID"];
+}
+
 // RestoreDataEntry will be specified at planning time to the SplitAndScatter
 // processors, then those processors will stream these, encoded as bytes in rows
 // to the RestoreDataProcessors.
@@ -240,11 +247,12 @@ message RestoreSpanEntry {
 message RestoreDataSpec {
   optional util.hlc.Timestamp restore_time = 1 [(gogoproto.nullable) = false];
   optional roachpb.FileEncryptionOptions encryption = 2;
-  repeated TableRekey rekeys = 3 [(gogoproto.nullable) = false];
-
+  repeated TableRekey table_rekeys = 3 [(gogoproto.nullable) = false];
+  repeated TenantRekey tenant_rekeys = 5[(gogoproto.nullable) = false];
   // PKIDs is used to convert result from an ExportRequest into row count
   // information passed back to track progress in the backup job.
   map<uint64, bool> pk_ids = 4 [(gogoproto.customname) = "PKIDs"];
+  // NEXT ID: 6.
 }
 
 message SplitAndScatterSpec {
@@ -253,7 +261,8 @@ message SplitAndScatterSpec {
   }
 
   repeated RestoreEntryChunk chunks = 1 [(gogoproto.nullable) = false];
-  repeated TableRekey rekeys = 2 [(gogoproto.nullable) = false];
+  repeated TableRekey table_rekeys = 2 [(gogoproto.nullable) = false];
+  repeated TenantRekey tenant_rekeys = 3 [(gogoproto.nullable) = false];
 }
 
 // FileCompression list of the compression codecs which are currently


### PR DESCRIPTION
Previously a non-system tenant could restore tables or databases from a
backup of tables or databases (including a "cluster" backup), made by
another non-system tenant, and a system tenant could do the same from a
backup made by another system tenant, and a system tenant could
additionally restore tenants from backups of tenants made by another
system tenant.

However. prior to this change, a system tenant could *not* restore from
a backup made by a non-system tenant.

This limitation / bug was due to the fact that the code used to restore
has to inspect each key and determine if it should be restored based on
what is being restored, and if so, to what tenant prefix and table ID.
Previously this code could not differentiate between a key that had a
tenant prefix because it was part of a backup _of_ a tenant versus one
that had a tenant prefix because it was backed up _by_ a tenant, and so
it assumed that if the system tenant was restoring and the key belonged
to a tenant, then it must be being restored as part of a restore of the
tenant, which would be incorrect if the system tenant was restoring a
backup made by a tenant. To avoid violating this assumption, which cause
the system tenant to incorrectly restore data for a table backed up by a
tenant to that tenant on the restoring cluster instead of to that table,
such a RESTORE would be rejected as unsupported.

This change removes that restriction, by extending the metadata passed
to that key replacement function, so that it now if the backup was made
by a system tenant, which would mean any keys with tenant prefixes are
part of tenant backups and thus only restored as part of tenant restores
or if it was made by a tenant, in which case keys are never part of a
tenant backup, and should be restored as table keys.

Release note (bug fix): Dedicated clusters can now restore tables and databases from backups made by tenants.