### PR TITLE
ui: save sort settings on cache for Database page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -16,28 +16,61 @@ import { withBackground, withRouterProvider } from "src/storybook/decorators";
 import { randomName } from "src/storybook/fixtures";
 import { DatabasesPage, DatabasesPageProps } from "./databasesPage";
 
+import * as H from "history";
+const history = H.createHashHistory();
+
 const withLoadingIndicator: DatabasesPageProps = {
   loading: true,
   loaded: false,
   databases: [],
+  sortSetting: {
+    ascending: false,
+    columnTitle: "name",
+  },
+  onSortingChange: () => {},
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  location: history.location,
+  history,
+  match: {
+    url: "",
+    path: history.location.pathname,
+    isExact: false,
+    params: {},
+  },
 };
 
 const withoutData: DatabasesPageProps = {
   loading: false,
   loaded: true,
   databases: [],
+  sortSetting: {
+    ascending: false,
+    columnTitle: "name",
+  },
+  onSortingChange: () => {},
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  location: history.location,
+  history,
+  match: {
+    url: "",
+    path: history.location.pathname,
+    isExact: false,
+    params: {},
+  },
 };
 
 const withData: DatabasesPageProps = {
   loading: false,
   loaded: true,
   showNodeRegionsColumn: true,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "name",
+  },
   databases: _.map(Array(42), _item => {
     return {
       loading: false,
@@ -51,10 +84,18 @@ const withData: DatabasesPageProps = {
         "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
     };
   }),
-
+  onSortingChange: () => {},
   refreshDatabases: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
+  location: history.location,
+  history,
+  match: {
+    url: "",
+    path: history.location.pathname,
+    isExact: false,
+    params: {},
+  },
 };
 
 storiesOf("Databases Page", module)

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -95,6 +95,7 @@ describe("Databases Page", function() {
       loading: false,
       loaded: false,
       databases: [],
+      sortSetting: { ascending: true, columnTitle: "name" },
       showNodeRegionsColumn: false,
     });
   });
@@ -131,6 +132,7 @@ describe("Databases Page", function() {
           missingTables: [],
         },
       ],
+      sortSetting: { ascending: true, columnTitle: "name" },
       showNodeRegionsColumn: false,
     });
   });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -10,6 +10,7 @@
 
 import _ from "lodash";
 import { createSelector } from "reselect";
+import { LocalSetting } from "src/redux/localsettings";
 import {
   DatabasesPageData,
   DatabasesPageDataDatabase,
@@ -41,6 +42,12 @@ const selectLoading = createSelector(
 const selectLoaded = createSelector(
   (state: AdminUIState) => state.cachedData.databases,
   databases => databases.valid,
+);
+
+const sortSettingLocalSetting = new LocalSetting(
+  "sortSetting/DatabasesPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: true, columnTitle: "name" },
 );
 
 const selectDatabases = createSelector(
@@ -115,21 +122,28 @@ export const mapStateToProps = (state: AdminUIState): DatabasesPageData => ({
   loading: selectLoading(state),
   loaded: selectLoaded(state),
   databases: selectDatabases(state),
+  sortSetting: sortSettingLocalSetting.selector(state),
   showNodeRegionsColumn: selectIsMoreThanOneNode(state),
 });
 
 export const mapDispatchToProps = {
   refreshDatabases,
-
   refreshDatabaseDetails: (database: string) => {
     return refreshDatabaseDetails(
       new DatabaseDetailsRequest({ database, include_stats: true }),
     );
   },
-
   refreshTableStats: (database: string, table: string) => {
     return refreshTableStats(new TableStatsRequest({ database, table }));
   },
-
   refreshNodes,
+  onSortingChange: (
+    _tableName: string,
+    columnName: string,
+    ascending: boolean,
+  ) =>
+    sortSettingLocalSetting.set({
+      ascending: ascending,
+      columnTitle: columnName,
+    }),
 };


### PR DESCRIPTION
Previously, sort setting on Databases page were not
being stored. With this commits we save the info about sort settings,
so the value is the same when the user goes back to those pages.
This commit also updates the value on query params and that value
take priority over the cached valued.

Partially addresses #68199

Release note: None