### PR TITLE
errwrap: include gosdk in bazel deps

### DIFF
--- a/pkg/testutils/lint/passes/errwrap/BUILD.bazel
+++ b/pkg/testutils/lint/passes/errwrap/BUILD.bazel
@@ -19,7 +19,9 @@ go_library(
 go_test(
     name = "errwrap_test",
     srcs = ["errwrap_test.go"],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + [
+        "@go_sdk//:files",
+    ],
     deps = [
         ":errwrap",
         "//pkg/build/bazel",


### PR DESCRIPTION
Release note: none.