### PR TITLE
keys,*: adopt SystemIDChecker

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4258,7 +4258,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	gcr := roachpb.GCRequest{
 		// Bogus span to make it a valid request.
 		RequestHeader: roachpb.RequestHeader{
-			Key:    keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID),
+			Key:    keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)),
 			EndKey: keys.MaxKey,
 		},
 		Threshold: tc.Server(0).Clock().Now(),

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -192,7 +192,7 @@ CREATE TABLE data2.foo (a int);
 
 		// Check there is no data in the span that we expect user data to be imported.
 		store := tcRestore.GetFirstStoreFromServer(t, 0)
-		startKey := keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID)
+		startKey := keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0))
 		endKey := keys.SystemSQLCodec.TablePrefix(uint32(maxBackupTableID)).PrefixEnd()
 		it := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 			UpperBound: endKey,
@@ -429,7 +429,7 @@ func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
 	sqlDBRestore.Exec(t, `CREATE DATABASE foo`)
 	sqlDBRestore.ExpectErr(t,
-		"pq: full cluster restore can only be run on a cluster with no tables or databases but found 2 descriptors: \\[foo public\\]",
+		"pq: full cluster restore can only be run on a cluster with no tables or databases but found 2 descriptors: foo, public",
 		`RESTORE FROM $1`, LocalFoo,
 	)
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -967,15 +967,14 @@ func isSchemaEmpty(
 	return true, nil
 }
 
