### PR TITLE
changefeedccl: limit in-memory rowfetcher cache

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -80,6 +80,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/bitarray",
         "//pkg/util/bufalloc",
+        "//pkg/util/cache",
         "//pkg/util/ctxgroup",
         "//pkg/util/duration",
         "//pkg/util/encoding",


### PR DESCRIPTION
We generate a row.Fetcher for each new version of a watched
table, and cache it in-memory. This is technically an unbounded
memory usage and thus could cause an OOM, although in practice
you won't hit that unless you are Schema Changes Georg, the
hypothetical outlier who makes thousands of schema changes a second.
To support Schema Changes Georg, this PR bounds the size of the
cache and evicts the oldest record. There's smarter stuff we could
do (per an existing TODO) to eagerly evict records using resolved
timestamps, but that's an optimization only a small subset of
hypothetical Georgs would care about (those running single
changefeeds on many tables, all with many rapid schema changes)
so I doubt we'll want to bother.

Release note: None