### PR TITLE
sql/opt/exec: output index/expiry in EXPLAIN SPLIT/RELOCATE statements

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -101,6 +101,8 @@ vectorized: true
 • split
 │ columns: (key, pretty, split_enforced_until)
 │ estimated row count: 10 (missing stats)
+│ index: s@s_pkey
+│ expiry: CAST(NULL AS STRING)
 │
 └── • scan
       columns: (k1, k2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -170,6 +170,25 @@ vectorized: true
 • split
 │ columns: (key, pretty, split_enforced_until)
 │ estimated row count: 10 (missing stats)
+│ index: foo@foo_pkey
+│ expiry: CAST(NULL AS STRING)
+│
+└── • values
+      columns: (column1)
+      size: 1 column, 1 row
+      row 0, expr 0: 42
+
+query T
+EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42) WITH EXPIRATION '2200-01-01 00:00:00.0'
+----
+distribution: local
+vectorized: true
+·
+• split
+│ columns: (key, pretty, split_enforced_until)
+│ estimated row count: 10 (missing stats)
+│ index: foo@foo_pkey
+│ expiry: '2200-01-01 00:00:00.0'
 │
 └── • values
       columns: (column1)
@@ -183,6 +202,7 @@ distribution: local
 vectorized: true
 ·
 • relocate table
+│ index: foo@foo_pkey
 │
 └── • values
       size: 2 columns, 1 row
@@ -196,6 +216,7 @@ vectorized: true
 • relocate table
 │ columns: (key, pretty)
 │ estimated row count: 10 (missing stats)
+│ index: foo@foo_pkey
 │
 └── • values
       columns: (column1, column2)
@@ -210,6 +231,7 @@ distribution: local
 vectorized: true
 ·
 • relocate table
+│ index: foo@a
 │
 └── • values
       size: 2 columns, 1 row
@@ -223,6 +245,7 @@ vectorized: true
 • relocate table
 │ columns: (key, pretty)
 │ estimated row count: 10 (missing stats)
+│ index: foo@a
 │
 └── • values
       columns: (column1, column2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -15,6 +15,8 @@ vectorized: true
 • root
 │
 ├── • split
+│   │ index: abc@abc_pkey
+│   │ expiry: CAST(NULL AS STRING)
 │   │
 │   └── • values
 │         size: 1 column, 1 row

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -822,6 +822,23 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		}
 		e.emitSpans("spans", a.Table, a.Table.Index(cat.PrimaryIndex), params)
 
+	case alterTableSplitOp:
+		a := n.args.(*alterTableSplitArgs)
+		ob.Attrf("index", "%s@%s", a.Index.Table().Name(), a.Index.Name())
+		ob.Expr("expiry", a.Expiration, nil /* columns */)
+
+	case alterTableUnsplitOp:
+		a := n.args.(*alterTableUnsplitArgs)
+		ob.Attrf("index", "%s@%s", a.Index.Table().Name(), a.Index.Name())
+
+	case alterTableUnsplitAllOp:
+		a := n.args.(*alterTableUnsplitAllArgs)
+		ob.Attrf("index", "%s@%s", a.Index.Table().Name(), a.Index.Name())
+
+	case alterTableRelocateOp:
+		a := n.args.(*alterTableRelocateArgs)
+		ob.Attrf("index", "%s@%s", a.Index.Table().Name(), a.Index.Name())
+
 	case recursiveCTEOp:
 		a := n.args.(*recursiveCTEArgs)
 		if e.ob.flags.Verbose && a.Deduplicate {
@@ -852,10 +869,6 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		saveTableOp,
 		errorIfRowsOp,
 		opaqueOp,
-		alterTableSplitOp,
-		alterTableUnsplitOp,
-		alterTableUnsplitAllOp,
-		alterTableRelocateOp,
 		controlJobsOp,
 		controlSchedulesOp,
 		cancelQueriesOp,

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -862,11 +862,14 @@ hash: 12193483658718214527
 plan-gist: AgICAgYCLGoCBgY=
 explain(shape):
 • split
+│ index: foo@foo_pkey
+│ expiry: CAST(_ AS STRING)
 │
 └── • values
       size: 1 column, 1 row
 explain(gist):
 • split
+│ index: foo@foo_pkey
 │
 └── • values
       size: 1 column, 1 row
@@ -879,11 +882,13 @@ hash: 8861506885543083786
 plan-gist: AgICAgYCLWoCBgQ=
 explain(shape):
 • unsplit
+│ index: foo@foo_pkey
 │
 └── • values
       size: 1 column, 1 row
 explain(gist):
 • unsplit
+│ index: foo@foo_pkey
 │
 └── • values
       size: 1 column, 1 row
@@ -897,8 +902,10 @@ hash: 16533768908468588919
 plan-gist: Ai5qAgYE
 explain(shape):
 • unsplit all
+  index: foo@foo_pkey
 explain(gist):
 • unsplit all
+  index: foo@foo_pkey
 
 # alterTableRelocateOp
 gist-explain-roundtrip
@@ -908,11 +915,13 @@ hash: 8656743312841134920
 plan-gist: AgICBAYEL24CBgQ=
 explain(shape):
 • relocate table
+│ index: abc@abc_pkey
 │
 └── • values
       size: 2 columns, 1 row
 explain(gist):
 • relocate table
+│ index: abc@abc_pkey
 │
 └── • values
       size: 2 columns, 1 row


### PR DESCRIPTION
Release note (sql change): The output of `EXPLAIN ALTER INDEX/TABLE
... RELOCATE/SPLIT` now includes the target table/index name and, for
the SPLIT AT variants, the expiry timestamp.