### PR TITLE
bazel: reduce work done by bazel-generate.sh

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -2,14 +2,60 @@
 
 set -euo pipefail
 
+# files_unchanged_from_upstream takes file globs as arguments and checks
+# whether all these files are unchanged from the upstream master branch.
+# It is best effort.
+# This optimization can be disabled by setting env var
+# COCKROACH_BAZEL_FORCE_GENERATE=1.
+files_unchanged_from_upstream () {
+  if [ "${COCKROACH_BAZEL_FORCE_GENERATE:-}" = 1 ]; then
+    return 1
+  fi
+  
+  if ! which git >/dev/null; then
+    return 1
+  fi
+
+  # First, figure out the correct remote.
+  UPSTREAM=$(git remote -v | grep 'github.com[/:]cockroachdb/cockroach.*(fetch)' | awk '{print $1}') || return 1
+  if [ -z "$UPSTREAM" ]; then
+    return 1
+  fi
+
+  # Find the upstream commit which this branch is based on.
+  BASE=$(git merge-base $UPSTREAM/master HEAD 2>/dev/null) || return 1
+  if [ -z "$BASE" ]; then
+    return 1
+  fi
+
+  # Check if the files are unchanged.
+  DIFF=$(git diff --no-ext-diff --name-only $BASE -- "$@") || return 1
+  if [ -z "$DIFF" ]; then
+    # No diffs.
+    return 0
+  fi
+  return 1
+}
+
 # Even with --symlink_prefix, some sub-command somewhere hardcodes the
 # creation of a "bazel-out" symlink. This bazel-out symlink can only
 # be blocked by the existence of a file before the bazel command is
 # invoked. For now, this is left as an exercise for the user.
 
-CONTENTS=$(bazel run //pkg/cmd/mirror)
-echo "$CONTENTS" > DEPS.bzl
-bazel run pkg/cmd/generate-staticcheck --run_under="cd $PWD && "
+if files_unchanged_from_upstream go.mod go.sum DEPS.bzl; then
+  echo "Skipping //pkg/cmd/mirror (relevant files are unchanged from upstream)."
+  echo "Skipping //pkg/cmd/generate-staticcheck (relevant files are unchanged from upstream)."
+else
+  CONTENTS=$(bazel run //pkg/cmd/mirror)
+  echo "$CONTENTS" > DEPS.bzl
+  bazel run pkg/cmd/generate-staticcheck --run_under="cd $PWD && "
+fi
+
 bazel run //:gazelle
-CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")
-echo "$CONTENTS" > pkg/BUILD.bazel
+
+if files_unchanged_from_upstream $(find -name BUILD.bazel) $(find -name '*.bzl'); then
+  echo "Skipping //pkg/cmd/generate-test-suites (relevant files are unchanged from upstream)."
+else
+  CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")
+  echo "$CONTENTS" > pkg/BUILD.bazel
+fi

--- a/build/bazelutil/generate_redact_safe.sh
+++ b/build/bazelutil/generate_redact_safe.sh
@@ -8,9 +8,9 @@ echo "File | Type"; echo "--|--"
 git grep --recurse-submodules -n '^func \(.*\) SafeValue\(\)' | \
     grep -v '^vendor/github.com/cockroachdb/redact' | \
     sed -E -e 's/^([^:]*):[0-9]+:func \(([^ ]* )?(.*)\) SafeValue.*$$/\1 | \`\3\`/g' | \
-    sort
+    LC_ALL=C sort
 git grep --recurse-submodules -n 'redact\.RegisterSafeType' | \
     grep -vE '^([^:]*):[0-9]+:[ 	]*//' | \
     grep -v '^vendor/github.com/cockroachdb/redact' | \
     sed -E -e 's/^([^:]*):[0-9]+:.*redact\.RegisterSafeType\((.*)\).*/\1 | \`\2\`/g' | \
-    sort
+    LC_ALL=C sort

--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -27,7 +27,11 @@ if ! (run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat
     exit 1
 fi
 rm artifacts/buildshort.log
-run run_bazel build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+
+run run_bazel build/bazelutil/bazel-generate.sh \
+  BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_BAZEL_FORCE_GENERATE=1" \
+  &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+
 rm artifacts/buildshort.log
 if grep TODO DEPS.bzl; then
     echo "Missing TODO comment in DEPS.bzl. Did you run \`./dev generate bazel --mirror\`?"


### PR DESCRIPTION
This seems to work for me, perhaps someone else can try it in their environment? I'll also take a look at the log in CI and make sure nothing unexpected happens.

----
#### bazel: reduce work done by bazel-generate.sh

The logic for dev generate bazel/make bazel-generate lives in the
script `build/bazelutil/bazel-generate.sh`.

If `go.mod`, `go.sum`, and `DEPS.bzl` are unchanged relative to
master, `bazel run //pkg/cmd/mirror` and `generate-staticcheck` can be
skipped. Similarly, if all `BUILD.bazel / *.bzl` files are unchanged,
then generate-test-suites can be skipped as well.

This commit adds a function that verifies whether a set of files is
unchanged from the upstream branch and uses it to implement these
improvements. The function is designed to fail silently if git is not
available or other errors are hit.

Fixes #73355.

Release note: None