### PR TITLE
tracing: improve tracer-mixing assertion

### DIFF
--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -118,9 +118,14 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	// Makes sure no values are set when no environment variables are set.
 	cfg := MakeConfig(context.Background(), st)
 	cfgExpected := MakeConfig(context.Background(), st)
-
 	resetEnvVar()
 	cfg.readEnvironmentVariables()
+
+	// Tracers store their stack trace in NewTracer, and this wouldn't match.
+	cfg.Tracer = nil
+	cfg.AmbientCtx.Tracer = nil
+	cfgExpected.Tracer = nil
+	cfgExpected.AmbientCtx.Tracer = nil
 	require.Equal(t, cfgExpected, cfg)
 
 	// Set all the environment variables to valid values and ensure they are set


### PR DESCRIPTION
The panic previously wasn't helpful. Now it's telling us where the two
tracers were created, which should usually enable us to fix things up.

Release note: None
