### PR TITLE
ui: update jobs page colors

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/BUILD.bazel
+++ b/pkg/ui/workspaces/cluster-ui/BUILD.bazel
@@ -22,6 +22,7 @@ DEPENDENCIES = [
     "@npm//@cockroachlabs/eslint-config",
     "@npm//@cockroachlabs/icons",
     "@npm//@cockroachlabs/ui-components",
+    "@npm//@cockroachlabs/design-tokens",
     "@npm//@popperjs/core",
     "@npm//@reduxjs/toolkit",
     "@npm//@storybook/addon-actions",

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -44,6 +44,7 @@
     "@cockroachlabs/eslint-config": "^0.1.11",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.20",
+    "@cockroachlabs/design-tokens": "0.4.5",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.5.0",
     "@storybook/addon-actions": "^6.1.21",

--- a/pkg/ui/workspaces/cluster-ui/src/badge/badge.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/badge/badge.module.scss
@@ -1,4 +1,5 @@
 @import '../core/index.module.scss';
+@import "~@cockroachlabs/design-tokens/dist/web/_tokens.scss";
 
 .badge {
   display: flex;
@@ -23,8 +24,8 @@
 }
 
 .badge--status-success {
-  color: $colors--primary-green-3;
-  background-color: $colors--primary-green-1;
+  color: $color-intent-success-4;
+  background-color: $color-intent-success-1;
   border-radius: 3px;
 }
 

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -119,6 +119,7 @@ DEV_DEPENDENCIES = [
 
 DEPENDENCIES = [
     "@npm//@cockroachlabs/icons",
+    "@npm//@cockroachlabs/design-tokens",
     "@npm//analytics-node",
     "@npm//antd",
     "@npm//babel-polyfill",

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -20,6 +20,7 @@
     "@cockroachlabs/cluster-ui": "link:../cluster-ui",
     "@cockroachlabs/crdb-protobuf-client": "link:./src/js",
     "@cockroachlabs/icons": "0.3.0",
+    "@cockroachlabs/design-tokens": "0.4.5",
     "analytics-node": "^3.5.0",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/workspaces/db-console/src/components/badge/badge.module.styl
+++ b/pkg/ui/workspaces/db-console/src/components/badge/badge.module.styl
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 @require '~src/components/core/index.styl'
+@require "~@cockroachlabs/design-tokens/dist/web/tokens";
 
 .badge
   display flex
@@ -32,8 +33,8 @@
   letter-spacing 1.5px
 
 .badge--status-success
-  color $colors--primary-green-3
-  background-color $colors--primary-green-1
+  color $color-intent-success-4
+  background-color $color-intent-success-1
   border-radius 3px
 
 .badge--status-danger

--- a/pkg/ui/workspaces/db-console/src/views/jobs/progressBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/progressBar.tsx
@@ -17,6 +17,7 @@ import Job = cockroach.server.serverpb.IJobResponse;
 import { cockroach } from "src/js/protos";
 import { Badge } from "src/components";
 import { Line } from "rc-progress";
+import { ColorIntentInfo3 } from "@cockroachlabs/design-tokens";
 
 export class JobStatusBadge extends React.PureComponent<{ jobStatus: string }> {
   render() {
@@ -46,7 +47,7 @@ export class ProgressBar extends React.PureComponent<{
           percent={percent}
           strokeWidth={this.props.lineWidth}
           trailWidth={this.props.lineWidth}
-          strokeColor="#0788ff"
+          strokeColor={ColorIntentInfo3}
           trailColor="#d6dbe7"
           className="jobs-table__progress-bar"
         />

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1392,7 +1392,7 @@
     minimist "^1.2.0"
 
 "@cockroachlabs/cluster-ui@link:workspaces/cluster-ui":
-  version "22.1.0-prerelease-1"
+  version "22.1.0-prerelease-3"
   dependencies:
     "@babel/runtime" "^7.12.13"
 
@@ -1402,6 +1402,11 @@
 "@cockroachlabs/crdb-protobuf-client@link:workspaces/db-console/src/js":
   version "0.0.0"
   uid ""
+
+"@cockroachlabs/design-tokens@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/design-tokens/-/design-tokens-0.4.5.tgz#e3792263000c82020a98ed51a912e9c0e397c935"
+  integrity sha512-az2aIuGjnD0UBN5igLmaKvVWnZJ9r7v2jQ9C4fNR6bxxiF5DkOcD1DXf8EXHIbgwJtorpB74zaic7MQhhMY45w==
 
 "@cockroachlabs/eslint-config@^0.1.11":
   version "0.1.11"


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/72674

This commit modifies colors for success badges, and the progress bar in the Jobs
page.

In doing so, it also installs `@cockroachlabs/design-tokens` in cluster-ui and
db-console.

Before: 
<img width="882" alt="image" src="https://user-images.githubusercontent.com/91907326/146408053-b9e0c968-8624-4de6-8426-1533e879dd90.png">

After: 
<img width="897" alt="image" src="https://user-images.githubusercontent.com/91907326/146408201-9bd3a25e-ff31-443a-bb2c-286249df7b8a.png">