### PR TITLE
kvserver: add `addsstable.aswrites` metric

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -242,7 +242,13 @@ func EvalAddSSTable(
 			}
 			sstIter.Next()
 		}
-		return result.Result{}, nil
+		return result.Result{
+			Local: result.LocalResult{
+				Metrics: &result.Metrics{
+					AddSSTableAsWrites: 1,
+				},
+			},
+		}, nil
 	}
 
 	return result.Result{

--- a/pkg/kv/kvserver/batcheval/result/metrics.go
+++ b/pkg/kv/kvserver/batcheval/result/metrics.go
@@ -20,6 +20,7 @@ type Metrics struct {
 	ResolveCommit        int // intent commit evaluated successfully
 	ResolveAbort         int // non-poisoning intent abort evaluated successfully
 	ResolvePoison        int // poisoning intent abort evaluated successfully
+	AddSSTableAsWrites   int // AddSSTable requests with IngestAsWrites set
 }
 
 // Add absorbs the supplied Metrics into the receiver.
@@ -31,4 +32,5 @@ func (mt *Metrics) Add(o Metrics) {
 	mt.ResolveCommit += o.ResolveCommit
 	mt.ResolveAbort += o.ResolveAbort
 	mt.ResolvePoison += o.ResolvePoison
+	mt.AddSSTableAsWrites += o.AddSSTableAsWrites
 }

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -170,7 +170,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	// them everywhere.
 	{
 		act := fmt.Sprintf("%+v", result.Metrics{})
-		exp := "{LeaseRequestSuccess:0 LeaseRequestError:0 LeaseTransferSuccess:0 LeaseTransferError:0 ResolveCommit:0 ResolveAbort:0 ResolvePoison:0}"
+		exp := "{LeaseRequestSuccess:0 LeaseRequestError:0 LeaseTransferSuccess:0 LeaseTransferError:0 ResolveCommit:0 ResolveAbort:0 ResolvePoison:0 AddSSTableAsWrites:0}"
 		if act != exp {
 			t.Errorf("need to update this test due to added fields: %v", act)
 		}

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1155,6 +1155,18 @@ not occurring.
 		Measurement: "Ingestions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAddSSTableAsWrites = metric.Metadata{
+		Name: "addsstable.aswrites",
+		Help: `Number of SSTables ingested as normal writes.
+
+These AddSSTable requests do not count towards the addsstable metrics
+'proposals', 'applications', or 'copies', as they are not ingested as AddSSTable
+Raft commands, but rather normal write commands. However, if these requests get
+throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
+`,
+		Measurement: "Ingestions",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaAddSSTableEvalTotalDelay = metric.Metadata{
 		Name:        "addsstable.delay.total",
 		Help:        "Amount by which evaluation of AddSSTable requests was delayed",
@@ -1418,6 +1430,7 @@ type StoreMetrics struct {
 	AddSSTableProposals           *metric.Counter
 	AddSSTableApplications        *metric.Counter
 	AddSSTableApplicationCopies   *metric.Counter
+	AddSSTableAsWrites            *metric.Counter
 	AddSSTableProposalTotalDelay  *metric.Counter
 	AddSSTableProposalEngineDelay *metric.Counter
 
@@ -1853,6 +1866,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		// AddSSTable proposal + applications counters.
 		AddSSTableProposals:           metric.NewCounter(metaAddSSTableProposals),
 		AddSSTableApplications:        metric.NewCounter(metaAddSSTableApplications),
+		AddSSTableAsWrites:            metric.NewCounter(metaAddSSTableAsWrites),
 		AddSSTableApplicationCopies:   metric.NewCounter(metaAddSSTableApplicationCopies),
 		AddSSTableProposalTotalDelay:  metric.NewCounter(metaAddSSTableEvalTotalDelay),
 		AddSSTableProposalEngineDelay: metric.NewCounter(metaAddSSTableEvalEngineDelay),
@@ -1968,6 +1982,9 @@ func (sm *StoreMetrics) handleMetricsResult(ctx context.Context, metric result.M
 	metric.ResolveAbort = 0
 	sm.ResolvePoisonCount.Inc(int64(metric.ResolvePoison))
 	metric.ResolvePoison = 0
+
+	sm.AddSSTableAsWrites.Inc(int64(metric.AddSSTableAsWrites))
+	metric.AddSSTableAsWrites = 0
 
 	if metric != (result.Metrics{}) {
 		log.Fatalf(ctx, "unhandled fields in metrics result: %+v", metric)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2436,6 +2436,7 @@ var charts = []sectionDescription{
 					"addsstable.copies",
 					"addsstable.applications",
 					"addsstable.proposals",
+					"addsstable.aswrites",
 				},
 			},
 			{


### PR DESCRIPTION
This patch adds a metric `addsstable.aswrites` counting the number of
`AddSSTable` requests applied as write batches due to `IngestAsWrites`.

Release note (ops change): Added a metric `addsstable.aswrites` which
tracks the number of `AddSSTable` requests ingested as regular write
batches.