### PR TITLE
sql: primary key to allow virtual columns

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -386,6 +386,25 @@ func (p *planner) AlterPrimaryKey(
 				}
 			}
 		}
+
+		// If there is any virtual column of the secondary index not a primary key
+		// column, we should rewrite the index as well because we don't allow
+		// non-primary key virtual column in secondary index's suffix columns, and
+		// this would be violated if we don't rewrite the index.
+		if !idx.Primary() {
+			newPrimaryKeyColIDs := catalog.MakeTableColSet(newPrimaryIndexDesc.KeyColumnIDs...)
+			for i := 0; i < idx.NumKeySuffixColumns(); i++ {
+				colID := idx.GetKeySuffixColumnID(i)
+				col, err := tableDesc.FindColumnWithID(colID)
+				if err != nil {
+					return false, err
+				}
+				if col.IsVirtual() && !newPrimaryKeyColIDs.Contains(colID) {
+					return true, err
+				}
+			}
+		}
+
 		return !idx.IsUnique() || idx.GetType() == descpb.IndexDescriptor_INVERTED, nil
 	}
 	var indexesToRewrite []catalog.Index
@@ -468,6 +487,10 @@ func (p *planner) AlterPrimaryKey(
 		swapArgs.LocalityConfigSwap = &alterPrimaryKeyLocalitySwap.localityConfigSwap
 	}
 	tableDesc.AddPrimaryKeySwapMutation(swapArgs)
+
+	if err := catalog.ValidateSelf(tableDesc); err != nil {
+		return err
+	}
 
 	// Mark the primary key of the table as valid.
 	{
@@ -612,4 +635,34 @@ func shouldCopyPrimaryKey(
 		desc.HasPrimaryKey() &&
 		!desc.IsPrimaryIndexDefaultRowID() &&
 		!idsAndDirsMatch(oldPK, newPK)
+}
+
+// addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given
+// table descriptor, but sets up the index with KeySuffixColumnIDs from the
+// given index, rather than the table's primary key.
+func addIndexMutationWithSpecificPrimaryKey(
+	ctx context.Context,
+	table *tabledesc.Mutable,
+	toAdd *descpb.IndexDescriptor,
+	primary *descpb.IndexDescriptor,
+) error {
+	// Reset the ID so that a call to AllocateIDs will set up the index.
+	toAdd.ID = 0
+	if err := table.AddIndexMutation(toAdd, descpb.DescriptorMutation_ADD); err != nil {
+		return err
+	}
+	if err := table.AllocateIDsWithoutValidation(ctx); err != nil {
+		return err
+	}
+	// Use the columns in the given primary index to construct this indexes
+	// KeySuffixColumnIDs list.
+	presentColIDs := catalog.MakeTableColSet(toAdd.KeyColumnIDs...)
+	presentColIDs.UnionWith(catalog.MakeTableColSet(toAdd.StoreColumnIDs...))
+	toAdd.KeySuffixColumnIDs = nil
+	for _, colID := range primary.KeyColumnIDs {
+		if !presentColIDs.Contains(colID) {
+			toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
+		}
+	}
+	return nil
 }

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1096,36 +1096,6 @@ func (n *alterTableNode) Next(runParams) (bool, error) { return false, nil }
 func (n *alterTableNode) Values() tree.Datums          { return tree.Datums{} }
 func (n *alterTableNode) Close(context.Context)        {}
 
-// addIndexMutationWithSpecificPrimaryKey adds an index mutation into the given
-// table descriptor, but sets up the index with KeySuffixColumnIDs from the
-// given index, rather than the table's primary key.
-func addIndexMutationWithSpecificPrimaryKey(
-	ctx context.Context,
-	table *tabledesc.Mutable,
-	toAdd *descpb.IndexDescriptor,
-	primary *descpb.IndexDescriptor,
-) error {
-	// Reset the ID so that a call to AllocateIDs will set up the index.
-	toAdd.ID = 0
-	if err := table.AddIndexMutation(toAdd, descpb.DescriptorMutation_ADD); err != nil {
-		return err
-	}
-	if err := table.AllocateIDs(ctx); err != nil {
-		return err
-	}
-	// Use the columns in the given primary index to construct this indexes
-	// KeySuffixColumnIDs list.
-	presentColIDs := catalog.MakeTableColSet(toAdd.KeyColumnIDs...)
-	presentColIDs.UnionWith(catalog.MakeTableColSet(toAdd.StoreColumnIDs...))
-	toAdd.KeySuffixColumnIDs = nil
-	for _, colID := range primary.KeyColumnIDs {
-		if !presentColIDs.Contains(colID) {
-			toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
-		}
-	}
-	return nil
-}
-
 // applyColumnMutation applies the mutation specified in `mut` to the given
 // columnDescriptor, and saves the containing table descriptor. If the column's
 // dependencies on sequences change, it updates them as well.

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -623,8 +623,29 @@ func (desc *Mutable) MaybeFillColumnID(
 }
 
 // AllocateIDs allocates column, family, and index ids for any column, family,
-// or index which has an ID of 0.
+// or index which has an ID of 0. It's the same as AllocateIDsWithoutValidation,
+// but does validation on the table elements.
 func (desc *Mutable) AllocateIDs(ctx context.Context) error {
+	if err := desc.AllocateIDsWithoutValidation(ctx); err != nil {
+		return err
+	}
+
+	// This is sort of ugly. If the descriptor does not have an ID, we hack one in
+	// to pass the table ID check. We use a non-reserved ID, reserved ones being set
+	// before AllocateIDs.
+	savedID := desc.ID
+	if desc.ID == 0 {
+		desc.ID = keys.SystemDatabaseID
+	}
+	err := catalog.ValidateSelf(desc)
+	desc.ID = savedID
+
+	return err
+}
+
+// AllocateIDsWithoutValidation allocates column, family, and index ids for any
+// column, family, or index which has an ID of 0.
+func (desc *Mutable) AllocateIDsWithoutValidation(ctx context.Context) error {
 	// Only tables with physical data can have / need a primary key.
 	if desc.IsPhysicalTable() {
 		if err := desc.ensurePrimaryKey(); err != nil {
@@ -654,15 +675,7 @@ func (desc *Mutable) AllocateIDs(ctx context.Context) error {
 		}
 	}
 
-	// This is sort of ugly. If the descriptor does not have an ID, we hack one in
-	// to pass the table ID check.
-	savedID := desc.ID
-	if desc.ID == 0 {
-		desc.ID = keys.SystemDatabaseID
-	}
-	err := catalog.ValidateSelf(desc)
-	desc.ID = savedID
-	return err
+	return nil
 }
 
 func (desc *Mutable) ensurePrimaryKey() error {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1045,31 +1045,286 @@ func TestValidateTableDesc(t *testing.T) {
 					},
 				},
 			}},
