### PR TITLE
scplan: break out stage building into scstage package and invert rule directions

### DIFF
--- a/pkg/sql/schemachanger/scgraph/depedgekind_string.go
+++ b/pkg/sql/schemachanger/scgraph/depedgekind_string.go
@@ -8,13 +8,13 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[HappensAfter-1]
-	_ = x[SameStage-2]
+	_ = x[Precedence-1]
+	_ = x[SameStagePrecedence-2]
 }
 
-const _DepEdgeKind_name = "HappensAfterSameStage"
+const _DepEdgeKind_name = "PrecedenceSameStagePrecedence"
 
-var _DepEdgeKind_index = [...]uint8{0, 12, 21}
+var _DepEdgeKind_index = [...]uint8{0, 10, 29}
 
 func (i DepEdgeKind) String() string {
 	i -= 1

--- a/pkg/sql/schemachanger/scgraph/edge.go
+++ b/pkg/sql/schemachanger/scgraph/edge.go
@@ -76,15 +76,13 @@ type DepEdgeKind int
 const (
 	_ DepEdgeKind = iota
 
-	// HappensAfter indicates that the source (from) of the edge must not be
-	// entered until after the destination (to) has entered the state. It could
-	// be in the same stage, or it could be in a subsequent stage.
-	HappensAfter
+	// Precedence indicates that the source (from) of the edge must be
+	// reached before the destination (to), possibly doing so in the same stage.
+	Precedence
 
-	// SameStage indicates that the source (from) of the edge must
-	// not be entered until after the destination (to) has entered the state and
-	// that both nodes must enter the state in the same stage.
-	SameStage
+	// SameStagePrecedence indicates that the source (from) of the edge must
+	// be reached before the destination (to), and _must_ do so in the same stage.
+	SameStagePrecedence
 )
 
 // DepEdge represents a dependency between two nodes. A dependency

--- a/pkg/sql/schemachanger/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scgraph/graph.go
@@ -46,8 +46,8 @@ type Graph struct {
 	opEdgesFrom map[*scpb.Node]*OpEdge
 
 	// depEdgesFrom and depEdgesTo map a Node from and to its dependencies.
-	// A Node dependency is another target node which must be
-	// reached before or concurrently with this node.
+	// A Node dependency is another target node which cannot be reached before
+	// reaching this node.
 	depEdgesFrom, depEdgesTo *depEdgeTree
 
 	// opToNode maps from an operation back to the
@@ -295,14 +295,14 @@ func (g *Graph) GetNodeRanks() (nodeRanks map[*scpb.Node]int, err error) {
 	visit = func(n *scpb.Node) {
 		permanent, marked := marks[n]
 		if marked && !permanent {
-			panic(errors.AssertionFailedf("graph is not a dag"))
+			panic(errors.AssertionFailedf("graph is not acyclical"))
 		}
 		if marked && permanent {
 			return
 		}
 		marks[n] = false
-		_ = g.ForEachDepEdgeFrom(n, func(de *DepEdge) error {
-			visit(de.To())
+		_ = g.ForEachDepEdgeTo(n, func(de *DepEdge) error {
+			visit(de.From())
 			return nil
 		})
 		marks[n] = true

--- a/pkg/sql/schemachanger/scgraph/graph_test.go
+++ b/pkg/sql/schemachanger/scgraph/graph_test.go
@@ -48,7 +48,7 @@ func TestGraphRanks(t *testing.T) {
 				{0, 1},
 				{3, 0},
 			},
-			expectedOrder: []int{1, 0, 2, 3},
+			expectedOrder: []int{3, 0, 1, 2},
 		},
 
 		// We will set up the dependency graph, so that its intentionally cyclic,
@@ -62,7 +62,7 @@ func TestGraphRanks(t *testing.T) {
 				{1, 3},
 				{3, 1},
 			},
-			expectedRankErr: "graph is not a dag",
+			expectedRankErr: "graph is not acyclical",
 		},
 
 		// We will set up the dependency graph to have a swap, which won't affect
@@ -75,7 +75,7 @@ func TestGraphRanks(t *testing.T) {
 				{1, 0},
 				{2, 0},
 			},
-			expectedRankErr: "graph is not a dag",
+			expectedRankErr: "graph is not acyclical",
 		},
 	}
 
@@ -132,7 +132,7 @@ func TestGraphRanks(t *testing.T) {
 		for _, edge := range tc.depEdges {
 			require.NoError(t, graph.AddDepEdge(
 				fmt.Sprintf("%d to %d", edge.from, edge.to),
-				scgraph.HappensAfter,
+				scgraph.Precedence,
 				state.Nodes[edge.from].Target,
 				scpb.Status_PUBLIC,
 				state.Nodes[edge.to].Target,

--- a/pkg/sql/schemachanger/scgraph/iteration.go
+++ b/pkg/sql/schemachanger/scgraph/iteration.go
@@ -57,13 +57,14 @@ func (g *Graph) ForEachEdge(it EdgeIterator) error {
 // to return early with no error.
 type DepEdgeIterator func(de *DepEdge) error
 
-// ForEachDepEdgeFrom iterates the dep edges in the graph.
+// ForEachDepEdgeFrom iterates the dep edges in the graph with the selected
+// source.
 func (g *Graph) ForEachDepEdgeFrom(n *scpb.Node, it DepEdgeIterator) (err error) {
 	return g.depEdgesFrom.iterateSourceNode(n, it)
 }
 
-// ForEachSameStageDepEdgeTo iterates the dep edges in the graph of kind
-// SameStage which point to the provided node.
-func (g *Graph) ForEachSameStageDepEdgeTo(n *scpb.Node, it DepEdgeIterator) (err error) {
-	return g.sameStageDepEdgesTo.iterateSourceNode(n, it)
+// ForEachDepEdgeTo iterates the dep edges in the graph with the selected
+// destination.
+func (g *Graph) ForEachDepEdgeTo(n *scpb.Node, it DepEdgeIterator) (err error) {
+	return g.depEdgesTo.iterateSourceNode(n, it)
 }

--- a/pkg/sql/schemachanger/scgraphviz/BUILD.bazel
+++ b/pkg/sql/schemachanger/scgraphviz/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/schemachanger/scgraph",
+        "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/util/protoutil",

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -2,26 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "scplan",
-    srcs = [
-        "job_augmentation.go",
-        "plan.go",
-    ],
+    srcs = ["plan.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/jobs",
         "//pkg/jobs/jobspb",
-        "//pkg/security",
-        "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/scgraph",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/deprules",
         "//pkg/sql/schemachanger/scplan/opgen",
         "//pkg/sql/schemachanger/scplan/scopt",
-        "//pkg/sql/schemachanger/screl",
-        "//pkg/util/iterutil",
+        "//pkg/sql/schemachanger/scplan/scstage",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/deprules/testdata/rules
+++ b/pkg/sql/schemachanger/scplan/deprules/testdata/rules
@@ -1,8 +1,8 @@
 rules
 ----
 - name: parent dependencies
-  from: parent-node
-  to: other-node
+  from: other-node
+  to: parent-node
   query:
     - $parent[Type] IN ['*scpb.Database', '*scpb.Schema']
     - $other[Type] IN ['*scpb.Type', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.Schema']
@@ -20,8 +20,8 @@ rules
     - $other-target[Direction] = DROP
     - $other-node[Status] = ABSENT
 - name: column depends on indexes
-  from: column-node
-  to: index-node
+  from: index-node
+  to: column-node
   query:
     - $index-status IN [DELETE_AND_WRITE_ONLY, PUBLIC]
     - $direction = ADD
@@ -43,8 +43,8 @@ rules
     - $index-node[Type] = '*scpb.Node'
     - $index-node[Target] = $index-target
 - name: index depends on column
-  from: index-node
-  to: column-node
+  from: column-node
+  to: index-node
   query:
     - $column[Type] = '*scpb.Column'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
@@ -64,8 +64,8 @@ rules
     - $index-target[Direction] = ADD
     - $index-node[Status] = DELETE_ONLY
 - name: primary index add depends on drop
-  from: add-idx-node
-  to: drop-idx-node
+  from: drop-idx-node
+  to: add-idx-node
   query:
     - $add-idx[Type] = '*scpb.PrimaryIndex'
     - $drop-idx[Type] = '*scpb.PrimaryIndex'
@@ -85,8 +85,8 @@ rules
     - $drop-idx-target[Direction] = DROP
     - $drop-idx-node[Status] = DELETE_AND_WRITE_ONLY
 - name: partitioning information needs the basic index as created
-  from: partitioning-node
-  to: add-idx-node
+  from: add-idx-node
+  to: partitioning-node
   query:
     - $add-idx[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $partitioning[Type] = '*scpb.Partitioning'
@@ -107,8 +107,8 @@ rules
     - $partitioning-target[Direction] = ADD
     - $partitioning-node[Status] = PUBLIC
 - name: index needs partitioning information to be filled
-  from: partitioning-node
-  to: add-idx-node
+  from: add-idx-node
+  to: partitioning-node
   query:
     - $add-idx[Type] = '*scpb.PrimaryIndex'
     - $partitioning[Type] = '*scpb.Partitioning'
@@ -129,8 +129,8 @@ rules
     - $partitioning-target[Direction] = ADD
     - $partitioning-node[Status] = PUBLIC
 - name: dependency needs relation/type as non-synthetically dropped
-  from: dep-node
-  to: relation-node
+  from: relation-node
+  to: dep-node
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.Type']
     - $dep[Type] IN ['*scpb.DefaultExpression', '*scpb.RelationDependedOnBy', '*scpb.SequenceOwnedBy', '*scpb.ForeignKey']
@@ -149,8 +149,8 @@ rules
     - $dep-target[Direction] = DROP
     - $dep-node[Status] = ABSENT
 - name: dependency needs relation/type as non-synthetically dropped
-  from: dep-node
-  to: relation-node
+  from: relation-node
+  to: dep-node
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.Type']
     - $dep[Type] IN ['*scpb.ForeignKeyBackReference', '*scpb.RelationDependedOnBy', '*scpb.ViewDependsOnType', '*scpb.DefaultExprTypeReference', '*scpb.OnUpdateExprTypeReference', '*scpb.ComputedExprTypeReference', '*scpb.ColumnTypeReference', '*scpb.CheckConstraintTypeReference']
@@ -169,26 +169,6 @@ rules
     - $dep-target[Direction] = DROP
     - $dep-node[Status] = ABSENT
 - name: namespace needs descriptor to be dropped
-  from: namespace-node
-  to: dep-node
-  query:
-    - $namespace[Type] = '*scpb.Namespace'
-    - $dep[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.Database', '*scpb.Schema', '*scpb.Type']
-    - $dep[DescID] = $desc-id
-    - $namespace[DescID] = $desc-id
-    - $namespace-target[Type] = '*scpb.Target'
-    - $namespace-target[Element] = $namespace
-    - $namespace-node[Type] = '*scpb.Node'
-    - $namespace-node[Target] = $namespace-target
-    - $namespace-target[Direction] = DROP
-    - $namespace-node[Status] = ABSENT
-    - $dep-target[Type] = '*scpb.Target'
-    - $dep-target[Element] = $dep
-    - $dep-node[Type] = '*scpb.Node'
-    - $dep-node[Target] = $dep-target
-    - $dep-target[Direction] = DROP
-    - $dep-node[Status] = DROPPED
-- name: descriptor can only be cleaned up once the name is drained
   from: dep-node
   to: namespace-node
   query:
@@ -207,30 +187,28 @@ rules
     - $dep-node[Type] = '*scpb.Node'
     - $dep-node[Target] = $dep-target
     - $dep-target[Direction] = DROP
+    - $dep-node[Status] = DROPPED
+- name: descriptor can only be cleaned up once the name is drained
+  from: namespace-node
+  to: dep-node
+  query:
+    - $namespace[Type] = '*scpb.Namespace'
+    - $dep[Type] IN ['*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.Database', '*scpb.Schema', '*scpb.Type']
+    - $dep[DescID] = $desc-id
+    - $namespace[DescID] = $desc-id
+    - $namespace-target[Type] = '*scpb.Target'
+    - $namespace-target[Element] = $namespace
+    - $namespace-node[Type] = '*scpb.Node'
+    - $namespace-node[Target] = $namespace-target
+    - $namespace-target[Direction] = DROP
+    - $namespace-node[Status] = ABSENT
+    - $dep-target[Type] = '*scpb.Target'
+    - $dep-target[Element] = $dep
+    - $dep-node[Type] = '*scpb.Node'
+    - $dep-node[Target] = $dep-target
+    - $dep-target[Direction] = DROP
     - $dep-node[Status] = ABSENT
 - name: column name is assigned once the column is created
-  from: column-name-node
-  to: column-node
-  query:
-    - $column-name[Type] = '*scpb.ColumnName'
-    - $column[Type] = '*scpb.Column'
-    - $column[DescID] = $desc-id
-    - $column-name[DescID] = $desc-id
-    - $column[ColumnID] = $column-id
-    - $column-name[ColumnID] = $column-id
-    - $column-name-target[Type] = '*scpb.Target'
-    - $column-name-target[Element] = $column-name
-    - $column-name-node[Type] = '*scpb.Node'
-    - $column-name-node[Target] = $column-name-target
-    - $column-name-target[Direction] = ADD
-    - $column-name-node[Status] = PUBLIC
-    - $column-target[Type] = '*scpb.Target'
-    - $column-target[Element] = $column
-    - $column-node[Type] = '*scpb.Node'
-    - $column-node[Target] = $column-target
-    - $column-target[Direction] = ADD
-    - $column-node[Status] = DELETE_ONLY
-- name: column needs a name to be assigned
   from: column-node
   to: column-name-node
   query:
@@ -251,10 +229,32 @@ rules
     - $column-node[Type] = '*scpb.Node'
     - $column-node[Target] = $column-target
     - $column-target[Direction] = ADD
+    - $column-node[Status] = DELETE_ONLY
+- name: column needs a name to be assigned
+  from: column-name-node
+  to: column-node
+  query:
+    - $column-name[Type] = '*scpb.ColumnName'
+    - $column[Type] = '*scpb.Column'
+    - $column[DescID] = $desc-id
+    - $column-name[DescID] = $desc-id
+    - $column[ColumnID] = $column-id
+    - $column-name[ColumnID] = $column-id
+    - $column-name-target[Type] = '*scpb.Target'
+    - $column-name-target[Element] = $column-name
+    - $column-name-node[Type] = '*scpb.Node'
+    - $column-name-node[Target] = $column-name-target
+    - $column-name-target[Direction] = ADD
+    - $column-name-node[Status] = PUBLIC
+    - $column-target[Type] = '*scpb.Target'
+    - $column-target[Element] = $column
+    - $column-node[Type] = '*scpb.Node'
+    - $column-node[Target] = $column-target
+    - $column-target[Direction] = ADD
     - $column-node[Status] = DELETE_AND_WRITE_ONLY
 - name: index name is assigned once the index is created
-  from: index-name-node
-  to: index-node
+  from: index-node
+  to: index-name-node
   query:
     - $index-name[Type] = '*scpb.IndexName'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
@@ -275,8 +275,8 @@ rules
     - $index-target[Direction] = ADD
     - $index-node[Status] = DELETE_ONLY
 - name: index needs a name to be assigned
-  from: index-node
-  to: index-name-node
+  from: index-name-node
+  to: index-node
   query:
     - $index-name[Type] = '*scpb.IndexName'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
@@ -319,8 +319,8 @@ rules
     - $type-ref-add-target[Direction] = ADD
     - $type-ref-add-node[Status] = PUBLIC
 - name: table deps removal happens after table marked as dropped
-  from: dep-drop-node
-  to: table-drop-node
+  from: table-drop-node
+  to: dep-drop-node
   query:
     - $dep-drop[Type] IN ['*scpb.Owner', '*scpb.UserPrivileges']
     - $table-drop[Type] IN ['*scpb.Table', '*scpb.Sequence', '*scpb.View']
@@ -339,8 +339,8 @@ rules
     - $table-drop-target[Direction] = DROP
     - $table-drop-node[Status] = DROPPED
 - name: schema can be dropped after schema entry inside the database
-  from: schema-node
-  to: schema-entry-node
+  from: schema-entry-node
+  to: schema-node
   query:
     - $schema[Type] = '*scpb.Schema'
     - $schema-entry[Type] = '*scpb.DatabaseSchemaEntry'
@@ -359,8 +359,8 @@ rules
     - $schema-entry-target[Direction] = DROP
     - $schema-entry-node[Status] = ABSENT
 - name: schema entry can be dropped after the database has exited synth drop
-  from: schema-entry-node
-  to: database-node
+  from: database-node
+  to: schema-entry-node
   query:
     - $database[Type] = '*scpb.Database'
     - $schema-entry[Type] = '*scpb.DatabaseSchemaEntry'

--- a/pkg/sql/schemachanger/scplan/opgen/op_gen.go
+++ b/pkg/sql/schemachanger/scplan/opgen/op_gen.go
@@ -43,13 +43,14 @@ func (r *registry) buildGraph(initial scpb.State) (*scgraph.Graph, error) {
 	for _, t := range r.targets {
 		edgesToAdd = edgesToAdd[:0]
 		if err := t.iterateFunc(g.Database(), func(n *scpb.Node) error {
-			var in bool
+			status := n.Status
 			for _, op := range t.transitions {
-				if in = in || op.from == n.Status; in {
+				if op.from == status {
 					edgesToAdd = append(edgesToAdd, toAdd{
 						transition: op,
 						n:          n,
 					})
+					status = op.to
 				}
 			}
 			return nil

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -11,9 +11,6 @@
 package scplan
 
 import (
-	"fmt"
-	"sort"
-
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scgraph"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
@@ -21,8 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/deprules"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/opgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scopt"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scstage"
 	"github.com/cockroachdb/errors"
 )
 
@@ -43,12 +39,12 @@ type Plan struct {
 	Initial scpb.State
 	Graph   *scgraph.Graph
 	JobID   jobspb.JobID
-	stages  []Stage
+	stages  []scstage.Stage
 }
 
 // StagesForCurrentPhase returns the stages in the execution phase specified in
 // the plan params.
-func (p Plan) StagesForCurrentPhase() []Stage {
+func (p Plan) StagesForCurrentPhase() []scstage.Stage {
 	for i, s := range p.stages {
 		if s.Phase > p.Params.ExecutionPhase {
 			return p.stages[:i]
@@ -59,35 +55,8 @@ func (p Plan) StagesForCurrentPhase() []Stage {
 
 // StagesForAllPhases returns the stages in the execution phase specified in
 // the plan params and also all subsequent stages.
-func (p Plan) StagesForAllPhases() []Stage {
+func (p Plan) StagesForAllPhases() []scstage.Stage {
 	return p.stages
-}
-
-// A Stage is a sequence of ops to be executed "together" as part of a schema
-// change.
-//
-// stages also contain the state before and after the execution of the ops in
-// the stage, reflecting the fact that any set of ops can be thought of as a
-// transition from one state to another.
-type Stage struct {
-	Before, After          scpb.State
-	Ops                    scop.Ops
-	Revertible             bool
-	Phase                  scop.Phase
-	Ordinal, StagesInPhase int
-}
-
-func (s Stage) String() string {
-	revertible := ""
-	if !s.Revertible {
-		revertible = "non-revertible "
-	}
-	if s.Ops == nil {
-		return fmt.Sprintf("%s %sstage %d of %d with no ops",
-			s.Phase.String(), revertible, s.Ordinal, s.StagesInPhase)
-	}
-	return fmt.Sprintf("%s %sstage %d of %d with %d %s ops",
-		s.Phase.String(), revertible, s.Ordinal, s.StagesInPhase, len(s.Ops.Slice()), s.Ops.Type().String())
 }
 
 // MakePlan generates a Plan for a particular phase of a schema change, given
@@ -121,363 +90,14 @@ func MakePlan(initial scpb.State, params Params) (p Plan, err error) {
 	}
 	p.Graph = optimizedGraph
 
-	p.stages = buildStages(initial, params.ExecutionPhase, optimizedGraph)
-	if err = validateStages(p.stages); err != nil {
+	p.stages = scstage.BuildStages(initial, params.ExecutionPhase, optimizedGraph)
+	if err = scstage.ValidateStages(p.stages); err != nil {
 		return p, errors.WithAssertionFailure(errors.Wrapf(err, "invalid basic execution plan"))
 	}
-	p.stages = collapseStages(p.stages)
-	p.stages, p.JobID = augmentStagesForJob(p.Params, p.stages)
-	if err = validateStages(p.stages); err != nil {
+	p.stages = scstage.CollapseStages(p.stages)
+	p.stages, p.JobID = scstage.AugmentStagesForJob(p.stages, params.ExecutionPhase, params.JobIDGenerator)
+	if err = scstage.ValidateStages(p.stages); err != nil {
 		return p, errors.WithAssertionFailure(errors.Wrapf(err, "invalid improved execution plan"))
 	}
 	return p, nil
-}
-
-// validateStages checks that the plan is valid.
-func validateStages(stages []Stage) error {
-	if len(stages) == 0 {
-		return nil
-	}
-
-	// Check that the terminal node statuses are valid for their target direction.
-	initial := stages[0].Before.Nodes
-	final := stages[len(stages)-1].After.Nodes
-	if nInitial, nFinal := len(initial), len(final); nInitial != nFinal {
-		return errors.Errorf("initial state has %d nodes, final state has %d", nInitial, nFinal)
-	}
-	for i, initialNode := range initial {
-		finalNode := final[i]
-		initialTarget, finalTarget := initialNode.Target, finalNode.Target
-		if initialTarget != finalTarget {
-			return errors.Errorf("target mismatch between initial and final nodes at index %d: %s != %s",
-				i, initialTarget.String(), finalTarget.String())
-		}
-
-		e := initialTarget.Element()
-		switch initialTarget.Direction {
-		case scpb.Target_ADD:
-			if finalNode.Status != scpb.Status_PUBLIC {
-				return errors.Errorf("final status is %s instead of public at index %d for adding %T %s",
-					finalNode.Status, i, e, e)
-			}
-		case scpb.Target_DROP:
-			if finalNode.Status != scpb.Status_ABSENT {
-				return errors.Errorf("final status is %s instead of absent at index %d for dropping %T %s",
-					finalNode.Status, i, e, e)
-			}
-		}
-	}
-
-	// Check that phases are monotonically increasing.
-	currentPhase := scop.StatementPhase
-	for _, stage := range stages {
-		if stage.Phase < currentPhase {
-			return errors.Errorf("%s: preceded by %s stage",
-				stage.String(), currentPhase)
-		}
-	}
-
-	// Check that revertibility is monotonically decreasing.
-	revertibleAllowed := true
-	for _, stage := range stages {
-		if !stage.Revertible {
-			revertibleAllowed = false
-		}
-		if stage.Revertible && !revertibleAllowed {
-			return errors.Errorf("%s: preceded by non-revertible stage",
-				stage.String())
-		}
-	}
-	return nil
-}
-
-func buildStages(init scpb.State, phase scop.Phase, g *scgraph.Graph) []Stage {
-	// Fetch the order of the graph, which will be used to
-	// evaluating edges in topological order.
-	nodeRanks, err := g.GetNodeRanks()
-	if err != nil {
-		panic(err)
-	}
-	// TODO(ajwerner): deal with the case where the target status was
-	// fulfilled by something that preceded the initial state.
-	cur := init
-	fulfilled := map[*scpb.Node]struct{}{}
-	filterUnsatisfiedEdgesStep := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
-		candidates := make(map[*scpb.Node]*scgraph.OpEdge)
-		for _, e := range edges {
-			candidates[e.To()] = e
-		}
-		// Check to see if the current set of edges will have their dependencies met
-		// if they are all run. Any which will not must be pruned. This greedy
-		// algorithm works, but a justification is in order.
-		failed := map[*scgraph.OpEdge]struct{}{}
-		for _, e := range edges {
-			if !e.IsPhaseSatisfied(phase) {
-				failed[e] = struct{}{}
-			}
-		}
-		for _, e := range edges {
-			if err := g.ForEachDepEdgeFrom(e.To(), func(de *scgraph.DepEdge) error {
-				_, isFulfilled := fulfilled[de.To()]
-				_, isCandidate := candidates[de.To()]
-				if de.Kind() == scgraph.SameStage && isFulfilled {
-					// This is bad, we have a happens-after relationship, and it has
-					// already happened.
-					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
-						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
-				}
-				if isFulfilled || isCandidate {
-					return nil
-				}
-				failed[e] = struct{}{}
-				return iterutil.StopIteration()
-			}); err != nil {
-				panic(err)
-			}
-		}
-		// Ensure that all SameStage DepEdges are met appropriately.
-		for _, e := range edges {
-			if err := g.ForEachSameStageDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
-				if _, isFulfilled := fulfilled[de.From()]; isFulfilled {
-					// This is bad, we have a happens-after relationship, and it has
-					// already happened.
-					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
-						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
-				}
-				fromCandidate, fromIsCandidate := candidates[de.From()]
-				if !fromIsCandidate {
-					failed[e] = struct{}{}
-					return iterutil.StopIteration()
-				}
-				_, fromIsFailed := failed[fromCandidate]
-				if fromIsFailed {
-					failed[e] = struct{}{}
-					return iterutil.StopIteration()
-				}
-				if _, eIsFailed := failed[e]; eIsFailed {
-					failed[fromCandidate] = struct{}{}
-				}
-				return nil
-			}); err != nil {
-				panic(err)
-			}
-		}
-		if len(failed) == 0 {
-			return edges, true
-		}
-		truncated := edges[:0]
-		for _, e := range edges {
-			if _, found := failed[e]; !found {
-				truncated = append(truncated, e)
-			}
-		}
-		return truncated, false
-	}
-	filterUnsatisfiedEdges := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
-		for len(edges) > 0 {
-			if filtered, done := filterUnsatisfiedEdgesStep(edges); !done {
-				edges = filtered
-			} else {
-				return filtered, true
-			}
-		}
-		return edges, false
-	}
-	isRevertiblePreferred := true
-	buildStageType := func(edges []*scgraph.OpEdge) (Stage, bool) {
-		edges, ok := filterUnsatisfiedEdges(edges)
-		if !ok {
-			return Stage{}, false
-		}
-		sort.SliceStable(edges,
-			func(i, j int) bool {
-				// Higher ranked edges should go first.
-				return nodeRanks[edges[i].To()] > nodeRanks[edges[j].To()]
-			})
-
-		next := shallowCopy(cur)
-		var ops []scop.Op
-		var isStageRevertible bool
-		for _, isStageRevertible = range []bool{true, false} {
-			if isStageRevertible && !isRevertiblePreferred {
-				continue
-			}
-			hasTransitions := false
-			for _, e := range edges {
-				for i, ts := range cur.Nodes {
-					if e.From() == ts && (!isStageRevertible || e.Revertible()) {
-						next.Nodes[i] = e.To()
-						hasTransitions = true
-						// If this edge has been marked as a no-op, then a state transition
-						// can happen without executing anything.
-						if !g.IsOpEdgeOptimizedOut(e) {
-							ops = append(ops, e.Op()...)
-						}
-						break
-					}
-				}
-			}
-			if hasTransitions {
-				break
-			}
-		}
-		if isRevertiblePreferred && !isStageRevertible {
-			isRevertiblePreferred = false
-		}
-		return Stage{
-			Before:     cur,
-			After:      next,
-			Ops:        scop.MakeOps(ops...),
-			Revertible: isStageRevertible,
-			Phase:      phase,
-		}, true
-	}
-
-	// Build stages for this phase and all subsequent phases.
-	var stages []Stage
-	for ; phase <= scop.PostCommitPhase; phase++ {
-		for {
-			// Note that the current nodes are fulfilled for the sake of dependency
-			// checking.
-			for _, ts := range cur.Nodes {
-				fulfilled[ts] = struct{}{}
-			}
-
-			// Extract the set of op edges for the current stage.
-			var opEdges []*scgraph.OpEdge
-			for _, t := range cur.Nodes {
-				// TODO(ajwerner): improve the efficiency of this lookup.
-				// Look for an opEdge from this node. Then, for the other side
-				// of the opEdge, look for dependencies.
-				if oe, ok := g.GetOpEdgeFrom(t); ok {
-					opEdges = append(opEdges, oe)
-				}
-			}
-
-			// Group the op edges a per-type basis.
-			opTypes := make(map[scop.Type][]*scgraph.OpEdge)
-			for _, oe := range opEdges {
-				opTypes[oe.Type()] = append(opTypes[oe.Type()], oe)
-			}
-
-			// Greedily attempt to find a stage which can be executed. This is sane
-			// because once a dependency is met, it never becomes unmet.
-			var didSomething bool
-			var s Stage
-			for _, typ := range []scop.Type{
-				scop.MutationType,
-				scop.BackfillType,
-				scop.ValidationType,
-			} {
-				if s, didSomething = buildStageType(opTypes[typ]); didSomething {
-					break
-				}
-			}
-			if !didSomething {
-				break
-			}
-			stages = append(stages, s)
-			cur = s.After
-		}
-	}
-
-	return decorateStages(stages)
-}
-
-// collapseStages collapses stages with no ops together whenever possible.
-func collapseStages(stages []Stage) (collapsedStages []Stage) {
-	if len(stages) <= 1 {
-		return stages
-	}
-
-	accumulator := stages[0]
-	for _, s := range stages[1:] {
-		if isCollapsible(accumulator, s) {
-			accumulator.After = s.After
-			accumulator.Revertible = s.Revertible
-			if s.Ops != nil {
-				accumulator.Ops = s.Ops
-			} else if accumulator.Ops == nil {
-				panic("missing ops")
-			}
-		} else {
-			collapsedStages = append(collapsedStages, accumulator)
-			accumulator = s
-		}
-	}
-	collapsedStages = append(collapsedStages, accumulator)
-	return decorateStages(collapsedStages)
-}
-
-// decorateStages decorates stages with position in plan.
-func decorateStages(stages []Stage) []Stage {
-	if len(stages) == 0 {
-		return nil
-	}
-	phaseMap := map[scop.Phase][]int{}
-	for i, s := range stages {
-		phaseMap[s.Phase] = append(phaseMap[s.Phase], i)
-	}
-	for _, indexes := range phaseMap {
-		for i, j := range indexes {
-			s := &stages[j]
-			s.Ordinal = i + 1
-			s.StagesInPhase = len(indexes)
-		}
-	}
-	return stages
-}
-
-// isCollapsible returns true iff s can be collapsed into acc. The collapsed
-// state will have:
-//   - the Before state from acc,
-//   - the After state from s,
-//   - the Revertible flag from s.
-//
-// The collapse rules are:
-// 1. Both states must be in the same phase.
-// 2. If acc doesn't have ops and s does, we can collapse acc and s together.
-//    This means we lose the ability to revert the acc state, but since it
-//    doesn't have any ops this effectively doesn't matter.
-// 3. If s doesn't have ops, then it can be collapsed into acc. However,
-//    unlike the previous case, assuming acc is revertible, we don't want to
-//    lose that property when s isn't revertible.
-func isCollapsible(acc Stage, s Stage) bool {
-	if acc.Phase != s.Phase {
-		return false
-	}
-	// At this point acc and s are in the same phase, we can consider collapsing.
-	if acc.Ops == nil {
-		return true
-	}
-	if s.Ops != nil {
-		return false
-	}
-	// At this point, acc has ops, s has none, and they are in the same phase.
-	// From now on, collapsibility will be determined by revertibility.
-	if !acc.Revertible {
-		// If acc is not revertible, then nothing after can be anyway.
-		return true
-	}
-	// If acc is revertible, only collapse no-op stage s into it if it's also
-	// revertible, otherwise acc will be made non-revertible. We don't want that
-	// because it has ops and s doesn't.
-	return s.Revertible
-}
-
-// shallowCopy creates a shallow copy of the passed state. Importantly, it
-// retains copies to the same underlying nodes while allocating new backing
-// slices.
-func shallowCopy(cur scpb.State) scpb.State {
-	return scpb.State{
-		Nodes: append(
-			make([]*scpb.Node, 0, len(cur.Nodes)),
-			cur.Nodes...,
-		),
-		Statements: append(
-			make([]*scpb.Statement, 0, len(cur.Statements)),
-			cur.Statements...,
-		),
-		Authorization: cur.Authorization,
-	}
 }

--- a/pkg/sql/schemachanger/scplan/scstage/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/scstage/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "scstage",
+    srcs = [
+        "build.go",
+        "collapse.go",
+        "job_augmentation.go",
+        "stage.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scstage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs",
+        "//pkg/jobs/jobspb",
+        "//pkg/security",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/schemachanger/scgraph",
+        "//pkg/sql/schemachanger/scop",
+        "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/schemachanger/screl",
+        "//pkg/util/iterutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/sql/schemachanger/scplan/scstage/build.go
+++ b/pkg/sql/schemachanger/scplan/scstage/build.go
@@ -167,7 +167,10 @@ func (b buildCtx) collectFailedEdges(
 	}
 	// Ensure that all SameStage DepEdges are met appropriately.
 	for _, e := range edges {
-		if err := b.g.ForEachSameStageDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
+		if err := b.g.ForEachDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
+			if de.Kind() != scgraph.SameStage {
+				return nil
+			}
 			if _, isFulfilled := b.fulfilled[de.From()]; isFulfilled {
 				// This is bad, we have a happens-after relationship, and it has
 				// already happened.

--- a/pkg/sql/schemachanger/scplan/scstage/build.go
+++ b/pkg/sql/schemachanger/scplan/scstage/build.go
@@ -1,0 +1,233 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scstage
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scgraph"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/errors"
+)
+
+// BuildStages builds the plan's stages.
+func BuildStages(init scpb.State, phase scop.Phase, g *scgraph.Graph) []Stage {
+	// Fetch the order of the graph, which will be used to
+	// evaluating edges in topological order.
+	nodeRanks, err := g.GetNodeRanks()
+	if err != nil {
+		panic(err)
+	}
+	// TODO(ajwerner): deal with the case where the target status was
+	// fulfilled by something that preceded the initial state.
+	cur := init
+	fulfilled := map[*scpb.Node]struct{}{}
+	filterUnsatisfiedEdgesStep := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
+		candidates := make(map[*scpb.Node]*scgraph.OpEdge)
+		for _, e := range edges {
+			candidates[e.To()] = e
+		}
+		// Check to see if the current set of edges will have their dependencies met
+		// if they are all run. Any which will not must be pruned. This greedy
+		// algorithm works, but a justification is in order.
+		failed := map[*scgraph.OpEdge]struct{}{}
+		for _, e := range edges {
+			if !e.IsPhaseSatisfied(phase) {
+				failed[e] = struct{}{}
+			}
+		}
+		for _, e := range edges {
+			if err := g.ForEachDepEdgeFrom(e.To(), func(de *scgraph.DepEdge) error {
+				_, isFulfilled := fulfilled[de.To()]
+				_, isCandidate := candidates[de.To()]
+				if de.Kind() == scgraph.SameStage && isFulfilled {
+					// This is bad, we have a happens-after relationship, and it has
+					// already happened.
+					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
+						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
+				}
+				if isFulfilled || isCandidate {
+					return nil
+				}
+				failed[e] = struct{}{}
+				return iterutil.StopIteration()
+			}); err != nil {
+				panic(err)
+			}
+		}
+		// Ensure that all SameStage DepEdges are met appropriately.
+		for _, e := range edges {
+			if err := g.ForEachSameStageDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
+				if _, isFulfilled := fulfilled[de.From()]; isFulfilled {
+					// This is bad, we have a happens-after relationship, and it has
+					// already happened.
+					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
+						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
+				}
+				fromCandidate, fromIsCandidate := candidates[de.From()]
+				if !fromIsCandidate {
+					failed[e] = struct{}{}
+					return iterutil.StopIteration()
+				}
+				_, fromIsFailed := failed[fromCandidate]
+				if fromIsFailed {
+					failed[e] = struct{}{}
+					return iterutil.StopIteration()
+				}
+				if _, eIsFailed := failed[e]; eIsFailed {
+					failed[fromCandidate] = struct{}{}
+				}
+				return nil
+			}); err != nil {
+				panic(err)
+			}
+		}
+		if len(failed) == 0 {
+			return edges, true
+		}
+		truncated := edges[:0]
+		for _, e := range edges {
+			if _, found := failed[e]; !found {
+				truncated = append(truncated, e)
+			}
+		}
+		return truncated, false
+	}
+	filterUnsatisfiedEdges := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
+		for len(edges) > 0 {
+			if filtered, done := filterUnsatisfiedEdgesStep(edges); !done {
+				edges = filtered
+			} else {
+				return filtered, true
+			}
+		}
+		return edges, false
+	}
+	isRevertiblePreferred := true
+	buildStageType := func(edges []*scgraph.OpEdge) (Stage, bool) {
+		edges, ok := filterUnsatisfiedEdges(edges)
+		if !ok {
+			return Stage{}, false
+		}
+		sort.SliceStable(edges,
+			func(i, j int) bool {
+				// Higher ranked edges should go first.
+				return nodeRanks[edges[i].To()] > nodeRanks[edges[j].To()]
+			})
+
+		next := shallowCopy(cur)
+		var ops []scop.Op
+		var isStageRevertible bool
+		for _, isStageRevertible = range []bool{true, false} {
+			if isStageRevertible && !isRevertiblePreferred {
+				continue
+			}
+			hasTransitions := false
+			for _, e := range edges {
+				for i, ts := range cur.Nodes {
+					if e.From() == ts && (!isStageRevertible || e.Revertible()) {
+						next.Nodes[i] = e.To()
+						hasTransitions = true
+						// If this edge has been marked as a no-op, then a state transition
+						// can happen without executing anything.
+						if !g.IsOpEdgeOptimizedOut(e) {
+							ops = append(ops, e.Op()...)
+						}
+						break
+					}
+				}
+			}
+			if hasTransitions {
+				break
+			}
+		}
+		if isRevertiblePreferred && !isStageRevertible {
+			isRevertiblePreferred = false
+		}
+		return Stage{
+			Before:     cur,
+			After:      next,
+			Ops:        scop.MakeOps(ops...),
+			Revertible: isStageRevertible,
+			Phase:      phase,
+		}, true
+	}
+
+	// Build stages for this phase and all subsequent phases.
+	var stages []Stage
+	for ; phase <= scop.PostCommitPhase; phase++ {
+		for {
+			// Note that the current nodes are fulfilled for the sake of dependency
+			// checking.
+			for _, ts := range cur.Nodes {
+				fulfilled[ts] = struct{}{}
+			}
+
+			// Extract the set of op edges for the current stage.
+			var opEdges []*scgraph.OpEdge
+			for _, t := range cur.Nodes {
+				// TODO(ajwerner): improve the efficiency of this lookup.
+				// Look for an opEdge from this node. Then, for the other side
+				// of the opEdge, look for dependencies.
+				if oe, ok := g.GetOpEdgeFrom(t); ok {
+					opEdges = append(opEdges, oe)
+				}
+			}
+
+			// Group the op edges a per-type basis.
+			opTypes := make(map[scop.Type][]*scgraph.OpEdge)
+			for _, oe := range opEdges {
+				opTypes[oe.Type()] = append(opTypes[oe.Type()], oe)
+			}
+
+			// Greedily attempt to find a stage which can be executed. This is sane
+			// because once a dependency is met, it never becomes unmet.
+			var didSomething bool
+			var s Stage
+			for _, typ := range []scop.Type{
+				scop.MutationType,
+				scop.BackfillType,
+				scop.ValidationType,
+			} {
+				if s, didSomething = buildStageType(opTypes[typ]); didSomething {
+					break
+				}
+			}
+			if !didSomething {
+				break
+			}
+			stages = append(stages, s)
+			cur = s.After
+		}
+	}
+
+	return decorateStages(stages)
+}
+
+// shallowCopy creates a shallow copy of the passed state. Importantly, it
+// retains copies to the same underlying nodes while allocating new backing
+// slices.
+func shallowCopy(cur scpb.State) scpb.State {
+	return scpb.State{
+		Nodes: append(
+			make([]*scpb.Node, 0, len(cur.Nodes)),
+			cur.Nodes...,
+		),
+		Statements: append(
+			make([]*scpb.Statement, 0, len(cur.Statements)),
+			cur.Statements...,
+		),
+		Authorization: cur.Authorization,
+	}
+}

--- a/pkg/sql/schemachanger/scplan/scstage/build.go
+++ b/pkg/sql/schemachanger/scplan/scstage/build.go
@@ -22,197 +22,217 @@ import (
 )
 
 // BuildStages builds the plan's stages.
-func BuildStages(init scpb.State, phase scop.Phase, g *scgraph.Graph) []Stage {
-	// Fetch the order of the graph, which will be used to
-	// evaluating edges in topological order.
-	nodeRanks, err := g.GetNodeRanks()
-	if err != nil {
-		panic(err)
-	}
-	// TODO(ajwerner): deal with the case where the target status was
-	// fulfilled by something that preceded the initial state.
-	cur := init
-	fulfilled := map[*scpb.Node]struct{}{}
-	filterUnsatisfiedEdgesStep := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
-		candidates := make(map[*scpb.Node]*scgraph.OpEdge)
-		for _, e := range edges {
-			candidates[e.To()] = e
-		}
-		// Check to see if the current set of edges will have their dependencies met
-		// if they are all run. Any which will not must be pruned. This greedy
-		// algorithm works, but a justification is in order.
-		failed := map[*scgraph.OpEdge]struct{}{}
-		for _, e := range edges {
-			if !e.IsPhaseSatisfied(phase) {
-				failed[e] = struct{}{}
-			}
-		}
-		for _, e := range edges {
-			if err := g.ForEachDepEdgeFrom(e.To(), func(de *scgraph.DepEdge) error {
-				_, isFulfilled := fulfilled[de.To()]
-				_, isCandidate := candidates[de.To()]
-				if de.Kind() == scgraph.SameStage && isFulfilled {
-					// This is bad, we have a happens-after relationship, and it has
-					// already happened.
-					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
-						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
-				}
-				if isFulfilled || isCandidate {
-					return nil
-				}
-				failed[e] = struct{}{}
-				return iterutil.StopIteration()
-			}); err != nil {
-				panic(err)
-			}
-		}
-		// Ensure that all SameStage DepEdges are met appropriately.
-		for _, e := range edges {
-			if err := g.ForEachSameStageDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
-				if _, isFulfilled := fulfilled[de.From()]; isFulfilled {
-					// This is bad, we have a happens-after relationship, and it has
-					// already happened.
-					return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
-						screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
-				}
-				fromCandidate, fromIsCandidate := candidates[de.From()]
-				if !fromIsCandidate {
-					failed[e] = struct{}{}
-					return iterutil.StopIteration()
-				}
-				_, fromIsFailed := failed[fromCandidate]
-				if fromIsFailed {
-					failed[e] = struct{}{}
-					return iterutil.StopIteration()
-				}
-				if _, eIsFailed := failed[e]; eIsFailed {
-					failed[fromCandidate] = struct{}{}
-				}
-				return nil
-			}); err != nil {
-				panic(err)
-			}
-		}
-		if len(failed) == 0 {
-			return edges, true
-		}
-		truncated := edges[:0]
-		for _, e := range edges {
-			if _, found := failed[e]; !found {
-				truncated = append(truncated, e)
-			}
-		}
-		return truncated, false
-	}
-	filterUnsatisfiedEdges := func(edges []*scgraph.OpEdge) ([]*scgraph.OpEdge, bool) {
-		for len(edges) > 0 {
-			if filtered, done := filterUnsatisfiedEdgesStep(edges); !done {
-				edges = filtered
-			} else {
-				return filtered, true
-			}
-		}
-		return edges, false
-	}
-	isRevertiblePreferred := true
-	buildStageType := func(edges []*scgraph.OpEdge) (Stage, bool) {
-		edges, ok := filterUnsatisfiedEdges(edges)
-		if !ok {
-			return Stage{}, false
-		}
-		sort.SliceStable(edges,
-			func(i, j int) bool {
-				// Higher ranked edges should go first.
-				return nodeRanks[edges[i].To()] > nodeRanks[edges[j].To()]
-			})
-
-		next := shallowCopy(cur)
-		var ops []scop.Op
-		var isStageRevertible bool
-		for _, isStageRevertible = range []bool{true, false} {
-			if isStageRevertible && !isRevertiblePreferred {
-				continue
-			}
-			hasTransitions := false
-			for _, e := range edges {
-				for i, ts := range cur.Nodes {
-					if e.From() == ts && (!isStageRevertible || e.Revertible()) {
-						next.Nodes[i] = e.To()
-						hasTransitions = true
-						// If this edge has been marked as a no-op, then a state transition
-						// can happen without executing anything.
-						if !g.IsOpEdgeOptimizedOut(e) {
-							ops = append(ops, e.Op()...)
-						}
-						break
-					}
-				}
-			}
-			if hasTransitions {
-				break
-			}
-		}
-		if isRevertiblePreferred && !isStageRevertible {
-			isRevertiblePreferred = false
-		}
-		return Stage{
-			Before:     cur,
-			After:      next,
-			Ops:        scop.MakeOps(ops...),
-			Revertible: isStageRevertible,
-			Phase:      phase,
-		}, true
-	}
-
+func BuildStages(init scpb.State, phase scop.Phase, g *scgraph.Graph) (stages []Stage) {
+	b := makeBuildContext(init, phase, g)
 	// Build stages for this phase and all subsequent phases.
-	var stages []Stage
-	for ; phase <= scop.PostCommitPhase; phase++ {
-		for {
-			// Note that the current nodes are fulfilled for the sake of dependency
-			// checking.
-			for _, ts := range cur.Nodes {
-				fulfilled[ts] = struct{}{}
-			}
+	for b.phase <= scop.PostCommitPhase {
+		// Note that the current nodes are fulfilled for the sake of dependency
+		// checking.
+		for _, ts := range b.state.Nodes {
+			b.fulfilled[ts] = struct{}{}
+		}
 
-			// Extract the set of op edges for the current stage.
-			var opEdges []*scgraph.OpEdge
-			for _, t := range cur.Nodes {
-				// TODO(ajwerner): improve the efficiency of this lookup.
-				// Look for an opEdge from this node. Then, for the other side
-				// of the opEdge, look for dependencies.
-				if oe, ok := g.GetOpEdgeFrom(t); ok {
-					opEdges = append(opEdges, oe)
-				}
+		// Extract the set of op edges for the current stage.
+		var opEdges []*scgraph.OpEdge
+		for _, t := range b.state.Nodes {
+			// TODO(ajwerner): improve the efficiency of this lookup.
+			// Look for an opEdge from this node. Then, for the other side
+			// of the opEdge, look for dependencies.
+			if oe, ok := b.g.GetOpEdgeFrom(t); ok {
+				opEdges = append(opEdges, oe)
 			}
+		}
 
-			// Group the op edges a per-type basis.
-			opTypes := make(map[scop.Type][]*scgraph.OpEdge)
-			for _, oe := range opEdges {
-				opTypes[oe.Type()] = append(opTypes[oe.Type()], oe)
-			}
-
-			// Greedily attempt to find a stage which can be executed. This is sane
-			// because once a dependency is met, it never becomes unmet.
-			var didSomething bool
-			var s Stage
-			for _, typ := range []scop.Type{
-				scop.MutationType,
-				scop.BackfillType,
-				scop.ValidationType,
-			} {
-				if s, didSomething = buildStageType(opTypes[typ]); didSomething {
-					break
-				}
-			}
-			if !didSomething {
-				break
-			}
-			stages = append(stages, s)
-			cur = s.After
+		if s := b.tryBuildStage(opEdges); s != nil {
+			stages = append(stages, *s)
+			b.state = s.After
+			b.isRevertiblePreferred = b.isRevertiblePreferred && s.Revertible
+		} else {
+			// No further progress is possible in this phase, move on to the next one.
+			b.phase++
 		}
 	}
 
 	return decorateStages(stages)
+}
+
+// buildCtx contains the necessary context for building a stage.
+// When building a stage, this struct is read-only.
+type buildCtx struct {
+	g                     *scgraph.Graph
+	nodeRanks             map[*scpb.Node]int
+	state                 scpb.State
+	phase                 scop.Phase
+	isRevertiblePreferred bool
+	fulfilled             map[*scpb.Node]struct{}
+}
+
+// makeBuildContext is the constructor for buildCtx.
+func makeBuildContext(init scpb.State, phase scop.Phase, g *scgraph.Graph) buildCtx {
+	// Fetch the ranks of the nodes, which will be used to evaluate edges
+	// in topological order.
+	nodeRanks, err := g.GetNodeRanks()
+	if err != nil {
+		panic(err)
+	}
+	return buildCtx{
+		g:                     g,
+		phase:                 phase,
+		isRevertiblePreferred: true,
+		nodeRanks:             nodeRanks,
+		// TODO(ajwerner): deal with the case where the target status was
+		// fulfilled by something that preceded the initial state.
+		state:     init,
+		fulfilled: make(map[*scpb.Node]struct{}, len(nodeRanks)),
+	}
+}
+
+// tryBuildStage tries to build a stage using the provided op-edges.
+// This is done on a best-effort basis, if not possible nil is returned.
+func (b buildCtx) tryBuildStage(edges []*scgraph.OpEdge) *Stage {
+	// Group the op edges a per-type basis.
+	opTypes := make(map[scop.Type][]*scgraph.OpEdge)
+	for _, oe := range edges {
+		opTypes[oe.Type()] = append(opTypes[oe.Type()], oe)
+	}
+
+	// Greedily attempt to find a stage which can be executed. This is sane
+	// because once a dependency is met, it never becomes unmet.
+	for _, typ := range []scop.Type{
+		scop.MutationType,
+		scop.BackfillType,
+		scop.ValidationType,
+	} {
+		if filteredEdges := b.filterUnsatisfiedEdges(opTypes[typ]); len(filteredEdges) > 0 {
+			s := b.makeStage(filteredEdges)
+			return &s
+		}
+	}
+	return nil
+}
+
+func (b buildCtx) filterUnsatisfiedEdges(edges []*scgraph.OpEdge) []*scgraph.OpEdge {
+	for len(edges) > 0 {
+		failed := b.collectFailedEdges(edges)
+		if len(failed) == 0 {
+			return edges
+		}
+
+		// Remove all failed edges from the edges slice.
+		filtered := edges[:0]
+		for _, e := range edges {
+			if _, found := failed[e]; !found {
+				filtered = append(filtered, e)
+			}
+		}
+		edges = filtered
+	}
+	return nil
+}
+
+func (b buildCtx) collectFailedEdges(
+	edges []*scgraph.OpEdge,
+) (failed map[*scgraph.OpEdge]struct{}) {
+	candidates := make(map[*scpb.Node]*scgraph.OpEdge)
+	for _, e := range edges {
+		candidates[e.To()] = e
+	}
+	// Check to see if the current set of edges will have their dependencies met
+	// if they are all run. Any which will not must be pruned. This greedy
+	// algorithm works, but a justification is in order.
+	failed = make(map[*scgraph.OpEdge]struct{}, len(edges))
+	for _, e := range edges {
+		if !e.IsPhaseSatisfied(b.phase) {
+			failed[e] = struct{}{}
+		}
+	}
+	for _, e := range edges {
+		if err := b.g.ForEachDepEdgeFrom(e.To(), func(de *scgraph.DepEdge) error {
+			_, isFulfilled := b.fulfilled[de.To()]
+			_, isCandidate := candidates[de.To()]
+			if de.Kind() == scgraph.SameStage && isFulfilled {
+				// This is bad, we have a happens-after relationship, and it has
+				// already happened.
+				return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
+					screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
+			}
+			if isFulfilled || isCandidate {
+				return nil
+			}
+			failed[e] = struct{}{}
+			return iterutil.StopIteration()
+		}); err != nil {
+			panic(err)
+		}
+	}
+	// Ensure that all SameStage DepEdges are met appropriately.
+	for _, e := range edges {
+		if err := b.g.ForEachSameStageDepEdgeTo(e.To(), func(de *scgraph.DepEdge) error {
+			if _, isFulfilled := b.fulfilled[de.From()]; isFulfilled {
+				// This is bad, we have a happens-after relationship, and it has
+				// already happened.
+				return errors.AssertionFailedf("failed to satisfy %v->%v (%s) dependency",
+					screl.NodeString(de.From()), screl.NodeString(de.To()), de.Name())
+			}
+			fromCandidate, fromIsCandidate := candidates[de.From()]
+			if !fromIsCandidate {
+				failed[e] = struct{}{}
+				return iterutil.StopIteration()
+			}
+			_, fromIsFailed := failed[fromCandidate]
+			if fromIsFailed {
+				failed[e] = struct{}{}
+				return iterutil.StopIteration()
+			}
+			if _, eIsFailed := failed[e]; eIsFailed {
+				failed[fromCandidate] = struct{}{}
+			}
+			return nil
+		}); err != nil {
+			panic(err)
+		}
+	}
+	return failed
+}
+
+func (b buildCtx) makeStage(filteredEdges []*scgraph.OpEdge) Stage {
+	sort.SliceStable(filteredEdges,
+		func(i, j int) bool {
+			// Higher ranked edges should go first.
+			return b.nodeRanks[filteredEdges[i].To()] > b.nodeRanks[filteredEdges[j].To()]
+		})
+
+	s := Stage{
+		Before: b.state,
+		After:  shallowCopy(b.state),
+		Phase:  b.phase,
+	}
+	var ops []scop.Op
+	for _, s.Revertible = range []bool{true, false} {
+		if s.Revertible && !b.isRevertiblePreferred {
+			continue
+		}
+		hasTransitions := false
+		for _, e := range filteredEdges {
+			for i, ts := range b.state.Nodes {
+				if e.From() == ts && (!s.Revertible || e.Revertible()) {
+					s.After.Nodes[i] = e.To()
+					hasTransitions = true
+					// If this edge has been marked as a no-op, then a state transition
+					// can happen without executing anything.
+					if !b.g.IsOpEdgeOptimizedOut(e) {
+						ops = append(ops, e.Op()...)
+					}
+					break
+				}
+			}
+		}
+		if hasTransitions {
+			break
+		}
+	}
+	s.Ops = scop.MakeOps(ops...)
+	return s
 }
 
 // shallowCopy creates a shallow copy of the passed state. Importantly, it

--- a/pkg/sql/schemachanger/scplan/scstage/collapse.go
+++ b/pkg/sql/schemachanger/scplan/scstage/collapse.go
@@ -1,0 +1,73 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scstage
+
+// CollapseStages collapses stages with no ops together whenever possible.
+func CollapseStages(stages []Stage) (collapsedStages []Stage) {
+	if len(stages) <= 1 {
+		return stages
+	}
+
+	accumulator := stages[0]
+	for _, s := range stages[1:] {
+		if isCollapsible(accumulator, s) {
+			accumulator.After = s.After
+			accumulator.Revertible = s.Revertible
+			if s.Ops != nil {
+				accumulator.Ops = s.Ops
+			} else if accumulator.Ops == nil {
+				panic("missing ops")
+			}
+		} else {
+			collapsedStages = append(collapsedStages, accumulator)
+			accumulator = s
+		}
+	}
+	collapsedStages = append(collapsedStages, accumulator)
+	return decorateStages(collapsedStages)
+}
+
+// isCollapsible returns true iff s can be collapsed into acc. The collapsed
+// state will have:
+//   - the Before state from acc,
+//   - the After state from s,
+//   - the Revertible flag from s.
+//
+// The collapse rules are:
+// 1. Both states must be in the same phase.
+// 2. If acc doesn't have ops and s does, we can collapse acc and s together.
+//    This means we lose the ability to revert the acc state, but since it
+//    doesn't have any ops this effectively doesn't matter.
+// 3. If s doesn't have ops, then it can be collapsed into acc. However,
+//    unlike the previous case, assuming acc is revertible, we don't want to
+//    lose that property when s isn't revertible.
+func isCollapsible(acc Stage, s Stage) bool {
+	if acc.Phase != s.Phase {
+		return false
+	}
+	// At this point acc and s are in the same phase, we can consider collapsing.
+	if acc.Ops == nil {
+		return true
+	}
+	if s.Ops != nil {
+		return false
+	}
+	// At this point, acc has ops, s has none, and they are in the same phase.
+	// From now on, collapsibility will be determined by revertibility.
+	if !acc.Revertible {
+		// If acc is not revertible, then nothing after can be anyway.
+		return true
+	}
+	// If acc is revertible, only collapse no-op stage s into it if it's also
+	// revertible, otherwise acc will be made non-revertible. We don't want that
+	// because it has ops and s doesn't.
+	return s.Revertible
+}

--- a/pkg/sql/schemachanger/scplan/scstage/job_augmentation.go
+++ b/pkg/sql/schemachanger/scplan/scstage/job_augmentation.go
@@ -174,7 +174,7 @@ func createSchemaChangeJobAndAddDescriptorJobReferenceOps(
 		RunningStatus: "",
 		NonCancelable: !revertible,
 	}
-	opsToAdd = append(opsToAdd, scop.CreateDeclarativeSchemaChangerJob{
+	opsToAdd = append(opsToAdd, &scop.CreateDeclarativeSchemaChangerJob{
 		Record: record,
 	})
 	opsToAdd = append(opsToAdd, generateOpsToAddJobIDs(descIDs, jobID)...)
@@ -189,7 +189,7 @@ func statementStrings(statements []*scpb.Statement) (strs []string) {
 }
 
 func generateUpdateJobProgressOp(id jobspb.JobID, after scpb.State) scop.Op {
-	return scop.UpdateSchemaChangeJobProgress{
+	return &scop.UpdateSchemaChangeJobProgress{
 		JobID:    id,
 		Statuses: after.Statuses(),
 	}
@@ -197,13 +197,13 @@ func generateUpdateJobProgressOp(id jobspb.JobID, after scpb.State) scop.Op {
 
 func generateOpsToRemoveJobIDs(descIDs []descpb.ID, jobID jobspb.JobID) []scop.Op {
 	return generateOpsForJobIDs(descIDs, jobID, func(descID descpb.ID, id jobspb.JobID) scop.Op {
-		return scop.RemoveJobReference{DescriptorID: descID, JobID: jobID}
+		return &scop.RemoveJobReference{DescriptorID: descID, JobID: jobID}
 	})
 }
 
 func generateOpsToAddJobIDs(descIDs []descpb.ID, jobID jobspb.JobID) []scop.Op {
 	return generateOpsForJobIDs(descIDs, jobID, func(descID descpb.ID, id jobspb.JobID) scop.Op {
-		return scop.AddJobReference{DescriptorID: descID, JobID: jobID}
+		return &scop.AddJobReference{DescriptorID: descID, JobID: jobID}
 	})
 }
 

--- a/pkg/sql/schemachanger/scplan/scstage/stage.go
+++ b/pkg/sql/schemachanger/scplan/scstage/stage.go
@@ -1,0 +1,123 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scstage
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/errors"
+)
+
+// A Stage is a sequence of ops to be executed "together" as part of a schema
+// change.
+//
+// stages also contain the state before and after the execution of the ops in
+// the stage, reflecting the fact that any set of ops can be thought of as a
+// transition from one state to another.
+type Stage struct {
+	Before, After          scpb.State
+	Ops                    scop.Ops
+	Revertible             bool
+	Phase                  scop.Phase
+	Ordinal, StagesInPhase int
+}
+
+func (s Stage) String() string {
+	revertible := ""
+	if !s.Revertible {
+		revertible = "non-revertible "
+	}
+	if s.Ops == nil {
+		return fmt.Sprintf("%s %sstage %d of %d with no ops",
+			s.Phase.String(), revertible, s.Ordinal, s.StagesInPhase)
+	}
+	return fmt.Sprintf("%s %sstage %d of %d with %d %s ops",
+		s.Phase.String(), revertible, s.Ordinal, s.StagesInPhase, len(s.Ops.Slice()), s.Ops.Type().String())
+}
+
+// decorateStages decorates stages with position in plan.
+func decorateStages(stages []Stage) []Stage {
+	if len(stages) == 0 {
+		return nil
+	}
+	phaseMap := map[scop.Phase][]int{}
+	for i, s := range stages {
+		phaseMap[s.Phase] = append(phaseMap[s.Phase], i)
+	}
+	for _, indexes := range phaseMap {
+		for i, j := range indexes {
+			s := &stages[j]
+			s.Ordinal = i + 1
+			s.StagesInPhase = len(indexes)
+		}
+	}
+	return stages
+}
+
+// ValidateStages checks that the plan is valid.
+func ValidateStages(stages []Stage) error {
+	if len(stages) == 0 {
+		return nil
+	}
+
+	// Check that the terminal node statuses are valid for their target direction.
+	initial := stages[0].Before.Nodes
+	final := stages[len(stages)-1].After.Nodes
+	if nInitial, nFinal := len(initial), len(final); nInitial != nFinal {
+		return errors.Errorf("initial state has %d nodes, final state has %d", nInitial, nFinal)
+	}
+	for i, initialNode := range initial {
+		finalNode := final[i]
+		initialTarget, finalTarget := initialNode.Target, finalNode.Target
+		if initialTarget != finalTarget {
+			return errors.Errorf("target mismatch between initial and final nodes at index %d: %s != %s",
+				i, initialTarget.String(), finalTarget.String())
+		}
+
+		e := initialTarget.Element()
+		switch initialTarget.Direction {
+		case scpb.Target_ADD:
+			if finalNode.Status != scpb.Status_PUBLIC {
+				return errors.Errorf("final status is %s instead of public at index %d for adding %T %s",
+					finalNode.Status, i, e, e)
+			}
+		case scpb.Target_DROP:
+			if finalNode.Status != scpb.Status_ABSENT {
+				return errors.Errorf("final status is %s instead of absent at index %d for dropping %T %s",
+					finalNode.Status, i, e, e)
+			}
+		}
+	}
+
+	// Check that phases are monotonically increasing.
+	currentPhase := scop.StatementPhase
+	for _, stage := range stages {
+		if stage.Phase < currentPhase {
+			return errors.Errorf("%s: preceded by %s stage",
+				stage.String(), currentPhase)
+		}
+	}
+
+	// Check that revertibility is monotonically decreasing.
+	revertibleAllowed := true
+	for _, stage := range stages {
+		if !stage.Revertible {
+			revertibleAllowed = false
+		}
+		if stage.Revertible && !revertibleAllowed {
+			return errors.Errorf("%s: preceded by non-revertible stage",
+				stage.String())
+		}
+	}
+	return nil
+}

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -59,13 +59,13 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
-  kind: HappensAfter
-  rule: index name is assigned once the index is created
-- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
-  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  kind: HappensAfter
+  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
+  kind: Precedence
   rule: index needs a name to be assigned
+- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
+  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
+  kind: Precedence
+  rule: index name is assigned once the index is created
 
 ops
 CREATE INVERTED INDEX CONCURRENTLY id1 ON defaultdb.t1 (id, name) STORING (money)
@@ -126,13 +126,13 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
-  kind: HappensAfter
-  rule: index name is assigned once the index is created
-- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
-  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  kind: HappensAfter
+  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
+  kind: Precedence
   rule: index needs a name to be assigned
+- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
+  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
+  kind: Precedence
+  rule: index name is assigned once the index is created
 
 ops
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
@@ -202,14 +202,14 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
 ----
 - from: [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
-  kind: HappensAfter
-  rule: index name is assigned once the index is created
-- from: [Partitioning:{DescID: 54, IndexID: 2}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
-  kind: HappensAfter
-  rule: partitioning information needs the basic index as created
-- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
-  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
-  kind: HappensAfter
+  to:   [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_AND_WRITE_ONLY]
+  kind: Precedence
   rule: index needs a name to be assigned
+- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
+  to:   [IndexName:{DescID: 54, IndexID: 2, Name: id1}, PUBLIC]
+  kind: Precedence
+  rule: index name is assigned once the index is created
+- from: [SecondaryIndex:{DescID: 54, IndexID: 2}, DELETE_ONLY]
+  to:   [Partitioning:{DescID: 54, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: partitioning information needs the basic index as created

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -541,383 +541,383 @@ PostCommitPhase non-revertible stage 1 of 1 with 31 MutationType ops
 deps
 DROP DATABASE db1 CASCADE
 ----
-- from: [Database:{DescID: 54}, ABSENT]
-  to:   [Schema:{DescID: 55}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Database:{DescID: 54}, ABSENT]
-  to:   [Schema:{DescID: 56}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 55}, ABSENT]
-  to:   [Database:{DescID: 54}, DROPPED]
-  kind: HappensAfter
-  rule: schema entry can be dropped after the database has exited synth drop
-- from: [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 56}, ABSENT]
-  to:   [Database:{DescID: 54}, DROPPED]
-  kind: HappensAfter
-  rule: schema entry can be dropped after the database has exited synth drop
-- from: [DefaultExpression:{DescID: 59, ColumnID: 3}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [DefaultExpression:{DescID: 60, ColumnID: 3}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Namespace:{DescID: 57, Name: sq1}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 58, Name: sq1}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 59, Name: t1}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 60, Name: t1}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 61, Name: v1}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 62, Name: v2}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 63, Name: v3}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 64, Name: v4}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 65, Name: typ}, ABSENT]
-  to:   [Type:{DescID: 65}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 66, Name: _typ}, ABSENT]
-  to:   [Type:{DescID: 66}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 67, Name: v5}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 57}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 58}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 59}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 60}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 61}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 62}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 63}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 64}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 67}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 60}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 60}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 62}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 62}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 64}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 64}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 64, ReferencedDescID: 67}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 64, ReferencedDescID: 67}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Schema:{DescID: 55}, ABSENT]
+- from: [Database:{DescID: 54}, DROPPED]
   to:   [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 55}, ABSENT]
