### PR TITLE
opt: minor optbuilder improvements related to assignment casts

### DIFF
--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -47,6 +48,22 @@ func NewTransactionCommittedError() error {
 // NewNonNullViolationError creates an error for a violation of a non-NULL constraint.
 func NewNonNullViolationError(columnName string) error {
 	return pgerror.Newf(pgcode.NotNullViolation, "null value in column %q violates not-null constraint", columnName)
+}
+
+// NewInvalidAssignmentCastError creates an error that is used when a mutation
+// cannot be performed because there is not a valid assignment cast from a
+// value's type to the type of the target column.
+func NewInvalidAssignmentCastError(
+	sourceType *types.T, targetType *types.T, targetColName string,
+) error {
+	return errors.WithHint(
+		pgerror.Newf(
+			pgcode.DatatypeMismatch,
+			"value type %s doesn't match type %s of column %q",
+			sourceType, targetType, tree.ErrNameString(targetColName),
+		),
+		"you will need to rewrite or cast the expression",
+	)
 }
 
 // NewGeneratedAlwaysAsIdentityColumnOverrideError creates an error for


### PR DESCRIPTION
#### opt: do not rely on column names for GENERATED ALWAYS AS IDENTITY checks

Previously, optbuilder relied on matching column names to validate that
mutations do not explicitly write to `GENERATED ALWAYS AS IDENTITY`
columns. There are no known bugs caused by this, but relying on column
names can be brittle. This commit updates the logic to use ordinals of
columns within their table instead.

Release note: None

#### opt: simplify optbuilder update logic

Release note: None

#### opt: simplify assignment cast logic for inserts

Creation of invalid assignment cast errors has been abstracted to a
helper function for reuse for other mutations in a future commit.

Release note: None
