### PR TITLE
kvcoord: simplify txn already committed assertion

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -150,7 +150,6 @@ go_test(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/rangecache:with-mocks",
         "//pkg/kv/kvserver",
-        "//pkg/kv/kvserver/batcheval",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
+++ b/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -53,43 +55,45 @@ func TestCommitSanityCheckAssertionFiresOnUndetectedAmbiguousCommit(t *testing.T
 
 	ctx := context.Background()
 	var args base.TestClusterArgs
-	args.ServerArgs.Knobs.KVClient = &kvcoord.ClientTestingKnobs{TransportFactory: func(
-		options kvcoord.SendOptions,
-		dialer *nodedialer.Dialer,
-		slice kvcoord.ReplicaSlice,
-	) (kvcoord.Transport, error) {
-		tf, err := kvcoord.GRPCTransportFactory(options, dialer, slice)
-		if err != nil {
-			return nil, err
-		}
-		return &interceptingTransport{
-			Transport: tf,
-			intercept: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse, err error) (*roachpb.BatchResponse, error) {
-				if err != nil || ba.Txn == nil || br.Txn == nil ||
-					ba.Txn.Status != roachpb.PENDING || br.Txn.Status != roachpb.COMMITTED ||
-					!keys.ScratchRangeMin.Equal(br.Txn.Key) {
-					// Only want to inject error on successful commit for "our" txn.
-					return br, err
-				}
-				err = circuit.ErrBreakerOpen
-				assert.True(t, grpcutil.RequestDidNotStart(err)) // avoid Fatal on goroutine
+	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+		IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
+			// Disable async intent resolution, as it could possibly GC the txn record
+			// out from under us, leading to the retried commit taking a path
+			// different from the one we want to exercise in this test.
+			DisableAsyncIntentResolution: true,
+		},
+	}
+	args.ServerArgs.Knobs.KVClient = &kvcoord.ClientTestingKnobs{
+		TransportFactory: func(
+			options kvcoord.SendOptions,
+			dialer *nodedialer.Dialer,
+			slice kvcoord.ReplicaSlice,
+		) (kvcoord.Transport, error) {
+			tf, err := kvcoord.GRPCTransportFactory(options, dialer, slice)
+			if err != nil {
 				return nil, err
-			},
-		}, nil
-	},
+			}
+			return &interceptingTransport{
+				Transport: tf,
+				intercept: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse, err error) (*roachpb.BatchResponse, error) {
+					if err != nil || ba.Txn == nil || br.Txn == nil ||
+						ba.Txn.Status != roachpb.PENDING || br.Txn.Status != roachpb.COMMITTED ||
+						!keys.ScratchRangeMin.Equal(br.Txn.Key) {
+						// Only want to inject error on successful commit for "our" txn.
+						return br, err
+					}
+					err = circuit.ErrBreakerOpen
+					assert.True(t, grpcutil.RequestDidNotStart(err)) // avoid Fatal on goroutine
+					return nil, err
+				},
+			}, nil
+		},
+		// Turn the assertion into an error returned via the txn.
+		DisableCommitSanityCheck: true,
 	}
 
 	tc := testcluster.StartTestCluster(t, 1, args)
 	defer tc.Stopper().Stop(ctx)
