### PR TITLE
ui: fix index count on Database Details Page indexes column

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -196,7 +196,53 @@ describe("Database Details Page", function() {
       ],
       // The actual contents below don't matter to us; we just count them.
       columns: [{}, {}, {}, {}, {}],
-      indexes: [{}, {}, {}],
+      indexes: [
+        {
+          name: "jobs_run_stats_idx",
+          unique: false,
+          seq: new Long(6),
+          column: "claim_instance_id",
+          direction: "N/A",
+          storing: true,
+          implicit: false,
+        },
+        {
+          name: "jobs_run_stats_idx",
+          unique: false,
+          seq: new Long(7),
+          column: "id",
+          direction: "ASC",
+          storing: false,
+          implicit: true,
+        },
+        {
+          name: "jobs_status_created_idx",
+          unique: false,
+          seq: new Long(2),
+          column: "created",
+          direction: "ASC",
+          storing: false,
+          implicit: false,
+        },
+        {
+          name: "jobs_status_created_idx",
+          unique: false,
+          seq: new Long(3),
+          column: "id",
+          direction: "ASC",
+          storing: false,
+          implicit: true,
+        },
+        {
+          name: "primary",
+          unique: true,
+          seq: new Long(1),
+          column: "id",
+          direction: "ASC",
+          storing: false,
+          implicit: false,
+        },
+      ],
     });
 
     fakeApi.stubTableDetails("things", "bar", {
@@ -207,7 +253,44 @@ describe("Database Details Page", function() {
       ],
       // The actual contents below don't matter to us; we just count them.
       columns: [{}, {}, {}, {}],
-      indexes: [{}, {}],
+      indexes: [
+        {
+          name: "primary",
+          unique: true,
+          seq: new Long(1),
+          column: "type",
+          direction: "ASC",
+          storing: false,
+          implicit: false,
+        },
+        {
+          name: "primary",
+          unique: true,
+          seq: new Long(2),
+          column: "object_id",
+          direction: "ASC",
+          storing: false,
+          implicit: false,
+        },
+        {
+          name: "primary",
+          unique: true,
+          seq: new Long(3),
+          column: "sub_id",
+          direction: "ASC",
+          storing: false,
+          implicit: false,
+        },
+        {
+          name: "primary",
+          unique: true,
+          seq: new Long(4),
+          column: "comment",
+          direction: "N/A",
+          storing: true,
+          implicit: false,
+        },
+      ],
     });
 
     await driver.refreshDatabaseDetails();
@@ -228,7 +311,7 @@ describe("Database Details Page", function() {
       loading: false,
       loaded: true,
       columnCount: 4,
-      indexCount: 2,
+      indexCount: 1,
       userCount: 3,
       roles: ["root", "app", "data"],
       grants: ["ALL", "SELECT", "INSERT"],

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -101,6 +101,9 @@ export const mapStateToProps = createSelector(
           _.flatMap(details?.data?.grants, "privileges"),
         );
         const nodes = stats?.data?.node_ids || [];
+        const numIndexes = _.uniq(
+          _.map(details?.data?.indexes, index => index.name),
+        ).length;
 
         return {
           name: table,
@@ -108,7 +111,7 @@ export const mapStateToProps = createSelector(
             loading: !!details?.inFlight,
             loaded: !!details?.valid,
             columnCount: details?.data?.columns?.length || 0,
-            indexCount: details?.data?.indexes?.length || 0,
+            indexCount: numIndexes,
             userCount: roles.length,
             roles: roles,
             grants: grants,


### PR DESCRIPTION
Resolves #72655

Previously, the index count on the Database Details page was misleading
because it referred to the total number of columns that contained an
index rather than the number of indexes. This commit fixes that issue by
counting the unique index names returned in the API response rather than
the total length of the indexes array.

Release note (bug fix): use correct index count on the indexes column on
the Database Details page