### PR TITLE
indexrec: preserve uniqueness and consider existing indexes

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -676,10 +676,6 @@ vectorized: true
           table: xyz@zyx
           spans: /7/!NULL-/7.000000000000001
           limit: 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (z) STORING (y);
 
 query T
 EXPLAIN (TYPES) SELECT max(y) FROM xyz WHERE z = 7
@@ -701,10 +697,6 @@ vectorized: true
           table: xyz@zyx
           spans: /7/!NULL-/7.000000000000001
           limit: 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (z) STORING (y);
 
 query T
 EXPLAIN (TYPES) SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0)
@@ -726,10 +718,6 @@ vectorized: true
           table: xyz@zyx
           spans: /3/2-/3/3
           limit: 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (y, z);
 
 statement ok
 SET tracing = on,kv,results; SELECT min(x) FROM xyz WHERE (y, z) = (2, 3.0); SET tracing = off
@@ -762,10 +750,6 @@ vectorized: true
           table: xyz@zyx
           spans: /3/2-/3/3
           limit: 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (z, y);
 
 # MULTIPLE MIN/MAX
 
@@ -967,10 +951,6 @@ vectorized: true
                       missing stats
                       table: xyz@xy
                       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (y) STORING (z);
 
 # Scalar subquery in filter is supported.
 query T
@@ -1980,12 +1960,6 @@ vectorized: true
               estimated row count: 1,000 (missing stats)
               table: kv@kv_pkey
               spans: FULL SCAN
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON kv (v);
-2. type: index creation
-   SQL command: CREATE INDEX ON xyz (y);
 
 
 # Regression test for #31882: make sure we don't incorrectly advertise an
@@ -2012,10 +1986,6 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: uvw@uvw
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uvw (w) STORING (u, v);
 
 query T
 EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -299,7 +299,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xyz@xyz_y_idx; CREATE INDEX ON xyz (y) STORING (z);
+   SQL commands: CREATE INDEX ON xyz (y) STORING (z); DROP INDEX xyz@xyz_y_idx;
 
 # With the hint, we use a constrained scan.
 query T
@@ -332,4 +332,4 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xyz@xyz_y_idx; CREATE INDEX ON xyz (y) STORING (z);
+   SQL commands: CREATE INDEX ON xyz (y) STORING (z); DROP INDEX xyz@xyz_y_idx;

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -37,10 +37,6 @@ vectorized: true
       missing stats
       table: xyz@foo
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (z) STORING (y);
 
 query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
@@ -120,10 +116,6 @@ vectorized: true
       missing stats
       table: xyz@foo
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (z) STORING (y);
 
 query T
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -909,10 +909,6 @@ vectorized: true
           spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUktFq2zAUhu_3FOK_SkAlsd3d6MrZlo0M186SFFqGCYp1ZgyO5UkydAS_-7A9tqZgr73Ukb7zf4ejC-zPEgLrh2202sRs9mmzP-y_RXO2X0frjwd24uwsn2bZnH3eJXfMauNIHZV0MvyhNfuyS-637MMjO4Gj0opieSYL8R0eON4j5aiNzshabbrypX-0UU8QS46iqhvXlVOOTBuCuMAVriQIxPpG14sAHIqcLMr-WcuhG_cPsk7mBHHb8meNvenGB3kqaUdSkVksr9rjxXTg2NeysoLdgCNpnGChhzEJ7y0SX3VR_XHwxh1qU5yl-fU33OdhMJrvvyV_leeGcum0WfjX-WHnkxhFhlQ_L8cqfjzGyeEY30fRLPTm4LhbPcxCfz4qE1zJ_GfVO7K1riy9atfLNuUgldPwnaxuTEZbo7M-ZjgmPdcXFFk33N4Oh001XHWCz2FvEvanYX8SDqbhYBJevoDT9t3vAAAA__-IXTK3
-·
-index recommendations: 1
-1. type: index replacement
-   SQL commands: DROP INDEX sorted_data@foo; CREATE INDEX ON sorted_data (b) STORING (c);
 
 query T
 EXPLAIN (DISTSQL) SELECT * FROM (SELECT a, max(c) FROM sorted_data GROUP BY a) JOIN (SELECT b, min(c) FROM sorted_data@foo GROUP BY b) ON a = b

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -40,7 +40,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUUE9L-0AQvf8-x
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@v; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@v;
 
 query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 10 AND v < 50 ORDER BY v
@@ -63,7 +63,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkUFLw0AQhe_-i
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@v; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@v;
 
 # Here we care about ordering by v, but v is not otherwise used.
 query T
@@ -87,7 +87,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUUV1ro0AUfd9fc
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@v; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@v;
 
 # The single join reader should be on node 5, and doesn't need to output v.
 query T
@@ -108,4 +108,4 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkVGPmkAQx9_7K
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@v; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@v;

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -918,7 +918,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX tc@c; CREATE INDEX ON tc (a) STORING (b);
+   SQL commands: CREATE INDEX ON tc (a) STORING (b); DROP INDEX tc@c;
 
 # Ensure that the query above no longer has index recommendations if they are
 # disabled.
@@ -1209,7 +1209,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX tt@a; CREATE INDEX ON tt (x) STORING (y);
+   SQL commands: CREATE INDEX ON tt (x) STORING (y); DROP INDEX tt@a;
 
 # TODO(radu): we don't support placeholders with no values.
 #query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -133,10 +133,6 @@ vectorized: true
                           estimated row count: 1,000 (missing stats)
                           table: ltable@ltable_pkey
                           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON rtable (rk1) STORING (geom);
 
 query T
 EXPLAIN (VERBOSE)
@@ -188,10 +184,6 @@ vectorized: true
                           estimated row count: 1,000 (missing stats)
                           table: ltable@ltable_pkey
                           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON rtable (rk1) STORING (geom);
 
 query T
 EXPLAIN (VERBOSE)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -2225,12 +2225,6 @@ vectorized: true
   right table: zigzag@c_idx
   right columns: (c)
   right fixed values: 1 column
-·
-index recommendations: 2
-1. type: index replacement
-   SQL commands: DROP INDEX zigzag@b_idx; CREATE INDEX ON zigzag (b) STORING (c);
-2. type: index replacement
-   SQL commands: DROP INDEX zigzag@c_idx; CREATE INDEX ON zigzag (c) STORING (b);
 
 
 # Zigzag join nested inside a lookup.
@@ -2254,11 +2248,9 @@ vectorized: true
       right columns: (c)
       right fixed values: 1 column
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX zigzag@b_idx; CREATE INDEX ON zigzag (b) STORING (c, d);
-2. type: index replacement
-   SQL commands: DROP INDEX zigzag@c_idx; CREATE INDEX ON zigzag (c) STORING (b, d);
+   SQL commands: CREATE INDEX ON zigzag (c) STORING (b, d); DROP INDEX zigzag@c_idx;
 
 # Zigzag join nested inside a lookup, with an on condition on lookup join.
 query T
@@ -2282,11 +2274,9 @@ vectorized: true
       right columns: (c)
       right fixed values: 1 column
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX zigzag@b_idx; CREATE INDEX ON zigzag (b) STORING (c, d);
-2. type: index replacement
-   SQL commands: DROP INDEX zigzag@c_idx; CREATE INDEX ON zigzag (c) STORING (b, d);
+   SQL commands: CREATE INDEX ON zigzag (c) STORING (b, d); DROP INDEX zigzag@c_idx;
 
 
 # Regression test for part of #34695.
