### PR TITLE
ui: select grants tab on table details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -366,7 +366,7 @@ export class DatabaseDetailsPage extends React.Component<
         ),
         cell: table => (
           <Link
-            to={`/database/${this.props.name}/table/${table.name}`}
+            to={`/database/${this.props.name}/table/${table.name}?tab=grants`}
             className={cx("icon__container")}
           >
             <DatabaseIcon className={cx("icon--s")} />

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -20,6 +20,8 @@ import {
 } from "src/storybook/fixtures";
 import { DatabaseTablePage, DatabaseTablePageProps } from "./databaseTablePage";
 import moment from "moment";
+import * as H from "history";
+const history = H.createHashHistory();
 
 const withLoadingIndicator: DatabaseTablePageProps = {
   databaseName: randomName(),
@@ -43,6 +45,14 @@ const withLoadingIndicator: DatabaseTablePageProps = {
     loaded: false,
     stats: [],
     lastReset: moment("2021-09-04T13:55:00Z"),
+  },
+  location: history.location,
+  history,
+  match: {
+    url: "",
+    path: history.location.pathname,
+    isExact: false,
+    params: {},
   },
   refreshTableDetails: () => {},
   refreshTableStats: () => {},
@@ -113,6 +123,14 @@ const withData: DatabaseTablePageProps = {
       },
     ],
     lastReset: moment("2021-09-04T13:55:00Z"),
+  },
+  location: history.location,
+  history,
+  match: {
+    url: "",
+    path: history.location.pathname,
+    isExact: false,
+    params: {},
   },
   refreshTableDetails: () => {},
   refreshTableStats: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -10,6 +10,7 @@
 
 import React from "react";
 import { Col, Row, Tabs } from "antd";
+import { RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
 import _ from "lodash";
 import { Tooltip } from "antd";
@@ -22,6 +23,7 @@ import { SqlBox } from "src/sql";
 import { ColumnDescriptor, SortSetting, SortedTable } from "src/sortedtable";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import * as format from "src/util/format";
+import { syncHistory } from "src/util";
 
 import styles from "./databaseTablePage.module.scss";
 import { commonStyles } from "src/common";
@@ -129,10 +131,12 @@ export interface DatabaseTablePageActions {
 }
 
 export type DatabaseTablePageProps = DatabaseTablePageData &
-  DatabaseTablePageActions;
+  DatabaseTablePageActions &
+  RouteComponentProps;
 
 interface DatabaseTablePageState {
   sortSetting: SortSetting;
+  tab: string;
 }
 
 class DatabaseTableGrantsTable extends SortedTable<Grant> {}
@@ -145,18 +149,33 @@ export class DatabaseTablePage extends React.Component<
   constructor(props: DatabaseTablePageProps) {
     super(props);
 
+    const { history } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+    const defaultTab = searchParams.get("tab") || "overview";
+
     this.state = {
       sortSetting: {
         ascending: true,
       },
+      tab: defaultTab,
     };
   }
 
-  componentDidMount() {
+  onTabChange = (tab: string): void => {
+    this.setState({ tab });
+    syncHistory(
+      {
+        tab: tab,
+      },
+      this.props.history,
+    );
+  };
+
+  componentDidMount(): void {
     this.refresh();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(): void {
     this.refresh();
   }
 
@@ -284,7 +303,7 @@ export class DatabaseTablePage extends React.Component<
     },
   ];
 
-  render() {
+  render(): React.ReactElement {
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
@@ -313,7 +332,11 @@ export class DatabaseTablePage extends React.Component<
         </section>
 
         <section className={(baseHeadingClasses.wrapper, cx("tab-area"))}>
-          <Tabs className={commonStyles("cockroach--tabs")}>
+          <Tabs
+            className={commonStyles("cockroach--tabs")}
+            onChange={this.onTabChange}
+            activeKey={this.state.tab}
+          >
             <TabPane tab="Overview" key="overview">
               <Row gutter={18}>
                 <Col className="gutter-row" span={18}>


### PR DESCRIPTION
Previosuly, when the grants view was selected on the Database
Details page, it was going to the Table Details with the Overview
tab selected.
With this commit, if the view mode selected is Grant, the grant
tab is selected on the Table Details page.

Fixes #68829

Release note: None