### PR TITLE
backupccl: add incremental_storage option to RESTORE

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2113,6 +2113,7 @@ restore_options ::=
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
 	| 'NEW_DB_NAME' '=' string_or_placeholder
+	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -333,6 +333,7 @@ func resolveOptionsForBackupJobDescription(
 	}
 
 	var err error
+	// TODO(msbutler): use cloud.RedactKMSURI(uri) here instead?
 	newOpts.EncryptionKMSURI, err = sanitizeURIList(kmsURIs)
 	if err != nil {
 		return tree.BackupOptions{}, err

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -864,7 +864,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	_, _, sqlDB, tmpDir, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/`, `nodelocal://1/`, `nodelocal://2/`
+	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
 
 	const localFoo1, localFoo2, localFoo3 = LocalFoo + "/1", LocalFoo + "/2", LocalFoo + "/3"
 	backups := []interface{}{
@@ -879,19 +880,27 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", c3, url.QueryEscape("dc=dc2")),
 	}
 
+	incrementals := []interface{}{
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i1, url.QueryEscape("default")),
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i3, url.QueryEscape("dc=dc2")),
+	}
+
 	sqlDB.Exec(t, "BACKUP TO ($1, $2, $3)", backups...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+	sqlDB.Exec(t, "BACKUP INTO LATEST IN $4 WITH incremental_storage = ($1, $2, $3)",
+		append(incrementals, collections[0])...)
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
-	matches, err := filepath.Glob(path.Join(tmpDir, "*/*/*/"+backupManifestName))
+	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupManifestName))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 	for i := range matches {
 		matches[i] = strings.TrimPrefix(filepath.Dir(matches[i]), tmpDir)
 	}
-	full1 := matches[0]
+	full1 := strings.TrimPrefix(matches[0], "/full")
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS]",
 		[][]string{
@@ -899,10 +908,13 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 				backups[2].(string))},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1, collections[0],
 				collections[1], collections[2])},
-			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", strings.TrimPrefix(full1, "/"),
+			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1,
 				collections[0], collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir",
 				collections[0], collections[1], collections[2])},
+			{fmt.Sprintf("BACKUP INTO '%s' IN '%s' WITH incremental_storage = ('%s', '%s', '%s')",
+				"/subdir", collections[0], incrementals[0],
+				incrementals[1], incrementals[2])},
 		},
 	)
 
@@ -918,12 +930,17 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
 
+	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, "+
+		"$3) WITH incremental_storage = ($4, $5, $6)",
+		append(collections, incrementals[0], incrementals[1], incrementals[2])...)
+
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
 	// to the job description.
-	getResolvedCollectionURIs := func(subdir string) []string {
-		resolvedCollectionURIs := make([]string, len(collections))
-		for i, collection := range collections {
+	getResolvedCollectionURIs := func(prefixes []interface{}, subdir string) []string {
+		resolvedCollectionURIs := make([]string, len(prefixes))
+		for i, collection := range prefixes {
 			parsed, err := url.Parse(collection.(string))
 			require.NoError(t, err)
 			parsed.Path = path.Join(parsed.Path, subdir)
@@ -933,8 +950,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		return resolvedCollectionURIs
 	}
 
-	resolvedCollectionURIs := getResolvedCollectionURIs(full1)
-	resolvedSubdirURIs := getResolvedCollectionURIs("subdir")
+	resolvedCollectionURIs := getResolvedCollectionURIs(collections, full1)
+	resolvedSubdirURIs := getResolvedCollectionURIs(collections, "subdir")
+	resolvedIncURIs := getResolvedCollectionURIs(incrementals, "subdir")
 
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS] WHERE job_type='RESTORE'",
@@ -951,6 +969,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
 				resolvedSubdirURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_storage = ('%s', '%s', '%s')",
+				resolvedSubdirURIs[0], resolvedSubdirURIs[1], resolvedSubdirURIs[2],
+				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
 		},
 	)
 }
@@ -9008,4 +9029,74 @@ CREATE SCHEMA db.s;
 `)
 
 	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://0/test/2'`)
