### PR TITLE
colexec: fix the materializer instantiation to use a copy of eval ctx

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -60,7 +60,7 @@ exp,benchmark
 2,ORMQueries/has_column_privilege_using_column_name
 2,ORMQueries/has_table_privilege_real_table
 2,ORMQueries/has_table_privilege_virtual_table
-3,ORMQueries/information_schema._pg_index_position
+15,ORMQueries/information_schema._pg_index_position
 2,ORMQueries/pg_attribute
 2,ORMQueries/pg_class
 13,ORMQueries/pg_is_other_temp_schema

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -117,7 +117,13 @@ func newColumnarizer(
 	c.ProcessorBaseNoHelper.Init(
 		nil, /* self */
 		flowCtx,
-		flowCtx.EvalCtx,
+		// Similar to the materializer, the columnarizer will update the eval
+		// context when closed, so we give it a copy of the eval context to
+		// preserve the "global" eval context from being mutated. In practice,
+		// the columnarizer is closed only when DrainMeta() is called which
+		// occurs at the very end of the execution, yet we choose to be
+		// defensive here.
+		flowCtx.NewEvalCtx(),
 		processorID,
 		nil, /* output */
 		execinfra.ProcStateOpts{

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -148,6 +149,33 @@ var materializerPool = sync.Pool{
 func NewMaterializer(
 	flowCtx *execinfra.FlowCtx, processorID int32, input colexecargs.OpWithMetaInfo, typs []*types.T,
 ) *Materializer {
+	// When the materializer is created in the middle of the chain of operators,
+	// it will modify the eval context when it is done draining, so we have to
+	// give it a copy to preserve the "global" eval context from being mutated.
+	return newMaterializerInternal(flowCtx, flowCtx.NewEvalCtx(), processorID, input, typs)
+}
+
+// NewMaterializerNoEvalCtxCopy is the same as NewMaterializer but doesn't make
+// a copy of the eval context (i.e. it'll use the "global" one coming from the
+// flowCtx).
+//
+// This should only be used when the materializer is at the root of the operator
+// tree which is acceptable because the root materializer is closed (which
+// modifies the eval context) only when the whole flow is done, at which point
+// the eval context won't be used anymore.
+func NewMaterializerNoEvalCtxCopy(
+	flowCtx *execinfra.FlowCtx, processorID int32, input colexecargs.OpWithMetaInfo, typs []*types.T,
+) *Materializer {
+	return newMaterializerInternal(flowCtx, flowCtx.EvalCtx, processorID, input, typs)
+}
+
+func newMaterializerInternal(
+	flowCtx *execinfra.FlowCtx,
+	evalCtx *tree.EvalContext,
+	processorID int32,
+	input colexecargs.OpWithMetaInfo,
+	typs []*types.T,
+) *Materializer {
 	m := materializerPool.Get().(*Materializer)
 	*m = Materializer{
 		ProcessorBaseNoHelper: m.ProcessorBaseNoHelper,
@@ -168,9 +196,7 @@ func NewMaterializer(
 	m.Init(
 		m,
 		flowCtx,
-		// Materializer doesn't modify the eval context, so it is safe to reuse
-		// the one from the flow context.
-		flowCtx.EvalCtx,
+		evalCtx,
 		processorID,
 		nil, /* output */
 		execinfra.ProcStateOpts{

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1007,7 +1007,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 					s.numClosers--
 				}
 			} else {
-				input = colexec.NewMaterializer(
+				input = colexec.NewMaterializerNoEvalCtxCopy(
 					flowCtx,
 					pspec.ProcessorID,
 					opWithMetaInfo,

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -87,6 +87,10 @@ func (p *planNodeToRowSource) InitWithOutput(
 		post,
 		p.outputTypes,
 		flowCtx,
+		// Note that we have already created a copy of the extendedEvalContext
+		// (which made a copy of the EvalContext) right before calling
+		// makePlanNodeToRowSource, so we can just use the eval context from the
+		// params.
 		p.params.EvalContext(),
 		0, /* processorID */
 		output,


### PR DESCRIPTION
This commit makes it so that during the materializer instantiation we
give it a copy of the eval context. Previously, we assumed that because the
materializer itself doesn't modify the eval context, it was ok to use
the global one; however, we missed the fact that the materializer will
update the context on the eval context when the materializer is closed
(which will happen after the materializer has been drained). In
particular, if the materializer is in the middle of the chain of
operators, it might be drained when the rest of the chain is still
running, and the update to the context would invalidate the global eval
context for still running things. This broke tracing in some cases, and
it is now fixed. The only exception to making a copy of the eval context
is when the materializer is used at the root of the operator tree.

This commit also applies the same change to the columnarizer, and
although that seems unnecessary to me, we choose to be defensive.
Additionally, this commit clarifies non-making a copy in case of
a planNodeToRowSource adapter.

Release note: None