### PR TITLE
ci: fix `teamcity-trigger` when running under `bazel`

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -52,15 +52,21 @@ func main() {
 	})
 }
 
-const baseImportPath = "github.com/cockroachdb/cockroach/pkg/"
-
-var importPaths = gotool.ImportPaths([]string{baseImportPath + "..."})
+func getBaseImportPath() string {
+	if bazel.BuiltWithBazel() {
+		return "./"
+	}
+	return "github.com/cockroachdb/cockroach/pkg/"
+}
 
 func runTC(queueBuild func(string, map[string]string)) {
 	buildID := "Cockroach_Nightlies_Stress"
 	if bazel.BuiltWithBazel() {
 		buildID = "Cockroach_Nightlies_StressBazel"
 	}
+	baseImportPath := getBaseImportPath()
+	importPaths := gotool.ImportPaths([]string{baseImportPath + "..."})
+
 	// Queue stress builds. One per configuration per package.
 	for _, importPath := range importPaths {
 		// By default, run each package for up to 100 iterations.

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -38,9 +38,9 @@ func Example_runTC() {
 	// Shows sample output for the following packages, some of which runs with
 	// non-default configurations.
 	pkgs := map[string]struct{}{
-		baseImportPath + "kv/kvnemesis":  {},
-		baseImportPath + "sql/logictest": {},
-		baseImportPath + "storage":       {},
+		getBaseImportPath() + "kv/kvnemesis":  {},
+		getBaseImportPath() + "sql/logictest": {},
+		getBaseImportPath() + "storage":       {},
 	}
 
 	runTC(func(buildID string, opts map[string]string) {


### PR DESCRIPTION
`gotool.ImportPaths` can't find all the go packages when you query the
typical way in the Bazel build container for whatever reason, but I've
validated that `./...` works as a workaround.

Closes #73643.

Release note: None