### PR TITLE
lint: delete previously skipped Misspell

### DIFF
--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -48,7 +48,6 @@ def lint_binary(name, test):
         data = [
             test,
             "//pkg/sql/opt/optgen/cmd/optfmt",
-            "@com_github_client9_misspell//cmd/misspell:misspell",
             "@com_github_cockroachdb_crlfmt//:crlfmt",
             "@go_sdk//:bin/go",
             "@org_golang_x_lint//golint:golint",

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -29,7 +29,6 @@ test_bin="$(rlocation_ck cockroach/$PACKAGE/${NAME}_/$NAME)"
 go_bin="$(rlocation_ck go_sdk/bin/go)"
 crlfmt_bin="$(rlocation_ck com_github_cockroachdb_crlfmt/crlfmt_/crlfmt)"
 golint_bin="$(rlocation_ck org_golang_x_lint/golint/golint_/golint)"
-misspell_bin="$(rlocation_ck com_github_client9_misspell/cmd/misspell/misspell_/misspell)"
 optfmt_bin="$(rlocation_ck cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
 
 # Need to run this so that Go can find the runfiles.
@@ -43,6 +42,6 @@ fi
 cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
 
 TEST_WORKSPACE=cockroach \
-    PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $misspell_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
+    PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
     GOROOT="$(dirname $(dirname $go_bin))" \
     "$test_bin" "$@"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1295,61 +1295,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestMisspell", func(t *testing.T) {
-		skip.IgnoreLint(t, `this lint causes extra rounds through CI for which the cost-
-benefit analysis is not favorable. We could re-instate this as a nightly lint
-instead.
-`)
-		t.Parallel()
-		if pkgSpecified {
-			skip.IgnoreLint(t, "PKG specified")
-		}
-		cmd, stderr, filter, err := dirCmd(pkgDir, "git", "ls-files")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		ignoredRules := []string{
-			"licence",
-			"mitre",     // PostGIS commands spell these as mitre.
-			"analyse",   // required by SQL grammar
-			"seperator", // pkg/ui depends on 3rd party package (rc-calendar) with spelling
-			"strat",     // PostgreSQL has table: pg_amop_fam_strat_index
-		}
-
-		if err := stream.ForEach(stream.Sequence(
-			filter,
-			stream.GrepNot(`.*\.lock`),
-			stream.GrepNot(`^storage\/rocksdb_error_dict\.go$`),
-			stream.GrepNot(`^workload/geospatial/geospatial.go$`),
-			stream.GrepNot(`^workload/tpcds/tpcds.go$`),
-			stream.GrepNot(`^geo/geoprojbase/projections.go$`),
-			stream.GrepNot(`^sql/logictest/testdata/logic_test/pg_extension$`),
-			stream.GrepNot(`^sql/opt/testutils/opttester/testfixtures/.*`),
-			stream.GrepNot(`^util/timeutil/lowercase_timezones_generated.go$`),
-			stream.GrepNot(`^cmd/roachtest/tests/ruby_pg_blocklist.go$`),
-			stream.GrepNot(`^cmd/roachtest/tests/asyncpg_blocklist.go$`),
-			stream.Map(func(s string) string {
-				return filepath.Join(pkgDir, s)
-			}),
-			stream.Xargs("misspell", "-locale", "US", "-i", strings.Join(ignoredRules, ",")),
-		), func(s string) {
-			t.Errorf("\n%s", s)
-		}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	t.Run("TestGofmtSimplify", func(t *testing.T) {
 		t.Parallel()
 		if pkgSpecified {


### PR DESCRIPTION
As requested by @andreimatei and supported by @nvanbenschoten (and
myself too):

https://github.com/cockroachdb/cockroach/pull/73638#issuecomment-991331443

Release note: None
