### PR TITLE
changefeedccl: handle virtual columns

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -251,6 +251,9 @@ func changefeedPlanHook(
 				if err := changefeedbase.ValidateTable(targets, table); err != nil {
 					return err
 				}
+				for _, warning := range changefeedbase.WarningsForTable(targets, table) {
+					p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
+				}
 			}
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2232,13 +2232,12 @@ func TestChangefeedNoBackfill(t *testing.T) {
 	t.Run(`webhook`, webhookTest(testFn))
 }
 
-func TestChangefeedComputedColumn(t *testing.T) {
+func TestChangefeedStoredComputedColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(db)
-		// TODO(dan): Also test a non-STORED computed column once we support them.
 		sqlDB.Exec(t, `CREATE TABLE cc (
 		a INT, b INT AS (a + 1) STORED, c INT AS (a + 2) STORED, PRIMARY KEY (b, a)
 	)`)
@@ -2254,6 +2253,36 @@ func TestChangefeedComputedColumn(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (10)`)
 		assertPayloads(t, cc, []string{
 			`cc: [11, 10]->{"after": {"a": 10, "b": 11, "c": 12}}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`kafka`, kafkaTest(testFn))
+	t.Run(`webhook`, webhookTest(testFn))
+}
+
+func TestChangefeedVirtualComputedColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE cc (
+		a INT primary key, b INT, c INT AS (b + 1) VIRTUAL NOT NULL
+	)`)
+		sqlDB.Exec(t, `INSERT INTO cc VALUES (1, 1)`)
+
+		cc := feed(t, f, `CREATE CHANGEFEED FOR cc with diff`)
+		defer closeFeed(t, cc)
+
+		assertPayloads(t, cc, []string{
+			`cc: [1]->{"after": {"a": 1, "b": 1, "c": null}, "before": null}`,
+		})
+
+		sqlDB.Exec(t, `UPDATE cc SET b=10 WHERE a=1`)
+		assertPayloads(t, cc, []string{
+			`cc: [1]->{"after": {"a": 1, "b": 10, "c": null}, "before": {"a": 1, "b": 1, "c": null}}`,
 		})
 	}
 

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -55,3 +55,16 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 
 	return nil
 }
+
+// WarningsForTable returns any known nonfatal issues with running a changefeed on this kind of table.
+func WarningsForTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDescriptor) []error {
+	warnings := []error{}
+	for _, col := range tableDesc.AccessibleColumns() {
+		if col.IsVirtual() {
+			warnings = append(warnings,
+				errors.Errorf("Changefeeds will emit null values for virtual column %s in table %s", col.ColName(), tableDesc.GetName()),
+			)
+		}
+	}
+	return warnings
+}

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -173,6 +173,10 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 	); err != nil {
 		return nil, err
 	}
+
+	// Necessary because virtual columns are not populated.
+	rf.IgnoreUnexpectedNulls = true
+
 	// TODO(dan): Bound the size of the cache. Resolved notifications will let
 	// us evict anything for timestamps entirely before the notification. Then
 	// probably an LRU just in case?


### PR DESCRIPTION
Virtual computed columns aren't populated in kvfeed, so changefeeds
have been quietly populating them with null. We need to maintain this
behavior for now for backwards compatibility and performance, but
this PR tests it and adds a warning when the feed is created.
It also fixes a bug where if a NOT NULL constraint was set on a virtual column,
the changefeed would error out when fetching a row.

Release note (bug fix): Changefeeds will emit null values for virtual computed columns. Previously, they would crash if these were set to NOT NULL.

fixes https://github.com/cockroachdb/cockroach/issues/73138 