### PR TITLE
roachprod: propagating context through the library

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -124,7 +125,7 @@ Local Clusters
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		createVMOpts.ClusterName = args[0]
-		return roachprod.Create(username, numNodes, createVMOpts, providerOptsContainer)
+		return roachprod.Create(context.Background(), username, numNodes, createVMOpts, providerOptsContainer)
 	}),
 }
 
@@ -143,7 +144,7 @@ if the user would like to update the keys on the remote hosts.
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.SetupSSH(args[0])
+		return roachprod.SetupSSH(context.Background(), args[0])
 	}),
 }
 
@@ -395,7 +396,7 @@ cluster setting will be set to its value.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
-		return roachprod.Start(args[0], startOpts, clusterSettingsOpts...)
+		return roachprod.Start(context.Background(), args[0], startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -424,7 +425,7 @@ signals.
 		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
 			wait = true
 		}
-		return roachprod.Stop(args[0], tag, sig, wait)
+		return roachprod.Stop(context.Background(), args[0], tag, sig, wait)
 	}),
 }
 
@@ -467,7 +468,7 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
-		return roachprod.StartTenant(tenantCluster, hostCluster, startOpts, clusterSettingsOpts...)
+		return roachprod.StartTenant(context.Background(), tenantCluster, hostCluster, startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -482,7 +483,7 @@ default cluster settings. It's intended to be used in conjunction with
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Init(args[0])
+		return roachprod.Init(context.Background(), args[0])
 	}),
 }
 
@@ -502,7 +503,7 @@ The "status" command outputs the binary and PID for the specified nodes:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Status(args[0], tag)
+		return roachprod.Status(context.Background(), args[0], tag)
 	}),
 }
 
@@ -550,7 +551,7 @@ of nodes, outputting a line whenever a change is detected:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Monitor(args[0], monitorOpts)
+		return roachprod.Monitor(context.Background(), args[0], monitorOpts)
 	}),
 }
 
@@ -565,7 +566,7 @@ nodes.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Wipe(args[0], wipePreserveCerts)
+		return roachprod.Wipe(context.Background(), args[0], wipePreserveCerts)
 	}),
 }
 
@@ -595,7 +596,7 @@ the 'zfs rollback' command:
 
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Reformat(args[0], args[1])
+		return roachprod.Reformat(context.Background(), args[0], args[1])
 	}),
 }
 
@@ -607,7 +608,7 @@ var runCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
-		return roachprod.Run(args[0], extraSSHOptions, tag, secure, args[1:])
+		return roachprod.Run(context.Background(), args[0], extraSSHOptions, tag, secure, args[1:])
 	}),
 }
 
@@ -631,7 +632,7 @@ var installCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Install(args[0], args[1:])
+		return roachprod.Install(context.Background(), args[0], args[1:])
 	}),
 }
 
@@ -646,7 +647,7 @@ var downloadCmd = &cobra.Command{
 		if len(args) == 4 {
 			dest = args[3]
 		}
-		return roachprod.Download(args[0], src, sha, dest)
+		return roachprod.Download(context.Background(), args[0], src, sha, dest)
 	}),
 }
 
@@ -707,7 +708,7 @@ Some examples of usage:
 		if len(args) == 3 {
 			versionArg = args[2]
 		}
-		return roachprod.Stage(args[0], stageOS, stageDir, args[1], versionArg)
+		return roachprod.Stage(context.Background(), args[0], stageOS, stageDir, args[1], versionArg)
 	}),
 }
 
@@ -721,7 +722,7 @@ start."
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.DistributeCerts(args[0])
+		return roachprod.DistributeCerts(context.Background(), args[0])
 	}),
 }
 
@@ -737,7 +738,7 @@ var putCmd = &cobra.Command{
 		if len(args) == 3 {
 			dest = args[2]
 		}
-		return roachprod.Put(args[0], src, dest, useTreeDist)
+		return roachprod.Put(context.Background(), args[0], src, dest, useTreeDist)
 	}),
 }
 
@@ -764,7 +765,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(args[0], secure, args[1:])
+		return roachprod.SQL(context.Background(), args[0], secure, args[1:])
 	}),
 }
 