-		{`primary index column "v" cannot be virtual`,
+		{`index "sec" cannot store virtual column "c3"`,
 			descpb.TableDescriptor{
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
 				FormatVersion: descpb.InterleavedFormatVersion,
 				Columns: []descpb.ColumnDescriptor{
-					{ID: 1, Name: "bar"},
-					{ID: 2, Name: "v", ComputeExpr: &computedExpr, Virtual: true},
+					{ID: 1, Name: "c1"},
+					{ID: 2, Name: "c2"},
+					{ID: 3, Name: "c3", ComputeExpr: &computedExpr, Virtual: true},
 				},
 				PrimaryIndex: descpb.IndexDescriptor{
-					ID:             1,
-					Name:           "primary",
-					Unique:         true,
-					KeyColumnIDs:   []descpb.ColumnID{1, 2},
-					KeyColumnNames: []string{"bar", "v"},
+					ID:                  1,
+					Name:                "primary",
+					Unique:              true,
+					KeyColumnIDs:        []descpb.ColumnID{1},
+					KeyColumnNames:      []string{"c1"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+					EncodingType:        descpb.PrimaryIndexEncoding,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{ID: 2, Name: "sec", KeyColumnIDs: []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"c2"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						KeySuffixColumnIDs:  []descpb.ColumnID{3},
+					},
 				},
 				Families: []descpb.ColumnFamilyDescriptor{
 					{ID: 0, Name: "primary",
-						ColumnIDs:   []descpb.ColumnID{1},
-						ColumnNames: []string{"bar"},
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"c1", "c2"},
 					},
 				},
-				NextColumnID: 3,
+				NextColumnID: 4,
 				NextFamilyID: 1,
+				NextIndexID:  3,
+			}},
+		{"",
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "c1"},
+					{ID: 2, Name: "c2"},
+					{ID: 3, Name: "c3", ComputeExpr: &computedExpr, Virtual: true},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  1,
+					Name:                "primary",
+					Unique:              true,
+					KeyColumnIDs:        []descpb.ColumnID{1},
+					KeyColumnNames:      []string{"c1"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+					EncodingType:        descpb.PrimaryIndexEncoding,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{ID: 2, Name: "sec", KeyColumnIDs: []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"c2"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						KeySuffixColumnIDs:  []descpb.ColumnID{},
+					},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"c1", "c2"},
+					},
+				},
+				Mutations: []descpb.DescriptorMutation{
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID:                  3,
+								Name:                "new_primary_key",
+								Unique:              true,
+								KeyColumnIDs:        []descpb.ColumnID{3},
+								KeyColumnNames:      []string{"c3"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+								EncodingType:        descpb.PrimaryIndexEncoding,
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID: 4, Name: "new_sec", KeyColumnIDs: []descpb.ColumnID{2},
+								KeyColumnNames:      []string{"c2"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								KeySuffixColumnIDs:  []descpb.ColumnID{3},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{
+							PrimaryKeySwap: &descpb.PrimaryKeySwap{
+								OldPrimaryIndexId: 1,
+								NewPrimaryIndexId: 3,
+								NewIndexes:        []descpb.IndexID{4},
+								OldIndexes:        []descpb.IndexID{2},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+				},
+				NextColumnID: 4,
+				NextFamilyID: 1,
+				NextIndexID:  5,
+				Privileges:   descpb.NewBasePrivilegeDescriptor(security.AdminRoleName()),
+			}},
+		{`index "sec" cannot store virtual column "c3"`,
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "c1"},
+					{ID: 2, Name: "c2"},
+					{ID: 3, Name: "c3", ComputeExpr: &computedExpr, Virtual: true},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  1,
+					Name:                "primary",
+					Unique:              true,
+					KeyColumnIDs:        []descpb.ColumnID{1},
+					KeyColumnNames:      []string{"c1"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+					EncodingType:        descpb.PrimaryIndexEncoding,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{ID: 2, Name: "sec", KeyColumnIDs: []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"c2"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						KeySuffixColumnIDs:  []descpb.ColumnID{3},
+					},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"c1", "c2"},
+					},
+				},
+				Mutations: []descpb.DescriptorMutation{
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID:                  3,
+								Name:                "new_primary_key",
+								Unique:              true,
+								KeyColumnIDs:        []descpb.ColumnID{3},
+								KeyColumnNames:      []string{"c3"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+								EncodingType:        descpb.PrimaryIndexEncoding,
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID: 4, Name: "new_sec", KeyColumnIDs: []descpb.ColumnID{2},
+								KeyColumnNames:      []string{"c2"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								KeySuffixColumnIDs:  []descpb.ColumnID{3},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{
+							PrimaryKeySwap: &descpb.PrimaryKeySwap{
+								OldPrimaryIndexId: 1,
+								NewPrimaryIndexId: 3,
+								NewIndexes:        []descpb.IndexID{4},
+								OldIndexes:        []descpb.IndexID{2},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+				},
+				NextColumnID: 4,
+				NextFamilyID: 1,
+				NextIndexID:  5,
+				Privileges:   descpb.NewBasePrivilegeDescriptor(security.AdminRoleName()),
+			}},
+		{`index "new_sec" cannot store virtual column "c3"`,
+			descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "c1"},
+					{ID: 2, Name: "c2"},
+					{ID: 3, Name: "c3", ComputeExpr: &computedExpr, Virtual: true},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:                  1,
+					Name:                "primary",
+					Unique:              true,
+					KeyColumnIDs:        []descpb.ColumnID{1, 3},
+					KeyColumnNames:      []string{"c1", "c3"},
+					KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
+					Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+					EncodingType:        descpb.PrimaryIndexEncoding,
+				},
+				Indexes: []descpb.IndexDescriptor{
+					{ID: 2, Name: "sec", KeyColumnIDs: []descpb.ColumnID{2},
+						KeyColumnNames:      []string{"c2"},
+						KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+						KeySuffixColumnIDs:  []descpb.ColumnID{1, 3},
+					},
+				},
+				Families: []descpb.ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary",
+						ColumnIDs:   []descpb.ColumnID{1, 2},
+						ColumnNames: []string{"c1", "c2"},
+					},
+				},
+				Mutations: []descpb.DescriptorMutation{
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID:                  3,
+								Name:                "new_primary_key",
+								Unique:              true,
+								KeyColumnIDs:        []descpb.ColumnID{1},
+								KeyColumnNames:      []string{"c1"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								Version:             descpb.PrimaryIndexWithStoredColumnsVersion,
+								EncodingType:        descpb.PrimaryIndexEncoding,
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_Index{
+							Index: &descpb.IndexDescriptor{
+								ID: 4, Name: "new_sec", KeyColumnIDs: []descpb.ColumnID{2},
+								KeyColumnNames:      []string{"c2"},
+								KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC},
+								KeySuffixColumnIDs:  []descpb.ColumnID{1, 3},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+					{
+						Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{
+							PrimaryKeySwap: &descpb.PrimaryKeySwap{
+								OldPrimaryIndexId: 1,
+								NewPrimaryIndexId: 3,
+								NewIndexes:        []descpb.IndexID{4},
+								OldIndexes:        []descpb.IndexID{2},
+							},
+						},
+						Direction: descpb.DescriptorMutation_ADD,
+						State:     descpb.DescriptorMutation_DELETE_ONLY,
+					},
+				},
+				NextColumnID: 4,
+				NextFamilyID: 1,
+				NextIndexID:  5,
+				Privileges:   descpb.NewBasePrivilegeDescriptor(security.AdminRoleName()),
 			}},
 		{`index "sec" cannot store virtual column "v"`,
 			descpb.TableDescriptor{
@@ -1338,9 +1593,12 @@ func TestValidateTableDesc(t *testing.T) {
 		t.Run(d.err, func(t *testing.T) {
 			desc := NewBuilder(&d.desc).BuildImmutableTable()
 			expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), d.err)
-			if err := catalog.ValidateSelf(desc); err == nil {
+			err := catalog.ValidateSelf(desc)
+			if d.err == "" && err != nil {
+				t.Errorf("%d: expected success, but found error: \"%+v\"", i, err)
+			} else if d.err != "" && err == nil {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, d.desc)
-			} else if expectedErr != err.Error() {
+			} else if d.err != "" && expectedErr != err.Error() {
 				t.Errorf("%d: expected \"%s\", but found \"%+v\"", i, expectedErr, err)
 			}
 		})

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1207,3 +1207,169 @@ query II
 SELECT * FROM t71553@t71553_b_key
 ----
 1  1
+
+subtest virtual_primary_index
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  k INT NOT NULL AS (a+b) VIRTUAL,
+  PRIMARY KEY (a),
+  INDEX t_idx_b_k (b, k),
+  FAMILY "primary" (a, b)
+);
+
+statement ok
+INSERT INTO t VALUES (1,2), (3,4);
+
+query III colnames,rowsort
+SELECT * FROM t@t_pkey;
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_idx_b_k;
+----
+a  b  k
+1  2  3
+3  4  7
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+    a INT8 NOT NULL,
+    b INT8 NOT NULL,
+    k INT8 NOT NULL AS (a + b) VIRTUAL,
+    CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+    UNIQUE INDEX t_a_key (a ASC),
+    INDEX t_idx_b_k (b ASC, k ASC),
+    FAMILY "primary" (a, b)
+)
+
+query III colnames,rowsort
+SELECT * FROM t@t_pkey
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_a_key
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_idx_b_k
+----
+a  b  k
+1  2  3
+3  4  7
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b, k);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+    a INT8 NOT NULL,
+    b INT8 NOT NULL,
+    k INT8 NOT NULL AS (a + b) VIRTUAL,
+    CONSTRAINT t_pkey PRIMARY KEY (b ASC, k ASC),
+    UNIQUE INDEX t_k_key (k ASC),
+    UNIQUE INDEX t_a_key (a ASC),
+    INDEX t_idx_b_k (b ASC, k ASC),
+    FAMILY "primary" (a, b)
+)
+
+query III colnames,rowsort
+SELECT * FROM t@t_pkey
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_a_key
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_k_key
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_idx_b_k
+----
+a  b  k
+1  2  3
+3  4  7
+
+statement ok
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+    a INT8 NOT NULL,
+    b INT8 NOT NULL,
+    k INT8 NOT NULL AS (a + b) VIRTUAL,
+    CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+    UNIQUE INDEX t_b_k_key (b ASC, k ASC),
+    UNIQUE INDEX t_k_key (k ASC),
+    UNIQUE INDEX t_a_key (a ASC),
+    INDEX t_idx_b_k (b ASC, k ASC),
+    FAMILY "primary" (a, b)
+)
+
+query III colnames,rowsort
+SELECT * FROM t@t_pkey
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_a_key
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_k_key
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_idx_b_k
+----
+a  b  k
+1  2  3
+3  4  7
+
+query III colnames,rowsort
+SELECT * FROM t@t_b_k_key
+----
+a  b  k
+1  2  3
+3  4  7

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -17,14 +17,6 @@ CREATE TABLE t (
   FAMILY (v)
 )
 
-statement error primary index column "v" cannot be virtual
-CREATE TABLE t (
-  a INT,
-  b INT,
-  v INT AS (a+b) VIRTUAL,
-  PRIMARY KEY (b,v)
-)
-
 statement error index "t_b_idx" cannot store virtual column "v"
 CREATE TABLE t (
   a INT PRIMARY KEY,


### PR DESCRIPTION
To use virtual column as shard column for hash index, we need to
first allow primary key to accept virtual columns. This pr loosen
the constraint on primary key, allow virtual columns in suffix cols
of secondary index as long as they are in primary key. Also added
extra logic to make sure secondary index is rewritten if it contains
any virtual column not exists in new primary when altering primary
key.

Release not (sql change): Virtual columns are now allowed in primary
keys.