### PR TITLE
kvclient/rangefeed: add `EventHandler` interface

### DIFF
--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -11,10 +11,6 @@
 package rangefeed
 
 import (
-	"context"
-
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
@@ -24,35 +20,15 @@ type Option interface {
 }
 
 type config struct {
-	retryOptions         retry.Options
-	onInitialScanDone    OnInitialScanDone
-	withInitialScan      bool
-	withDiff             bool
-	onInitialScanError   OnInitialScanError
-	onUnrecoverableError OnUnrecoverableError
-	onCheckpoint         OnCheckpoint
-	onFrontierAdvance    OnFrontierAdvance
+	retryOptions       retry.Options
+	withInitialScan    bool
+	initialScanHandler InitialScanHandler
+	withDiff           bool
 }
 
 type optionFunc func(*config)
 
 func (o optionFunc) set(c *config) { o(c) }
-
-// OnInitialScanDone is called when an initial scan is finished before any rows
-// from the rangefeed are supplied.
-type OnInitialScanDone func(ctx context.Context)
-
-// OnInitialScanError is called when an initial scan encounters an error. It
-// allows the caller to tell the RangeFeed to stop as opposed to retrying
-// endlessly.
-type OnInitialScanError func(ctx context.Context, err error) (shouldFail bool)
-
-// OnUnrecoverableError is called when the rangefeed exits with an unrecoverable
-// error (preventing internal retries). One example is when the rangefeed falls
-// behind to a point where the frontier timestamp precedes the GC threshold, and
-// thus will never work. The callback lets callers find out about such errors
-// (possibly, in our example, to start a new rangefeed with an initial scan).
-type OnUnrecoverableError func(ctx context.Context, err error)
 
 // WithInitialScan enables an initial scan of the data in the span. The rows of
 // an initial scan will be passed to the value function used to construct the
@@ -60,28 +36,10 @@ type OnUnrecoverableError func(ctx context.Context, err error)
 // non-nil) will be called. The initial scan may be restarted and thus rows
 // may be observed multiple times. The caller cannot rely on rows being returned
 // in order.
-func WithInitialScan(f OnInitialScanDone) Option {
+func WithInitialScan(initialScanHandler InitialScanHandler) Option {
 	return optionFunc(func(c *config) {
 		c.withInitialScan = true
-		c.onInitialScanDone = f
-	})
-}
-
-// WithOnInitialScanError sets up a callback to report errors during the initial
-// scan to the caller. The caller may instruct the RangeFeed to halt rather than
-// retrying endlessly. This option will not enable an initial scan; it must be
-// used in conjunction with WithInitialScan to have any effect.
-func WithOnInitialScanError(f OnInitialScanError) Option {
-	return optionFunc(func(c *config) {
-		c.onInitialScanError = f
-	})
-}
-
-// WithOnInternalError sets up a callback to report unrecoverable errors during
-// operation.
-func WithOnInternalError(f OnUnrecoverableError) Option {
-	return optionFunc(func(c *config) {
-		c.onUnrecoverableError = f
+		c.initialScanHandler = initialScanHandler
 	})
 }
 
@@ -97,29 +55,6 @@ func WithDiff() Option {
 func WithRetry(options retry.Options) Option {
 	return optionFunc(func(c *config) {
 		c.retryOptions = options
-	})
-}
-
-// OnCheckpoint is called when a rangefeed checkpoint occurs.
-type OnCheckpoint func(ctx context.Context, checkpoint *roachpb.RangeFeedCheckpoint)
-
-// WithOnCheckpoint sets up a callback that's invoked whenever a check point
-// event is emitted.
-func WithOnCheckpoint(f OnCheckpoint) Option {
-	return optionFunc(func(c *config) {
-		c.onCheckpoint = f
-	})
-}
-
-// OnFrontierAdvance is called when the rangefeed frontier is advanced with the
-// new frontier timestamp.
-type OnFrontierAdvance func(ctx context.Context, timestamp hlc.Timestamp)
-
-// WithOnFrontierAdvance sets up a callback that's invoked whenever the
-// rangefeed frontier is advanced.
-func WithOnFrontierAdvance(f OnFrontierAdvance) Option {
-	return optionFunc(func(c *config) {
-		c.onFrontierAdvance = f
 	})
 }
 


### PR DESCRIPTION
The `RangeFeed` client uses event callbacks to process rangefeed events.
However, these were registered individually and apart from `OnValue`
were optional. This is brittle, especially when adding new events, since
callers may not have sufficient handling of all events.

This patch changes the `RangeFeed` to take an `EventHandler` interface
containing all event callbacks. This forces all callers to explicitly
handle every event, with compile-time errors. It also adds an
`InitialScanHandler` interface with event callbacks for initial scans,
when requested.

Release note: None

---

@ajwerner In preparation for `AddSSTable` and `DeleteRange` events across rangefeeds (see e.g. #73487), we've discussed using an event handler interface for the `RangeFeed` client library, such that all callers must explicitly take all events into account instead of silently ignoring new or unknown events.

This is a quick draft of the new API, with a couple of callers migrated as examples. Let me know if you're on board with this, and I'll wrap up all the callers and tests.

Most callers seem to have pretty lax error handling and such (e.g. no `OnUnrecoverableError` handling), I'm inclined to keep the current behavior and let the respective teams consider that separately.