-  kind: HappensAfter
-  rule: schema can be dropped after schema entry inside the database
-- from: [Schema:{DescID: 55}, ABSENT]
-  to:   [Sequence:{DescID: 57}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 55}, ABSENT]
-  to:   [Table:{DescID: 60}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: schema entry can be dropped after the database has exited synth drop
+- from: [Database:{DescID: 54}, DROPPED]
   to:   [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 56}, ABSENT]
-  kind: HappensAfter
+  kind: Precedence
+  rule: schema entry can be dropped after the database has exited synth drop
+- from: [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 55}, ABSENT]
+  to:   [Schema:{DescID: 55}, ABSENT]
+  kind: Precedence
   rule: schema can be dropped after schema entry inside the database
-- from: [Schema:{DescID: 56}, ABSENT]
+- from: [DatabaseSchemaEntry:{DescID: 54, ReferencedDescID: 56}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: schema can be dropped after schema entry inside the database
+- from: [Namespace:{DescID: 57, Name: sq1}, ABSENT]
+  to:   [Sequence:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 58, Name: sq1}, ABSENT]
   to:   [Sequence:{DescID: 58}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 59, Name: t1}, ABSENT]
   to:   [Table:{DescID: 59}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
-  to:   [Type:{DescID: 65}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
-  to:   [Type:{DescID: 66}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 60, Name: t1}, ABSENT]
+  to:   [Table:{DescID: 60}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 61, Name: v1}, ABSENT]
   to:   [View:{DescID: 61}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 62, Name: v2}, ABSENT]
   to:   [View:{DescID: 62}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 63, Name: v3}, ABSENT]
   to:   [View:{DescID: 63}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 64, Name: v4}, ABSENT]
   to:   [View:{DescID: 64}, ABSENT]
