### PR TITLE
scripts: add pprof-post to upload to polar signals

### DIFF
--- a/scripts/pprof-post.sh
+++ b/scripts/pprof-post.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: $0 "optional description, defaults to current date" < somefile.pb.gz
+out=$(curl -s 'https://api.polarsignals.com/api/share/v1/profiles' \
+	-X POST \
+	-F "description=${1-$(date -u)}" \
+	-F "profile=@-")
+echo -n "https://share.polarsignals.com/"
+grep -Eo '[0-9a-f]{4,}' <<< "${out}"
+	


### PR DESCRIPTION
Ever since discovering [Polar Signal]'s online pprof web
interface, we've been using it regularly during investigations. It
significantly reduces the friction associated with sharing a profile
with others (or even looking at it by yourself). However, it was always
a little painful to manually upload the profile.

This commit adds a script that makes it very simple:

```
$ scripts/pprof-post.sh < ~/Downloads/logs/2.unredacted/heap_profiler/memprof.2021-12-09T13_25_01.236.4456698968.pprof
```

which outputs the link:

https://share.polarsignals.com/d7b5e1e

Kudos to Polar Signals for providing this very useful service.

[Polar Signal]: https://www.polarsignals.com

Release note: None
