### PR TITLE
settings: mark changefeed.mem.pushback_enabled as retired

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -104,6 +104,7 @@ var retiredSettings = map[string]struct{}{
 	"sql.telemetry.query_sampling.qps_threshold":                     {},
 	"sql.telemetry.query_sampling.sample_rate":                       {},
 	"diagnostics.sql_stat_reset.interval":                            {},
+	"changefeed.mem.pushback_enabled":                                {},
 
 	// removed as of 22.1.
 	"sql.defaults.drop_enum_value.enabled":                             {},


### PR DESCRIPTION
This change adds changefeed.mem.pushback_enabled to the
`retiredSettings` map so that any node upgrading from 21.1
to 21.2 does not attempt to refresh this setting. This setting
was removed in 21.2 and its behaviour is enabled by default.

Release note: None