### PR TITLE
jobs: add error type to request pause

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1607,8 +1607,9 @@ func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error 
 			const errorFmt = "job failed with error (%v) but is being paused due to the %s=%s setting"
 			log.Warningf(ctx, errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn)
 
-			return r.execCfg.JobRegistry.PauseRequested(ctx, nil, r.job.ID(),
-				fmt.Sprintf(errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn))
+			return jobs.MarkPauseRequestError(errors.Wrapf(err,
+				"pausing job due to the %s=%s setting",
+				restoreOptDebugPauseOn, details.DebugPauseOn))
 		}
 		return err
 	}

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -48,6 +48,17 @@ func IsPermanentJobError(err error) bool {
 	return errors.Is(err, errJobPermanentSentinel)
 }
 
+// errPauseSelfSentinel exists so the errors returned from PauseRequestErr can
+// be marked with it.
+var errPauseSelfSentinel = errors.New("job requested it be paused")
+
+// MarkPauseRequestError marks an error as a pause request job error, which
+// indicates to the Registry that the job would like to be paused rather than
+// failing.
+func MarkPauseRequestError(reason error) error {
+	return errors.Mark(reason, errPauseSelfSentinel)
+}
+
 // InvalidStatusError is the error returned when the desired operation is
 // invalid given the job's current status.
 type InvalidStatusError struct {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1221,6 +1221,10 @@ func (r *Registry) stepThroughStateMachine(
 			jm.ResumeRetryError.Inc(1)
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
+
+		if errors.Is(err, errPauseSelfSentinel) {
+			return r.PauseRequested(ctx, nil, job.ID(), err.Error())
+		}
 		// TODO(spaskob): enforce a limit on retries.
 
 		if nonCancelableRetry := job.Payload().Noncancelable && !IsPermanentJobError(err); nonCancelableRetry ||


### PR DESCRIPTION
This adds a new function to the jobs library that can be used to construct
an error that, when returned by a resumer, indicates to the registry that
that execution did not finish successfully but, rather than be considered
a failure, the job would like to be paused, with the error text as the
reason.

This pattern has started to occur locally in individual job resumers, with
both RESTORE and CDC adding some form of pause-self behaviors when they
want to wait for operator intervention, and seems like it could be useful
for writing some types of mid-job tests as well, so a small helper like this
in the registry could streamline future uses of the pattern.

The existing RESTORE usage is migrated to the new helper here as well.

Release note: none.