### PR TITLE
kv: Use frontier when resuming initial scan after an error.

### DIFF
--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -51,6 +51,9 @@ type scanConfig struct {
 
 	// callback to invoke when initial scan of a span completed.
 	onSpanDone OnScanCompleted
+
+	// configures retry behavior
+	retryBehavior ScanRetryBehavior
 }
 
 type optionFunc func(*config)
@@ -177,13 +180,32 @@ func WithMemoryMonitor(mon *mon.BytesMonitor) Option {
 }
 
 // OnScanCompleted is called when the rangefeed initial scan completes scanning
-// the span.
-type OnScanCompleted func(ctx context.Context, sp roachpb.Span)
+// the span.  An error returned from this function is handled based on the WithOnInitialScanError
+// option.  If the error handler is not set, the scan is retried based on the
+// WithSAcanRetryBehavior option.
+type OnScanCompleted func(ctx context.Context, sp roachpb.Span) error
 
 // WithOnScanCompleted sets up a callback which is invoked when a span (or part of the span)
 // have been completed when performing an initial scan.
 func WithOnScanCompleted(fn OnScanCompleted) Option {
 	return optionFunc(func(c *config) {
 		c.onSpanDone = fn
+	})
+}
+
+// ScanRetryBehavior specifies how rangefeed should handle errors during initial scan.
+type ScanRetryBehavior int
+
+const (
+	// ScanRetryAll will retry all spans if any error occurred during initial scan.
+	ScanRetryAll ScanRetryBehavior = iota
+	// ScanRetryRemaining will retry remaining spans, including the one that failed.
+	ScanRetryRemaining
+)
+
+// WithScanRetryBehavior configures range feed to retry initial scan as per specified behavior.
+func WithScanRetryBehavior(b ScanRetryBehavior) Option {
+	return optionFunc(func(c *config) {
+		c.retryBehavior = b
 	})
 }

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -194,13 +194,15 @@ func (dbc *dbAdapter) scanSpan(
 			}
 			if res.ResumeSpan == nil {
 				if onScanDone != nil {
-					onScanDone(ctx, sp)
+					return onScanDone(ctx, sp)
 				}
 				return nil
 			}
 
 			if onScanDone != nil {
-				onScanDone(ctx, roachpb.Span{Key: sp.Key, EndKey: res.ResumeSpan.Key})
+				if err := onScanDone(ctx, roachpb.Span{Key: sp.Key, EndKey: res.ResumeSpan.Key}); err != nil {
+					return err
+				}
 			}
 
 			sp = res.ResumeSpanAsValue()

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +125,10 @@ func TestDBClientScan(t *testing.T) {
 	t.Run("parallel scan requests", func(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY)`)
+		defer func() {
+			sqlDB.Exec(t, `DROP TABLE foo`)
+		}()
+
 		sqlDB.Exec(t, `INSERT INTO foo (key) SELECT * FROM generate_series(1, 1000)`)
 		sqlDB.Exec(t, "ALTER TABLE foo SPLIT AT VALUES (250), (500), (750)")
 
@@ -143,9 +148,10 @@ func TestDBClientScan(t *testing.T) {
 			return dba.ScanWithOptions(ctx, []roachpb.Span{fooSpan}, db.Clock().Now(),
 				func(value roachpb.KeyValue) {},
 				rangefeed.WithInitialScanParallelismFn(func() int { return parallelism }),
-				rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) {
+				rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
 					atomic.AddInt32(&barrier, 1)
 					<-proceed
+					return nil
 				}),
 			)
 		})
@@ -158,5 +164,100 @@ func TestDBClientScan(t *testing.T) {
 		})
 		close(proceed)
 		require.NoError(t, g.Wait())
+	})
+
+	// Verify when errors occur during scan, only the failed spans are retried.
+	t.Run("scan retries failed spans", func(t *testing.T) {
+		sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY)`)
+		defer func() {
+			sqlDB.Exec(t, `DROP TABLE foo`)
+		}()
+
+		sqlDB.Exec(t, `INSERT INTO foo (key) SELECT * FROM generate_series(1, 1000)`)
+		sqlDB.Exec(t, "ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(100, 900, 100))")
+
+		fooDesc := catalogkv.TestingGetTableDescriptor(
+			db, keys.SystemSQLCodec, "defaultdb", "foo")
+		fooSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
+
+		scanData := struct {
+			syncutil.Mutex
+			numSucceeded int
+			failedSpan   roachpb.Span
+			succeeded    roachpb.SpanGroup
+		}{}
+
+		// We expect 11 splits.
+		// One span will fail.  Verify we retry only the spans that we have not attempted before.
+		var parallelism = 6
+		f := rangefeed.NewFactoryWithDB(tc.Server(0).Stopper(), dba, nil /* knobs */)
+		scanComplete := make(chan struct{})
+		scanErr := make(chan error, 1)
+		retryScanErr := errors.New("retry scan")
+
+		feed, err := f.RangeFeed(ctx, "foo-feed", []roachpb.Span{fooSpan}, db.Clock().Now(),
+			func(ctx context.Context, value *roachpb.RangeFeedValue) {},
+
+			rangefeed.WithScanRetryBehavior(rangefeed.ScanRetryRemaining),
+			rangefeed.WithInitialScanParallelismFn(func() int { return parallelism }),
+
+			rangefeed.WithInitialScan(func(ctx context.Context) {
+				close(scanComplete)
+			}),
+
+			rangefeed.WithOnInitialScanError(func(ctx context.Context, err error) (shouldFail bool) {
+				if errors.Is(err, retryScanErr) {
+					// If we see retry marker -- then retry.
+					shouldFail = false
+				} else {
+					// Otherwise, fail the scan.
+					shouldFail = true
+					select {
+					case scanErr <- err:
+					default:
+					}
+				}
+				return shouldFail
+			}),
+
+			rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
+				scanData.Lock()
+				defer scanData.Unlock()
+
+				// We expect 11 ranges to generate scan request, so we want to fail some range after
+				// we have done scanning some spans.
+				const numSpansToSucceedBeforeFail = 7
+				if scanData.failedSpan.Key.Equal(scanData.failedSpan.EndKey) &&
+					scanData.numSucceeded == numSpansToSucceedBeforeFail {
+					scanData.failedSpan = sp
+					return retryScanErr
+				} else {
+					// Verify we do not retry spans we've seen before.
+					if scanData.succeeded.Contains(sp.Key) {
+						return errors.Newf("span %s already scanned", sp)
+					} else {
+						scanData.succeeded.Add(sp)
+						scanData.numSucceeded++
+					}
+				}
+				return nil
+			}),
+		)
+
+		require.NoError(t, err)
+		defer feed.Close()
+
+		select {
+		case <-scanComplete:
+		case err := <-scanErr:
+			t.Fatalf("scan terminated in error: %v", err)
+		}
+
+		// Verify we have scanned entire table.
+		require.Equal(t, 1, scanData.succeeded.Len(),
+			"scanned spans: %v failed: %s", scanData.succeeded.Slice(), scanData.failedSpan)
+		require.True(t, fooSpan.Equal(scanData.succeeded.Slice()[0]),
+			"table=%s slice=%s", fooSpan, scanData.succeeded.Slice()[0])
 	})
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -188,6 +188,7 @@ func (f *RangeFeed) Start(ctx context.Context, spans []roachpb.Span) error {
 	if err != nil {
 		return err
 	}
+
 	for _, sp := range spans {
 		if _, err := frontier.Forward(sp, f.initialTimestamp); err != nil {
 			return err


### PR DESCRIPTION
Avoid rescanning previously completed ranges when performing
initial scan.

Release Notes: None