### PR TITLE
rpc: use system certificates when certs dir not specified or empty

### DIFF
--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -333,6 +333,11 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslrootcert=blih/loh.crt"}, nil, `invalid file name for "sslrootcert": expected .* got .*`, ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslcert=blih/loh.crt"}, nil, `invalid file name for "sslcert": expected .* got .*`, ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslkey=blih/loh.crt"}, nil, `invalid file name for "sslkey": expected .* got .*`, ""},
+
+		// Check that not specifying a certs dir will cause Go to use root trust store.
+		{anyCmd, []string{"--url=postgresql://foo?sslmode=verify-full"}, []string{"--host=foo"}, "", ""},
+		{anySQL, []string{"--url=postgresql://foo?sslmode=verify-ca"}, []string{"--host=foo"}, "", ""},
+		{anySQL, []string{"--url=postgresql://foo?sslmode=require"}, []string{"--host=foo"}, "", ""},
 	}
 
 	type capturedFlags struct {

--- a/pkg/cli/interactive_tests/test_error_hints.tcl
+++ b/pkg/cli/interactive_tests/test_error_hints.tcl
@@ -30,8 +30,8 @@ end_test
 
 start_test "Connecting a SQL client to a non-started server"
 send "$argv sql -e 'select 1'\r"
-eexpect "ERROR: cannot load certificates.\r\nCheck your certificate settings"
-eexpect "or use --insecure"
+eexpect "ERROR: cannot dial server.\r\nIs the server running?"
+eexpect "connection refused"
 eexpect ":/# "
 
 send "$argv sql -e 'select 1' --certs-dir=$certs_dir\r"

--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -15,7 +15,8 @@ start_test "Check that the SSL settings come from flags is URL does not set them
 set ::env(COCKROACH_INSECURE) "false"
 
 spawn $argv sql --url "postgresql://test@localhost:26257" -e "select 1"
-eexpect "cannot load certificates"
+eexpect "ERROR: cannot establish secure connection to insecure server."
+eexpect "Maybe use --insecure?"
 eexpect eof
 
 spawn $argv sql --url "postgresql://test@localhost:26257" --insecure -e "select 1"

--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -104,12 +104,14 @@ func (ctx *SecurityContext) GetCertificateManager() (*security.CertificateManage
 				// If we know there should be certificates (we're in secure mode)
 				// but there aren't any, this likely indicates that the certs dir
 				// was misconfigured.
-				ctx.lazy.certificateManager.err = errors.New("no certificates found; does certs dir exist?")
+				ctx.lazy.certificateManager.err = errNoCertificatesFound
 			}
 		}
 	})
 	return ctx.lazy.certificateManager.cm, ctx.lazy.certificateManager.err
 }
+
+var errNoCertificatesFound = errors.New("no certificates found; does certs dir exist?")
 
 // GetServerTLSConfig returns the server TLS config, initializing it if needed.
 // If Insecure is true, return a nil config, otherwise ask the certificate

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -269,6 +269,11 @@ func (cl CertsLocator) CACertPath() string {
 	return filepath.Join(cl.certsDir, CACertFilename())
 }
 
+// FullPath takes a CertInfo and returns the full path for it.
+func (cl CertsLocator) FullPath(ci *CertInfo) string {
+	return filepath.Join(cl.certsDir, ci.Filename)
+}
+
 // EnsureCertsDirectory ensures that the certs directory exists by
 // creating it if does not exist yet.
 func (cl CertsLocator) EnsureCertsDirectory() error {


### PR DESCRIPTION
Previously, we always required either a certs dir path to be specified
as an option or a root cert path in the connection url.

This was incorrect because when sslmode was set to "require"
or any other mode which did not require certificate checking,
not specifying a certs dir would cause an error asking for one.
Another problem was that in modes that did need certificate checking,
like "verify-full" and "verify-ca", we did not first check the system
trust store for any available certificates.

To address this, this patch removes the requirement that certificate
paths need to be checked for require or disable sslmodes. Also removed
is the error when certificates were required, we now check the system
trust store for the CA. This only applies to deployments which use certs
ultimately signed by a public CA, such as CockroachCloud serverless
(which uses LetsEncrypt) or when using a publicly rooted CA chain.
It does not apply to certificates derived from a CA generated via
"cockroach cert create-ca". This also allows us to reduce
the number of steps required to connect to CockroachCloud serverless
clusters by not having the user download a certificate they already have.

Fixes cockroachdb#70946.

Release note (cli change): Not finding the right certs in the certs dir
or not specifying a certs dir or certificate path will now fall back on
checking server CA using Go's TLS code to find the certificates in
the OS trust store. If no matching certificate is found, then an x509
error will occur announcing that the certificate is signed by an
unknown authority.

Release note (bug fix): Setting sslmode=require would check for local
certificates, so omitting a certs path would cause an error even though
"require" does not verify server certificates. This has been fixed by
bypassing certificate path checking for sslmode=require. This bug has
been present since 21.2.0.