### PR TITLE
kvserver: avoid unprotected keyspace during MergeRange

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -347,7 +347,7 @@ func (r *Replica) handleChangeReplicasResult(
 		log.Infof(ctx, "removing replica due to ChangeReplicasTrigger: %v", chng)
 	}
 
-	if err := r.store.removeInitializedReplicaRaftMuLocked(ctx, r, chng.NextReplicaID(), RemoveOptions{
+	if _, err := r.store.removeInitializedReplicaRaftMuLocked(ctx, r, chng.NextReplicaID(), RemoveOptions{
 		// We destroyed the data when the batch committed so don't destroy it again.
 		DestroyData: false,
 	}); err != nil {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -770,6 +770,25 @@ func (r *Replica) applySnapshot(
 	}
 
 	isInitialSnap := !r.IsInitialized()
+	{
+		var from, to roachpb.RKey
+		if isInitialSnap {
+			// For uninitialized replicas, there must be a placeholder that covers
+			// the snapshot's bounds, so basically check that. A synchronous check
+			// here would be simpler but this works well enough.
+			d := inSnap.placeholder.Desc()
+			from, to = d.StartKey, d.EndKey
+			defer r.store.maybeAssertNoHole(ctx, from, to)()
+		} else {
+			// For snapshots to existing replicas, from and to usually match (i.e.
+			// nothing is asserted) but if the snapshot spans a merge then we're
+			// going to assert that we're transferring the keyspace from the subsumed
+			// replicas to this replica seamlessly.
+			d := r.Desc()
+			from, to = d.EndKey, inSnap.Desc.EndKey
+			defer r.store.maybeAssertNoHole(ctx, from, to)()
+		}
+	}
 	defer func() {
 		if e := recover(); e != nil {
 			// Re-panic to avoid the log.Fatal() below.
@@ -906,7 +925,8 @@ func (r *Replica) applySnapshot(
 	// has not yet been updated. Any errors past this point must therefore be
 	// treated as fatal.
 
-	if err := r.clearSubsumedReplicaInMemoryData(ctx, subsumedRepls, mergedTombstoneReplicaID); err != nil {
+	subPHs, err := r.clearSubsumedReplicaInMemoryData(ctx, subsumedRepls, mergedTombstoneReplicaID)
+	if err != nil {
 		log.Fatalf(ctx, "failed to clear in-memory data of subsumed replicas while applying snapshot: %+v", err)
 	}
 
@@ -925,13 +945,19 @@ func (r *Replica) applySnapshot(
 	// the on-disk state.
 
 	r.store.mu.Lock()
-	r.mu.Lock()
 	if inSnap.placeholder != nil {
-		_, err := r.store.removePlaceholderLocked(ctx, inSnap.placeholder, removePlaceholderFilled)
+		subPHs = append(subPHs, inSnap.placeholder)
+	}
+	for _, ph := range subPHs {
+		_, err := r.store.removePlaceholderLocked(ctx, ph, removePlaceholderFilled)
 		if err != nil {
-			log.Fatalf(ctx, "unable to remove placeholder: %s", err)
+			log.Fatalf(ctx, "unable to remove placeholder %s: %s", ph, err)
 		}
 	}
+
+	// NB: we lock `r.mu` only now because removePlaceholderLocked operates on
+	// replicasByKey and this may end up calling r.Desc().
+	r.mu.Lock()
 	r.setDescLockedRaftMuLocked(ctx, desc)
 	if err := r.store.maybeMarkReplicaInitializedLockedReplLocked(ctx, r); err != nil {
 		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)
@@ -1136,28 +1162,32 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 // held.
 func (r *Replica) clearSubsumedReplicaInMemoryData(
 	ctx context.Context, subsumedRepls []*Replica, subsumedNextReplicaID roachpb.ReplicaID,
-) error {
+) ([]*ReplicaPlaceholder, error) {
+	//
+	var phs []*ReplicaPlaceholder
 	for _, sr := range subsumedRepls {
 		// We already hold sr's raftMu, so we must call removeReplicaImpl directly.
-		// Note that it's safe to update the store's metadata for sr's removal
-		// separately from updating the store's metadata for r's new descriptor
-		// (i.e., under a different store.mu acquisition). Each store.mu
-		// acquisition leaves the store in a consistent state, and access to the
-		// replicas themselves is protected by their raftMus, which are held from
-		// start to finish.
-		if err := r.store.removeInitializedReplicaRaftMuLocked(ctx, sr, subsumedNextReplicaID, RemoveOptions{
+		// As the subsuming range is planning to expand to cover the subsumed ranges,
+		// we introduce corresponding placeholders and return them to the caller to
+		// consume. Without this, there would be a risk of errant snapshots being
+		// allowed in (perhaps not involving any of the RangeIDs known to the merge
+		// but still touching its keyspace) and causing corruption.
+		ph, err := r.store.removeInitializedReplicaRaftMuLocked(ctx, sr, subsumedNextReplicaID, RemoveOptions{
 			// The data was already destroyed by clearSubsumedReplicaDiskData.
-			DestroyData: false,
-		}); err != nil {
-			return err
+			DestroyData:       false,
+			InsertPlaceholder: true,
+		})
+		if err != nil {
+			return nil, err
 		}
+		phs = append(phs, ph)
 		// We removed sr's data when we committed the batch. Finish subsumption by
 		// updating the in-memory bookkeping.
 		if err := sr.postDestroyRaftMuLocked(ctx, sr.GetMVCCStats()); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return phs, nil
 }
 
 type raftCommandEncodingVersion byte

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6940,7 +6940,7 @@ func TestReplicaDestroy(t *testing.T) {
 	func() {
 		tc.repl.raftMu.Lock()
 		defer tc.repl.raftMu.Unlock()
-		if err := tc.store.removeInitializedReplicaRaftMuLocked(ctx, tc.repl, repl.Desc().NextReplicaID, RemoveOptions{
+		if _, err := tc.store.removeInitializedReplicaRaftMuLocked(ctx, tc.repl, repl.Desc().NextReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
 			t.Fatal(err)
@@ -7034,7 +7034,7 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 	func() {
 		tc.repl.raftMu.Lock()
 		defer tc.repl.raftMu.Unlock()
-		if err := tc.store.removeInitializedReplicaRaftMuLocked(ctx, repl, repl.Desc().NextReplicaID, RemoveOptions{
+		if _, err := tc.store.removeInitializedReplicaRaftMuLocked(ctx, repl, repl.Desc().NextReplicaID, RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -884,17 +884,24 @@ type Store struct {
 
 	mu struct {
 		syncutil.RWMutex
-		// Map of replicas by Range ID (map[roachpb.RangeID]*Replica). This
-		// includes `uninitReplicas`. May be read without holding Store.mu.
+		// Map of replicas by Range ID (map[roachpb.RangeID]*Replica).
+		// May be read without holding Store.mu.
 		replicasByRangeID rangeIDReplicaMap
 		// A btree key containing objects of type *Replica or *ReplicaPlaceholder.
 		// Both types have an associated key range; the btree is keyed on their
 		// start keys.
-		replicasByKey  *storeReplicaBTree
+		//
+		// INVARIANT: Any ReplicaPlaceholder in this map is also in replicaPlaceholders.
+		// INVARIANT: Any Replica with Replica.IsInitialized()==true is also in replicasByRangeID.
+		replicasByKey *storeReplicaBTree
+		// All *Replica objects for which Replica.IsInitialized is false.
+		//
+		// INVARIANT: any entry in this map is also in replicasByRangeID.
 		uninitReplicas map[roachpb.RangeID]*Replica // Map of uninitialized replicas by Range ID
 		// replicaPlaceholders is a map to access all placeholders, so they can
-		// be directly accessed and cleared after stepping all raft groups. This
-		// is always in sync with the placeholders in replicasByKey.
+		// be directly accessed and cleared after stepping all raft groups.
+		//
+		// INVARIANT: any entry in this map is also in replicasByKey.
 		replicaPlaceholders map[roachpb.RangeID]*ReplicaPlaceholder
 	}
 

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -23,6 +23,10 @@ import (
 type RemoveOptions struct {
 	// If true, the replica's destroyStatus must be marked as removed.
 	DestroyData bool
+	// InsertPlaceholder can be specified when removing an initialized Replica
+	// and will result in the insertion of a ReplicaPlaceholder covering the
+	// keyspace previously occupied by the (now deleted) Replica.
+	InsertPlaceholder bool
 }
 
 // RemoveReplica removes the replica from the store's replica map and from the
@@ -40,7 +44,11 @@ func (s *Store) RemoveReplica(
 ) error {
 	rep.raftMu.Lock()
 	defer rep.raftMu.Unlock()
-	return s.removeInitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID, opts)
+	if opts.InsertPlaceholder {
+		return errors.Errorf("InsertPlaceholder not supported in RemoveReplica")
+	}
+	_, err := s.removeInitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID, opts)
+	return err
 }
 
 // removeReplicaRaftMuLocked removes the passed replica. If the replica is
@@ -50,7 +58,11 @@ func (s *Store) removeReplicaRaftMuLocked(
 ) error {
 	rep.raftMu.AssertHeld()
 	if rep.IsInitialized() {
-		return errors.Wrap(s.removeInitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID, opts),
+		if opts.InsertPlaceholder {
+			return errors.Errorf("InsertPlaceholder unsupported in removeReplicaRaftMuLocked")
+		}
+		_, err := s.removeInitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID, opts)
+		return errors.Wrap(err,
 			"failed to remove replica")
 	}
 	s.removeUninitializedReplicaRaftMuLocked(ctx, rep, nextReplicaID)
@@ -62,8 +74,18 @@ func (s *Store) removeReplicaRaftMuLocked(
 // It requires that Replica.raftMu is held and that s.mu is not held.
 func (s *Store) removeInitializedReplicaRaftMuLocked(
 	ctx context.Context, rep *Replica, nextReplicaID roachpb.ReplicaID, opts RemoveOptions,
-) error {
+) (*ReplicaPlaceholder, error) {
 	rep.raftMu.AssertHeld()
+	if !rep.IsInitialized() {
+		return nil, errors.AssertionFailedf("cannot remove uninitialized replica %s", rep)
+	}
+
+	if opts.InsertPlaceholder {
+		if opts.DestroyData {
+			return nil, errors.AssertionFailedf("cannot specify both InsertPlaceholder and DestroyData")
+		}
+
+	}
 
 	// Sanity checks before committing to the removal by setting the
 	// destroy status.
@@ -78,7 +100,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 			if rep.mu.destroyStatus.Removed() {
 				rep.mu.Unlock()
 				rep.readOnlyCmdMu.Unlock()
-				return nil // already removed, noop
+				return nil, nil // already removed, noop
 			}
 		} else {
 			// If the caller doesn't want to destroy the data because it already
@@ -158,11 +180,11 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	rep.disconnectReplicationRaftMuLocked(ctx)
 	if opts.DestroyData {
 		if err := rep.destroyRaftMuLocked(ctx, nextReplicaID); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	func() {
+	ph := func() *ReplicaPlaceholder {
 		s.mu.Lock()
 		defer s.mu.Unlock() // must unlock before s.scanner.RemoveReplica(), to avoid deadlock
 
@@ -173,19 +195,39 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 		if ph, ok := s.mu.replicaPlaceholders[rep.RangeID]; ok {
 			log.Fatalf(ctx, "initialized replica %s unexpectedly had a placeholder: %+v", rep, ph)
 		}
-		if it := s.mu.replicasByKey.DeleteReplica(ctx, rep); it.repl != rep {
+		desc := rep.Desc()
+		ph := &ReplicaPlaceholder{
+			rangeDesc: *roachpb.NewRangeDescriptor(desc.RangeID, desc.StartKey, desc.EndKey, desc.Replicas()),
+		}
+
+		if it := s.mu.replicasByKey.ReplaceOrInsertPlaceholder(ctx, ph); it.repl != rep {
 			// We already checked that our replica was present in replicasByKey
 			// above. Nothing should have been able to change that.
 			log.Fatalf(ctx, "replica %+v unexpectedly overlapped by %+v", rep, it.item)
 		}
-		if it := s.getOverlappingKeyRangeLocked(desc); it.item != nil {
+		if exPH, ok := s.mu.replicaPlaceholders[desc.RangeID]; ok {
+			log.Fatalf(ctx, "cannot insert placeholder %s, already have %s", ph, exPH)
+		}
+		s.mu.replicaPlaceholders[desc.RangeID] = ph
+
+		if opts.InsertPlaceholder {
+			return ph
+		}
+		// If placeholder not desired, remove it now, otherwise, that's the caller's
+		// job. We could elide the placeholder altogether but wish to instead
+		// minimize the divergence between the two code paths.
+
+		s.mu.replicasByKey.DeletePlaceholder(ctx, ph)
+		delete(s.mu.replicaPlaceholders, desc.RangeID)
+		if it := s.getOverlappingKeyRangeLocked(desc); it.item != nil && it.item != ph {
 			log.Fatalf(ctx, "corrupted replicasByKey map: %s and %s overlapped", rep, it.item)
 		}
+		return nil
 	}()
 
 	s.maybeGossipOnCapacityChange(ctx, rangeRemoveEvent)
 	s.scanner.RemoveReplica(rep)
-	return nil
+	return ph, nil
 }
 
 // removeUninitializedReplicaRaftMuLocked removes an uninitialized replica.

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -462,9 +462,12 @@ func (s *Store) canAcceptSnapshotLocked(
 		return nil, errors.Errorf("canAcceptSnapshotLocked requires a replica present")
 	}
 	// The raftMu is held which allows us to use the existing replica as a
-	// placeholder when we decide that the snapshot can be applied. As long
-	// as the caller releases the raftMu only after feeding the snapshot
-	// into the replica, this is safe.
+	// placeholder when we decide that the snapshot can be applied. As long as the
+	// caller releases the raftMu only after feeding the snapshot into the
+	// replica, this is safe. This is true even when the snapshot spans a merge,
+	// because we will be guaranteed to have the subsumed (initialized) Replicas
+	// in place as well. This is because they are present when the merge first
+	// commits, and cannot have been replicaGC'ed yet (see replicaGCQueue.process).
 	existingRepl.raftMu.AssertHeld()
 
 	existingRepl.mu.RLock()


### PR DESCRIPTION
In #73721 we saw the following assertion fire:

> kv/kvserver/replica_raftstorage.go:932  [n4,s4,r46/3:{-}] 1  unable to
> remove placeholder: corrupted replicasByKey map: <nil> and [...]

This is because `MergeRange` removes from the Store's in-memory map the
right-hand side Replica before extending the left-hand side, leaving a
gap for a snapshot to sneak in. A similar problem exists when a snapshot
widens the existing range (i.e. the snapshot reflects the results of a
merge). This commit closes both gaps.

I verified the fix by calling the newly-introduced (but promptly
disabled, see comment within) `(*Store).maybeAssertNoHole` from
both `(*Store).MergeRange` and `applySnapshot`.

The bug reproduced via this assertion, before this fix, in
`TestStoreRangeMergeTimestampCache` and
`TestChangeReplicasLeaveAtomicRacesWithMerge`, covering both the
snapshot and merge trigger cases. I'm not too happy to merge this
without the same kind of active test coverage, but since this will
require a backport, it's better not to rattle the cage too much.
I filed #74384 to clean this up fully.

Release note (bug fix): A bug was fixed that, in very rare cases, could
result in a node terminating with fatal error "unable to remove
placeholder: corrupted replicasByKey map". To avoid potential data
corruption, users affected by this crash should not restart the node,
but instead decommission it in absentia and have it rejoin the cluster
under a new NodeID.