+}
+
+// TestBackupRestoreSeperateIncrementalPrefix tests that a backup/restore round
+// trip using the 'incremental_storage' parameter restores the same db as a BR
+// round trip without the parameter.
+func TestBackupRestoreSeparateIncrementalPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
+
+	collections := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape("default")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c3, url.QueryEscape("dc=dc2")),
+	}
+
+	incrementals := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i1, url.QueryEscape("default")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i3, url.QueryEscape("dc=dc2")),
+	}
+	tests := []struct {
+		dest []string
+		inc  []string
+	}{{dest: []string{collections[0]}, inc: []string{incrementals[0]}},
+		{dest: collections, inc: incrementals}}
+
+	for _, br := range tests {
+
+		dest := strings.Join(br.dest, ", ")
+		inc := strings.Join(br.inc, ", ")
+
+		if len(br.dest) > 1 {
+			dest = "(" + dest + ")"
+			inc = "(" + inc + ")"
+		}
+		// create db
+		sqlDB.Exec(t, `CREATE DATABASE fkdb`)
+		sqlDB.Exec(t, `CREATE TABLE fkdb.fk (ind INT)`)
+
+		for i := 0; i < 10; i++ {
+			sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, i)
+		}
+		fb := fmt.Sprintf("BACKUP DATABASE fkdb INTO %s", dest)
+		sqlDB.Exec(t, fb)
+
+		sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, 200)
+
+		sib := fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s WITH incremental_storage = %s", dest, inc)
+		sqlDB.Exec(t, sib)
+		sir := fmt.Sprintf("RESTORE DATABASE fkdb FROM LATEST IN %s WITH new_db_name = 'inc_fkdb', incremental_storage = %s", dest, inc)
+		sqlDB.Exec(t, sir)
+
+		ib := fmt.Sprintf("BACKUP DATABASE fkdb INTO LATEST IN %s", dest)
+		sqlDB.Exec(t, ib)
+		ir := fmt.Sprintf("RESTORE DATABASE fkdb FROM LATEST IN %s WITH new_db_name = 'trad_fkdb'", dest)
+		sqlDB.Exec(t, ir)
+
+		sqlDB.CheckQueryResults(t, `SELECT * FROM trad_fkdb.fk`, sqlDB.QueryStr(t, `SELECT * FROM inc_fkdb.fk`))
+
+		sqlDB.Exec(t, "DROP DATABASE fkdb")
+		sqlDB.Exec(t, "DROP DATABASE trad_fkdb;")
+		sqlDB.Exec(t, "DROP DATABASE inc_fkdb;")
+	}
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1390,7 +1390,7 @@ func getUserDescriptorNames(
 // them to be suitable for displaying in the jobs' description.
 // This includes redacting secrets from external storage URIs.
 func resolveOptionsForRestoreJobDescription(
-	opts tree.RestoreOptions, intoDB string, newDBName string, kmsURIs []string,
+	opts tree.RestoreOptions, intoDB string, newDBName string, kmsURIs []string, incFrom []string,
 ) (tree.RestoreOptions, error) {
 	if opts.IsDefault() {
 		return opts, nil
@@ -1424,6 +1424,14 @@ func resolveOptionsForRestoreJobDescription(
 		newOpts.DecryptionKMSURI = append(newOpts.DecryptionKMSURI, tree.NewDString(redactedURI))
 	}
 
+	if opts.IncrementalStorage != nil {
+		var err error
+		newOpts.IncrementalStorage, err = sanitizeURIList(incFrom)
+		if err != nil {
+			return tree.RestoreOptions{}, err
+		}
+	}
+
 	return newOpts, nil
 }
 
@@ -1431,6 +1439,7 @@ func restoreJobDescription(
 	p sql.PlanHookState,
 	restore *tree.Restore,
 	from [][]string,
+	incFrom []string,
 	opts tree.RestoreOptions,
 	intoDB string,
 	newDBName string,
@@ -1446,19 +1455,16 @@ func restoreJobDescription(
 	var options tree.RestoreOptions
 	var err error
 	if options, err = resolveOptionsForRestoreJobDescription(opts, intoDB, newDBName,
-		kmsURIs); err != nil {
+		kmsURIs, incFrom); err != nil {
 		return "", err
 	}
 	r.Options = options
 
 	for i, backup := range from {
 		r.From[i] = make(tree.StringOrPlaceholderOptList, len(backup))
-		for j, uri := range backup {
-			sf, err := cloud.SanitizeExternalStorageURI(uri, nil /* extraParams */)
-			if err != nil {
-				return "", err
-			}
-			r.From[i][j] = tree.NewDString(sf)
+		r.From[i], err = sanitizeURIList(backup)
+		if err != nil {
+			return "", err
 		}
 	}
 
@@ -1525,6 +1531,20 @@ func restorePlanHook(
 	subdirFn := func() (string, error) { return "", nil }
 	if restoreStmt.Subdir != nil {
 		subdirFn, err = p.TypeAsString(ctx, restoreStmt.Subdir, "RESTORE")
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+	}
+
+	var incStorageFn func() ([]string, error)
+	if restoreStmt.Options.IncrementalStorage != nil {
+		if restoreStmt.Subdir == nil {
+			err = errors.New("incremental_storage can only be used with the following" +
+				" syntax: 'RESTORE [target] FROM [subdirectory] IN [destination]'")
+			return nil, nil, nil, false, err
+		}
+		incStorageFn, err = p.TypeAsStringArray(ctx, tree.Exprs(restoreStmt.Options.IncrementalStorage),
+			"RESTORE")
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
@@ -1610,6 +1630,19 @@ func restorePlanHook(
 			}
 		}
 
+		// incFrom will contain the directory URIs for incremental backups (i.e.
+		// <prefix>/<subdir>) iff len(From)==1, regardless of the
+		// 'incremental_storage' param. len(From)=1 implies that the user has not
+		// explicitly passed incremental backups, so we'll have to look for any in
+		// <prefix>/<subdir>. len(incFrom)>1 implies the incremental backups are
+		// locality aware.
+		var incFrom []string
+		if incStorageFn != nil {
+			incFrom, err = incStorageFn()
+			if err != nil {
+				return err
+			}
+		}
 		if subdir != "" {
 			if strings.EqualFold(subdir, "LATEST") {
 				// set subdir to content of latest file
@@ -1622,18 +1655,31 @@ func restorePlanHook(
 			if len(from) != 1 {
 				return errors.Errorf("RESTORE FROM ... IN can only by used against a single collection path (per-locality)")
 			}
-			for i := range from[0] {
-				parsed, err := url.Parse(from[0][i])
-				if err != nil {
+
+			appendPaths := func(uris []string, tailDir string) error {
+				for i, uri := range uris {
+					parsed, err := url.Parse(uri)
+					if err != nil {
+						return err
+					}
+					parsed.Path = path.Join(parsed.Path, tailDir)
+					uris[i] = parsed.String()
+				}
+				return nil
+			}
+
+			if err = appendPaths(from[0][:], subdir); err != nil {
+				return err
+			}
+			if len(incFrom) != 0 {
+				if err = appendPaths(incFrom[:], subdir); err != nil {
 					return err
 				}
-				parsed.Path = path.Join(parsed.Path, subdir)
-				from[0][i] = parsed.String()
 			}
 		}
 
-		return doRestorePlan(ctx, restoreStmt, p, from, passphrase, kms, intoDB, newDBName, endTime,
-			resultsCh)
+		return doRestorePlan(ctx, restoreStmt, p, from, incFrom, passphrase, kms, intoDB,
+			newDBName, endTime, resultsCh)
 	}
 
 	if restoreStmt.Options.Detached {
@@ -1752,6 +1798,7 @@ func doRestorePlan(
 	restoreStmt *tree.Restore,
 	p sql.PlanHookState,
 	from [][]string,
+	incFrom []string,
 	passphrase string,
 	kms []string,
 	intoDB string,
@@ -1762,6 +1809,7 @@ func doRestorePlan(
 	if len(from) < 1 || len(from[0]) < 1 {
 		return errors.New("invalid base backup specified")
 	}
+
 	baseStores := make([]cloud.ExternalStorage, len(from[0]))
 	for i := range from[0] {
 		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, from[0][i], p.User())
@@ -1801,8 +1849,8 @@ func doRestorePlan(
 	}
 
 	defaultURIs, mainBackupManifests, localityInfo, err := resolveBackupManifests(
-		ctx, baseStores, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, from, endTime, encryption,
-		p.User(),
+		ctx, baseStores, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, from,
+		incFrom, endTime, encryption, p.User(),
 	)
 	if err != nil {
 		return err
@@ -2014,7 +2062,8 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
-	description, err := restoreJobDescription(p, restoreStmt, from, restoreStmt.Options, intoDB,
+	description, err := restoreJobDescription(p, restoreStmt, from, incFrom, restoreStmt.Options,
+		intoDB,
 		newDBName, kms)
 	if err != nil {
 		return err

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3132,7 +3132,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{NewDBName: $3.expr()}
   }
-
+| INCREMENTAL_STORAGE '=' string_or_placeholder_opt_list
+	{
+		$$.val = &tree.RestoreOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
+	}
 import_format:
   name
   {

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -487,6 +487,14 @@ RESTORE DATABASE foo FROM '_' WITH new_db_name = '_' -- literals removed
 RESTORE DATABASE _ FROM 'bar' WITH new_db_name = 'baz' -- identifiers removed
 
 parse
+RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_storage = 'baz'
+----
+RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- normalized!
+RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH incremental_storage = ('baz') -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH incremental_storage = '_' -- literals removed
+RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- identifiers removed
+
+parse
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
 ----
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -131,6 +131,7 @@ type RestoreOptions struct {
 	SkipLocalitiesCheck       bool
 	DebugPauseOn              Expr
 	NewDBName                 Expr
+	IncrementalStorage        StringOrPlaceholderOptList
 }
 
 var _ NodeFormatter = &RestoreOptions{}
@@ -139,10 +140,22 @@ var _ NodeFormatter = &RestoreOptions{}
 type Restore struct {
 	Targets            TargetList
 	DescriptorCoverage DescriptorCoverage
-	From               []StringOrPlaceholderOptList
-	AsOf               AsOfClause
-	Options            RestoreOptions
-	Subdir             Expr
+
+	// From contains the URIs for the backup(s) we seek to restore.
+	//   - len(From)>1 implies the user explicitly passed incremental backup paths,
+	//     which is only allowed using the old syntax, `RESTORE <targets> FROM <destination>.
+	//     In this case, From[0] contains the URI(s) for the full backup.
+	//   - len(From)==1 implies we'll have to look for incremental backups in planning
+	//   - len(From[0]) > 1 implies the backups are locality aware
+	//   - From[i][0] must be the default locality.
+	From    []StringOrPlaceholderOptList
+	AsOf    AsOfClause
+	Options RestoreOptions
+
+	// Subdir may be set by the parser when the SQL query is of the form `RESTORE
+	// ... FROM 'from' IN 'subdir'...`. Alternatively, restore_planning.go will set
+	// it for the query `RESTORE ... FROM 'from' IN LATEST...`
+	Subdir Expr
 }
 
 var _ Statement = &Restore{}
@@ -376,6 +389,11 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("new_db_name = ")
 		ctx.FormatNode(o.NewDBName)
 	}
+	if o.IncrementalStorage != nil {
+		maybeAddSep()
+		ctx.WriteString("incremental_storage = ")
+		ctx.FormatNode(&o.IncrementalStorage)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -459,6 +477,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		return errors.New("new_db_name specified multiple times")
 	}
 
+	if o.IncrementalStorage == nil {
+		o.IncrementalStorage = other.IncrementalStorage
+	} else if other.IncrementalStorage != nil {
+		return errors.New("incremental_storage option specified multiple times")
+	}
+
 	return nil
 }
 
@@ -475,5 +499,6 @@ func (o RestoreOptions) IsDefault() bool {
 		o.Detached == options.Detached &&
 		o.SkipLocalitiesCheck == options.SkipLocalitiesCheck &&
 		o.DebugPauseOn == options.DebugPauseOn &&
-		o.NewDBName == options.NewDBName
+		o.NewDBName == options.NewDBName &&
+		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }


### PR DESCRIPTION
Previously, the user could not restore incremental backups created with BACKUP
... WITH incremental_storage. This change adds the 'incremental_storage' option
to RESTORE, allowing users to restore a [locality aware] incremental backup
chain stored in 'incremental_storage'.

One UI subtlety: when creating a locality aware incremental backup with
'incremental_storage', users don't need to specify the localities of the full
backup, i.e.:

BACKUP INTO LATEST IN
'path_to_full_backup',
WITH incremental_storage=('path_to_inc_backup?COCKROACH_LOCALITY=default',
'path_to_inc_backup?COCKROACH_LOCALITY=region%3Dus-west');

However, users must do so in RESTORE:

RESTORE foo FROM LATEST IN ('path_to_full_backup?COCKROACH_LOCALITY=default',
'path_to_full_backup?COCKROACH_LOCALITY=region%3Dus-west') WITH
incremental_storage = ('path_to_inc_backup?COCKROACH_LOCALITY=default',
'path_to_inc_backup?COCKROACH_LOCALITY=region%3Dus-west')

Informs: #72236

Release note (sql change): users can now RESTORE [locality aware] incremental
backups created with the 'incremental_storage' parameter.