### PR TITLE
roachtest: don't abort test suite when cluster creation fails

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/cmd/roachtest/test",
         "//pkg/roachprod/logger",
         "//pkg/testutils",
+        "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/version",

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -415,7 +415,7 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 	err = runner.Run(
 		ctx, tests, cfg.count, cfg.parallelism, opt,
 		testOpts{versionsBinaryOverride: cfg.versionsBinaryOverride},
-		lopt)
+		lopt, nil /* clusterAllocator */)
 
 	// Make sure we attempt to clean up. We run with a non-canceled ctx; the
 	// ctx above might be canceled in case a signal was received. If that's

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -27,4 +27,5 @@ const (
 	OwnerSQLSchema     Owner = `sql-schema`
 	OwnerStorage       Owner = `storage`
 	OwnerTestEng       Owner = `test-eng`
+	OwnerDevInf        Owner = `dev-inf`
 )

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -87,6 +88,16 @@ func nilLogger() *logger.Logger {
 		panic(err)
 	}
 	return l
+}
+
+func alwaysFailingClusterAllocator(
+	ctx context.Context,
+	t registry.TestSpec,
+	alloc *quotapool.IntAlloc,
+	artifactsDir string,
+	wStatus *workerStatus,
+) (*clusterImpl, error) {
+	return nil, errors.New("cluster creation failed")
 }
 
 func TestRunnerRun(t *testing.T) {
@@ -153,17 +164,50 @@ func TestRunnerRun(t *testing.T) {
 				cpuQuota:                  1000,
 				keepClustersOnTestFailure: false,
 			}
+			var clusterAllocator clusterAllocatorFn
+			// run without cluster allocator error injection
 			err := runner.Run(ctx, tests, 1, /* count */
-				defaultParallelism, copt, testOpts{}, lopt)
+				defaultParallelism, copt, testOpts{}, lopt, clusterAllocator)
 
-			if !testutils.IsError(err, c.expErr) {
-				t.Fatalf("expected err: %q, but found %v. Filters: %s", c.expErr, err, c.filters)
+			assertTestCompletion(t, tests, c.filters, runner.getCompletedTests(), err, c.expErr)
+
+			// N.B. skip the case of no matching tests
+			if len(tests) > 0 {
+				// run _with_ cluster allocator error injection
+				clusterAllocator = alwaysFailingClusterAllocator
+				err = runner.Run(ctx, tests, 1, /* count */
+					defaultParallelism, copt, testOpts{}, lopt, clusterAllocator)
+
+				assertTestCompletion(t, tests, c.filters, runner.getCompletedTests(), err, "some clusters could not be created")
 			}
 			out := stdout.String() + "\n" + stderr.String()
 			if exp := c.expOut; exp != "" && !strings.Contains(out, exp) {
 				t.Fatalf("'%s' not found in output:\n%s", exp, out)
 			}
 		})
+	}
+}
+
+// verifies that actual test completion conditions match the expected
+func assertTestCompletion(
+	t *testing.T,
+	tests []registry.TestSpec,
+	filters []string,
+	completed []completedTestInfo,
+	actualErr error,
+	expectedErr string,
+) {
+	require.True(t, len(completed) == len(tests))
+
+	for _, info := range completed {
+		if info.test == "pass" {
+			require.True(t, info.pass)
+		} else if info.test == "fail" {
+			require.True(t, !info.pass)
+		}
+	}
+	if !testutils.IsError(actualErr, expectedErr) {
+		t.Fatalf("expected err: %q, but found %v. Filters: %s", expectedErr, actualErr, filters)
 	}
 }
 
@@ -215,7 +259,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		},
 	}
 	err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
-		defaultParallelism, copt, testOpts{}, lopt)
+		defaultParallelism, copt, testOpts{}, lopt, nil /* clusterAllocator */)
 	if !testutils.IsError(err, "some tests failed") {
 		t.Fatalf("expected error \"some tests failed\", got: %v", err)
 	}
@@ -307,7 +351,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 		stderr:       ioutil.Discard,
 		artifactsDir: "",
 	}
-	return runner.Run(ctx, tests, 1, 1, clustersOpt{}, testOpts{}, lopt)
+	return runner.Run(ctx, tests, 1, 1, clustersOpt{}, testOpts{}, lopt, nil /* clusterAllocator */)
 }
 
 func TestExitCode(t *testing.T) {

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -172,6 +172,9 @@ func (p *workPool) selectTestForCluster(
 // If multiple tests are eligible to run, one with the most runs left is chosen.
 // TODO(andrei): We could be smarter in guessing what kind of cluster is best to
 // allocate.
+//
+// ensures:  !testToRunRes.noWork || error == nil
+//
 func (p *workPool) selectTest(ctx context.Context, qp *quotapool.IntPool) (testToRunRes, error) {
 	var ttr testToRunRes
 	alloc, err := qp.AcquireFunc(ctx, func(ctx context.Context, pi quotapool.PoolInfo) (uint64, error) {


### PR DESCRIPTION
Previously, any cluster creation failure would have immediately resulted in
termination of the entire test suite. Cluster creation can fail for any
number of reasons including transient errors related to
resource exhaustion (e.g., ZONE_RESOURCE_POOL_EXHAUSTED in GCP).
In the case of transient errors, it's likely that other roachtests may be
able to provision successfully. Hence, with this change we explicitly handle
cluster creation failure so that each remaining roachtest is attempted.
The total number of failed cluster create ops is reported on exit.
If it's non-zero, the exit code will be 1, thereby resulting in CI failure.

Release note: None