### PR TITLE
backupccl: allow columns of type array in EXPORT PARQUET

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -273,7 +273,13 @@ func TestExportOrder(t *testing.T) {
 // fields below name and stmt validate some aspect of the exported parquet file.
 // If a validation field is empty, then that field will not be used in the test.
 type parquetTest struct {
+	// name is the name of the test.
 	name string
+
+	// prep contains sql commands that will execute before the stmt.
+	prep []string
+
+	// stmt contains the EXPORT PARQUET statement.
 	stmt string
 
 	// colNames provides the expected column names for the parquet file.
@@ -287,8 +293,8 @@ type parquetTest struct {
 	vals [][]interface{}
 }
 
-// validateParquetFile reads the parquet file, converts each value in the parquet file to its
-// native go type, and asserts its values match the truth.
+// validateParquetFile reads the parquet file, conducts a test related to each
+// non nil field in the parquetTest struct
 func validateParquetFile(t *testing.T, file string, test parquetTest) error {
 	r, err := os.Open(file)
 	if err != nil {
@@ -314,12 +320,9 @@ func validateParquetFile(t *testing.T, file string, test parquetTest) error {
 			require.Equal(t, *col.SchemaElement.RepetitionType, test.colFieldRepType[i])
 		}
 	}
-
 	if test.vals != nil {
-
 		require.Equal(t, len(cols), len(test.vals[0]))
 		require.Equal(t, int(fr.NumRows()), len(test.vals))
-
 		count := 0
 		for {
 			row, err := fr.NextRow()
@@ -333,36 +336,68 @@ func validateParquetFile(t *testing.T, file string, test parquetTest) error {
 			t.Logf("\n Record %v:", count)
 			for i := 0; i < len(cols); i++ {
 				if test.vals[count][i] == nil {
-					// If we expect a null value, the row created by the parquet reader will not have the
-					// associated column.
+					// If we expect a null value, the row created by the parquet reader
+					// will not have the associated column.
 					_, ok := row[cols[i].SchemaElement.Name]
 					require.Equal(t, ok, false)
 					continue
 				}
-				var decodedV interface{}
 				v := row[cols[i].SchemaElement.Name]
-				switch vv := v.(type) {
-				case []byte:
-					// the parquet exporter encodes native go strings as []byte, so an extra
-					// step is required here
-					// TODO (MB): as we add more type support, this
-					// test will be insufficient: many go native types are encoded as
-					// []byte, so in the future, each column will have to call it's own
-					// custom decoder ( this is how IMPORT Parquet will work)
-					decodedV = string(vv)
-				case int64, float64, bool:
-					decodedV = vv
-				default:
-					t.Fatalf("unexepected type: %T", vv)
-				}
+				decodedV := decodeEl(t, v)
 				t.Logf("\t %v", decodedV)
 				require.Equal(t, test.vals[count][i], decodedV)
 			}
 			count++
 		}
 	}
-
 	return nil
+}
+
+func decodeEl(t *testing.T, v interface{}) interface{} {
+	var decodedV interface{}
+	switch vv := v.(type) {
+	case []byte:
+		// The parquet exporter encodes native go strings as []byte, so an extra
+		// step is required here.
+
+		// TODO (MB): as we add more type support, this switch statement will be
+		// insufficient: many go native types are encoded as []byte, so in the
+		// future, each column will have to call it's own custom decoder ( this is
+		// how IMPORT Parquet will work).
+		decodedV = string(vv)
+	case int64, float64, bool:
+		decodedV = vv
+	case map[string]interface{}:
+		var arrDecodedV []interface{}
+		b := vv["list"].([]map[string]interface{})
+
+		// Array values are stored in an array of maps: []map[string]interface{},
+		// where the ith map contains a single key value pair. The key is always "element"
+		// and the value is the ith value in the array.
+
+		// If the array of maps only contains an empty map, the array is empty. This
+		// occurs IFF "element" is not in the map.
+
+		// NB: there's a bug in the fraugster-parquet vendor library around reading
+		// an ARRAY[NULL]. See the "arrays" test case for more info. Ideally, once
+		// the bug gets fixed, ARRAY[NULL] will get read as the kvp {"element":interface{}} while
+		// ARRAY[] will continue to get read as an empty map.
+		if _, nonEmpty := b[0]["element"]; !nonEmpty {
+			arrDecodedV = []interface{}{}
+			if len(b) > 1 {
+				t.Fatalf("array is empty, it shouldn't have a length greater than 1")
+			}
+		} else {
+			// For non-empty arrays
+			for _, elMap := range b {
+				arrDecodedV = append(arrDecodedV, decodeEl(t, elMap["element"]))
+			}
+		}
+		decodedV = arrDecodedV
+	default:
+		t.Fatalf("unexepected type: %T", vv)
+	}
+	return decodedV
 }
 
 // TestBasicParquetTypes exports a relation with bool, int, float and string
@@ -416,10 +451,36 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 				parquet.FieldRepetitionType_REQUIRED,
 				parquet.FieldRepetitionType_OPTIONAL},
 		},
+		{
+			// TODO (mb): switch one of the values in the array to NULL once the
+			// vendor's parquet file reader bug resolves.
+			// https://github.com/fraugster/parquet-go/issues/60
+			//
+			// I already verified that the vendor's parquet writer can write arrays
+			// with null values just fine, so EXPORT PARQUET is bug free; however this
+			// roundtrip test would fail.
+			name: "arrays",
+			prep: []string{"CREATE TABLE atable (i INT PRIMARY KEY, x INT[])",
+				"INSERT INTO atable VALUES (1, ARRAY[1,2]), (2, ARRAY[2]), (3,ARRAY[1,13,5]),(4, NULL),(5, ARRAY[])"},
+			stmt:     `EXPORT INTO PARQUET 'nodelocal://0/arrays' FROM SELECT * FROM atable`,
+			colNames: []string{"i", "x"},
+			vals: [][]interface{}{
+				{int64(1), []interface{}{int64(1), int64(2)}},
+				{int64(2), []interface{}{int64(2)}},
+				{int64(3), []interface{}{int64(1), int64(13), int64(5)}},
+				{int64(4), nil},
+				{int64(5), []interface{}{}},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Logf("Test %s", test.name)
+		if test.prep != nil {
+			for _, cmd := range test.prep {
+				sqlDB.Exec(t, cmd)
+			}
+		}
 		sqlDB.Exec(t, test.stmt)
 		paths, err := filepath.Glob(filepath.Join(dir, test.name,
 			parquetExportFilePattern))

--- a/pkg/ccl/importccl/exportparquet.go
+++ b/pkg/ccl/importccl/exportparquet.go
@@ -150,8 +150,8 @@ func newParquetColumn(typ *types.T, name string, nullable bool) (parquetColumn, 
 		  cannot have null values). A column is set to required if the user
 		  specified the CRDB column as NOT NULL.
 		  - optional: 0 or 1 occurrence (i.e. same as above, but can have values)
-		  - repeated: 0 or more occurrences (the column value can be an array of values,
-		  so the value within the array will have its own repetition type)
+		  - repeated: 0 or more occurrences (the column value will be an array. A
+				value within the array will have its own repetition type)
 
 			See this blog post for more on parquet type specification:
 			https://blog.twitter.com/engineering/en_us/a/2013/dremel-made-simple-with-parquet
@@ -208,10 +208,60 @@ func newParquetColumn(typ *types.T, name string, nullable bool) (parquetColumn, 
 		}
 
 	case types.ArrayFamily:
-		// TODO(mb): Figure out how to modify the encodeFn for arrays.
-		// One possibility: recurse on type within array, define encodeFn elsewhere
-		// col.definition.Children[0] =  newParquetColumn(typ.ArrayContents(), name)
-		return col, errors.Errorf("parquet export does not support array type yet")
+
+		// Define a list such that the parquet schema in json is:
+		/*
+			required group colName (LIST){ // parent
+				repeated group list { // child
+					required colType element; //grandChild
+				}
+			}
+		*/
+		// MB figured this out by running toy examples of the fraugster-parquet
+		// vendor repository for added context, checkout this issue
+		// https://github.com/fraugster/parquet-go/issues/18
+
+		// First, define the grandChild definition, the schema for the array value.
+		grandChild, err := newParquetColumn(typ.ArrayContents(), "element", true)
+		if err != nil {
+			return col, err
+		}
+
+		// Next define the child definition, required by fraugster-parquet vendor library. Again,
+		// there's little documentation on this. MB figured this out using a debugger.
+		child := &parquetschema.ColumnDefinition{}
+		child.SchemaElement = parquet.NewSchemaElement()
+		child.SchemaElement.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.
+			FieldRepetitionType_REPEATED)
+		child.SchemaElement.Name = "list"
+		child.Children = []*parquetschema.ColumnDefinition{grandChild.definition}
+		ngc := int32(len(child.Children))
+		child.SchemaElement.NumChildren = &ngc
+
+		// Finally, define the parent definition.
+		col.definition.Children = []*parquetschema.ColumnDefinition{child}
+		nc := int32(len(col.definition.Children))
+		child.SchemaElement.NumChildren = &nc
+		col.definition.SchemaElement.ConvertedType = parquet.ConvertedTypePtr(parquet.ConvertedType_LIST)
+		col.encodeFn = func(d tree.Datum) (interface{}, error) {
+
+			datumArr := d.(*tree.DArray)
+			els := make([]map[string]interface{}, datumArr.Len())
+			for i, elt := range datumArr.Array {
+				var el interface{}
+				if elt.ResolvedType().Family() == types.UnknownFamily {
+					// skip encoding the datum
+				} else {
+					el, err = grandChild.encodeFn(elt)
+					if err != nil {
+						return col, err
+					}
+				}
+				els[i] = map[string]interface{}{"element": el}
+			}
+			encEl := map[string]interface{}{"list": els}
+			return encEl, nil
+		}
 
 	default:
 		return col, errors.Errorf("parquet export does not support the %v type yet", typ.Family())


### PR DESCRIPTION
Previously, EXPORT PARQUET only supported CRDB relations whose columns were
scalars of type int, string, float, or  boolean. This change allows columns of
type array whose values can be int, string, float, boolean. Following the CRDB
ARRAY documentation, a value in an exported array can be NULL as well.

Informs: #67710

Release note (sql change): EXPORT PARQUET can export columns of type array