-func getTempSystemDBID(details jobspb.RestoreDetails) descpb.ID {
-	tempSystemDBID := keys.MinNonPredefinedUserDescID
+func getTempSystemDBID(details jobspb.RestoreDetails, idChecker keys.SystemIDChecker) descpb.ID {
+	tempSystemDBID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(idChecker))
 	for id := range details.DescriptorRewrites {
-		if int(id) > tempSystemDBID {
-			tempSystemDBID = int(id)
+		if id > tempSystemDBID {
+			tempSystemDBID = id
 		}
 	}
-
-	return descpb.ID(tempSystemDBID)
+	return tempSystemDBID
 }
 
 // spansForAllRestoreTableIndexes returns non-overlapping spans for every index
@@ -1106,7 +1105,7 @@ func createImportingDescriptors(
 
 	tempSystemDBID := descpb.InvalidID
 	if details.DescriptorCoverage == tree.AllDescriptors {
-		tempSystemDBID = getTempSystemDBID(details)
+		tempSystemDBID = getTempSystemDBID(details, p.ExecCfg().SystemIDChecker)
 		tempSystemDB := dbdesc.NewInitial(tempSystemDBID, restoreTempSystemDB,
 			security.AdminRoleName(), dbdesc.WithPublicSchemaID(keys.SystemPublicSchemaID))
 		databases = append(databases, tempSystemDB)
@@ -2667,7 +2666,7 @@ func (r *restoreResumer) restoreSystemTables(
 	restoreDetails jobspb.RestoreDetails,
 	tables []catalog.TableDescriptor,
 ) error {
-	tempSystemDBID := getTempSystemDBID(restoreDetails)
+	tempSystemDBID := getTempSystemDBID(restoreDetails, r.execCfg.SystemIDChecker)
 	details := r.job.Details().(jobspb.RestoreDetails)
 	if details.SystemTablesMigrated == nil {
 		details.SystemTablesMigrated = make(map[string]bool)

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -206,7 +206,7 @@ ORDER BY object_type, object_name`, full)
 		// Create tables with the same ID as data.tableA to ensure that comments
 		// from different tables in the restoring cluster don't appear.
 		tableA := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "data", "tablea")
-		for i := keys.MinUserDescID; i < int(tableA.GetID()); i++ {
+		for i := keys.TestingUserDescID(0); i < uint32(tableA.GetID()); i++ {
 			tableName := fmt.Sprintf("foo%d", i)
 			sqlDBRestore.Exec(t, fmt.Sprintf("CREATE TABLE %s ();", tableName))
 			sqlDBRestore.Exec(t, fmt.Sprintf("COMMENT ON TABLE %s IS 'table comment'", tableName))

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -65,8 +65,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
 	st := cluster.MakeTestingClusterSettings()
-	const parentID = descpb.ID(keys.MaxReservedDescID + 1)
-	const tableID = descpb.ID(keys.MaxReservedDescID + 2)
+	parentID := descpb.ID(keys.TestingUserDescID(0))
+	tableID := descpb.ID(keys.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3466,7 +3466,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		userSpan = roachpb.Span{
-			Key:    keys.UserTableDataMin,
+			Key:    keys.TestingUserTableDataMin(),
 			EndKey: keys.TableDataMax,
 		}
 		done               = make(chan struct{})

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/ccl/utilccl",
         "//pkg/jobs/jobspb",
-        "//pkg/keys",
         "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/catalog",

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -10,7 +10,6 @@ package changefeedbase
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/errors"
 )
@@ -27,7 +26,7 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 	// saved in it), but there are subtle differences in the way many of them
 	// work and this will be under-tested, so disallow them all until demand
 	// dictates.
-	if tableDesc.GetID() < keys.MinUserDescID {
+	if catalog.IsSystemDescriptor(tableDesc) {
 		return errors.Errorf(`CHANGEFEEDs are not supported on system tables`)
 	}
 	if tableDesc.IsView() {

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -164,6 +164,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catformat",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkImportWorkload(b *testing.B) {
 	ts := timeutil.Now()
 	var tableSSTs []tableSSTable
 	for i, table := range g.Tables() {
-		tableID := descpb.ID(keys.MinUserDescID + 1 + i)
+		tableID := descpb.ID(keys.TestingUserDescID(1 + uint32(i)))
 		sst, err := format.ToSSTable(table, tableID, ts)
 		require.NoError(b, err)
 
@@ -160,7 +160,7 @@ func BenchmarkConvertToKVs(b *testing.B) {
 
 func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 	ctx := context.Background()
-	const tableID = descpb.ID(keys.MinUserDescID)
+	tableID := descpb.ID(keys.TestingUserDescID(0))
 	ts := timeutil.Now()
 
 	var bytes int64

--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -66,6 +68,9 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			)`,
 		},
 	}
+	parentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(keys.TestingSystemIDChecker()))
+	tableID := parentID + 2
+
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
 	st := cluster.MakeTestingClusterSettings()
@@ -79,7 +84,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			if !ok {
 				t.Fatal("expected CREATE TABLE statement in table file")
 			}
-			_, err = MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, defaultCSVParentID, keys.PublicSchemaID, defaultCSVTableID, NoFKs, 0)
+			_, err = MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, parentID, keys.PublicSchemaID, tableID, NoFKs, 0)
 			if !testutils.IsError(err, tc.error) {
 				t.Fatalf("expected %v, got %+v", tc.error, err)
 			}

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -866,10 +866,11 @@ func parseAndCreateBundleTableDescs(
 	}}
 	switch format.Format {
 	case roachpb.IOFileFormat_Mysqldump:
+		id := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(p.ExecCfg().SystemIDChecker))
 		fks.resolver.format.Format = roachpb.IOFileFormat_Mysqldump
 		evalCtx := &p.ExtendedEvalContext().EvalContext
 		tableDescs, err = readMysqlCreateTable(
-			ctx, reader, evalCtx, p, defaultCSVTableID, parentDB, tableName, fks,
+			ctx, reader, evalCtx, p, id, parentDB, tableName, fks,
 			seqVals, owner, walltime,
 		)
 	case roachpb.IOFileFormat_PgDump:

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -37,14 +37,6 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-const (
-	// We need to choose arbitrary database and table IDs. These aren't important,
-	// but they do match what would happen when creating a new database and
-	// table on an empty cluster.
-	defaultCSVParentID descpb.ID = keys.MinNonPredefinedUserDescID
-	defaultCSVTableID  descpb.ID = defaultCSVParentID + 2
-)
-
 type fkHandler struct {
 	allowed  bool
 	skip     bool

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -142,7 +143,7 @@ func (pt *partitioningTest) parse() error {
 			return errors.Errorf("expected *tree.CreateTable got %T", stmt)
 		}
 		st := cluster.MakeTestingClusterSettings()
-		const parentID, tableID = keys.MinUserDescID, keys.MinUserDescID + 1
+		parentID, tableID := descpb.ID(keys.TestingUserDescID(0)), descpb.ID(keys.TestingUserDescID(1))
 		mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 			ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())
 		if err != nil {

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -46,7 +46,10 @@ func ToTableDescriptor(
 	if !ok {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
-	const parentID descpb.ID = keys.MaxReservedDescID
+	// We need to assign a valid parent database ID to the table descriptor, but
+	// the value itself doesn't matter, so we arbitrarily pick the system database
+	// ID because we know it's valid.
+	parentID := descpb.ID(keys.SystemDatabaseID)
 	testSettings := cluster.MakeTestingClusterSettings()
 	tableDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 		ctx, &semaCtx, testSettings, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, ts.UnixNano())

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -53,7 +53,7 @@ var (
 
 	// testingLargestIDHook is a function used to bypass GetLargestObjectID
 	// in tests.
-	testingLargestIDHook func(SystemTenantObjectID) SystemTenantObjectID
+	testingLargestIDHook func(checker keys.SystemIDChecker) SystemTenantObjectID
 )
 
 type zoneEntry struct {
@@ -195,17 +195,17 @@ func (s *SystemConfig) getIndexBound(key roachpb.Key) int {
 }
 
 // GetLargestObjectID returns the largest object ID found in the config which is
-// less than or equal to maxID. The objects in the config are augmented with the
-// provided pseudo IDs. If maxID is 0, returns the largest ID in the config
+// a system ID. The objects in the config are augmented with the provided pseudo
+// IDs. If idChecker is nil, returns the largest ID in the config
 // (again, augmented by the pseudo IDs).
 func (s *SystemConfig) GetLargestObjectID(
-	maxID SystemTenantObjectID, pseudoIDs []uint32,
+	idChecker keys.SystemIDChecker, pseudoIDs []uint32,
 ) (SystemTenantObjectID, error) {
 	testingLock.Lock()
 	hook := testingLargestIDHook
 	testingLock.Unlock()
 	if hook != nil {
-		return hook(maxID), nil
+		return hook(idChecker), nil
 	}
 
 	// Search for the descriptor table entries within the SystemConfig. lowIndex
@@ -223,14 +223,14 @@ func (s *SystemConfig) GetLargestObjectID(
 	maxPseudoID := SystemTenantObjectID(0)
 	for _, id := range pseudoIDs {
 		objID := SystemTenantObjectID(id)
-		if objID > maxPseudoID && (maxID == 0 || objID <= maxID) {
+		if objID > maxPseudoID && (idChecker == nil || idChecker.IsSystemID(uint32(objID))) {
 			maxPseudoID = objID
 		}
 	}
 
 	// No maximum specified; maximum ID is the last entry in the descriptor
 	// table or the largest pseudo ID, whichever is larger.
-	if maxID == 0 {
+	if idChecker == nil {
 		id, err := keys.SystemSQLCodec.DecodeDescMetadataID(s.Values[highIndex-1].Key)
 		if err != nil {
 			return 0, err
@@ -253,7 +253,7 @@ func (s *SystemConfig) GetLargestObjectID(
 		}
 		var id uint32
 		id, err = keys.SystemSQLCodec.DecodeDescMetadataID(searchSlice[i].Key)
-		return SystemTenantObjectID(id) >= maxID
+		return !idChecker.IsSystemID(id)
 	})
 	if err != nil {
 		return 0, err
@@ -266,13 +266,13 @@ func (s *SystemConfig) GetLargestObjectID(
 		if err != nil {
 			return 0, err
 		}
-		if SystemTenantObjectID(id) == maxID {
+		if idChecker.IsSystemID(id) {
 			return SystemTenantObjectID(id), nil
 		}
 	}
 
 	if maxIdx == 0 {
-		return 0, fmt.Errorf("no descriptors present with ID < %d", maxID)
+		return 0, fmt.Errorf("no system descriptors present")
 	}
 
 	// Return ID of the immediately preceding descriptor.
@@ -520,6 +520,7 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 		return nil
 	}
 
+	idChecker := keys.DeprecatedSystemIDChecker()
 	startID, _, ok := DecodeSystemTenantObjectID(startKey)
 	if !ok || startID <= keys.MaxSystemConfigDescID {
 		// The start key is either:
@@ -542,7 +543,7 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 		for id := startID; id <= endID; id++ {
 			tableKey := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(uint32(id)))
 			// This logic is analogous to the well-commented static split logic above.
-			if startKey.Less(tableKey) && s.shouldSplitOnSystemTenantObject(id) {
+			if startKey.Less(tableKey) && s.shouldSplitOnSystemTenantObject(id, idChecker) {
 				if tableKey.Less(endKey) {
 					return tableKey
 				}
@@ -576,8 +577,8 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 
 	// If the startKey falls within the non-system reserved range, compute those
 	// keys first.
-	if startID <= keys.MaxReservedDescID {
-		endID, err := s.GetLargestObjectID(keys.MaxReservedDescID, keys.PseudoTableIDs)
+	if idChecker.IsSystemID(uint32(startID)) {
+		endID, err := s.GetLargestObjectID(idChecker, keys.PseudoTableIDs)
 		if err != nil {
 			log.Errorf(ctx, "unable to determine largest reserved object ID from system config: %s", err)
 			return nil
@@ -585,11 +586,11 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 		if splitKey := findSplitKey(startID, endID); splitKey != nil {
 			return splitKey
 		}
-		startID = keys.MaxReservedDescID + 1
+		startID = SystemTenantObjectID(keys.MinUserDescriptorID(idChecker))
 	}
 
 	// Find the split key in the system tenant's user space.
-	endID, err := s.GetLargestObjectID(0, keys.PseudoTableIDs)
+	endID, err := s.GetLargestObjectID(nil /* systemIDChecker */, keys.PseudoTableIDs)
 	if err != nil {
 		log.Errorf(ctx, "unable to determine largest object ID from system config: %s", err)
 		return nil
@@ -691,7 +692,9 @@ func (s *SystemConfig) NeedsSplit(ctx context.Context, startKey, endKey roachpb.
 // shouldSplitOnSystemTenantObject checks if the ID is eligible for a split at
 // all. It uses the internal cache to find a value, and tries to find it using
 // the hook if ID isn't found in the cache.
-func (s *SystemConfig) shouldSplitOnSystemTenantObject(id SystemTenantObjectID) bool {
+func (s *SystemConfig) shouldSplitOnSystemTenantObject(
+	id SystemTenantObjectID, idChecker keys.SystemIDChecker,
+) bool {
 	// Check the cache.
 	{
 		s.mu.RLock()
@@ -703,7 +706,7 @@ func (s *SystemConfig) shouldSplitOnSystemTenantObject(id SystemTenantObjectID) 
 	}
 
 	var shouldSplit bool
-	if id < keys.MinUserDescID {
+	if idChecker.IsSystemID(uint32(id)) {
 		// The ID might be one of the reserved IDs that refer to ranges but not any
 		// actual descriptors.
 		shouldSplit = true

--- a/pkg/config/testutil.go
+++ b/pkg/config/testutil.go
@@ -12,6 +12,7 @@ package config
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -40,11 +41,11 @@ func TestingSetupZoneConfigHook(stopper *stop.Stopper) {
 	testingZoneConfig = make(zoneConfigMap)
 	testingPreviousHook = ZoneConfigHook
 	ZoneConfigHook = testingZoneConfigHook
-	testingLargestIDHook = func(maxID SystemTenantObjectID) (max SystemTenantObjectID) {
+	testingLargestIDHook = func(systemIDChecker keys.SystemIDChecker) (max SystemTenantObjectID) {
 		testingLock.Lock()
 		defer testingLock.Unlock()
 		for id := range testingZoneConfig {
-			if maxID > 0 && id > maxID {
+			if systemIDChecker != nil && !systemIDChecker.IsSystemID(uint32(id)) {
 				continue
 			}
 			if id > max {

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -300,9 +300,6 @@ var (
 	NamespaceTableMin = SystemSQLCodec.TablePrefix(NamespaceTableID)
 	// NamespaceTableMax is the end key of system.namespace.
 	NamespaceTableMax = SystemSQLCodec.TablePrefix(NamespaceTableID + 1)
-	//
-	// UserTableDataMin is the start key of user structured data.
-	UserTableDataMin = SystemSQLCodec.TablePrefix(MinUserDescID)
 
 	// 4. Non-system tenant SQL keys
 	//
@@ -320,21 +317,11 @@ const (
 	// this ID range.
 	MaxSystemConfigDescID = 10
 
-	// MaxReservedDescID is the maximum value of reserved descriptor
-	// IDs. Reserved IDs are used by namespaces and tables used internally by
-	// cockroach.
-	MaxReservedDescID = 49
-
-	// MinUserDescID is the first descriptor ID available for user
-	// structured data.
-	MinUserDescID = MaxReservedDescID + 1
-
-	// MinNonPredefinedUserDescID is the first descriptor ID used by
-	// user-level objects that are not created automatically on empty
-	// clusters (default databases).
-	// Two default databases and two public schemas are created by default using
-	// 4 ids.
-	MinNonPredefinedUserDescID = MinUserDescID + 4
+	// minUserDescID is the first descriptor ID available for user
+	// structured data. This is the ID following the maximum value of reserved
+	// descriptor IDs. Reserved IDs are used by namespaces and tables used
+	// internally by cockroach.
+	minUserDescID = 50
 
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID = 0

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -261,7 +261,6 @@ var _ = [...]interface{}{
 	// 	table data.
 	TableDataMin,
 	NamespaceTableMin,
-	UserTableDataMin,
 	TableDataMax,
 
 	//  4. Non-system tenant SQL keys: This is where we store all non-system

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -115,7 +115,6 @@ func TestPrettyPrint(t *testing.T) {
 
 		// table
 		{keys.SystemConfigSpan.Key, "/Table/SystemConfigSpan/Start", revertSupportUnknown},
-		{keys.UserTableDataMin, "/Table/50", revertMustSupport},
 		{tenSysCodec.TablePrefix(111), "/Table/111", revertMustSupport},
 		{makeKey(tenSysCodec.TablePrefix(42), encoding.EncodeUvarintAscending(nil, 1)), `/Table/42/1`, revertMustSupport},
 		{makeKey(tenSysCodec.TablePrefix(42), roachpb.RKey("foo")), `/Table/42/"foo"`, revertSupportUnknown},
@@ -193,7 +192,7 @@ func TestPrettyPrint(t *testing.T) {
 		// tenant table
 		{ten5Codec.TenantPrefix(), "/Tenant/5", revertMustSupport},
 		{ten5Codec.TablePrefix(0), "/Tenant/5/Table/SystemConfigSpan/Start", revertSupportUnknown},
-		{ten5Codec.TablePrefix(keys.MinUserDescID), "/Tenant/5/Table/50", revertMustSupport},
+		{ten5Codec.TablePrefix(50), "/Tenant/5/Table/50", revertMustSupport},
 		{ten5Codec.TablePrefix(111), "/Tenant/5/Table/111", revertMustSupport},
 		{makeKey(ten5Codec.TablePrefix(42), encoding.EncodeUvarintAscending(nil, 1)), `/Tenant/5/Table/42/1`, revertMustSupport},
 		{makeKey(ten5Codec.TablePrefix(42), roachpb.RKey("foo")), `/Tenant/5/Table/42/"foo"`, revertSupportUnknown},

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -58,7 +58,7 @@ func TestExportCmd(t *testing.T) {
 		t *testing.T, start hlc.Timestamp, mvccFilter roachpb.MVCCFilter, maxResponseSSTBytes int64,
 	) (roachpb.Response, *roachpb.Error) {
 		req := &roachpb.ExportRequest{
-			RequestHeader: roachpb.RequestHeader{Key: keys.UserTableDataMin, EndKey: keys.MaxKey},
+			RequestHeader: roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 			StartTime:     start,
 			Storage: roachpb.ExternalStorage{
 				Provider:  roachpb.ExternalStorageProvider_nodelocal,
@@ -423,7 +423,7 @@ func TestExportGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.ExportRequest{
-		RequestHeader: roachpb.RequestHeader{Key: keys.UserTableDataMin, EndKey: keys.MaxKey},
+		RequestHeader: roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 		StartTime:     hlc.Timestamp{WallTime: -1},
 	}
 	_, pErr := kv.SendWrapped(ctx, kvDB.NonTransactionalSender(), req)

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -529,7 +529,7 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	key := keys.UserTableDataMin
+	key := keys.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, key)
 	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 2)...))
@@ -633,7 +633,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	key := keys.UserTableDataMin
+	key := keys.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, key)
 	tc.AddVotersOrFatal(t, key, tc.Targets(2, 4)...)
 	repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(key))
@@ -811,7 +811,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = 'false'`)
 	require.NoError(t, err)
 
-	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.UserTableDataMin)
+	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.TestingUserTableDataMin())
 	tc.AddVotersOrFatal(t, rhsDesc.StartKey.AsRawKey(), tc.Targets(1, 2, 3)...)
 	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0), tc.Target(1))
 
@@ -965,7 +965,7 @@ func TestAlterRangeRelocate(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 
-	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.UserTableDataMin)
+	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.TestingUserTableDataMin())
 	tc.AddVotersOrFatal(t, rhsDesc.StartKey.AsRawKey(), tc.Targets(1, 2)...)
 
 	// We start with having the range under test on (1,2,3).

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3700,7 +3700,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.UserTableDataMin
+	splitKey := keys.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, splitKey)
 
 	tc.StopServer(0)
@@ -4203,7 +4203,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.UserTableDataMin
+	splitKey := keys.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, splitKey)
 	tc.AddVotersOrFatal(t, splitKey, tc.Target(1))
 	desc := tc.LookupRangeOrFatal(t, splitKey)

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -50,6 +50,7 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 
 	db := tc.Server(0).DB()
 	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+	tc.Server(0)
 
 	t.Run("works on system ranges", func(t *testing.T) {
 		startTS := db.Clock().Now()
@@ -68,7 +69,7 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 
 		// Note: 42 is a system descriptor.
 		const junkDescriptorID = 42
-		require.GreaterOrEqual(t, keys.MaxReservedDescID, junkDescriptorID)
+		require.True(t, keys.TestingSystemIDChecker().IsSystemID(junkDescriptorID))
 		junkDescriptorKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, junkDescriptorID)
 		junkDescriptor := dbdesc.NewInitial(
 			junkDescriptorID, "junk", security.AdminRoleName())

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3822,7 +3822,7 @@ func TestTenantID(t *testing.T) {
 	t.Run("(1) initial set", func(t *testing.T) {
 		// Ensure that a normal range has the system tenant.
 		{
-			_, repl := getFirstStoreReplica(t, tc.Server(0), keys.UserTableDataMin)
+			_, repl := getFirstStoreReplica(t, tc.Server(0), keys.TestingUserTableDataMin())
 			ri := repl.State(ctx)
 			require.Equal(t, roachpb.SystemTenantID.ToUint64(), ri.TenantID, "%v", repl)
 		}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -271,7 +271,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	store, err := s.Stores().GetStore(s.GetFirstStoreID())
 	require.NoError(t, err)
 
-	key := keys.UserTableDataMin
+	key := keys.TestingUserTableDataMin()
 	args := adminSplitArgs(key)
 	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, pErr)
@@ -289,7 +289,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 			return err
 		}
 		// We don't care about the values, just the keys.
-		k := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(keys.MinUserDescID))
+		k := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(keys.TestingUserDescID(0)))
 		return txn.Put(ctx, k, &desc)
 	}); err != nil {
 		t.Fatal(err)
@@ -339,7 +339,7 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	// Manually create some the column keys corresponding to the table:
 	//
 	//   CREATE TABLE t (id STRING PRIMARY KEY, col1 INT, col2 INT)
-	tableKey := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID))
+	tableKey := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)))
 	rowKey := roachpb.Key(encoding.EncodeVarintAscending(append([]byte(nil), tableKey...), 1))
 	rowKey = encoding.EncodeStringAscending(encoding.EncodeVarintAscending(rowKey, 1), "a")
 	col1Key, err := keys.EnsureSafeSplitKey(keys.MakeFamilyKey(append([]byte(nil), rowKey...), 1))
@@ -703,7 +703,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	start := s.Clock().Now()
 
 	// Split the range after the last table data key.
-	keyPrefix := keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID)
+	keyPrefix := keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0))
 	args := adminSplitArgs(keyPrefix)
 	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatal(pErr)
@@ -830,7 +830,7 @@ func TestStoreEmptyRangeSnapshotSize(t *testing.T) {
 
 	// Split the range after the last table data key to get a range that contains
 	// no user data.
-	splitKey := keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID)
+	splitKey := keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0))
 	splitArgs := adminSplitArgs(splitKey)
 	if _, err := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), splitArgs); err != nil {
 		t.Fatal(err)
@@ -906,7 +906,7 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	start := s.Clock().Now()
 
 	// Split the range after the last table data key.
-	keyPrefix := keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID)
+	keyPrefix := keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0))
 	args := adminSplitArgs(keyPrefix)
 	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatal(pErr)
@@ -1025,7 +1025,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 
 	const maxBytes = 1 << 16
 	// Set max bytes.
-	descID := uint32(keys.MinUserDescID)
+	descID := keys.TestingUserDescID(0)
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 	config.TestingSetZoneConfig(config.SystemTenantObjectID(descID), zoneConfig)
@@ -1096,7 +1096,7 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 
 	// Set max bytes.
 	const maxBytes = 1 << 16
-	descID := uint32(keys.MinUserDescID)
+	descID := keys.TestingUserDescID(0)
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 	config.TestingSetZoneConfig(config.SystemTenantObjectID(descID), zoneConfig)
@@ -1155,7 +1155,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			var activateSplitFilter int32
-			splitKey := roachpb.RKey(keys.UserTableDataMin)
+			splitKey := roachpb.RKey(keys.TestingUserTableDataMin())
 			splitPending, blockSplits := make(chan struct{}), make(chan struct{})
 
 			// Set maxBytes to something small so we can exceed the maximum split
@@ -1311,7 +1311,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	userTableMax := keys.MinUserDescID + 4
+	userTableMax := keys.TestingUserDescID(4)
 	var exceptions map[int]struct{}
 	schema := bootstrap.MakeMetadataSchema(
 		keys.SystemSQLCodec, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
@@ -1335,7 +1335,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 				return err
 			}
 		}
-		for i := keys.MinUserDescID; i <= userTableMax; i++ {
+		for i := keys.TestingUserDescID(0); i <= userTableMax; i++ {
 			// We don't care about the value, just the key.
 			id := descpb.ID(i)
 			key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, id)
@@ -1370,10 +1370,10 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 				testutils.MakeKey(keys.Meta2Prefix, keys.SystemSQLCodec.TablePrefix(i)),
 			)
 		}
-		for i := keys.MinUserDescID; i <= userTableMax; i++ {
-			if _, ok := exceptions[i]; !ok {
+		for i := keys.TestingUserDescID(0); i <= userTableMax; i++ {
+			if _, ok := exceptions[int(i)]; !ok {
 				expKeys = append(expKeys,
-					testutils.MakeKey(keys.Meta2Prefix, keys.SystemSQLCodec.TablePrefix(uint32(i))),
+					testutils.MakeKey(keys.Meta2Prefix, keys.SystemSQLCodec.TablePrefix(i)),
 				)
 			}
 		}
@@ -1399,7 +1399,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 
 	// Write another, disjoint (+3) descriptor for a user table.
 	userTableMax += 3
-	exceptions = map[int]struct{}{userTableMax - 1: {}, userTableMax - 2: {}}
+	exceptions = map[int]struct{}{int(userTableMax) - 1: {}, int(userTableMax) - 2: {}}
 	if err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		if err := txn.SetSystemConfigTrigger(true /* forSystemTenant */); err != nil {
 			return err
@@ -2404,13 +2404,13 @@ func TestStoreTxnWaitQueueEnabledOnSplit(t *testing.T) {
 	store, err := s.Stores().GetStore(s.GetFirstStoreID())
 	require.NoError(t, err)
 
-	key := keys.UserTableDataMin
+	key := keys.TestingUserTableDataMin()
 	args := adminSplitArgs(key)
 	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, pErr)
 	}
 
-	rhsRepl := store.LookupReplica(roachpb.RKey(keys.UserTableDataMin))
+	rhsRepl := store.LookupReplica(roachpb.RKey(keys.TestingUserTableDataMin()))
 	if !rhsRepl.GetConcurrencyManager().TestingTxnWaitQueue().IsEnabled() {
 		t.Errorf("expected RHS replica's push txn queue to be enabled post-split")
 	}
@@ -2904,6 +2904,8 @@ func TestRangeLookupAfterMeta2Split(t *testing.T) {
 	s := srv.(*server.TestServer)
 	defer s.Stopper().Stop(ctx)
 
+	// The following assumes that keys.TestingUserDescID(0) returns 50.
+	//
 	// Create a split at /Table/48 and /Meta2/Table/51. This creates:
 	//   meta ranges [/Min-/Meta2/Table/51) and [/Meta2/Table/51-/System)
 	//   user ranges [/Table/19-/Table/48)  and [/Table/48-/Max)
@@ -2912,7 +2914,7 @@ func TestRangeLookupAfterMeta2Split(t *testing.T) {
 	// will first search for meta(/Table/49) which is on the left meta2 range. However,
 	// the user range [/Table/48-/Max) is stored on the right meta2 range, so the lookup
 	// will require a scan that continues into the next meta2 range.
-	const tableID = keys.MinUserDescID + 1 // 51
+	tableID := keys.TestingUserDescID(1) // 51
 	splitReq := adminSplitArgs(keys.SystemSQLCodec.TablePrefix(tableID - 3 /* 48 */))
 	if _, pErr := kv.SendWrapped(ctx, s.DB().NonTransactionalSender(), splitReq); pErr != nil {
 		t.Fatal(pErr)
@@ -3567,7 +3569,7 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	config.TestingSetupZoneConfigHook(s.Stopper())
 
 	// Set global reads.
-	descID := uint32(keys.MinUserDescID)
+	descID := keys.TestingUserDescID(0)
 	descKey := keys.SystemSQLCodec.TablePrefix(descID)
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.GlobalReads = proto.Bool(true)

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -731,7 +731,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	// which means keys.MaxReservedDescID+1.
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
-	config.TestingSetZoneConfig(keys.MaxReservedDescID+2, zoneConfig)
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(keys.TestingUserDescID(1)), zoneConfig)
 
 	// Check our config.
 	neverSplitsDesc = neverSplits.Desc()

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -196,6 +196,7 @@ type Replica struct {
 	log.AmbientContext
 
 	RangeID roachpb.RangeID // Only set by the constructor
+
 	// The start key of a Range remains constant throughout its lifetime (it does
 	// not change through splits or merges). This field carries a copy of
 	// r.mu.state.Desc.StartKey (and nil if the replica is not initialized). The
@@ -986,7 +987,7 @@ func (r *Replica) isSystemRange() bool {
 
 func (r *Replica) isSystemRangeRLocked() bool {
 	rem, _, err := keys.DecodeTenantPrefix(r.mu.state.Desc.StartKey.AsRawKey())
-	return err == nil && roachpb.Key(rem).Compare(keys.UserTableDataMin) < 0
+	return err == nil && roachpb.Key(rem).Compare(r.store.systemRangeStartUpperBound) < 0
 }
 
 // maxReplicaIDOfAny returns the maximum ReplicaID of any replica, including

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -741,7 +741,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}
 		// Split the range so that the RHS is not a system range and thus will
 		// respect the rangefeed_enabled cluster setting.
-		startKey := keys.UserTableDataMin
+		startKey := keys.TestingUserTableDataMin()
 		tc.SplitRangeOrFatal(t, startKey)
 
 		rightRangeID := store.LookupReplica(roachpb.RKey(startKey)).RangeID

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -76,9 +76,9 @@ func TestReplicateQueueRebalance(t *testing.T) {
 
 	const newRanges = 10
 	trackedRanges := map[roachpb.RangeID]struct{}{}
-	for i := 0; i < newRanges; i++ {
-		tableID := keys.MinUserDescID + i
-		splitKey := keys.SystemSQLCodec.TablePrefix(uint32(tableID))
+	for i := uint32(0); i < newRanges; i++ {
+		tableID := keys.TestingUserDescID(i)
+		splitKey := keys.SystemSQLCodec.TablePrefix(tableID)
 		// Retry the splits on descriptor errors which are likely as the replicate
 		// queue is already hard at work.
 		testutils.SucceedsSoon(t, func() error {
@@ -117,7 +117,12 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		return counts
 	}
 
-	initialRanges, err := server.ExpectedInitialRangeCount(tc.Servers[0].DB(), zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef())
+	initialRanges, err := server.ExpectedInitialRangeCount(
+		tc.Servers[0].DB(),
+		zonepb.DefaultZoneConfigRef(),
+		zonepb.DefaultSystemZoneConfigRef(),
+		tc.Servers[0].SystemIDChecker().(keys.SystemIDChecker),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -392,7 +392,7 @@ func (v *constraintConformanceVisitor) reset(ctx context.Context) {
 	// wouldn't create entries for constraints that aren't violated, and
 	// definitely not for zones that don't apply to any ranges.
 	maxObjectID, err := v.cfg.GetLargestObjectID(
-		0 /* maxID - return the largest ID in the config */, keys.PseudoTableIDs)
+		nil /* systemIDChecker - return the largest ID in the config */, keys.PseudoTableIDs)
 	if err != nil {
 		log.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
 	}

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -760,7 +760,7 @@ func compileTestCase(tc baseReportTestCase) (compiledTestCase, error) {
 	// Databases and tables share the id space, so we'll use a common counter for them.
 	// And we're going to use keys in user space, otherwise there's special cases
 	// in the zone config lookup that we bump into.
-	objectCounter := keys.MinUserDescID
+	objectCounter := int(keys.TestingUserDescID(0))
 	sysCfgBuilder := makeSystemConfigBuilder()
 	if err := sysCfgBuilder.setDefaultZoneConfig(tc.defaultZone.toZoneConfig()); err != nil {
 		return compiledTestCase{}, err

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -299,7 +299,7 @@ func (v *replicationStatsVisitor) reset(ctx context.Context) {
 	// zones that have constraints. Otherwise, just iterating through the ranges
 	// wouldn't create entries for zones that don't apply to any ranges.
 	maxObjectID, err := v.cfg.GetLargestObjectID(
-		0 /* maxID - return the largest ID in the config */, keys.PseudoTableIDs,
+		nil /* systemIDChecker - return the largest ID in the config */, keys.PseudoTableIDs,
 	)
 	if err != nil {
 		log.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -1274,7 +1274,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 		},
 		&cfg)
 
-	baseID := uint32(keys.MinUserDescID)
+	baseID := keys.TestingUserDescID(0)
 	testData := []struct {
 		repl        *Replica
 		expMaxBytes int64

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2411,7 +2411,7 @@ func (s *adminServer) DataDistribution(
 		defer acct.Close(txnCtx)
 
 		kvs, err := kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
-			Key:    keys.UserTableDataMin,
+			Key:    keys.SystemSQLCodec.TablePrefix(keys.MinUserDescriptorID(s.server.sqlServer.execCfg.SystemIDChecker)),
 			EndKey: keys.MaxKey,
 		})
 		if err != nil {

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -326,7 +326,7 @@ func (r *Reporter) collectSchemaInfo(ctx context.Context) ([]descpb.TableDescrip
 			return nil, errors.Wrapf(err, "%s: unable to unmarshal SQL descriptor", kv.Key)
 		}
 		t, _, _, _ := descpb.FromDescriptorWithMVCCTimestamp(&desc, kv.Value.Timestamp)
-		if t != nil && t.ID > keys.MaxReservedDescID {
+		if t != nil && t.ParentID != keys.SystemDatabaseID {
 			if err := reflectwalk.Walk(t, redactor); err != nil {
 				panic(err) // stringRedactor never returns a non-nil err
 			}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -426,7 +426,7 @@ func TestNodeStatusWritten(t *testing.T) {
 	}
 
 	// Wait for full replication of initial ranges.
-	initialRanges, err := ExpectedInitialRangeCount(kvDB, &ts.cfg.DefaultZoneConfig, &ts.cfg.DefaultSystemZoneConfig)
+	initialRanges, err := ExpectedInitialRangeCount(kvDB, &ts.cfg.DefaultZoneConfig, &ts.cfg.DefaultSystemZoneConfig, ts.sqlServer.execCfg.SystemIDChecker)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -697,7 +697,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		RangeFeedFactory:           cfg.rangeFeedFactory,
 		CollectionFactory:          collectionFactory,
 
-		SystemIDChecker: catalog.SystemIDChecker{
+		SystemIDChecker: &catalog.SystemIDChecker{
 			SystemIDChecker: keys.DeprecatedSystemIDChecker(),
 		},
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -396,7 +396,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	ts := s.(*TestServer)
 
-	key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, keys.MaxReservedDescID)
+	key := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(keys.MaxSystemConfigDescID+1))
 	valAt := func(i int) *descpb.Descriptor {
 		return dbdesc.NewInitial(
 			descpb.ID(i), "foo", security.AdminRoleName(),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -558,6 +559,11 @@ func (t *TestTenant) ExecutorConfig() interface{} {
 	return *t.SQLServer.execCfg
 }
 
+// SystemIDChecker is part of TestTenantInterface.
+func (t *TestTenant) SystemIDChecker() interface{} {
+	return *t.SQLServer.execCfg.SystemIDChecker
+}
+
 // RangeFeedFactory is part of TestTenantInterface.
 func (t *TestTenant) RangeFeedFactory() interface{} {
 	return t.SQLServer.execCfg.RangeFeedFactory
@@ -708,13 +714,21 @@ func (ts *TestServer) StartTenant(
 // assuming no additional information is added outside of the normal bootstrap
 // process.
 func (ts *TestServer) ExpectedInitialRangeCount() (int, error) {
-	return ExpectedInitialRangeCount(ts.DB(), &ts.cfg.DefaultZoneConfig, &ts.cfg.DefaultSystemZoneConfig)
+	return ExpectedInitialRangeCount(
+		ts.DB(),
+		&ts.cfg.DefaultZoneConfig,
+		&ts.cfg.DefaultSystemZoneConfig,
+		ts.sqlServer.execCfg.SystemIDChecker,
+	)
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should
 // be on the server after bootstrap.
 func ExpectedInitialRangeCount(
-	db *kv.DB, defaultZoneConfig *zonepb.ZoneConfig, defaultSystemZoneConfig *zonepb.ZoneConfig,
+	db *kv.DB,
+	defaultZoneConfig *zonepb.ZoneConfig,
+	defaultSystemZoneConfig *zonepb.ZoneConfig,
+	idChecker keys.SystemIDChecker,
 ) (int, error) {
 	descriptorIDs, err := startupmigrations.ExpectedDescriptorIDs(
 		context.Background(), db, keys.SystemSQLCodec, defaultZoneConfig, defaultSystemZoneConfig,
@@ -729,7 +743,7 @@ func ExpectedInitialRangeCount(
 	// the span does not have an associated descriptor.
 	maxSystemDescriptorID := descriptorIDs[0]
 	for _, descID := range descriptorIDs {
-		if descID > maxSystemDescriptorID && descID <= keys.MaxReservedDescID {
+		if descID > maxSystemDescriptorID && catalog.IsSystemID(idChecker, descID) {
 			maxSystemDescriptorID = descID
 		}
 	}
@@ -1300,6 +1314,11 @@ func (ts *TestServer) GetRangeLease(
 // ExecutorConfig is part of the TestServerInterface.
 func (ts *TestServer) ExecutorConfig() interface{} {
 	return *ts.sqlServer.execCfg
+}
+
+// SystemIDChecker is part of the TestServerInterface.
+func (ts *TestServer) SystemIDChecker() interface{} {
+	return *ts.sqlServer.execCfg.SystemIDChecker
 }
 
 // TracerI is part of the TestServerInterface.

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -36,16 +36,12 @@ var DefaultUserDBs = []string{
 	DefaultDatabaseName, PgDatabaseName,
 }
 
-// MaxDefaultDescriptorID is the maximum ID of a descriptor that exists in a
-// new cluster.
-// For each DefaultUserDB, we also create a public schema in it, hence we
-// multiply the number of default user dbs by 2 to get the number of descriptors.
-var MaxDefaultDescriptorID = keys.MaxReservedDescID + descpb.ID(len(DefaultUserDBs))*2
-
-// IsDefaultCreatedDescriptor returns whether or not a given descriptor ID is
-// present at the time of starting a cluster.
-func IsDefaultCreatedDescriptor(descID descpb.ID) bool {
-	return descID <= MaxDefaultDescriptorID
+// MinNonDefaultUserDescriptorID returns the smallest possible user-created
+// descriptor ID after a cluster is bootstrapped.
+func MinNonDefaultUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
+	// Each default DB comes with a public schema descriptor.
+	numDefaultDescs := len(DefaultUserDBs) * 2
+	return keys.MinUserDescriptorID(idChecker) + uint32(numDefaultDescs)
 }
 
 // IndexKeyValDirs returns the corresponding encoding.Directions for all the

--- a/pkg/sql/catalog/catalogkv/BUILD.bazel
+++ b/pkg/sql/catalog/catalogkv/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemadesc",

--- a/pkg/sql/catalog/catprivilege/BUILD.bazel
+++ b/pkg/sql/catalog/catprivilege/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     deps = [
         "//pkg/keys",
         "//pkg/security",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/catalog/catprivilege/fix_test.go
+++ b/pkg/sql/catalog/catprivilege/fix_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -484,7 +485,7 @@ func TestMaybeFixSchemaPrivileges(t *testing.T) {
 		for u, p := range tc.input {
 			desc.Grant(u, p, false /* withGrantOption */)
 		}
-		testParentID := descpb.ID(keys.MaxReservedDescID + 1)
+		testParentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(keys.TestingSystemIDChecker()))
 		MaybeFixPrivileges(&desc,
 			testParentID,
 			descpb.InvalidID,

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -257,7 +257,8 @@ func TestPrivilegeValidate(t *testing.T) {
 
 	descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
 	validate := func() error {
-		return descriptor.Validate(ID(keys.MinUserDescID), privilege.Table, "whatever", DefaultSuperuserPrivileges)
+		id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
+		return descriptor.Validate(id, privilege.Table, "whatever", DefaultSuperuserPrivileges)
 	}
 
 	if err := validate(); err != nil {
@@ -289,7 +290,7 @@ func TestPrivilegeValidate(t *testing.T) {
 
 func TestValidPrivilegesForObjects(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	id := ID(keys.MinUserDescID)
+	id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
 
 	testUser := security.TestUserName()
 
@@ -435,7 +436,7 @@ func TestValidateOwnership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Use a non-system id.
-	id := ID(keys.MinUserDescID)
+	id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
 	validate := func(privs PrivilegeDescriptor) error {
 		return privs.Validate(id, privilege.Table, "whatever", DefaultSuperuserPrivileges)
 	}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -770,8 +770,11 @@ func FormatSafeDescriptorProperties(w *redact.StringBuilder, desc Descriptor) {
 // IsSystemDescriptor returns true iff the descriptor is a system or a reserved
 // descriptor.
 func IsSystemDescriptor(desc Descriptor) bool {
-	if desc.GetID() <= keys.MaxReservedDescID {
+	if desc.GetParentID() == keys.SystemDatabaseID {
 		return true
 	}
-	return desc.GetParentID() == keys.SystemDatabaseID
+	if desc.GetID() == keys.SystemDatabaseID {
+		return true
+	}
+	return false
 }

--- a/pkg/sql/catalog/descriptor_id.go
+++ b/pkg/sql/catalog/descriptor_id.go
@@ -26,7 +26,9 @@ type SystemIDChecker struct {
 	keys.SystemIDChecker
 }
 
+var _ keys.SystemIDChecker = SystemIDChecker{}
+
 // IsSystemID returns true if the ID is part of the system database.
-func (s SystemIDChecker) IsSystemID(id descpb.ID) bool {
-	return IsSystemID(s.SystemIDChecker, id)
+func (s SystemIDChecker) IsSystemID(id uint32) bool {
+	return s.SystemIDChecker.IsSystemID(id)
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1271,6 +1271,7 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	var testAcquisitionBlockCount int32
 
 	params := createTestServerParams()
+	idChecker := atomic.Value{}
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
 			LeaseStoreTestingKnobs: lease.StorageTestingKnobs{
@@ -1280,12 +1281,15 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 					if err != nil {
 						return
 					}
-					if desc.GetID() > keys.MaxReservedDescID {
+					if !catalog.IsSystemDescriptor(desc) {
 						atomic.AddInt32(&testAcquiredCount, 1)
 					}
 				},
 				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
-					if id > keys.MaxReservedDescID {
+					if idChecker.Load() == nil {
+						return
+					}
+					if !catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
 						atomic.AddInt32(&testAcquisitionBlockCount, 1)
 					}
 				},
@@ -1301,6 +1305,7 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 		lease.LeaseDuration.Get(&params.SV))
 
 	t := newLeaseTest(testingT, params)
+	idChecker.Store(t.server.SystemIDChecker())
 	defer t.cleanup()
 
 	if _, err := t.db.Exec(`
@@ -1725,18 +1730,22 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 	var testAcquisitionBlockCount int32
 
 	params := createTestServerParams()
+	idChecker := atomic.Value{}
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
 			LeaseStoreTestingKnobs: lease.StorageTestingKnobs{
 				// We want to track when leases get acquired and when they are renewed.
 				// We also want to know when acquiring blocks to test lease renewal.
 				LeaseAcquiredEvent: func(desc catalog.Descriptor, _ error) {
-					if desc.GetID() > keys.MaxReservedDescID {
+					if !catalog.IsSystemDescriptor(desc) {
 						atomic.AddInt32(&testAcquiredCount, 1)
 					}
 				},
 				LeaseReleasedEvent: func(id descpb.ID, _ descpb.DescriptorVersion, _ error) {
-					if id < keys.MaxReservedDescID {
+					if idChecker.Load() == nil {
+						return
+					}
+					if catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
 						return
 					}
 					mu.Lock()
@@ -1744,7 +1753,10 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 					releasedIDs[id] = struct{}{}
 				},
 				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
-					if id > keys.MaxReservedDescID {
+					if idChecker.Load() == nil {
+						return
+					}
+					if !catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
 						atomic.AddInt32(&testAcquisitionBlockCount, 1)
 					}
 				},
@@ -1765,6 +1777,7 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 	lease.LeaseRenewalDuration.Override(ctx, &params.SV, 0)
 
 	t := newLeaseTest(testingT, params)
+	idChecker.Store(t.server.SystemIDChecker())
 	defer t.cleanup()
 
 	if _, err := t.db.Exec(`

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -655,11 +655,10 @@ func (desc *Mutable) AllocateIDs(ctx context.Context) error {
 	}
 
 	// This is sort of ugly. If the descriptor does not have an ID, we hack one in
-	// to pass the table ID check. We use a non-reserved ID, reserved ones being set
-	// before AllocateIDs.
+	// to pass the table ID check.
 	savedID := desc.ID
 	if desc.ID == 0 {
-		desc.ID = keys.MinUserDescID
+		desc.ID = keys.SystemDatabaseID
 	}
 	err := catalog.ValidateSelf(desc)
 	desc.ID = savedID

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -54,8 +54,8 @@ func TestAllocateIDs(t *testing.T) {
 	ctx := context.Background()
 
 	desc := NewBuilder(&descpb.TableDescriptor{
-		ParentID: keys.MinUserDescID,
-		ID:       keys.MinUserDescID + 1,
+		ParentID: descpb.ID(keys.TestingUserDescID(0)),
+		ID:       descpb.ID(keys.TestingUserDescID(1)),
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{
 			{Name: "a", Type: types.Int},
@@ -86,8 +86,8 @@ func TestAllocateIDs(t *testing.T) {
 	}
 
 	expected := NewBuilder(&descpb.TableDescriptor{
-		ParentID: keys.MinUserDescID,
-		ID:       keys.MinUserDescID + 1,
+		ParentID: descpb.ID(keys.TestingUserDescID(0)),
+		ID:       descpb.ID(keys.TestingUserDescID(1)),
 		Version:  1,
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -377,7 +377,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	invalidPrivileges := descpb.NewBasePrivilegeDescriptor(security.RootUserName())
 	// Make the PrivilegeDescriptor invalid by granting SELECT to a type.
 	invalidPrivileges.Grant(security.TestUserName(), privilege.List{privilege.SELECT}, false)
-	typeDescID := descpb.ID(keys.MaxReservedDescID + 1)
+	typeDescID := descpb.ID(keys.TestingUserDescID(0))
 	testData := []struct {
 		err  string
 		desc descpb.TypeDescriptor

--- a/pkg/sql/colexec/colexecspan/span_assembler.eg.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler.eg.go
@@ -349,7 +349,7 @@ func canSplitSpans(numNeededFamilies int, table catalog.TableDescriptor, index c
 	// * The table is not a special system table. (System tables claim to have
 	//   column families, but actually do not, since they're written to with
 	//   raw KV puts in a "legacy" way.)
-	if table.GetID() > 0 && table.GetID() < keys.MaxReservedDescID {
+	if catalog.IsSystemDescriptor(table) {
 		return false
 	}
 

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -181,7 +181,7 @@ func spanGeneratorOracle(
 }
 
 func makeTable(useColFamilies bool) catalog.TableDescriptor {
-	tableID := keys.MinNonPredefinedUserDescID
+	tableID := keys.TestingUserDescID(0)
 	if !useColFamilies {
 		// We can prevent the span builder from splitting spans into separate column
 		// families by using a system table ID, since system tables do not have

--- a/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_tmpl.go
@@ -341,7 +341,7 @@ func canSplitSpans(numNeededFamilies int, table catalog.TableDescriptor, index c
 	// * The table is not a special system table. (System tables claim to have
 	//   column families, but actually do not, since they're written to with
 	//   raw KV puts in a "legacy" way.)
-	if table.GetID() > 0 && table.GetID() < keys.MaxReservedDescID {
+	if catalog.IsSystemDescriptor(table) {
 		return false
 	}
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4805,8 +4805,13 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 			descEnd = 0
 			return nil
 		}
-		// Loop over every possible descriptor ID
-		for id := keys.MinUserDescID; id < int(maxDescID); id++ {
+		idChecker := p.ExecCfg().SystemIDChecker
+		// Loop over every possible non-system descriptor ID
+		for id := uint32(keys.MaxSystemConfigDescID); id < uint32(maxDescID); id++ {
+			if idChecker.IsSystemID(id) {
+				continue
+			}
+
 			// Skip over descriptors that are known
 			if _, ok := dg.Descriptors[descpb.ID(id)]; ok {
 				err := scanAndGenerateRows()
@@ -4817,12 +4822,12 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 			}
 			// Update our span range to include this
 			// descriptor.
-			prefix := p.extendedEvalCtx.Codec.TablePrefix(uint32(id))
+			prefix := p.extendedEvalCtx.Codec.TablePrefix(id)
 			if unusedDescSpan.Key == nil {
-				descStart = id
+				descStart = int(id)
 				unusedDescSpan.Key = prefix
 			}
-			descEnd = id
+			descEnd = int(id)
 			unusedDescSpan.EndKey = prefix.PrefixEnd()
 
 		}

--- a/pkg/sql/doctor/BUILD.bazel
+++ b/pkg/sql/doctor/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/util/hlc",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1169,7 +1169,7 @@ type ExecutorConfig struct {
 
 	// SystemIDChecker is used to check whether an ID is part of the
 	// system database.
-	SystemIDChecker catalog.SystemIDChecker
+	SystemIDChecker *catalog.SystemIDChecker
 }
 
 // UpdateVersionSystemSettingHook provides a callback that allows us

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -90,9 +90,9 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				sqlDB.Exec(t, "ALTER TABLE my_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 				sqlDB.Exec(t, "ALTER TABLE my_other_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 			}
-			myDBID := descpb.ID(keys.MinUserDescID + 2)
-			myTableID := descpb.ID(keys.MinUserDescID + 3)
-			myOtherTableID := descpb.ID(keys.MinUserDescID + 4)
+			myDBID := descpb.ID(keys.TestingUserDescID(2))
+			myTableID := descpb.ID(keys.TestingUserDescID(3))
+			myOtherTableID := descpb.ID(keys.TestingUserDescID(4))
 
 			var myTableDesc *tabledesc.Mutable
 			var myOtherTableDesc *tabledesc.Mutable

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
@@ -163,7 +162,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 		if n.isGrant {
 			op = "GRANT"
 		}
-		if descriptor.GetID() < keys.MinUserDescID {
+		if catalog.IsSystemDescriptor(descriptor) {
 			return pgerror.Newf(pgcode.InsufficientPrivilege, "cannot %s on system object", op)
 		}
 

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -99,7 +99,7 @@ func TestRevertGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.RevertRangeRequest{
-		RequestHeader:                       roachpb.RequestHeader{Key: keys.UserTableDataMin, EndKey: keys.MaxKey},
+		RequestHeader:                       roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 		TargetTime:                          hlc.Timestamp{WallTime: -1},
 		EnableTimeBoundIteratorOptimization: true,
 	}

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -46,7 +46,7 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine) []roachpb.KeyValue {
 		kvs = nil
 		it := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
-		for it.SeekGE(storage.MVCCKey{Key: keys.UserTableDataMin}); ; it.NextKey() {
+		for it.SeekGE(storage.MVCCKey{Key: keys.TestingUserTableDataMin()}); ; it.NextKey() {
 			ok, err := it.Valid()
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -221,7 +221,7 @@ func (s *Builder) CanSplitSpanIntoFamilySpans(
 	// * The table is not a special system table. (System tables claim to have
 	//   column families, but actually do not, since they're written to with
 	//   raw KV puts in a "legacy" way.)
-	if s.table.GetID() > 0 && s.table.GetID() < keys.MaxReservedDescID {
+	if catalog.IsSystemDescriptor(s.table) {
 		return false
 	}
 

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -13,6 +13,7 @@ package stats_test
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,14 +59,16 @@ func TestCreateStatsControlJob(t *testing.T) {
 	var allowRequest chan struct{}
 
 	var serverArgs base.TestServerArgs
+	idChecker := atomic.Value{}
 	params := base.TestClusterArgs{ServerArgs: serverArgs}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: createStatsRequestFilter(&allowRequest),
+		TestingRequestFilter: createStatsRequestFilter(&allowRequest, &idChecker),
 	}
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, nodes, params)
+	idChecker.Store(tc.Servers[0].SystemIDChecker())
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE d`)
@@ -133,15 +136,17 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 	var allowRequest chan struct{}
 
 	var serverArgs base.TestServerArgs
+	idChecker := atomic.Value{}
 	params := base.TestClusterArgs{ServerArgs: serverArgs}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: createStatsRequestFilter(&allowRequest),
+		TestingRequestFilter: createStatsRequestFilter(&allowRequest, &idChecker),
 	}
 
 	ctx := context.Background()
 	const nodes = 1
 	tc := testcluster.StartTestCluster(t, nodes, params)
+	idChecker.Store(tc.Servers[0].SystemIDChecker())
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
@@ -303,9 +308,10 @@ func TestCreateStatsProgress(t *testing.T) {
 
 	var allowRequest chan struct{}
 	var serverArgs base.TestServerArgs
+	idChecker := atomic.Value{}
 	params := base.TestClusterArgs{ServerArgs: serverArgs}
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: createStatsRequestFilter(&allowRequest),
+		TestingRequestFilter: createStatsRequestFilter(&allowRequest, &idChecker),
 	}
 	params.ServerArgs.Knobs.DistSQL = &execinfra.TestingKnobs{
 		// Force the stats job to iterate through the input rows instead of reading
@@ -316,6 +322,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	ctx := context.Background()
 	const nodes = 1
 	tc := testcluster.StartTestCluster(t, nodes, params)
+	idChecker.Store(tc.Servers[0].SystemIDChecker())
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
@@ -478,14 +485,21 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 // Create a blocking request filter for the actions related
 // to CREATE STATISTICS, i.e. Scanning a user table. See discussion
 // on jobutils.RunJob for where this might be useful.
-func createStatsRequestFilter(allowProgressIota *chan struct{}) kvserverbase.ReplicaRequestFilter {
+func createStatsRequestFilter(
+	allowProgressIota *chan struct{}, idChecker *atomic.Value,
+) kvserverbase.ReplicaRequestFilter {
 	return func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
 		if req, ok := ba.GetArg(roachpb.Scan); ok {
 			_, tableID, _ := encoding.DecodeUvarintAscending(req.(*roachpb.ScanRequest).Key)
 			// Ensure that the tableID is within the expected range for a table,
 			// but is not a system table.
-			if tableID > 0 && tableID < 100 &&
-				!catalog.IsSystemID(keys.DeprecatedSystemIDChecker(), descpb.ID(uint32(tableID))) {
+
+			var c keys.SystemIDChecker
+			if idChecker.Load() != nil {
+				c = idChecker.Load().(keys.SystemIDChecker)
+			}
+			if tableID > 0 && tableID < 100 && c != nil &&
+				!catalog.IsSystemID(c, descpb.ID(uint32(tableID))) {
 				// Read from the channel twice to allow jobutils.RunJob to complete
 				// even though there is only one ScanRequest.
 				<-*allowProgressIota

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -76,7 +76,11 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
-	expectedInitialRanges, err := server.ExpectedInitialRangeCount(kvDB, &s.(*server.TestServer).Cfg.DefaultZoneConfig, &s.(*server.TestServer).Cfg.DefaultSystemZoneConfig)
+	expectedInitialRanges, err := server.ExpectedInitialRangeCount(
+		kvDB,
+		&s.(*server.TestServer).Cfg.DefaultZoneConfig,
+		&s.(*server.TestServer).Cfg.DefaultSystemZoneConfig,
+		s.(*server.TestServer).SystemIDChecker().(keys.SystemIDChecker))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -61,7 +61,7 @@ func TestInitialKeys(t *testing.T) {
 		desc, err := sql.CreateTestTableDescriptor(
 			context.Background(),
 			keys.SystemDatabaseID,
-			keys.MaxReservedDescID,
+			descpb.ID(1000 /* suitably large descriptor ID */),
 			"CREATE TABLE system.x (val INTEGER PRIMARY KEY)",
 			descpb.NewBasePrivilegeDescriptor(security.NodeUserName()),
 		)
@@ -95,7 +95,7 @@ func TestInitialKeys(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if a, e := i, int64(keys.MinUserDescID); a != e {
+		if a, e := i, int64(keys.TestingUserDescID(0)); a != e {
 			t.Fatalf("Expected next descriptor ID to be %d, was %d", e, a)
 		}
 	})

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -46,7 +46,7 @@ func TestUpsertFastPath(t *testing.T) {
 	var scans uint64
 	var endTxn uint64
 	filter := func(filterArgs kvserverbase.FilterArgs) *roachpb.Error {
-		if bytes.Compare(filterArgs.Req.Header().Key, keys.UserTableDataMin) >= 0 {
+		if bytes.Compare(filterArgs.Req.Header().Key, keys.TestingUserTableDataMin()) >= 0 {
 			switch filterArgs.Req.Method() {
 			case roachpb.Scan:
 				atomic.AddUint64(&scans, 1)

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var configID = descpb.ID(1)
-var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, keys.MaxReservedDescID)
+var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(keys.TestingUserDescID(0)))
 
 // forceNewConfig forces a system config update by writing a bogus descriptor with an
 // incremented value inside. It then repeatedly fetches the gossip config until the
@@ -207,7 +207,7 @@ func TestGetZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{keys.MaxSystemConfigDescID + 1, nil, "", defaultZoneConfig},
 		{db1, nil, "", defaultZoneConfig},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", defaultZoneConfig},
@@ -291,7 +291,7 @@ func TestGetZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{keys.MaxSystemConfigDescID + 1, nil, "", defaultZoneConfig},
 		{db1, nil, "", db1Cfg},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", tb11Cfg},
@@ -439,7 +439,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{keys.MaxSystemConfigDescID + 1, nil, "", defaultZoneConfig},
 		{db1, nil, "", defaultZoneConfig},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", defaultZoneConfig},
@@ -568,7 +568,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	verifyZoneConfigs([]testCase{
 		{0, nil, "", defaultZoneConfig},
 		{1, nil, "", defaultZoneConfig},
-		{keys.MaxReservedDescID, nil, "", defaultZoneConfig},
+		{keys.MaxSystemConfigDescID + 1, nil, "", defaultZoneConfig},
 		{db1, nil, "", expectedDb1Cfg},
 		{db2, nil, "", defaultZoneConfig},
 		{tb11, nil, "", expectedTb11Cfg},
@@ -648,7 +648,7 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID))
+		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)))
 		_, err := cfg.GetZoneConfigForKey(key)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/startupmigrations/migrations_test.go
+++ b/pkg/startupmigrations/migrations_test.go
@@ -543,7 +543,7 @@ func TestCreateSystemTable(t *testing.T) {
 	ctx := context.Background()
 
 	table := tabledesc.NewBuilder(systemschema.NamespaceTable.TableDesc()).BuildExistingMutableTable()
-	table.ID = keys.MaxReservedDescID
+	table.ID = descpb.ID(1000 /* suitably large descriptor ID */)
 
 	table.Name = "dummy"
 	nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, table.ParentID, table.Name)

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4523,7 +4523,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	const userID = keys.MinUserDescID
+	userID := keys.TestingUserDescID(0)
 	// Manually creates rows corresponding to the schema:
 	// CREATE TABLE t (id1 STRING, id2 STRING, ... PRIMARY KEY (id1, id2, ...))
 	addTablePrefix := func(prefix roachpb.Key, id uint32, rowVals ...string) roachpb.Key {
@@ -4728,7 +4728,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				addColFam(tablePrefix(userID, "b"), 1),
 				addColFam(tablePrefix(userID, "c"), 1),
 			},
-			rangeStart: keys.SystemSQLCodec.TablePrefix(keys.MinUserDescID),
+			rangeStart: keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)),
 			expSplit:   tablePrefix(userID, "b"),
 			expError:   false,
 		},
@@ -5191,7 +5191,7 @@ func TestMVCCGarbageCollectUsesSeekLTAppropriately(t *testing.T) {
 		batch := engine.NewBatch()
 		defer batch.Close()
 		it := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-			UpperBound: keys.UserTableDataMin,
+			UpperBound: keys.TestingUserTableDataMin(),
 			LowerBound: keys.MaxKey,
 		})
 		defer it.Close()

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -66,6 +66,10 @@ type TestTenantInterface interface {
 	// The real return type is sql.ExecutorConfig.
 	ExecutorConfig() interface{}
 
+	// ExecutorConfig returns a copy of the tenant's SystemIDChecker.
+	// The real return type is keys.SystemIDChecker.
+	SystemIDChecker() interface{}
+
 	// RangeFeedFactory returns the range feed factory used by the tenant.
 	// The real return type is *rangefeed.Factory.
 	RangeFeedFactory() interface{}


### PR DESCRIPTION
This commit removes many references to `keys` package constants 49, 50
and 54, and replaces them with functions that take a SystemIDChecker.
Existing functionality should remain unchanged.

This is a prerequisite to making the system descriptor ID space dynamic.

Release note: None