### PR TITLE
sqlsmith: Add multiregion syntax to sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -60,6 +61,7 @@ func registerSQLSmith(r registry.Registry) {
 		"default":      sqlsmith.Settings["default"],
 		"no-mutations": sqlsmith.Settings["no-mutations"],
 		"no-ddl":       sqlsmith.Settings["no-ddl"],
+		"multi-region": sqlsmith.Settings["multi-region"],
 	}
 
 	runSQLSmith := func(ctx context.Context, t test.Test, c cluster.Cluster, setupName, settingName string) {
@@ -115,6 +117,38 @@ func registerSQLSmith(r registry.Registry) {
 			t.Fatal(err)
 		} else {
 			logStmt(setup)
+		}
+
+		if settingName == "multi-region" {
+			regionsSet := make(map[string]struct{})
+			var region, zone string
+			rows, err := conn.Query("SHOW REGIONS FROM CLUSTER")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for rows.Next() {
+				if err := rows.Scan(&region, &zone); err != nil {
+					t.Fatal(err)
+				}
+				regionsSet[region] = struct{}{}
+			}
+
+			var regionList []string
+			for region := range regionsSet {
+				regionList = append(regionList, region)
+			}
+
+			if len(regionList) == 0 {
+				t.Fatal(errors.New("no regions, cannot run multi-region config"))
+			}
+
+			if _, err := conn.Exec(
+				fmt.Sprintf(`ALTER DATABASE defaultdb SET PRIMARY REGION "%s";
+ALTER TABLE seed_mr_table SET LOCALITY REGIONAL BY ROW;
+INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
+			); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		const timeout = time.Minute
@@ -247,11 +281,17 @@ func registerSQLSmith(r registry.Registry) {
 	}
 
 	register := func(setup, setting string) {
+		var clusterSpec spec.ClusterSpec
+		if strings.Contains(setting, "multi-region") {
+			clusterSpec = r.MakeClusterSpec(numNodes, spec.Geo())
+		} else {
+			clusterSpec = r.MakeClusterSpec(numNodes)
+		}
 		r.Add(registry.TestSpec{
 			Name: fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			// NB: sqlsmith failures should never block a release.
 			Owner:   registry.OwnerSQLQueries,
-			Cluster: r.MakeClusterSpec(numNodes),
+			Cluster: clusterSpec,
 			Timeout: time.Minute * 20,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runSQLSmith(ctx, t, c, setup, setting)
@@ -265,8 +305,10 @@ func registerSQLSmith(r registry.Registry) {
 		}
 	}
 	setups["seed-vec"] = sqlsmith.Setups["seed-vec"]
+	setups["seed-multi-region"] = sqlsmith.Setups["seed-multi-region"]
 	settings["ddl-nodrop"] = sqlsmith.Settings["ddl-nodrop"]
 	settings["vec"] = sqlsmith.SettingVectorize
 	register("seed-vec", "vec")
 	register("tpcc", "ddl-nodrop")
+	register("seed-multi-region", "multi-region")
 }

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -35,8 +35,9 @@ var Setups = map[string]Setup{
 	"seed": wrapCommonSetup(stringSetup(seedTable)),
 	// seed-vec is like seed except only types supported by vectorized
 	// execution are used.
-	"seed-vec":         wrapCommonSetup(stringSetup(vecSeedTable)),
-	RandTableSetupName: wrapCommonSetup(randTables),
+	"seed-vec":          wrapCommonSetup(stringSetup(vecSeedTable)),
+	"seed-multi-region": wrapCommonSetup(stringSetup(multiregionSeed)),
+	RandTableSetupName:  wrapCommonSetup(randTables),
 }
 
 // wrapCommonSetup wraps setup steps common to all SQLSmith setups around the
@@ -163,6 +164,26 @@ CREATE TABLE IF NOT EXISTS seed_vec AS
 INSERT INTO seed_vec DEFAULT VALUES;
 CREATE INDEX on seed_vec (_int8, _float8, _date);
 `
+
+	multiregionSeed = `
+CREATE TABLE IF NOT EXISTS seed_mr_table AS
+	SELECT
+		g::INT2 AS _int2,
+		g::INT4 AS _int4,
+		g::INT8 AS _int8,
+		g::FLOAT8 AS _float8,
+		'2001-01-01'::DATE + g AS _date,
+		'2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp,
+		'2001-01-01'::TIMESTAMPTZ + g * '1 day'::INTERVAL AS _timestamptz,
+		g * '1 day'::INTERVAL AS _interval,
+		g % 2 = 1 AS _bool,
+		g::DECIMAL AS _decimal,
+		g::STRING AS _string,
+		g::STRING::BYTES AS _bytes,
+		substring('00000000-0000-0000-0000-' || g::STRING || '00000000000', 1, 36)::UUID AS _uuid
+	FROM
+		generate_series(1, 5) AS g;
+`
 )
 
 // SettingFunc generates a Setting.
@@ -195,6 +216,7 @@ var Settings = map[string]SettingFunc{
 	"no-mutations+rand": randSetting(Parallel, DisableMutations()),
 	"no-ddl+rand":       randSetting(NoParallel, DisableDDLs()),
 	"ddl-nodrop":        randSetting(NoParallel, OnlyNoDropDDLs()),
+	"multi-region":      randSetting(Parallel, MultiRegionDDLs()),
 }
 
 // SettingVectorize is the setting for vectorizable. It is not included in

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -272,6 +272,11 @@ var OnlyNoDropDDLs = simpleOption("only DDLs", func(s *Smither) {
 	)
 })
 
+// MultiRegionDDLs causes the Smither to enable multiregion features.
+var MultiRegionDDLs = simpleOption("include multiregion DDLs", func(s *Smither) {
+	s.alterWeights = append(s.alterWeights, alterMultiregion...)
+})
+
 // DisableWith causes the Smither to not emit WITH clauses.
 var DisableWith = simpleOption("disable WITH", func(s *Smither) {
 	s.disableWith = true


### PR DESCRIPTION
Add sqlsmith testing for multiregion syntax.
Added support for

ALTER TABLE LOCALITY
ALTER DATABASE PRIMARY REGION
ALTER DATABASE ADD/DROP REGION

Release note: None

Resolves https://github.com/cockroachdb/cockroach/issues/65492