### PR TITLE
indexrec: add support for inverted index recommendations (JSON/array)

### DIFF
--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -14,8 +14,10 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -37,17 +39,31 @@ func BuildOptAndHypTableMaps(
 		var hypTable HypotheticalTable
 		hypTable.init(t)
 
-		for i, index := range indexes {
-			indexOrd := hypTable.Table.IndexCount() + i
+		for _, indexCols := range indexes {
+			indexOrd := hypTable.Table.IndexCount() + len(hypIndexes)
+			lastKeyCol := indexCols[len(indexCols)-1]
+			inverted := !colinfo.ColumnTypeIsIndexable(lastKeyCol.DatumType())
+			if inverted {
+				invertedCol := hypTable.addInvertedCol(lastKeyCol.Column)
+				indexCols[len(indexCols)-1] = cat.IndexColumn{Column: invertedCol}
+			}
 			var hypIndex hypotheticalIndex
 			hypIndex.init(
 				&hypTable,
 				tree.Name(fmt.Sprintf("_hyp_%d", indexOrd)),
-				index,
+				indexCols,
 				indexOrd,
+				inverted,
 				t.Zone().(*zonepb.ZoneConfig),
 			)
-			hypIndexes = append(hypIndexes, hypIndex)
+
+			// Do not add hypothetical inverted indexes for which there is an existing
+			// index with the same key. Inverted indexes do not have stored columns,
+			// so we should not make a recommendation if the same index already
+			// exists.
+			if !inverted || hypTable.existingRedundantIndex(&hypIndex) == nil {
+				hypIndexes = append(hypIndexes, hypIndex)
+			}
 		}
 
 		hypTable.hypotheticalIndexes = hypIndexes
@@ -63,6 +79,7 @@ func BuildOptAndHypTableMaps(
 // potentially speed up queries to this table.
 type HypotheticalTable struct {
 	cat.Table
+	invertedCols         []*cat.Column
 	primaryKeyColsOrdSet util.FastIntSet
 	hypotheticalIndexes  []hypotheticalIndex
 }
@@ -78,6 +95,20 @@ func (ht *HypotheticalTable) init(table cat.Table) {
 	for i := 0; i < numPrimaryKeyCols; i++ {
 		ht.primaryKeyColsOrdSet.Add(primaryIndex.Column(i).Ordinal())
 	}
+}
+
+// ColumnCount is part of the cat.Table interface.
+func (ht *HypotheticalTable) ColumnCount() int {
+	return ht.Table.ColumnCount() + len(ht.invertedCols)
+}
+
+// Column is part of the cat.Table interface.
+func (ht *HypotheticalTable) Column(i int) *cat.Column {
+	originalColCount := ht.Table.ColumnCount()
+	if i < originalColCount {
+		return ht.Table.Column(i)
+	}
+	return ht.invertedCols[i-originalColCount]
 }
 
 // IndexCount is part of the cat.Table interface.
@@ -121,7 +152,14 @@ func (ht *HypotheticalTable) existingRedundantIndex(index *hypotheticalIndex) ca
 		indexExists := true
 		for j, m := 0, existingIndex.ExplicitColumnCount(); j < m; j++ {
 			indexCol := existingIndex.Column(j)
-			if indexCol != indexCols[j] {
+			// If the columns are inverted, compare the source columns. Otherwise,
+			// compare the columns directly.
+			if index.IsInverted() && existingIndex.IsInverted() && j == m-1 {
+				if indexCol.InvertedSourceColumnOrdinal() != indexCols[j].InvertedSourceColumnOrdinal() {
+					indexExists = false
+					break
+				}
+			} else if indexCol != indexCols[j] {
 				indexExists = false
 				break
 			}
@@ -132,4 +170,23 @@ func (ht *HypotheticalTable) existingRedundantIndex(index *hypotheticalIndex) ca
 		}
 	}
 	return nil
+}
+
+// addInvertedCol adds an inverted column corresponding to a source column to
+// the HypotheticalTable.
+func (ht *HypotheticalTable) addInvertedCol(invertedSourceCol *cat.Column) *cat.Column {
+	invertedCol := cat.Column{}
+
+	// All inverted columns have type bytes.
+	typ := types.Bytes
+	invertedCol.InitInverted(
+		ht.ColumnCount(),
+		tree.Name(string(invertedSourceCol.ColName())+"_inverted_key"),
+		typ,
+		false, /* nullable */
+		invertedSourceCol.Ordinal(),
+	)
+
+	ht.invertedCols = append(ht.invertedCols, &invertedCol)
+	return &invertedCol
 }

--- a/pkg/sql/opt/indexrec/index_candidate_set.go
+++ b/pkg/sql/opt/indexrec/index_candidate_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -32,6 +33,7 @@ import (
 //  4. If there exist multiple columns from the same table in a JOIN predicate,
 //     create a single index on all such columns.
 //  5. Construct three groups for each table: EQ, R, and J.
+//     - eq is all single-column indexes that come from equality predicates.
 //     - EQ is a single index of all columns that appear in equality predicates.
 //     - R is all indexes that come from rule 2.
 //     - J is all indexes that come from rules 3 and 4.
@@ -41,6 +43,9 @@ import (
 //     set operations. This is in order to allow streaming set operations to
 //     be performed. All set operations are considered, except for UNION ALL,
 //     because indexes do not benefit here.
+//  7. For JSON and array columns, we create single column inverted indexes. We
+//     also create the following multi-column combination candidates for each
+//     inverted column: eq + 'inverted column', EQ + 'inverted column'.
 // TODO(nehageorge): Add a rule for columns that are referenced in the statement
 // but do not fall into one of these categories. In order to account for this,
 // *memo.VariableExpr would be the final case in the switch statement, hit only
@@ -59,11 +64,12 @@ func FindIndexCandidateSet(rootExpr opt.Expr, md *opt.Metadata) map[cat.Table][]
 // indexCandidateSet stores potential indexes that could be recommended for a
 // given query, as well as the query's metadata.
 type indexCandidateSet struct {
-	md                *opt.Metadata
-	equalCandidates   map[cat.Table][][]cat.IndexColumn
-	rangeCandidates   map[cat.Table][][]cat.IndexColumn
-	joinCandidates    map[cat.Table][][]cat.IndexColumn
-	overallCandidates map[cat.Table][][]cat.IndexColumn
+	md                 *opt.Metadata
+	equalCandidates    map[cat.Table][][]cat.IndexColumn
+	rangeCandidates    map[cat.Table][][]cat.IndexColumn
+	joinCandidates     map[cat.Table][][]cat.IndexColumn
+	invertedCandidates map[cat.Table][][]cat.IndexColumn
+	overallCandidates  map[cat.Table][][]cat.IndexColumn
 }
 
 // init allocates memory for the maps in the set.
@@ -73,6 +79,7 @@ func (ics *indexCandidateSet) init(md *opt.Metadata) {
 	ics.equalCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.rangeCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.joinCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
+	ics.invertedCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 	ics.overallCandidates = make(map[cat.Table][][]cat.IndexColumn, numTables)
 }
 
@@ -84,12 +91,14 @@ func (ics *indexCandidateSet) combineIndexCandidates() {
 	copyIndexes(ics.equalCandidates, ics.overallCandidates)
 	copyIndexes(ics.rangeCandidates, ics.overallCandidates)
 	copyIndexes(ics.joinCandidates, ics.overallCandidates)
+	copyIndexes(ics.invertedCandidates, ics.overallCandidates)
 
 	numTables := len(ics.overallCandidates)
 	equalJoinCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
 	equalGroupedCandidates := make(map[cat.Table][][]cat.IndexColumn, numTables)
 
-	// Construct EQ, EQ + R, J + R, EQ + J, EQ + J + R.
+	// Construct EQ, EQ + R, J + R, EQ + J, EQ + J + R, eq + (inverted),
+	// EQ + (inverted).
 	groupIndexesByTable(ics.equalCandidates, equalGroupedCandidates)
 	copyIndexes(equalGroupedCandidates, ics.overallCandidates)
 	constructIndexCombinations(equalGroupedCandidates, ics.rangeCandidates, ics.overallCandidates)
@@ -97,6 +106,8 @@ func (ics *indexCandidateSet) combineIndexCandidates() {
 	constructIndexCombinations(equalGroupedCandidates, ics.joinCandidates, equalJoinCandidates)
 	copyIndexes(equalJoinCandidates, ics.overallCandidates)
 	constructIndexCombinations(equalJoinCandidates, ics.rangeCandidates, ics.overallCandidates)
+	constructIndexCombinations(ics.equalCandidates, ics.invertedCandidates, ics.overallCandidates)
+	constructIndexCombinations(equalGroupedCandidates, ics.invertedCandidates, ics.overallCandidates)
 }
 
 // categorizeIndexCandidates finds potential index candidates for a given
@@ -106,24 +117,24 @@ func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
 	case *memo.SortExpr:
 		ics.addOrderingIndex(expr.ProvidedPhysical().Ordering)
 	case *memo.GroupByExpr:
-		addMultiColumnIndex(expr.GroupingCols.ToList(), nil /* desc */, ics.md, ics.overallCandidates)
+		ics.addMultiColumnIndex(expr.GroupingCols.ToList(), nil /* desc */, ics.overallCandidates)
 	case *memo.EqExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.equalCandidates)
-		addVariableExprIndex(expr.Right, ics.md, ics.equalCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.equalCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.equalCandidates)
 	case *memo.IsExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.equalCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.equalCandidates)
 	case *memo.LtExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
-		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.rangeCandidates)
 	case *memo.GtExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
-		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.rangeCandidates)
 	case *memo.LeExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
-		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.rangeCandidates)
 	case *memo.GeExpr:
