### PR TITLE
roachprod: add get-providers command

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	// Do not populate providerOptsContainer here as we need to call initProviders() first.
+	// Do not populate providerOptsContainer here as we need to call InitProivders() first.
 	providerOptsContainer vm.ProviderOptionsContainer
 	pprofOpts             roachprod.PprofOpts
 	numNodes              int

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -856,8 +856,20 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var getProvidersCmd = &cobra.Command{
+	Use:   `get-providers`,
+	Short: `print providers state (active/inactive)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		providers := roachprod.InitProviders()
+		for provider, state := range providers {
+			fmt.Printf("%s: %s\n", provider, state)
+		}
+		return nil
+	},
+}
+
 func main() {
-	roachprod.InitProviders()
+	_ = roachprod.InitProviders()
 	providerOptsContainer = vm.CreateProviderOptionsContainer()
 	// The commands are displayed in the order they are added to rootCmd. Note
 	// that gcCmd and adminurlCmd contain a trailing \n in their Short help in
@@ -897,6 +909,7 @@ func main() {
 		pprofCmd,
 		cachedHostsCmd,
 		versionCmd,
+		getProvidersCmd,
 	)
 	setBashCompletionFunction()
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -54,7 +54,7 @@ import (
 )
 
 func init() {
-	roachprod.InitProviders()
+	_ = roachprod.InitProviders()
 }
 
 var (

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1184,11 +1184,34 @@ func StageURL(applicationName, version, stageOS string) ([]*url.URL, error) {
 	return urls, nil
 }
 
-// InitProviders initializes the vm.Providers.
-func InitProviders() {
-	// Initialize providers.
-	aws.Init()
-	gce.Init()
-	azure.Init()
-	local.Init(localVMStorage{})
+// InitProviders initializes providers and returns a map that indicates
+// if a provider is active or inactive.
+func InitProviders() map[string]string {
+	providersState := make(map[string]string)
+
+	if err := aws.Init(); err != nil {
+		providersState[aws.ProviderName] = "Inactive - " + err.Error()
+	} else {
+		providersState[aws.ProviderName] = "Active"
+	}
+
+	if err := gce.Init(); err != nil {
+		providersState[gce.ProviderName] = "Inactive - " + err.Error()
+	} else {
+		providersState[gce.ProviderName] = "Active"
+	}
+
+	if err := azure.Init(); err != nil {
+		providersState[azure.ProviderName] = "Inactive - " + err.Error()
+	} else {
+		providersState[azure.ProviderName] = "Active"
+	}
+
+	if err := local.Init(localVMStorage{}); err != nil {
+		providersState[local.ProviderName] = "Inactive - " + err.Error()
+	} else {
+		providersState[local.ProviderName] = "Active"
+	}
+
+	return providersState
 }

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -43,7 +43,7 @@ var providerInstance = &Provider{}
 // Init initializes the AWS provider and registers it into vm.Providers.
 //
 // If the aws tool is not available on the local path, the provider is a stub.
-func Init() {
+func Init() error {
 	// aws-cli version 1 automatically base64 encodes the string passed as --public-key-material.
 	// Version 2 supports file:// and fileb:// prefixes for text and binary files.
 	// The latter prefix will base64-encode the file contents. See
@@ -70,7 +70,7 @@ func Init() {
 	}
 	if !haveRequiredVersion() {
 		vm.Providers[ProviderName] = flagstub.New(&Provider{}, unimplemented)
-		return
+		return errors.New("doesn't have the required version")
 	}
 
 	// NB: This is a bit hacky, but using something like `aws iam get-user` is
@@ -87,9 +87,10 @@ func Init() {
 	}
 	if !haveCredentials() {
 		vm.Providers[ProviderName] = flagstub.New(&Provider{}, noCredentials)
-		return
+		return errors.New("missing/invalid credentials")
 	}
 	vm.Providers[ProviderName] = providerInstance
+	return nil
 }
 
 // ebsDisk represent EBS disk device.

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -51,7 +51,7 @@ var providerInstance = &Provider{}
 // Init registers the Azure provider with vm.Providers.
 //
 // If the Azure CLI utilities are not installed, the provider is a stub.
-func Init() {
+func Init() error {
 	const unimplemented = "please install the Azure CLI utilities +" +
 		"(https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)"
 
@@ -60,9 +60,10 @@ func Init() {
 	providerInstance.SyncDelete = false
 	if _, err := providerInstance.getAuthToken(); err != nil {
 		vm.Providers[ProviderName] = flagstub.New(&Provider{}, unimplemented)
-		return
+		return err
 	}
 	vm.Providers[ProviderName] = providerInstance
+	return nil
 }
 
 // Provider implements the vm.Provider interface for the Microsoft Azure

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -51,7 +51,7 @@ var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
 //
 // If the gcloud tool is not available on the local path, the provider is a
 // stub.
-func Init() {
+func Init() error {
 	providerInstance.Projects = []string{defaultProject}
 	projectFromEnv := os.Getenv("GCE_PROJECT")
 	if projectFromEnv != "" {
@@ -61,9 +61,10 @@ func Init() {
 	if _, err := exec.LookPath("gcloud"); err != nil {
 		vm.Providers[ProviderName] = flagstub.New(&Provider{}, "please install the gcloud CLI utilities "+
 			"(https://cloud.google.com/sdk/downloads)")
-		return
+		return errors.New("gcloud not found")
 	}
 	vm.Providers[ProviderName] = providerInstance
+	return nil
 }
 
 func runJSONCommand(args []string, parsed interface{}) error {

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -53,11 +53,12 @@ func VMDir(clusterName string, nodeIdx int) string {
 }
 
 // Init initializes the Local provider and registers it into vm.Providers.
-func Init(storage VMStorage) {
+func Init(storage VMStorage) error {
 	vm.Providers[ProviderName] = &Provider{
 		clusters: make(cloud.Clusters),
 		storage:  storage,
 	}
+	return nil
 }
 
 // AddCluster adds the metadata of a local cluster; used when loading the saved


### PR DESCRIPTION
This patch adds a new command called get-providers
which prints providers and the state of each
provider (active/inactive).

Release note: None