### PR TITLE
ui: Updated old usage of "Query" on console UI filter drop-down to "Statement" for consistency

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -529,7 +529,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           className={checkbox.input}
         />
         <label htmlFor="full-table-scan-toggle" className={checkbox.label}>
-          Only show statements that contain queries with full table scans
+          Only show statements with full table scans
         </label>
       </div>
     );
@@ -549,7 +549,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
             {showRegions ? regionsFilter : ""}
             {showNodes ? nodesFilter : ""}
             <div className={filterLabel.margin}>
-              Query fingerprint runs longer than
+              Statement fingerprint runs longer than
             </div>
             <section className={timePair.wrapper}>
               <Input


### PR DESCRIPTION
Previously, the text on the filtering drop-down used both "query" and
"statement" to refer to the same thing.  This change removes the old
usage of "query" on the drop-down, replacing it with "statement" for
consistency.

Resolves: #73464

Release note (ui change): updated text of filter drop-down for
consistency