### PR TITLE
sql: add test asserting CREATE/USAGE on public schema

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1567,6 +1567,8 @@ func remapPublicSchemas(
 		// In CockroachDB, root is our substitute for the postgres user.
 		publicSchemaPrivileges := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 		// By default, everyone has USAGE and CREATE on the public schema.
+		// Once https://github.com/cockroachdb/cockroach/issues/70266 is resolved,
+		// the public role will no longer have CREATE privilege.
 		publicSchemaPrivileges.Grant(security.PublicRoleName(), privilege.List{privilege.CREATE, privilege.USAGE}, false)
 		publicSchemaDesc := schemadesc.NewBuilder(&descpb.SchemaDescriptor{
 			ParentID:   db.GetID(),

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -169,6 +169,8 @@ func (p *planner) maybeCreatePublicSchemaWithDescriptor(
 	// In CockroachDB, root is our substitute for the postgres user.
 	publicSchemaPrivileges := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 	// By default, everyone has USAGE and CREATE on the public schema.
+	// Once https://github.com/cockroachdb/cockroach/issues/70266 is resolved,
+	// the public role will no longer have CREATE privileges.
 	publicSchemaPrivileges.Grant(security.PublicRoleName(), privilege.List{privilege.CREATE, privilege.USAGE}, false)
 	publicSchemaDesc := schemadesc.NewBuilder(&descpb.SchemaDescriptor{
 		ParentID:   dbID,

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -8,6 +8,18 @@ user testuser
 statement ok
 USE d;
 
+# The public schema is special and has hard-coded privileges for the public role.
+# When https://github.com/cockroachdb/cockroach/issues/70266 is resolved,
+# the public role will no longer have CREATE privilege.
+query TTTT colnames
+SHOW GRANTS ON SCHEMA public
+----
+database_name  schema_name  grantee  privilege_type
+d              public       admin    ALL
+d              public       public   CREATE
+d              public       public   USAGE
+d              public       root     ALL
+
 statement ok
 CREATE SCHEMA testuser_s;
 


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/70266

The public schema currently always has CREATE/USAGE privileges
for the public role. Add a test that confirms this.

Release note: None