### PR TITLE
release-release-21.2: server: add current time to instant metrics

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -120,6 +120,12 @@ var (
 		Measurement: "CPU Time",
 		Unit:        metric.Unit_PERCENT,
 	}
+	metaCPUNowNS = metric.Metadata{
+		Name:        "sys.cpu.now.ns",
+		Help:        "Number of nanoseconds elapsed since January 1, 1970 UTC",
+		Measurement: "CPU Time",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaRSSBytes = metric.Metadata{
 		Name:        "sys.rss",
 		Help:        "Current process RSS",
@@ -283,6 +289,7 @@ type RuntimeStatSampler struct {
 	CPUSysNS               *metric.Gauge
 	CPUSysPercent          *metric.GaugeFloat64
 	CPUCombinedPercentNorm *metric.GaugeFloat64
+	CPUNowNS               *metric.Gauge
 	// Memory stats.
 	RSSBytes *metric.Gauge
 	// File descriptor stats.
@@ -360,6 +367,7 @@ func NewRuntimeStatSampler(ctx context.Context, clock *hlc.Clock) *RuntimeStatSa
 		CPUSysNS:                 metric.NewGauge(metaCPUSysNS),
 		CPUSysPercent:            metric.NewGaugeFloat64(metaCPUSysPercent),
 		CPUCombinedPercentNorm:   metric.NewGaugeFloat64(metaCPUCombinedPercentNorm),
+		CPUNowNS:                 metric.NewGauge(metaCPUNowNS),
 		RSSBytes:                 metric.NewGauge(metaRSSBytes),
 		HostDiskReadBytes:        metric.NewGauge(metaHostDiskReadBytes),
 		HostDiskReadCount:        metric.NewGauge(metaHostDiskReadCount),
@@ -570,6 +578,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 	rsr.CPUSysNS.Update(stime)
 	rsr.CPUSysPercent.Update(srate)
 	rsr.CPUCombinedPercentNorm.Update(combinedNormalizedPerc)
+	rsr.CPUNowNS.Update(now)
 	rsr.FDOpen.Update(int64(fds.Open))
 	rsr.FDSoftLimit.Update(int64(fds.SoftLimit))
 	rsr.RSSBytes.Update(int64(mem.Resident))

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -322,9 +322,11 @@ func loadVarsHandler(
 ) func(http.ResponseWriter, *http.Request) {
 	cpuUserNanos := metric.NewGauge(rsr.CPUUserNS.GetMetadata())
 	cpuSysNanos := metric.NewGauge(rsr.CPUSysNS.GetMetadata())
+	cpuNowNanos := metric.NewGauge(rsr.CPUNowNS.GetMetadata())
 	registry := metric.NewRegistry()
 	registry.AddMetric(cpuUserNanos)
 	registry.AddMetric(cpuSysNanos)
+	registry.AddMetric(cpuNowNanos)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		userTimeMillis, sysTimeMillis, err := status.GetCPUTime(ctx)
@@ -332,11 +334,13 @@ func loadVarsHandler(
 			// Just log but don't return an error to match the _status/vars metrics handler.
 			log.Ops.Errorf(ctx, "unable to get cpu usage: %v", err)
 		}
+
 		// cpuTime.{User,Sys} are in milliseconds, convert to nanoseconds.
 		utime := userTimeMillis * 1e6
 		stime := sysTimeMillis * 1e6
 		cpuUserNanos.Update(utime)
 		cpuSysNanos.Update(stime)
+		cpuNowNanos.Update(timeutil.Now().UnixNano())
 
 		exporter := metric.MakePrometheusExporter()
 		exporter.ScrapeRegistry(registry, true)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -119,6 +119,7 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"sys.cpu.sys.ns",
 					"sys.cpu.user.ns",
+					"sys.cpu.now.ns",
 				},
 			},
 		},


### PR DESCRIPTION
Backport 1/1 commits from #72066.

/cc @cockroachdb/release

---

We currently have two metrics - user and system cpu times that reflect
the time spend in userspace and system space by the process. We want to
use these to compute CPU utilization for the tenant processes. To do
that however, we need to also know the absolute amount of time that
passed between two consecutive measurements. While this is possible to
be done by the caller, this isn't ideal as any delays in the metrics
retrieval will skew the result. Retrieval retries may be performed
automatically and be invisible for the caller. To ensure that these
delays don't affect the calculation, this PR adds an additional metric
to the two already available instant metrics - the current time. That
allows a more precise computation of the CPU loads, unaffected by the
retrieval delays.

Release note: None

Release justification: needed for CC autoscaler changes