### PR TITLE
ui: avoid re-defining consts from cluster-ui in db-console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import moment, { Moment } from "moment";
 import {
   aggregateStatementStats,
   appAttr,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -11,7 +11,6 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
-import { Moment } from "moment";
 
 import { AppState } from "src/store";
 import { actions as statementDiagnosticsActions } from "src/store/statementDiagnostics";

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -8,23 +8,26 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const aggregationIntervalAttr = "aggregation_interval";
-export const aggregatedTsAttr = "aggregated_ts";
-export const appAttr = "app";
-export const dashQueryString = "dash";
-export const dashboardNameAttr = "dashboard_name";
-export const databaseAttr = "database";
-export const databaseNameAttr = "database_name";
-export const implicitTxnAttr = "implicitTxn";
-export const indexNameAttr = "index_name";
-export const nodeIDAttr = "node_id";
-export const nodeQueryString = "node";
-export const rangeIDAttr = "range_id";
-export const statementAttr = "statement";
-export const sessionAttr = "session";
-export const tabAttr = "tab";
-export const tableNameAttr = "table_name";
-export const txnFingerprintIdAttr = "txn_fingerprint_id";
+import { util } from "@cockroachlabs/cluster-ui";
 
-export const REMOTE_DEBUGGING_ERROR_TEXT =
-  "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";
+export const indexNameAttr = "index_name";
+
+export const {
+  aggregationIntervalAttr,
+  aggregatedTsAttr,
+  appAttr,
+  dashQueryString,
+  dashboardNameAttr,
+  databaseAttr,
+  databaseNameAttr,
+  implicitTxnAttr,
+  nodeIDAttr,
+  nodeQueryString,
+  rangeIDAttr,
+  statementAttr,
+  sessionAttr,
+  tabAttr,
+  tableNameAttr,
+  txnFingerprintIdAttr,
+  REMOTE_DEBUGGING_ERROR_TEXT,
+} = util;


### PR DESCRIPTION
Partially addresses #71826

Previously, we re-defined many constants across cluster-ui and
db-console. This commit imports shared constants in both packages
into db-console to avoid the duplication.

Release note: None