@@ -775,7 +776,7 @@ var pgurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		urls, err := roachprod.PgURL(args[0], pgurlCertsDir, external, secure)
+		urls, err := roachprod.PgURL(context.Background(), args[0], pgurlCertsDir, external, secure)
 		if err != nil {
 			return err
 		}
@@ -836,7 +837,7 @@ var ipCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		ips, err := roachprod.IP(args[0], external)
+		ips, err := roachprod.IP(context.Background(), args[0], external)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -933,7 +933,7 @@ func (f *clusterFactory) newCluster(
 
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name
-		err = roachprod.Create(cfg.username, cfg.spec.NodeCount, createVMOpts, providerOptsContainer)
+		err = roachprod.Create(ctx, cfg.username, cfg.spec.NodeCount, createVMOpts, providerOptsContainer)
 		if err == nil {
 			if err := f.r.registerCluster(c); err != nil {
 				return nil, err
@@ -1327,7 +1327,7 @@ func (c *clusterImpl) FailOnDeadNodes(ctx context.Context, t test.Test) {
 
 	// Don't hang forever.
 	_ = contextutil.RunWithTimeout(ctx, "detect dead nodes", time.Minute, func(ctx context.Context) error {
-		err := roachprod.Monitor(c.name, install.MonitorOpts{OneShot: true, IgnoreEmptyNodes: true})
+		err := roachprod.Monitor(ctx, c.name, install.MonitorOpts{OneShot: true, IgnoreEmptyNodes: true})
 		// If there's an error, it means either that the monitor command failed
 		// completely, or that it found a dead node worth complaining about.
 		if err != nil {
@@ -1610,7 +1610,7 @@ func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan st
 		} else {
 			l.PrintfCtx(ctx, "wiping cluster %s", c)
 			c.status("wiping cluster")
-			if err := roachprod.Wipe(c.name, false /* preserveCerts */); err != nil {
+			if err := roachprod.Wipe(ctx, c.name, false /* preserveCerts */); err != nil {
 				l.Errorf("%s", err)
 			}
 			if c.localCertsDir != "" {
@@ -1649,7 +1649,7 @@ func (c *clusterImpl) PutE(
 
 	c.status("uploading file")
 	defer c.status("")
-	return errors.Wrap(roachprod.Put(c.MakeNodes(nodes...), src, dest, false /* useTreeDist */), "cluster.PutE")
+	return errors.Wrap(roachprod.Put(ctx, c.MakeNodes(nodes...), src, dest, false /* useTreeDist */), "cluster.PutE")
 }
 
 // PutLibraries inserts all available library files into all nodes on the cluster
@@ -1691,7 +1691,7 @@ func (c *clusterImpl) Stage(
 	}
 	c.status("staging binary")
 	defer c.status("")
-	return errors.Wrap(roachprod.Stage(c.MakeNodes(opts...), "" /* stageOS */, dir, application, versionOrSHA), "cluster.Stage")
+	return errors.Wrap(roachprod.Stage(ctx, c.MakeNodes(opts...), "" /* stageOS */, dir, application, versionOrSHA), "cluster.Stage")
 }
 
 // Get gets files from remote hosts.
@@ -1941,7 +1941,7 @@ func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...opti
 	}
 	c.setStatusForClusterOpt("wiping", nodes...)
 	defer c.clearStatusForClusterOpt(nodes...)
-	return roachprod.Wipe(c.MakeNodes(nodes...), false /* preserveCerts */)
+	return roachprod.Wipe(ctx, c.MakeNodes(nodes...), false /* preserveCerts */)
 }
 
 // Wipe is like WipeE, except instead of returning an error, it does
@@ -1967,7 +1967,7 @@ func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args 
 func (c *clusterImpl) Reformat(
 	ctx context.Context, node option.NodeListOption, filesystem string,
 ) error {
-	return roachprod.Reformat(c.name, filesystem)
+	return roachprod.Reformat(ctx, c.name, filesystem)
 }
 
 // Silence unused warning.
@@ -2088,7 +2088,7 @@ func (c *clusterImpl) RunWithBuffer(
 func (c *clusterImpl) pgURLErr(
 	ctx context.Context, node option.NodeListOption, external bool,
 ) ([]string, error) {
-	urls, err := roachprod.PgURL(c.MakeNodes(node), c.localCertsDir, external, c.localCertsDir != "" /* secure */)
+	urls, err := roachprod.PgURL(ctx, c.MakeNodes(node), c.localCertsDir, external, c.localCertsDir != "" /* secure */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/install/download.go
+++ b/pkg/roachprod/install/download.go
@@ -11,6 +11,7 @@
 package install
 
 import (
+	"context"
 	_ "embed" // required for go:embed
 	"fmt"
 	"net/url"
@@ -27,7 +28,9 @@ const (
 var downloadScript string
 
 // Download downloads the remote resource, preferring a GCS cache if available.
-func Download(c *SyncedCluster, sourceURLStr string, sha string, dest string) error {
+func Download(
+	ctx context.Context, c *SyncedCluster, sourceURLStr string, sha string, dest string,
+) error {
 	// https://example.com/foo/bar.txt
 	sourceURL, err := url.Parse(sourceURLStr)
 	if err != nil {
@@ -63,7 +66,7 @@ func Download(c *SyncedCluster, sourceURLStr string, sha string, dest string) er
 		sha,
 		dest,
 	)
-	if err := c.Run(os.Stdout, os.Stderr,
+	if err := c.Run(ctx, os.Stdout, os.Stderr,
 		downloadNodes,
 		fmt.Sprintf("downloading %s", basename),
 		downloadCmd,
@@ -76,7 +79,7 @@ func Download(c *SyncedCluster, sourceURLStr string, sha string, dest string) er
 	if c.IsLocal() && !filepath.IsAbs(dest) {
 		src := filepath.Join(c.localVMDir(downloadNodes[0]), dest)
 		cpCmd := fmt.Sprintf(`cp "%s" "%s"`, src, dest)
-		return c.Run(os.Stdout, os.Stderr, c.Nodes[1:], "copying to remaining nodes", cpCmd)
+		return c.Run(ctx, os.Stdout, os.Stderr, c.Nodes[1:], "copying to remaining nodes", cpCmd)
 	}
 
 	return nil

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -12,6 +12,7 @@ package install
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 )
@@ -158,10 +159,10 @@ func SortedCmds() []string {
 }
 
 // Install TODO(peter): document
-func Install(c *SyncedCluster, args []string) error {
+func Install(ctx context.Context, c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.Run(&buf, &buf, c.Nodes, "installing "+title, cmd)
+		err := c.Run(ctx, &buf, &buf, c.Nodes, "installing "+title, cmd)
 		if err != nil {
 			fmt.Print(buf.String())
 		}

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -11,6 +11,7 @@
 package roachprod
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 // The host and tenant can use the same underlying cluster, as long as different
 // subsets of nodes are selected (e.g. "local:1,2" and "local:3,4").
 func StartTenant(
+	ctx context.Context,
 	tenantCluster string,
 	hostCluster string,
 	startOpts install.StartOpts,
@@ -67,7 +69,7 @@ func StartTenant(
 	saveNodes := hc.Nodes
 	hc.Nodes = hc.Nodes[:1]
 	fmt.Printf("Creating tenant metadata\n")
-	if err := hc.RunSQL([]string{
+	if err := hc.RunSQL(ctx, []string{
 		`-e`,
 		fmt.Sprintf(createTenantIfNotExistsQuery, startOpts.TenantID),
 	}); err != nil {
@@ -80,7 +82,7 @@ func StartTenant(
 		kvAddrs = append(kvAddrs, fmt.Sprintf("%s:%d", hc.Host(node), hc.NodePort(node)))
 	}
 	startOpts.KVAddrs = strings.Join(kvAddrs, ",")
-	return tc.Start(startOpts)
+	return tc.Start(ctx, startOpts)
 }
 
 // createTenantIfNotExistsQuery is used to initialize the tenant metadata, if

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -345,7 +345,9 @@ func List(listMine bool, clusterNamePattern string) (cloud.Cloud, error) {
 }
 
 // Run runs a command on the nodes in a cluster.
-func Run(clusterName, SSHOptions, processTag string, secure bool, cmdArray []string) error {
+func Run(
+	ctx context.Context, clusterName, SSHOptions, processTag string, secure bool, cmdArray []string,
+) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -357,7 +359,7 @@ func Run(clusterName, SSHOptions, processTag string, secure bool, cmdArray []str
 	// Use "ssh" if an interactive session was requested (i.e. there is no
 	// remote command to run).
 	if len(cmdArray) == 0 {
-		return c.SSH(strings.Split(SSHOptions, " "), cmdArray)
+		return c.SSH(ctx, strings.Split(SSHOptions, " "), cmdArray)
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
@@ -365,11 +367,11 @@ func Run(clusterName, SSHOptions, processTag string, secure bool, cmdArray []str
 	if len(title) > 30 {
 		title = title[:27] + "..."
 	}
-	return c.Run(os.Stdout, os.Stderr, c.Nodes, title, cmd)
+	return c.Run(ctx, os.Stdout, os.Stderr, c.Nodes, title, cmd)
 }
 
 // SQL runs `cockroach sql` on a remote cluster.
-func SQL(clusterName string, secure bool, cmdArray []string) error {
+func SQL(ctx context.Context, clusterName string, secure bool, cmdArray []string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -377,11 +379,11 @@ func SQL(clusterName string, secure bool, cmdArray []string) error {
 	if err != nil {
 		return err
 	}
-	return c.SQL(cmdArray)
+	return c.SQL(ctx, cmdArray)
 }
 
 // IP gets the ip addresses of the nodes in a cluster.
-func IP(clusterName string, external bool) ([]string, error) {
+func IP(ctx context.Context, clusterName string, external bool) ([]string, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err
 	}
@@ -400,7 +402,7 @@ func IP(clusterName string, external bool) ([]string, error) {
 	} else {
 		var err error
 		if err := c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
-			ips[i], err = c.GetInternalIP(nodes[i])
+			ips[i], err = c.GetInternalIP(ctx, nodes[i])
 			return nil, err
 		}); err != nil {
 			return nil, err
@@ -410,7 +412,7 @@ func IP(clusterName string, external bool) ([]string, error) {
 }
 
 // Status retrieves the status of nodes in a cluster.
-func Status(clusterName, processTag string) error {
+func Status(ctx context.Context, clusterName, processTag string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -418,12 +420,14 @@ func Status(clusterName, processTag string) error {
 	if err != nil {
 		return err
 	}
-	return c.Status()
+	return c.Status(ctx)
 }
 
 // Stage stages release and edge binaries to the cluster.
 // stageOS, stageDir, version can be "" to use default values
-func Stage(clusterName string, stageOS, stageDir, applicationName, version string) error {
+func Stage(
+	ctx context.Context, clusterName string, stageOS, stageDir, applicationName, version string,
+) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -444,7 +448,7 @@ func Stage(clusterName string, stageOS, stageDir, applicationName, version strin
 		dir = stageDir
 	}
 
-	return install.StageApplication(c, applicationName, version, os, dir)
+	return install.StageApplication(ctx, c, applicationName, version, os, dir)
 }
 
 // Reset resets all VMs in a cluster.
@@ -472,7 +476,7 @@ func Reset(clusterName string) error {
 }
 
 // SetupSSH sets up the keys and host keys for the vms in the cluster.
-func SetupSSH(clusterName string) error {
+func SetupSSH(ctx context.Context, clusterName string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -511,7 +515,7 @@ func SetupSSH(clusterName string) error {
 			installCluster.VMs[i].RemoteUser = config.OSUser.Username
 		}
 	}
-	if err := installCluster.Wait(); err != nil {
+	if err := installCluster.Wait(ctx); err != nil {
 		return err
 	}
 	// Fetch public keys from gcloud to set up ssh access for all users into the
@@ -520,7 +524,7 @@ func SetupSSH(clusterName string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve authorized keys from gcloud")
 	}
-	return installCluster.SetupSSH()
+	return installCluster.SetupSSH(ctx)
 }
 
 // Extend extends the lifetime of the specified cluster to prevent it from being destroyed.
@@ -559,6 +563,7 @@ func Extend(clusterName string, lifetime time.Duration) error {
 
 // Start starts nodes on a cluster.
 func Start(
+	ctx context.Context,
 	clusterName string,
 	startOpts install.StartOpts,
 	clusterSettingsOpts ...install.ClusterSettingOption,
@@ -570,16 +575,16 @@ func Start(
 	if err != nil {
 		return err
 	}
-	return c.Start(startOpts)
+	return c.Start(ctx, startOpts)
 }
 
 // Monitor monitors the status of cockroach nodes in a cluster.
-func Monitor(clusterName string, opts install.MonitorOpts) error {
+func Monitor(ctx context.Context, clusterName string, opts install.MonitorOpts) error {
 	c, err := newCluster(clusterName)
 	if err != nil {
 		return err
 	}
-	messages := c.Monitor(opts)
+	messages := c.Monitor(ctx, opts)
 	for msg := range messages {
 		if msg.Err != nil {
 			msg.Msg += "error: " + msg.Err.Error()
@@ -594,7 +599,7 @@ func Monitor(clusterName string, opts install.MonitorOpts) error {
 }
 
 // Stop stops nodes on a cluster.
-func Stop(clusterName, processTag string, sig int, wait bool) error {
+func Stop(ctx context.Context, clusterName, processTag string, sig int, wait bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -602,11 +607,11 @@ func Stop(clusterName, processTag string, sig int, wait bool) error {
 	if err != nil {
 		return err
 	}
-	return c.Stop(sig, wait)
+	return c.Stop(ctx, sig, wait)
 }
 
 // Init initializes the cluster.
-func Init(clusterName string) error {
+func Init(ctx context.Context, clusterName string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -614,11 +619,11 @@ func Init(clusterName string) error {
 	if err != nil {
 		return err
 	}
-	return c.Init()
+	return c.Init(ctx)
 }
 
 // Wipe wipes the nodes in a cluster.
-func Wipe(clusterName string, preserveCerts bool) error {
+func Wipe(ctx context.Context, clusterName string, preserveCerts bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -626,11 +631,11 @@ func Wipe(clusterName string, preserveCerts bool) error {
 	if err != nil {
 		return err
 	}
-	return c.Wipe(preserveCerts)
+	return c.Wipe(ctx, preserveCerts)
 }
 
 // Reformat reformats disks in a cluster to use the specified filesystem.
-func Reformat(clusterName string, fs string) error {
+func Reformat(ctx context.Context, clusterName string, fs string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -642,7 +647,7 @@ func Reformat(clusterName string, fs string) error {
 	var fsCmd string
 	switch fs {
 	case vm.Zfs:
-		if err := install.Install(c, []string{vm.Zfs}); err != nil {
+		if err := install.Install(ctx, c, []string{vm.Zfs}); err != nil {
 			return err
 		}
 		fsCmd = `sudo zpool create -f data1 -m /mnt/data1 /dev/sdb`
@@ -652,7 +657,7 @@ func Reformat(clusterName string, fs string) error {
 		return fmt.Errorf("unknown filesystem %q", fs)
 	}
 
-	err = c.Run(os.Stdout, os.Stderr, c.Nodes, "reformatting", fmt.Sprintf(`
+	err = c.Run(ctx, os.Stdout, os.Stderr, c.Nodes, "reformatting", fmt.Sprintf(`
 set -euo pipefail
 if sudo zpool list -Ho name 2>/dev/null | grep ^data1$; then
 sudo zpool destroy -f data1
@@ -670,7 +675,7 @@ sudo chmod 777 /mnt/data1
 }
 
 // Install installs third party software.
-func Install(clusterName string, software []string) error {
+func Install(ctx context.Context, clusterName string, software []string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -678,11 +683,11 @@ func Install(clusterName string, software []string) error {
 	if err != nil {
 		return err
 	}
-	return install.Install(c, software)
+	return install.Install(ctx, c, software)
 }
 
 // Download downloads 3rd party tools, using a GCS cache if possible.
-func Download(clusterName string, src, sha, dest string) error {
+func Download(ctx context.Context, clusterName string, src, sha, dest string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -690,12 +695,12 @@ func Download(clusterName string, src, sha, dest string) error {
 	if err != nil {
 		return err
 	}
-	return install.Download(c, src, sha, dest)
+	return install.Download(ctx, c, src, sha, dest)
 }
 
 // DistributeCerts distributes certificates to the nodes in a cluster.
 // If the certificates already exist, no action is taken.
-func DistributeCerts(clusterName string) error {
+func DistributeCerts(ctx context.Context, clusterName string) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -703,11 +708,11 @@ func DistributeCerts(clusterName string) error {
 	if err != nil {
 		return err
 	}
-	return c.DistributeCerts()
+	return c.DistributeCerts(ctx)
 }
 
 // Put copies a local file to the nodes in a cluster.
-func Put(clusterName, src, dest string, useTreeDist bool) error {
+func Put(ctx context.Context, clusterName, src, dest string, useTreeDist bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -715,7 +720,7 @@ func Put(clusterName, src, dest string, useTreeDist bool) error {
 	if err != nil {
 		return err
 	}
-	return c.Put(src, dest)
+	return c.Put(ctx, src, dest)
 }
 
 // Get copies a remote file from the nodes in a cluster.
@@ -733,7 +738,9 @@ func Get(clusterName, src, dest string) error {
 }
 
 // PgURL generates pgurls for the nodes in a cluster.
-func PgURL(clusterName, certsDir string, external, secure bool) ([]string, error) {
+func PgURL(
+	ctx context.Context, clusterName, certsDir string, external, secure bool,
+) ([]string, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err
 	}
@@ -751,7 +758,7 @@ func PgURL(clusterName, certsDir string, external, secure bool) ([]string, error
 	} else {
 		var err error
 		if err := c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
-			ips[i], err = c.GetInternalIP(nodes[i])
+			ips[i], err = c.GetInternalIP(ctx, nodes[i])
 			return nil, err
 		}); err != nil {
 			return nil, err
@@ -997,7 +1004,7 @@ func Destroy(destroyAllMine bool, destroyAllLocal bool, clusterNames ...string) 
 		func(ctx context.Context, idx int) error {
 			name := clusterNames[idx]
 			if config.IsLocalClusterName(name) {
-				return destroyLocalCluster(name)
+				return destroyLocalCluster(ctx, name)
 			}
 			if cld == nil {
 				var err error
@@ -1023,7 +1030,7 @@ func destroyCluster(cld *cloud.Cloud, clusterName string) error {
 	return cloud.DestroyCluster(c)
 }
 
-func destroyLocalCluster(clusterName string) error {
+func destroyLocalCluster(ctx context.Context, clusterName string) error {
 	if _, ok := readSyncedClusters(clusterName); !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
@@ -1032,7 +1039,7 @@ func destroyLocalCluster(clusterName string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.Wipe(false); err != nil {
+	if err := c.Wipe(ctx, false); err != nil {
 		return err
 	}
 	return local.DeleteCluster(clusterName)
@@ -1063,6 +1070,7 @@ func cleanupFailedCreate(clusterName string) error {
 
 // Create TODO
 func Create(
+	ctx context.Context,
 	username string,
 	numNodes int,
 	createVMOpts vm.CreateOpts,
@@ -1131,7 +1139,7 @@ func Create(
 		// No need for ssh for local clusters.
 		return LoadClusters()
 	}
-	return SetupSSH(clusterName)
+	return SetupSSH(ctx, clusterName)
 }
 
 // GC garbage-collects expired clusters and unused SSH keypairs in AWS.


### PR DESCRIPTION
Previously, we didn’t need to pass context to roachprod because
the binary is just a single process, and from the roachtest
perspective roachprod is a single process so when context is cancelled,
the process would be killed (since it depends on CommandContext),
without needing to pass any context to roachprod.

Now we need to pass context to avoid leaking resources and
also avoid roachtest timeouts in cases where users depend on context
cancellation to cancel a remote command.

Release note: None