### PR TITLE
ci: fix `teamcity-trigger` when running under bazel

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -116,7 +116,7 @@ func runTC(queueBuild func(string, map[string]string)) {
 		}
 
 		if bazel.BuiltWithBazel() {
-			opts["env.TESTTIMEOUTSECS"] = testTimeout.String()
+			opts["env.TESTTIMEOUTSECS"] = fmt.Sprintf("%.0f", testTimeout.Seconds())
 		} else {
 			opts["env.TESTTIMEOUT"] = testTimeout.String()
 		}


### PR DESCRIPTION
This was just a typo -- the two branches here are supposed to have
different logic. This should fix an error we see in CI where stress
builds fail with:

    While parsing option --test_timeout=40m0s: '40m0s' is not an int

Release note: None