-  kind: HappensAfter
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 65, Name: typ}, ABSENT]
+  to:   [Type:{DescID: 65}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 66, Name: _typ}, ABSENT]
+  to:   [Type:{DescID: 66}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 67, Name: v5}, ABSENT]
+  to:   [View:{DescID: 67}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Schema:{DescID: 55}, ABSENT]
+  to:   [Database:{DescID: 54}, ABSENT]
+  kind: Precedence
   rule: parent dependencies
 - from: [Schema:{DescID: 56}, ABSENT]
-  to:   [View:{DescID: 67}, ABSENT]
-  kind: HappensAfter
+  to:   [Database:{DescID: 54}, ABSENT]
+  kind: Precedence
   rule: parent dependencies
 - from: [Sequence:{DescID: 57}, ABSENT]
+  to:   [Schema:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Sequence:{DescID: 57}, DROPPED]
   to:   [Namespace:{DescID: 57, Name: sq1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Sequence:{DescID: 57}, DROPPED]
+  to:   [Owner:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 60}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Sequence:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Sequence:{DescID: 58}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Sequence:{DescID: 58}, DROPPED]
   to:   [Namespace:{DescID: 58, Name: sq1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [Owner:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Table:{DescID: 59}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [DefaultExpression:{DescID: 59, ColumnID: 3}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 59}, DROPPED]
   to:   [Namespace:{DescID: 59, Name: t1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [Owner:{DescID: 59}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Table:{DescID: 60}, ABSENT]
+  to:   [Schema:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [DefaultExpression:{DescID: 60, ColumnID: 3}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 60}, DROPPED]
   to:   [Namespace:{DescID: 60, Name: t1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [Owner:{DescID: 60}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 60}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Type:{DescID: 65}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Type:{DescID: 65}, DROPPED]
   to:   [Namespace:{DescID: 65, Name: typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Type:{DescID: 65}, DROPPED]
+  to:   [ViewDependsOnType:{DescID: 67, ReferencedDescID: 65}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
 - from: [Type:{DescID: 66}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Type:{DescID: 66}, DROPPED]
   to:   [Namespace:{DescID: 66, Name: _typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
-  to:   [Sequence:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
-  to:   [Table:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: admin}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: public}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: root}, ABSENT]
-  to:   [Table:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: admin}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: public}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: root}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 62, Username: admin}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 62, Username: public}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 62, Username: root}, ABSENT]
-  to:   [View:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: admin}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: public}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: root}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 64, Username: admin}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 64, Username: public}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 64, Username: root}, ABSENT]
-  to:   [View:{DescID: 64}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 67, Username: admin}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 67, Username: public}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 67, Username: root}, ABSENT]
-  to:   [View:{DescID: 67}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Type:{DescID: 66}, DROPPED]
+  to:   [ViewDependsOnType:{DescID: 67, ReferencedDescID: 66}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
 - from: [View:{DescID: 61}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 61}, DROPPED]
   to:   [Namespace:{DescID: 61, Name: v1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [Owner:{DescID: 61}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 59, ReferencedDescID: 61}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 62}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 62}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 62}, DROPPED]
   to:   [Namespace:{DescID: 62, Name: v2}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [Owner:{DescID: 62}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 62}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 64}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [UserPrivileges:{DescID: 62, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [UserPrivileges:{DescID: 62, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 62}, DROPPED]
+  to:   [UserPrivileges:{DescID: 62, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 63}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 63}, DROPPED]
   to:   [Namespace:{DescID: 63, Name: v3}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [Owner:{DescID: 63}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 61, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 64}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 64}, DROPPED]
   to:   [Namespace:{DescID: 64, Name: v4}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [Owner:{DescID: 64}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 62, ReferencedDescID: 64}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 64, ReferencedDescID: 67}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [UserPrivileges:{DescID: 64, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [UserPrivileges:{DescID: 64, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 64}, DROPPED]
+  to:   [UserPrivileges:{DescID: 64, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 67}, ABSENT]
+  to:   [Schema:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 67}, DROPPED]
   to:   [Namespace:{DescID: 67, Name: v5}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [ViewDependsOnType:{DescID: 67, ReferencedDescID: 65}, ABSENT]
-  to:   [Type:{DescID: 65}, DROPPED]
-  kind: SameStage
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 67}, DROPPED]
+  to:   [Owner:{DescID: 67}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 67}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 64, ReferencedDescID: 67}, ABSENT]
+  kind: SameStagePrecedence
   rule: dependency needs relation/type as non-synthetically dropped
