### PR TITLE
kvserver: bump timeout in TestStoreScanIntents

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2098,7 +2098,7 @@ func TestStoreScanIntents(t *testing.T) {
 			errChan <- pErr
 		}()
 
-		wait := 1 * time.Second
+		wait := testutils.DefaultSucceedsSoonDuration
 		if !test.expFinish {
 			wait = 10 * time.Millisecond
 		}


### PR DESCRIPTION
Fixes #69672.

Release note: None
