### PR TITLE
release-21.1: kv: add telemetry for node liveness

### DIFF
--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
+        "//pkg/server/telemetry",
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/util/contextutil",

--- a/pkg/server/telemetry/BUILD.bazel
+++ b/pkg/server/telemetry/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     srcs = ["features_test.go"],
     deps = [
         ":telemetry",
+        "//pkg/util/metric",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -129,6 +129,13 @@ func (c CounterWithMetric) Inc() {
 	c.metric.Inc(1)
 }
 
+// Count returns the value of the metric, not the telemetry. Note that the
+// telemetry value may reset to zero when, for example, GetFeatureCounts() is
+// called with ResetCounts to generate a report.
+func (c CounterWithMetric) Count() int64 {
+	return c.metric.Count()
+}
+
 // Forward the metric.Iterable interface to the metric counter. We
 // don't just embed the counter because our Inc() interface is a bit
 // different.

--- a/pkg/server/telemetry/features_test.go
+++ b/pkg/server/telemetry/features_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +91,24 @@ func TestBucket(t *testing.T) {
 			t.Errorf("%d: expected %d, got %d", tc.input, expected, actual)
 		}
 	}
+}
+
+// TestCounterWithMetric verifies that only the telemetry is reset to zero when,
+// for example, a report is created.
+func TestCounterWithMetric(t *testing.T) {
+	cm := telemetry.NewCounterWithMetric(metric.Metadata{Name: "test-metric"})
+	cm.Inc()
+
+	// Using GetFeatureCounts to read the telemetry value.
+	m1 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
+	require.Equal(t, int32(1), m1["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
+
+	// Reset the telemetry.
+	telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ResetCounts)
+
+	// Verify only the telemetry is back to 0.
+	m2 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
+	require.Equal(t, int32(0), m2["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
 }


### PR DESCRIPTION
Backport 1/1 commits from #72989.

/cc @cockroachdb/release

---

Exporting the existing metrics 'HeartbeatFailures' and 'EpochIncrements'
as telementry counters.

These telemetry values can be seen in cockroach demo by decommissioning
a node and then querying crdb_internal.feature_usage, and also in the
'Diagnostics Reporting Data' page (/_status/diagnostics/local ->
"featureUsage").

Issue #71662

Release note: None
