### PR TITLE
schemachanger: add statement tags and full resolve names in event logging

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3095,6 +3095,8 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 	return f.CloseAndGetString(), true
 }
 
+// formatStmtKeyAsRedactableString given an AST node this function will fully
+// qualify names using annotations to format it out into a redactable string.
 func formatStmtKeyAsRedactableString(
 	vt VirtualTabler, rootAST tree.Statement, ann *tree.Annotations,
 ) redact.RedactableString {

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -982,7 +982,7 @@ query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog;
 ----
-1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW v1ev CASCADE", "User": "root", "ViewName": "test.public.v1ev"}
+1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW test.public.v1ev CASCADE", "User": "root", "ViewName": "test.public.v1ev"}
 
 statement ok
 CREATE VIEW v1ev AS (SELECT name FROM T1EV);
@@ -1001,8 +1001,8 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE t1ev, t2ev CASCADE", "TableName": "test.public.t2ev", "User": "root"}
-1  {"CascadeDroppedViews": ["test.public.v1ev", "test.public.v4ev"], "EventType": "drop_table", "Statement": "DROP TABLE t1ev, t2ev CASCADE", "TableName": "test.public.t1ev", "User": "root"}
+1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t2ev", "User": "root"}
+1  {"CascadeDroppedViews": ["test.public.v1ev", "test.public.v4ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t1ev", "User": "root"}
 
 statement ok
 CREATE TABLE fooev (i INT PRIMARY KEY);

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -982,7 +982,7 @@ query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog;
 ----
-1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW test.public.v1ev CASCADE", "User": "root", "ViewName": "test.public.v1ev"}
+1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW test.public.v1ev CASCADE", "Tag": "DROP VIEW", "User": "root", "ViewName": "test.public.v1ev"}
 
 statement ok
 CREATE VIEW v1ev AS (SELECT name FROM T1EV);
@@ -1001,8 +1001,8 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t2ev", "User": "root"}
-1  {"CascadeDroppedViews": ["test.public.v1ev", "test.public.v4ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t1ev", "User": "root"}
+1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t2ev", "Tag": "DROP TABLE", "User": "root"}
+1  {"CascadeDroppedViews": ["test.public.v1ev", "test.public.v4ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t1ev", "Tag": "DROP TABLE", "User": "root"}
 
 statement ok
 CREATE TABLE fooev (i INT PRIMARY KEY);
@@ -1018,7 +1018,7 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE fooev ADD COLUMN j INT8", "TableName": "test.public.fooev", "User": "root"}
+1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.fooev ADD COLUMN j INT8", "TableName": "test.public.fooev", "Tag": "ALTER TABLE", "User": "root"}
 
 subtest names-with-escaped-chars
 
@@ -1065,8 +1065,8 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"DatabaseName": "'db1-a'", "DroppedSchemaObjects": ["'db1-a'.public", "'db1-a'.sc1", "'db1-a'.sc2"], "EventType": "drop_database", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "User": "root"}
-1  {"DatabaseName": "db2", "DroppedSchemaObjects": ["db2.public", "db2.sc3"], "EventType": "drop_database", "Statement": "DROP DATABASE db2 CASCADE", "User": "root"}
+1  {"DatabaseName": "'db1-a'", "DroppedSchemaObjects": ["'db1-a'.public", "'db1-a'.sc1", "'db1-a'.sc2"], "EventType": "drop_database", "Statement": "DROP DATABASE \"'db1-a'\" CASCADE", "Tag": "DROP DATABASE", "User": "root"}
+1  {"DatabaseName": "db2", "DroppedSchemaObjects": ["db2.public", "db2.sc3"], "EventType": "drop_database", "Statement": "DROP DATABASE db2 CASCADE", "Tag": "DROP DATABASE", "User": "root"}
 
 # Sanity: Dropping multiple objects in the builder or resolving any dependencies
 # should function fine.

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -35,8 +35,12 @@ import (
 )
 
 // FormatAstAsRedactableString implements scbuild.AstFormatter
-func (p *planner) FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString {
-	return formatStmtKeyAsRedactableString(p.getVirtualTabler(), statement, p.EvalContext().Annotations)
+func (p *planner) FormatAstAsRedactableString(
+	statement tree.Statement, annotations *tree.Annotations,
+) redact.RedactableString {
+	return formatStmtKeyAsRedactableString(p.getVirtualTabler(),
+		statement,
+		annotations)
 }
 
 // SchemaChange provides the planNode for the new schema changer.

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -31,10 +31,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/redact"
 )
+
+// FormatAstAsRedactableString implements scbuild.AstFormatter
+func (p *planner) FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString {
+	return formatStmtKeyAsRedactableString(p.getVirtualTabler(), statement, p.EvalContext().Annotations)
+}
 
 // SchemaChange provides the planNode for the new schema changer.
 func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNode, bool, error) {
+
 	// TODO(ajwerner): Call featureflag.CheckEnabled appropriately.
 	mode := p.extendedEvalCtx.SchemaChangerState.mode
 	// When new schema changer is on we will not support it for explicit
@@ -51,6 +58,7 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 		p.ExecCfg().Codec,
 		p.Txn(),
 		p.Descriptors(),
+		p,
 		p,
 		p,
 		p.SessionData(),

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "scbuild",
     srcs = [
+        "ast_annotator.go",
         "build.go",
         "builder_state.go",
         "descriptor_reader.go",
@@ -20,6 +21,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/faketreeeval",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/schemachanger/scbuild/internal/scbuildstmt",

--- a/pkg/sql/schemachanger/scbuild/ast_annotator.go
+++ b/pkg/sql/schemachanger/scbuild/ast_annotator.go
@@ -1,0 +1,88 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scbuild
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+var _ scbuildstmt.TreeAnnotator = (*astAnnotator)(nil)
+
+// astAnnotator creates a copy of the AST that can be annotated or modified
+// safely without impacting the original statement.
+type astAnnotator struct {
+	statement        tree.Statement
+	annotation       tree.Annotations
+	nonExistentNames map[*tree.TableName]struct{}
+}
+
+func newAstAnnotator(original tree.Statement) (*astAnnotator, error) {
+	// Clone the original tree by re-parsing the input back into an AST.
+	statement, err := parser.ParseOne(original.String())
+	if err != nil {
+		return nil, err
+	}
+	return &astAnnotator{
+		nonExistentNames: map[*tree.TableName]struct{}{},
+		statement:        statement.AST,
+		annotation:       tree.MakeAnnotations(statement.NumAnnotations),
+	}, nil
+}
+
+// GetStatement returns the cloned copy of the AST that is stored inside
+// the annotator.
+func (ann *astAnnotator) GetStatement() tree.Statement {
+	return ann.statement
+}
+
+// GetAnnotations implements scbuildstmt.TreeAnnotator.
+func (ann *astAnnotator) GetAnnotations() *tree.Annotations {
+	// Sanity: Validate the annotations before returning them
+	return &ann.annotation
+}
+
+// MarkNameAsNonExistent implements scbuildstmt.TreeAnnotator.
+func (ann *astAnnotator) MarkNameAsNonExistent(name *tree.TableName) {
+	ann.nonExistentNames[name] = struct{}{}
+}
+
+// SetUnresolvedNameAnnotation implements scbuildstmt.TreeAnnotator.
+func (ann *astAnnotator) SetUnresolvedNameAnnotation(
+	unresolvedName *tree.UnresolvedObjectName, annotation interface{},
+) {
+	unresolvedName.SetAnnotation(&ann.annotation, annotation)
+}
+
+// ValidateAnnotations validates if expected modifications have been applied
+// on the AST. After the build phase all names should be fully resolved either
+// by directly modifying the AST or through annotations.
+func (ann *astAnnotator) ValidateAnnotations() {
+	// Sanity: Goes through the entire AST and confirms that and table names that
+	// appear inside it are fully resolved, meaning that both the database and
+	// schema are known.
+	f := tree.NewFmtCtx(
+		tree.FmtAlwaysQualifyTableNames|tree.FmtMarkRedactionNode,
+		tree.FmtAnnotations(&ann.annotation),
+		tree.FmtReformatTableNames(func(ctx *tree.FmtCtx, name *tree.TableName) {
+			// Name was not found during lookup inside the builder.
+			if _, ok := ann.nonExistentNames[name]; ok {
+				return
+			}
+			if name.CatalogName == "" || name.SchemaName == "" {
+				panic(errors.AssertionFailedf("unresolved name inside annotated AST "+
+					"(%v)", name.String()))
+			}
+		}))
+	f.FormatNode(ann.statement)
+}

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -143,7 +143,8 @@ func newEventLogState(
 	stmts := initial.Statements
 	els := eventLogState{
 		statements: append(stmts, scpb.Statement{
-			Statement: n.String(),
+			Statement:    n.String(),
+			StatementTag: n.StatementTag(),
 		}),
 		authorization: scpb.Authorization{
 			AppName:  d.SessionData().ApplicationName,

--- a/pkg/sql/schemachanger/scbuild/event_log_state.go
+++ b/pkg/sql/schemachanger/scbuild/event_log_state.go
@@ -13,6 +13,7 @@ package scbuild
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 var _ scbuildstmt.EventLogState = (*eventLogState)(nil)
@@ -41,4 +42,9 @@ func (e *eventLogState) EventLogStateWithNewSourceElementID() scbuildstmt.EventL
 			SourceElementID: *e.sourceElementID,
 		},
 	}
+}
+
+func (e *eventLogState) FinalizeEventLogState(statement tree.Statement) {
+	e.statements[len(e.statements)-1].RedactedStatement =
+		string(e.astFormatter.FormatAstAsRedactableString(statement))
 }

--- a/pkg/sql/schemachanger/scbuild/event_log_state.go
+++ b/pkg/sql/schemachanger/scbuild/event_log_state.go
@@ -13,7 +13,6 @@ package scbuild
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 var _ scbuildstmt.EventLogState = (*eventLogState)(nil)
@@ -42,9 +41,4 @@ func (e *eventLogState) EventLogStateWithNewSourceElementID() scbuildstmt.EventL
 			SourceElementID: *e.sourceElementID,
 		},
 	}
-}
-
-func (e *eventLogState) FinalizeEventLogState(statement tree.Statement) {
-	e.statements[len(e.statements)-1].RedactedStatement =
-		string(e.astFormatter.FormatAstAsRedactableString(statement))
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -28,7 +28,7 @@ import (
 
 // CreateIndex implements CREATE INDEX.
 func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
-	_, rel, idx := b.ResolveIndex(n.Table.ToUnresolvedObjectName(), n.Name, ResolveParams{
+	prefix, rel, idx := b.ResolveIndex(n.Table.ToUnresolvedObjectName(), n.Name, ResolveParams{
 		IsExistenceOptional: true,
 		RequiredPrivilege:   privilege.CREATE,
 	})
@@ -36,6 +36,9 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		// Table must exist.
 		panic(sqlerrors.NewUndefinedRelationError(n.Table.ToUnresolvedObjectName()))
 	}
+	// Mutate the AST to have the fully resolved name from above, which will be
+	// used for both event logging and errors.
+	n.Table.ObjectNamePrefix = prefix.NamePrefix()
 	if idx != nil {
 		if n.IfNotExists {
 			return

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/redact"
 )
 
 // BuildCtx wraps BuilderState and exposes various convenience methods for the
@@ -64,6 +65,8 @@ type Dependencies interface {
 
 	// Statements returns the statements behind this schema change.
 	Statements() []string
+
+	AstFormatter() AstFormatter
 }
 
 // CatalogReader should implement descriptor resolution, namespace lookups, and
@@ -140,6 +143,8 @@ type EventLogState interface {
 	// EventLogStateWithNewSourceElementID returns an EventLogState with an
 	// incremented source element ID
 	EventLogStateWithNewSourceElementID() EventLogState
+
+	FinalizeEventLogState(statement tree.Statement)
 }
 
 // TreeContextBuilder exposes convenient tree-package context builder methods.
@@ -265,4 +270,11 @@ type TableElementIDGenerator interface {
 	// NextIndexID returns the ID that should be used for any new index added to
 	// this table descriptor.
 	NextIndexID(tbl catalog.TableDescriptor) descpb.IndexID
+}
+
+// AstFormatter provides interfaces for formatting AST nodes.
+type AstFormatter interface {
+	// FormatAstAsRedactableString formats a tree.Statement into SQL with fully
+	// qualified names, where parts can be redacted.
+	FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -34,6 +34,7 @@ type BuildCtx interface {
 	Dependencies
 	BuilderState
 	EventLogState
+	TreeAnnotator
 
 	TreeContextBuilder
 	PrivilegeChecker
@@ -143,8 +144,6 @@ type EventLogState interface {
 	// EventLogStateWithNewSourceElementID returns an EventLogState with an
 	// incremented source element ID
 	EventLogStateWithNewSourceElementID() EventLogState
-
-	FinalizeEventLogState(statement tree.Statement)
 }
 
 // TreeContextBuilder exposes convenient tree-package context builder methods.
@@ -276,5 +275,18 @@ type TableElementIDGenerator interface {
 type AstFormatter interface {
 	// FormatAstAsRedactableString formats a tree.Statement into SQL with fully
 	// qualified names, where parts can be redacted.
-	FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString
+	FormatAstAsRedactableString(statement tree.Statement, annotations *tree.Annotations) redact.RedactableString
+}
+
+// TreeAnnotator provides interfaces to be able to modify the AST safely,
+// by providing a copy and support for adding annotations.
+type TreeAnnotator interface {
+
+	// SetUnresolvedNameAnnotation sets an annotation on an unresolved object name.
+	SetUnresolvedNameAnnotation(unresolvedName *tree.UnresolvedObjectName, ann interface{})
+
+	// MarkNameAsNonExistent indicates that a table name is non-existent
+	// in the AST, which will cause it to skip full namespace resolution
+	// validation.
+	MarkNameAsNonExistent(name *tree.TableName)
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
@@ -23,14 +23,19 @@ import (
 
 // DropSequence implements DROP SEQUENCE.
 func DropSequence(b BuildCtx, n *tree.DropSequence) {
-	for _, name := range n.Names {
-		_, seq := b.ResolveSequence(name.ToUnresolvedObjectName(), ResolveParams{
+	for idx := range n.Names {
+		name := &n.Names[idx]
+		prefix, seq := b.ResolveSequence(name.ToUnresolvedObjectName(), ResolveParams{
 			IsExistenceOptional: n.IfExists,
 			RequiredPrivilege:   privilege.DROP,
 		})
 		if seq == nil {
+			b.MarkNameAsNonExistent(name)
 			continue
 		}
+		// Mutate the AST to have the fully resolved name from above, which will be
+		// used for both event logging and errors.
+		name.ObjectNamePrefix = prefix.NamePrefix()
 		dropSequence(b, seq, n.DropBehavior)
 		b.IncrementSubWorkID()
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_table.go
@@ -28,14 +28,19 @@ func DropTable(b BuildCtx, n *tree.DropTable) {
 	}
 	// Find the table first.
 	tables := make([]tblDropCtx, 0, len(n.Names))
-	for _, name := range n.Names {
-		_, tbl := b.ResolveTable(name.ToUnresolvedObjectName(), ResolveParams{
+	for idx := range n.Names {
+		name := &n.Names[idx]
+		prefix, tbl := b.ResolveTable(name.ToUnresolvedObjectName(), ResolveParams{
 			IsExistenceOptional: n.IfExists,
 			RequiredPrivilege:   privilege.DROP,
 		})
 		if tbl == nil {
+			b.MarkNameAsNonExistent(name)
 			continue
 		}
+		// Mutate the AST to have the fully resolved name from above, which will be
+		// used for both event logging and errors.
+		name.ObjectNamePrefix = prefix.NamePrefix()
 		// Only decompose the tables first into elements, next we will check for
 		// dependent objects, in case they are all dropped *together*.
 		newCtx := dropTableBasic(b, tbl)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
@@ -29,13 +29,17 @@ func DropType(b BuildCtx, n *tree.DropType) {
 		panic(unimplemented.NewWithIssue(51480, "DROP TYPE CASCADE is not yet supported"))
 	}
 	for _, name := range n.Names {
-		_, typ := b.ResolveType(name, ResolveParams{
+		prefix, typ := b.ResolveType(name, ResolveParams{
 			IsExistenceOptional: n.IfExists,
 			RequiredPrivilege:   privilege.DROP,
 		})
 		if typ == nil {
 			continue
 		}
+		// Mutate the AST to have the fully resolved name from above, which will be
+		// used for both event logging and errors.
+		tn := tree.MakeTypeNameWithPrefix(prefix.NamePrefix(), typ.GetName())
+		b.SetUnresolvedNameAnnotation(name, &tn)
 		// If the descriptor is already being dropped, nothing to do.
 		if checkIfDescOrElementAreDropped(b, typ.GetID()) {
 			return

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -93,4 +93,6 @@ func Process(b BuildCtx, n tree.Statement) {
 	fn := reflect.ValueOf(info.fn)
 	in := []reflect.Value{reflect.ValueOf(b), reflect.ValueOf(n)}
 	fn.Call(in)
+	// Finalize, the event log state for the current statement.
+	b.FinalizeEventLogState(n)
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -88,11 +88,8 @@ func Process(b BuildCtx, n tree.Statement) {
 	if !info.IsFullySupported(b.EvalCtx().SessionData().NewSchemaChangerMode) {
 		panic(scerrors.NotImplementedError(n))
 	}
-
 	// Next invoke the callback function, with the concrete types.
 	fn := reflect.ValueOf(info.fn)
 	in := []reflect.Value{reflect.ValueOf(b), reflect.ValueOf(n)}
 	fn.Call(in)
-	// Finalize, the event log state for the current statement.
-	b.FinalizeEventLogState(n)
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -35,6 +35,7 @@ func NewBuilderDependencies(
 	descsCollection *descs.Collection,
 	schemaResolver resolver.SchemaResolver,
 	authAccessor scbuild.AuthorizationAccessor,
+	astFormatter scbuild.AstFormatter,
 	sessionData *sessiondata.SessionData,
 	settings *cluster.Settings,
 	statements []string,
@@ -48,6 +49,7 @@ func NewBuilderDependencies(
 		sessionData:     sessionData,
 		settings:        settings,
 		statements:      statements,
+		astFormatter:    astFormatter,
 	}
 }
 
@@ -60,6 +62,7 @@ type buildDeps struct {
 	sessionData     *sessiondata.SessionData
 	settings        *cluster.Settings
 	statements      []string
+	astFormatter    scbuild.AstFormatter
 }
 
 var _ scbuild.CatalogReader = (*buildDeps)(nil)
@@ -222,4 +225,8 @@ func (d *buildDeps) ClusterSettings() *cluster.Settings {
 // Statements implements the scbuild.Dependencies interface.
 func (d *buildDeps) Statements() []string {
 	return d.statements
+}
+
+func (d *buildDeps) AstFormatter() scbuild.AstFormatter {
+	return d.astFormatter
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -18,10 +18,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/redact"
 )
 
 // TestState is a backing struct used to implement all schema changer
@@ -97,4 +100,16 @@ func (s *TestState) JobRecord(jobID jobspb.JobID) *jobs.Record {
 		return nil
 	}
 	return &s.jobs[idx]
+}
+
+// FormatAstAsRedactableString implements scbuild.AstFormatter
+func (s *TestState) FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString {
+	// Return the SQL back non-redacted and not fully resolved for the purposes
+	// of testing.
+	return redact.RedactableString(statement.String())
+}
+
+// AstFormatter dummy formatter for AST nodes.
+func (s *TestState) AstFormatter() scbuild.AstFormatter {
+	return s
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -103,10 +103,17 @@ func (s *TestState) JobRecord(jobID jobspb.JobID) *jobs.Record {
 }
 
 // FormatAstAsRedactableString implements scbuild.AstFormatter
-func (s *TestState) FormatAstAsRedactableString(statement tree.Statement) redact.RedactableString {
+func (s *TestState) FormatAstAsRedactableString(
+	statement tree.Statement, ann *tree.Annotations,
+) redact.RedactableString {
 	// Return the SQL back non-redacted and not fully resolved for the purposes
 	// of testing.
-	return redact.RedactableString(statement.String())
+	f := tree.NewFmtCtx(
+		tree.FmtAlwaysQualifyTableNames|tree.FmtMarkRedactionNode,
+		tree.FmtAnnotations(ann))
+	f.FormatNode(statement)
+	formattedRedactableStatementString := f.CloseAndGetString()
+	return redact.RedactableString(formattedRedactableStatementString)
 }
 
 // AstFormatter dummy formatter for AST nodes.

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -63,6 +63,7 @@ func WithBuilderDependenciesFromTestServer(
 		SessionData() *sessiondata.SessionData
 		resolver.SchemaResolver
 		scbuild.AuthorizationAccessor
+		scbuild.AstFormatter
 	})
 	// For setting up a builder inside tests we will ensure that the new schema
 	// changer will allow non-fully implemented operations.
@@ -71,6 +72,7 @@ func WithBuilderDependenciesFromTestServer(
 		execCfg.Codec,
 		planner.Txn(),
 		planner.Descriptors(),
+		planner,
 		planner,
 		planner,
 		planner.SessionData(),

--- a/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/scmutationexec.go
@@ -903,6 +903,7 @@ func (m *visitor) LogEvent(ctx context.Context, op scop.LogEvent) error {
 		ApplicationName: op.Authorization.AppName,
 		User:            op.Authorization.UserName,
 		Statement:       redact.RedactableString(op.Statement),
+		Tag:             op.StatementTag,
 	}
 	return m.s.EnqueueEvent(descID, op.TargetMetadata, details, event)
 }

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -298,6 +298,7 @@ type LogEvent struct {
 	TargetMetadata scpb.TargetMetadata
 	Authorization  scpb.Authorization
 	Statement      string
+	StatementTag   string
 	Element        scpb.ElementProto
 	TargetStatus   scpb.Status
 }

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -61,6 +61,7 @@ message TargetState {
 
 message Statement {
   string statement = 1;
+  string redacted_statement = 2;
 }
 
 message Authorization {

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -62,6 +62,7 @@ message TargetState {
 message Statement {
   string statement = 1;
   string redacted_statement = 2;
+  string statement_tag = 3;
 }
 
 message Authorization {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -26,7 +26,7 @@ func newLogEventOp(e scpb.Element, ts scpb.TargetState) *scop.LogEvent {
 			return &scop.LogEvent{
 				TargetMetadata: *protoutil.Clone(&t.Metadata).(*scpb.TargetMetadata),
 				Authorization:  *protoutil.Clone(&ts.Authorization).(*scpb.Authorization),
-				Statement:      ts.Statements[t.Metadata.StatementID].Statement,
+				Statement:      ts.Statements[t.Metadata.StatementID].RedactedStatement,
 				Element:        *protoutil.Clone(&t.ElementProto).(*scpb.ElementProto),
 				TargetStatus:   t.TargetStatus,
 			}

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -27,6 +27,7 @@ func newLogEventOp(e scpb.Element, ts scpb.TargetState) *scop.LogEvent {
 				TargetMetadata: *protoutil.Clone(&t.Metadata).(*scpb.TargetMetadata),
 				Authorization:  *protoutil.Clone(&ts.Authorization).(*scpb.Authorization),
 				Statement:      ts.Statements[t.Metadata.StatementID].RedactedStatement,
+				StatementTag:   ts.Statements[t.Metadata.StatementID].StatementTag,
 				Element:        *protoutil.Clone(&t.ElementProto).(*scpb.ElementProto),
 				TargetStatus:   t.TargetStatus,
 			}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table
@@ -34,7 +34,8 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -60,6 +61,8 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
           UserName: root
         Statements:
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8
+          statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 4 with 3 MutationType ops
   transitions:
     [[Column:{DescID: 54, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -181,7 +184,8 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8 DEFAULT ‹123›
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -207,6 +211,9 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
           UserName: root
         Statements:
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8 DEFAULT
+            ‹123›
+          statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 4 with 3 MutationType ops
   transitions:
     [[Column:{DescID: 54, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -330,7 +337,8 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8 DEFAULT ‹123›
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -361,7 +369,8 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN k INT8 DEFAULT 456
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹k› INT8 DEFAULT ‹456›
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         StatementID: 1
@@ -389,7 +398,13 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
           UserName: root
         Statements:
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN j INT8 DEFAULT 123
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹j› INT8 DEFAULT
+            ‹123›
+          statementtag: ALTER TABLE
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN k INT8 DEFAULT 456
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹k› INT8 DEFAULT
+            ‹456›
+          statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 4 with 4 MutationType ops
   transitions:
     [[Column:{DescID: 54, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -524,7 +539,9 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8 AS (i + 1) STORED
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹a› INT8 AS (‹i› + ‹1›)
+        STORED
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -550,6 +567,9 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
           UserName: root
         Statements:
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8 AS (i + 1) STORED
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹a› INT8 AS
+            (‹i› + ‹1›) STORED
+          statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 4 with 3 MutationType ops
   transitions:
     [[Column:{DescID: 54, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -677,7 +697,8 @@ PreCommitPhase stage 1 of 1 with 9 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8
+      Statement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹a› INT8
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -717,7 +738,8 @@ PreCommitPhase stage 1 of 1 with 9 MutationType ops
             family: IntFamily
             oid: 20
             width: 64
-      Statement: ALTER TABLE defaultdb.bar ADD COLUMN b INT8
+      Statement: ALTER TABLE ‹defaultdb›.public.‹bar› ADD COLUMN ‹b› INT8
+      StatementTag: ALTER TABLE
       TargetMetadata:
         SourceElementID: 1
         StatementID: 1
@@ -748,7 +770,11 @@ PreCommitPhase stage 1 of 1 with 9 MutationType ops
           UserName: root
         Statements:
         - statement: ALTER TABLE defaultdb.foo ADD COLUMN a INT8
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹foo› ADD COLUMN ‹a› INT8
+          statementtag: ALTER TABLE
         - statement: ALTER TABLE defaultdb.bar ADD COLUMN b INT8
+          redactedstatement: ALTER TABLE ‹defaultdb›.public.‹bar› ADD COLUMN ‹b› INT8
+          statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 4 with 5 MutationType ops
   transitions:
     [[Column:{DescID: 54, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -31,6 +31,9 @@ PreCommitPhase stage 1 of 1 with 3 MutationType ops
           UserName: root
         Statements:
         - statement: CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
+          redactedstatement: CREATE INDEX ‹id1› ON ‹defaultdb›.public.‹t1› (‹id›, ‹name›)
+            STORING (‹money›)
+          statementtag: CREATE INDEX
 PostCommitPhase stage 1 of 4 with 2 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 54, IndexID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -117,6 +120,9 @@ PreCommitPhase stage 1 of 1 with 3 MutationType ops
         Statements:
         - statement: CREATE INVERTED INDEX CONCURRENTLY id1 ON defaultdb.t1 (id, name) STORING
             (money)
+          redactedstatement: CREATE INVERTED INDEX CONCURRENTLY ‹id1› ON ‹defaultdb›.public.‹t1›
+            (‹id›, ‹name›) STORING (‹money›)
+          statementtag: CREATE INDEX
 PostCommitPhase stage 1 of 4 with 2 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 54, IndexID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY
@@ -212,6 +218,9 @@ PreCommitPhase stage 1 of 1 with 4 MutationType ops
         Statements:
         - statement: CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money) PARTITION
             BY LIST (id) (PARTITION p1 VALUES IN (1))
+          redactedstatement: CREATE INDEX ‹id1› ON ‹defaultdb›.public.‹t1› (‹id›, ‹name›)
+            STORING (‹money›) PARTITION BY LIST (‹id›) (PARTITION ‹p1› VALUES IN (‹1›))
+          statementtag: CREATE INDEX
 PostCommitPhase stage 1 of 4 with 2 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 54, IndexID: 2}, PUBLIC], DELETE_ONLY] -> DELETE_AND_WRITE_ONLY

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -342,6 +342,8 @@ PreCommitPhase stage 1 of 1 with 56 MutationType ops
           UserName: root
         Statements:
         - statement: DROP DATABASE db1 CASCADE
+          redactedstatement: DROP DATABASE ‹db1› CASCADE
+          statementtag: DROP DATABASE
 PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
   transitions:
     [[Sequence:{DescID: 57}, ABSENT], DROPPED] -> ABSENT
@@ -373,7 +375,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Sequence:
           sequenceId: 57
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 3
         SubWorkID: 1
@@ -386,7 +389,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Table:
           tableId: 60
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 3
         SubWorkID: 1
@@ -404,7 +408,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
           - 57
           - 60
           schemaId: 55
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -417,7 +422,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Sequence:
           sequenceId: 58
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -430,7 +436,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Table:
           tableId: 59
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -443,7 +450,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         View:
           tableId: 61
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 8
         SubWorkID: 1
@@ -456,7 +464,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         View:
           tableId: 62
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 9
         SubWorkID: 1
@@ -469,7 +478,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         View:
           tableId: 63
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 10
         SubWorkID: 1
@@ -482,7 +492,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         View:
           tableId: 64
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 10
         SubWorkID: 1
@@ -495,7 +506,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         View:
           tableId: 67
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 12
         SubWorkID: 1
@@ -508,7 +520,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Type:
           typeId: 65
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -521,7 +534,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
       Element:
         Type:
           typeId: 66
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -546,7 +560,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
           - 66
           - 67
           schemaId: 56
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -564,7 +579,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
           dependentObjects:
           - 55
           - 56
-      Statement: DROP DATABASE db1 CASCADE
+      Statement: DROP DATABASE ‹db1› CASCADE
+      StatementTag: DROP DATABASE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -615,6 +615,8 @@ PreCommitPhase stage 1 of 1 with 43 MutationType ops
           UserName: root
         Statements:
         - statement: DROP SCHEMA defaultdb.sc1 CASCADE
+          redactedstatement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+          statementtag: DROP SCHEMA
 PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
   transitions:
     [[Sequence:{DescID: 55}, ABSENT], DROPPED] -> ABSENT
@@ -638,7 +640,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         Sequence:
           sequenceId: 55
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -651,7 +654,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         Table:
           tableId: 56
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -664,7 +668,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         View:
           tableId: 57
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 4
         SubWorkID: 1
@@ -677,7 +682,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         View:
           tableId: 58
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 5
         SubWorkID: 1
@@ -690,7 +696,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         View:
           tableId: 59
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -703,7 +710,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         View:
           tableId: 60
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 6
         SubWorkID: 1
@@ -716,7 +724,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         View:
           tableId: 63
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 8
         SubWorkID: 1
@@ -729,7 +738,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         Type:
           typeId: 61
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -742,7 +752,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
       Element:
         Type:
           typeId: 62
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -767,7 +778,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 33 MutationType ops
           - 62
           - 63
           schemaId: 54
-      Statement: DROP SCHEMA defaultdb.sc1 CASCADE
+      Statement: DROP SCHEMA ‹defaultdb›.‹sc1› CASCADE
+      StatementTag: DROP SCHEMA
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -35,6 +35,8 @@ PreCommitPhase stage 1 of 1 with 4 MutationType ops
           UserName: root
         Statements:
         - statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+          redactedstatement: DROP SEQUENCE ‹defaultdb›.public.‹sq1› CASCADE
+          statementtag: DROP SEQUENCE
 PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
   transitions:
     [[Sequence:{DescID: 54}, ABSENT], DROPPED] -> ABSENT
@@ -45,7 +47,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
       Element:
         Sequence:
           sequenceId: 54
-      Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+      Statement: DROP SEQUENCE ‹defaultdb›.public.‹sq1› CASCADE
+      StatementTag: DROP SEQUENCE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -126,6 +129,8 @@ PreCommitPhase stage 1 of 1 with 12 MutationType ops
           UserName: root
         Statements:
         - statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+          redactedstatement: DROP SEQUENCE ‹defaultdb›.public.‹sq1› CASCADE
+          statementtag: DROP SEQUENCE
 PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
   transitions:
     [[Sequence:{DescID: 54}, ABSENT], DROPPED] -> ABSENT
@@ -136,7 +141,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
       Element:
         Sequence:
           sequenceId: 54
-      Statement: DROP SEQUENCE defaultdb.sq1 CASCADE
+      Statement: DROP SEQUENCE ‹defaultdb›.public.‹sq1› CASCADE
+      StatementTag: DROP SEQUENCE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -156,6 +156,8 @@ PreCommitPhase stage 1 of 1 with 22 MutationType ops
           UserName: root
         Statements:
         - statement: DROP TABLE defaultdb.shipments CASCADE
+          redactedstatement: DROP TABLE ‹defaultdb›.public.‹shipments› CASCADE
+          statementtag: DROP TABLE
 PostCommitNonRevertiblePhase stage 1 of 1 with 13 MutationType ops
   transitions:
     [[Table:{DescID: 57}, ABSENT], DROPPED] -> ABSENT
@@ -174,7 +176,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 13 MutationType ops
       Element:
         Table:
           tableId: 57
-      Statement: DROP TABLE defaultdb.shipments CASCADE
+      Statement: DROP TABLE ‹defaultdb›.public.‹shipments› CASCADE
+      StatementTag: DROP TABLE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -187,7 +190,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 13 MutationType ops
       Element:
         View:
           tableId: 59
-      Statement: DROP TABLE defaultdb.shipments CASCADE
+      Statement: DROP TABLE ‹defaultdb›.public.‹shipments› CASCADE
+      StatementTag: DROP TABLE
       TargetMetadata:
         SourceElementID: 3
         SubWorkID: 1
@@ -200,7 +204,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 13 MutationType ops
       Element:
         Sequence:
           sequenceId: 58
-      Statement: DROP TABLE defaultdb.shipments CASCADE
+      Statement: DROP TABLE ‹defaultdb›.public.‹shipments› CASCADE
+      StatementTag: DROP TABLE
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -42,6 +42,8 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
           UserName: root
         Statements:
         - statement: DROP TYPE defaultdb.typ
+          redactedstatement: DROP TYPE ‹defaultdb›.‹public›.‹typ›
+          statementtag: DROP TYPE
 PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
   transitions:
     [[Type:{DescID: 54}, ABSENT], DROPPED] -> ABSENT
@@ -53,7 +55,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
       Element:
         Type:
           typeId: 54
-      Statement: DROP TYPE defaultdb.typ
+      Statement: DROP TYPE ‹defaultdb›.‹public›.‹typ›
+      StatementTag: DROP TYPE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -66,7 +69,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
       Element:
         Type:
           typeId: 55
-      Statement: DROP TYPE defaultdb.typ
+      Statement: DROP TYPE ‹defaultdb›.‹public›.‹typ›
+      StatementTag: DROP TYPE
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -46,6 +46,8 @@ PreCommitPhase stage 1 of 1 with 6 MutationType ops
           UserName: root
         Statements:
         - statement: DROP VIEW defaultdb.v1
+          redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1›
+          statementtag: DROP VIEW
 PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
   transitions:
     [[View:{DescID: 55}, ABSENT], DROPPED] -> ABSENT
@@ -56,7 +58,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
       Element:
         View:
           tableId: 55
-      Statement: DROP VIEW defaultdb.v1
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1›
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -265,6 +268,8 @@ PreCommitPhase stage 1 of 1 with 25 MutationType ops
           UserName: root
         Statements:
         - statement: DROP VIEW defaultdb.v1 CASCADE
+          redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+          statementtag: DROP VIEW
 PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
   transitions:
     [[View:{DescID: 55}, ABSENT], DROPPED] -> ABSENT
@@ -279,7 +284,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
       Element:
         View:
           tableId: 55
-      Statement: DROP VIEW defaultdb.v1 CASCADE
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 1
         SubWorkID: 1
@@ -292,7 +298,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
       Element:
         View:
           tableId: 56
-      Statement: DROP VIEW defaultdb.v1 CASCADE
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 2
         SubWorkID: 1
@@ -305,7 +312,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
       Element:
         View:
           tableId: 57
-      Statement: DROP VIEW defaultdb.v1 CASCADE
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 3
         SubWorkID: 1
@@ -318,7 +326,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
       Element:
         View:
           tableId: 58
-      Statement: DROP VIEW defaultdb.v1 CASCADE
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 3
         SubWorkID: 1
@@ -331,7 +340,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 17 MutationType ops
       Element:
         View:
           tableId: 61
-      Statement: DROP VIEW defaultdb.v1 CASCADE
+      Statement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
+      StatementTag: DROP VIEW
       TargetMetadata:
         SourceElementID: 5
         SubWorkID: 1

--- a/pkg/sql/schemachanger/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/testdata/alter_table_add_column
@@ -17,7 +17,7 @@ begin transaction #1
 ## PreCommitPhase stage 1 of 1 with 5 MutationType ops
 create job #1: "schema change job"
   descriptor IDs: [56]
-write *eventpb.AlterTable to event log for descriptor #56: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+write *eventpb.AlterTable to event log for descriptor #56: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›
 upsert descriptor #56
   ...
      - columnIds:

--- a/pkg/sql/schemachanger/testdata/drop
+++ b/pkg/sql/schemachanger/testdata/drop
@@ -38,7 +38,7 @@ commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
-write *eventpb.DropSchema to event log for descriptor #56: DROP SCHEMA db.sc
+write *eventpb.DropSchema to event log for descriptor #56: DROP SCHEMA ‹db›.‹sc›
 update progress of schema change job #1
 set schema change job #1 to non-cancellable
 delete schema namespace entry {54 0 sc} -> 56
@@ -90,7 +90,7 @@ begin transaction #2
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
 create job #2: "GC for dropping descriptor 58"
   descriptor IDs: [58]
-write *eventpb.DropTable to event log for descriptor #58: DROP TABLE db.sc.t
+write *eventpb.DropTable to event log for descriptor #58: DROP TABLE ‹db›.‹sc›.‹t›
 update progress of schema change job #1
 set schema change job #1 to non-cancellable
 upsert descriptor #58
@@ -155,7 +155,7 @@ commit transaction #1
 # begin PostCommitPhase
 begin transaction #2
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 12 MutationType ops
-write *eventpb.DropSchema to event log for descriptor #57: DROP SCHEMA db.sc CASCADE
+write *eventpb.DropSchema to event log for descriptor #57: DROP SCHEMA ‹db›.‹sc› CASCADE
 update progress of schema change job #1
 set schema change job #1 to non-cancellable
 delete schema namespace entry {54 0 sc} -> 57
@@ -201,7 +201,7 @@ begin transaction #2
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 9 MutationType ops
 create job #2: "GC for dropping descriptors and parent database 54"
   descriptor IDs: []
-write *eventpb.DropDatabase to event log for descriptor #54: DROP DATABASE db CASCADE
+write *eventpb.DropDatabase to event log for descriptor #54: DROP DATABASE ‹db› CASCADE
 update progress of schema change job #1
 set schema change job #1 to non-cancellable
 delete database namespace entry {0 0 db} -> 54
@@ -566,7 +566,7 @@ begin transaction #2
 ## PostCommitNonRevertiblePhase stage 1 of 1 with 46 MutationType ops
 create job #2: "GC for dropping descriptors 64 67 65 66 68 69 70 71 74 and parent database 61"
   descriptor IDs: [64 67 65 66 68 69 70 71 74]
-write *eventpb.DropDatabase to event log for descriptor #61: DROP DATABASE db1 CASCADE
+write *eventpb.DropDatabase to event log for descriptor #61: DROP DATABASE ‹db1› CASCADE
 update progress of schema change job #1
 set schema change job #1 to non-cancellable
 delete database namespace entry {0 0 db1} -> 61


### PR DESCRIPTION
Previously, the declarative schema changer did not include
tags or fully resolve object names in event log entries. This was 
inadequate because the declarative schema changer did not 
have the same event logs as the existing schema changer. 
To address this, these patches will add a statement tags, 
fully resolve schema names and add the ability to annotate
the names inside the SQL AST inside the declarative schema 
change builder.

Release Note: None