### PR TITLE
kvserver/loqrecovery: check full key coverage in quorum recovery

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -280,8 +280,9 @@ Discarded live replicas: %d
 `, report.TotalReplicas, len(report.PlannedUpdates), report.DiscardedNonSurvivors)
 	for _, r := range report.PlannedUpdates {
 		_, _ = fmt.Fprintf(stderr, "Recovering range r%d:%s updating replica %s to %s. "+
-			"Discarding replicas: %s\n",
-			r.RangeID, r.StartKey, r.OldReplica, r.Replica, r.DiscardedReplicas)
+			"Discarding available replicas: [%s], discarding dead replicas: [%s].\n",
+			r.RangeID, r.StartKey, r.OldReplica, r.Replica,
+			r.DiscardedAvailableReplicas, r.DiscardedDeadReplicas)
 	}
 
 	deadStoreMsg := fmt.Sprintf("\nDiscovered dead stores from provided files: %s",

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_etcd_raft_v3//raftpb",

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -102,7 +102,7 @@ func PrepareUpdateReplicas(
 	}
 
 	if len(missing) > 0 {
-		report.MissingStores = storeListFromSet(missing)
+		report.MissingStores = storeSliceFromSet(missing)
 	}
 	return report, nil
 }
@@ -113,7 +113,7 @@ func applyReplicaUpdate(
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	report := PrepareReplicaReport{
 		RangeID:  update.RangeID,
-		Replica:  *update.NewReplica,
+		Replica:  update.NewReplica,
 		StartKey: update.StartKey.AsRKey(),
 	}
 

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.go
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.go
@@ -60,3 +60,15 @@ func (m ReplicaUpdate) NodeID() roachpb.NodeID {
 func (m ReplicaUpdate) StoreID() roachpb.StoreID {
 	return m.NewReplica.StoreID
 }
+
+// Replica gets replica for the store where this info and range
+// descriptor were collected. Returns err if it can't find replica
+// descriptor for the store it originated from.
+func (m *ReplicaInfo) Replica() (roachpb.ReplicaDescriptor, error) {
+	if d, ok := m.Desc.GetReplicaDescriptor(m.StoreID); ok {
+		return d, nil
+	}
+	return roachpb.ReplicaDescriptor{}, errors.Errorf(
+		"invalid replica info: its own store s%d is not present in descriptor replicas %s",
+		m.StoreID, m.Desc)
+}

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -50,7 +50,8 @@ message ReplicaUpdate {
   int32 old_replica_id = 3 [(gogoproto.customname) = "OldReplicaID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID",
     (gogoproto.moretags) = "yaml:\"OldReplicaID\""];
-  roachpb.ReplicaDescriptor new_replica = 4 [(gogoproto.moretags) = "yaml:\"NewReplica\""];
+  roachpb.ReplicaDescriptor new_replica = 4 [(gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"NewReplica\""];
   int32 next_replica_id = 5 [(gogoproto.customname) = "NextReplicaID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID",
     (gogoproto.moretags) = "yaml:\"NextReplicaID\""];

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -12,6 +12,7 @@ package loqrecovery
 
 import (
 	"context"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -20,8 +21,8 @@ import (
 )
 
 // nextReplicaIDIncrement defines how much forward we want to advance an ID of
-// the designated winning replica to avoid any potential replicaID conflicts in
-// case we've picked not the most up-to-date replica.
+// the designated surviving replica to avoid any potential replicaID conflicts
+// in case we've picked not the most up-to-date replica.
 const nextReplicaIDIncrement = 10
 
 // updatedLocationsMap is tracking which stores we plan to update with a plan.
@@ -43,58 +44,62 @@ func (m updatedLocationsMap) add(node roachpb.NodeID, store roachpb.StoreID) {
 func (m updatedLocationsMap) asMapOfSlices() map[roachpb.NodeID][]roachpb.StoreID {
 	newMap := make(map[roachpb.NodeID][]roachpb.StoreID)
 	for k, v := range m {
-		newMap[k] = storeListFromSet(v)
+		newMap[k] = storeSliceFromSet(v)
 	}
 	return newMap
 }
 
-// PlanningReport provides aggregate stats and details of replica updates that is used
-// for user confirmation.
+// PlanningReport provides aggregate stats and details of replica updates that
+// is used for user confirmation.
 type PlanningReport struct {
-	// TotalReplicas is the number of replicas that were found on nodes present in the
-	// cluster
+	// TotalReplicas is the number of replicas that were found on nodes present
+	// in the cluster
 	TotalReplicas int
-	// DiscardedNonSurvivors is the number of replicas from ranges that lost quorum that
+	// DiscardedNonSurvivors is the number of replicas from ranges that lost
+	// quorum that
 	// we decided not to use according to selection criteria used by planner.
 	DiscardedNonSurvivors int
 	// TODO(oleg): track total analyzed range count in subsequent version
 
-	// PresentStores is deduced list of stores that we collected replica info from. This
-	// set is filled from analyzed descriptors and may not strictly match stores on which
-	// collection was run if some stores are empty.
+	// PresentStores is deduced list of stores that we collected replica info
+	// from. This set is filled from analyzed descriptors and may not strictly
+	// match stores on which collection was run if some stores are empty.
 	PresentStores []roachpb.StoreID
-	// MissingStores is a deduced list of stores that were found in replica descriptors
-	// but were not found in range descriptors e.g. collection was not run on those stores
-	// because they are dead or because of human error.
+	// MissingStores is a deduced list of stores that were found in replica
+	// descriptors but were not found in range descriptors e.g. collection was not
+	// run on those stores because they are dead or because of human error.
 	MissingStores []roachpb.StoreID
 
-	// PlannedUpdates contains detailed update info about each planned update. This
-	// information is presented to user for action confirmation and can contain details
-	// that are not needed for actual plan application.
+	// PlannedUpdates contains detailed update info about each planned update.
+	// This information is presented to user for action confirmation and can
+	// contain details that are not needed for actual plan application.
 	PlannedUpdates []ReplicaUpdateReport
 	// UpdatedNodes contains information about nodes with their stores where plan
 	// needs to be applied. Stores are sorted in ascending order.
 	UpdatedNodes map[roachpb.NodeID][]roachpb.StoreID
 }
 
-// ReplicaUpdateReport contains detailed info about changes planned for particular replica
-// that was chosen as a designated survivor for the range.
-// This information is more detailed than update plan and collected for reporting purposes.
-// While information in update plan is meant for loqrecovery components, Report is meant for
-// cli interaction to keep user informed of changes.
+// ReplicaUpdateReport contains detailed info about changes planned for
+// particular replica that was chosen as a designated survivor for the range.
+// This information is more detailed than update plan and collected for
+// reporting purposes.
+// While information in update plan is meant for loqrecovery components, Report
+// is meant for cli interaction to keep user informed of changes.
 type ReplicaUpdateReport struct {
-	RangeID           roachpb.RangeID
-	StartKey          roachpb.RKey
-	Replica           roachpb.ReplicaDescriptor
-	OldReplica        roachpb.ReplicaDescriptor
-	StoreID           roachpb.StoreID
-	DiscardedReplicas roachpb.ReplicaSet
+	RangeID                    roachpb.RangeID
+	StartKey                   roachpb.RKey
+	Replica                    roachpb.ReplicaDescriptor
+	OldReplica                 roachpb.ReplicaDescriptor
+	StoreID                    roachpb.StoreID
+	DiscardedAvailableReplicas roachpb.ReplicaSet
+	DiscardedDeadReplicas      roachpb.ReplicaSet
 }
 
-// PlanReplicas analyzes captured replica information to determine which replicas could serve
-// as dedicated survivors in ranges where quorum was lost.
-// Devised plan doesn't guarantee data consistency after the recovery, only the fact that ranges
-// could progress and subsequently perform up-replication.
+// PlanReplicas analyzes captured replica information to determine which
+// replicas could serve as dedicated survivors in ranges where quorum was
+// lost.
+// Devised plan doesn't guarantee data consistency after the recovery, only
+// the fact that ranges could progress and subsequently perform up-replication.
 func PlanReplicas(
 	ctx context.Context, nodes []loqrecoverypb.NodeReplicaInfo, deadStores []roachpb.StoreID,
 ) (loqrecoverypb.ReplicaUpdatePlan, PlanningReport, error) {
@@ -108,130 +113,53 @@ func PlanReplicas(
 	if err != nil {
 		return loqrecoverypb.ReplicaUpdatePlan{}, PlanningReport{}, err
 	}
-	report.PresentStores = storeListFromSet(availableStoreIDs)
-	report.MissingStores = storeListFromSet(missingStores)
+	report.PresentStores = storeSliceFromSet(availableStoreIDs)
+	report.MissingStores = storeSliceFromSet(missingStores)
+
+	replicasByRangeID := groupReplicasByRangeID(replicas)
+	// proposedSurvivors contain decisions for all ranges in keyspace. it
+	// contains ranges that lost quorum as well as the ones that didn't.
+	var proposedSurvivors []rankedReplicas
+	for _, rangeReplicas := range replicasByRangeID {
+		proposedSurvivors = append(proposedSurvivors, rankReplicasBySurvivability(rangeReplicas))
+	}
+	if err = checkKeyspaceCovering(proposedSurvivors); err != nil {
+		return loqrecoverypb.ReplicaUpdatePlan{}, PlanningReport{}, err
+	}
 
 	var plan []loqrecoverypb.ReplicaUpdate
-	// Find ranges that lost quorum and create updates for them.
-	// This approach is only using local info stored in each replica independently.
-	// It is inherited in unchanged form from existing recovery operation
-	// `debug unsafe-remove-dead-replicas`.
-	// TODO(oleg): #73662 Use additional field and information about all replicas of
-	// range to determine winner.
-	for _, rangeDesc := range replicas {
-		report.TotalReplicas++
-		numDeadPeers := 0
-		desc := rangeDesc.Desc
-		allReplicas := desc.Replicas().Descriptors()
-		maxLiveVoter := roachpb.StoreID(-1)
-		var winningReplica roachpb.ReplicaDescriptor
-		for _, rep := range allReplicas {
-			if _, ok := availableStoreIDs[rep.StoreID]; !ok {
-				numDeadPeers++
-				continue
-			}
-			// The designated survivor will be the voter with the highest storeID.
-			// Note that an outgoing voter cannot be designated, as the only
-			// replication change it could make is to turn itself into a learner, at
-			// which point the range is completely messed up.
-			//
-			// Note: a better heuristic might be to choose the leaseholder store, not
-			// the largest store, as this avoids the problem of requests still hanging
-			// after running the tool in a rolling-restart fashion (when the lease-
-			// holder is under a valid epoch and was ont chosen as designated
-			// survivor). However, this choice is less deterministic, as leaseholders
-			// are more likely to change than replication configs. The hanging would
-			// independently be fixed by the below issue, so staying with largest store
-			// is likely the right choice. See:
-			//
-			// https://github.com/cockroachdb/cockroach/issues/33007
-			if rep.IsVoterNewConfig() && rep.StoreID > maxLiveVoter {
-				maxLiveVoter = rep.StoreID
-				winningReplica = rep
-			}
+	for _, p := range proposedSurvivors {
+		report.TotalReplicas += len(p)
+		u, ok := makeReplicaUpdateIfNeeded(ctx, p, availableStoreIDs)
+		if ok {
+			plan = append(plan, u)
+			report.DiscardedNonSurvivors += len(p) - 1
+			report.PlannedUpdates = append(report.PlannedUpdates, makeReplicaUpdateReport(ctx, p, u))
+			updatedLocations.add(u.NodeID(), u.StoreID())
+			log.Infof(ctx, "replica has lost quorum, recovering: %s -> %s", p.survivor().Desc, u)
+		} else {
+			log.Infof(ctx, "range r%d didn't lose quorum", p.rangeID())
 		}
-
-		// If there's no dead peer in this group (so can't hope to fix
-		// anything by rewriting the descriptor) or the current store is not the
-		// one we want to turn into the sole voter, don't do anything.
-		if numDeadPeers == 0 {
-			continue
-		}
-
-		// The replica thinks it can make progress anyway, so we leave it alone.
-		if desc.Replicas().CanMakeProgress(func(rep roachpb.ReplicaDescriptor) bool {
-			_, ok := availableStoreIDs[rep.StoreID]
-			return ok
-		}) {
-			log.Infof(ctx, "Replica has not lost quorum, skipping: %s", desc)
-			continue
-		}
-
-		if rangeDesc.StoreID != maxLiveVoter {
-			log.Infof(ctx, "Not designated survivor, skipping: %s", desc)
-			report.DiscardedNonSurvivors++
-			continue
-		}
-
-		// We're the designated survivor and the range needs to be recovered.
-		//
-		// Rewrite the range as having a single replica. The winning replica is
-		// picked arbitrarily: the one with the highest store ID. This is not always
-		// the best option: it may lose writes that were committed on another
-		// surviving replica that had applied more of the raft log. However, in
-		// practice when we have multiple surviving replicas but still need this
-		// tool (because the replication factor was 4 or higher), we see that the
-		// logs are nearly always in sync and the choice doesn't matter. Correctly
-		// picking the replica with the longer log would complicate the use of this
-		// tool.
-		// Rewrite the replicas list. Bump the replica ID so that in case there are
-		// other surviving nodes that were members of the old incarnation of the
-		// range, they no longer recognize this revived replica (because they are
-		// not in sync with it).
-		update := loqrecoverypb.ReplicaUpdate{
-			RangeID:      rangeDesc.Desc.RangeID,
-			StartKey:     loqrecoverypb.RecoveryKey(desc.StartKey),
-			OldReplicaID: winningReplica.ReplicaID,
-			NewReplica: &roachpb.ReplicaDescriptor{
-				NodeID:    rangeDesc.NodeID,
-				StoreID:   rangeDesc.StoreID,
-				ReplicaID: desc.NextReplicaID + nextReplicaIDIncrement,
-			},
-			NextReplicaID: desc.NextReplicaID + nextReplicaIDIncrement + 1,
-		}
-		log.Infof(ctx, "Replica has lost quorum, recovering: %s -> %s", desc, update)
-		plan = append(plan, update)
-
-		discarded := desc.Replicas().DeepCopy()
-		discarded.RemoveReplica(rangeDesc.NodeID, rangeDesc.StoreID)
-		report.PlannedUpdates = append(report.PlannedUpdates, ReplicaUpdateReport{
-			RangeID:           desc.RangeID,
-			StartKey:          desc.StartKey,
-			Replica:           *update.NewReplica,
-			OldReplica:        winningReplica,
-			StoreID:           rangeDesc.StoreID,
-			DiscardedReplicas: discarded,
-		})
-		updatedLocations.add(rangeDesc.NodeID, rangeDesc.StoreID)
 	}
 	report.UpdatedNodes = updatedLocations.asMapOfSlices()
 	return loqrecoverypb.ReplicaUpdatePlan{Updates: plan}, report, nil
 }
 
-// validateReplicaSets evaluates provided set of replicas and an optional deadStoreIDs
-// request and produces consistency info containing:
-// availableStores  - all storeIDs for which info was collected, i.e. (barring operator
-//                    error) the conclusive list of all remaining stores in the cluster.
-// missingStores    - all dead stores (stores that are referenced by replicas, but not
-//                    present in any of descriptors)
-// If inconsistency is found e.g. no info was provided for a store but it is not present
-// in explicit deadStoreIDs list, error is returned.
+// validateReplicaSets evaluates provided set of replicas and an optional
+// deadStoreIDs request and produces consistency info containing:
+// availableStores  - all storeIDs for which info was collected, i.e.
+//                    (barring operator error) the conclusive list of all
+//                    remaining stores in the cluster.
+// missingStores    - all dead stores (stores that are referenced by replicas,
+//                    but not present in any of descriptors)
+// If inconsistency is found e.g. no info was provided for a store but it is
+// not present in explicit deadStoreIDs list, error is returned.
 func validateReplicaSets(
 	replicas []loqrecoverypb.ReplicaInfo, deadStores []roachpb.StoreID,
 ) (availableStoreIDs, missingStoreIDs storeIDSet, _ error) {
-	// Populate availableStoreIDs with all StoreIDs from which we collected info and,
-	// populate missingStoreIDs with all StoreIDs referenced in replica descriptors for
-	// which no information was collected.
+	// Populate availableStoreIDs with all StoreIDs from which we collected info
+	// and, populate missingStoreIDs with all StoreIDs referenced in replica
+	// descriptors for which no information was collected.
 	availableStoreIDs = make(storeIDSet)
 	missingStoreIDs = make(storeIDSet)
 	for _, replicaDescriptor := range replicas {
@@ -240,11 +168,11 @@ func validateReplicaSets(
 			missingStoreIDs[replicaDesc.StoreID] = struct{}{}
 		}
 	}
-	// The difference between all referenced StoreIDs (missingStoreIDs) and the present
-	// StoreIDs (presentStoreIDs) should exactly equal the user-provided list of dead
-	// stores (deadStores), and the former must be a superset of the latter (since each
-	// descriptor found on a store references that store). Verify all of these conditions
-	// and error out if one of them does not hold.
+	// The difference between all referenced StoreIDs (missingStoreIDs) and the
+	// present StoreIDs (presentStoreIDs) should exactly equal the user-provided
+	// list of dead stores (deadStores), and the former must be a superset of the
+	// latter (since each descriptor found on a store references that store).
+	// Verify all of these conditions and error out if one of them does not hold.
 	for id := range availableStoreIDs {
 		delete(missingStoreIDs, id)
 	}
@@ -273,4 +201,290 @@ func validateReplicaSets(
 			joinStoreIDs(missingButNotDeadStoreIDs))
 	}
 	return availableStoreIDs, missingStoreIDs, nil
+}
+
+func groupReplicasByRangeID(
+	descriptors []loqrecoverypb.ReplicaInfo,
+) map[roachpb.RangeID][]loqrecoverypb.ReplicaInfo {
+	groupedRanges := make(map[roachpb.RangeID][]loqrecoverypb.ReplicaInfo)
+	for _, descriptor := range descriptors {
+		groupedRanges[descriptor.Desc.RangeID] = append(
+			groupedRanges[descriptor.Desc.RangeID], descriptor)
+	}
+	return groupedRanges
+}
+
+// rankedReplicas contains replica resolution details e.g. preferred replica as
+// well as extra info to produce a report of the planned action.
+type rankedReplicas []loqrecoverypb.ReplicaInfo
+
+func (p rankedReplicas) startKey() roachpb.RKey {
+	return p[0].Desc.StartKey
+}
+
+func (p rankedReplicas) endKey() roachpb.RKey {
+	return p[0].Desc.EndKey
+}
+
+func (p rankedReplicas) span() roachpb.Span {
+	return roachpb.Span{Key: roachpb.Key(p[0].Desc.StartKey), EndKey: roachpb.Key(p[0].Desc.EndKey)}
+}
+
+func (p rankedReplicas) rangeID() roachpb.RangeID {
+	return p[0].Desc.RangeID
+}
+
+func (p rankedReplicas) nodeID() roachpb.NodeID {
+	return p[0].NodeID
+}
+
+func (p rankedReplicas) storeID() roachpb.StoreID {
+	return p[0].StoreID
+}
+
+func (p rankedReplicas) survivor() *loqrecoverypb.ReplicaInfo {
+	return &p[0]
+}
+
+// rankReplicasBySurvivability given a slice of replicas for the range from
+// all live stores, pick one to survive recovery. if progress can be made,
+// still pick one replica so that it could be used to do key covering
+// validation.
+// Note that replicas argument would be sorted in process of picking a
+// survivor
+func rankReplicasBySurvivability(replicas []loqrecoverypb.ReplicaInfo) rankedReplicas {
+	isVoter := func(desc loqrecoverypb.ReplicaInfo) int {
+		for _, replica := range desc.Desc.InternalReplicas {
+			if replica.StoreID == desc.StoreID {
+				if replica.IsVoterNewConfig() {
+					return 1
+				}
+				return 0
+			}
+		}
+		// This is suspicious, our descriptor is not in replicas. Panic maybe?
+		return 0
+	}
+	sort.Slice(replicas, func(i, j int) bool {
+		// When finding the best suitable replica evaluate 3 conditions in order:
+		//  - replica is a voter
+		//  - replica has the higher range committed index
+		//  - replica has the higher store id
+		//
+		// Note: that an outgoing voter cannot be designated, as the only
+		// replication change it could make is to turn itself into a learner, at
+		// which point the range is completely messed up.
+		//
+		// Note: a better heuristic might be to choose the leaseholder store, not
+		// the largest store, as this avoids the problem of requests still hanging
+		// after running the tool in a rolling-restart fashion (when the lease-
+		// holder is under a valid epoch and was ont chosen as designated
+		// survivor). However, this choice is less deterministic, as leaseholders
+		// are more likely to change than replication configs. The hanging would
+		// independently be fixed by the below issue, so staying with largest store
+		// is likely the right choice. See:
+		//
+		// https://github.com/cockroachdb/cockroach/issues/33007
+		voterI := isVoter(replicas[i])
+		voterJ := isVoter(replicas[j])
+		if voterI > voterJ {
+			return true
+		}
+		if voterI < voterJ {
+			return false
+		}
+		if replicas[i].RaftAppliedIndex > replicas[j].RaftAppliedIndex {
+			return true
+		}
+		if replicas[i].RaftAppliedIndex < replicas[j].RaftAppliedIndex {
+			return false
+		}
+		return replicas[i].StoreID > replicas[j].StoreID
+	})
+	return replicas
+}
+
+// checkKeyspaceCovering given slice of all survivor ranges, checks that full
+// keyspace is covered.
+// Note that slice would be sorted in process of the check.
+func checkKeyspaceCovering(replicas []rankedReplicas) error {
+	sort.Slice(replicas, func(i, j int) bool {
+		// We only need to sort replicas in key order to detect
+		// key collisions or gaps, but if we have matching keys
+		// sort becomes unstable which makes it produce different
+		// errors on different runs on the same data. To address
+		// that, we also add RangeID as a sorting criteria as a
+		// second level key to add stability.
+		if replicas[i].startKey().Less(replicas[j].startKey()) {
+			return true
+		}
+		if replicas[i].startKey().Equal(replicas[j].startKey()) {
+			return replicas[i].rangeID() < replicas[j].rangeID()
+		}
+		return false
+	})
+	var anomalies []keyspaceCoverageAnomaly
+	prevDesc := rankedReplicas{{Desc: roachpb.RangeDescriptor{}}}
+	// We validate that first range starts at min key, last range ends at max key
+	// and that for every range start key is equal to end key of previous range.
+	// If any of those conditions fail, we record this as anomaly to indicate
+	// there's a gap between ranges or an overlap between two or more ranges.
+	for _, rankedDescriptors := range replicas {
+		// We need to take special care of the case where the survivor replica is
+		// outgoing voter. It cannot be designated, as the only replication change
+		// it could make is to turn itself into a learner, at which point the range
+		// is completely messed up. If it is not a stale replica of some sorts,
+		// then that would be a gap in keyspace coverage.
+		r, err := rankedDescriptors.survivor().Replica()
+		if err != nil {
+			return err
+		}
+		if !r.IsVoterNewConfig() {
+			continue
+		}
+		switch {
+		case rankedDescriptors.startKey().Less(prevDesc.endKey()):
+			start := keyMax(rankedDescriptors.startKey(), prevDesc.startKey())
+			end := keyMin(rankedDescriptors.endKey(), prevDesc.endKey())
+			anomalies = append(anomalies, keyspaceCoverageAnomaly{
+				span:       roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)},
+				overlap:    true,
+				range1:     prevDesc.rangeID(),
+				range1Span: prevDesc.span(),
+				range2:     rankedDescriptors.rangeID(),
+				range2Span: rankedDescriptors.span(),
+			})
+		case prevDesc.endKey().Less(rankedDescriptors.startKey()):
+			anomalies = append(anomalies, keyspaceCoverageAnomaly{
+				span: roachpb.Span{
+					Key:    roachpb.Key(prevDesc.endKey()),
+					EndKey: roachpb.Key(rankedDescriptors.startKey()),
+				},
+				overlap:    false,
+				range1:     prevDesc.rangeID(),
+				range1Span: prevDesc.span(),
+				range2:     rankedDescriptors.rangeID(),
+				range2Span: rankedDescriptors.span(),
+			})
+		}
+		// We want to advance previous range details only when new range will
+		// advance upper bound. This is not always the case as theoretically ranges
+		// could be "nested" or range could be an earlier version encompassing LHS
+		// and RHS parts.
+		if prevDesc.endKey().Less(rankedDescriptors.endKey()) {
+			prevDesc = rankedDescriptors
+		}
+	}
+	if !prevDesc.endKey().Equal(roachpb.RKeyMax) {
+		anomalies = append(anomalies, keyspaceCoverageAnomaly{
+			span:       roachpb.Span{Key: roachpb.Key(prevDesc.endKey()), EndKey: roachpb.KeyMax},
+			overlap:    false,
+			range1:     prevDesc.rangeID(),
+			range1Span: prevDesc.span(),
+			range2:     roachpb.RangeID(0),
+			range2Span: roachpb.Span{Key: roachpb.KeyMax, EndKey: roachpb.KeyMax},
+		})
+	}
+
+	if len(anomalies) > 0 {
+		return &KeyspaceCoverageError{anomalies: anomalies}
+	}
+	return nil
+}
+
+// makeReplicaUpdateIfNeeded if candidate range can't make progress, create an
+// update using preferred replica.
+// Returns a replica update and a flag indicating if update needs to be
+// performed.
+// For replicas that can make progress return empty update and false to exclude
+// range from update plan.
+func makeReplicaUpdateIfNeeded(
+	ctx context.Context, p rankedReplicas, liveStoreIDs storeIDSet,
+) (loqrecoverypb.ReplicaUpdate, bool) {
+	if p.survivor().Desc.Replicas().CanMakeProgress(func(rep roachpb.ReplicaDescriptor) bool {
+		_, ok := liveStoreIDs[rep.StoreID]
+		return ok
+	}) {
+		return loqrecoverypb.ReplicaUpdate{}, false
+	}
+
+	// We want to have replicaID which is greater or equal nextReplicaID across
+	// all available replicas. We'll use that as a base to bump it by arbitrary
+	// number to avoid potential conflicts with other replicas applying
+	// uncommitted raft log with descriptor updates.
+	nextReplicaID := p.survivor().Desc.NextReplicaID
+	for _, r := range p[1:] {
+		if r.Desc.NextReplicaID > nextReplicaID {
+			nextReplicaID = r.Desc.NextReplicaID
+		}
+	}
+
+	replica, err := p.survivor().Replica()
+	if err != nil {
+		// We don't expect invalid replicas reaching this stage because we will err
+		// out on earlier stages. This is covered by invalid input tests and if we
+		// ended up here that means tests are not run, or code changed sufficiently
+		// and both checks and tests were lost.
+		log.Fatalf(ctx, "unexpected invalid replica info while making recovery plan, "+
+			"we should never have unvalidated descriptors at planning stage, they must be detected "+
+			"while performing keyspace coverage check: %s", err)
+	}
+
+	// The range needs to be recovered and this replica is a designated survivor.
+	// To recover the range rewrite it as having a single replica:
+	// - Rewrite the replicas list.
+	// - Bump the replica ID so that in case there are other surviving nodes that
+	//   were members of the old incarnation of the range, they no longer
+	//   recognize this revived replica (because they are not in sync with it).
+	return loqrecoverypb.ReplicaUpdate{
+		RangeID:      p.rangeID(),
+		StartKey:     loqrecoverypb.RecoveryKey(p.startKey()),
+		OldReplicaID: replica.ReplicaID,
+		NewReplica: roachpb.ReplicaDescriptor{
+			NodeID:    p.nodeID(),
+			StoreID:   p.storeID(),
+			ReplicaID: nextReplicaID + nextReplicaIDIncrement,
+		},
+		NextReplicaID: nextReplicaID + nextReplicaIDIncrement + 1,
+	}, true
+}
+
+// makeReplicaUpdateReport creates a detailed report of changes that needs to
+// be performed on range. It uses decision as well as information about all
+// replicas of range to provide information about what is being discarded and
+// how new replica would be configured.
+func makeReplicaUpdateReport(
+	ctx context.Context, p rankedReplicas, update loqrecoverypb.ReplicaUpdate,
+) ReplicaUpdateReport {
+	oldReplica, err := p.survivor().Replica()
+	if err != nil {
+		// We don't expect invalid replicas reaching this stage because we will err
+		// out on earlier stages. This is covered by invalid input tests and if we
+		// ended up here that means tests are not run, or code changed sufficiently
+		// and both checks and tests were lost.
+		log.Fatalf(ctx, "unexpected invalid replica info while making recovery plan: %s", err)
+	}
+
+	// Replicas that belonged to unavailable nodes based on surviving range
+	// descriptor.
+	discardedDead := p.survivor().Desc.Replicas()
+	discardedDead.RemoveReplica(update.NodeID(), update.StoreID())
+	// Replicas that we collected info about for the range, but decided they are
+	// not preferred choice.
+	discardedAvailable := roachpb.ReplicaSet{}
+	for _, replica := range p[1:] {
+		discardedDead.RemoveReplica(replica.NodeID, replica.StoreID)
+		r, _ := replica.Desc.GetReplicaDescriptor(replica.StoreID)
+		discardedAvailable.AddReplica(r)
+	}
+
+	return ReplicaUpdateReport{
+		RangeID:                    p.rangeID(),
+		StartKey:                   p.startKey(),
+		OldReplica:                 oldReplica,
+		Replica:                    update.NewReplica,
+		StoreID:                    p.storeID(),
+		DiscardedDeadReplicas:      discardedDead,
+		DiscardedAvailableReplicas: discardedAvailable,
+	}
 }

--- a/pkg/kv/kvserver/loqrecovery/testdata/invalid_input
+++ b/pkg/kv/kvserver/loqrecovery/testdata/invalid_input
@@ -1,0 +1,23 @@
+# Test verifies that if we have replica with incorrect descriptor that doesn't contain its own store replica,
+# we detect that and don't produce bad results or crash.
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:  # this replica is bad, it doesn't contain itself in the replicas set
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 1}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1)
+----
+ok
+
+make-plan
+----
+ERROR: invalid replica info: its own store s1 is not present in descriptor replicas r1:/M{in-ax} [(n2,s2):2, (n3,s3):3, (n4,s4):1, next=4, gen=3]

--- a/pkg/kv/kvserver/loqrecovery/testdata/keyspace_coverage
+++ b/pkg/kv/kvserver/loqrecovery/testdata/keyspace_coverage
@@ -1,0 +1,194 @@
+# Tests verifying that gaps between range spans or overlaps of range spans block recovery.
+
+
+# Check that ranges with perfectly matching spans are correctly detected as an overlap
+# even if they are not adjacent with respect of range ids.
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min  # first range for the [/Min-/Table/3) keyspan
+  EndKey: /Table/3
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 1
+  RangeID: 2
+  StartKey: /Table/3
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 2
+  RangeID: 3
+  StartKey: /Min
+  EndKey: /Table/3  # second (conflicting) range for the [/Min-/Table/3) keyspan
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 20
+  RaftCommittedIndex: 20
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range overlap /{Min-Table/3}
+  r1: /{Min-Table/3}
+  r3: /{Min-Table/3}
+
+
+# Check range gap where range 2 is missing leaving a hole between ranges 1 and 3.
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/3  # first range ends short of the second one leaving a missing [Table/3, Table/4)
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 1
+  RangeID: 3
+  StartKey: /Table/4
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1)
+----
+ok
+
+make-plan
+----
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range gap /Table/{3-4}
+  r1: /{Min-Table/3}
+  r3: /{Table/4-Max}
+
+# Check range overlap with stale range in a way of newly split ones.
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min  # range covers the full range which was split, but node has some stale data
+  EndKey: /Table/10
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 2}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 1
+  RangeID: 10
+  StartKey: /Table/10
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 2}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 2
+  RangeID: 3  # newer range that covers part of it parent range
+  StartKey: /Table/1
+  EndKey: /Table/3
+  Replicas:
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 3}
+  - { NodeID: 7, StoreID: 7, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 2
+  RangeID: 4
+  StartKey: /Table/3
+  EndKey: /Table/10  # newer range that covers part of it parent range
+  Replicas:
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 3}
+  - { NodeID: 7, StoreID: 7, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range overlap /Table/{1-3}
+  r1: /{Min-Table/10}
+  r3: /Table/{1-3}
+range overlap /Table/{3-10}
+  r1: /{Min-Table/10}
+  r4: /Table/{3-10}
+
+
+# Check that gaps at the start and end of keyspace are detected and reported correctly.
+# For this we will create range that start long of min and short of max.
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Table/1  # range starts in the middle of keyspace
+  EndKey: /Table/99   # and ends short of Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 2}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 3}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1)
+----
+ok
+
+make-plan
+----
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range gap /{Min-Table/1}
+  r0: /Min
+  r1: /Table/{1-99}
+range gap /{Table/99-Max}
+  r1: /Table/{1-99}
+  r0: /Max{-}
+
+
+# Check that empty replica set will be correctly handled as a non covering keyset.
+replication-data
+----
+ok
+
+collect-replica-info
+----
+ok
+
+make-plan
+----
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range gap /M{in-ax}
+  r0: /Min
+  r0: /Max{-}
+

--- a/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
+++ b/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
@@ -1,8 +1,8 @@
 # Tests verifying that learners don't become survivors.
 
-# First use case where we can make a right decision
+# First use case where we can make a right decision.
 # With two out of five replicas remaining, check that learner
-# is not picked as a survivor even if all other criteria are met
+# is not picked as a survivor even if all other criteria are met.
 # Note: for replica type codes, see metadata.proto
 
 replication-data
@@ -24,7 +24,7 @@ replication-data
   EndKey: /Max
   Replicas:
   - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 2, StoreID: 2, ReplicaID: 2, ReplicaType: 1}   # learner has highest storeID but must not win
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2, ReplicaType: 1}  # learner has highest storeID but must not win
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
   - { NodeID: 5, StoreID: 5, ReplicaID: 5}
@@ -73,9 +73,8 @@ dump-store stores=(1,2)
     - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
     - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
 
-# Second use case where we can't make a decision and leave replica as is
-# Only a single learner is left, there is no way to recover.
-
+# Second use case where we can't make a decision and fail keyspace coverage as
+# only a single learner is left, there is no way to recover.
 replication-data
 - StoreID: 1
   RangeID: 1
@@ -116,35 +115,7 @@ ok
 
 make-plan
 ----
-[]
-
-apply-plan stores=(1,2)
-----
-ok
-
-dump-store stores=(1,2)
-----
-- NodeID: 1
-  StoreID: 1
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1, ReplicaType: 1}
-    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 2}
-    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 3}
-  - RangeID: 2
-    StartKey: /Table/1
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
-    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
-- NodeID: 2
-  StoreID: 2
-  Descriptors:
-  - RangeID: 2
-    StartKey: /Table/1
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
-    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
+ERROR: Key space covering is not complete. Discovered following inconsistencies:
+range gap /{Min-Table/1}
+  r0: /Min
+  r2: /{Table/1-Max}

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
@@ -1,0 +1,221 @@
+# With two out of five replicas remaining, check that replica with highest
+# range applied index is chosen regardless of replica storeID.
+# We have a 5-way replication and have two out of five nodes left so quorum
+# is lost.
+
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}  # replicas 3-5 are located on unavailable stores
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 11  # this replica has higher applied index so is preferred over the other one
+  RaftCommittedIndex: 13
+- StoreID: 2
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}  # replicas 3-5 are located on unavailable stores
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 10    # applied index takes precedence over store ID so this replica loses
+  RaftCommittedIndex: 14   # committed index while higher, should not confuse planner and use applied index
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 1
+  NewReplica:
+    NodeID: 1
+    StoreID: 1
+    ReplicaID: 16
+  NextReplicaID: 17
+
+apply-plan stores=(1,2)
+----
+ok
+
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+- NodeID: 2
+  StoreID: 2
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
+    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
+    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
+
+
+# Second use case where stale replica which remained from before split
+# on store with higher ID will conflict with later one spanning smaller range.
+# We have a stale replica in s2 which still remembers group across s3 and s4
+# but they are not available anymore. While LHS and RHS across s1, s4, s5 are
+# now more recent. Stale replica loses based on raft applied index being lower.
+replication-data
+- StoreID: 1  # this is the LHS replica post split
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+- StoreID: 1  # this is the RHS replica post split
+  RangeID: 2
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+- StoreID: 2
+  RangeID: 1  # this is the old version of range which got stale
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+- StoreID: 5
+  RangeID: 1  # this is the LHS replica post split
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+- StoreID: 5
+  RangeID: 2  # this is the RHS replica post split
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+- StoreID: 6
+  RangeID: 1  # this is the LHS replica post split
+  StartKey: /Min
+  EndKey: /Table/1
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+- StoreID: 6
+  RangeID: 2  # this is the RHS replica post split
+  StartKey: /Table/1
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
+  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
+  RangeAppliedIndex: 15
+  RaftCommittedIndex: 15
+----
+ok
+
+collect-replica-info stores=(1,2,5,6)
+----
+ok
+
+make-plan
+----
+[]
+
+apply-plan stores=(1,2,5,6)
+----
+ok
+
+dump-store stores=(1,2,5,6)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
+- NodeID: 2
+  StoreID: 2
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
+    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
+    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
+- NodeID: 5
+  StoreID: 5
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
+- NodeID: 6
+  StoreID: 6
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
+  - RangeID: 2
+    StartKey: /Table/1
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
+    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
@@ -1,9 +1,8 @@
-# Test verifying that voter with max StoreID would be designated survivor.
+# Tests verifying that voter with max StoreID would be designated survivor.
 
-# First use case where we can successfully resolve replica by store ID
+# First use case where we can successfully resolve replica by store ID.
 # With two out of five replicas remaining, check that replica with highest
 # store ID is chosen as a survivor.
-# Note: for replica type codes, see metadata.proto
 
 replication-data
 - StoreID: 1
@@ -11,7 +10,7 @@ replication-data
   StartKey: /Min
   EndKey: /Max
   Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # This replica is identical to one in store 2 but has lower storeID 1
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # this replica is identical to one in store 2 but has lower storeID 1
   - { NodeID: 2, StoreID: 2, ReplicaID: 2}
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
@@ -24,7 +23,7 @@ replication-data
   EndKey: /Max
   Replicas:
   - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # This replica has the same state n1 but has higher storeID so it wins
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID so it wins
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
   - { NodeID: 5, StoreID: 5, ReplicaID: 5}
@@ -72,157 +71,3 @@ dump-store stores=(1,2)
     StartKey: /Min
     Replicas:
     - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 16}
-
-# Second use case where stale replica which remained from before split
-# on store with higher ID will conflict with later one spanning smaller range.
-# We have a stale replica in s2 which still remembers group across s3 and s4
-# which are not available anymore. While LHS and RHS across s1, s4, s5 are now
-# more recent. But they can't win against old version as we don't analyze enough
-# info.
-replication-data
-- StoreID: 1  # This is a LHS post split
-  RangeID: 1
-  StartKey: /Min
-  EndKey: /Table/1
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-- StoreID: 1  # This is RHS replica post split
-  RangeID: 2
-  StartKey: /Table/1
-  EndKey: /Max
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-- StoreID: 2
-  RangeID: 1  # This is an old version of range which got lost
-  StartKey: /Min
-  EndKey: /Max
-  Replicas:
-  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
-  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
-  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
-  RangeAppliedIndex: 10
-  RaftCommittedIndex: 13
-- StoreID: 5
-  RangeID: 1  # This is a LHS post split
-  StartKey: /Min
-  EndKey: /Table/1
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-- StoreID: 5
-  RangeID: 2  # This is RHS replica post split
-  StartKey: /Table/1
-  EndKey: /Max
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-- StoreID: 6
-  RangeID: 1  # This is a LHS post split
-  StartKey: /Min
-  EndKey: /Table/1
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-- StoreID: 6
-  RangeID: 2  # This is RHS replica post split
-  StartKey: /Table/1
-  EndKey: /Max
-  Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 6}
-  - { NodeID: 6, StoreID: 6, ReplicaID: 7}
-  RangeAppliedIndex: 15
-  RaftCommittedIndex: 15
-----
-ok
-
-collect-replica-info stores=(1,2,5,6)
-----
-ok
-
-make-plan
-----
-- RangeID: 1
-  StartKey: /Min
-  OldReplicaID: 2
-  NewReplica:
-    NodeID: 2
-    StoreID: 2
-    ReplicaID: 15
-  NextReplicaID: 16
-
-apply-plan stores=(1,2,5,6)
-----
-ok
-
-dump-store stores=(1,2,5,6)
-----
-- NodeID: 1
-  StoreID: 1
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
-  - RangeID: 2
-    StartKey: /Table/1
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
-- NodeID: 2
-  StoreID: 2
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 15}
-- NodeID: 5
-  StoreID: 5
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
-  - RangeID: 2
-    StartKey: /Table/1
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
-- NodeID: 6
-  StoreID: 6
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}
-  - RangeID: 2
-    StartKey: /Table/1
-    Replicas:
-    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
-    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 6}
-    - Replica: {NodeID: 6, StoreID: 6, ReplicaID: 7}

--- a/pkg/kv/kvserver/loqrecovery/utils.go
+++ b/pkg/kv/kvserver/loqrecovery/utils.go
@@ -20,8 +20,8 @@ import (
 
 type storeIDSet map[roachpb.StoreID]struct{}
 
-// storeListFromSet unwraps map to a sorted list of StoreIDs.
-func storeListFromSet(set storeIDSet) []roachpb.StoreID {
+// storeSliceFromSet unwraps map to a sorted list of StoreIDs.
+func storeSliceFromSet(set storeIDSet) []roachpb.StoreID {
 	storeIDs := make([]roachpb.StoreID, 0, len(set))
 	for k := range set {
 		storeIDs = append(storeIDs, k)
@@ -35,8 +35,70 @@ func storeListFromSet(set storeIDSet) []roachpb.StoreID {
 // Make a string of stores 'set' in ascending order.
 func joinStoreIDs(storeIDs storeIDSet) string {
 	storeNames := make([]string, 0, len(storeIDs))
-	for _, id := range storeListFromSet(storeIDs) {
+	for _, id := range storeSliceFromSet(storeIDs) {
 		storeNames = append(storeNames, fmt.Sprintf("s%d", id))
 	}
 	return strings.Join(storeNames, ", ")
+}
+
+func keyMax(key1 roachpb.RKey, key2 roachpb.RKey) roachpb.RKey {
+	if key1.Less(key2) {
+		return key2
+	}
+	return key1
+}
+
+func keyMin(key1 roachpb.RKey, key2 roachpb.RKey) roachpb.RKey {
+	if key2.Less(key1) {
+		return key2
+	}
+	return key1
+}
+
+// keyspaceCoverageAnomaly records errors found when checking keyspace coverage.
+// Anomaly is a key span where there's no coverage or there are more than one
+// range that covers the span.
+// Anomaly also contains additional information about ranges that either
+// bordering the gap or overlap over the anomaly span.
+type keyspaceCoverageAnomaly struct {
+	span    roachpb.Span
+	overlap bool
+
+	range1     roachpb.RangeID
+	range1Span roachpb.Span
+
+	range2     roachpb.RangeID
+	range2Span roachpb.Span
+}
+
+func (i keyspaceCoverageAnomaly) String() string {
+	if i.overlap {
+		return fmt.Sprintf("range overlap %v\n  r%d: %v\n  r%d: %v",
+			i.span, i.range1, i.range1Span, i.range2, i.range2Span)
+	}
+	return fmt.Sprintf("range gap %v\n  r%d: %v\n  r%d: %v",
+		i.span, i.range1, i.range1Span, i.range2, i.range2Span)
+}
+
+// KeyspaceCoverageError is returned by replica planner when it detects problems
+// with key coverage. Error contains all anomalies found. It also provides a
+// convenience function to print report.
+type KeyspaceCoverageError struct {
+	anomalies []keyspaceCoverageAnomaly
+}
+
+func (e *KeyspaceCoverageError) Error() string {
+	return "keyspace coverage error"
+}
+
+// ErrorDetail returns a properly formatted report that could be presented
+// to user.
+func (e *KeyspaceCoverageError) ErrorDetail() string {
+	descriptions := make([]string, 0, len(e.anomalies))
+	for _, id := range e.anomalies {
+		descriptions = append(descriptions, fmt.Sprintf("%v", id))
+	}
+	return fmt.Sprintf(
+		"Key space covering is not complete. Discovered following inconsistencies:\n%s\n",
+		strings.Join(descriptions, "\n"))
 }


### PR DESCRIPTION
Previously when doing unsafe replica recovery, if some ranges are
missing or represented by stale replicas that were split or merged,
recovery will change cluster to inconsistent state with gaps or
overlaps in keyspace.
This change adds checks for range completeness as well as adds a
preference for replicas with higher range applied index.

Release note: None

Fixes #73662