### PR TITLE
release-21.2: sql: do not use GetRequests for reverse scans

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -208,7 +208,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if params.InvertedConstraint != nil {
 		spans, err = sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint)
 	} else {
-		spans, err = sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
+		spans, err = sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */, params.Reverse)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/sqllite
+++ b/pkg/sql/logictest/testdata/logic_test/sqllite
@@ -449,3 +449,12 @@ SELECT pk, col0 FROM tab64784 WHERE (col0 IN (SELECT col3 FROM tab64784 WHERE co
 4  216
 1  213
 0  212
+
+# Regression test for crashing when intertwining Get and RevScan requests
+# (which is illegal at the moment).
+statement ok
+CREATE TABLE t73103(pk INT PRIMARY KEY, col0 INT, col1 INT, UNIQUE INDEX idx_storing (col0) STORING (col1));
+
+query II
+SELECT pk, col0 FROM t73103@idx_storing WHERE col0 <= 63 OR col0 IN (27,11,93,41) ORDER BY 2 DESC
+----

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1919,3 +1919,24 @@ vectorized: true
   missing stats
   table: t4@primary
   spans: [/1/1 - /1/1] [/1/5 - /1/5] [/5/1 - /5/1] [/5/5 - /5/5]
+
+# Regression test for crashing when intertwining Get and RevScan requests
+# (which is illegal at the moment).
+statement ok
+CREATE TABLE t73103(pk INT PRIMARY KEY, col0 INT, col1 INT, UNIQUE INDEX idx_storing (col0) STORING (col1));
+
+# Get the range id.
+let $rangeid
+SELECT range_id FROM [ SHOW RANGES FROM TABLE t73103 ]
+
+statement ok
+SET tracing = on,kv,results;
+SELECT pk, col0 FROM t73103@idx_storing WHERE col0 <= 63 OR col0 IN (27,11,93,41) ORDER BY 2 DESC;
+SET tracing = off
+
+# Ensure that two RevScan requests are used.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+WHERE message LIKE '%r$rangeid: sending batch%'
+----
+r45: sending batch 2 RevScan to (n1,s1):1

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -151,7 +151,7 @@ func generateScanSpans(
 	if params.InvertedConstraint != nil {
 		return sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint)
 	}
-	return sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */)
+	return sb.SpansFromConstraint(params.IndexConstraint, params.NeededCols, false /* forDelete */, params.Reverse)
 }
 
 func (ef *execFactory) constructVirtualScan(
@@ -1719,7 +1719,7 @@ func (ef *execFactory) ConstructDeleteRange(
 
 	// Setting the "forDelete" flag includes all column families in case where a
 	// single record is deleted.
-	spans, err := sb.SpansFromConstraint(indexConstraint, needed, true /* forDelete */)
+	spans, err := sb.SpansFromConstraint(indexConstraint, needed, true /* forDelete */, false /* reverse */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -313,13 +313,13 @@ func (s *Builder) CanSplitSpanIntoFamilySpans(
 // TODO (rohany): In future work, there should be a single API to generate spans
 //  from constraints, datums and encdatums.
 func (s *Builder) SpansFromConstraint(
-	c *constraint.Constraint, needed exec.TableColumnOrdinalSet, forDelete bool,
+	c *constraint.Constraint, needed exec.TableColumnOrdinalSet, forDelete bool, reverse bool,
 ) (roachpb.Spans, error) {
 	var spans roachpb.Spans
 	var err error
 	if c == nil || c.IsUnconstrained() {
 		// Encode a full span.
-		spans, err = s.appendSpansFromConstraintSpan(spans, &constraint.UnconstrainedSpan, needed, forDelete)
+		spans, err = s.appendSpansFromConstraintSpan(spans, &constraint.UnconstrainedSpan, needed, forDelete, reverse)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func (s *Builder) SpansFromConstraint(
 
 	spans = make(roachpb.Spans, 0, c.Spans.Count())
 	for i := 0; i < c.Spans.Count(); i++ {
-		spans, err = s.appendSpansFromConstraintSpan(spans, c.Spans.Get(i), needed, forDelete)
+		spans, err = s.appendSpansFromConstraintSpan(spans, c.Spans.Get(i), needed, forDelete, reverse)
 		if err != nil {
 			return nil, err
 		}
@@ -339,16 +339,21 @@ func (s *Builder) SpansFromConstraint(
 // UnconstrainedSpans returns the full span corresponding to the Builder's
 // table and index.
 func (s *Builder) UnconstrainedSpans() (roachpb.Spans, error) {
-	return s.SpansFromConstraint(nil, exec.TableColumnOrdinalSet{}, false /* forDelete */)
+	return s.SpansFromConstraint(nil, exec.TableColumnOrdinalSet{}, false /* forDelete */, false /* reverse */)
 }
 
 // appendSpansFromConstraintSpan converts a constraint.Span to one or more
 // roachpb.Spans and appends them to the provided spans. It appends multiple
 // spans in the case that multiple, non-adjacent column families should be
 // scanned. The forDelete parameter indicates whether these spans will be used
-// for row deletion.
+// for row deletion. The reverse parameter indicates whether these spans will be
+// scanned in the reverse order.
 func (s *Builder) appendSpansFromConstraintSpan(
-	appendTo roachpb.Spans, cs *constraint.Span, needed exec.TableColumnOrdinalSet, forDelete bool,
+	appendTo roachpb.Spans,
+	cs *constraint.Span,
+	needed exec.TableColumnOrdinalSet,
+	forDelete bool,
+	reverse bool,
 ) (roachpb.Spans, error) {
 	var span roachpb.Span
 	var err error
@@ -375,9 +380,13 @@ func (s *Builder) appendSpansFromConstraintSpan(
 	// families, only scan the relevant column families, and use GetRequests
 	// instead of ScanRequests when doing the column family fetches. This is
 	// disabled for deletions on tables with multiple column families to ensure
-	// that the entire row (all of its column families) is deleted.
-
-	if needed.Len() > 0 && span.Key.Equal(span.EndKey) && !forDelete {
+	// that the entire row (all of its column families) is deleted. It is also
+	// disabled when spans will be scanned in the reverse order because of the
+	// limitations of the DistSender (which cannot have multiple sub-batches
+	// when setting limits, and we'll get two sub-batches when combining Get and
+	// ReverseScan requests because these two types are considered to be of
+	// different directions at the moment).
+	if needed.Len() > 0 && span.Key.Equal(span.EndKey) && !forDelete && !reverse {
 		neededFamilyIDs := rowenc.NeededColumnFamilyIDs(needed, s.table, s.index)
 		if s.CanSplitSpanIntoFamilySpans(len(neededFamilyIDs), cs.StartKey().Length(), containsNull) {
 			return rowenc.SplitRowKeyIntoFamilySpans(appendTo, span.Key, neededFamilyIDs), nil


### PR DESCRIPTION
During 21.2 release cycle we expanded the usage of GetRequests. However,
currently the DistSender doesn't support intertwining "forward" and
"reverse" requests in a single batch, and GetRequests are (mistakenly)
considered "forward". As a result, when performing a reverse scan, if we
end up using a mix of Get and ReverseScan requests, CRDB node crashes.
This is fixed by disabling the usage of the Get requests if the spans
will be scanned in the reverse order.

Fixes: #73698.

Release note (bug fix): Previously, CockroachDB could crash when reading
of a secondary index with STORING clause in reverse direction (because
of ORDER BY col DESC). The bug was introduced in 21.2.