-		addVariableExprIndex(expr.Left, ics.md, ics.rangeCandidates)
-		addVariableExprIndex(expr.Right, ics.md, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Left, ics.rangeCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.rangeCandidates)
 	case *memo.InnerJoinExpr:
 		ics.addJoinIndexes(expr.On)
 	case *memo.LeftJoinExpr:
@@ -146,6 +157,14 @@ func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
 		ics.addSetOperationIndexes(expr.LeftCols, expr.RightCols)
 	case *memo.ExceptAllExpr:
 		ics.addSetOperationIndexes(expr.LeftCols, expr.RightCols)
+	case *memo.FetchValExpr:
+		ics.addVariableExprIndex(expr.Json, ics.overallCandidates)
+	case *memo.ContainsExpr:
+		ics.addVariableExprIndex(expr.Left, ics.overallCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.overallCandidates)
+	case *memo.ContainedByExpr:
+		ics.addVariableExprIndex(expr.Left, ics.overallCandidates)
+		ics.addVariableExprIndex(expr.Right, ics.overallCandidates)
 	}
 	for i, n := 0, expr.ChildCount(); i < n; i++ {
 		ics.categorizeIndexCandidates(expr.Child(i))
@@ -155,8 +174,8 @@ func (ics *indexCandidateSet) categorizeIndexCandidates(expr opt.Expr) {
 // addSetOperationIndexes is used to add index candidates on the output columns
 // of set operations (UNION, INTERSECT, INTERSECT ALL, EXCEPT, EXCEPT ALL).
 func (ics *indexCandidateSet) addSetOperationIndexes(leftCols, rightCols opt.ColList) {
-	addMultiColumnIndex(leftCols, nil /* desc */, ics.md, ics.overallCandidates)
-	addMultiColumnIndex(rightCols, nil /* desc */, ics.md, ics.overallCandidates)
+	ics.addMultiColumnIndex(leftCols, nil /* desc */, ics.overallCandidates)
+	ics.addMultiColumnIndex(rightCols, nil /* desc */, ics.overallCandidates)
 }
 
 // addOrderingIndex adds indexes for a *memo.SortExpr. One index is constructed
@@ -184,7 +203,7 @@ func (ics indexCandidateSet) addOrderingIndex(ordering opt.Ordering) {
 		descList = append(descList, orderingCol.Descending())
 	}
 	if len(columnList) > 0 {
-		addMultiColumnIndex(columnList, descList, ics.md, ics.overallCandidates)
+		ics.addMultiColumnIndex(columnList, descList, ics.overallCandidates)
 	}
 }
 
@@ -195,9 +214,13 @@ func (ics indexCandidateSet) addOrderingIndex(ordering opt.Ordering) {
 func (ics *indexCandidateSet) addJoinIndexes(expr memo.FiltersExpr) {
 	outerCols := expr.OuterCols().ToList()
 	for _, col := range outerCols {
-		addSingleColumnIndex(col, false /* desc */, ics.md, ics.joinCandidates)
+		if colinfo.ColumnTypeIsIndexable(ics.md.ColumnMeta(col).Type) {
+			ics.addSingleColumnIndex(col, false /* desc */, ics.joinCandidates)
+		} else {
+			ics.addSingleColumnIndex(col, false /* desc */, ics.invertedCandidates)
+		}
 	}
-	addMultiColumnIndex(outerCols, nil /* desc */, ics.md, ics.joinCandidates)
+	ics.addMultiColumnIndex(outerCols, nil /* desc */, ics.joinCandidates)
 }
 
 // copyIndexes copies indexes from one map to another, getting rid of duplicates
@@ -271,54 +294,58 @@ func constructLeftIndexCombination(
 // addVariableExprIndex adds an index candidate to indexCandidates if the expr
 // argument can be cast to a *memo.VariableExpr and the index does not already
 // exist.
-func addVariableExprIndex(
-	expr opt.Expr, md *opt.Metadata, indexCandidates map[cat.Table][][]cat.IndexColumn,
+func (ics *indexCandidateSet) addVariableExprIndex(
+	expr opt.Expr, indexCandidates map[cat.Table][][]cat.IndexColumn,
 ) {
 	switch expr := expr.(type) {
 	case *memo.VariableExpr:
-		addSingleColumnIndex(expr.Col, false /* desc */, md, indexCandidates)
+		col := expr.Col
+		if colinfo.ColumnTypeIsIndexable(ics.md.ColumnMeta(col).Type) {
+			ics.addSingleColumnIndex(col, false /* desc */, indexCandidates)
+		} else {
+			ics.addSingleColumnIndex(col, false /* desc */, ics.invertedCandidates)
+		}
 	}
 }
 
 // addMultiColumnIndex adds indexes to indexCandidates for groups of columns
 // in a column set that are from the same table, without duplicates.
-func addMultiColumnIndex(
-	cols opt.ColList,
-	desc []bool,
-	md *opt.Metadata,
-	indexCandidates map[cat.Table][][]cat.IndexColumn,
+func (ics *indexCandidateSet) addMultiColumnIndex(
+	cols opt.ColList, desc []bool, indexCandidates map[cat.Table][][]cat.IndexColumn,
 ) {
 	// Group columns by table in a temporary map as single-column indexes,
 	// getting rid of duplicates.
-	tableToCols := make(map[cat.Table][][]cat.IndexColumn, len(md.AllTables()))
+	tableToCols := make(map[cat.Table][][]cat.IndexColumn, len(ics.md.AllTables()))
 	for i, colID := range cols {
 		if desc != nil {
-			addSingleColumnIndex(colID, desc[i], md, tableToCols)
+			ics.addSingleColumnIndex(colID, desc[i], tableToCols)
 		} else {
-			addSingleColumnIndex(colID, false /* desc */, md, tableToCols)
+			ics.addSingleColumnIndex(colID, false /* desc */, tableToCols)
 		}
 	}
 
 	// Combine all single-column indexes for a given table into one, and add
 	// the corresponding multi-column index.
 	for currTable := range tableToCols {
-		index := make([]cat.IndexColumn, len(tableToCols[currTable]))
-		for i, colSlice := range tableToCols[currTable] {
-			index[i] = colSlice[0]
+		index := make([]cat.IndexColumn, 0, len(tableToCols[currTable]))
+		for _, colSlice := range tableToCols[currTable] {
+			indexCol := colSlice[0]
+			if colinfo.ColumnTypeIsIndexable(indexCol.Column.DatumType()) {
+				index = append(index, indexCol)
+			}
 		}
-		addIndexToCandidates(index, currTable, indexCandidates)
+		if len(index) > 0 {
+			addIndexToCandidates(index, currTable, indexCandidates)
+		}
 	}
 }
 
 // addSingleColumnIndex adds an index to indexCandidates on the column with the
 // given opt.ColumnID if it does not already exist.
-func addSingleColumnIndex(
-	colID opt.ColumnID,
-	desc bool,
-	md *opt.Metadata,
-	indexCandidates map[cat.Table][][]cat.IndexColumn,
+func (ics *indexCandidateSet) addSingleColumnIndex(
+	colID opt.ColumnID, desc bool, indexCandidates map[cat.Table][][]cat.IndexColumn,
 ) {
-	columnMeta := md.ColumnMeta(colID)
+	columnMeta := ics.md.ColumnMeta(colID)
 
 	// If there's no base table for the column, return.
 	tableID := columnMeta.Table
@@ -328,7 +355,7 @@ func addSingleColumnIndex(
 
 	// Find the column instance in the current table and add the corresponding
 	// index to indexCandidates.
-	currTable := md.Table(tableID)
+	currTable := ics.md.Table(tableID)
 	currCol := currTable.Column(tableID.ColumnOrdinal(colID))
 	indexCol := cat.IndexColumn{Column: currCol, Descending: desc}
 	addIndexToCandidates([]cat.IndexColumn{indexCol}, currTable, indexCandidates)
@@ -346,9 +373,10 @@ func addIndexToCandidates(
 		return
 	}
 
-	// Do not add candidates that require inverted indexes.
+	// Do not add indexes on spatial columns.
 	for _, indexCol := range newIndex {
-		if !colinfo.ColumnTypeIsIndexable(indexCol.Column.DatumType()) {
+		colFamily := indexCol.Column.DatumType().Family()
+		if colFamily == types.GeometryFamily || colFamily == types.GeographyFamily {
 			return
 		}
 	}

--- a/pkg/sql/opt/indexrec/index_recommendation_set.go
+++ b/pkg/sql/opt/indexrec/index_recommendation_set.go
@@ -256,6 +256,10 @@ func (ir *indexRecommendation) indexCols() []tree.IndexElem {
 		indexCol := ir.index.Column(i)
 		colName := indexCol.Column.ColName()
 
+		if ir.index.IsInverted() && i == len(ir.index.cols)-1 {
+			colName = ir.index.tab.Column(indexCol.InvertedSourceColumnOrdinal()).ColName()
+		}
+
 		var direction tree.Direction
 		if indexCol.Descending {
 			direction = tree.Descending
@@ -305,10 +309,11 @@ func (ir *indexRecommendation) indexRecommendationString(
 	}
 
 	createCmd := tree.CreateIndex{
-		Table:   *tableName,
-		Columns: indexCols,
-		Storing: storing,
-		Unique:  unique,
+		Table:    *tableName,
+		Columns:  indexCols,
+		Storing:  storing,
+		Unique:   unique,
+		Inverted: ir.index.IsInverted(),
 	}
 	sb.WriteString(createCmd.String() + ";")
 	if len(dropCmd.IndexList) > 0 {

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -7,27 +7,19 @@ CREATE TABLE t2 (k INT, i INT, s STRING)
 ----
 
 exec-ddl
-CREATE TABLE t3 (k INT, i INT, f FLOAT)
+CREATE TABLE t3 (k INT, i INT, f FLOAT, g GEOMETRY)
 ----
 
 exec-ddl
 CREATE TABLE t4 (k INT, i INT, f FLOAT, j JSONB, a INT[])
 ----
 
-# Ensure that columns that require inverted indexes do not have candidates. This
-# is temporary until we support inverted index recommendations.
+# Ensure that spatial indexes don't have candidates. This is temporary until we
+# support spatial index recommendations.
 
 index-candidates
-SELECT k, f FROM t4 WHERE j IS NULL
+SELECT * FROM t3 WHERE g IS NULL
 ----
-
-index-candidates
-SELECT * FROM t4 WHERE k = 2 AND a IS NULL OR f > 2
-----
-t4:
- (f)
- (k)
- (k, f)
 
 # Ensure that index candidates are not created for virtual tables.
 index-candidates
@@ -540,7 +532,7 @@ project
                 └── k:1
 
 # Test joins with more complex predicates. See rule 3 and rule 4 in
-# indexrec.FindIndexCandidates.
+# indexrec.FindIndexCandidateSet.
 
 index-candidates
 SELECT t1.f, t2.k, t2.i
@@ -621,7 +613,7 @@ left-join (cross)
       ├── t1.k:1 != t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
       └── t1.s:4 IS NOT NULL [outer=(4), constraints=(/4: (/NULL - ]; tight)]
 
-# Test more complex queries. See rule 5 in indexrec.FindIndexCandidates. The
+# Test more complex queries. See rule 5 in indexrec.FindIndexCandidateSet. The
 # aspects of rule 5 that are demonstrated by each test are highlighted the
 # test's comment.
 
@@ -914,7 +906,7 @@ index-recommendations
 SELECT t1.k, t1.i, t2.i
 FROM t1 LEFT JOIN t2
 ON t1.k = t2.k
-WHERE EXISTS (SELECT * FROM t3 WHERE t3.f > t3.k)
+WHERE EXISTS (SELECT k, i FROM t3 WHERE t3.f > t3.k)
 ORDER BY t1.k, t2.i, t1.i DESC
 ----
 index recommendations: 3
@@ -928,21 +920,21 @@ index recommendations: 3
 Optimal Plan.
 sort (segmented)
  ├── columns: k:1 i:2 i:9
- ├── cost: 2416.02948
+ ├── cost: 2416.08954
  ├── ordering: +1,+9,-2
  └── project
       ├── columns: t1.k:1 t1.i:2 t2.i:9
-      ├── cost: 2263.34815
+      ├── cost: 2263.40821
       ├── ordering: +1
       └── left-join (merge)
            ├── columns: t1.k:1 t1.i:2 t2.k:8 t2.i:9
            ├── left ordering: +1
            ├── right ordering: +8
-           ├── cost: 2252.02095
+           ├── cost: 2252.08102
            ├── ordering: +1
            ├── select
            │    ├── columns: t1.k:1 t1.i:2
-           │    ├── cost: 1122.06355
+           │    ├── cost: 1122.09358
            │    ├── ordering: +1
            │    ├── scan t1@_hyp_1
            │    │    ├── columns: t1.k:1 t1.i:2
@@ -953,24 +945,24 @@ sort (segmented)
            │              └── limit
            │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
            │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 17.3135466
+           │                   ├── cost: 17.3435766
            │                   ├── key: ()
            │                   ├── fd: ()-->(14-16)
            │                   ├── select
            │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 17.2935466
+           │                   │    ├── cost: 17.3235766
            │                   │    ├── limit hint: 1.00
            │                   │    ├── scan t3@_hyp_1
            │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
-           │                   │    │    ├── constraint: /16/17: (/NULL - ]
-           │                   │    │    ├── cost: 17.2332132
+           │                   │    │    ├── constraint: /16/18: (/NULL - ]
+           │                   │    │    ├── cost: 17.2632432
            │                   │    │    └── limit hint: 3.00
            │                   │    └── filters
            │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │                   └── 1
            ├── select
            │    ├── columns: t2.k:8 t2.i:9
-           │    ├── cost: 1111.96355
+           │    ├── cost: 1111.99358
            │    ├── ordering: +8
            │    ├── scan t2@_hyp_2
            │    │    ├── columns: t2.k:8 t2.i:9
@@ -981,24 +973,25 @@ sort (segmented)
            │              └── limit
            │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
            │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 17.3135466
+           │                   ├── cost: 17.3435766
            │                   ├── key: ()
            │                   ├── fd: ()-->(14-16)
            │                   ├── select
            │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 17.2935466
+           │                   │    ├── cost: 17.3235766
            │                   │    ├── limit hint: 1.00
            │                   │    ├── scan t3@_hyp_1
            │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
-           │                   │    │    ├── constraint: /16/17: (/NULL - ]
-           │                   │    │    ├── cost: 17.2332132
+           │                   │    │    ├── constraint: /16/18: (/NULL - ]
+           │                   │    │    ├── cost: 17.2632432
            │                   │    │    └── limit hint: 3.00
            │                   │    └── filters
            │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │                   └── 1
            └── filters (true)
 
-# Tests for set operation indexes. See rule 6 in indexrec.FindIndexCandidates.
+# Tests for set operation indexes. See rule 6 in indexrec.FindIndexCandidateSet.
+
 index-candidates
 SELECT k FROM t1 UNION SELECT i FROM t1
 ----
@@ -1195,6 +1188,403 @@ union
       ├── cost: 1094.72
       └── ordering: +9,+10
 
+# Tests for inverted index recommendations. See rule 7 of
+# indexrec.FindIndexCandidateSet.
+
+index-candidates
+SELECT k, f FROM t4 WHERE j->'a' = '1'
+----
+t4:
+ (j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j->'a' = '1'
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (j);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 807.393333
+ └── index-join t4
+      ├── columns: t4.k:1 f:3 j:4
+      ├── immutable
+      ├── cost: 806.262222
+      └── scan t4@_hyp_1
+           ├── columns: rowid:6!null
+           ├── inverted constraint: /9/6
+           │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
+           ├── cost: 128.464444
+           └── key: (6)
+
+index-candidates
+SELECT k, f FROM t4 WHERE j @> '{"foo": "1"}'
+----
+t4:
+ (j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j @> '{"foo": "1"}'
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (j);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 805.048889
+ └── index-join t4
+      ├── columns: t4.k:1 f:3 j:4!null
+      ├── immutable
+      ├── cost: 803.928889
+      └── scan t4@_hyp_1
+           ├── columns: rowid:6!null
+           ├── inverted constraint: /9/6
+           │    └── spans: ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
+           ├── cost: 128.464444
+           └── key: (6)
+
+index-candidates
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}'
+----
+t4:
+ (j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}'
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (j);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 816.998889
+ └── select
+      ├── columns: t4.k:1 f:3 j:4
+      ├── immutable
+      ├── cost: 813.645556
+      ├── index-join t4
+      │    ├── columns: t4.k:1 f:3 j:4
+      │    ├── cost: 812.504444
+      │    └── inverted-filter
+      │         ├── columns: rowid:6!null
+      │         ├── inverted expression: /9
+      │         │    ├── tight: false, unique: false
+      │         │    └── union spans
+      │         │         ├── ["7\x00\x019", "7\x00\x019"]
+      │         │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
+      │         ├── cost: 134.706667
+      │         ├── key: (6)
+      │         └── scan t4@_hyp_1
+      │              ├── columns: rowid:6!null k:9!null
+      │              ├── inverted constraint: /9/6
+      │              │    └── spans
+      │              │         ├── ["7\x00\x019", "7\x00\x019"]
+      │              │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
+      │              ├── cost: 133.575556
+      │              ├── key: (6)
+      │              └── fd: (6)-->(9)
+      └── filters
+           └── j:4 <@ '{"foo": "1"}' [outer=(4), immutable]
+
+index-candidates
+SELECT j FROM t4 WHERE j @> '{"foo": "1", "bar": "2"}'
+----
+t4:
+ (j)
+
+index-recommendations
+SELECT j FROM t4 WHERE j @> '{"foo": "1", "bar": "2"}'
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (j);
+--
+Optimal Plan.
+inner-join (lookup t4)
+ ├── columns: j:4!null
+ ├── key columns: [6] = [6]
+ ├── lookup columns are key
+ ├── immutable
+ ├── cost: 110.790741
+ ├── inner-join (zigzag t4@_hyp_1 t4@_hyp_1)
+ │    ├── columns: rowid:6!null
+ │    ├── eq columns: [6] = [6]
+ │    ├── left fixed columns: [9] = ['\x37626172000112320001']
+ │    ├── right fixed columns: [9] = ['\x37666f6f000112310001']
+ │    ├── cost: 35.6990123
+ │    └── filters (true)
+ └── filters
+      └── j:4 @> '{"bar": "2", "foo": "1"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+index-candidates
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}' AND k = 1
+----
+t4:
+ (j)
+ (k)
+ (k, j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}' AND k = 1
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (k, j);
+--
+Optimal Plan.
+project
+ ├── columns: k:1!null f:3
+ ├── immutable
+ ├── cost: 22.11
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: t4.k:1!null f:3 j:4
+      ├── immutable
+      ├── cost: 22.0566667
+      ├── fd: ()-->(1)
+      ├── index-join t4
+      │    ├── columns: t4.k:1 f:3 j:4
+      │    ├── cost: 22.0155556
+      │    └── inverted-filter
+      │         ├── columns: rowid:6!null
+      │         ├── inverted expression: /10
+      │         │    ├── tight: false, unique: false
+      │         │    └── union spans
+      │         │         ├── ["7\x00\x019", "7\x00\x019"]
+      │         │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
+      │         ├── cost: 15.2177778
+      │         ├── key: (6)
+      │         └── scan t4@_hyp_3
+      │              ├── columns: rowid:6!null k:10!null
+      │              ├── constraint: /1: [/1 - /1]
+      │              ├── inverted constraint: /10/6
+      │              │    └── spans
+      │              │         ├── ["7\x00\x019", "7\x00\x019"]
+      │              │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
+      │              ├── cost: 15.1866667
+      │              ├── key: (6)
+      │              └── fd: (6)-->(10)
+      └── filters
+           └── j:4 <@ '{"foo": "1"}' [outer=(4), immutable]
+
+index-candidates
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}' AND k = 1 AND i = 2
+----
+t4:
+ (i)
+ (i, j)
+ (j)
+ (k)
+ (k, i)
+ (k, i, j)
+ (k, j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}' AND k = 1 AND i = 2
+----
+index recommendations: 2
+1. type: index creation
+   SQL command: CREATE INDEX ON t4 (k) STORING (i, f, j);
+2. type: index creation
+   SQL command: CREATE INDEX ON t4 (i) STORING (k, f, j);
+--
+Optimal Plan.
+project
+ ├── columns: k:1!null f:3
+ ├── immutable
+ ├── cost: 10.7379279
+ ├── fd: ()-->(1)
+ └── inner-join (zigzag t4@_hyp_1 t4@_hyp_2)
+      ├── columns: t4.k:1!null i:2!null f:3 j:4
+      ├── eq columns: [6] = [6]
+      ├── left fixed columns: [1] = [1]
+      ├── right fixed columns: [2] = [2]
+      ├── immutable
+      ├── cost: 10.7148919
+      ├── fd: ()-->(1,2)
+      └── filters
+           ├── j:4 <@ '{"foo": "1"}' [outer=(4), immutable]
+           ├── t4.k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+           └── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+
+index-candidates
+SELECT k, f FROM t4 WHERE j IS NULL
+----
+t4:
+ (j)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE j IS NULL
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 1125.07
+ └── select
+      ├── columns: t4.k:1 f:3 j:4
+      ├── immutable
+      ├── cost: 1124.95
+      ├── fd: ()-->(4)
+      ├── scan t4
+      │    ├── columns: t4.k:1 f:3 j:4
+      │    └── cost: 1114.92
+      └── filters
+           └── j:4 IS NULL [outer=(4), immutable, constraints=(/4: [/NULL - /NULL]; tight), fd=()-->(4)]
+
+index-candidates
+SELECT k, f FROM t4 WHERE a IS NULL
+----
+t4:
+ (a)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE a IS NULL
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── cost: 1125.07
+ └── select
+      ├── columns: t4.k:1 f:3 a:5
+      ├── cost: 1124.95
+      ├── fd: ()-->(5)
+      ├── scan t4
+      │    ├── columns: t4.k:1 f:3 a:5
+      │    └── cost: 1114.92
+      └── filters
+           └── a:5 IS NULL [outer=(5), constraints=(/5: [/NULL - /NULL]; tight), fd=()-->(5)]
+
+index-candidates
+SELECT k, f FROM t4 WHERE a @> ARRAY[1]
+----
+t4:
+ (a)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE a @> ARRAY[1]
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (a);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 805.048889
+ └── index-join t4
+      ├── columns: t4.k:1 f:3 a:5!null
+      ├── immutable
+      ├── cost: 803.928889
+      └── scan t4@_hyp_1
+           ├── columns: rowid:6!null
+           ├── inverted constraint: /9/6
+           │    └── spans: ["\x89", "\x89"]
+           ├── cost: 128.464444
+           └── key: (6)
+
+index-candidates
+SELECT k, f FROM t4 WHERE a = ARRAY[1]
+----
+t4:
+ (a)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE a = ARRAY[1]
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── cost: 1125.07
+ └── select
+      ├── columns: t4.k:1 f:3 a:5!null
+      ├── cost: 1124.95
+      ├── fd: ()-->(5)
+      ├── scan t4
+      │    ├── columns: t4.k:1 f:3 a:5
+      │    └── cost: 1114.92
+      └── filters
+           └── a:5 = ARRAY[1] [outer=(5), constraints=(/5: [/ARRAY[1] - /ARRAY[1]]; tight), fd=()-->(5)]
+
+index-candidates
+SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND i = 1
+----
+t4:
+ (a)
+ (i)
+ (i, a)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND i = 1
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (i, a);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3
+ ├── immutable
+ ├── cost: 21.992
+ └── index-join t4
+      ├── columns: t4.k:1 i:2!null f:3 a:5!null
+      ├── immutable
+      ├── cost: 21.961
+      ├── fd: ()-->(2)
+      └── scan t4@_hyp_3
+           ├── columns: rowid:6!null
+           ├── constraint: /2: [/1 - /1]
+           ├── inverted constraint: /10/6
+           │    └── spans: ["\x89", "\x89"]
+           ├── cost: 15.1755556
+           └── key: (6)
+
+index-candidates
+SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND f > 3
+----
+t4:
+ (a)
+ (f)
+
+index-recommendations
+SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND f > 3
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t4 (f) STORING (k, a);
+--
+Optimal Plan.
+project
+ ├── columns: k:1 f:3!null
+ ├── immutable
+ ├── cost: 381.103333
+ └── select
+      ├── columns: t4.k:1 f:3!null a:5!null
+      ├── immutable
+      ├── cost: 380.716667
+      ├── scan t4@_hyp_1
+      │    ├── columns: t4.k:1 f:3!null a:5
+      │    ├── constraint: /3/6: [/3.0000000000000004 - ]
+      │    └── cost: 377.353333
+      └── filters
+           └── a:5 @> ARRAY[1] [outer=(5), immutable, constraints=(/5: (/NULL - ])]
+
 # Ensure that index recommendations are not made if there is an existing
 # inverted, partial, or expression index that can be used to create an
 # equivalent or better plan.
@@ -1230,6 +1620,9 @@ DROP INDEX t4@inverted
 
 # 2. Partial index case:
 
+# Test queries that should use existing partial indexes, partial unique indexes,
+# and partial inverted indexes.
+
 exec-ddl
 CREATE INDEX partial_idx ON t4 (i) WHERE k > 1;
 ----
@@ -1251,8 +1644,54 @@ project
       ├── key: (6)
       └── fd: ()-->(2)
 
-# Ensure that we don't recommend replacing partial indexes or partial unique
-# indexes.
+exec-ddl
+CREATE UNIQUE INDEX partial_unique_idx ON t4 (f) WHERE i > 1;
+----
+
+index-recommendations
+SELECT f FROM t4 WHERE f > 5 AND i > 1
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: f:3!null
+ ├── cost: 340.706667
+ └── scan t4@partial_unique_idx,partial
+      ├── columns: f:3!null rowid:6!null
+      ├── constraint: /3: [/5.000000000000001 - ]
+      ├── cost: 337.575556
+      ├── key: (6)
+      └── fd: (6)-->(3), (3)-->(6)
+
+exec-ddl
+CREATE INVERTED INDEX partial_inverted_idx ON t4 (j) WHERE i = 1;
+----
+
+index-recommendations
+SELECT j FROM t4 WHERE j->'a' = '1' AND i = 1
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: j:4
+ ├── immutable
+ ├── cost: 21.9822222
+ └── index-join t4
+      ├── columns: i:2!null j:4
+      ├── immutable
+      ├── cost: 21.9511111
+      ├── fd: ()-->(2)
+      └── scan t4@partial_inverted_idx,partial
+           ├── columns: rowid:6!null
+           ├── inverted constraint: /10/6
+           │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
+           ├── cost: 15.1644444
+           └── key: (6)
+
+# Ensure that we don't recommend replacing partial indexes, partial unique
+# indexes, or partial inverted indexes.
 
 index-recommendations
 SELECT i FROM t4 WHERE i > 5
@@ -1262,14 +1701,10 @@ index recommendations: 1
    SQL command: CREATE INDEX ON t4 (i);
 --
 Optimal Plan.
-scan t4@_hyp_2
+scan t4@_hyp_4
  ├── columns: i:2!null
  ├── constraint: /2/6: [/6 - ]
- └── cost: 374.02
-
-exec-ddl
-CREATE UNIQUE INDEX partial_unique_idx ON t4 (f) WHERE i > 1;
-----
+ └── cost: 377.353333
 
 index-recommendations
 SELECT i, f FROM t4 WHERE f > 5
@@ -1279,10 +1714,29 @@ index recommendations: 1
    SQL command: CREATE INDEX ON t4 (f) STORING (i);
 --
 Optimal Plan.
-scan t4@_hyp_3
+scan t4@_hyp_4
  ├── columns: i:2 f:3!null
  ├── constraint: /3/6: [/5.000000000000001 - ]
- └── cost: 377.353333
+ └── cost: 380.686667
+
+index-recommendations
+SELECT j FROM t4 WHERE j->'a' = '1'
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INVERTED INDEX ON t4 (j);
+--
+Optimal Plan.
+index-join t4
+ ├── columns: j:4
+ ├── immutable
+ ├── cost: 804.04
+ └── scan t4@_hyp_4
+      ├── columns: rowid:6!null
+      ├── inverted constraint: /11/6
+      │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
+      ├── cost: 128.464444
+      └── key: (6)
 
 exec-ddl
 DROP INDEX t4@partial_idx
@@ -1290,6 +1744,10 @@ DROP INDEX t4@partial_idx
 
 exec-ddl
 DROP INDEX t4@partial_unique_idx
+----
+
+exec-ddl
+DROP INDEX t4@partial_inverted_idx
 ----
 
 # 3. Expression index case:

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -590,6 +590,12 @@ func (md *Metadata) QualifiedAlias(colID ColumnID, fullyQualify bool, catalog ca
 func (md *Metadata) UpdateTableMeta(tables map[cat.StableID]cat.Table) {
 	for i := range md.tables {
 		if tab, ok := tables[md.tables[i].Table.ID()]; ok {
+			// If there are any inverted hypothetical indexes, the hypothetical table
+			// will have extra inverted columns added. Add any new inverted columns to
+			// the metadata.
+			for j, n := md.tables[i].Table.ColumnCount(), tab.ColumnCount(); j < n; j++ {
+				md.AddColumn(string(tab.Column(i).ColName()), types.Bytes)
+			}
 			md.tables[i].Table = tab
 		}
 	}

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -728,11 +728,17 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		return result
 
 	case "index-candidates":
-		result := ot.IndexCandidates()
+		result, err := ot.IndexCandidates()
+		if err != nil {
+			d.Fatalf(tb, "%+v", err)
+		}
 		return result
 
 	case "index-recommendations":
-		result := ot.IndexRecommendations()
+		result, err := ot.IndexRecommendations()
+		if err != nil {
+			d.Fatalf(tb, "%+v", err)
+		}
 		return result
 
 	default:
@@ -2020,8 +2026,11 @@ func (ot *OptTester) CheckSize() (string, error) {
 
 // IndexCandidates is used with the index-candidates option. It finds index
 // candidates for the SQL statement and formats them as a sorted string.
-func (ot *OptTester) IndexCandidates() string {
-	expr, _ := ot.OptNorm()
+func (ot *OptTester) IndexCandidates() (string, error) {
+	expr, err := ot.OptNorm()
+	if err != nil {
+		return "", err
+	}
 	indexCandidates := indexrec.FindIndexCandidateSet(expr, expr.(memo.RelExpr).Memo().Metadata())
 
 	// Build a formatted string to output from the map of indexCandidates.
@@ -2053,27 +2062,33 @@ func (ot *OptTester) IndexCandidates() string {
 		tablesOutput = append(tablesOutput, tableSb.String())
 	}
 	sort.Strings(tablesOutput)
-	return strings.Join(tablesOutput, "")
+	return strings.Join(tablesOutput, ""), nil
 }
 
 // IndexRecommendations is used with the index-recommendations option. It
 // determines index recommendations for the SQL statement, if they exist, and
 // formats them as a human-readable string.
-func (ot *OptTester) IndexRecommendations() string {
-	normExpr, _ := ot.OptNorm()
+func (ot *OptTester) IndexRecommendations() (string, error) {
+	normExpr, err := ot.OptNorm()
+	if err != nil {
+		return "", err
+	}
 	md := normExpr.(memo.RelExpr).Memo().Metadata()
 	indexCandidates := indexrec.FindIndexCandidateSet(normExpr, md)
 	_, hypTables := indexrec.BuildOptAndHypTableMaps(indexCandidates)
 
-	optExpr, _ := ot.OptimizeWithTables(hypTables)
+	optExpr, err := ot.OptimizeWithTables(hypTables)
+	if err != nil {
+		return "", err
+	}
 	md = optExpr.(memo.RelExpr).Memo().Metadata()
 	indexRecommendations := indexrec.FindIndexRecommendationSet(optExpr, md)
 	result := indexRecommendations.Output()
 
 	if result == nil {
-		return fmt.Sprintf("No index recommendations.\n--\nOptimal Plan.\n%s", ot.FormatExpr(optExpr))
+		return fmt.Sprintf("No index recommendations.\n--\nOptimal Plan.\n%s", ot.FormatExpr(optExpr)), nil
 	}
-	return fmt.Sprintf("%s\n--\nOptimal Plan.\n%s", strings.Join(result, "\n"), ot.FormatExpr(optExpr))
+	return fmt.Sprintf("%s\n--\nOptimal Plan.\n%s", strings.Join(result, "\n"), ot.FormatExpr(optExpr)), nil
 }
 
 func (ot *OptTester) buildExpr(factory *norm.Factory) error {


### PR DESCRIPTION
**indexrec: add support for inverted index recommendations (JSON/array)**

This commit adds support for inverted index recommendations. Previously, we were
unable to recommend indexes on JSON and array columns, which was inadequate
because we can index these columns with an inverted index. Note that spatial
index recommendations are not added in this commit.

Release note: None

**opttester: return error for index candidates/recommendations**

Previously, errors were ignored for index candidate and
index recommendation tests, which is not desired. We now
return any errors to the function caller.

Release note: None