### PR TITLE
ui: update reset index stats button text

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -368,7 +368,7 @@ export class DatabaseTablePage extends React.Component<
                     <div className={cx("index-stats__reset-info")}>
                       <Tooltip
                         placement="bottom"
-                        title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset index stats’ will reset index stats for the entire cluster."
+                        title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
                       >
                         <div
                           className={cx("index-stats__last-reset", "underline")}
@@ -390,7 +390,7 @@ export class DatabaseTablePage extends React.Component<
                             )
                           }
                         >
-                          Reset index stats
+                          Reset all index stats
                         </a>
                       </div>
                     </div>

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -157,7 +157,7 @@ export class IndexDetailsPage extends React.Component<
             <div className={cx("reset-info")}>
               <Tooltip
                 placement="bottom"
-                title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset index stats’ will reset index stats for the entire cluster."
+                title="Index stats accumulate from the time they were last cleared. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
               >
                 <div className={cx("last-reset", "underline")}>
                   Last reset:{" "}
@@ -174,7 +174,7 @@ export class IndexDetailsPage extends React.Component<
                     )
                   }
                 >
-                  Reset index stats
+                  Reset all index stats
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Since the "reset index stats" button currently clears all index stats
for a database, we're updating the button text to be a little more
clear. This can be changed back once resetting by level (index, table,
cluster) is implemented.

<img width="398" alt="Screen Shot 2021-12-10 at 5 21 44 PM" src="https://user-images.githubusercontent.com/29153209/145649181-f7165f67-024e-40c5-893b-05c59e1e85e1.png">
<img width="398" alt="Screen Shot 2021-12-10 at 5 21 37 PM" src="https://user-images.githubusercontent.com/29153209/145649190-99f5ddcf-0648-4c21-9af9-92a2c5d0825e.png">


Release note (ui change): update "reset index stats" button text to be
more clear