### PR TITLE
builtins: add digest and hmac functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -367,6 +367,21 @@
 </span></td></tr></tbody>
 </table>
 
+### Cryptographic functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><a name="digest"></a><code>digest(data: <a href="bytes.html">bytes</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Computes a binary hash of the given <code>data</code>. <code>type</code> is the algorithm to use (md5, sha1, sha224, sha256, sha384, or sha512).</p>
+</span></td></tr>
+<tr><td><a name="digest"></a><code>digest(data: <a href="string.html">string</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Computes a binary hash of the given <code>data</code>. <code>type</code> is the algorithm to use (md5, sha1, sha224, sha256, sha384, or sha512).</p>
+</span></td></tr>
+<tr><td><a name="hmac"></a><code>hmac(data: <a href="bytes.html">bytes</a>, key: <a href="bytes.html">bytes</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Calculates hashed MAC for <code>data</code> with key <code>key</code>. <code>type</code> is the same as in <code>digest()</code>.</p>
+</span></td></tr>
+<tr><td><a name="hmac"></a><code>hmac(data: <a href="string.html">string</a>, key: <a href="string.html">string</a>, type: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Calculates hashed MAC for <code>data</code> with key <code>key</code>. <code>type</code> is the same as in <code>digest()</code>.</p>
+</span></td></tr></tbody>
+</table>
+
 ### DECIMAL functions
 
 <table>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3079,3 +3079,56 @@ SELECT crdb_internal.check_password_hash_format(('SCRAM-SHA-256$'||'4096:B5VaTCv
 ----
 scram-sha-256
 
+# NB: CockroachDB currently differs from Postgres, since the shaX functions
+# return a string in CockroachDB, while Postgres returns bytea.
+query BTT
+SELECT
+  encode(digest('abc', alg), 'hex') = expected, digest(NULL, alg), digest('abc', NULL)
+FROM
+  (
+    VALUES
+      ('md5', md5('abc')),
+      ('sha1', sha1('abc')),
+      ('sha224', sha224('abc')),
+      ('sha256', sha256('abc')),
+      ('sha384', sha384('abc')),
+      ('sha512', sha512('abc'))
+  )
+    AS v (alg, expected);
+----
+true  NULL  NULL
+true  NULL  NULL
+true  NULL  NULL
+true  NULL  NULL
+true  NULL  NULL
+true  NULL  NULL
+
+query T
+SELECT digest(NULL, 'made up alg')
+----
+NULL
+
+statement error pgcode 22023 cannot use "made up alg", no such hash algorithm
+SELECT digest('cat', 'made up alg')
+
+# NB: These results were manually confirmed to match the hashed values
+# created by Postgres.
+query T
+SELECT encode(hmac('abc', 'key', alg), 'hex')
+FROM (VALUES ('md5'), ('sha1'), ('sha224'), ('sha256'), ('sha384'), ('sha512')) v(alg)
+----
+d2fe98063f876b03193afb49b4979591
+4fd0b215276ef12f2b3e4c8ecac2811498b656fc
+f524670b7e34f31467de0aa96593861cf65117d414fb2d86158d760e
+9c196e32dc0175f86f4b1cb89289d6619de6bee699e4c378e68309ed97a1a6ab
+30ddb9c8f347cffbfb44e519d814f074cf4047a55d6f563324f1c6a33920e5edfb2a34bac60bdc96cd33a95623d7d638
+3926a207c8c42b0c41792cbd3e1a1aaaf5f7a25704f62dfc939c4987dd7ce060009c5bb1c2447355b3216f10b537e9afa7b64a4e5391b0d631172d07939e087a
+
+query TTT
+SELECT hmac('abc', 'key', NULL), hmac('abc', NULL, 'made up alg'), hmac(NULL, 'key', 'sha256')
+----
+NULL  NULL  NULL
+
+statement error pgcode 22023 cannot use "made up alg", no such hash algorithm
+SELECT hmac('dog', 'key', 'made up alg')
+

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -13,6 +13,7 @@ package builtins
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/hmac"
 	"crypto/md5"
 	cryptorand "crypto/rand"
 	"crypto/sha1"
@@ -111,6 +112,7 @@ const (
 	categoryArray               = "Array"
 	categoryComparison          = "Comparison"
 	categoryCompatibility       = "Compatibility"
+	categoryCrypto              = "Cryptographic"
 	categoryDateAndTime         = "Date and time"
 	categoryEnum                = "Enum"
 	categoryFullTextSearch      = "Full Text Search"
@@ -1241,6 +1243,90 @@ var builtins = map[string]builtinDefinition{
 	"crc32c": hash32Builtin(
 		func() hash.Hash32 { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) },
 		"Calculates the CRC-32 hash using the Castagnoli polynomial.",
+	),
+
+	"digest": makeBuiltin(
+		tree.FunctionProperties{Category: categoryCrypto},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"data", types.String}, {"type", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				alg := tree.MustBeDString(args[1])
+				hashFunc, err := getHashFunc(string(alg))
+				if err != nil {
+					return nil, err
+				}
+				h := hashFunc()
+				if ok, err := feedHash(h, args[:1]); !ok || err != nil {
+					return tree.DNull, err
+				}
+				return tree.NewDBytes(tree.DBytes(h.Sum(nil))), nil
+			},
+			Info: "Computes a binary hash of the given `data`. `type` is the algorithm " +
+				"to use (md5, sha1, sha224, sha256, sha384, or sha512).",
+			Volatility: tree.VolatilityLeakProof,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"data", types.Bytes}, {"type", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				alg := tree.MustBeDString(args[1])
+				hashFunc, err := getHashFunc(string(alg))
+				if err != nil {
+					return nil, err
+				}
+				h := hashFunc()
+				if ok, err := feedHash(h, args[:1]); !ok || err != nil {
+					return tree.DNull, err
+				}
+				return tree.NewDBytes(tree.DBytes(h.Sum(nil))), nil
+			},
+			Info: "Computes a binary hash of the given `data`. `type` is the algorithm " +
+				"to use (md5, sha1, sha224, sha256, sha384, or sha512).",
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+
+	"hmac": makeBuiltin(
+		tree.FunctionProperties{Category: categoryCrypto},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"data", types.String}, {"key", types.String}, {"type", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				key := tree.MustBeDString(args[1])
+				alg := tree.MustBeDString(args[2])
+				hashFunc, err := getHashFunc(string(alg))
+				if err != nil {
+					return nil, err
+				}
+				h := hmac.New(hashFunc, []byte(key))
+				if ok, err := feedHash(h, args[:1]); !ok || err != nil {
+					return tree.DNull, err
+				}
+				return tree.NewDBytes(tree.DBytes(h.Sum(nil))), nil
+			},
+			Info:       "Calculates hashed MAC for `data` with key `key`. `type` is the same as in `digest()`.",
+			Volatility: tree.VolatilityLeakProof,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"data", types.Bytes}, {"key", types.Bytes}, {"type", types.String}},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				key := tree.MustBeDBytes(args[1])
+				alg := tree.MustBeDString(args[2])
+				hashFunc, err := getHashFunc(string(alg))
+				if err != nil {
+					return nil, err
+				}
+				h := hmac.New(hashFunc, []byte(key))
+				if ok, err := feedHash(h, args[:1]); !ok || err != nil {
+					return tree.DNull, err
+				}
+				return tree.NewDBytes(tree.DBytes(h.Sum(nil))), nil
+			},
+			Info:       "Calculates hashed MAC for `data` with key `key`. `type` is the same as in `digest()`.",
+			Volatility: tree.VolatilityImmutable,
+		},
 	),
 
 	"to_hex": makeBuiltin(
@@ -7338,6 +7424,27 @@ func bitsOverload2(
 		},
 		Info:       info,
 		Volatility: volatility,
+	}
+}
+
+// getHashFunc returns a function that will create a new hash.Hash using the
+// given algorithm.
+func getHashFunc(alg string) (func() hash.Hash, error) {
+	switch strings.ToLower(alg) {
+	case "md5":
+		return md5.New, nil
+	case "sha1":
+		return sha1.New, nil
+	case "sha224":
+		return sha256.New224, nil
+	case "sha256":
+		return sha256.New, nil
+	case "sha384":
+		return sha512.New384, nil
+	case "sha512":
+		return sha512.New, nil
+	default:
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue, "cannot use %q, no such hash algorithm", alg)
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/73864
fixes https://github.com/cockroachdb/cockroach/issues/73865

Release note (sql change): The digest and hmac builtin functions were
added. They match the PostgreSQL (pgcrypto) implementation. Supported
hash algorithms are md5, sha1, sha224, sha256, sha384, and sha512.