-
-	{
-		// Turn the assertion into an error.
-		prev := kvcoord.DisableCommitSanityCheck
-		kvcoord.DisableCommitSanityCheck = true
-		defer func() {
-			kvcoord.DisableCommitSanityCheck = prev
-		}()
-	}
 
 	k := tc.ScratchRange(t)
 	kNext := k.Next()

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -44,6 +44,10 @@ type ClientTestingKnobs struct {
 	// the descriptor, instead of trying to reorder them by latency. The knob
 	// only applies to requests sent with the LEASEHOLDER routing policy.
 	DontReorderReplicas bool
+
+	// DisableCommitSanityCheck allows "setting" the DisableCommitSanityCheck to
+	// true without actually overriding the variable.
+	DisableCommitSanityCheck bool
 }
 
 var _ base.ModuleTestingKnobs = &ClientTestingKnobs{}

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -916,39 +916,47 @@ func (tc *TxnCoordSender) updateStateLocked(
 
 	// Update our transaction with any information the error has.
 	if errTxn := pErr.GetTxn(); errTxn != nil {
-		if errTxn.Status == roachpb.COMMITTED {
-			pErr = sanityCheckCommittedErr(ctx, pErr, ba)
+		if err := sanityCheckErrWithTxn(ctx, pErr, ba, &tc.testingKnobs); err != nil {
+			return roachpb.NewError(err)
 		}
 		tc.mu.txn.Update(errTxn)
 	}
 	return pErr
 }
 
-// sanityCheckCommittedErr verifies the circumstances in which we're receiving
-// an error indicating a COMMITTED transaction. Only rollbacks should be
-// encountering such errors. Marking a transaction as explicitly-committed can
-// also encounter these errors, but those errors don't make it to the
-// TxnCoordSender.
+// sanityCheckErrWithTxn verifies whether the error (which must have a txn
+// attached) contains a COMMITTED transaction. Only rollbacks should be able to
+// encounter such errors. Marking a transaction as explicitly-committed can also
+// encounter these errors, but those errors don't make it to the TxnCoordSender.
 //
-// Returns the passed-in error or fatals (depending on DisableCommitSanityCheck env var),
-// wrapping the input error in case of an assertion violation.
+// Returns the passed-in error or fatals (depending on DisableCommitSanityCheck
+// env var), wrapping the input error in case of an assertion violation.
 //
-// Requires: pErrWithCommittedTxn is non-nil and GetTxn() is also non-nil.
-func sanityCheckCommittedErr(
-	ctx context.Context, pErrWithCommittedTxn *roachpb.Error, ba roachpb.BatchRequest,
-) *roachpb.Error {
+// The assertion is known to have failed in the wild, see:
+// https://github.com/cockroachdb/cockroach/issues/67765
+func sanityCheckErrWithTxn(
+	ctx context.Context,
+	pErrWithTxn *roachpb.Error,
+	ba roachpb.BatchRequest,
+	knobs *ClientTestingKnobs,
+) error {
+	txn := pErrWithTxn.GetTxn()
+	if txn.Status != roachpb.COMMITTED {
+		return nil
+	}
 	// The only case in which an error can have a COMMITTED transaction in it is
 	// when the request was a rollback. Rollbacks can race with commits if a
 	// context timeout expires while a commit request is in flight.
 	if ba.IsSingleAbortTxnRequest() {
-		return pErrWithCommittedTxn
+		return nil
 	}
+
 	// Finding out about our transaction being committed indicates a serious bug.
 	// Requests are not supposed to be sent on transactions after they are
 	// committed.
-	err := errors.Wrapf(pErrWithCommittedTxn.GoError(),
+	err := errors.Wrapf(pErrWithTxn.GoError(),
 		"transaction unexpectedly committed, ba: %s. txn: %s",
-		ba, pErrWithCommittedTxn.GetTxn(),
+		ba, pErrWithTxn.GetTxn(),
 	)
 	err = errors.WithAssertionFailure(
 		errors.WithIssueLink(err, errors.IssueLink{
@@ -958,10 +966,10 @@ func sanityCheckCommittedErr(
 				"This assertion can be disabled by setting the environment variable " +
 				"COCKROACH_DISABLE_COMMIT_SANITY_CHECK=true",
 		}))
-	if !DisableCommitSanityCheck {
+	if !DisableCommitSanityCheck && !knobs.DisableCommitSanityCheck {
 		log.Fatalf(ctx, "%s", err)
 	}
-	return roachpb.NewError(err)
+	return err
 }
 
 // setTxnAnchorKey sets the key at which to anchor the transaction record. The


### PR DESCRIPTION
- kvcoord: improve TestCommitSanityCheckAssertionFiresOnUndetectedAmbiguousCommit
- kvcoord: simplify txn already committed assertion
