### PR TITLE
kvserver: decline rebalance snapshots on receivers with poor LSM

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -154,6 +154,8 @@ message SnapshotRequest {
   }
 
   message Header {
+    reserved 1;
+
     // The replica state at the time the snapshot was generated. Note
     // that ReplicaState.Desc differs from the above range_descriptor
     // field which holds the updated descriptor after the new replica
@@ -166,6 +168,11 @@ message SnapshotRequest {
 
     // The estimated size of the range, to be used in reservation decisions.
     int64 range_size = 3;
+
+    // can_decline is set on preemptive snapshots, but not those generated
+    // by raft because at that point it is better to queue up the stream
+    // than to cancel it.
+    bool can_decline = 4;
 
     // The priority of the snapshot.
     Priority priority = 6;
@@ -187,8 +194,6 @@ message SnapshotRequest {
     //
     // TODO(irfansharif): Remove this in v22.1.
     bool deprecated_unreplicated_truncated_state = 8;
-
-    reserved 1, 4;
   }
 
   Header header = 1;
@@ -207,7 +212,7 @@ message SnapshotResponse {
     ACCEPTED = 1;
     APPLIED = 2;
     ERROR = 3;
-    reserved 4;
+    DECLINED = 4;
   }
   Status status = 1;
   string message = 2;

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -169,11 +169,6 @@ message SnapshotRequest {
     // The estimated size of the range, to be used in reservation decisions.
     int64 range_size = 3;
 
-    // can_decline is set on preemptive snapshots, but not those generated
-    // by raft because at that point it is better to queue up the stream
-    // than to cancel it.
-    bool can_decline = 4;
-
     // The priority of the snapshot.
     Priority priority = 6;
 

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -359,15 +360,7 @@ func TestLearnerSnapshotFailsRollback(t *testing.T) {
 	})
 }
 
-// TestNonVoterCatchesUpViaRaftSnapshotQueue ensures that a non-voting replica
-// in need of a snapshot will receive one via the raft snapshot queue. This is
-// also meant to test that a non-voting replica that is initialized via an
-// `INITIAL` snapshot during its addition is not ignored by the raft snapshot
-// queue for future snapshots.
-func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
+func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	skip.UnderShort(t, "this test sleeps for a few seconds")
 
 	var skipInitialSnapshot int64
@@ -388,6 +381,7 @@ func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
 	// Disable the raft snapshot queue, we will manually queue a replica into it
 	// below.
 	ltk.storeKnobs.DisableRaftSnapshotQueue = true
+
 	tc := testcluster.StartTestCluster(
 		t, 2, base.TestClusterArgs{
 			ServerArgs:      base.TestServerArgs{Knobs: knobs},
@@ -407,6 +401,8 @@ func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
 		return err
 	})
 
+	// Wait until we remove the lock that prevents the raft snapshot queue from
+	// sending this replica a snapshot.
 	select {
 	case <-nonVoterSnapLockRemoved:
 	case <-time.After(testutils.DefaultSucceedsSoonDuration):
@@ -421,6 +417,16 @@ func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
 	require.NotNil(t, leaseholderRepl)
 
 	time.Sleep(kvserver.RaftLogQueuePendingSnapshotGracePeriod)
+
+	if drainReceivingNode {
+		// Draining nodes shouldn't reject raft snapshots, so this should have no
+		// effect on the outcome of this test.
+		const drainingServerIdx = 1
+		const drainingNodeID = drainingServerIdx + 1
+		client, err := tc.GetAdminClient(ctx, t, drainingServerIdx)
+		require.NoError(t, err)
+		drain(ctx, t, client, drainingNodeID)
+	}
 
 	testutils.SucceedsSoon(t, func() error {
 		// Manually enqueue the leaseholder replica into its store's raft snapshot
@@ -445,6 +451,64 @@ func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, g.Wait())
+}
+
+func drain(ctx context.Context, t *testing.T, client serverpb.AdminClient, drainingNodeID int) {
+	stream, err := client.Drain(ctx, &serverpb.DrainRequest{
+		NodeId:  strconv.Itoa(drainingNodeID),
+		DoDrain: true,
+	})
+	require.NoError(t, err)
+
+	// Wait until the draining node acknowledges that it's draining.
+	_, err = stream.Recv()
+	require.NoError(t, err)
+}
+
+// TestSnapshotsToDrainingNodes tests that INITIAL (i.e. rebalancing) snapshots
+// to draining receivers are rejected, but `VIA_SNAPSHOT_QUEUE` snapshots
+// aren't.
+func TestSnapshotsToDrainingNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("rebalancing snapshots", func(t *testing.T) {
+		ctx := context.Background()
+
+		// We set up a 2 node test cluster with the second node marked draining.
+		const drainingServerIdx = 1
+		const drainingNodeID = drainingServerIdx + 1
+		tc := testcluster.StartTestCluster(
+			t, 2, base.TestClusterArgs{
+				ReplicationMode: base.ReplicationManual,
+			},
+		)
+		defer tc.Stopper().Stop(ctx)
+		client, err := tc.GetAdminClient(ctx, t, drainingServerIdx)
+		require.NoError(t, err)
+		drain(ctx, t, client, drainingNodeID)
+
+		// Now, we try to add a replica to it, we expect that to fail.
+		scratchKey := tc.ScratchRange(t)
+		_, err = tc.AddVoters(scratchKey, makeReplicationTargets(drainingNodeID)...)
+		require.Regexp(t, "store is draining", err)
+	})
+
+	t.Run("raft snapshots", func(t *testing.T) {
+		testRaftSnapshotsToNonVoters(t, true /* drainReceivingNode */)
+	})
+
+}
+
+// TestNonVoterCatchesUpViaRaftSnapshotQueue ensures that a non-voting replica
+// in need of a snapshot will receive one via the raft snapshot queue. This is
+// also meant to test that a non-voting replica that is initialized via an
+// `INITIAL` snapshot during its addition is not ignored by the raft snapshot
+// queue for future snapshots.
+func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testRaftSnapshotsToNonVoters(t, false /* drainReceivingNode */)
 }
 
 func TestSplitWithLearnerOrJointConfig(t *testing.T) {

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -850,15 +850,30 @@ func TestStorePoolThrottle(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
 
-	expected := sp.clock.Now().GoTime().Add(FailedReservationsTimeout.Get(&sp.st.SV))
-	sp.throttle(throttleFailed, "", 1)
+	{
+		expected := sp.clock.Now().GoTime().Add(DeclinedReservationsTimeout.Get(&sp.st.SV))
+		sp.throttle(throttleDeclined, "", 1)
 
-	sp.detailsMu.Lock()
-	detail := sp.getStoreDetailLocked(1)
-	sp.detailsMu.Unlock()
-	if !detail.throttledUntil.Equal(expected) {
-		t.Errorf("expected store to have been throttled to %v, found %v",
-			expected, detail.throttledUntil)
+		sp.detailsMu.Lock()
+		detail := sp.getStoreDetailLocked(1)
+		sp.detailsMu.Unlock()
+		if !detail.throttledUntil.Equal(expected) {
+			t.Errorf("expected store to have been throttled to %v, found %v",
+				expected, detail.throttledUntil)
+		}
+	}
+
+	{
+		expected := sp.clock.Now().GoTime().Add(FailedReservationsTimeout.Get(&sp.st.SV))
+		sp.throttle(throttleFailed, "", 1)
+
+		sp.detailsMu.Lock()
+		detail := sp.getStoreDetailLocked(1)
+		sp.detailsMu.Unlock()
+		if !detail.throttledUntil.Equal(expected) {
+			t.Errorf("expected store to have been throttled to %v, found %v",
+				expected, detail.throttledUntil)
+		}
 	}
 }
 

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -851,7 +851,7 @@ func TestStorePoolThrottle(t *testing.T) {
 	sg.GossipStores(uniqueStore, t)
 
 	{
-		expected := sp.clock.Now().GoTime().Add(DeclinedReservationsTimeout.Get(&sp.st.SV))
+		expected := sp.clock.Now().GoTime().Add(DeclinedSnapshotTimeout.Get(&sp.st.SV))
 		sp.throttle(throttleDeclined, "", 1)
 
 		sp.detailsMu.Lock()

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -73,13 +73,6 @@ func (s *Store) HandleSnapshot(
 	return s.stopper.RunTaskWithErr(ctx, name, func(ctx context.Context) error {
 		s.metrics.RaftRcvdMessages[raftpb.MsgSnap].Inc(1)
 
-		if s.IsDraining() {
-			return stream.Send(&kvserverpb.SnapshotResponse{
-				Status:  kvserverpb.SnapshotResponse_ERROR,
-				Message: storeDrainingMsg,
-			})
-		}
-
 		return s.receiveSnapshot(ctx, header, stream)
 	})
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -405,6 +407,83 @@ func (kvSS *kvBatchSnapshotStrategy) Close(ctx context.Context) {
 	}
 }
 
+const readAmpSnapshotDeclineDefaultThreshold = 1000
+
+// ReadAmpSnapshotDeclineThreshold defines the read amplification threshold
+// beyond which all incoming rebalance snapshots will be declined by the
+// receiving store.
+var ReadAmpSnapshotDeclineThreshold = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.snapshot_decline.read_amp_threshold",
+	"when the receiving store's read amplification exceeds this threshold,"+
+		" the store will decline all incoming rebalance snapshots",
+	readAmpSnapshotDeclineDefaultThreshold,
+	settings.PositiveInt,
+)
+
+type snapshotDeclineReason string
+
+func (r snapshotDeclineReason) String() string {
+	return redact.StringWithoutMarkers(r)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (r snapshotDeclineReason) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(string(r))
+}
+
+// shouldDeclineSnapshot determines whether the store should decline the
+// incoming rebalance snapshot due to poor LSM health. Note that recovery
+// snapshots are never declined.
+func (s *Store) shouldDeclineSnapshot(
+	header *kvserverpb.SnapshotRequest_Header,
+) (declined bool, reason string) {
+	switch t := header.Priority; t {
+	case kvserverpb.SnapshotRequest_RECOVERY:
+		// Don't obstruct recovery snapshots.
+	case kvserverpb.SnapshotRequest_REBALANCE:
+		if s.IsDraining() {
+			// Draining nodes will generally not be rebalanced to (see the filtering
+			// that happens in getStoreListFromIDsLocked()), but in case they are,
+			// they should reject the incoming rebalancing snapshots.
+			//
+			// We can not reject Raft snapshots because draining nodes may have
+			// replicas in `StateSnapshot` that need to catch up.
+			//
+			// TODO(aayush): We also do not reject snapshots sent to replace dead
+			// replicas here, but draining stores are still filtered out in
+			// getStoreListFromIDsLocked(). Is that sound? Don't we want to
+			// upreplicate to draining nodes if there are no other candidates?
+			return true, storeDrainingMsg
+		}
+
+		// Stores with high read amp should not be rebalanced to.
+		readAmpThreshold := ReadAmpSnapshotDeclineThreshold.Get(&s.cfg.Settings.SV)
+		if ra := int64(s.engine.GetMetrics().ReadAmp()); ra > readAmpThreshold {
+			return true, fmt.Sprintf(
+				"read-amplification %v higher than kv.snapshot_decline.read_amp_threshold",
+				ra,
+			)
+		}
+
+		// Stores with an almost full disk should not be rebalanced to.
+		storeDesc, ok := s.cfg.StorePool.getStoreDescriptor(s.StoreID())
+
+		// Avoid performing the disk fullness check in most test builds (unless the
+		// testing knob says otherwise) because most test cluster users shouldn't
+		// have to care about figuring out the correct start up incantation to
+		// populate and gossip store stats.
+		diskFullCheckEnabled := s.cfg.TestingKnobs.EnableDiskFullnessCheckForSnapshots || !buildutil.CrdbTestBuild
+		if ok && diskFullCheckEnabled && (!maxCapacityCheck(storeDesc) || header.RangeSize > storeDesc.Capacity.Available) {
+			return true, snapshotStoreTooFullMsg
+		}
+	default:
+		// If this a new snapshot type that this cockroach version does not know
+		// about, we let it through.
+	}
+	return false, ""
+}
+
 // reserveSnapshot throttles incoming snapshots. The returned closure is used
 // to cleanup the reservation and release its resources. A nil cleanup function
 // and a non-empty rejectionMessage indicates the reservation was declined.
@@ -412,26 +491,12 @@ func (s *Store) reserveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header,
 ) (_cleanup func(), _err error) {
 	tBegin := timeutil.Now()
-	if header.RangeSize == 0 {
-		// Empty snapshots are exempt from rate limits because they're so cheap to
-		// apply. This vastly speeds up rebalancing any empty ranges created by a
-		// RESTORE or manual SPLIT AT, since it prevents these empty snapshots from
-		// getting stuck behind large snapshots managed by the replicate queue.
-	} else if header.CanDecline {
-		storeDesc, ok := s.cfg.StorePool.getStoreDescriptor(s.StoreID())
-		if ok && (!maxCapacityCheck(storeDesc) || header.RangeSize > storeDesc.Capacity.Available) {
-			return nil, nil
-		}
-		select {
-		case s.snapshotApplySem <- struct{}{}:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-s.stopper.ShouldQuiesce():
-			return nil, errors.Errorf("stopped")
-		default:
-			return nil, nil
-		}
-	} else {
+
+	// Empty snapshots are exempt from rate limits because they're so cheap to
+	// apply. This vastly speeds up rebalancing any empty ranges created by a
+	// RESTORE or manual SPLIT AT, since it prevents these empty snapshots from
+	// getting stuck behind large snapshots managed by the replicate queue.
+	if header.RangeSize != 0 {
 		queueCtx := ctx
 		if deadline, ok := queueCtx.Deadline(); ok {
 			// Enforce a more strict timeout for acquiring the snapshot reservation to
@@ -472,7 +537,6 @@ func (s *Store) reserveSnapshot(
 			replDesc.ReplicaID,
 		)
 	}
-
 	s.metrics.ReservedReplicaCount.Inc(1)
 	s.metrics.Reserved.Inc(header.RangeSize)
 	return func() {
@@ -615,27 +679,6 @@ func (s *Store) checkSnapshotOverlapLocked(
 func (s *Store) receiveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header, stream incomingSnapshotStream,
 ) error {
-	// Draining nodes will generally not be rebalanced to (see the filtering that
-	// happens in getStoreListFromIDsLocked()), but in case they are, they should
-	// reject the incoming rebalancing snapshots.
-	if s.IsDraining() {
-		switch t := header.Priority; t {
-		case kvserverpb.SnapshotRequest_RECOVERY:
-			// We can not reject Raft snapshots because draining nodes may have
-			// replicas in `StateSnapshot` that need to catch up.
-			//
-			// TODO(aayush): We also do not reject snapshots sent to replace dead
-			// replicas here, but draining stores are still filtered out in
-			// getStoreListFromIDsLocked(). Is that sound? Don't we want to
-			// upreplicate to draining nodes if there are no other candidates?
-		case kvserverpb.SnapshotRequest_REBALANCE:
-			return sendSnapshotError(stream, errors.New(storeDrainingMsg))
-		default:
-			// If this a new snapshot type that this cockroach version does not know
-			// about, we let it through.
-		}
-	}
-
 	if fn := s.cfg.TestingKnobs.ReceiveSnapshot; fn != nil {
 		if err := fn(header); err != nil {
 			return sendSnapshotError(stream, err)
@@ -647,20 +690,21 @@ func (s *Store) receiveSnapshot(
 	if _, ok := header.State.Desc.GetReplicaDescriptor(storeID); !ok {
 		return errors.AssertionFailedf(
 			`snapshot of type %s was sent to s%d which did not contain it as a replica: %s`,
-			header.Type, storeID, header.State.Desc.Replicas())
+			header.Type, storeID, header.State.Desc.Replicas(),
+		)
 	}
 
+	if declined, reason := s.shouldDeclineSnapshot(header); declined {
+		return sendSnapshotError(stream, errors.Newf("%v", snapshotDeclineReason(reason)))
+	}
 	cleanup, err := s.reserveSnapshot(ctx, header)
+
 	if err != nil {
 		return err
 	}
-	if cleanup == nil {
-		return stream.Send(&kvserverpb.SnapshotResponse{
-			Status:  kvserverpb.SnapshotResponse_DECLINED,
-			Message: err.Error(),
-		})
+	if cleanup != nil {
+		defer cleanup()
 	}
-	defer cleanup()
 
 	// The comment on ReplicaPlaceholder motivates and documents
 	// ReplicaPlaceholder semantics. Please be familiar with them
@@ -747,10 +791,12 @@ func (s *Store) receiveSnapshot(
 }
 
 func sendSnapshotError(stream incomingSnapshotStream, err error) error {
-	return stream.Send(&kvserverpb.SnapshotResponse{
-		Status:  kvserverpb.SnapshotResponse_ERROR,
-		Message: err.Error(),
-	})
+	return stream.Send(
+		&kvserverpb.SnapshotResponse{
+			Status:  kvserverpb.SnapshotResponse_ERROR,
+			Message: err.Error(),
+		},
+	)
 }
 
 // SnapshotStorePool narrows StorePool to make sendSnapshot easier to test.
@@ -1130,24 +1176,20 @@ func sendSnapshot(
 		return err
 	}
 	switch resp.Status {
-	case kvserverpb.SnapshotResponse_DECLINED:
-		if header.CanDecline {
-			declinedMsg := "reservation rejected"
-			if len(resp.Message) > 0 {
-				declinedMsg = resp.Message
-			}
-			err := &benignError{errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)}
-			storePool.throttle(throttleDeclined, err.Error(), to.StoreID)
-			return err
-		}
-		err := errors.Errorf("%s: programming error: remote declined required %s: %s",
-			to, snap, resp.Message)
-		storePool.throttle(throttleFailed, err.Error(), to.StoreID)
-		return err
 	case kvserverpb.SnapshotResponse_ERROR:
 		storePool.throttle(throttleFailed, resp.Message, to.StoreID)
-		return errors.Errorf("%s: remote couldn't accept %s with error: %s",
-			to, snap, resp.Message)
+		return errors.Errorf(
+			"%s: remote couldn't accept %s with error: %s",
+			to, snap, resp.Message,
+		)
+	case kvserverpb.SnapshotResponse_DECLINED:
+		// The snapshot was declined by the receiver. See shouldDeclineSnapshot()
+		// for why this can happen.
+		storePool.throttle(throttleDeclined, resp.Message, to.StoreID)
+		return errors.Errorf(
+			"%s: remote couldn't accept %s with message: %s",
+			to, snap, resp.Message,
+		)
 	case kvserverpb.SnapshotResponse_ACCEPTED:
 	// This is the response we're expecting. Continue with snapshot sending.
 	default:

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -40,7 +40,9 @@ import (
 
 const (
 	// Messages that provide detail about why a snapshot was rejected.
-	storeDrainingMsg = "store is draining"
+	snapshotStoreTooFullMsg = "store almost out of disk space"
+	snapshotApplySemBusyMsg = "store busy applying snapshots"
+	storeDrainingMsg        = "store is draining"
 
 	// IntersectingSnapshotMsg is part of the error message returned from
 	// canAcceptSnapshotLocked and is exposed here so testing can rely on it.
@@ -404,17 +406,32 @@ func (kvSS *kvBatchSnapshotStrategy) Close(ctx context.Context) {
 }
 
 // reserveSnapshot throttles incoming snapshots. The returned closure is used
-// to cleanup the reservation and release its resources.
+// to cleanup the reservation and release its resources. A nil cleanup function
+// and a non-empty rejectionMessage indicates the reservation was declined.
 func (s *Store) reserveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header,
 ) (_cleanup func(), _err error) {
 	tBegin := timeutil.Now()
-
-	// Empty snapshots are exempt from rate limits because they're so cheap to
-	// apply. This vastly speeds up rebalancing any empty ranges created by a
-	// RESTORE or manual SPLIT AT, since it prevents these empty snapshots from
-	// getting stuck behind large snapshots managed by the replicate queue.
-	if header.RangeSize != 0 {
+	if header.RangeSize == 0 {
+		// Empty snapshots are exempt from rate limits because they're so cheap to
+		// apply. This vastly speeds up rebalancing any empty ranges created by a
+		// RESTORE or manual SPLIT AT, since it prevents these empty snapshots from
+		// getting stuck behind large snapshots managed by the replicate queue.
+	} else if header.CanDecline {
+		storeDesc, ok := s.cfg.StorePool.getStoreDescriptor(s.StoreID())
+		if ok && (!maxCapacityCheck(storeDesc) || header.RangeSize > storeDesc.Capacity.Available) {
+			return nil, nil
+		}
+		select {
+		case s.snapshotApplySem <- struct{}{}:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.stopper.ShouldQuiesce():
+			return nil, errors.Errorf("stopped")
+		default:
+			return nil, nil
+		}
+	} else {
 		queueCtx := ctx
 		if deadline, ok := queueCtx.Deadline(); ok {
 			// Enforce a more strict timeout for acquiring the snapshot reservation to
@@ -636,6 +653,12 @@ func (s *Store) receiveSnapshot(
 	cleanup, err := s.reserveSnapshot(ctx, header)
 	if err != nil {
 		return err
+	}
+	if cleanup == nil {
+		return stream.Send(&kvserverpb.SnapshotResponse{
+			Status:  kvserverpb.SnapshotResponse_DECLINED,
+			Message: err.Error(),
+		})
 	}
 	defer cleanup()
 
@@ -1107,6 +1130,20 @@ func sendSnapshot(
 		return err
 	}
 	switch resp.Status {
+	case kvserverpb.SnapshotResponse_DECLINED:
+		if header.CanDecline {
+			declinedMsg := "reservation rejected"
+			if len(resp.Message) > 0 {
+				declinedMsg = resp.Message
+			}
+			err := &benignError{errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)}
+			storePool.throttle(throttleDeclined, err.Error(), to.StoreID)
+			return err
+		}
+		err := errors.Errorf("%s: programming error: remote declined required %s: %s",
+			to, snap, resp.Message)
+		storePool.throttle(throttleFailed, err.Error(), to.StoreID)
+		return err
 	case kvserverpb.SnapshotResponse_ERROR:
 		storePool.throttle(throttleFailed, resp.Message, to.StoreID)
 		return errors.Errorf("%s: remote couldn't accept %s with error: %s",

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	enginepb "github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -598,6 +598,27 @@ func (s *Store) checkSnapshotOverlapLocked(
 func (s *Store) receiveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header, stream incomingSnapshotStream,
 ) error {
+	// Draining nodes will generally not be rebalanced to (see the filtering that
+	// happens in getStoreListFromIDsLocked()), but in case they are, they should
+	// reject the incoming rebalancing snapshots.
+	if s.IsDraining() {
+		switch t := header.Priority; t {
+		case kvserverpb.SnapshotRequest_RECOVERY:
+			// We can not reject Raft snapshots because draining nodes may have
+			// replicas in `StateSnapshot` that need to catch up.
+			//
+			// TODO(aayush): We also do not reject snapshots sent to replace dead
+			// replicas here, but draining stores are still filtered out in
+			// getStoreListFromIDsLocked(). Is that sound? Don't we want to
+			// upreplicate to draining nodes if there are no other candidates?
+		case kvserverpb.SnapshotRequest_REBALANCE:
+			return sendSnapshotError(stream, errors.New(storeDrainingMsg))
+		default:
+			// If this a new snapshot type that this cockroach version does not know
+			// about, we let it through.
+		}
+	}
+
 	if fn := s.cfg.TestingKnobs.ReceiveSnapshot; fn != nil {
 		if err := fn(header); err != nil {
 			return sendSnapshotError(stream, err)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -228,6 +228,10 @@ type StoreTestingKnobs struct {
 	// SplitQueuePurgatoryChan allows a test to control the channel used to
 	// trigger split queue purgatory processing.
 	SplitQueuePurgatoryChan <-chan time.Time
+	// EnableDiskFullnessCheckForSnapshots enables the check that rejects
+	// snapshots to stores with an almost full disk. This check is always enabled
+	// in production code, but disabled in test code unless this knob is set.
+	EnableDiskFullnessCheckForSnapshots bool
 	// SkipMinSizeCheck, if set, makes the store creation process skip the check
 	// for a minimum size.
 	SkipMinSizeCheck bool

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -117,7 +117,6 @@ var retiredSettings = map[string]struct{}{
 	"trace.datadog.project":                                            {},
 	"sql.defaults.interleaved_tables.enabled":                          {},
 	"sql.defaults.copy_partitioning_when_deinterleaving_table.enabled": {},
-	"server.declined_reservation_timeout":                              {},
 	"bulkio.backup.resolve_destination_in_job.enabled":                 {},
 	"sql.defaults.experimental_hash_sharded_indexes.enabled":           {},
 }


### PR DESCRIPTION
First commit from https://github.com/cockroachdb/cockroach/pull/77246.

This patch introduces two new cluster settings:
```
kv.snapshot_decline.read_amp_threshold

server.declined_snapshot_timeout
```

With this commit, stores with a read amplification level higher than
`kv.snapshot_decline.read_amp_threshold` will decline all `REBALANCE`
snapshots. Upon receiving a `DECLINED` response, the senders of these snapshots
will consider these receivers `throttled` for `server.declined_snapshot_timeout`.

This means that stores with poor LSM health will not be considered as valid
candidates for replica rebalancing.

Fixes #73714
Related to #62168

Release justification: This patch adds a tunable guardrail that could prevent 
or mitigate cluster instability.

Release note: None

\cc. @cockroachdb/storage 