### PR TITLE
rttanalysis: fix deadlock

### DIFF
--- a/pkg/bench/rttanalysis/rtt_analysis_bench.go
+++ b/pkg/bench/rttanalysis/rtt_analysis_bench.go
@@ -140,7 +140,7 @@ func executeRoundTripTest(b testingB, tc RoundTripBenchTestCase, cc ClusterConst
 
 	res := float64(roundTrips) / float64(b.N())
 	if haveExp && !exp.matches(int(res)) && !*rewriteFlag {
-		b.Fatalf(`got %v, expected %v. trace:
+		b.Errorf(`got %v, expected %v. trace:
 %v
 (above trace from test %s. got %v, expected %v)
 `, res, exp, r, b.Name(), res, exp)

--- a/pkg/bench/rttanalysis/validate_benchmark_data.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data.go
@@ -11,7 +11,6 @@
 package rttanalysis
 
 import (
-	"context"
 	"encoding/csv"
 	"flag"
 	"os"
@@ -81,12 +80,9 @@ func runBenchmarkExpectationTests(t *testing.T, r *Registry) {
 	limiter := quotapool.NewIntPool("rttanalysis", uint64(concurrency))
 	isRewrite := *rewriteFlag
 	for b, cases := range r.r {
-		quota, err := limiter.Acquire(context.Background(), 1)
-		require.NoError(t, err)
 		wg.Add(1)
 		go func(b string, cases []RoundTripBenchTestCase) {
 			defer wg.Done()
-			defer quota.Release()
 			t.Run(b, func(t *testing.T) {
 				runs := 1
 				if isRewrite {


### PR DESCRIPTION
This test is using a quotapool to limit the concurrency of the subtests.
In order for a test to run, it needs to take tokens out of the quota
pool twice, in two stages. If enough parallel tests are doing stage one
close to each other, and there's no more tokens for stage two ->
deadlock.

This patch fixes it by removing stage 1. I'm not sure why we were
allocating that quota in the first place.

This patch also switches a t.Fatal to t.Error, because the respective
code runs on a goroutine. There's plenty more of Fatals still around, but
hopefully they're less likely.

Release note: None