### PR TITLE
 jobs: add Registry.CheckPausepoint/SetPausepoints helpers

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1607,8 +1607,9 @@ func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error 
 			const errorFmt = "job failed with error (%v) but is being paused due to the %s=%s setting"
 			log.Warningf(ctx, errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn)
 
-			return r.execCfg.JobRegistry.PauseRequested(ctx, nil, r.job.ID(),
-				fmt.Sprintf(errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn))
+			return jobs.MarkPauseRequestError(errors.Wrapf(err,
+				"pausing job due to the %s=%s setting",
+				restoreOptDebugPauseOn, details.DebugPauseOn))
 		}
 		return err
 	}

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -31,6 +31,7 @@ const (
 	retryMaxDelaySettingKey        = "jobs.registry.retry.max_delay"
 	executionErrorsMaxEntriesKey   = "jobs.execution_errors.max_entries"
 	executionErrorsMaxEntrySizeKey = "jobs.execution_errors.max_entry_size"
+	debugPausePointsSettingKey     = "jobs.debug.pausepoints"
 )
 
 const (
@@ -147,6 +148,12 @@ var (
 			" for introspection",
 		defaultExecutionErrorsMaxEntrySize,
 		settings.NonNegativeInt,
+	)
+
+	debugPausepoints = settings.RegisterStringSetting(
+		debugPausePointsSettingKey,
+		"the list, comma separated, of named pausepoints currently enabled for debugging",
+		"",
 	)
 )
 

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -48,6 +48,17 @@ func IsPermanentJobError(err error) bool {
 	return errors.Is(err, errJobPermanentSentinel)
 }
 
+// errPauseSelfSentinel exists so the errors returned from PauseRequestErr can
+// be marked with it.
+var errPauseSelfSentinel = errors.New("job requested it be paused")
+
+// MarkPauseRequestError marks an error as a pause request job error, which
+// indicates to the Registry that the job would like to be paused rather than
+// failing.
+func MarkPauseRequestError(reason error) error {
+	return errors.Mark(reason, errPauseSelfSentinel)
+}
+
 // InvalidStatusError is the error returned when the desired operation is
 // invalid given the job's current status.
 type InvalidStatusError struct {

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -3350,3 +3350,65 @@ func TestJobsRetry(t *testing.T) {
 		rts.check(t, jobs.StatusFailed)
 	})
 }
+
+func TestPausepoints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	registry := s.JobRegistry().(*jobs.Registry)
+	defer s.Stopper().Stop(ctx)
+
+	jobs.RegisterConstructor(jobspb.TypeImport, func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+		return jobs.FakeResumer{
+			OnResume: func(ctx context.Context) error {
+				if err := registry.CheckPausepoint("test_pause_foo"); err != nil {
+					return err
+				}
+				return nil
+			},
+		}
+	})
+
+	rec := jobs.Record{
+		DescriptorIDs: []descpb.ID{1},
+		Details:       jobspb.ImportDetails{},
+		Progress:      jobspb.ImportProgress{},
+	}
+
+	for _, tc := range []struct {
+		name     string
+		points   string
+		expected jobs.Status
+	}{
+		{"none", "", jobs.StatusSucceeded},
+		{"pausepoint-only", "test_pause_foo", jobs.StatusPaused},
+		{"other-var-only", "test_pause_bar", jobs.StatusSucceeded},
+		{"pausepoint-and-other", "test_pause_bar,test_pause_foo,test_pause_baz", jobs.StatusPaused},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := sqlDB.Exec("SET CLUSTER SETTING jobs.debug.pausepoints = $1", tc.points)
+			require.NoError(t, err)
+
+			jobID := registry.MakeJobID()
+			var sj *jobs.StartableJob
+			require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+				return registry.CreateStartableJobWithTxn(ctx, &sj, jobID, txn, rec)
+			}))
+			require.NoError(t, sj.Start(ctx))
+			require.NoError(t, sj.AwaitCompletion(ctx))
+			status, err := sj.CurrentStatus(ctx, nil)
+			// Map pause-requested to paused to avoid races.
+			if status == jobs.StatusPauseRequested {
+				status = jobs.StatusPaused
+			}
+			require.Equal(t, tc.expected, status)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1221,6 +1221,10 @@ func (r *Registry) stepThroughStateMachine(
 			jm.ResumeRetryError.Inc(1)
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
+
+		if errors.Is(err, errPauseSelfSentinel) {
+			return r.PauseRequested(ctx, nil, job.ID(), err.Error())
+		}
 		// TODO(spaskob): enforce a limit on retries.
 
 		if nonCancelableRetry := job.Payload().Noncancelable && !IsPermanentJobError(err); nonCancelableRetry ||


### PR DESCRIPTION

This new Registry.CheckPausepoint helper can be called in the middle of
the implementation of some job, for example between particular phases or
after updating persisted state, with names for those points in the job
execution. These then function somewhat like breakpoints: When called,
it will return a PauseRequest error if that named point has been enabled
pausing the job at that point to allow inspection, alteration, etc.

This is in some ways similar to TestingKnobs structs used in many cases
like this, but has a key difference which is that these can be enabled
in any binary, including a real one, while TestingKnobs require being
manually setup in a specially crafted Go unit test and passed to the
TestServer. Being usable in any binary is expected to make these easier
to use in demos, roachtests, SQL-driven logic tests or even when trying
to diagnose or fix a real production deployment.

Release note: none.