### PR TITLE
bazel: set a special env variable in the bazel builder image

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -92,3 +92,4 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/au
 
 ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home"]
 CMD ["/usr/bin/bash"]
+ENV CRDB_BAZEL_BUILDER=1

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20211124-095044
+BAZEL_IMAGE=cockroachdb/bazel:20211214-144628
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.


### PR DESCRIPTION
I'd like to implement some optimizations (see #73355) and it would be
nice to have a robust way to skip those optimizations in CI. Testing for
the presence of this environment variable is a good way to do that.

Release note: None