-- from: [ViewDependsOnType:{DescID: 67, ReferencedDescID: 66}, ABSENT]
-  to:   [Type:{DescID: 66}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 67}, DROPPED]
+  to:   [UserPrivileges:{DescID: 67, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 67}, DROPPED]
+  to:   [UserPrivileges:{DescID: 67, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 67}, DROPPED]
+  to:   [UserPrivileges:{DescID: 67, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -37,298 +37,298 @@ CREATE VIEW sc1.v5 AS (SELECT 'a'::sc1.typ::STRING AS k, n2, n1 FROM sc1.v4)
 deps
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
-- from: [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Namespace:{DescID: 55, Name: sq1}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 56, Name: t1}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 57, Name: v1}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 58, Name: v2}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 59, Name: v3}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 60, Name: v4}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 61, Name: typ}, ABSENT]
-  to:   [Type:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 62, Name: _typ}, ABSENT]
-  to:   [Type:{DescID: 62}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Namespace:{DescID: 63, Name: v5}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 55}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 56}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 57}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 58}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 59}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 60}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 63}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 58}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 58}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 60, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 60, ReferencedDescID: 63}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Schema:{DescID: 54}, ABSENT]
-  to:   [DatabaseSchemaEntry:{DescID: 50, ReferencedDescID: 54}, ABSENT]
-  kind: HappensAfter
+- from: [DatabaseSchemaEntry:{DescID: 50, ReferencedDescID: 54}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
   rule: schema can be dropped after schema entry inside the database
-- from: [Schema:{DescID: 54}, ABSENT]
+- from: [Namespace:{DescID: 55, Name: sq1}, ABSENT]
   to:   [Sequence:{DescID: 55}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 56, Name: t1}, ABSENT]
   to:   [Table:{DescID: 56}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
-  to:   [Type:{DescID: 61}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
-  to:   [Type:{DescID: 62}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 57, Name: v1}, ABSENT]
   to:   [View:{DescID: 57}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 58, Name: v2}, ABSENT]
   to:   [View:{DescID: 58}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 59, Name: v3}, ABSENT]
   to:   [View:{DescID: 59}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 60, Name: v4}, ABSENT]
   to:   [View:{DescID: 60}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
-- from: [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 61, Name: typ}, ABSENT]
+  to:   [Type:{DescID: 61}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 62, Name: _typ}, ABSENT]
+  to:   [Type:{DescID: 62}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Namespace:{DescID: 63, Name: v5}, ABSENT]
   to:   [View:{DescID: 63}, ABSENT]
