### PR TITLE
keys,systemschema: add Testing*ID functions

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4258,7 +4258,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	gcr := roachpb.GCRequest{
 		// Bogus span to make it a valid request.
 		RequestHeader: roachpb.RequestHeader{
-			Key:    keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID),
+			Key:    keys.SystemSQLCodec.TablePrefix(systemschema.TestingUserDescID(0)),
 			EndKey: keys.MaxKey,
 		},
 		Threshold: tc.Server(0).Clock().Now(),

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -192,7 +192,7 @@ CREATE TABLE data2.foo (a int);
 
 		// Check there is no data in the span that we expect user data to be imported.
 		store := tcRestore.GetFirstStoreFromServer(t, 0)
-		startKey := keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID)
+		startKey := keys.SystemSQLCodec.TablePrefix(systemschema.TestingUserDescID(0))
 		endKey := keys.SystemSQLCodec.TablePrefix(uint32(maxBackupTableID)).PrefixEnd()
 		it := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 			UpperBound: endKey,

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -206,7 +207,7 @@ ORDER BY object_type, object_name`, full)
 		// Create tables with the same ID as data.tableA to ensure that comments
 		// from different tables in the restoring cluster don't appear.
 		tableA := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "data", "tablea")
-		for i := keys.MinUserDescID; i < int(tableA.GetID()); i++ {
+		for i := systemschema.TestingUserDescID(0); i < uint32(tableA.GetID()); i++ {
 			tableName := fmt.Sprintf("foo%d", i)
 			sqlDBRestore.Exec(t, fmt.Sprintf("CREATE TABLE %s ();", tableName))
 			sqlDBRestore.Exec(t, fmt.Sprintf("COMMENT ON TABLE %s IS 'table comment'", tableName))

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -176,6 +176,7 @@ go_test(
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/distsql",

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
@@ -65,8 +66,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
 	st := cluster.MakeTestingClusterSettings()
-	const parentID = descpb.ID(keys.MaxReservedDescID + 1)
-	const tableID = descpb.ID(keys.MaxReservedDescID + 2)
+	parentID := descpb.ID(systemschema.TestingUserDescID(0))
+	tableID := descpb.ID(systemschema.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -168,6 +168,7 @@ go_test(
         "//pkg/sql/catalog/catformat",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -55,7 +56,7 @@ func BenchmarkImportWorkload(b *testing.B) {
 	ts := timeutil.Now()
 	var tableSSTs []tableSSTable
 	for i, table := range g.Tables() {
-		tableID := descpb.ID(keys.MinUserDescID + 1 + i)
+		tableID := descpb.ID(systemschema.TestingUserDescID(1 + uint32(i)))
 		sst, err := format.ToSSTable(table, tableID, ts)
 		require.NoError(b, err)
 
@@ -160,7 +161,7 @@ func BenchmarkConvertToKVs(b *testing.B) {
 
 func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 	ctx := context.Background()
-	const tableID = descpb.ID(keys.MinUserDescID)
+	tableID := descpb.ID(systemschema.TestingUserDescID(0))
 	ts := timeutil.Now()
 
 	var bytes int64

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/gcjob",
         "//pkg/sql/parser",

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -142,7 +144,7 @@ func (pt *partitioningTest) parse() error {
 			return errors.Errorf("expected *tree.CreateTable got %T", stmt)
 		}
 		st := cluster.MakeTestingClusterSettings()
-		const parentID, tableID = keys.MinUserDescID, keys.MinUserDescID + 1
+		parentID, tableID := descpb.ID(systemschema.TestingUserDescID(0)), descpb.ID(systemschema.TestingUserDescID(1))
 		mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 			ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())
 		if err != nil {

--- a/pkg/ccl/workloadccl/format/BUILD.bazel
+++ b/pkg/ccl/workloadccl/format/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/parser",
         "//pkg/sql/row",
         "//pkg/sql/sem/tree",

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -46,7 +47,7 @@ func ToTableDescriptor(
 	if !ok {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
-	const parentID descpb.ID = keys.MaxReservedDescID
+	parentID := descpb.ID(systemschema.TestingMaxReservedDescID())
 	testSettings := cluster.MakeTestingClusterSettings()
 	tableDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 		ctx, &semaCtx, testSettings, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, ts.UnixNano())

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -367,7 +367,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	baseSql, _ /* splits */ := schema.GetInitialValues()
 	// Real system tables plus some user stuff.
 	kvs, _ /* splits */ := schema.GetInitialValues()
-	start := uint32(keys.MinUserDescID)
+	start := systemschema.TestingUserDescID(0)
 	userSQL := append(kvs, descriptor(start), descriptor(start+1), descriptor(start+5))
 	// Real system tables and partitioned user tables.
 	var subzoneSQL = make([]roachpb.KeyValue, len(userSQL))
@@ -469,7 +469,7 @@ func TestComputeSplitKeyTenantBoundaries(t *testing.T) {
 	schema := bootstrap.MakeMetadataSchema(
 		keys.SystemSQLCodec, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
 	)
-	minKey := tkey(keys.MinUserDescID)
+	minKey := tkey(systemschema.TestingUserDescID(0))
 
 	// Real system tenant only.
 	baseSql, _ /* splits */ := schema.GetInitialValues()
@@ -586,15 +586,15 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{tkey(keys.LivenessRangesID), keys.SystemDatabaseID},
 
 		// User tables should refer to themselves.
-		{tkey(keys.MinUserDescID), keys.MinUserDescID},
-		{tkey(keys.MinUserDescID + 22), keys.MinUserDescID + 22},
+		{tkey(systemschema.TestingUserDescID(0)), config.SystemTenantObjectID(systemschema.TestingUserDescID(0))},
+		{tkey(systemschema.TestingUserDescID(22)), config.SystemTenantObjectID(systemschema.TestingUserDescID(22))},
 		{roachpb.RKeyMax, keys.RootNamespaceID},
 
 		// Secondary tenant tables should refer to the TenantsRangesID.
-		{tenantTkey(5, keys.MinUserDescID), keys.TenantsRangesID},
-		{tenantTkey(5, keys.MinUserDescID+22), keys.TenantsRangesID},
-		{tenantTkey(10, keys.MinUserDescID), keys.TenantsRangesID},
-		{tenantTkey(10, keys.MinUserDescID+22), keys.TenantsRangesID},
+		{tenantTkey(5, systemschema.TestingUserDescID(0)), keys.TenantsRangesID},
+		{tenantTkey(5, systemschema.TestingUserDescID(22)), keys.TenantsRangesID},
+		{tenantTkey(10, systemschema.TestingUserDescID(0)), keys.TenantsRangesID},
+		{tenantTkey(10, systemschema.TestingUserDescID(22)), keys.TenantsRangesID},
 	}
 
 	originalZoneConfigHook := config.ZoneConfigHook

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -193,7 +193,7 @@ func TestPrettyPrint(t *testing.T) {
 		// tenant table
 		{ten5Codec.TenantPrefix(), "/Tenant/5", revertMustSupport},
 		{ten5Codec.TablePrefix(0), "/Tenant/5/Table/SystemConfigSpan/Start", revertSupportUnknown},
-		{ten5Codec.TablePrefix(keys.MinUserDescID), "/Tenant/5/Table/50", revertMustSupport},
+		{ten5Codec.TablePrefix(50), "/Tenant/5/Table/50", revertMustSupport},
 		{ten5Codec.TablePrefix(111), "/Tenant/5/Table/111", revertMustSupport},
 		{makeKey(ten5Codec.TablePrefix(42), encoding.EncodeUvarintAscending(nil, 1)), `/Tenant/5/Table/42/1`, revertMustSupport},
 		{makeKey(ten5Codec.TablePrefix(42), roachpb.RKey("foo")), `/Tenant/5/Table/42/"foo"`, revertSupportUnknown},

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -40,12 +41,12 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	mq := newMergeQueue(testCtx.store, testCtx.store.DB())
 	kvserverbase.MergeQueueEnabled.Override(ctx, &testCtx.store.ClusterSettings().SV, true)
 
-	tableKey := func(i uint32) []byte {
-		return keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + i)
+	tableKey := func(offset uint32) []byte {
+		return keys.SystemSQLCodec.TablePrefix(systemschema.TestingUserDescID(offset))
 	}
 
-	config.TestingSetZoneConfig(keys.MaxReservedDescID+1, *zonepb.NewZoneConfig())
-	config.TestingSetZoneConfig(keys.MaxReservedDescID+2, *zonepb.NewZoneConfig())
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(systemschema.TestingUserDescID(0)), *zonepb.NewZoneConfig())
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(systemschema.TestingUserDescID(1)), *zonepb.NewZoneConfig())
 
 	type testCase struct {
 		startKey, endKey []byte
@@ -58,13 +59,13 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	testCases := []testCase{
 		// The last range of table 1 should not be mergeable because table 2 exists.
 		{
-			startKey: tableKey(1),
-			endKey:   tableKey(2),
+			startKey: tableKey(0),
+			endKey:   tableKey(1),
 			minBytes: 1,
 		},
 		{
-			startKey: append(tableKey(1), 'z'),
-			endKey:   tableKey(2),
+			startKey: append(tableKey(0), 'z'),
+			endKey:   tableKey(1),
 			minBytes: 1,
 		},
 
@@ -72,15 +73,15 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 		// because there is no table that follows. (In this test, the system only
 		// knows about tables on which TestingSetZoneConfig has been called.)
 		{
-			startKey:    tableKey(2),
-			endKey:      tableKey(3),
+			startKey:    tableKey(1),
+			endKey:      tableKey(2),
 			minBytes:    1,
 			expShouldQ:  true,
 			expPriority: 1,
 		},
 		{
-			startKey:    append(tableKey(2), 'z'),
-			endKey:      tableKey(3),
+			startKey:    append(tableKey(1), 'z'),
+			endKey:      tableKey(2),
 			minBytes:    1,
 			expShouldQ:  true,
 			expPriority: 1,
@@ -88,12 +89,12 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 
 		// The last range is never mergeable.
 		{
-			startKey: tableKey(3),
+			startKey: tableKey(2),
 			endKey:   roachpb.KeyMax,
 			minBytes: 1,
 		},
 		{
-			startKey: append(tableKey(3), 'z'),
+			startKey: append(tableKey(2), 'z'),
 			endKey:   roachpb.KeyMax,
 			minBytes: 1,
 		},
@@ -101,16 +102,16 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 		// An interior range of a table is not mergeable if it meets or exceeds the
 		// minimum byte threshold.
 		{
-			startKey:    tableKey(1),
-			endKey:      append(tableKey(1), 'a'),
+			startKey:    tableKey(0),
+			endKey:      append(tableKey(0), 'a'),
 			minBytes:    1024,
 			bytes:       1024,
 			expShouldQ:  false,
 			expPriority: 0,
 		},
 		{
-			startKey:    tableKey(1),
-			endKey:      append(tableKey(1), 'a'),
+			startKey:    tableKey(0),
+			endKey:      append(tableKey(0), 'a'),
 			minBytes:    1024,
 			bytes:       1024,
 			expShouldQ:  false,
@@ -119,8 +120,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 		// Edge case: a minimum byte threshold of zero. This effectively disables
 		// the threshold, as an empty range is no longer considered mergeable.
 		{
-			startKey:    tableKey(1),
-			endKey:      append(tableKey(1), 'a'),
+			startKey:    tableKey(0),
+			endKey:      append(tableKey(0), 'a'),
 			minBytes:    0,
 			bytes:       0,
 			expShouldQ:  false,
@@ -130,16 +131,16 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 		// An interior range of a table is mergeable if it does not meet the minimum
 		// byte threshold. Its priority is inversely related to its size.
 		{
-			startKey:    tableKey(1),
-			endKey:      append(tableKey(1), 'a'),
+			startKey:    tableKey(0),
+			endKey:      append(tableKey(0), 'a'),
 			minBytes:    1024,
 			bytes:       0,
 			expShouldQ:  true,
 			expPriority: 1,
 		},
 		{
-			startKey:    tableKey(1),
-			endKey:      append(tableKey(1), 'a'),
+			startKey:    tableKey(0),
+			endKey:      append(tableKey(0), 'a'),
 			minBytes:    1024,
 			bytes:       768,
 			expShouldQ:  true,

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -731,7 +732,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	// which means keys.MaxReservedDescID+1.
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
-	config.TestingSetZoneConfig(keys.MaxReservedDescID+2, zoneConfig)
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(systemschema.TestingUserDescID(1)), zoneConfig)
 
 	// Check our config.
 	neverSplitsDesc = neverSplits.Desc()

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -76,9 +77,9 @@ func TestReplicateQueueRebalance(t *testing.T) {
 
 	const newRanges = 10
 	trackedRanges := map[roachpb.RangeID]struct{}{}
-	for i := 0; i < newRanges; i++ {
-		tableID := keys.MinUserDescID + i
-		splitKey := keys.SystemSQLCodec.TablePrefix(uint32(tableID))
+	for i := uint32(0); i < newRanges; i++ {
+		tableID := systemschema.TestingUserDescID(i)
+		splitKey := keys.SystemSQLCodec.TablePrefix(tableID)
 		// Retry the splits on descriptor errors which are likely as the replicate
 		// queue is already hard at work.
 		testutils.SucceedsSoon(t, func() error {

--- a/pkg/kv/kvserver/reports/BUILD.bazel
+++ b/pkg/kv/kvserver/reports/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -760,7 +761,7 @@ func compileTestCase(tc baseReportTestCase) (compiledTestCase, error) {
 	// Databases and tables share the id space, so we'll use a common counter for them.
 	// And we're going to use keys in user space, otherwise there's special cases
 	// in the zone config lookup that we bump into.
-	objectCounter := keys.MinUserDescID
+	objectCounter := int(systemschema.TestingUserDescID(0))
 	sysCfgBuilder := makeSystemConfigBuilder()
 	if err := sysCfgBuilder.setDefaultZoneConfig(tc.defaultZone.toZoneConfig()); err != nil {
 		return compiledTestCase{}, err

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1274,7 +1275,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 		},
 		&cfg)
 
-	baseID := uint32(keys.MinUserDescID)
+	baseID := systemschema.TestingUserDescID(0)
 	testData := []struct {
 		repl        *Replica
 		expMaxBytes int64

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -344,6 +344,7 @@ go_test(
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -396,7 +397,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	ts := s.(*TestServer)
 
-	key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, keys.MaxReservedDescID)
+	key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(systemschema.TestingMaxReservedDescID()))
 	valAt := func(i int) *descpb.Descriptor {
 		return dbdesc.NewInitial(
 			descpb.ID(i), "foo", security.AdminRoleName(),

--- a/pkg/sql/catalog/catprivilege/fix_test.go
+++ b/pkg/sql/catalog/catprivilege/fix_test.go
@@ -484,7 +484,7 @@ func TestMaybeFixSchemaPrivileges(t *testing.T) {
 		for u, p := range tc.input {
 			desc.Grant(u, p, false /* withGrantOption */)
 		}
-		testParentID := descpb.ID(keys.MaxReservedDescID + 1)
+		testParentID := descpb.ID(keys.MinUserDescID)
 		MaybeFixPrivileges(&desc,
 			testParentID,
 			descpb.InvalidID,

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -2293,3 +2293,24 @@ var (
 
 // SpanConfigurationsTableName represents system.span_configurations.
 var SpanConfigurationsTableName = tree.NewTableNameWithSchema("system", tree.PublicSchemaName, tree.Name(catconstants.SpanConfigurationsTableName))
+
+// TestingNonPredefinedUserDescID is intended to replace direct usage of
+// keys.MinNonPredefinedUserDescID in tests. In the future we will have the
+// return value depend on the bootstrapped system schema.
+func TestingNonPredefinedUserDescID(offset uint32) uint32 {
+	return keys.MinNonPredefinedUserDescID + offset
+}
+
+// TestingUserDescID is intended to replace direct usage of keys.MinUserDescID
+// in tests. In the future we will have the return value depend on the
+// bootstrapped system schema.
+func TestingUserDescID(offset uint32) uint32 {
+	return keys.MinUserDescID + offset
+}
+
+// TestingMaxReservedDescID is intended to replace direct usage of
+// keys.MaxReservedDescID in tests. In the future we will have the return value
+// depend on the bootstrapped system schema.
+func TestingMaxReservedDescID() uint32 {
+	return keys.MaxReservedDescID
+}

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/types",
         "//pkg/testutils",

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	. "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -54,8 +55,8 @@ func TestAllocateIDs(t *testing.T) {
 	ctx := context.Background()
 
 	desc := NewBuilder(&descpb.TableDescriptor{
-		ParentID: keys.MinUserDescID,
-		ID:       keys.MinUserDescID + 1,
+		ParentID: descpb.ID(systemschema.TestingUserDescID(0)),
+		ID:       descpb.ID(systemschema.TestingUserDescID(1)),
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{
 			{Name: "a", Type: types.Int},
@@ -86,8 +87,8 @@ func TestAllocateIDs(t *testing.T) {
 	}
 
 	expected := NewBuilder(&descpb.TableDescriptor{
-		ParentID: keys.MinUserDescID,
-		ID:       keys.MinUserDescID + 1,
+		ParentID: descpb.ID(systemschema.TestingUserDescID(0)),
+		ID:       descpb.ID(systemschema.TestingUserDescID(1)),
 		Version:  1,
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{

--- a/pkg/sql/catalog/typedesc/BUILD.bazel
+++ b/pkg/sql/catalog/typedesc/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemadesc",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/oidext",
         "//pkg/sql/privilege",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -377,7 +378,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	invalidPrivileges := descpb.NewBasePrivilegeDescriptor(security.RootUserName())
 	// Make the PrivilegeDescriptor invalid by granting SELECT to a type.
 	invalidPrivileges.Grant(security.TestUserName(), privilege.List{privilege.SELECT}, false)
-	typeDescID := descpb.ID(keys.MaxReservedDescID + 1)
+	typeDescID := descpb.ID(systemschema.TestingUserDescID(0))
 	testData := []struct {
 		err  string
 		desc descpb.TypeDescriptor

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/colconv",
         "//pkg/sql/colexec/colexectestutils",

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
@@ -181,7 +182,7 @@ func spanGeneratorOracle(
 }
 
 func makeTable(useColFamilies bool) catalog.TableDescriptor {
-	tableID := keys.MinNonPredefinedUserDescID
+	tableID := systemschema.TestingNonPredefinedUserDescID(0)
 	if !useColFamilies {
 		// We can prevent the span builder from splitting spans into separate column
 		// families by using a system table ID, since system tables do not have

--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/gcjob",
         "//pkg/testutils",

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -90,9 +91,9 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				sqlDB.Exec(t, "ALTER TABLE my_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 				sqlDB.Exec(t, "ALTER TABLE my_other_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 			}
-			myDBID := descpb.ID(keys.MinUserDescID + 2)
-			myTableID := descpb.ID(keys.MinUserDescID + 3)
-			myOtherTableID := descpb.ID(keys.MinUserDescID + 4)
+			myDBID := descpb.ID(systemschema.TestingUserDescID(2))
+			myTableID := descpb.ID(systemschema.TestingUserDescID(3))
+			myOtherTableID := descpb.ID(systemschema.TestingUserDescID(4))
 
 			var myTableDesc *tabledesc.Mutable
 			var myOtherTableDesc *tabledesc.Mutable

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -61,7 +61,7 @@ func TestInitialKeys(t *testing.T) {
 		desc, err := sql.CreateTestTableDescriptor(
 			context.Background(),
 			keys.SystemDatabaseID,
-			keys.MaxReservedDescID,
+			descpb.ID(systemschema.TestingMaxReservedDescID()),
 			"CREATE TABLE system.x (val INTEGER PRIMARY KEY)",
 			descpb.NewBasePrivilegeDescriptor(security.NodeUserName()),
 		)
@@ -95,7 +95,7 @@ func TestInitialKeys(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if a, e := i, int64(keys.MinUserDescID); a != e {
+		if a, e := i, int64(systemschema.TestingUserDescID(0)); a != e {
 			t.Fatalf("Expected next descriptor ID to be %d, was %d", e, a)
 		}
 	})

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1308,7 +1309,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 	// targetKey is represents one of the rows in the table.
 	// +2 since the first two available ids are allocated to the database and
 	// public schema.
-	firstTableID := uint32(keys.MinNonPredefinedUserDescID + 2)
+	firstTableID := systemschema.TestingNonPredefinedUserDescID(2)
 	indexID := uint32(1)
 	valInTable := uint64(2)
 	indexKey := keys.SystemSQLCodec.IndexPrefix(firstTableID, indexID)

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var configID = descpb.ID(1)
-var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, keys.MaxReservedDescID)
+var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(systemschema.TestingMaxReservedDescID()))
 
 // forceNewConfig forces a system config update by writing a bogus descriptor with an
 // incremented value inside. It then repeatedly fetches the gossip config until the
@@ -439,7 +439,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{systemschema.TestingMaxReservedDescID(), nil, "", defaultZoneConfig},
 		{db1, nil, "", defaultZoneConfig},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", defaultZoneConfig},
@@ -568,7 +568,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{systemschema.TestingMaxReservedDescID(), nil, "", defaultZoneConfig},
 		{db1, nil, "", expectedDb1Cfg},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", expectedTb11Cfg},
@@ -648,7 +648,7 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID))
+		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(systemschema.TestingUserDescID(0)))
 		_, err := cfg.GetZoneConfigForKey(key)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/startupmigrations/migrations_test.go
+++ b/pkg/startupmigrations/migrations_test.go
@@ -543,7 +543,7 @@ func TestCreateSystemTable(t *testing.T) {
 	ctx := context.Background()
 
 	table := tabledesc.NewBuilder(systemschema.NamespaceTable.TableDesc()).BuildExistingMutableTable()
-	table.ID = keys.MaxReservedDescID
+	table.ID = descpb.ID(systemschema.TestingMaxReservedDescID())
 
 	table.Name = "dummy"
 	nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, table.ParentID, table.Name)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/kv/kvserver/uncertainty",
         "//pkg/roachpb:with-mocks",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/testutils",

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -4523,7 +4524,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	const userID = keys.MinUserDescID
+	userID := systemschema.TestingUserDescID(0)
 	// Manually creates rows corresponding to the schema:
 	// CREATE TABLE t (id1 STRING, id2 STRING, ... PRIMARY KEY (id1, id2, ...))
 	addTablePrefix := func(prefix roachpb.Key, id uint32, rowVals ...string) roachpb.Key {
@@ -4728,7 +4729,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				addColFam(tablePrefix(userID, "b"), 1),
 				addColFam(tablePrefix(userID, "c"), 1),
 			},
-			rangeStart: keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID),
+			rangeStart: keys.SystemSQLCodec.TablePrefix(systemschema.TestingUserDescID(0)),
 			expSplit:   tablePrefix(userID, "b"),
 			expError:   false,
 		},


### PR DESCRIPTION
These new functions in the systemschema package replace direct references to
the following constants in tests:
- TestingMaxReservedDescID replaces keys.MaxReservedDescID,
- TestingUserDescID replaces keys.MinUserDescID,
- TestingNonPredefinedUserDescID replaces keys.MinNonPredefinedUserDescID.

Release note: None