### PR TITLE
ui: added formatting to statements on the statement & transaction details pages.

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2673,6 +2673,12 @@ The output can be used to recreate a database.’</p>
 </span></td></tr>
 <tr><td><a name="parse_timetz"></a><code>parse_timetz(val: <a href="string.html">string</a>) &rarr; timetz</code></td><td><span class="funcdesc"><p>Parses a timetz assuming the date (if any) is in MDY format.</p>
 </span></td></tr>
+<tr><td><a name="prettify_statement"></a><code>prettify_statement(statement: <a href="string.html">string</a>, line_width: <a href="int.html">int</a>, align_mode: <a href="int.html">int</a>, case_mode: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Prettifies a statement using a user-configured pretty-printing config.
+Align mode values range from 0 - 3, representing no, partial, full, and extra alignment respectively.
+Case mode values range between 0 - 1, representing lower casing and upper casing respectively.</p>
+</span></td></tr>
+<tr><td><a name="prettify_statement"></a><code>prettify_statement(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Prettifies a statement using a the default pretty-printing config.</p>
+</span></td></tr>
 <tr><td><a name="quote_ident"></a><code>quote_ident(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as identifier in a SQL statement.</p>
 </span></td></tr>
 <tr><td><a name="quote_literal"></a><code>quote_literal(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Return <code>val</code> suitably quoted to serve as string literal in a SQL statement.</p>

--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",
         "//pkg/testutils",

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -111,19 +112,35 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	tenantStatusServer := tenant.StatusServer().(serverpb.SQLStatusServer)
 
 	type testCase struct {
-		stmt        string
-		fingerprint string
+		stmt                 string
+		formattedStmt        string
+		fingerprint          string
+		formattedFingerprint string
 	}
 
 	testCaseTenant := []testCase{
-		{stmt: `CREATE DATABASE roachblog_t`},
-		{stmt: `SET database = roachblog_t`},
-		{stmt: `CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:        `INSERT INTO posts_t VALUES (1, 'foo')`,
-			fingerprint: `INSERT INTO posts_t VALUES (_, '_')`,
+			stmt:          `CREATE DATABASE roachblog_t`,
+			formattedStmt: "CREATE DATABASE roachblog_t\n",
 		},
-		{stmt: `SELECT * FROM posts_t`},
+		{
+			stmt:          `SET database = roachblog_t`,
+			formattedStmt: "SET database = roachblog_t\n",
+		},
+		{
+			stmt:          `CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)`,
+			formattedStmt: "CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)\n",
+		},
+		{
+			stmt:                 `INSERT INTO posts_t VALUES (1, 'foo')`,
+			fingerprint:          `INSERT INTO posts_t VALUES (_, '_')`,
+			formattedStmt:        "INSERT INTO posts_t VALUES (1, 'foo')\n",
+			formattedFingerprint: "INSERT INTO posts_t VALUES (_, '_')\n",
+		},
+		{
+			stmt:          `SELECT * FROM posts_t`,
+			formattedStmt: "SELECT * FROM posts_t\n",
+		},
 	}
 
 	for _, stmt := range testCaseTenant {
@@ -135,14 +152,28 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	require.NoError(t, err)
 
 	testCaseNonTenant := []testCase{
-		{stmt: `CREATE DATABASE roachblog_nt`},
-		{stmt: `SET database = roachblog_nt`},
-		{stmt: `CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:        `INSERT INTO posts_nt VALUES (1, 'foo')`,
-			fingerprint: `INSERT INTO posts_nt VALUES (_, '_')`,
+			stmt:          `CREATE DATABASE roachblog_nt`,
+			formattedStmt: "CREATE DATABASE roachblog_nt\n",
 		},
-		{stmt: `SELECT * FROM posts_nt`},
+		{
+			stmt:          `SET database = roachblog_nt`,
+			formattedStmt: "SET database = roachblog_nt\n",
+		},
+		{
+			stmt:          `CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)`,
+			formattedStmt: "CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)\n",
+		},
+		{
+			stmt:                 `INSERT INTO posts_nt VALUES (1, 'foo')`,
+			fingerprint:          `INSERT INTO posts_nt VALUES (_, '_')`,
+			formattedStmt:        "INSERT INTO posts_nt VALUES (1, 'foo')\n",
+			formattedFingerprint: "INSERT INTO posts_nt VALUES (_, '_')\n",
+		},
+		{
+			stmt:          `SELECT * FROM posts_nt`,
+			formattedStmt: "SELECT * FROM posts_nt\n",
+		},
 	}
 
 	pgURL, cleanupGoDB := sqlutils.PGUrl(
@@ -195,14 +226,22 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	err = serverutils.GetJSONProto(nonTenant, path, &nonTenantCombinedStats)
 	require.NoError(t, err)
 
-	checkStatements := func(t *testing.T, tc []testCase, actual *serverpb.StatementsResponse) {
+	checkStatements := func(t *testing.T, tc []testCase, actual *serverpb.StatementsResponse, combined bool) {
 		t.Helper()
 		var expectedStatements []string
 		for _, stmt := range tc {
 			var expectedStmt = stmt.stmt
-			if stmt.fingerprint != "" {
-				expectedStmt = stmt.fingerprint
+			if combined {
+				expectedStmt = stmt.formattedStmt
 			}
+			if stmt.fingerprint != "" {
+				if combined {
+					expectedStmt = stmt.formattedFingerprint
+				} else {
+					expectedStmt = stmt.fingerprint
+				}
+			}
+
 			expectedStatements = append(expectedStatements, expectedStmt)
 		}
 
@@ -229,14 +268,14 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 
 	// First we verify that we have expected stats from tenants.
 	t.Run("tenant-stats", func(t *testing.T) {
-		checkStatements(t, testCaseTenant, tenantStats)
-		checkStatements(t, testCaseTenant, tenantCombinedStats)
+		checkStatements(t, testCaseTenant, tenantStats, false)
+		checkStatements(t, testCaseTenant, tenantCombinedStats, true)
 	})
 
 	// Now we verify the non tenant stats are what we expected.
 	t.Run("non-tenant-stats", func(t *testing.T) {
-		checkStatements(t, testCaseNonTenant, &nonTenantStats)
-		checkStatements(t, testCaseNonTenant, &nonTenantCombinedStats)
+		checkStatements(t, testCaseNonTenant, &nonTenantStats, false)
+		checkStatements(t, testCaseNonTenant, &nonTenantCombinedStats, true)
 	})
 
 	// Now we verify that tenant and non-tenant have no visibility into each other's stats.
@@ -270,10 +309,29 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 func testResetSQLStatsRPCForTenant(
 	ctx context.Context, t *testing.T, testHelper *tenantTestHelper,
 ) {
-	stmts := []string{
-		"SELECT 1",
-		"SELECT 1, 1",
-		"SELECT 1, 1, 1",
+
+	type testCase struct {
+		stmt          string
+		formattedStmt string
+	}
+	stmts := []testCase{
+		{
+			stmt:          "SELECT 1",
+			formattedStmt: "SELECT 1\n",
+		},
+		{
+			stmt:          "SELECT 1, 1",
+			formattedStmt: "SELECT 1, 1\n",
+		},
+		{
+			stmt:          "SELECT 1, 1, 1",
+			formattedStmt: "SELECT 1, 1\n",
+		},
+	}
+
+	var expectedStatements []string
+	for _, tc := range stmts {
+		expectedStatements = append(expectedStatements, tc.formattedStmt)
 	}
 
 	testCluster := testHelper.testCluster()
@@ -303,8 +361,8 @@ func testResetSQLStatsRPCForTenant(
 			}()
 
 			for _, stmt := range stmts {
-				testCluster.tenantConn(randomServer).Exec(t, stmt)
-				controlCluster.tenantConn(randomServer).Exec(t, stmt)
+				testCluster.tenantConn(randomServer).Exec(t, stmt.stmt)
+				controlCluster.tenantConn(randomServer).Exec(t, stmt.stmt)
 			}
 
 			if flushed {
@@ -321,7 +379,7 @@ func testResetSQLStatsRPCForTenant(
 
 			require.NotEqual(t, 0, len(statsPreReset.Statements),
 				"expected to find stats for at least one statement, but found: %d", len(statsPreReset.Statements))
-			ensureExpectedStmtFingerprintExistsInRPCResponse(t, stmts, statsPreReset, "test")
+			ensureExpectedStmtFingerprintExistsInRPCResponse(t, expectedStatements, statsPreReset, "test")
 
 			_, err = status.ResetSQLStats(ctx, &serverpb.ResetSQLStatsRequest{
 				ResetPersistedStats: true,
@@ -358,7 +416,7 @@ func testResetSQLStatsRPCForTenant(
 				})
 			require.NoError(t, err)
 
-			ensureExpectedStmtFingerprintExistsInRPCResponse(t, stmts, statsFromControlCluster, "control")
+			ensureExpectedStmtFingerprintExistsInRPCResponse(t, expectedStatements, statsFromControlCluster, "control")
 		})
 	}
 }
@@ -545,10 +603,10 @@ SET DATABASE=test_db1;
 SELECT * FROM test;
 `)
 
-	getCreateStmtQuery := `
-SELECT indexdef
-FROM pg_catalog.pg_indexes
-WHERE tablename = 'test' AND indexname = $1`
+	getCreateStmtQuery := fmt.Sprintf(`
+		SELECT prettify_statement(indexdef, %d, %d, %d)
+		FROM pg_catalog.pg_indexes
+		WHERE tablename = 'test' AND indexname = $1`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase)
 
 	// Get index usage stats and assert expected results.
 	resp := getTableIndexStats(testHelper, "test_db1")

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -116,12 +116,18 @@ func collectCombinedStatements(
 				transaction_fingerprint_id,
 				app_name,
 				aggregated_ts,
-				metadata,
+				jsonb_set(
+					metadata,
+					array['query'],
+					to_jsonb(
+						prettify_statement(metadata ->> 'query', %d, %d, %d)
+					)
+				),
 				statistics,
 				sampled_plan,
 				aggregation_interval
 			FROM crdb_internal.statement_statistics
-			%s`, whereClause)
+			%s`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase, whereClause)
 
 	const expectedNumDatums = 8
 

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -223,14 +223,13 @@ func getTableIndexUsageStats(
 
 	q := makeSQLQuery()
 	// TODO(#72930): Implement virtual indexes on index_usages_statistics and table_indexes
-	q.Append(`
-		SELECT
+	q.Append(`SELECT
 			ti.index_id,
 			ti.index_name,
 			ti.index_type,
 			total_reads,
 			last_read,
-			indexdef
+			prettify_statement(indexdef, $, $, $)
 		FROM crdb_internal.index_usage_statistics AS us
   	JOIN crdb_internal.table_indexes AS ti ON us.index_id = ti.index_id 
 		AND us.table_id = ti.descriptor_id
@@ -238,6 +237,9 @@ func getTableIndexUsageStats(
   	JOIN pg_catalog.pg_indexes AS pgidxs ON pgidxs.crdb_oid = indexrelid
 		AND indexname = ti.index_name
  		WHERE ti.descriptor_id = $::REGCLASS`,
+		tree.ConsoleLineWidth,
+		tree.PrettyAlignAndDeindent,
+		tree.UpperCase,
 		tableID,
 	)
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1922,17 +1922,33 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	thirdServerSQL := sqlutils.MakeSQLRunner(testCluster.ServerConn(2))
 
 	statements := []struct {
-		stmt          string
-		fingerprinted string
+		stmt                 string
+		formattedStmt        string
+		fingerprint          string
+		formattedFingerprint string
 	}{
-		{stmt: `CREATE DATABASE roachblog`},
-		{stmt: `SET database = roachblog`},
-		{stmt: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
-			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
+			stmt:          `CREATE DATABASE roachblog`,
+			formattedStmt: "CREATE DATABASE roachblog\n",
 		},
-		{stmt: `SELECT * FROM posts`},
+		{
+			stmt:          `SET database = roachblog`,
+			formattedStmt: "SET database = roachblog\n",
+		},
+		{
+			stmt:          `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`,
+			formattedStmt: "CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)\n",
+		},
+		{
+			stmt:                 `INSERT INTO posts VALUES (1, 'foo')`,
+			formattedStmt:        "INSERT INTO posts VALUES (1, 'foo')\n",
+			fingerprint:          `INSERT INTO posts VALUES (_, '_')`,
+			formattedFingerprint: "INSERT INTO posts VALUES (_, '_')\n",
+		},
+		{
+			stmt:          `SELECT * FROM posts`,
+			formattedStmt: "SELECT * FROM posts\n",
+		},
 	}
 
 	for _, stmt := range statements {
@@ -1992,9 +2008,9 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 
 	var expectedStatements []string
 	for _, stmt := range statements {
-		var expectedStmt = stmt.stmt
-		if stmt.fingerprinted != "" {
-			expectedStmt = stmt.fingerprinted
+		var expectedStmt = stmt.formattedStmt
+		if stmt.fingerprint != "" {
+			expectedStmt = stmt.formattedFingerprint
 		}
 		expectedStatements = append(expectedStatements, expectedStmt)
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -341,6 +341,45 @@ var builtins = map[string]builtinDefinition{
 		),
 	),
 
+	"prettify_statement": makeBuiltin(tree.FunctionProperties{Category: categoryString},
+		stringOverload1(
+			func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
+				formattedStmt, err := prettyStatement(tree.DefaultPrettyCfg(), s)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(formattedStmt), nil
+			},
+			types.String,
+			"Prettifies a statement using a the default pretty-printing config.",
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"statement", types.String},
+				{"line_width", types.Int},
+				{"align_mode", types.Int},
+				{"case_mode", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				stmt := string(tree.MustBeDString(args[0]))
+				lineWidth := int(tree.MustBeDInt(args[1]))
+				alignMode := int(tree.MustBeDInt(args[2]))
+				caseMode := int(tree.MustBeDInt(args[3]))
+				formattedStmt, err := prettyStatementCustomConfig(stmt, lineWidth, alignMode, caseMode)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(formattedStmt), nil
+			},
+			Info: "Prettifies a statement using a user-configured pretty-printing config.\n" +
+				"Align mode values range from 0 - 3, representing no, partial, full, and extra alignment respectively.\n" +
+				"Case mode values range between 0 - 1, representing lower casing and upper casing respectively.",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
 	"substr":    substringImpls,
 	"substring": substringImpls,
 
@@ -8809,4 +8848,35 @@ func parseContextFromDateStyle(
 		ctx.GetTxnTimestamp(time.Microsecond).Time,
 		tree.NewParseTimeContextOptionDateStyle(ds),
 	), nil
+}
+
+func prettyStatementCustomConfig(
+	stmt string, lineWidth int, alignMode int, caseSetting int,
+) (string, error) {
+	cfg := tree.DefaultPrettyCfg()
+	cfg.LineWidth = lineWidth
+	cfg.Align = tree.PrettyAlignMode(alignMode)
+	caseMode := tree.CaseMode(caseSetting)
+	if caseMode == tree.LowerCase {
+		cfg.Case = func(str string) string { return strings.ToLower(str) }
+	} else if caseMode == tree.UpperCase {
+		cfg.Case = func(str string) string { return strings.ToUpper(str) }
+	}
+	return prettyStatement(cfg, stmt)
+}
+
+func prettyStatement(p tree.PrettyCfg, stmt string) (string, error) {
+	stmts, err := parser.Parse(stmt)
+	if err != nil {
+		return "", err
+	}
+	var formattedStmt strings.Builder
+	for idx := range stmts {
+		formattedStmt.WriteString(p.Pretty(stmts[idx].AST))
+		if len(stmts) > 1 {
+			formattedStmt.WriteString(";")
+		}
+		formattedStmt.WriteString("\n")
+	}
+	return formattedStmt.String(), nil
 }

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -65,7 +65,7 @@ type PrettyCfg struct {
 // configuration.
 func DefaultPrettyCfg() PrettyCfg {
 	return PrettyCfg{
-		LineWidth: 60,
+		LineWidth: DefaultLineWidth,
 		Simplify:  true,
 		TabWidth:  4,
 		UseTabs:   true,
@@ -93,6 +93,26 @@ const (
 	// also extra indents the operands of AND and OR operators so
 	// that they appear aligned but also indented.
 	PrettyAlignAndExtraIndent = 3
+)
+
+// CaseMode directs which casing mode to use.
+type CaseMode int
+
+const (
+	// LowerCase transforms case-insensitive strings (like SQL keywords) to lowercase.
+	LowerCase CaseMode = 0
+	// UpperCase transforms case-insensitive strings (like SQL keywords) to uppercase.
+	UpperCase CaseMode = 1
+)
+
+// LineWidthMode directs which mode of line width to use.
+type LineWidthMode int
+
+const (
+	// DefaultLineWidth is the line width used with the default pretty-printing configuration.
+	DefaultLineWidth = 60
+	// ConsoleLineWidth is the line width used on the frontend console.
+	ConsoleLineWidth = 108
 )
 
 // keywordWithText returns a pretty.Keyword with left and/or right

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -323,7 +323,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 />
                 <Link
                   to={StatementLinkTarget({
-                    statement: stmt.sql,
+                    statementFingerprintID: stmt.id,
                     statementNoConstants: stmt.sql_no_constants,
                     implicitTxn: session.active_txn?.implicit,
                     app: "",

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -27,7 +27,6 @@
     font-family: SFMono-Semibold;
     font-size: 14px;
     line-height: 1.57;
-    white-space: pre-line;
     word-wrap: break-word;
 
     span {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -122,27 +122,25 @@ const statementStats: any = {
   exec_stats: execStats,
 };
 
+const fingerprintID = "4705782015019656142";
 const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
 const aggregationInterval = 3600; // 1 hour
 
 export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   history,
   location: {
-    pathname:
-      "/statement/true/SELECT city%2C id FROM vehicles WHERE city %3D %241",
+    pathname: "/statement/true/4705782015019656142",
     search: "",
     hash: "",
     state: null,
   },
   match: {
-    path: "/statement/:database/:implicitTxn/:statement",
-    url:
-      "/statement/defaultdb/true/SELECT city%2C id FROM vehicles WHERE city %3D %241",
+    path: "/statement/:implicitTxn/:statement",
+    url: "/statement/true/4705782015019656142",
     isExact: true,
     params: {
       implicitTxn: "true",
-      statement: "SELECT city%2C id FROM vehicles WHERE city %3D %241",
-      database: "defaultdb",
+      statement: "4705782015019656142",
     },
   },
   timeScale: {
@@ -152,13 +150,23 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
     key: "Custom",
   },
   statement: {
-    statement: "SELECT city, id FROM vehicles WHERE city = $1",
+    statement:
+      "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
+      "  code            VARCHAR NOT NULL,\n" +
+      "  description     VARCHAR NULL,\n" +
+      "  creation_time   TIMESTAMP NULL,\n" +
+      "  expiration_time TIMESTAMP NULL,\n" +
+      "  rules           JSONB NULL,\n" +
+      "  PRIMARY KEY (code ASC)\n" +
+      ")",
     stats: statementStats,
     database: "defaultdb",
     byNode: [
       {
+        aggregatedFingerprintID: fingerprintID,
         label: "4",
-        summary: "SELECT city, id FROM vehicles",
+        summary:
+          "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
         aggregatedTs,
         aggregationInterval,
         implicitTxn: true,
@@ -167,8 +175,10 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
         stats: statementStats,
       },
       {
+        aggregatedFingerprintID: fingerprintID,
         label: "3",
-        summary: "SELECT city, id FROM vehicles",
+        summary:
+          "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
         aggregatedTs,
         aggregationInterval,
         implicitTxn: true,
@@ -177,8 +187,10 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
         stats: statementStats,
       },
       {
+        aggregatedFingerprintID: fingerprintID,
         label: "2",
-        summary: "SELECT city, id FROM vehicles",
+        summary:
+          "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
         aggregatedTs,
         aggregationInterval,
         implicitTxn: true,
@@ -187,8 +199,10 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
         stats: statementStats,
       },
       {
+        aggregatedFingerprintID: fingerprintID,
         label: "1",
-        summary: "SELECT city, id FROM vehicles",
+        summary:
+          "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
         aggregatedTs,
         aggregationInterval,
         implicitTxn: true,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -282,10 +282,17 @@ const statementsPagePropsFixture: StatementsPageProps = {
     regions: "",
     nodes: "",
   },
+  // Aggregate key values in these statements will need to change if implementation
+  // of 'statementKey' in appStats.ts changes.
   statements: [
     {
+      aggregatedFingerprintID: "1253500548539870016",
       label:
-        "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+        "SELECT IFNULL(a, b)\n" +
+        "    FROM (\n" +
+        "          SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a,\n" +
+        "                 (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b\n" +
+        "         )",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -295,6 +302,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "1985666523427702831",
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
       summary: "INSERT INTO vehicles",
       aggregatedTs,
@@ -305,8 +313,13 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "13649565517143827225",
       label:
-        "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
+        "SELECT IFNULL(a, b)\n" +
+        "    FROM (\n" +
+        "          SELECT (SELECT id FROM users WHERE city = $1 AND id > $2 ORDER BY id LIMIT _) AS a,\n" +
+        "                 (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b\n" +
+        "         )",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -316,6 +329,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "1533636712988872414",
       label:
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       summary: "UPSERT INTO vehicle_location_histories",
@@ -327,6 +341,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "2461578209191418170",
       label: "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
       summary: "INSERT INTO user_promo_codes",
       aggregatedTs,
@@ -337,6 +352,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "4705782015019656142",
       label: "SELECT city, id FROM vehicles WHERE city = $1",
       summary: "SELECT city, id FROM vehicles",
       aggregatedTs,
@@ -347,6 +363,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "2298970482983227199",
       label:
         "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
       summary: "INSERT INTO rides",
@@ -358,6 +375,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "4716433305747424413",
       label: "SELECT IFNULL(a, b) FROM (SELECT  AS a, AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
@@ -368,6 +386,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "367828504526856403",
       label:
         "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
       summary: "UPDATE rides SET end_address = $... WHERE (city = $1) AND...",
@@ -379,6 +398,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "14972494059652918390",
       label: "INSERT INTO users VALUES ($1, $2, __more3__)",
       summary: "INSERT INTO users",
       aggregatedTs,
@@ -389,6 +409,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "15897033026745880862",
       label:
         "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
       summary: "SELECT count(*) FROM user_promo_codes",
@@ -400,6 +421,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '49958554803360403681',
       label: "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
       summary: "INSERT INTO promo_codes",
       aggregatedTs,
@@ -410,6 +432,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '9233296116064220812',
       label: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -420,6 +443,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '6117473345491440803',
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
       summary:
@@ -432,6 +456,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '1301242584620444873',
       label: "SHOW database",
       summary: "SHOW database",
       aggregatedTs,
@@ -443,8 +468,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
       diagnosticsReports,
     },
     {
+      aggregatedFingerprintID: '11195381626529102926',
       label:
-        "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
+        "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
+        "      code            VARCHAR NOT NULL,\n" +
+        "      description     VARCHAR NULL,\n" +
+        "      creation_time   TIMESTAMP NULL,\n" +
+        "      expiration_time TIMESTAMP NULL,\n" +
+        "      rules           JSONB NULL,\n" +
+        "      PRIMARY KEY (code ASC)\n" +
+        "  )",
       summary:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       aggregatedTs,
@@ -455,6 +488,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '18127289707013477303',
       label: "ALTER TABLE users SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE users SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -465,6 +499,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '2499764450427976233',
       label: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -475,6 +510,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '818321793552651414',
       label:
         "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
       summary:
@@ -487,8 +523,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '13217779306501326587',
       label:
-        'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
+        'CREATE TABLE IF NOT EXISTS user_promo_codes (\n' +
+        '      city        VARCHAR NOT NULL,\n' +
+        '      user_id     UUID NOT NULL,\n' +
+        '      code        VARCHAR NOT NULL,\n' +
+        '      "timestamp" TIMESTAMP NULL,\n' +
+        '      usage_count INT8 NULL,\n' +
+        '      PRIMARY KEY (city ASC, user_id ASC, code ASC)\n' +
+        '  )',
       summary:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       aggregatedTs,
@@ -499,6 +543,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '6325213731862855938',
       label: "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
       summary: "INSERT INTO users VALUES",
       aggregatedTs,
@@ -509,6 +554,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '17372586739449521577',
       label: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -519,6 +565,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '17098541896015126122',
       label: 'SET CLUSTER SETTING "cluster.organization" = $1',
       summary: 'SET CLUSTER SETTING "cluster.organization" = $1',
       aggregatedTs,
@@ -529,6 +576,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '13350023170184726428',
       label:
         "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
       summary:
@@ -541,8 +589,24 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '2695725667586429780',
       label:
-        "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
+        "CREATE TABLE IF NOT EXISTS rides (\n" +
+        "      id            UUID NOT NULL,\n" +
+        "      city          VARCHAR NOT NULL,\n" +
+        "      vehicle_city  VARCHAR NULL,\n" +
+        "      rider_id      UUID NULL,\n" +
+        "      vehicle_id    UUID NULL,\n" +
+        "      start_address VARCHAR NULL,\n" +
+        "      end_address   VARCHAR NULL,\n" +
+        "      start_time    TIMESTAMP NULL,\n" +
+        "      end_time      TIMESTAMP NULL,\n" +
+        "      revenue       DECIMAL(10,2) NULL,\n" +
+        "      PRIMARY KEY (city ASC, id ASC),\n" +
+        "      INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),\n" +
+        "      INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),\n" +
+        "      CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)\n" +
+        "  )",
       summary:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       aggregatedTs,
@@ -553,8 +617,20 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '6754865160812330169',
       label:
-        "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
+        "CREATE TABLE IF NOT EXISTS vehicles (\n" +
+        "      id               UUID NOT NULL,\n" +
+        "      city             VARCHAR NOT NULL,\n" +
+        "      type             VARCHAR NULL,\n" +
+        "      owner_id         UUID NULL,\n" +
+        "      creation_time    TIMESTAMP NULL,\n" +
+        "      status           VARCHAR NULL,\n" +
+        "      current_location VARCHAR NULL,\n" +
+        "      ext              JSONB NULL,\n" +
+        "      PRIMARY KEY (city ASC, id ASC),\n" +
+        "      INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC)\n" +
+        "  )",
       summary:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       aggregatedTs,
@@ -565,6 +641,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '6810471486115018510',
       label: "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
       summary: "INSERT INTO rides",
       aggregatedTs,
@@ -575,6 +652,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '13265908854908549668',
       label: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -585,6 +663,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '18377382163116490400',
       label: "SET sql_safe_updates = _",
       summary: "SET sql_safe_updates = _",
       aggregatedTs,
@@ -595,8 +674,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '8695470234690735168',
       label:
-        "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
+        "CREATE TABLE IF NOT EXISTS users (\n" +
+        "      id          UUID NOT NULL,\n" +
+        "      city        VARCHAR NOT NULL,\n" +
+        "      name        VARCHAR NULL,\n" +
+        "      address     VARCHAR NULL,\n" +
+        "      credit_card VARCHAR NULL,\n" +
+        "      PRIMARY KEY (city ASC, id ASC)\n" +
+        "  )",
       summary:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       aggregatedTs,
@@ -607,8 +694,16 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '9261848985398568228',
       label:
-        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
+        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (\n' +
+        '      city        VARCHAR NOT NULL,\n' +
+        '      ride_id     UUID NOT NULL,\n' +
+        '      "timestamp" TIMESTAMP NOT NULL,\n' +
+        '      lat         FLOAT8 NULL,\n' +
+        '      long        FLOAT8 NULL,\n' +
+        '      PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC)\n' +
+        '  )',
       summary:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       aggregatedTs,
@@ -619,6 +714,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: '4176684928840388768',
       label: "SELECT * FROM crdb_internal.node_build_info",
       summary: "SELECT * FROM crdb_internal.node_build_info",
       aggregatedTs,
@@ -629,6 +725,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "15868120298061590648",
       label: "CREATE DATABASE movr",
       summary: "CREATE DATABASE movr",
       implicitTxn: true,
@@ -640,6 +737,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       diagnosticsReports: diagnosticsReportsInProgress,
     },
     {
+      aggregatedFingerprintID: "13070583869906258880",
       label:
         "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
       summary: "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS...",
@@ -651,6 +749,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "641287435601027145",
       label: 'SET CLUSTER SETTING "enterprise.license" = $1',
       summary: 'SET CLUSTER SETTING "enterprise.license" = $1',
       aggregatedTs,
@@ -661,6 +760,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "16743225271705059729",
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
       summary:
@@ -673,6 +773,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "6075815909800602827",
       label:
         "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
       summary:
@@ -685,6 +786,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "5158086166870396309",
       label:
         "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
       summary: "INSERT INTO promo_codes",
@@ -696,6 +798,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "13494397675172244644",
       label: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -706,6 +809,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "101921598584277094",
       label: "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
       summary: "SELECT value FROM crdb_internal.node_build_info",
       aggregatedTs,
@@ -716,6 +820,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "7880339715822034020",
       label:
         "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
       summary: "INSERT INTO vehicle_location_histories",
@@ -727,6 +832,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       stats: statementStats,
     },
     {
+      aggregatedFingerprintID: "16819876564846676829",
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
       summary: "INSERT INTO vehicles",
       aggregatedTs,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -32,6 +32,7 @@ import { SQLStatsState } from "../store/sqlStats";
 
 type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 export interface StatementsSummaryData {
+  statementFingerprintID: string;
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
@@ -173,6 +174,7 @@ export const selectStatements = createSelector(
       const key = statementKey(stmt);
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
+          statementFingerprintID: stmt.statement_fingerprint_id?.toString(),
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
@@ -189,6 +191,7 @@ export const selectStatements = createSelector(
     return Object.keys(statsByStatementKey).map(key => {
       const stmt = statsByStatementKey[key];
       return {
+        aggregatedFingerprintID: stmt.statementFingerprintID,
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -10,7 +10,6 @@
 
 import React from "react";
 import classNames from "classnames/bind";
-import Long from "long";
 
 import {
   FixLong,
@@ -204,6 +203,7 @@ function makeCommonColumns(
 }
 
 export interface AggregateStatistics {
+  aggregatedFingerprintID: string;
   // label is either shortStatement (StatementsPage) or nodeId (StatementDetails).
   label: string;
   // summary exists only for SELECT/INSERT/UPSERT/UPDATE statements, and is

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -47,6 +47,7 @@ export const StatementTableCell = {
     onStatementClick?: (statement: string) => void,
   ) => (stmt: AggregateStatistics): React.ReactElement => (
     <StatementLink
+      statementFingerprintID={stmt.aggregatedFingerprintID}
       statement={stmt.label}
       statementSummary={stmt.summary}
       aggregatedTs={stmt.aggregatedTs}
@@ -134,7 +135,7 @@ export const StatementTableCell = {
 };
 
 type StatementLinkTargetProps = {
-  statement: string;
+  statementFingerprintID: string;
   aggregatedTs?: number;
   aggregationInterval?: number;
   app: string;
@@ -149,7 +150,7 @@ export const StatementLinkTarget = (
   props: StatementLinkTargetProps,
 ): string => {
   const base = `/statement/${props.implicitTxn}`;
-  const linkStatement = props.statementNoConstants || props.statement;
+  const statementFingerprintID = props.statementFingerprintID;
 
   const searchParams = propsToQueryString({
     [databaseAttr]: props.database,
@@ -158,10 +159,13 @@ export const StatementLinkTarget = (
     [aggregationIntervalAttr]: props.aggregationInterval,
   });
 
-  return `${base}/${encodeURIComponent(linkStatement)}?${searchParams}`;
+  return `${base}/${encodeURIComponent(
+    statementFingerprintID,
+  )}?${searchParams}`;
 };
 
 interface StatementLinkProps {
+  statementFingerprintID: string;
   aggregatedTs?: number;
   aggregationInterval?: number;
   statement: string;
@@ -175,6 +179,7 @@ interface StatementLinkProps {
 }
 
 export const StatementLink = ({
+  statementFingerprintID,
   aggregatedTs,
   aggregationInterval,
   statement,
@@ -193,6 +198,7 @@ export const StatementLink = ({
   }, [onClick, statement]);
 
   const linkProps = {
+    statementFingerprintID,
     aggregatedTs,
     aggregationInterval,
     statement,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -100,6 +100,7 @@ export const aggregateStatements = (
     const key = transactionScopedStatementKey(s);
     if (!(key in statsKey)) {
       statsKey[key] = {
+        aggregatedFingerprintID: s.statement_fingerprint_id?.toString(),
         label: s.statement,
         summary: s.statement_summary,
         aggregatedTs: s.aggregated_ts,

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -202,6 +202,7 @@ export function aggregateStatementStats(
 }
 
 export interface ExecutionStatistics {
+  statement_fingerprint_id: Long;
   statement: string;
   statement_summary: string;
   aggregated_ts: number;
@@ -222,6 +223,7 @@ export function flattenStatementStats(
   statementStats: CollectedStatementStatistics[],
 ): ExecutionStatistics[] {
   return statementStats.map(stmt => ({
+    statement_fingerprint_id: stmt.id,
     statement: stmt.key.key_data.query,
     statement_summary: stmt.key.key_data.query_summary,
     aggregated_ts: TimestampToNumber(stmt.key.aggregated_ts),
@@ -257,9 +259,7 @@ export const getSearchParams = (searchParams: string) => {
 // aggregated_ts and aggregation_interval.
 export function statementKey(stmt: ExecutionStatistics): string {
   return (
-    stmt.statement +
-    stmt.implicit_txn +
-    stmt.database +
+    stmt.statement_fingerprint_id?.toString() +
     stmt.aggregated_ts +
     stmt.aggregation_interval
   );

--- a/pkg/ui/workspaces/db-console/src/routes/RedirectToStatementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/routes/RedirectToStatementDetails.tsx
@@ -27,7 +27,7 @@ type Props = {
 // where app and database are route params, to the new StatementDetails route.
 export function RedirectToStatementDetails({ match }: Props) {
   const linkProps = {
-    statement: getMatchParamByName(match, statementAttr),
+    statementFingerprintID: getMatchParamByName(match, statementAttr),
     app: getMatchParamByName(match, appAttr),
     implicitTxn: getMatchParamByName(match, implicitTxnAttr) === "true",
     database: getMatchParamByName(match, databaseAttr),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -8,11 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 import { connect } from "react-redux";
-import {
-  RouteComponentProps,
-  match as Match,
-  withRouter,
-} from "react-router-dom";
+import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Location } from "history";
 import { createSelector } from "reselect";
 import _ from "lodash";
@@ -33,7 +29,6 @@ import {
   aggregationIntervalAttr,
   appAttr,
   databaseAttr,
-  implicitTxnAttr,
   statementAttr,
 } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
@@ -65,6 +60,7 @@ interface Fraction {
 }
 
 interface StatementDetailsData {
+  statementFingerprintID: string;
   nodeId: number;
   summary: string;
   aggregatedTs: number;
@@ -78,12 +74,13 @@ interface StatementDetailsData {
 function coalesceNodeStats(
   stats: ExecutionStatistics[],
 ): AggregateStatistics[] {
-  const statsKey: { [nodeId: string]: StatementDetailsData } = {};
+  const statsKey: { [stmtKey: string]: StatementDetailsData } = {};
 
   stats.forEach(stmt => {
     const key = statementKey(stmt);
     if (!(key in statsKey)) {
       statsKey[key] = {
+        statementFingerprintID: stmt.statement_fingerprint_id?.toString(),
         nodeId: stmt.node_id,
         summary: stmt.statement_summary,
         aggregatedTs: stmt.aggregated_ts,
@@ -100,6 +97,7 @@ function coalesceNodeStats(
   return Object.keys(statsKey).map(key => {
     const stmt = statsKey[key];
     return {
+      aggregatedFingerprintID: stmt.statementFingerprintID,
       label: stmt.nodeId.toString(),
       summary: stmt.summary,
       aggregatedTs: stmt.aggregatedTs,
@@ -130,31 +128,24 @@ function fractionMatching(
   return { numerator, denominator };
 }
 
-function filterByRouterParamsPredicate(
-  match: Match<any>,
+function filterByExecStatKey(
   location: Location,
   internalAppNamePrefix: string,
+  statementFingerprintID: string,
 ): (stat: ExecutionStatistics) => boolean {
-  const statement = getMatchParamByName(match, statementAttr);
-  const implicitTxn = getMatchParamByName(match, implicitTxnAttr) === "true";
-  const database =
-    queryByName(location, databaseAttr) === "(unset)"
-      ? ""
-      : queryByName(location, databaseAttr);
   const apps = queryByName(location, appAttr)
     ? queryByName(location, appAttr).split(",")
     : null;
+
   // If the aggregatedTs is unset, we will aggregate across the current date range.
   const aggregatedTs = queryByName(location, aggregatedTsAttr);
   const aggInterval = queryByName(location, aggregationIntervalAttr);
 
   const filterByKeys = (stmt: ExecutionStatistics) =>
-    stmt.statement === statement &&
+    stmt.statement_fingerprint_id?.toString() === statementFingerprintID &&
     (aggregatedTs == null || stmt.aggregated_ts.toString() === aggregatedTs) &&
     (aggInterval == null ||
-      stmt.aggregation_interval.toString() === aggInterval) &&
-    stmt.implicit_txn === implicitTxn &&
-    (stmt.database === database || database === null);
+      stmt.aggregation_interval.toString() === aggInterval);
 
   if (!apps) {
     return filterByKeys;
@@ -185,14 +176,26 @@ export const selectStatement = createSelector(
     const internalAppNamePrefix =
       statementsState.data?.internal_app_name_prefix;
     const flattened = flattenStatementStats(statements);
+
+    const statementFingerprintID = getMatchParamByName(
+      props.match,
+      statementAttr,
+    );
     const results = flattened.filter(
-      filterByRouterParamsPredicate(
-        props.match,
+      filterByExecStatKey(
         props.location,
         internalAppNamePrefix,
+        statementFingerprintID,
       ),
     );
-    const statement = getMatchParamByName(props.match, statementAttr);
+
+    // We expect a single result to be returned. The key used to retrieve results is specific per:
+    // - statement fingerprint id
+    // - aggregation timestamp
+    // - aggregation period
+    // see the `statementKey` function in appStats.ts for implementation.
+    const statement = results[0].statement;
+
     return {
       statement,
       stats: combineStatementStats(results.map(s => s.stats)),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -17,7 +17,6 @@ import { merge } from "lodash";
 
 import "src/protobufInit";
 import * as protos from "src/js/protos";
-import { util } from "@cockroachlabs/cluster-ui";
 import { appAttr, statementAttr } from "src/util/constants";
 import {
   selectStatements,
@@ -28,6 +27,7 @@ import {
 import { selectStatement } from "./statementDetails";
 import ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
+import { util } from "@cockroachlabs/cluster-ui";
 
 type CollectedStatementStatistics = util.CollectedStatementStatistics;
 type ExecStats = util.ExecStats;
@@ -53,7 +53,6 @@ describe("selectStatements", () => {
     const props = makeEmptyRouteProps();
 
     const result = selectStatements(state, props);
-
     assert.equal(result.length, 3);
 
     const expectedFingerprints = [stmtA, stmtB, stmtC].map(
@@ -276,8 +275,9 @@ describe("selectStatement", () => {
     const stmtB = makeFingerprint(2, "foobar");
     const stmtC = makeFingerprint(3, "another");
     const state = makeStateWithStatements([stmtA, stmtB, stmtC]);
-    const props = makeRoutePropsWithStatement(stmtA.key.key_data.query);
 
+    const stmtAFingerprintID = stmtA.id.toString();
+    const props = makeRoutePropsWithStatement(stmtAFingerprintID);
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
@@ -297,8 +297,8 @@ describe("selectStatement", () => {
       .add(stmtB.stats.count.add(stmtC.stats.count))
       .toNumber();
     const state = makeStateWithStatements([stmtA, stmtB, stmtC]);
-    const props = makeRoutePropsWithStatement(stmtA.key.key_data.query);
-
+    const stmtAFingerprintID = stmtA.id.toString();
+    const props = makeRoutePropsWithStatement(stmtAFingerprintID);
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
@@ -323,8 +323,8 @@ describe("selectStatement", () => {
       .add(stmtC.stats.count)
       .toNumber();
     const state = makeStateWithStatements([stmtA, stmtB, stmtC]);
-    const props = makeRoutePropsWithStatement(stmtA.key.key_data.query);
-
+    const stmtAFingerprintID = stmtA.id.toString();
+    const props = makeRoutePropsWithStatement(stmtAFingerprintID);
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
@@ -364,8 +364,8 @@ describe("selectStatement", () => {
       stmtG,
       stmtH,
     ]);
-    const props = makeRoutePropsWithStatement(stmtA.key.key_data.query);
-
+    const stmtAFingerprintID = stmtA.id.toString();
+    const props = makeRoutePropsWithStatement(stmtAFingerprintID);
     const result = selectStatement(state, props);
 
     assert.equal(result.statement, stmtA.key.key_data.query);
@@ -384,10 +384,8 @@ describe("selectStatement", () => {
       makeFingerprint(2, "bar"),
       makeFingerprint(3, "baz"),
     ]);
-    const props = makeRoutePropsWithStatementAndApp(
-      stmtA.key.key_data.query,
-      "foo",
-    );
+    const stmtAFingerprintID = stmtA.id.toString();
+    const props = makeRoutePropsWithStatementAndApp(stmtAFingerprintID, "foo");
 
     const result = selectStatement(state, props);
 
@@ -407,8 +405,9 @@ describe("selectStatement", () => {
       makeFingerprint(2, "bar"),
       makeFingerprint(3, "baz"),
     ]);
+    const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatementAndApp(
-      stmtA.key.key_data.query,
+      stmtAFingerprintID,
       "(unset)",
     );
 
@@ -430,8 +429,9 @@ describe("selectStatement", () => {
       makeFingerprint(2, "bar"),
       makeFingerprint(3, "baz"),
     ]);
+    const stmtAFingerprintID = stmtA.id.toString();
     const props = makeRoutePropsWithStatementAndApp(
-      stmtA.key.key_data.query,
+      stmtAFingerprintID,
       "$ internal",
     );
 
@@ -467,6 +467,7 @@ function makeFingerprint(
       },
       node_id: nodeId,
     },
+    id: Long.fromNumber(id),
     stats: makeStats(),
   };
 }

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -60,6 +60,7 @@ type ExecutionStatistics = util.ExecutionStatistics;
 type StatementStatistics = util.StatementStatistics;
 
 interface StatementsSummaryData {
+  statementFingerprintID: string;
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
@@ -118,6 +119,7 @@ export const selectStatements = createSelector(
       const key = statementKey(stmt);
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
+          statementFingerprintID: stmt.statement_fingerprint_id?.toString(),
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
@@ -134,6 +136,7 @@ export const selectStatements = createSelector(
     return Object.keys(statsByStatementKey).map(key => {
       const stmt = statsByStatementKey[key];
       return {
+        aggregatedFingerprintID: stmt.statementFingerprintID,
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,


### PR DESCRIPTION
Previously, statements displayed on the statement/transaction details
pages were not formatted.  Formatting was added to allow for better
readability of statements on these detail pages. Requested statements
are now formatted on the server using the existing pretty-printing
logic. Statements returned from the statement handler now include an
additional "formatted_statement" [field.](url)

Before changes:
![Screen Shot 2022-01-04 at 9 47 03 AM](https://user-images.githubusercontent.com/15315413/148076571-4ccba517-280f-4953-b412-bfe4ecc1b071.png)

After changes:
![Screen Shot 2022-01-04 at 9 37 56 AM](https://user-images.githubusercontent.com/15315413/148075588-cfa5e958-27f5-41da-b737-97ad5c1cb3fc.png)

These formatting changes can also be seen on the transaction details page, databases page (now includes indentation for table creation statements), and the index details page.

Resolves: #71544

Release note (ui change): added formatting to statemenets on the
statement & transaction details pages.