-  kind: HappensAfter
-  rule: parent dependencies
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Sequence:{DescID: 55}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Sequence:{DescID: 55}, DROPPED]
   to:   [Namespace:{DescID: 55, Name: sq1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Sequence:{DescID: 55}, DROPPED]
+  to:   [Owner:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 55}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Sequence:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Table:{DescID: 56}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [DefaultExpression:{DescID: 56, ColumnID: 3}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 56}, DROPPED]
   to:   [Namespace:{DescID: 56, Name: t1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [Owner:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [Type:{DescID: 61}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Type:{DescID: 61}, DROPPED]
   to:   [Namespace:{DescID: 61, Name: typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Type:{DescID: 61}, DROPPED]
+  to:   [ViewDependsOnType:{DescID: 63, ReferencedDescID: 61}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
 - from: [Type:{DescID: 62}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [Type:{DescID: 62}, DROPPED]
   to:   [Namespace:{DescID: 62, Name: _typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
-  to:   [Sequence:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: admin}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: public}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: root}, ABSENT]
-  to:   [Table:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: admin}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: public}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 60, Username: root}, ABSENT]
-  to:   [View:{DescID: 60}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: admin}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: public}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 63, Username: root}, ABSENT]
-  to:   [View:{DescID: 63}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Type:{DescID: 62}, DROPPED]
+  to:   [ViewDependsOnType:{DescID: 63, ReferencedDescID: 62}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
 - from: [View:{DescID: 57}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 57}, DROPPED]
   to:   [Namespace:{DescID: 57, Name: v1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [Owner:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 58}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 58}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 58}, DROPPED]
   to:   [Namespace:{DescID: 58, Name: v2}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [Owner:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 58}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 59}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 59}, DROPPED]
   to:   [Namespace:{DescID: 59, Name: v3}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [Owner:{DescID: 59}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 60}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 60}, DROPPED]
   to:   [Namespace:{DescID: 60, Name: v4}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [Owner:{DescID: 60}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 60}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 60, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 60}, DROPPED]
