### PR TITLE
keys,sql/catalog: add interface to check whether an ID is in the system db

### DIFF
--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "printer.go",
         "spans.go",
         "sql.go",
+        "system.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/keys",
     visibility = ["//visibility:public"],

--- a/pkg/keys/system.go
+++ b/pkg/keys/system.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+// SystemIDChecker determines whether a table ID corresponds to a system
+// table. In the earlier days of cockroachdb (prior to 22.1), these IDs were
+// all constants and had a value less than 50. In later versions, these IDs
+// are generated dynamically.
+type SystemIDChecker interface {
+
+	// IsSystemID is used to determine whether a descriptor ID is part
+	// of the system database. Implementations do not need to be aware of the
+	// type of descriptor which may correspond to this ID. It may be that the
+	// descriptor does not exist. However, if it returns true and a descriptor
+	// exists with the given ID, that descriptor is part of the system database.
+	IsSystemID(id uint32) bool
+}
+
+// DeprecatedSystemIDChecker returns the deprecated implementation of
+// SystemIDChecker.
+func DeprecatedSystemIDChecker() SystemIDChecker {
+	return &deprecatedSystemIDChecker{}
+}
+
+type deprecatedSystemIDChecker struct{}
+
+func (d deprecatedSystemIDChecker) IsSystemID(id uint32) bool {
+	return id <= MaxReservedDescID
+}
+
+var _ SystemIDChecker = (*deprecatedSystemIDChecker)(nil)

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -118,6 +118,7 @@ go_library(
         "//pkg/spanconfig/spanconfigsqltranslator",
         "//pkg/spanconfig/spanconfigsqlwatcher",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catconstants",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqltranslator"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydratedtables"
@@ -689,6 +690,10 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		GCJobNotifier:              gcJobNotifier,
 		RangeFeedFactory:           cfg.rangeFeedFactory,
 		CollectionFactory:          collectionFactory,
+
+		SystemIDChecker: catalog.SystemIDChecker{
+			SystemIDChecker: keys.DeprecatedSystemIDChecker(),
+		},
 	}
 
 	if sqlSchemaChangerTestingKnobs := cfg.TestingKnobs.SQLSchemaChanger; sqlSchemaChangerTestingKnobs != nil {

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "catalog.go",
         "desc_getter.go",
         "descriptor.go",
+        "descriptor_id.go",
         "descriptor_id_set.go",
         "errors.go",
         "schema.go",

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -292,11 +292,6 @@ func IsSystemConfigID(id ID) bool {
 	return id > 0 && id <= keys.MaxSystemConfigDescID
 }
 
-// IsReservedID returns whether this ID is for any system object.
-func IsReservedID(id ID) bool {
-	return id > 0 && id <= keys.MaxReservedDescID
-}
-
 // AnonymousTable is the empty table name, used when a data source
 // has no own name, e.g. VALUES, subqueries or the empty source.
 var AnonymousTable = tree.TableName{}

--- a/pkg/sql/catalog/descriptor_id.go
+++ b/pkg/sql/catalog/descriptor_id.go
@@ -1,0 +1,21 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package catalog
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+)
+
+// IsSystemID returns true if the ID is part of the system database.
+func IsSystemID(c keys.SystemIDChecker, id descpb.ID) bool {
+	return c.IsSystemID(uint32(id))
+}

--- a/pkg/sql/catalog/descriptor_id.go
+++ b/pkg/sql/catalog/descriptor_id.go
@@ -19,3 +19,14 @@ import (
 func IsSystemID(c keys.SystemIDChecker, id descpb.ID) bool {
 	return c.IsSystemID(uint32(id))
 }
+
+// SystemIDChecker is a higher-level interface above the keys.SystemIDChecker.
+// See the comments on that interface for semantics.
+type SystemIDChecker struct {
+	keys.SystemIDChecker
+}
+
+// IsSystemID returns true if the ID is part of the system database.
+func (s SystemIDChecker) IsSystemID(id descpb.ID) bool {
+	return IsSystemID(s.SystemIDChecker, id)
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
@@ -1161,6 +1162,10 @@ type ExecutorConfig struct {
 	// SessionData and other ExtraTxnState.
 	// This is currently only for builtin functions where we need to execute sql.
 	InternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
+
+	// SystemIDChecker is used to check whether an ID is part of the
+	// system database.
+	SystemIDChecker catalog.SystemIDChecker
 }
 
 // UpdateVersionSystemSettingHook provides a callback that allows us

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -19,10 +19,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
@@ -482,7 +484,8 @@ func createStatsRequestFilter(allowProgressIota *chan struct{}) kvserverbase.Rep
 			_, tableID, _ := encoding.DecodeUvarintAscending(req.(*roachpb.ScanRequest).Key)
 			// Ensure that the tableID is within the expected range for a table,
 			// but is not a system table.
-			if tableID > 0 && tableID < 100 && !descpb.IsReservedID(descpb.ID(tableID)) {
+			if tableID > 0 && tableID < 100 &&
+				!catalog.IsSystemID(keys.DeprecatedSystemIDChecker(), descpb.ID(uint32(tableID))) {
 				// Read from the channel twice to allow jobutils.RunJob to complete
 				// even though there is only one ScanRequest.
 				<-*allowProgressIota


### PR DESCRIPTION
This interface will be used to replace the functions which compare to
constants. Second commit does some plumbing into the server. 

Release note: None