@@ -2318,12 +2308,6 @@ vectorized: true
           missing stats
           table: zigzag2@a_b_idx
           spans: [/1/2 - /1/2]
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON zigzag2 (a) STORING (b, c, d);
-2. type: index creation
-   SQL command: CREATE INDEX ON zigzag2 (b) STORING (a, c, d);
 
 # Test that we can force a merge join.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -37,7 +37,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@t_v_idx; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@t_v_idx;
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
@@ -267,7 +267,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@t_v_idx; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@t_v_idx;
 
 query T
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
@@ -295,7 +295,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@t_v_idx; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@t_v_idx;
 
 query T
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v
@@ -491,10 +491,6 @@ vectorized: true
           table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
           spans: [/7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
           limit: 5
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON user_checklist_items (date_should_be_completed);
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY v, w LIMIT 5
@@ -558,9 +554,3 @@ vectorized: true
           estimated row count: 100 - 1,001 (100% of the table; stats collected <hidden> ago)
           table: a@a_i_j_idx
           spans: FULL SCAN
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON a (i) STORING (j);
-2. type: index creation
-   SQL command: CREATE INDEX ON b (k) STORING (s);

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -584,7 +584,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX large@bc; CREATE INDEX ON large (b) STORING (c, d);
+   SQL commands: CREATE INDEX ON large (b) STORING (c, d); DROP INDEX large@bc;
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
@@ -713,7 +713,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX large@bc; CREATE INDEX ON large (b) STORING (c, d);
+   SQL commands: CREATE INDEX ON large (b) STORING (c, d); DROP INDEX large@bc;
 
 # Left join with ON filter on covering index
 query T
@@ -901,11 +901,9 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
    SQL command: CREATE INDEX ON t (e) STORING (a, b, d);
-2. type: index creation
-   SQL command: CREATE INDEX ON u (d);
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -941,11 +939,9 @@ vectorized: true
               table: t@t_pkey
               spans: FULL SCAN
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
    SQL command: CREATE INDEX ON t (e) STORING (a, b, d);
-2. type: index creation
-   SQL command: CREATE INDEX ON u (d);
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -1837,11 +1833,11 @@ vectorized: true
 ·
 index recommendations: 3
 1. type: index replacement
-   SQL commands: DROP INDEX lineitem@l_sk; CREATE INDEX ON lineitem (l_suppkey) STORING (l_commitdate, l_receiptdate);
+   SQL commands: CREATE INDEX ON lineitem (l_suppkey) STORING (l_commitdate, l_receiptdate); DROP INDEX lineitem@l_sk;
 2. type: index creation
    SQL command: CREATE INDEX ON nation (n_name);
 3. type: index replacement
-   SQL commands: DROP INDEX supplier@s_nk; CREATE INDEX ON supplier (s_nationkey) STORING (s_name);
+   SQL commands: CREATE INDEX ON supplier (s_nationkey) STORING (s_name); DROP INDEX supplier@s_nk;
 
 # Regression test for #50964.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -138,7 +138,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -172,7 +172,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -208,7 +208,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -242,7 +242,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -273,7 +273,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -303,7 +303,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -339,7 +339,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -373,7 +373,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -409,7 +409,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -443,7 +443,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -479,7 +479,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 query T
 EXPLAIN
@@ -513,7 +513,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 # Test lookup conditions w/ a left join.
 query T
@@ -617,7 +617,7 @@ index recommendations: 2
 1. type: index creation
    SQL command: CREATE INDEX ON metric_values (nullable) STORING (value);
 2. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 # Test NULL values in bounded lookup span.
 query T
@@ -889,7 +889,7 @@ index recommendations: 2
 1. type: index creation
    SQL command: CREATE INDEX ON metric_values (nullable) STORING (value);
 2. type: index replacement
-   SQL commands: DROP INDEX metrics@name_index; CREATE INDEX ON metrics (name) STORING (nullable);
+   SQL commands: CREATE INDEX ON metrics (name) STORING (nullable); DROP INDEX metrics@name_index;
 
 
 # Test NULL values in simple equality condition.

--- a/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
+++ b/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
@@ -41,4 +41,4 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX v@i; CREATE INDEX ON v (y) STORING (x);
+   SQL commands: CREATE INDEX ON v (y) STORING (x); DROP INDEX v@i;

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -366,10 +366,6 @@ vectorized: true
   missing stats
   table: abc@ba
   spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (b, a, c);
 
 # We use the WHERE condition to force the use of the index.
 query T
@@ -566,10 +562,6 @@ vectorized: true
   missing stats
   table: abc@bc
   spans: [/2 - /2]
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (b);
 
 query T
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
@@ -581,10 +573,6 @@ vectorized: true
   missing stats
   table: abc@bc
   spans: [/2 - /2]
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (b);
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query T
@@ -620,10 +608,6 @@ vectorized: true
   estimated row count: 1,000 (missing stats)
   table: bar@i_bar
   spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON bar (baz, id);
 
 statement ok
 CREATE TABLE abcd (
@@ -869,10 +853,6 @@ vectorized: true
   estimated row count: 10 (missing stats)
   table: uvwxyz@ywxz
   spans: /1-/2
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uvwxyz (y) STORING (w, x);
 
 
 statement ok
@@ -1122,10 +1102,6 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: kv@foo
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON kv (v DESC, k);
 
 query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
@@ -1142,10 +1118,6 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: kv@foo
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON kv (v DESC, k);
 
 query T
 EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
@@ -1182,10 +1154,6 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: kv@foo
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON kv (v DESC, k);
 
 # Check the syntax can be used with joins.
 #
@@ -1262,10 +1230,6 @@ vectorized: true
               estimated row count: 1,000 (missing stats)
               table: kv@foo
               spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON kv (v DESC, k);
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -77,10 +77,6 @@ vectorized: true
           missing stats
           table: inv@i (partial index)
           spans: 1 span
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON inv (c) STORING (b);
 
 query T
 EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
@@ -175,7 +171,3 @@ vectorized: true
       missing stats
       table: t70116@a_idx (partial index)
       spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t70116 (b);

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families_nonmetamorphic
@@ -265,10 +265,6 @@ vectorized: true
   missing stats
   table: t@i
   spans: [/2.01/3.001 - /2.01/3.001]
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t (y) STORING (z, v);
 
 # Ensure that we always have a k/v in family 0.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -702,10 +702,6 @@ vectorized: true
   estimated row count: 333 (missing stats)
   table: c@str
   spans: -/"moo"/PrefixEnd
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON c (str);
 
 statement ok
 DROP TABLE c
@@ -1525,10 +1521,6 @@ vectorized: true
       table: xyz@xyz_x_y_z_idx
       spans: LIMITED SCAN
       limit: 10
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON xyz (x, z) STORING (y);
 
 # ------------------------------------------------------
 # Verify that multi-span point lookups are parallelized.
@@ -1644,7 +1636,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX a@p; CREATE INDEX ON a (price) STORING (item);
+   SQL commands: CREATE UNIQUE INDEX ON a (price) STORING (item); DROP INDEX a@p;
 
 query T
 EXPLAIN SELECT * FROM b WHERE (a = 10 AND b = 10) OR (a = 20 AND b = 20)
@@ -1740,10 +1732,6 @@ vectorized: true
   missing stats
   table: b@b_d_key
   spans: [/10 - /10] [/1 - /NULL)
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON b (d);
 
 statement ok
 CREATE UNIQUE INDEX ON b(c, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -529,10 +529,6 @@ vectorized: true
           estimated row count: 333 (missing stats)
           table: t@bc
           spans: /!NULL-/4/1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t (c) STORING (b);
 
 query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE c > 1.0
@@ -604,10 +600,6 @@ vectorized: true
           estimated row count: 333 (missing stats)
           table: t@bc
           spans: /!NULL-/5
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t (c) STORING (b);
 
 query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b < 5.0 AND c < 1
@@ -629,10 +621,6 @@ vectorized: true
           estimated row count: 333 (missing stats)
           table: t@bc
           spans: /!NULL-/4/1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t (b) STORING (c);
 
 query T
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE (b, c) = (5, 1)
@@ -650,10 +638,8 @@ vectorized: true
       table: t@bc
       spans: /5/1-/5/2
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
-   SQL command: CREATE INDEX ON t (b) STORING (c);
-2. type: index creation
    SQL command: CREATE INDEX ON t (c) STORING (b);
 
 query T
@@ -672,10 +658,8 @@ vectorized: true
       table: t@bc
       spans: /5/1-/5/2
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
-   SQL command: CREATE INDEX ON t (b) STORING (c);
-2. type: index creation
    SQL command: CREATE INDEX ON t (c) STORING (b);
 
 query T
@@ -851,10 +835,6 @@ vectorized: true
   table: abz@abz_c_b_key
   spans: LIMITED SCAN
   limit: 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abz (c DESC);
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -1028,10 +1008,6 @@ vectorized: true
   estimated row count: 9 (missing stats)
   table: abcd@abcd
   spans: /NULL/6-/!NULL
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (b) STORING (a, c, d);
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
@@ -1044,10 +1020,6 @@ vectorized: true
   estimated row count: 9 (missing stats)
   table: abcd@abcd
   spans: /NULL/!NULL-/NULL/5
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (b) STORING (a, c, d);
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
@@ -1061,10 +1033,6 @@ vectorized: true
   estimated row count: 10 (missing stats)
   table: abcd@abcd
   spans: /NULL-/!NULL
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (a) STORING (b, c, d);
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
@@ -1078,10 +1046,6 @@ vectorized: true
   estimated row count: 1 (missing stats)
   table: abcd@abcd
   spans: /1/NULL/1-/1/NULL/10
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (a) STORING (b, c, d);
 
 # Regression test for #3548: verify we create constraints on implicit columns
 # when they are part of the key (non-unique index).
@@ -1258,7 +1222,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xy@xy_y_idx; CREATE INDEX ON xy (y) STORING (x);
+   SQL commands: CREATE INDEX ON xy (y) STORING (x); DROP INDEX xy@xy_y_idx;
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
@@ -1280,7 +1244,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xy@xy_y_idx; CREATE INDEX ON xy (y) STORING (x);
+   SQL commands: CREATE INDEX ON xy (y) STORING (x); DROP INDEX xy@xy_y_idx;
 
 query T
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
@@ -1305,7 +1269,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xy@xy_y_idx; CREATE INDEX ON xy (y) STORING (x);
+   SQL commands: CREATE INDEX ON xy (y) STORING (x); DROP INDEX xy@xy_y_idx;
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
@@ -1408,7 +1372,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@b; CREATE INDEX ON noncover (b) STORING (c, d);
+   SQL commands: CREATE INDEX ON noncover (b) STORING (c, d); DROP INDEX noncover@b;
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -1449,7 +1413,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1518,7 +1482,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 AND d = 8
@@ -1560,7 +1524,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 query T
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
@@ -1579,7 +1543,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c OFFSET 5
@@ -1606,7 +1570,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 # TODO(radu): need to prefer the order-matching index when OFFSET is present.
 query T
@@ -1637,7 +1601,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 1000000
@@ -1660,7 +1624,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX noncover@c; CREATE INDEX ON noncover (c) STORING (b, d);
+   SQL commands: CREATE UNIQUE INDEX ON noncover (c) STORING (b, d); DROP INDEX noncover@c;
 
 # ------------------------------------------------------------------------------
 # These tests verify that while we are joining an index with the table, we
@@ -1880,10 +1844,6 @@ vectorized: true
       estimated row count: 3 (3.3% of the table; stats collected <hidden> ago)
       table: t2@bc
       spans: /2-/3
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t2 (b) STORING (s);
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
@@ -1913,7 +1873,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t3@v; CREATE INDEX ON t3 (v) STORING (w);
+   SQL commands: CREATE INDEX ON t3 (v) STORING (w); DROP INDEX t3@v;
 
 # ------------------------------------------------------------------------------
 # These tests are for the point lookup optimization: for single row lookups on

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -141,10 +141,6 @@ vectorized: true
       table: abcd@b
       spans: LIMITED SCAN
       limit: 5
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (b DESC) STORING (c, d);
 
 # Force index b, reverse scan.
 query T
@@ -161,10 +157,6 @@ vectorized: true
       table: abcd@b
       spans: LIMITED SCAN
       limit: 5
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (b DESC) STORING (c, d);
 
 
 # Force index b, forward scan.
@@ -185,10 +177,6 @@ vectorized: true
           missing stats
           table: abcd@b
           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (b DESC) STORING (c, d);
 
 # Force index cd
 query T
@@ -255,10 +243,6 @@ vectorized: true
           missing stats
           table: abcd@b
           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (c) STORING (b);
 
 # No hint, should be using index cd
 query T
@@ -271,10 +255,6 @@ vectorized: true
   missing stats
   table: abcd@cd
   spans: [/20 - /39]
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (c) STORING (d);
 
 # Force primary index
 query T
@@ -308,10 +288,6 @@ vectorized: true
           missing stats
           table: abcd@b
           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcd (c) STORING (d);
 
 query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30

--- a/pkg/sql/opt/exec/execbuilder/testdata/topk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/topk
@@ -51,7 +51,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t@v; CREATE INDEX ON t (v) STORING (w);
+   SQL commands: CREATE INDEX ON t (v) STORING (w); DROP INDEX t@v;
 
 # TopK descending.
 query T
@@ -159,7 +159,3 @@ vectorized: true
           estimated row count: 1,000 (missing stats)
           table: t@v
           spans: FULL SCAN
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON t (v, w);

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -245,12 +245,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkVFruzAUxd__nyLcp_9YRtW-5cl2dSB02mk3NoZINJciOOOSCErxu48qpXOsg26P99ycc35J9qDfS2DgPW_WCz8g_1d-vI0f1pQ8edEyjL0rEntr73ZLOLmLwnvCM_IY-GFwlFuyiI-7tiNhtPIisnwhHChUUmDA31ADewUbEgq1kjlqLdVB2g8HfNECsygUVd2Yg5xQyKVCYHswhSkRGGx5VmKEXKCaWUBBoOFFOcS2ndt2aZt2aSFaoBDXvNKM3ACFsDGMuDYkPQXZmFO8NnyHwOye_g7BniLwzOVZytPscgTnLMKpWSqBCsW007WvIem_4VwV2hRVbmbOV8NZiPkl7xChrmWlcZJ-Ltk6EKLY4XgjLRuV40bJfKgZx3DwDYJAbcatMw5-NayGj_pstv9idn40zydmq0_6fx8BAAD__07uAmE=
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON ab (a);
-2. type: index creation
-   SQL command: CREATE INDEX ON xy (x);
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT a, b FROM ab UNION SELECT x AS a, y AS b FROM xy ORDER BY a
@@ -305,12 +299,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykUV1rpDAUfd9fEe7TLpth1H3LkzM7LgiuzupsaSki0VwGwRqbRFAG_3tRW6ZCp7TTp3DPxz0nyQn0YwUMvNt9sPFD8n3nJ4fkX0DJjRdvo8T7QRIv8H4fCKckJ3_i6C_hOfkf-lFINkHwwnZkk4ySfjyfdV1PonjnxWR7RzhQqKXAkD-gBnYPNqQUGiUL1FqqETpNAl90wCwKZd20ZoRTCoVUCOwEpjQVAoMDzyuMkQtUawsoCDS8rKa1Xe92fdZlfVaKDigkDa81IyugELWGEdemrgPpQEG25pygDT8iMHug17Wwly147vI841l-VQvnYotzuFQCFYplrGv_hHR4o2ooV7JZOwv1pXTrM28Qo25krfGDm1MKKI44X0XLVhW4V7KYYuYxmnwTIFCbmXXmwa8navqk12b7K2bnXfOvhdka0uHbUwAAAP__lnwFDg==
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON ab (a) STORING (b);
-2. type: index creation
-   SQL command: CREATE INDEX ON xy (x) STORING (y);
 
 # TODO(yuzefovich): The synchronizers in the below DistSQL plans are all
 # unordered. This is not a problem, but we shouldn't need an input synchronizer
@@ -369,12 +357,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycUWGLnDAQ_d5fEebTHU059b4FCu71LAjeejVSWopINFMrWGOTCMrify8qx9Zlt-3et8ybeTPvvRzA_GqAQfDlOdqFe3LzGPKUf4oo-RwkDzEPbgkPouBDSgryMYmfiChIuE-DhM_YLope2gPZ8ZeZYSRx8hgk5OErKYBCqyTuxU80wL6BCxmFTqsSjVF6hg7LQCgHYA6Fuu16O8MZhVJpBHYAW9sGgUEqigYTFBL1nQMUJFpRN8vaYfSHMR_yMa_lABR4J1rDyDugEPeWEd-FbKKgentcb6yoEJg70ddJcLcSROGLIi9ycUmCd1GCd1HC8XLfKi1Ro9xczWbmv0bO-HhCXSFHG3d33tZGOnbItp8MFBr8bm989-3te11XP9bnf2R7f022CZpOtQZPDZ7d7MyuUFa4pmRUr0t81qpczqxlvPAWQKKxa9dbi7BdWkvyf5LdK8juKdn7K_l-Q3ambHrzOwAA__8EXx8z
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON ab (b);
-2. type: index creation
-   SQL command: CREATE INDEX ON xy (x);
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT b, a FROM ab INTERSECT ALL SELECT y AS b, x AS a FROM xy ORDER BY b
@@ -548,11 +530,9 @@ vectorized: true
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkm-L2kAQxt_3UwzzSuscukmEsiDsXc3RgE2u0f6jiMTscARsYndXOBC_ezER_MPF1vZNYGfmmeeXZ3eL9tcKJYbfnib3UQydcTSdTT9NCL6E6UMyDbswDSfh-xm8hcc0-QidwzEjWBLkBJqAm1a2zDXD5zhKYjhO5fXgxVQXvn4I0xA6OYxAdOE-HkNHwwi4C0k6DlN4-H6ynyBDwrLSHGc_2aL8gQLnhGtT5WxtZfalbT0Q6ReUA8KiXG_cvjwnzCvDKLfoCrdilDjLlitOOdNs-gMk1OyyYlWvrelU_V0sF_lCL3hR6BcknK6z0kroi7u-h_MdYbVxRwvrsmdGKXb09xiPxcqxYdMX5wxNXYIKYARqiITJxklQgpRPyiMVkBq2Ini3IJwm4d2YxF0rgv9PKfivp9BR_v6NSCmjePbu8FQO0XRbEYJWhKNzZTQb1ue2yuuR8nukgh4p0SM17OF89wr3uLCuKHPXDy4WiPqO_D9c0_CWjFK266q0fObUtnmwp2X9zM3f2mpjcn4yVV7bNMek1tUFzdY1XdEcorJp7QFPxeKqODgTi0uxd1XsX3f2_8c5uCoeXjjPd29-BwAA__-0e5X_
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
    SQL command: CREATE INDEX ON abcde (c, d, e, b);
-2. type: index creation
-   SQL command: CREATE INDEX ON abcde (b) STORING (c, d, e);
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT * FROM (SELECT * FROM abcde UNION ALL SELECT * FROM abcde) WHERE c = 1 AND d = e ORDER BY a
@@ -893,10 +873,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkU-r1DAUxfd-inBXylx5_eMqq6qvQmFsn-0ogpSSJpeh0GlqksLI0O8uTZGZkRlF36Zwz-m555fkBPZ7DxzSr0_bt1nOXj5m1a76tEX2JS3fFVX6ilXpNn2_YwJZi0yyD2XxkYlWKmKf86zIf_mLiUxd-IAwaEW5OJAF_g1CqBFGoyVZq80infwPmToCDxC6YZzcItcIUhsCfgLXuZ6Aw060PZUkFJmHABAUOdH1fq3vSvy3aRvZqIaaTh0BoRrFYDl7DQjF5DhLIkxiTN5APSPoyZ3rrBN7Ah7O-H9I4S2k0XQHYX7cAgnRs9wFie6CnPu1UWRIXTcn4QaTaINJvIF6vkH92FnXDdI9RL8H_4IU_8vdlGRHPVi66ri3OVg4Se1pPZ_Vk5H0ZLT0NetY-JwXFFm3utE6ZIO3_ONdhsPnhKM_huOrcDDX84ufAQAA__8HzgwQ
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcde (b, c, d);
 
 # Use a streaming set operation even though the ordering is not required.
 query T
@@ -924,10 +900,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycUWFrnTAU_b5fEe6nlndHn759CgzsNgeCfXYqYzBEorlzgjUuidDy8L8P46DPYre1XwI595ycc3JPYH51wCH8dhtfR0d28SnK8uxLjOxrmH5IsvCSZWEcfsyZQFYhq9nnNLlhoqolseiYh2k2D_9wZgIyecYBhF5JOoo7MsC_gwcFwqBVTcYoPUMnR4jkPfA9QtsPo53hAqFWmoCfwLa2I-CQi6qjlIQkfbUHBElWtJ171nkF7iyrsi5lSWUr7wEhG0RvOHsLCMloOQt8DA4YvINiQlCjfbQzVjQE3JvwdZG8rUiDbu-EftgK4qHL8mwQ_9kgj_5jr7QkTXLlXczKf1E22tyQbigjmwxX_rpM_jAQP9v3dRwDQkc_7EXg7TDwdxgcdpfvddv8XEP_Xffwkn9PyQyqN_S09ubL-7kryYaWvzNq1DXdalU7m-WaOJ0DJBm7TP3lEvVu5PZxLvZeIPaeiv2_ig8r8X4qpje_AwAA__8uVSl4
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcde (b, c, d);
 
 # Use a streaming set operation even though the ordering is not required.
 query T
@@ -955,10 +927,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0kU-LnEAQxe_5FE2ddpkK65-cGgJuEgOCO25UQiCIqF0xgrFNdwsTBr97sIVMHGYSJpCL0K_qVb2fdQT9vQcO4afn-DHas7t3UZZnH2JkH8P0TZKF9ywL4_BtzmpkDTLB3qfJE6vqRhCL9nmYZkvxMY6v9wHCIAXtq2-kgX8GFwqEUcmGtJZqkY62IRIH4A5CN4yTWeQCoZGKgB_BdKYn4JBXdU8pVYLUgwMIgkzV9Xas3RXYb1mXTSlKKjtxAIRsrAbN2UtASCbDWeBh4GPwCooZQU7mtE6bqiXg7oz_Fsn9b5G8q5FOSaZBKkGKxCZFsTj_1nKB64lUSxmZZHzwtlj5j5H49vqA0NMXcxe4Owy8HQb-7v616tqvW-kXrouW-Cquf8sFUtKjHDSdY1-c7CysJFpa_52Wk2roWcnGrlmfifVZQZA2a9VbH9FgS_Yev5vdG8zuudn7o9nfmJ25mF_8DAAA__94kS4Q
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcde (b, c, d);
 
 # Use a streaming set operation even though the ordering is not required.
 query T
@@ -986,10 +954,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckt9r2zAQx9_3V4h7aumNxD_yYhioaz0IuHUWm1EYxijWLTO4lifJ0BLyvw_blMYh8Za-BHS6jz7fu3gH5k8FAYRPq-h2-ciu7pdJmnyPkP0I11_jJLxmSRiFdynbICuQSfZtHT8wsSkksfDpLlylbw0CmURGBw2AUCtJj-KZDAQ_wYEModGqIGOU7kq7vmEpXyCYI5R109qunCEUShMEO7ClrQgCSMWmojUJSXo2BwRJVpRV_2zv4v1vvsmLXOaUl_IFEJJG1CZgnwEhbm3AuIvcQ-5DtkdQrX3XGSu2BIGzx49Fck5FanT5LPTrqSAOch_54mwQ95Ig96WxZV3YmTtO0Vm6iTurlqRJDua-ds7sfcjs_Y_5rNM_63xXtbUaXhqZso78V8uJ4A-kt5SQjZuZP46evjYUvH3at1EECBX9slfcuUHu3iD3bq6_6HL7e1w6_Gcn97u4ZL9rMo2qDR3PfPLleTcoyS0NizOq1QWttCp6zXCMe64vSDJ2uHWHw7IerrqAh7AzCXvTsDsJ-yPYOYa9C2D3GPYn4cVR7Gz_6W8AAAD__751mqU=
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcde (b, c, d);
 
 # Use a streaming set operation even though the ordering is not required.
 query T
@@ -1017,10 +981,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycktFrnEAQxt_7VyzzlHBTcnp9Wihsmlo4MPF6SgkUkT13agXj2t0VEg7_9-JKyRlM28uLsLPfN_P7xj2C_dUAh-h-F19v79jF522apV9jZN-i_ackjS5ZGsXRTcYksgOykn3ZJ7dMHkpFLLq_iXYZu47jP6JRgUydiACh1Yru5ANZ4N8hgByhM7oka7UZS0cv2KpH4GuEuu16N5ZzhFIbAn4EV7uGgEMmDw3tSSoyV2tAUORk3fi2fpboTP0gzRMgpJ1sLWfvASHpHWciQBGi2EA-IOjePQ-xTlYEPBjwbSDBEoj_FoeiLFRBRa0el5BGHhQfXkUKX0V6JulbbRQZUjOKfHT-S7KQ65ZMRSm5pLsK57Gyp474yQ8HhIZ-uAsRrFCEKxSb1eVHU1c_56X_Xv_mnPXvyXa6tfQy82Ln9RiUVEXT4qzuTUk7o0s_Zjom3ucLiqybbsPpsG39lX8fp-bgDHP40hz-1byZmddDPrz7HQAA___VKCih
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abcde (b, c, d);
 
 # Do not use a streaming set operation for UNION ALL.
 query T
@@ -1080,10 +1040,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyckl9r2zAUxd_3KcR9auktjZ03wcD9o0HArTPbjI5hgizdZAbX8iQZWkK--7BMaV3abdmjztHvnntk78H9aoGDuF-nl6s7dnKzKsria4rsm8ivskKcskKk4rpkGhkh27IveXbLNG2ZuL8W6_LZlshqZGqyZa1Ylt-InF19DyAgdEbTnXwgB_wHRFAh9NYocs7YUdqHCyv9CHyB0HT94Ee5QlDGEvA9-Ma3BBxKWbeUk9RkLxaAoMnLpg1jNW2T3jYP0j4BQtHLznF2DtUBwQz-ZaTzckfAowP-X2w0j5W1SmStNnJTb9Sm0Y-vwxGywXOWRJjEmCw_XCb-cJmXHYbOWE2W9Cy_Gsm_XXmn0S3ZHRXks_4inhcqn3rizx_4Mk0BoaWtP0miM0ziM0yW56efbbP7OZf-uevymIfPyfWmc_S287uTF2NR0juaHs6ZwSpaW6NCzHTMAhcETc5PbjwdVl2wwp_xGo6OgOO3cPxHeDmDF4fq8Ol3AAAA__8P8yLp
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (a, b, c);
 
 # Example where the interesting orderings do not include all columns.
 statement ok
@@ -1194,12 +1150,6 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycklFro0AQx9_vUyzz1NIpiZq-CAemjQcBW3MqR49DwrrO5QTP9XZX6BHy3Q-VXmpobJK37Mz-5vefjVvQf0pwwX9eBfPlE7taLOMk_hog--ZH92HsX7PYD_yHhHFkGZvHLLNef9jsSxQ-Mp4J5j8_-Kvk7VVkYt8Oo4UfsfvvXccChErm9MR_kwb3B1iQItRKCtJaqra07S4s8xdwpwhFVTemLacIQioCdwumMCWBCwnPSoqI56QmU0DIyfCi7MbyTHg8E2u-ztZiXeQvgBDXvNIuuwWEsDEu8yz0bPRsSHcIsjF7kTZ8Q-BaO7wsjHVxGOdoGPucMItCm6ISZmIPk_y3IIQqJ0V5bz6udS7SOqdpRxeeHTXvhU0l-3kDX9qSH115J_4jqQ3FZMJ6MhsukPytyX390OdBAAgl_TRXnnWDnn2DnnN7_VkVm1_D0sl_7t05rxyRrmWl6XDndydP20Up31D_cFo2StBKSdFp-mPYcV0hJ236rt0fllXfagO-ha1R2BmH7VF4NoCtQ9g5A7YP4dkofHcQO919-hcAAP___aifEw==
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (a, b);
-2. type: index creation
-   SQL command: CREATE INDEX ON abc (a, b, c);
 
 query T
 EXPLAIN (DISTSQL,VERBOSE) SELECT a, b AS b1, b AS b2 FROM abc INTERSECT SELECT a, c, b FROM abc ORDER by a, b2
@@ -1231,9 +1181,3 @@ vectorized: true
       spans: FULL SCAN
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJycktFvmzAQxt_3V1j31KquEkz6gjSJdGFSJBo6QNOmCUXGvmVIDDPbSJ2i_O8T0C0FNazJGz5_v_u-O7wH86sED4Ivj-FyvSFXq3WSJp9CSj4H8X2UBNckCcLgQ0o4JTlZJiR3_n4w8jGOHgjPBVlv0iBOWtlRLVrdP0UUr4KY3H_t-jCgUCmJG_4TDXjfwIGMQq2VQGOUbkv7TrCWT-DNKRRV3di2nFEQSiN4e7CFLRE8SHleYoxcop7NgYJEy4uya8tz4fNcbPk234ptIZ-AQlLzynjkFihEjfWI71DfpT6D7EBBNfZoZCzfIXjOgV4WxrksDJsKw84JsyqMLSphZ2yY5NnFbV21RI3yeQ0nbd2LbN032k4NvDjpfDRsKtX3G_hlLfk_ySvxH1DvMEEb1bPFcID0d43ei7e-DEOgUOJ3e-U7N9R3b6jPbq_f62L3Y1ga_d_Ti747Z9ExmlpVBsdjv9p53s6Kcof97oxqtMBHrURn0x-jjusKEo3tb93-sK76qzbgS9iZhNk0zCbhxQB2xrB7BszG8GISvhvFzg7v_gQAAP__Zfug5A==
-·
-index recommendations: 2
-1. type: index creation
-   SQL command: CREATE INDEX ON abc (a, b);
-2. type: index creation
-   SQL command: CREATE INDEX ON abc (a, c, b);

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -853,10 +853,6 @@ vectorized: true
                             └── • scan buffer
                                   columns: (column1, column2, column3, column4, check1)
                                   label: buffer 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_enum (s) STORING (j);
 
 # Test that we use the index when available for the insert checks. This uses
 # the default value for columns r and j.
@@ -1007,10 +1003,6 @@ vectorized: true
                           row 1, expr 1: 'bar'
                           row 1, expr 2: 2
                           row 1, expr 3: 2
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_enum (s, j);
 
 # None of the inserted values have nulls.
 query T
@@ -1521,10 +1513,6 @@ vectorized: true
                           row 1, expr 1: 2
                           row 1, expr 2: 2
                           row 1, expr 3: 'bar'
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_partial_enum (b) STORING (c);
 
 # We can eliminate uniqueness checks for i and s due to functional dependencies.
 # We cannot eliminate checks for d, since functional dependencies could not be
@@ -2392,10 +2380,6 @@ vectorized: true
                               row 0, expr 0: 'us-east'
                               row 1, expr 0: 'us-west'
                               row 2, expr 0: 'eu-west'
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_enum (j, i) STORING (s);
 
 # None of the updated values have nulls.
 query T
@@ -2696,11 +2680,9 @@ vectorized: true
                                       columns: (r, a, b, b_new, partial_index_put1, partial_index_put1, c)
                                       label: buffer 1
 ·
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
    SQL command: CREATE INDEX ON uniq_partial_enum (a) STORING (b, c);
-2. type: index creation
-   SQL command: CREATE INDEX ON uniq_partial_enum (b) STORING (c);
 
 # By default, we do not require checks on UUID columns set to gen_random_uuid(),
 # but we do for UUID columns set to other values.
@@ -3166,7 +3148,7 @@ index recommendations: 2
 1. type: index creation
    SQL command: CREATE INDEX ON other (v) STORING (k);
 2. type: index replacement
-   SQL commands: DROP INDEX uniq@uniq_v_key; CREATE INDEX ON uniq (v) STORING (w, x, y);
+   SQL commands: CREATE UNIQUE INDEX ON uniq (v) STORING (w, x, y); DROP INDEX uniq@uniq_v_key;
 
 # On conflict do update with constant input, conflict on UNIQUE WITHOUT INDEX
 # column.
@@ -3692,10 +3674,6 @@ vectorized: true
                             └── • scan buffer
                                   columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
                                   label: buffer 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_enum (s) STORING (j);
 
 # Test that we use the index when available for the ON CONFLICT checks.
 query T
@@ -3808,10 +3786,6 @@ vectorized: true
                             └── • scan buffer
                                   columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r)
                                   label: buffer 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_enum (s, j);
 
 # None of the upserted values have nulls.
 query T
@@ -4375,10 +4349,6 @@ vectorized: true
                                 └── • scan buffer
                                       columns: (column1, column2, column3, column4, r, a, b, c, column3, column4, r, check1, partial_index_put1, partial_index_del1, upsert_r, upsert_a)
                                       label: buffer 1
-·
-index recommendations: 1
-1. type: index creation
-   SQL command: CREATE INDEX ON uniq_partial_enum (b) STORING (c);
 
 # Test that we use the partial index when available for de-duplicating INSERT ON
 # CONFLICT DO UPDATE rows before inserting.

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -238,7 +238,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xyz@y_idx; CREATE INDEX ON xyz (y) STORING (z);
+   SQL commands: CREATE INDEX ON xyz (y) STORING (z); DROP INDEX xyz@y_idx;
 
 # With the hint, we use a constrained scan.
 query T
@@ -277,7 +277,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX xyz@y_idx; CREATE INDEX ON xyz (y) STORING (z);
+   SQL commands: CREATE INDEX ON xyz (y) STORING (z); DROP INDEX xyz@y_idx;
 
 statement ok
 CREATE TABLE pks (
@@ -583,7 +583,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX kv3@kv3_v_idx; CREATE INDEX ON kv3 (v) STORING (meta);
+   SQL commands: CREATE INDEX ON kv3 (v) STORING (meta); DROP INDEX kv3@kv3_v_idx;
 
 query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
@@ -607,7 +607,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX kv3@kv3_v_idx; CREATE INDEX ON kv3 (v) STORING (meta);
+   SQL commands: CREATE INDEX ON kv3 (v) STORING (meta); DROP INDEX kv3@kv3_v_idx;
 
 statement ok
 SET enable_implicit_select_for_update = false
@@ -734,7 +734,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX kv3@kv3_v_idx; CREATE INDEX ON kv3 (v) STORING (meta);
+   SQL commands: CREATE INDEX ON kv3 (v) STORING (meta); DROP INDEX kv3@kv3_v_idx;
 
 query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
@@ -757,7 +757,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX kv3@kv3_v_idx; CREATE INDEX ON kv3 (v) STORING (meta);
+   SQL commands: CREATE INDEX ON kv3 (v) STORING (meta); DROP INDEX kv3@kv3_v_idx;
 
 # Reset for rest of test.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -193,7 +193,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t_idx@t_idx_v_idx; CREATE INDEX ON t_idx (v) STORING (b);
+   SQL commands: CREATE INDEX ON t_idx (v) STORING (b); DROP INDEX t_idx@t_idx_v_idx;
 
 subtest Insert
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -21,12 +21,6 @@ vectorized: true
       right table: t71093@c_idx
       right columns: (c)
       right fixed values: 1 column
-·
-index recommendations: 2
-1. type: index replacement
-   SQL commands: DROP INDEX t71093@a_idx; CREATE INDEX ON t71093 (a) STORING (b, c);
-2. type: index creation
-   SQL command: CREATE INDEX ON t71093 (b) STORING (a, c);
 
 query T
 EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
@@ -44,12 +38,6 @@ vectorized: true
       right table: t71093@c_idx
       right columns: (c, d)
       right fixed values: 1 column
-·
-index recommendations: 2
-1. type: index replacement
-   SQL commands: DROP INDEX t71093@a_idx; CREATE INDEX ON t71093 (a) STORING (b, c, d);
-2. type: index replacement
-   SQL commands: DROP INDEX t71093@c_idx; CREATE INDEX ON t71093 (c) STORING (a, d);
 
 query T
 EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
@@ -67,12 +55,6 @@ vectorized: true
       right table: t71093@c_idx
       right columns: (c, d)
       right fixed values: 1 column
-·
-index recommendations: 2
-1. type: index replacement
-   SQL commands: DROP INDEX t71093@a_idx; CREATE INDEX ON t71093 (a) STORING (b, c, d);
-2. type: index creation
-   SQL command: CREATE INDEX ON t71093 (b) STORING (a, c, d);
 
 # Make sure that the zigzag join is used in the regression test for #71271.
 statement ok
@@ -92,9 +74,3 @@ vectorized: true
   right table: t71271@t71271_d_idx
   right columns: (d)
   right fixed values: 1 column
-·
-index recommendations: 2
-1. type: index replacement
-   SQL commands: DROP INDEX t71271@t71271_c_idx; CREATE INDEX ON t71271 (c) STORING (d);
-2. type: index replacement
-   SQL commands: DROP INDEX t71271@t71271_d_idx; CREATE INDEX ON t71271 (d) STORING (c);

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -35,10 +35,10 @@ func BuildOptAndHypTableMaps(
 	for t, indexes := range indexCandidates {
 		hypIndexes := make([]hypotheticalIndex, 0, len(indexes))
 		var hypTable HypotheticalTable
-		hypTable.init(t, hypIndexes)
+		hypTable.init(t)
 
 		for i, index := range indexes {
-			indexOrd := i + 1
+			indexOrd := hypTable.Table.IndexCount() + i
 			var hypIndex hypotheticalIndex
 			hypIndex.init(
 				&hypTable,
@@ -69,9 +69,8 @@ type HypotheticalTable struct {
 
 var _ cat.Table = &HypotheticalTable{}
 
-func (ht *HypotheticalTable) init(table cat.Table, hypIndexes []hypotheticalIndex) {
+func (ht *HypotheticalTable) init(table cat.Table) {
 	ht.Table = table
-	ht.hypotheticalIndexes = hypIndexes
 
 	// Get PK column ordinals.
 	primaryIndex := ht.Index(cat.PrimaryIndex)
@@ -83,9 +82,9 @@ func (ht *HypotheticalTable) init(table cat.Table, hypIndexes []hypotheticalInde
 
 // IndexCount is part of the cat.Table interface.
 func (ht *HypotheticalTable) IndexCount() int {
-	// A HypotheticalTable stores the embedded table's primary index in addition
-	// to its hypothetical indexes.
-	return len(ht.hypotheticalIndexes) + 1
+	// A HypotheticalTable stores the embedded table's existing indexes in
+	// addition to its hypothetical indexes.
+	return ht.Table.IndexCount() + len(ht.hypotheticalIndexes)
 }
 
 // WritableIndexCount is part of the cat.Table interface.
@@ -100,16 +99,18 @@ func (ht *HypotheticalTable) DeletableIndexCount() int {
 
 // Index is part of the cat.Table interface.
 func (ht *HypotheticalTable) Index(i cat.IndexOrdinal) cat.Index {
-	if i == cat.PrimaryIndex {
-		return ht.Table.Index(cat.PrimaryIndex)
+	existingIndexCount := ht.Table.IndexCount()
+	if i < existingIndexCount {
+		return ht.Table.Index(i)
 	}
-	return &ht.hypotheticalIndexes[i-1]
+	return &ht.hypotheticalIndexes[i-existingIndexCount]
 }
 
 // existingRedundantIndex checks whether an index with the same explicit columns
 // as the index argument is present in the HypotheticalTable's embedded table.
-// If so, it returns the first instance of such an existing index. Otherwise, it
-// returns nil.
+// If so, it returns the first instance of such an existing index (that is not a
+// partial index). Existing partial indexes and hypothetical standard indexes
+// are not considered redundant. Otherwise, the function returns nil.
 func (ht *HypotheticalTable) existingRedundantIndex(index *hypotheticalIndex) cat.Index {
 	for i, n := 0, ht.Table.IndexCount(); i < n; i++ {
 		indexCols := index.cols
@@ -125,7 +126,8 @@ func (ht *HypotheticalTable) existingRedundantIndex(index *hypotheticalIndex) ca
 				break
 			}
 		}
-		if indexExists {
+		_, isPartialIndex := existingIndex.Predicate()
+		if indexExists && !isPartialIndex {
 			return existingIndex
 		}
 	}

--- a/pkg/sql/opt/indexrec/hypothetical_table_test.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table_test.go
@@ -29,9 +29,9 @@ func TestBuildOptAndHypTableMaps(t *testing.T) {
 	}
 
 	// A hypothetical table's index count is equivalent to its number of index
-	// candidates plus 1 for the primary index.
-	indexCountTable1 := len(indexCandidates[table1]) + 1
-	indexCountTable2 := len(indexCandidates[table2]) + 1
+	// candidates plus the number of existing indexes.
+	indexCountTable1 := len(indexCandidates[table1]) + table1.IndexCount()
+	indexCountTable2 := len(indexCandidates[table2]) + table2.IndexCount()
 
 	if hypTables[1].IndexCount() != indexCountTable1 {
 		t.Errorf(

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -11,7 +11,7 @@ CREATE TABLE t3 (k INT, i INT, f FLOAT)
 ----
 
 exec-ddl
-CREATE TABLE t4 (k INT, f FLOAT, j JSONB, a INT[])
+CREATE TABLE t4 (k INT, i INT, f FLOAT, j JSONB, a INT[])
 ----
 
 # Ensure that columns that require inverted indexes do not have candidates. This
@@ -47,7 +47,7 @@ CREATE INDEX existing_t1_k ON t1(k) STORING (s)
 ----
 
 exec-ddl
-CREATE INDEX existing_t1_i ON t1(i)
+CREATE UNIQUE INDEX existing_t1_i ON t1(i)
 ----
 
 exec-ddl
@@ -61,10 +61,11 @@ SELECT i FROM t1 WHERE i >= 3
 No index recommendations.
 --
 Optimal Plan.
-scan t1@_hyp_1
+scan t1@existing_t1_i
  ├── columns: i:2!null
- ├── constraint: /2/5: [/3 - ]
- └── cost: 367.353333
+ ├── constraint: /2: [/3 - ]
+ ├── cost: 354.263333
+ └── key: (2)
 
 # No recommendations because an index with the same explicit columns exists
 # already, and no new columns are being stored.
@@ -74,10 +75,10 @@ SELECT k FROM t1 WHERE k >= 3
 No index recommendations.
 --
 Optimal Plan.
-scan t1@_hyp_1
+scan t1@existing_t1_k
  ├── columns: k:1!null
  ├── constraint: /1/5: [/3 - ]
- └── cost: 367.353333
+ └── cost: 360.686667
 
 # There is a replacement recommendation because an index with the same explicit
 # columns exists already and new columns are being stored here. We stored the
@@ -87,42 +88,48 @@ SELECT i FROM t1 WHERE k >= 3
 ----
 index recommendations: 1
 1. type: index replacement
-   SQL commands: DROP INDEX t1@existing_t1_k; CREATE INDEX ON t1 (k) STORING (i, s);
+   SQL commands: CREATE INDEX ON t1 (k) STORING (i, s); DROP INDEX t1@existing_t1_k;
 --
 Optimal Plan.
 project
  ├── columns: i:2
  ├── cost: 374.04
- └── scan t1@_hyp_1
+ └── scan t1@_hyp_3
       ├── columns: k:1!null i:2
       ├── constraint: /1/5: [/3 - ]
-      └── cost: 370.686667
+      ├── cost: 370.686667
+      ├── lax-key: (1,2)
+      └── fd: (2)~~>(1)
 
+# Replacement recommendations for existing unique indexes must also create
+# unique indexes.
 index-recommendations
 SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE t1.i > 3 AND t2.i > 3
 ----
 index recommendations: 2
 1. type: index replacement
-   SQL commands: DROP INDEX t1@existing_t1_i; CREATE INDEX ON t1 (i) STORING (k);
+   SQL commands: CREATE UNIQUE INDEX ON t1 (i) STORING (k); DROP INDEX t1@existing_t1_i;
 2. type: index creation
    SQL command: CREATE INDEX ON t2 (i) STORING (k);
 --
 Optimal Plan.
 project
  ├── columns: k:1!null
- ├── cost: 770.258392
+ ├── cost: 766.796132
  └── inner-join (hash)
       ├── columns: t1.k:1!null t1.i:2!null t2.k:8!null t2.i:9!null
-      ├── cost: 759.15621
-      ├── fd: (1)==(8), (8)==(1)
-      ├── scan t1@_hyp_2
-      │    ├── columns: t1.k:1 t1.i:2!null
-      │    ├── constraint: /2/5: [/4 - ]
-      │    └── cost: 370.686667
-      ├── scan t2@_hyp_2
+      ├── cost: 755.793689
+      ├── fd: (2)-->(1), (1)==(8), (8)==(1)
+      ├── scan t2@_hyp_3
       │    ├── columns: t2.k:8 t2.i:9!null
       │    ├── constraint: /9/11: [/4 - ]
       │    └── cost: 367.353333
+      ├── scan t1@_hyp_4
+      │    ├── columns: t1.k:1 t1.i:2!null
+      │    ├── constraint: /2/5: [/4 - ]
+      │    ├── cost: 367.476667
+      │    ├── lax-key: (1,2)
+      │    └── fd: (2)-->(1)
       └── filters
            └── t1.k:1 = t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
@@ -1187,3 +1194,128 @@ union
       ├── columns: i:9 t1.f:10
       ├── cost: 1094.72
       └── ordering: +9,+10
+
+# Ensure that index recommendations are not made if there is an existing
+# inverted, partial, or expression index that can be used to create an
+# equivalent or better plan.
+
+# 1. Inverted index case:
+
+exec-ddl
+CREATE INVERTED INDEX inverted ON t4 (k, j)
+----
+
+index-recommendations
+SELECT k, j FROM t4 WHERE k = 1 AND j->'a' = '1'
+----
+No index recommendations.
+--
+Optimal Plan.
+index-join t4
+ ├── columns: k:1!null j:4
+ ├── immutable
+ ├── cost: 21.9622222
+ ├── fd: ()-->(1)
+ └── scan t4@inverted
+      ├── columns: rowid:6!null
+      ├── constraint: /1: [/1 - /1]
+      ├── inverted constraint: /9/6
+      │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
+      ├── cost: 15.1755556
+      └── key: (6)
+
+exec-ddl
+DROP INDEX t4@inverted
+----
+
+# 2. Partial index case:
+
+exec-ddl
+CREATE INDEX partial_idx ON t4 (i) WHERE k > 1;
+----
+
+index-recommendations
+SELECT i FROM t4 WHERE i = 1 AND k > 1;
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: i:2!null
+ ├── cost: 23.84
+ ├── fd: ()-->(2)
+ └── scan t4@partial_idx,partial
+      ├── columns: i:2!null rowid:6!null
+      ├── constraint: /2/6: [/1 - /1]
+      ├── cost: 23.7266667
+      ├── key: (6)
+      └── fd: ()-->(2)
+
+# Ensure that we don't recommend replacing partial indexes or partial unique
+# indexes.
+
+index-recommendations
+SELECT i FROM t4 WHERE i > 5
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t4 (i);
+--
+Optimal Plan.
+scan t4@_hyp_2
+ ├── columns: i:2!null
+ ├── constraint: /2/6: [/6 - ]
+ └── cost: 374.02
+
+exec-ddl
+CREATE UNIQUE INDEX partial_unique_idx ON t4 (f) WHERE i > 1;
+----
+
+index-recommendations
+SELECT i, f FROM t4 WHERE f > 5
+----
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t4 (f) STORING (i);
+--
+Optimal Plan.
+scan t4@_hyp_3
+ ├── columns: i:2 f:3!null
+ ├── constraint: /3/6: [/5.000000000000001 - ]
+ └── cost: 377.353333
+
+exec-ddl
+DROP INDEX t4@partial_idx
+----
+
+exec-ddl
+DROP INDEX t4@partial_unique_idx
+----
+
+# 3. Expression index case:
+
+exec-ddl
+CREATE INDEX expr ON t1 (k, lower(s))
+----
+
+index-recommendations
+SELECT k FROM t1 WHERE lower(s) = 'cockroach' AND k = 1
+----
+No index recommendations.
+--
+Optimal Plan.
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── cost: 15.0296847
+ ├── fd: ()-->(1)
+ └── scan t1@expr
+      ├── columns: k:1!null rowid:5!null
+      ├── constraint: /1/8/5: [/1/'cockroach' - /1/'cockroach']
+      ├── cost: 14.9763514
+      ├── key: (5)
+      └── fd: ()-->(1)
+
+exec-ddl
+DROP INDEX t1@expr
+----


### PR DESCRIPTION
Previously, we had replacement recommendations for UNIQUE indexes that
would recommend non-unique indexes. This was fixed to preserve the uniqueness
property when making replacement recommendations.

Also, previously, we didn't consider existing indexes in our hypothetical
tables. This meant that if there were existing partial indexes, expression
indexes, or inverted indexes that would benefit the query, they wouldn't be
considered when optimizing with hypothetical tables. This led to unnecessary
index recommendations being made, which if applied, would not actually be
used in the best plan.

Additionally, for robustness, the order of the SQL commands in replacement
recommendations has been swapped. Previously, we dropped the existing index
and then created the new index, but now we do the opposite.

Finally, we previously made replacement recommendations for partial indexes,
which was not desired behaviour as they would be replaced with a standard
index. These recommendations are now "create" recommendations, to avoid
altering the existing partial index behaviour.

Fixes: #73814, #73816, #73817, #73818.

There is no release note as these bugs are not present in any release.

Release note: None