### PR TITLE
tracing: manually redact string in spanInner.Recordf

### DIFF
--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -187,10 +187,15 @@ func (s *spanInner) Recordf(format string, args ...interface{}) {
 		str = redact.Sprintf(format, args...)
 	} else {
 		// `fmt.Sprintf` when called on a logEntry will use the faster
-		// `logEntry.String` method instead of `logEntry.SafeFormat`.
-		// The additional use of `redact.Sprintf("%s",...)` is necessary
-		// to wrap the result in redaction markers.
-		str = redact.Sprintf("%s", fmt.Sprintf(format, args...))
+		// `logEntry.String` method instead of `logEntry.SafeFormat`. We are
+		// also avoiding using `redact.Sprintf("%s"...) to save on
+		// allocations.
+		s := fmt.Sprintf(format, args...)
+		strBytes := make([]byte, 0, len(s)+10)
+		strBytes = append(strBytes, redact.StartMarker()...)
+		strBytes = append(strBytes, redact.EscapeBytes([]byte(s))...)
+		strBytes = append(strBytes, redact.EndMarker()...)
+		str = redact.RedactableString(strBytes)
 	}
 	if s.otelSpan != nil {
 		// TODO(obs-inf): depending on the situation it may be more appropriate to


### PR DESCRIPTION
Remove usage of `redact.Sprintf` to save on allocations.

```
name                                            old time/op    new time/op    delta
Eventf_WithVerboseTraceSpan/redactable=false-8    3.67µs ± 2%    3.66µs ± 2%     ~     (p=0.483 n=10+9)
Eventf_WithVerboseTraceSpan/redactable=true-8     4.22µs ± 3%    4.07µs ± 3%   -3.52%  (p=0.002 n=8+10)

name                                            old alloc/op   new alloc/op   delta
Eventf_WithVerboseTraceSpan/redactable=false-8    1.11kB ± 0%    0.81kB ± 0%  -27.31%  (p=0.000 n=10+10)
Eventf_WithVerboseTraceSpan/redactable=true-8       864B ± 0%      864B ± 0%     ~     (all equal)

name                                            old allocs/op  new allocs/op  delta
Eventf_WithVerboseTraceSpan/redactable=false-8      20.0 ± 0%      17.0 ± 0%  -15.00%  (p=0.000 n=10+10)
Eventf_WithVerboseTraceSpan/redactable=true-8       14.0 ± 0%      14.0 ± 0%     ~     (all equal)
```

Release note: None