+  to:   [UserPrivileges:{DescID: 60, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 - from: [View:{DescID: 63}, ABSENT]
+  to:   [Schema:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: parent dependencies
+- from: [View:{DescID: 63}, DROPPED]
   to:   [Namespace:{DescID: 63, Name: v5}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [ViewDependsOnType:{DescID: 63, ReferencedDescID: 61}, ABSENT]
-  to:   [Type:{DescID: 61}, DROPPED]
-  kind: SameStage
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [Owner:{DescID: 63}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 60, ReferencedDescID: 63}, ABSENT]
+  kind: SameStagePrecedence
   rule: dependency needs relation/type as non-synthetically dropped
-- from: [ViewDependsOnType:{DescID: 63, ReferencedDescID: 62}, ABSENT]
-  to:   [Type:{DescID: 62}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 63}, DROPPED]
+  to:   [UserPrivileges:{DescID: 63, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 
 ops
 DROP SCHEMA defaultdb.SC1 CASCADE

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -119,34 +119,34 @@ deps
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 - from: [Namespace:{DescID: 54, Name: sq1}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 54}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Sequence:{DescID: 54}, ABSENT]
-  to:   [Namespace:{DescID: 54, Name: sq1}, ABSENT]
-  kind: HappensAfter
+  to:   [Sequence:{DescID: 54}, ABSENT]
+  kind: Precedence
   rule: descriptor can only be cleaned up once the name is drained
-- from: [UserPrivileges:{DescID: 54, Username: admin}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: HappensAfter
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [Namespace:{DescID: 54, Name: sq1}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [Owner:{DescID: 54}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 54, Username: public}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: HappensAfter
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 56}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [UserPrivileges:{DescID: 54, Username: admin}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 54, Username: root}, ABSENT]
-  to:   [Sequence:{DescID: 54}, DROPPED]
-  kind: HappensAfter
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [UserPrivileges:{DescID: 54, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 54}, DROPPED]
+  to:   [UserPrivileges:{DescID: 54, Username: root}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -189,115 +189,115 @@ PostCommitPhase non-revertible stage 1 of 1 with 6 MutationType ops
 deps
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-- from: [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [DefaultExpression:{DescID: 57, ColumnID: 5}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [ForeignKey:{DescID: 57, ReferencedDescID: 54, Name: fk_customers}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [ForeignKey:{DescID: 57, ReferencedDescID: 55, Name: fk_orders}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [ForeignKeyBackReference:{DescID: 54, ReferencedDescID: 57, Name: fk_customers}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [ForeignKeyBackReference:{DescID: 55, ReferencedDescID: 57, Name: fk_orders}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
 - from: [Namespace:{DescID: 57, Name: shipments}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [Table:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 58, Name: sq1}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [Sequence:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 59, Name: v1}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 57}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 58}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 59}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [Sequence:{DescID: 58}, ABSENT]
+  to:   [View:{DescID: 59}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Sequence:{DescID: 58}, DROPPED]
   to:   [Namespace:{DescID: 58, Name: sq1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [SequenceOwnedBy:{DescID: 58, ReferencedDescID: 57}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: SameStage
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [Owner:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [SequenceOwnedBy:{DescID: 58, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
   rule: dependency needs relation/type as non-synthetically dropped
-- from: [Table:{DescID: 57}, ABSENT]
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Sequence:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [DefaultExpression:{DescID: 57, ColumnID: 1}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [DefaultExpression:{DescID: 57, ColumnID: 5}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [ForeignKey:{DescID: 57, ReferencedDescID: 54, Name: fk_customers}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [ForeignKey:{DescID: 57, ReferencedDescID: 55, Name: fk_orders}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [ForeignKeyBackReference:{DescID: 54, ReferencedDescID: 57, Name: fk_customers}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [ForeignKeyBackReference:{DescID: 55, ReferencedDescID: 57, Name: fk_orders}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
   to:   [Namespace:{DescID: 57, Name: shipments}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: HappensAfter
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [Owner:{DescID: 57}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: HappensAfter
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
-  to:   [Table:{DescID: 57}, DROPPED]
-  kind: HappensAfter
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
+- from: [Table:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
+  kind: Precedence
   rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
-  to:   [Sequence:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
-  to:   [View:{DescID: 59}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [View:{DescID: 59}, ABSENT]
+- from: [View:{DescID: 59}, DROPPED]
   to:   [Namespace:{DescID: 59, Name: v1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [Owner:{DescID: 59}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 57, ReferencedDescID: 59}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 59}, DROPPED]
+  to:   [UserPrivileges:{DescID: 59, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -67,18 +67,18 @@ deps
 DROP TYPE defaultdb.typ
 ----
 - from: [Namespace:{DescID: 54, Name: typ}, ABSENT]
-  to:   [Type:{DescID: 54}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [Type:{DescID: 54}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 55, Name: _typ}, ABSENT]
-  to:   [Type:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Type:{DescID: 54}, ABSENT]
+  to:   [Type:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [Type:{DescID: 54}, DROPPED]
   to:   [Namespace:{DescID: 54, Name: typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [Type:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [Type:{DescID: 55}, DROPPED]
   to:   [Namespace:{DescID: 55, Name: _typ}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -56,33 +56,33 @@ deps
 DROP VIEW defaultdb.v1
 ----
 - from: [Namespace:{DescID: 55, Name: v1}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 55}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [View:{DescID: 55}, ABSENT]
-  to:   [Namespace:{DescID: 55, Name: v1}, ABSENT]
-  kind: HappensAfter
+  to:   [View:{DescID: 55}, ABSENT]
+  kind: Precedence
   rule: descriptor can only be cleaned up once the name is drained
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [Namespace:{DescID: 55, Name: v1}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [Owner:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
 
 create-view
 CREATE VIEW defaultdb.v2 AS (SELECT name AS n1, name AS n2 FROM v1)
@@ -298,166 +298,166 @@ deps
 DROP VIEW defaultdb.v1 CASCADE
 ----
 - from: [Namespace:{DescID: 55, Name: v1}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [View:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 56, Name: v2}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [View:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 57, Name: v3}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [View:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 58, Name: v4}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
+  to:   [View:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
 - from: [Namespace:{DescID: 61, Name: v5}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: namespace needs descriptor to be dropped
-- from: [Owner:{DescID: 55}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 56}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 57}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 58}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [Owner:{DescID: 61}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: SameStage
-  rule: dependency needs relation/type as non-synthetically dropped
-- from: [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
-  to:   [View:{DescID: 55}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: admin}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: public}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 56, Username: root}, ABSENT]
-  to:   [View:{DescID: 56}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
-  to:   [View:{DescID: 57}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
-  to:   [View:{DescID: 58}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: admin}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: public}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [UserPrivileges:{DescID: 61, Username: root}, ABSENT]
-  to:   [View:{DescID: 61}, DROPPED]
-  kind: HappensAfter
-  rule: table deps removal happens after table marked as dropped
-- from: [View:{DescID: 55}, ABSENT]
+  to:   [View:{DescID: 61}, ABSENT]
+  kind: Precedence
+  rule: descriptor can only be cleaned up once the name is drained
+- from: [View:{DescID: 55}, DROPPED]
   to:   [Namespace:{DescID: 55, Name: v1}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [View:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [Owner:{DescID: 55}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 54, ReferencedDescID: 55}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 55}, DROPPED]
+  to:   [UserPrivileges:{DescID: 55, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 56}, DROPPED]
   to:   [Namespace:{DescID: 56, Name: v2}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [View:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [Owner:{DescID: 56}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 56}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 56}, DROPPED]
+  to:   [UserPrivileges:{DescID: 56, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
   to:   [Namespace:{DescID: 57, Name: v3}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [View:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [Owner:{DescID: 57}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 55, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 57}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 57}, DROPPED]
+  to:   [UserPrivileges:{DescID: 57, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
   to:   [Namespace:{DescID: 58, Name: v4}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
-- from: [View:{DescID: 61}, ABSENT]
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [Owner:{DescID: 58}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 56, ReferencedDescID: 58}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 58}, DROPPED]
+  to:   [UserPrivileges:{DescID: 58, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
   to:   [Namespace:{DescID: 61, Name: v5}, ABSENT]
-  kind: HappensAfter
-  rule: descriptor can only be cleaned up once the name is drained
+  kind: Precedence
+  rule: namespace needs descriptor to be dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [Owner:{DescID: 61}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [RelationDependedOnBy:{DescID: 58, ReferencedDescID: 61}, ABSENT]
+  kind: SameStagePrecedence
+  rule: dependency needs relation/type as non-synthetically dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: admin}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: public}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped
+- from: [View:{DescID: 61}, DROPPED]
+  to:   [UserPrivileges:{DescID: 61, Username: root}, ABSENT]
+  kind: Precedence
+  rule: table deps removal happens after table marked as dropped

--- a/pkg/sql/schemachanger/scrun/BUILD.bazel
+++ b/pkg/sql/schemachanger/scrun/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
+        "//pkg/sql/schemachanger/scplan/scstage",
         "//pkg/util/log/logcrash",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scstage"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/errors"
 )
@@ -131,7 +132,7 @@ func executeStage(
 	deps scexec.Dependencies,
 	p scplan.Plan,
 	stageIdx int,
-	stage scplan.Stage,
+	stage scstage.Stage,
 ) error {
 	if knobs != nil && knobs.BeforeStage != nil {
 		if err := knobs.BeforeStage(p, stageIdx); err != nil {


### PR DESCRIPTION
These 4 commits introduce a new scstage package. This was motivated by the more immediate goal of inverting dependency edge directions, to express them as precedence constraints instead of succession constraints.