### PR TITLE
cli: avoid using background ctx in server start

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -75,7 +75,16 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx := context.Background()
+	// Set up a cancellable context for the entire start command.
+	// The context will be canceled at the end.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The context annotation ensures that server identifiers show up
+	// in the logging metadata as soon as they are known.
+	ambientCtx := serverCfg.AmbientCtx
+	ctx = ambientCtx.AnnotateCtx(ctx)
+
 	const clusterName = ""
 
 	stopper, err := setupAndInitializeLoggingAndProfiling(ctx, cmd, false /* isServerCmd */)

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -79,6 +79,7 @@ var requireConstFmt = map[string]bool{
 	"github.com/cockroachdb/cockroach/pkg/util/log.MakeLegacyEntry":        true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.makeUnstructuredEntry":  true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.FormatWithContextTags":  true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.formatOnlyArgs":         true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.renderArgsAsRedactable": true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.formatArgs":             true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.logfDepth":              true,

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -78,7 +78,7 @@ func shoutfDepth(
 		// it here.
 		fmt.Fprintf(OrigStderr, "*\n* %s: %s\n*\n", sev.String(),
 			strings.Replace(
-				FormatWithContextTags(ctx, format, args...),
+				formatOnlyArgs(format, args...),
 				"\n", "\n* ", -1))
 	}
 	logfDepth(ctx, depth+1, sev, ch, format, args...)

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -28,6 +28,12 @@ func FormatWithContextTags(ctx context.Context, format string, args ...interface
 	return buf.String()
 }
 
+func formatOnlyArgs(format string, args ...interface{}) string {
+	var buf strings.Builder
+	formatArgs(&buf, format, args...)
+	return buf.String()
+}
+
 func formatArgs(buf *strings.Builder, format string, args ...interface{}) {
 	if len(args) == 0 {
 		buf.WriteString(format)


### PR DESCRIPTION
Needed for #73306. 
Informs #58938.

This change ensures that the entire server startup and shutdown logic
operates under a go context that is connected to the main config's
tracer and AmbientCtx (and its log tags, and server identifiers).