### PR TITLE
sql: force current tenant prefix on read ResumeSpans

### DIFF
--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     srcs = [
         "keys_test.go",
         "printer_test.go",
+        "sql_test.go",
     ],
     embed = [":keys"],
     deps = [

--- a/pkg/keys/sql_test.go
+++ b/pkg/keys/sql_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteKeyToTenantPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		oldTenant, newTenant uint64
+		suffix               string
+	}{
+		{1, 1, "abc"},
+		{1, 2, "acc"},
+		{2, 1, "abc"},
+		{1, 1 << 15, "abc"},
+		{1 << 15, 1, "abc"},
+		{2, 1 << 15, "abc"},
+		{1 << 15, 2, "abc"},
+		{1 << 15, 1 << 15, "abc"},
+		{1 << 13, 1 << 15, "abc"},
+		{1 << 15, 1 << 13, "abc"},
+	} {
+		t.Run(fmt.Sprintf("%d to %d %s", tc.oldTenant, tc.newTenant, tc.suffix), func(t *testing.T) {
+			old := append(MakeSQLCodec(roachpb.MakeTenantID(tc.oldTenant)).TablePrefix(5), tc.suffix...)
+			new := MakeTenantPrefix(roachpb.MakeTenantID(tc.newTenant))
+			got, err := rewriteKeyToTenantPrefix(old, new)
+			require.NoError(t, err)
+
+			expect := append(MakeSQLCodec(roachpb.MakeTenantID(tc.newTenant)).TablePrefix(5), tc.suffix...)
+			require.Equal(t, expect, got)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -231,23 +231,72 @@ CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)
 statement error index with name "'t1-esc-index'" already exists
 CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)
 
-subtest pause
+subtest resume-with-diff-tenant-resume-spans
 
 statement ok
-SET CLUSTER SETTING jobs.debug.pausepoints = 'indexbackfill.before_flow'
+SET CLUSTER SETTING jobs.registry.interval.adopt = '50ms';
 
 # Lower the job registry loop interval to accelerate the test.
 statement ok
 SET CLUSTER SETTING jobs.registry.interval.cancel = '50ms'
 
 statement ok
-CREATE TABLE tbl (i INT PRIMARY KEY, j INT NOT NULL)
+SET CLUSTER SETTING jobs.registry.interval.cancel = '50ms';
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'indexbackfill.before_flow';
+
+statement ok
+CREATE TABLE tbl (i INT PRIMARY KEY, j INT NOT NULL);
 
 statement ok
 INSERT INTO tbl VALUES (1, 100), (2, 200), (3, 300);
 
 statement error job .* was paused before it completed with reason: pause point "indexbackfill.before_flow" hit
-CREATE INDEX idx ON tbl(j);
+CREATE INDEX pauseidx ON tbl(j);
+
+# clear the pause point now that the job is paused.
+statement ok
+RESET CLUSTER SETTING jobs.debug.pausepoints 
+
+# while the backfill is paused, go in and replace the resume spans with some new
+# spans that both the wrong tenant ID or no tenant ID before resuming it to make
+# sure that on resume it re-keys the spans correctly. We pretty_key these below
+# to confirm/show what is in them.
+statement ok 
+UPDATE system.jobs 
+  SET payload = crdb_internal.json_to_pb(
+    'cockroach.sql.jobs.jobspb.Payload',
+      json_set(
+        crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload), 
+        ARRAY['schemaChange', 'resumeSpanList', '0'], 
+        '{"resumeSpans": [{"key": "/u/IiQ==", "endKey": "/u/Iiew="}, {"key": "yIns", "endKey" : "yIo="}]}'::jsonb
+      )
+    )
+WHERE crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload)->>'description' LIKE 'CREATE INDEX pauseidx%';
+
+# confirm we see these bogus start and end keys in the job, both for the wrong
+# tenant and for no tenant.
+query TTTT
+SELECT 
+  crdb_internal.pretty_key(decode(j->'schemaChange'->'resumeSpanList'->0->'resumeSpans'->0->>'key', 'base64'), 0),
+  crdb_internal.pretty_key(decode(j->'schemaChange'->'resumeSpanList'->0->'resumeSpans'->0->>'endKey', 'base64'), 0),
+  crdb_internal.pretty_key(decode(j->'schemaChange'->'resumeSpanList'->0->'resumeSpans'->1->>'key', 'base64'), 0),
+  crdb_internal.pretty_key(decode(j->'schemaChange'->'resumeSpanList'->0->'resumeSpans'->1->>'endKey', 'base64'), 0)
+FROM (
+  SELECT crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload) j FROM system.jobs 
+) WHERE j->>'description' LIKE 'CREATE INDEX pauseidx%';
+----
+/103/Table/64/1   /103/Table/64/1/100   /64/1/100   /64/2
+
+# resume the job and ensure it completes, which includes validation.
+statement ok 
+RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'CREATE INDEX pauseidx%');
+
+query T
+SELECT status FROM [SHOW JOB WHEN COMPLETE (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'CREATE INDEX pauseidx%')];
+----
+succeeded
 
 statement ok
 SET CLUSTER SETTING jobs.registry.interval.cancel = DEFAULT;

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -249,8 +249,17 @@ func GetResumeSpans(
 		return nil, nil, 0, errors.AssertionFailedf(
 			"expected SchemaChangeDetails job type, got %T", job.Details())
 	}
+
+	spanList := details.ResumeSpanList[mutationIdx].ResumeSpans
+	prefix := codec.TenantPrefix()
+	for i := range spanList {
+		spanList[i], err = keys.RewriteSpanToTenantPrefix(spanList[i], prefix)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+	}
 	// Return the resume spans from the job using the mutation idx.
-	return details.ResumeSpanList[mutationIdx].ResumeSpans, job, mutationIdx, nil
+	return spanList, job, mutationIdx, nil
 }
 
 // SetResumeSpansInJob adds a list of resume spans into a job details field.


### PR DESCRIPTION
This changes the only two places where ResumeSpansList is read to force
every read span to have the current tenant's prefix, adding or updating
the existing prefix as needed. This ensures that even if the resume
spans actually stored in the job record value have a prefix
corresponding to some other tenant ID from when that job was backed up,
when read by the new tenant ID those spans instead cover the spans in
that new tenant's prefix.

A future change could update the persisted spans to not include a tenant
prefix in the first place, however such a change would need to take some
care with backwards compatibility -- older nodes, that read spans prior
to this change would expect still the spans they read to have the right
tenant prefix. This change thus paves the way for that future change,
though it becomes mostly an asthenic choice at that point, rather than
important to correctness of rekeyed jobs, as this change on its own
means the persisted prefix, if any, is now largely irrelevant.

Fixes #73801.

Release note: none.