### PR TITLE
setting: introduce setting classes

### DIFF
--- a/docs/RFCS/20211106_multitenant_cluster_settings.md
+++ b/docs/RFCS/20211106_multitenant_cluster_settings.md
@@ -215,11 +215,11 @@ following guidelines:
 
  - control settings relevant to tenant-specific internal implementation (like
    tenant throttling) that we want to be able to control per-tenant should be
-   `system`.
+   `tenant-ro`.
 
- - when in doubt the first choice to consider should be `tenant-ro`.
+ - when in doubt the first choice to consider should be `tenant-rw`.
 
- - `System` should be used with caution - we have to be sure that there is no
+ - `system` should be used with caution - we have to be sure that there is no
    internal code running on the tenant that needs to consult them.
 
 We fully hide `system` settings from non-system tenants. The cluster settings

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -81,6 +81,7 @@ var _ cloud.KMSEnv = &backupKMSEnv{}
 
 // featureBackupEnabled is used to enable and disable the BACKUP feature.
 var featureBackupEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.backup.enabled",
 	"set to true to enable backups, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -50,35 +50,41 @@ var backupOutputTypes = []*types.T{}
 
 var (
 	useTBI = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"kv.bulk_io_write.experimental_incremental_export_enabled",
 		"use experimental time-bound file filter when exporting in BACKUP",
 		true,
 	)
 	priorityAfter = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"bulkio.backup.read_with_priority_after",
 		"amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads",
 		time.Minute,
 		settings.NonNegativeDuration,
 	).WithPublic()
 	delayPerAttmpt = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"bulkio.backup.read_retry_delay",
 		"amount of time since the read-as-of time, per-prior attempt, to wait before making another attempt",
 		time.Second*5,
 		settings.NonNegativeDuration,
 	)
 	timeoutPerAttempt = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"bulkio.backup.read_timeout",
 		"amount of time after which a read attempt is considered timed out, which causes the backup to fail",
 		time.Minute*5,
 		settings.NonNegativeDuration,
 	).WithPublic()
 	targetFileSize = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"bulkio.backup.file_size",
 		"target size for individual data files produced during BACKUP",
 		128<<20,
 	).WithPublic()
 
 	smallFileBuffer = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"bulkio.backup.merge_file_buffer_size",
 		"size limit used when buffering backup files before merging them",
 		16<<20,
@@ -86,6 +92,7 @@ var (
 	)
 
 	splitKeysOnTimestamps = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"bulkio.backup.split_keys_on_timestamps",
 		"split backup data on timestamps when writing revision history",
 		false,

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -61,6 +61,7 @@ var scheduledBackupOptionExpectValues = map[string]sql.KVStringOptValidate{
 // scheduledBackupGCProtectionEnabled is used to enable and disable the chaining
 // of protected timestamps amongst scheduled backups.
 var scheduledBackupGCProtectionEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"schedules.backup.gc_protection.enabled",
 	"enable chaining of GC protection across backups run as part of a schedule; default is false",
 	false, /* defaultValue */

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -94,6 +94,7 @@ var defaultNumWorkers = util.ConstantWithMetamorphicTestRange(
 // The maximum is not enforced since if the maximum is reduced in the future that
 // may cause the cluster setting to fail.
 var numRestoreWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.restore_node_concurrency",
 	fmt.Sprintf("the number of workers processing a restore per job per node; maximum %d",
 		maxConcurrentRestoreWorkers),

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -84,6 +84,7 @@ var allowedDebugPauseOnValues = map[string]struct{}{
 
 // featureRestoreEnabled is used to enable and disable the RESTORE feature.
 var featureRestoreEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.restore.enabled",
 	"set to true to enable restore, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -60,6 +60,7 @@ import (
 
 // featureChangefeedEnabled is used to enable and disable the CHANGEFEED feature.
 var featureChangefeedEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.changefeed.enabled",
 	"set to true to enable changefeeds, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -22,6 +22,7 @@ import (
 // NB: The more generic name of this setting precedes its current
 // interpretation. It used to control additional polling rates.
 var TableDescriptorPollInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"changefeed.experimental_poll_interval",
 	"polling interval for the table descriptors",
 	1*time.Second,
@@ -43,6 +44,7 @@ func TestingSetDefaultMinCheckpointFrequency(f time.Duration) func() {
 // PerChangefeedMemLimit controls how much data can be buffered by
 // a single changefeed.
 var PerChangefeedMemLimit = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"changefeed.memory.per_changefeed_limit",
 	"controls amount of data that can be buffered per changefeed",
 	1<<30,
@@ -50,6 +52,7 @@ var PerChangefeedMemLimit = settings.RegisterByteSizeSetting(
 
 // SlowSpanLogThreshold controls when we will log slow spans.
 var SlowSpanLogThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"changefeed.slow_span_log_threshold",
 	"a changefeed will log spans with resolved timestamps this far behind the current wall-clock time; if 0, a default value is calculated based on other cluster settings",
 	0,
@@ -58,6 +61,7 @@ var SlowSpanLogThreshold = settings.RegisterDurationSetting(
 
 // FrontierCheckpointFrequency controls the frequency of frontier checkpoints.
 var FrontierCheckpointFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"changefeed.frontier_checkpoint_frequency",
 	"controls the frequency with which span level checkpoints will be written; if 0, disabled.",
 	10*time.Minute,
@@ -78,6 +82,7 @@ var FrontierCheckpointFrequency = settings.RegisterDurationSetting(
 // Therefore, we should write at most 6 MB of checkpoint/hour; OR, based on the default
 // FrontierCheckpointFrequency setting, 1 MB per checkpoint.
 var FrontierCheckpointMaxBytes = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"changefeed.frontier_checkpoint_max_bytes",
 	"controls the maximum size of the checkpoint as a total size of key bytes",
 	1<<20,
@@ -87,6 +92,7 @@ var FrontierCheckpointMaxBytes = settings.RegisterByteSizeSetting(
 // Scan requests are issued when changefeed performs the backfill.
 // If set to 0, a reasonable default will be chosen.
 var ScanRequestLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"changefeed.backfill.concurrent_scan_requests",
 	"number of concurrent scan requests per node issued during a backfill",
 	0,
@@ -112,6 +118,7 @@ type SinkThrottleConfig struct {
 // NodeSinkThrottleConfig is the node wide throttling configuration for changefeeds.
 var NodeSinkThrottleConfig = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		"changefeed.node_throttle_config",
 		"specifies node level throttling configuration for all changefeeeds",
 		"",
@@ -133,6 +140,7 @@ func validateSinkThrottleConfig(values *settings.Values, configStr string) error
 // MinHighWaterMarkCheckpointAdvance specifies the minimum amount of time the
 // changefeed high water mark must advance for it to be eligible for checkpointing.
 var MinHighWaterMarkCheckpointAdvance = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"changefeed.min_highwater_advance",
 	"minimum amount of time the changefeed high water mark must advance "+
 		"for it to be eligible for checkpointing; Default of 0 will checkpoint every time frontier "+
@@ -148,6 +156,7 @@ var MinHighWaterMarkCheckpointAdvance = settings.RegisterDurationSetting(
 // with complex schemes to accurately measure and adjust current memory usage,
 // we'll request the amount of memory multiplied by this fudge factor.
 var EventMemoryMultiplier = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"changefeed.event_memory_multiplier",
 	"the amount of memory required to process an event is multiplied by this factor",
 	3,

--- a/pkg/ccl/importccl/import_planning.go
+++ b/pkg/ccl/importccl/import_planning.go
@@ -191,6 +191,7 @@ var allowedIntoFormats = map[string]struct{}{
 
 // featureImportEnabled is used to enable and disable the IMPORT feature.
 var featureImportEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.import.enabled",
 	"set to true to enable imports, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -47,6 +47,7 @@ const readImportDataProcessorName = "readImportDataProcessor"
 
 var importPKAdderBufferSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.pk_buffer_size",
 		"the initial size of the BulkAdder buffer handling primary index imports",
 		32<<20,
@@ -56,6 +57,7 @@ var importPKAdderBufferSize = func() *settings.ByteSizeSetting {
 
 var importPKAdderMaxBufferSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.max_pk_buffer_size",
 		"the maximum size of the BulkAdder buffer handling primary index imports",
 		128<<20,
@@ -65,6 +67,7 @@ var importPKAdderMaxBufferSize = func() *settings.ByteSizeSetting {
 
 var importIndexAdderBufferSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.index_buffer_size",
 		"the initial size of the BulkAdder buffer handling secondary index imports",
 		32<<20,
@@ -74,6 +77,7 @@ var importIndexAdderBufferSize = func() *settings.ByteSizeSetting {
 
 var importIndexAdderMaxBufferSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.max_index_buffer_size",
 		"the maximum size of the BulkAdder buffer handling secondary index imports",
 		512<<20,
@@ -83,6 +87,7 @@ var importIndexAdderMaxBufferSize = func() *settings.ByteSizeSetting {
 
 var importBufferIncrementSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.buffer_increment",
 		"the size by which the BulkAdder attempts to grow its buffer before flushing",
 		32<<20,

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -35,6 +35,7 @@ import (
 // measure of how long closed timestamp updates are supposed to take from the
 // leaseholder to the followers.
 var ClosedTimestampPropagationSlack = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.closed_timestamp.propagation_slack",
 	"a conservative estimate of the amount of time expect for closed timestamps to "+
 		"propagate from a leaseholder to followers. This is taken into account by "+

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -31,6 +31,7 @@ import (
 
 // TargetPeriodSetting is exported for testing purposes.
 var TargetPeriodSetting = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"tenant_cost_control_period",
 	"target duration between token bucket requests from tenants (requires restart)",
 	10*time.Second,
@@ -39,6 +40,7 @@ var TargetPeriodSetting = settings.RegisterDurationSetting(
 
 // CPUUsageAllowance is exported for testing purposes.
 var CPUUsageAllowance = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"tenant_cpu_usage_allowance",
 	"this much CPU usage per second is considered background usage and "+
 		"doesn't contribute to consumption; for example, if it is set to 10ms, "+

--- a/pkg/ccl/multitenantccl/tenantcostserver/server.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server.go
@@ -32,6 +32,7 @@ type instance struct {
 // Note: the "four" in the description comes from
 //   tenantcostclient.extendedReportingPeriodFactor.
 var instanceInactivity = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"tenant_usage_instance_inactivity",
 	"instances that have not reported consumption for longer than this value are cleaned up; "+
 		"should be at least four times higher than the tenant_cost_control_period of any tenant",

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -38,6 +38,7 @@ const (
 // OIDCEnabled enables or disabled OIDC login for the DB Console.
 var OIDCEnabled = func() *settings.BoolSetting {
 	s := settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		OIDCEnabledSettingName,
 		"enables or disabled OIDC login for the DB Console",
 		false,
@@ -49,6 +50,7 @@ var OIDCEnabled = func() *settings.BoolSetting {
 // OIDCClientID is the OIDC client id.
 var OIDCClientID = func() *settings.StringSetting {
 	s := settings.RegisterStringSetting(
+		settings.TenantWritable,
 		OIDCClientIDSettingName,
 		"sets OIDC client id",
 		"",
@@ -60,6 +62,7 @@ var OIDCClientID = func() *settings.StringSetting {
 // OIDCClientSecret is the OIDC client secret.
 var OIDCClientSecret = func() *settings.StringSetting {
 	s := settings.RegisterStringSetting(
+		settings.TenantWritable,
 		OIDCClientSecretSettingName,
 		"sets OIDC client secret",
 		"",
@@ -170,6 +173,7 @@ func validateOIDCRedirectURL(values *settings.Values, s string) error {
 // will use the required `default_url` callback URL.
 var OIDCRedirectURL = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		OIDCRedirectURLSettingName,
 		"sets OIDC redirect URL via a URL string or a JSON string containing a required "+
 			"`redirect_urls` key with an object that maps from region keys to URL strings "+
@@ -186,6 +190,7 @@ var OIDCRedirectURL = func() *settings.StringSetting {
 // provider.
 var OIDCProviderURL = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		OIDCProviderURLSettingName,
 		"sets OIDC provider URL ({provider_url}/.well-known/openid-configuration must resolve)",
 		"",
@@ -204,6 +209,7 @@ var OIDCProviderURL = func() *settings.StringSetting {
 // OIDCScopes contains the list of scopes to request from the auth provider.
 var OIDCScopes = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		OIDCScopesSettingName,
 		"sets OIDC scopes to include with authentication request "+
 			"(space delimited list of strings, required to start with `openid`)",
@@ -223,6 +229,7 @@ var OIDCScopes = func() *settings.StringSetting {
 // OIDCClaimJSONKey is the key of the claim to extract from the OIDC id_token.
 var OIDCClaimJSONKey = func() *settings.StringSetting {
 	s := settings.RegisterStringSetting(
+		settings.TenantWritable,
 		OIDCClaimJSONKeySettingName,
 		"sets JSON key of principal to extract from payload after OIDC authentication completes "+
 			"(usually email or sid)",
@@ -235,6 +242,7 @@ var OIDCClaimJSONKey = func() *settings.StringSetting {
 // claim value to conver it to a DB principal.
 var OIDCPrincipalRegex = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		OIDCPrincipalRegexSettingName,
 		"regular expression to apply to extracted principal (see claim_json_key setting) to "+
 			"translate to SQL user (golang regex format, must include 1 grouping to extract)",
@@ -255,6 +263,7 @@ var OIDCPrincipalRegex = func() *settings.StringSetting {
 // login with OIDC.
 var OIDCButtonText = func() *settings.StringSetting {
 	s := settings.RegisterStringSetting(
+		settings.TenantWritable,
 		OIDCButtonTextSettingName,
 		"text to show on button on DB Console login page to login with your OIDC provider "+
 			"(only shown if OIDC is enabled)",
@@ -267,6 +276,7 @@ var OIDCButtonText = func() *settings.StringSetting {
 // the DB Console.
 var OIDCAutoLogin = func() *settings.BoolSetting {
 	s := settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		OIDCAutoLoginSettingName,
 		"if true, logged-out visitors to the DB Console will be "+
 			"automatically redirected to the OIDC login endpoint",

--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -26,12 +26,14 @@ import (
 )
 
 var remoteSSTs = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.bulk_ingest.stream_external_ssts.enabled",
 	"if enabled, external SSTables are iterated directly in some cases, rather than being downloaded entirely first",
 	true,
 )
 
 var remoteSSTSuffixCacheSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.bulk_ingest.stream_external_ssts.suffix_cache_size",
 	"size of suffix of remote SSTs to download and cache before reading from remote stream",
 	64<<10,

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -21,6 +21,7 @@ import (
 // payload in an AddSSTable request.
 var IngestBatchSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_ingest.batch_size",
 		"the maximum size of the payload in an AddSSTable request",
 		16<<20,

--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -17,6 +17,7 @@ import (
 // StreamReplicationStreamLivenessTrackFrequency controls frequency to check
 // the liveness of a streaming replication producer job.
 var StreamReplicationStreamLivenessTrackFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"stream_replication.stream_liveness_track_frequency",
 	"controls how frequent we check for the liveness of a replication stream producer job",
 	time.Minute,
@@ -25,6 +26,7 @@ var StreamReplicationStreamLivenessTrackFrequency = settings.RegisterDurationSet
 // StreamReplicationJobLivenessTimeout controls how long we wait for to kill
 // an inactive producer job.
 var StreamReplicationJobLivenessTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"stream_replication.job_liveness_timeout",
 	"controls how long we wait for to kill an inactive producer job",
 	time.Minute,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -33,6 +33,7 @@ import (
 
 // PartitionProgressFrequency controls the frequency of partition progress checkopints.
 var PartitionProgressFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"streaming.partition_progress_frequency",
 	"controls the frequency with which partitions update their progress; if 0, disabled.",
 	10*time.Second,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -39,6 +39,7 @@ import (
 )
 
 var minimumFlushInterval = settings.RegisterPublicDurationSettingWithExplicitUnit(
+	settings.TenantWritable,
 	"bulkio.stream_ingestion.minimum_flush_interval",
 	"the minimum timestamp between flushes; flushes may still occur if internal buffers fill up",
 	5*time.Second,
@@ -49,6 +50,7 @@ var minimumFlushInterval = settings.RegisterPublicDurationSettingWithExplicitUni
 // the system.jobs table to check whether the stream ingestion job has been
 // signaled to cutover.
 var cutoverSignalPollInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"bulkio.stream_ingestion.cutover_signal_poll_interval",
 	"the interval at which the stream ingestion job checks if it has been signaled to cutover",
 	30*time.Second,

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -34,6 +34,7 @@ import (
 
 var enterpriseLicense = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		"enterprise.license",
 		"the encoded cluster license",
 		"",

--- a/pkg/cli/cpuprofile.go
+++ b/pkg/cli/cpuprofile.go
@@ -30,6 +30,7 @@ import (
 )
 
 var maxCombinedCPUProfFileSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"server.cpu_profile.total_dump_size_limit",
 	"maximum combined disk size of preserved CPU profiles",
 	128<<20, // 128MiB

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -217,7 +217,7 @@ Output the list of cluster settings known to this binary.
 				panic(fmt.Sprintf("could not find setting %q", name))
 			}
 
-			if excludeSystemSettings && setting.SystemOnly() {
+			if excludeSystemSettings && setting.Class() == settings.SystemOnly {
 				continue
 			}
 

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -83,6 +83,7 @@ type s3Client struct {
 }
 
 var reuseSession = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"cloudstorage.s3.session_reuse.enabled",
 	"persist the last opened s3 session and re-use it when opening a new session with the same arguments",
 	true,

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -35,12 +35,14 @@ import (
 
 // Timeout is a cluster setting used for cloud storage interactions.
 var Timeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"cloudstorage.timeout",
 	"the timeout for import/export storage operations",
 	10*time.Minute,
 ).WithPublic()
 
 var httpCustomCA = settings.RegisterStringSetting(
+	settings.TenantWritable,
 	"cloudstorage.http.custom_ca",
 	"custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage",
 	"",

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -47,6 +47,7 @@ const (
 // gcsChunkingEnabled is used to enable and disable chunking of file upload to
 // Google Cloud Storage.
 var gcsChunkingEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"cloudstorage.gs.chunking.enabled",
 	"enable chunking of file upload to Google Cloud Storage",
 	true, /* default */

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -29,6 +29,7 @@ func TestClusterVersionOnChange(t *testing.T) {
 	cvs := &clusterVersionSetting{}
 	cvs.VersionSetting = settings.MakeVersionSetting(cvs)
 	settings.RegisterVersionSetting(
+		settings.TenantWritable,
 		"dummy version key",
 		"test description",
 		&cvs.VersionSetting)

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -62,6 +62,7 @@ func registerClusterVersionSetting() *clusterVersionSetting {
 	s := &clusterVersionSetting{}
 	s.VersionSetting = settings.MakeVersionSetting(s)
 	settings.RegisterVersionSetting(
+		settings.TenantWritable,
 		KeyVersionSetting,
 		"set the active cluster version in the format '<major>.<minor>'", // hide optional `-<internal>,
 		&s.VersionSetting)
@@ -241,6 +242,7 @@ var preserveDowngradeVersion = registerPreserveDowngradeVersionSetting()
 
 func registerPreserveDowngradeVersionSetting() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		"cluster.preserve_downgrade_option",
 		"disable (automatic or manual) cluster version upgrade from the specified version until reset",
 		"",

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -74,6 +74,7 @@ const (
 
 var (
 	intervalBaseSetting = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		intervalBaseSettingKey,
 		"the base multiplier for other intervals such as adopt, cancel, and gc",
 		defaultIntervalBase,
@@ -81,6 +82,7 @@ var (
 	)
 
 	adoptIntervalSetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		adoptIntervalSettingKey,
 		"the interval at which a node (a) claims some of the pending jobs and "+
 			"(b) restart its already claimed jobs that are in running or reverting "+
@@ -90,6 +92,7 @@ var (
 	)
 
 	cancelIntervalSetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		cancelIntervalSettingKey,
 		"the interval at which a node cancels the jobs belonging to the known "+
 			"dead sessions",
@@ -98,6 +101,7 @@ var (
 	)
 
 	gcIntervalSetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		gcIntervalSettingKey,
 		"the interval a node deletes expired job records that have exceeded their "+
 			"retention duration",
@@ -106,6 +110,7 @@ var (
 	)
 
 	retentionTimeSetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		retentionTimeSettingKey,
 		"the amount of time to retain records for completed jobs before",
 		defaultRetentionTime,
@@ -113,6 +118,7 @@ var (
 	).WithPublic()
 
 	cancellationsUpdateLimitSetting = settings.RegisterIntSetting(
+		settings.TenantWritable,
 		cancelUpdateLimitKey,
 		"the number of jobs that can be updated when canceling jobs concurrently from dead sessions",
 		defaultCancellationsUpdateLimit,
@@ -120,6 +126,7 @@ var (
 	)
 
 	retryInitialDelaySetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		retryInitialDelaySettingKey,
 		"the starting duration of exponential-backoff delay"+
 			" to retry a job which encountered a retryable error or had its coordinator"+
@@ -129,6 +136,7 @@ var (
 	)
 
 	retryMaxDelaySetting = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		retryMaxDelaySettingKey,
 		"the maximum duration by which a job can be delayed to retry",
 		defaultRetryMaxDelay,
@@ -136,6 +144,7 @@ var (
 	)
 
 	executionErrorsMaxEntriesSetting = settings.RegisterIntSetting(
+		settings.TenantWritable,
 		executionErrorsMaxEntriesKey,
 		"the maximum number of retriable error entries which will be stored for introspection",
 		defaultExecutionErrorsMaxEntries,
@@ -143,6 +152,7 @@ var (
 	)
 
 	executionErrorsMaxEntrySize = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		executionErrorsMaxEntrySizeKey,
 		"the maximum byte size of individual error entries which will be stored"+
 			" for introspection",
@@ -151,6 +161,7 @@ var (
 	)
 
 	debugPausepoints = settings.RegisterStringSetting(
+		settings.TenantWritable,
 		debugPausePointsSettingKey,
 		"the list, comma separated, of named pausepoints currently enabled for debugging",
 		"",

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -385,18 +385,21 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 }
 
 var schedulerEnabledSetting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"jobs.scheduler.enabled",
 	"enable/disable job scheduler",
 	true,
 )
 
 var schedulerPaceSetting = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"jobs.scheduler.pace",
 	"how often to scan system.scheduled_jobs table",
 	time.Minute,
 )
 
 var schedulerMaxJobsPerIterationSetting = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"jobs.scheduler.max_jobs_per_iteration",
 	"how many schedules to start per iteration; setting to 0 turns off this limit",
 	10,

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -49,6 +49,7 @@ const (
 )
 
 var traceableJobDumpTraceMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"jobs.trace.force_dump_mode",
 	"determines the state in which all traceable jobs will dump their cluster wide, inflight, "+
 		"trace recordings. Traces may be dumped never, on fail, "+

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -33,12 +33,14 @@ import (
 
 var (
 	tooSmallSSTSize = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"kv.bulk_io_write.small_write_size",
 		"size below which a 'bulk' write will be performed as a normal write instead",
 		400*1<<10, // 400 Kib
 	)
 
 	ingestDelay = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"bulkio.ingest.flush_delay",
 		"amount of time to wait before sending a file to the KV/Storage layer to ingest",
 		0,

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -166,12 +166,14 @@ const (
 )
 
 var rangeDescriptorCacheSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.range_descriptor_cache.size",
 	"maximum number of entries in the range descriptor cache",
 	1e6,
 )
 
 var senderConcurrencyLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.dist_sender.concurrency_limit",
 	"maximum number of asynchronous send requests",
 	max(defaultSenderConcurrency, int64(64*runtime.GOMAXPROCS(0))),

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -25,6 +25,7 @@ import (
 )
 
 var parallelCommitsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.transaction.parallel_commits_enabled",
 	"if enabled, transactional commits will be parallelized with transactional writes",
 	true,

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -30,11 +30,13 @@ import (
 const txnPipelinerBtreeDegree = 32
 
 var pipelinedWritesEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.transaction.write_pipelining_enabled",
 	"if enabled, transactional writes are pipelined through Raft consensus",
 	true,
 )
 var pipelinedWritesMaxBatchSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.transaction.write_pipelining_max_batch_size",
 	"if non-zero, defines that maximum size batch that will be pipelined through Raft consensus",
 	// NB: there is a tradeoff between the overhead of synchronously waiting for
@@ -73,6 +75,7 @@ var pipelinedWritesMaxBatchSize = settings.RegisterIntSetting(
 // find matching intents.
 // See #54029 for more details.
 var trackedWritesMaxSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.transaction.max_intents_bytes",
 	"maximum number of bytes used to track locks in transactions",
 	1<<22, /* 4 MB */
@@ -81,6 +84,7 @@ var trackedWritesMaxSize = settings.RegisterIntSetting(
 // rejectTxnOverTrackedWritesBudget dictates what happens when a txn exceeds
 // kv.transaction.max_intents_bytes.
 var rejectTxnOverTrackedWritesBudget = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.transaction.reject_over_max_intents_budget.enabled",
 	"if set, transactions that exceed their lock tracking budget (kv.transaction.max_intents_bytes) "+
 		"are rejected instead of having their lock spans imprecisely compressed",

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -36,6 +36,7 @@ const (
 // on the coordinator during the lifetime of a transaction. Refresh spans
 // are used for SERIALIZABLE transactions to avoid client restarts.
 var MaxTxnRefreshSpansBytes = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.transaction.max_refresh_spans_bytes",
 	"maximum number of bytes used to track refresh spans in serializable transactions",
 	256*1000,

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -39,6 +39,7 @@ type dbAdapter struct {
 var _ kvDB = (*dbAdapter)(nil)
 
 var maxScanParallelism = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.rangefeed.max_scan_parallelism",
 	"maximum number of concurrent scan requests that can be issued during initial scan",
 	64,

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -22,6 +22,7 @@ import (
 // ensures that kvprober will not be significantly affected if the cluster is
 // overloaded.
 var bypassAdmissionControl = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.prober.bypass_admission_control.enabled",
 	"set to bypass admission control queue for kvprober requests; "+
 		"note that dedicated clusters should have this set as users own capacity planning "+
@@ -30,6 +31,7 @@ var bypassAdmissionControl = settings.RegisterBoolSetting(
 )
 
 var readEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.prober.read.enabled",
 	"whether the KV read prober is enabled",
 	false)
@@ -37,6 +39,7 @@ var readEnabled = settings.RegisterBoolSetting(
 // TODO(josh): Another option is for the cluster setting to be a QPS target
 // for the cluster as a whole.
 var readInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.prober.read.interval",
 	"how often each node sends a read probe to the KV layer on average (jitter is added); "+
 		"note that a very slow read can block kvprober from sending additional probes; "+
@@ -49,6 +52,7 @@ var readInterval = settings.RegisterDurationSetting(
 	})
 
 var readTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.prober.read.timeout",
 	// Slow enough response times are not different than errors from the
 	// perspective of the user.
@@ -63,11 +67,13 @@ var readTimeout = settings.RegisterDurationSetting(
 	})
 
 var writeEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.prober.write.enabled",
 	"whether the KV write prober is enabled",
 	false)
 
 var writeInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.prober.write.interval",
 	"how often each node sends a write probe to the KV layer on average (jitter is added); "+
 		"note that a very slow read can block kvprober from sending additional probes; "+
@@ -80,6 +86,7 @@ var writeInterval = settings.RegisterDurationSetting(
 	})
 
 var writeTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.prober.write.timeout",
 	// Slow enough response times are not different than errors from the
 	// perspective of the user.
@@ -94,6 +101,7 @@ var writeTimeout = settings.RegisterDurationSetting(
 	})
 
 var scanMeta2Timeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.prober.planner.scan_meta2.timeout",
 	"timeout on scanning meta2 via db.Scan with max rows set to "+
 		"kv.prober.planner.num_steps_to_plan_at_once",
@@ -105,6 +113,7 @@ var scanMeta2Timeout = settings.RegisterDurationSetting(
 	})
 
 var numStepsToPlanAtOnce = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.prober.planner.num_steps_to_plan_at_once",
 	"the number of Steps to plan at once, where a Step is a decision on "+
 		"what range to probe; the order of the Steps is randomized within "+

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -59,6 +59,7 @@ var MinLeaseTransferStatsDuration = 30 * time.Second
 // via the new heuristic based on request load and latency or via the simpler
 // approach that purely seeks to balance the number of leases per node evenly.
 var enableLoadBasedLeaseRebalancing = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.allocator.load_based_lease_rebalancing.enabled",
 	"set to enable rebalancing of range leases based on load and latency",
 	true,
@@ -73,6 +74,7 @@ var enableLoadBasedLeaseRebalancing = settings.RegisterBoolSetting(
 // Setting this to 0 effectively disables load-based lease rebalancing, and
 // settings less than 0 are disallowed.
 var leaseRebalancingAggressiveness = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"kv.allocator.lease_rebalancing_aggressiveness",
 	"set greater than 1.0 to rebalance leases toward load more aggressively, "+
 		"or between 0 and 1.0 to be more conservative about rebalancing leases",

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -77,6 +77,7 @@ const (
 // of ranges.
 var rangeRebalanceThreshold = func() *settings.FloatSetting {
 	s := settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.allocator.range_rebalance_threshold",
 		"minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull",
 		0.05,

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -34,6 +34,7 @@ const SSTTargetSizeSetting = "kv.bulk_sst.target_size"
 // ExportRequestTargetFileSize controls the target file size for SSTs created
 // during backups.
 var ExportRequestTargetFileSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	SSTTargetSizeSetting,
 	fmt.Sprintf("target size for SSTs emitted from export requests; "+
 		"export requests (i.e. BACKUP) may buffer up to the sum of %s and %s in memory",
@@ -51,6 +52,7 @@ const MaxExportOverageSetting = "kv.bulk_sst.max_allowed_overage"
 // and an SST would exceed this size (due to large rows or large numbers of
 // versions), then the export will fail.
 var ExportRequestMaxAllowedFileSizeOverage = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	MaxExportOverageSetting,
 	fmt.Sprintf("if positive, allowed size in excess of target size for SSTs from export requests; "+
 		"export requests (i.e. BACKUP) may buffer up to the sum of %s and %s in memory",
@@ -65,6 +67,7 @@ var ExportRequestMaxAllowedFileSizeOverage = settings.RegisterByteSizeSetting(
 // If request takes longer than this threshold it would stop and return already
 // collected data and allow caller to use resume span to continue.
 var exportRequestMaxIterationTime = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.bulk_sst.max_request_time",
 	"if set, limits amount of time spent in export requests; "+
 		"if export request can not finish within allocated time it will resume from the point it stopped in "+

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
@@ -29,6 +29,7 @@ import (
 // QueryResolvedTimestampIntentCleanupAge configures the minimum intent age that
 // QueryResolvedTimestamp requests will consider for async intent cleanup.
 var QueryResolvedTimestampIntentCleanupAge = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.query_resolved_timestamp.intent_cleanup_age",
 	"minimum intent age that QueryResolvedTimestamp requests will consider for async intent cleanup",
 	10*time.Second,

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -18,6 +18,7 @@ import (
 
 // TargetDuration is the follower reads closed timestamp update target duration.
 var TargetDuration = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
 	3*time.Second,
@@ -26,6 +27,7 @@ var TargetDuration = settings.RegisterDurationSetting(
 
 // SideTransportCloseInterval determines the ClosedTimestampSender's frequency.
 var SideTransportCloseInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.closed_timestamp.side_transport_interval",
 	"the interval at which the closed-timestamp side-transport attempts to "+
 		"advance each range's closed timestamp; set to 0 to disable the side-transport",
@@ -38,6 +40,7 @@ var SideTransportCloseInterval = settings.RegisterDurationSetting(
 // (see TargetForPolicy), if it is set to a non-zero value. Meant as an escape
 // hatch.
 var LeadForGlobalReadsOverride = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.closed_timestamp.lead_for_global_reads_override",
 	"if nonzero, overrides the lead time that global_read ranges use to publish closed timestamps",
 	0,

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -56,6 +56,7 @@ import (
 // utilization and runaway queuing for misbehaving clients, a role it is well
 // positioned to serve.
 var MaxLockWaitQueueLength = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.lock_table.maximum_lock_wait_queue_length",
 	"the maximum length of a lock wait-queue that read-write requests are willing "+
 		"to enter and wait in. The setting can be used to ensure some level of quality-of-service "+
@@ -88,6 +89,7 @@ var MaxLockWaitQueueLength = settings.RegisterIntSetting(
 // discoveredCount > 100,000, caused by stats collection, where we definitely
 // want to avoid adding these locks to the lock table, if possible.
 var DiscoveredLocksThresholdToConsultFinalizedTxnCache = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.lock_table.discovered_locks_threshold_for_consulting_finalized_txn_cache",
 	"the maximum number of discovered locks by a waiter, above which the finalized txn cache"+
 		"is consulted and resolvable locks are not added to the lock table -- this should be a small"+

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -36,6 +36,7 @@ import (
 // LockTableLivenessPushDelay sets the delay before pushing in order to detect
 // coordinator failures of conflicting transactions.
 var LockTableLivenessPushDelay = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.lock_table.coordinator_liveness_push_delay",
 	"the delay before pushing in order to detect coordinator failures of conflicting transactions",
 	// This is set to a short duration to ensure that we quickly detect failed
@@ -67,6 +68,7 @@ var LockTableLivenessPushDelay = settings.RegisterDurationSetting(
 // LockTableDeadlockDetectionPushDelay sets the delay before pushing in order to
 // detect dependency cycles between transactions.
 var LockTableDeadlockDetectionPushDelay = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.lock_table.deadlock_detection_push_delay",
 	"the delay before pushing in order to detect dependency cycles between transactions",
 	// This is set to a medium duration to ensure that deadlock caused by

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -24,6 +24,7 @@ import (
 )
 
 var consistencyCheckInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"server.consistency_check.interval",
 	"the time between range consistency checks; set to 0 to disable consistency checking."+
 		" Note that intervals that are too short can negatively impact performance.",
@@ -32,6 +33,7 @@ var consistencyCheckInterval = settings.RegisterDurationSetting(
 )
 
 var consistencyCheckRate = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"server.consistency_check.max_rate",
 	"the rate limit (bytes/sec) to use for consistency checks; used in "+
 		"conjunction with server.consistency_check.interval to control the "+

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -49,6 +49,7 @@ const (
 // IntentAgeThreshold is the threshold after which an extant intent
 // will be resolved.
 var IntentAgeThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.gc.intent_age_threshold",
 	"intents older than this threshold will be resolved when encountered by the GC queue",
 	2*time.Hour,
@@ -72,6 +73,7 @@ var IntentAgeThreshold = settings.RegisterDurationSetting(
 // of writing. This value is subject to tuning in real environment as we have
 // more data available.
 var MaxIntentsPerCleanupBatch = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.gc.intent_cleanup_batch_size",
 	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
 	5000,
@@ -90,6 +92,7 @@ var MaxIntentsPerCleanupBatch = settings.RegisterIntSetting(
 // The default value is a conservative limit to prevent pending intent key sizes
 // from ballooning.
 var MaxIntentKeyBytesPerCleanupBatch = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.gc.intent_cleanup_batch_byte_size",
 	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
 	1e6,

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -28,6 +28,7 @@ import (
 // MergeQueueEnabled is a setting that controls whether the merge queue is
 // enabled.
 var MergeQueueEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.range_merge.queue_enabled",
 	"whether the automatic merge queue is enabled",
 	true,
@@ -209,6 +210,7 @@ func IntersectSpan(
 
 // SplitByLoadMergeDelay wraps "kv.range_split.by_load_merge_delay".
 var SplitByLoadMergeDelay = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.range_split.by_load_merge_delay",
 	"the delay that range splits created due to load will wait before considering being merged away",
 	5*time.Minute,

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -44,6 +44,7 @@ const (
 // MergeQueueInterval is a setting that controls how often the merge queue waits
 // between processing replicas.
 var MergeQueueInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.range_merge.queue_interval",
 	"how long the merge queue waits between processing replicas",
 	5*time.Second,

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -34,6 +34,7 @@ import (
 // ReconcileInterval is the interval between two generations of the reports.
 // When set to zero - disables the report generation.
 var ReconcileInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.protectedts.reconciliation.interval",
 	"the frequency for reconciling jobs with protected timestamp records",
 	5*time.Minute,

--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -22,6 +22,7 @@ import (
 // MaxBytes controls the maximum number of bytes worth of spans and metadata
 // which can be protected by all protected timestamp records.
 var MaxBytes = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.protectedts.max_bytes",
 	"if non-zero the limit of the number of bytes of spans and metadata which can be protected",
 	1<<20, // 1 MiB
@@ -31,6 +32,7 @@ var MaxBytes = settings.RegisterIntSetting(
 // MaxSpans controls the maximum number of spans which can be protected
 // by all protected timestamp records.
 var MaxSpans = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.protectedts.max_spans",
 	"if non-zero the limit of the number of spans which can be protected",
 	32768,
@@ -40,6 +42,7 @@ var MaxSpans = settings.RegisterIntSetting(
 // PollInterval defines how frequently the protectedts state is polled by the
 // Tracker.
 var PollInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.protectedts.poll_interval",
 	// TODO(ajwerner): better description.
 	"the interval at which the protectedts subsystem state is polled",

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -51,6 +51,7 @@ const (
 // which the processing of a queue may time out. It is an escape hatch to raise
 // the timeout for queues.
 var queueGuaranteedProcessingTimeBudget = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.queue.process.guaranteed_time_budget",
 	"the guaranteed duration before which the processing of a queue may "+
 		"time out",

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -58,6 +58,7 @@ const (
 
 // targetRaftOutgoingBatchSize wraps "kv.raft.command.target_batch_size".
 var targetRaftOutgoingBatchSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.raft.command.target_batch_size",
 	"size of a batch of raft commands after which it will be sent without further batching",
 	64<<20, // 64 MB

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -81,6 +81,7 @@ const (
 var testingDisableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_QUIESCENCE", false)
 
 var disableSyncRaftLog = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.raft_log.disable_synchronization_unsafe",
 	"set to true to disable synchronization on Raft log writes to persistent storage. "+
 		"Setting to true risks data loss or data corruption on server crashes. "+
@@ -99,6 +100,7 @@ const (
 
 // MaxCommandSize wraps "kv.raft.command.max_size".
 var MaxCommandSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.raft.command.max_size",
 	"maximum size of a raft command",
 	MaxCommandSizeDefault,
@@ -114,6 +116,7 @@ var MaxCommandSize = settings.RegisterByteSizeSetting(
 // threshold and the current GC TTL (true) or just based on the GC threshold
 // (false).
 var StrictGCEnforcement = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.gc_ttl.strict_enforcement.enabled",
 	"if true, fail to serve requests at timestamps below the TTL even if the data still exists",
 	true,

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -27,6 +27,7 @@ var backpressureLogLimiter = log.Every(500 * time.Millisecond)
 // range's size must grow to before backpressure will be applied on writes. Set
 // to 0 to disable backpressure altogether.
 var backpressureRangeSizeMultiplier = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"kv.range.backpressure_range_size_multiplier",
 	"multiple of range_max_bytes that a range is allowed to grow to without "+
 		"splitting before writes to that range are blocked, or 0 to disable",
@@ -65,6 +66,7 @@ var backpressureRangeSizeMultiplier = settings.RegisterFloatSetting(
 //     applying backpressure.
 //
 var backpressureByteTolerance = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.range.backpressure_byte_tolerance",
 	"defines the number of bytes above the product of "+
 		"backpressure_range_size_multiplier and the range_max_size at which "+

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -26,6 +26,7 @@ import (
 // information is collected and passed around, regardless of the value of this
 // setting.
 var FollowerReadsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.closed_timestamp.follower_reads_enabled",
 	"allow (all) replicas to serve consistent historical reads based on closed timestamp information",
 	true,

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -40,6 +40,7 @@ import (
 
 // RangefeedEnabled is a cluster setting that enables rangefeed requests.
 var RangefeedEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.rangefeed.enabled",
 	"if set, rangefeed registration is enabled",
 	false,
@@ -48,6 +49,7 @@ var RangefeedEnabled = settings.RegisterBoolSetting(
 // RangeFeedRefreshInterval controls the frequency with which we deliver closed
 // timestamp updates to rangefeeds.
 var RangeFeedRefreshInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.rangefeed.closed_timestamp_refresh_interval",
 	"the interval at which closed-timestamp updates"+
 		"are delivered to rangefeeds; set to 0 to use kv.closed_timestamp.side_transport_interval",
@@ -57,6 +59,7 @@ var RangeFeedRefreshInterval = settings.RegisterDurationSetting(
 
 // RangefeedTBIEnabled controls whether or not we use a TBI during catch-up scan.
 var RangefeedTBIEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.rangefeed.catchup_scan_iterator_optimization.enabled",
 	"if true, rangefeeds will use time-bound iterators for catchup-scans when possible",
 	util.ConstantWithMetamorphicTestBool("kv.rangefeed.catchup_scan_iterator_optimization.enabled", true),

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -27,6 +27,7 @@ import (
 )
 
 var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.concurrency.optimistic_eval_limited_scans.enabled",
 	"when true, limited scans are optimistically evaluated in the sense of not checking for "+
 		"conflicting latches or locks up front for the full key range of the scan, and instead "+

--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -21,6 +21,7 @@ import (
 
 // SplitByLoadEnabled wraps "kv.range_split.by_load_enabled".
 var SplitByLoadEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.range_split.by_load_enabled",
 	"allow automatic splits of ranges based on where load is concentrated",
 	true,
@@ -28,6 +29,7 @@ var SplitByLoadEnabled = settings.RegisterBoolSetting(
 
 // SplitByLoadQPSThreshold wraps "kv.range_split.load_qps_threshold".
 var SplitByLoadQPSThreshold = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.range_split.load_qps_threshold",
 	"the QPS over which, the range becomes a candidate for load based splitting",
 	2500, // 2500 req/s

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -43,6 +43,7 @@ import (
 // TODO(erikgrinaker): this, and the timeout handling, should be moved into a
 // migration helper that manages checkpointing and retries as well.
 var migrateApplicationTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.migration.migrate_application.timeout",
 	"timeout for a Migrate request to be applied across all replicas of a range",
 	1*time.Minute,

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -51,6 +51,7 @@ const (
 // for rebalancing. It does not prevent transferring leases in order to allow
 // a replica to be removed from a range.
 var MinLeaseTransferInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.allocator.min_lease_transfer_interval",
 	"controls how frequently leases can be transferred for rebalancing. "+
 		"It does not prevent transferring leases in order to allow a "+

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -43,6 +43,7 @@ import (
 // ReporterInterval is the interval between two generations of the reports.
 // When set to zero - disables the report generation.
 var ReporterInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"kv.replication_reports.interval",
 	"the frequency for generating the replication_constraint_stats, replication_stats_report and "+
 		"replication_critical_localities reports (set to 0 to disable)",

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -120,6 +120,7 @@ var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.max_rate",
 	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
 	1<<40,
@@ -127,6 +128,7 @@ var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 
 // addSSTableRequestLimit limits concurrent AddSSTable requests.
 var addSSTableRequestLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.concurrent_addsstable_requests",
 	"number of concurrent AddSSTable requests per store before queueing",
 	1,
@@ -139,6 +141,7 @@ var addSSTableRequestLimit = settings.RegisterIntSetting(
 // disk, so we can allow a greater amount of concurrency than regular AddSSTable
 // requests. Applied independently of concurrent_addsstable_requests.
 var addSSTableAsWritesRequestLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.concurrent_addsstable_as_writes_requests",
 	"number of concurrent AddSSTable requests ingested as writes per store before queueing",
 	10,
@@ -147,6 +150,7 @@ var addSSTableAsWritesRequestLimit = settings.RegisterIntSetting(
 
 // concurrentRangefeedItersLimit limits concurrent rangefeed catchup iterators.
 var concurrentRangefeedItersLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.rangefeed.concurrent_catchup_iterators",
 	"number of rangefeeds catchup iterators a store will allow concurrently before queueing",
 	64,
@@ -157,6 +161,7 @@ var concurrentRangefeedItersLimit = settings.RegisterIntSetting(
 // ScanInterleavedIntents requests that will be run on a store. Used as part
 // of pre-evaluation throttling.
 var concurrentscanInterleavedIntentsLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.migration.concurrent_scan_interleaved_intents",
 	"number of scan interleaved intents requests a store will handle concurrently before queueing",
 	1,
@@ -166,6 +171,7 @@ var concurrentscanInterleavedIntentsLimit = settings.RegisterIntSetting(
 // Minimum time interval between system config updates which will lead to
 // enqueuing replicas.
 var queueAdditionOnSystemConfigUpdateRate = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"kv.store.system_config_update.queue_add_rate",
 	"the rate (per second) at which the store will add, all replicas to the split and merge queue due to system config gossip",
 	.5,
@@ -176,6 +182,7 @@ var queueAdditionOnSystemConfigUpdateRate = settings.RegisterFloatSetting(
 // enqueuing replicas. The default is relatively high to deal with startup
 // scenarios.
 var queueAdditionOnSystemConfigUpdateBurst = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.store.system_config_update.queue_add_burst",
 	"the burst rate at which the store will add all replicas to the split and merge queue due to system config gossip",
 	32,
@@ -186,6 +193,7 @@ var queueAdditionOnSystemConfigUpdateBurst = settings.RegisterIntSetting(
 // and Raft leadership transfers.
 var leaseTransferWait = func() *settings.DurationSetting {
 	s := settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		leaseTransferWaitSettingName,
 		"the amount of time a server waits to transfer range leases before proceeding with the rest of the shutdown process "+
 			"(note that the --drain-wait parameter for cockroach node drain may need adjustment "+
@@ -213,6 +221,7 @@ const leaseTransferWaitSettingName = "server.shutdown.lease_transfer_wait"
 // here since we check it in in the caller to limit generated requests as well
 // to prevent excessive queuing.
 var ExportRequestsLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.concurrent_export_requests",
 	"number of export requests a store will handle concurrently before queuing",
 	3,

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -45,6 +45,7 @@ const (
 // replicate queue will not consider stores which have failed a reservation a
 // viable target.
 var FailedReservationsTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
 	5*time.Second,
@@ -56,6 +57,7 @@ const timeAfterStoreSuspectSettingName = "server.time_after_store_suspect"
 // TimeAfterStoreSuspect measures how long we consider a store suspect since
 // it's last failure.
 var TimeAfterStoreSuspect = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	timeAfterStoreSuspectSettingName,
 	"the amount of time we consider a store suspect for after it fails a node liveness heartbeat."+
 		" A suspect node would not receive any new replicas or lease transfers, but will keep the replicas it has.",
@@ -79,6 +81,7 @@ const timeUntilStoreDeadSettingName = "server.time_until_store_dead"
 // TimeUntilStoreDead wraps "server.time_until_store_dead".
 var TimeUntilStoreDead = func() *settings.DurationSetting {
 	s := settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		timeUntilStoreDeadSettingName,
 		"the time after which if there is no new gossiped information about a store, it is considered dead",
 		5*time.Minute,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -72,6 +72,7 @@ func makeStoreRebalancerMetrics() StoreRebalancerMetrics {
 // additional variables such as write load and disk usage into account.
 // If disabled, rebalancing is done purely based on replica count.
 var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"kv.allocator.load_based_rebalancing",
 	"whether to rebalance based on the distribution of QPS across stores",
 	"leases and replicas",
@@ -89,6 +90,7 @@ var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
 // forgiving to avoid thrashing.
 var qpsRebalanceThreshold = func() *settings.FloatSetting {
 	s := settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.allocator.qps_rebalance_threshold",
 		"minimum fraction away from the mean a store's QPS (such as queries per second) can be before it is considered overfull or underfull",
 		0.25,

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -696,11 +696,12 @@ func validatePositive(v int64) error {
 // context of up-replication or rebalancing (i.e. any snapshot that was not
 // requested by raft itself, to which `kv.snapshot_recovery.max_rate` applies).
 var rebalanceSnapshotRate = settings.RegisterByteSizeSetting(
+	settings.SystemOnly,
 	"kv.snapshot_rebalance.max_rate",
 	"the rate limit (bytes/sec) to use for rebalance and upreplication snapshots",
 	32<<20, // 32mb/s
 	validatePositive,
-).WithPublic().WithSystemOnly()
+).WithPublic()
 
 // recoverySnapshotRate is the rate at which Raft-initiated spanshots can be
 // sent. Ideally, one would never see a Raft-initiated snapshot; we'd like all
@@ -712,17 +713,19 @@ var rebalanceSnapshotRate = settings.RegisterByteSizeSetting(
 // to a semaphore at the receiver, and so the slower one ultimately determines
 // the pace at which things can move along.
 var recoverySnapshotRate = settings.RegisterByteSizeSetting(
+	settings.SystemOnly,
 	"kv.snapshot_recovery.max_rate",
 	"the rate limit (bytes/sec) to use for recovery snapshots",
 	32<<20, // 32mb/s
 	validatePositive,
-).WithPublic().WithSystemOnly()
+).WithPublic()
 
 // snapshotSenderBatchSize is the size that key-value batches are allowed to
 // grow to during Range snapshots before being sent to the receiver. This limit
 // places an upper-bound on the memory footprint of the sender of a Range
 // snapshot. It is also the granularity of rate limiting.
 var snapshotSenderBatchSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.snapshot_sender.batch_size",
 	"size of key-value batches sent over the network during snapshots",
 	256<<10, // 256 KB
@@ -733,6 +736,7 @@ var snapshotSenderBatchSize = settings.RegisterByteSizeSetting(
 // The default of 2 MiB was chosen to be in line with the behavior in bulk-io.
 // See sstWriteSyncRate.
 var snapshotSSTWriteSyncRate = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.snapshot_sst.sync_size",
 	"threshold after which snapshot SST writes must fsync",
 	bulkIOWriteBurst,

--- a/pkg/kv/kvserver/syncing_write.go
+++ b/pkg/kv/kvserver/syncing_write.go
@@ -63,6 +63,7 @@ func limitBulkIOWrite(ctx context.Context, limiter *rate.Limiter, cost int) erro
 
 // sstWriteSyncRate wraps "kv.bulk_sst.sync_size". 0 disables syncing.
 var sstWriteSyncRate = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"kv.bulk_sst.sync_size",
 	"threshold after which non-Rocks SST writes must fsync (0 disables)",
 	bulkIOWriteBurst,

--- a/pkg/kv/kvserver/tenantrate/settings.go
+++ b/pkg/kv/kvserver/tenantrate/settings.go
@@ -64,6 +64,7 @@ var (
 	// per CPU, or roughly 20% of the machine (by design 1 RU roughly maps to 1
 	// CPU-millisecond).
 	kvcuRateLimit = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.rate_limit",
 		"per-tenant rate limit in KV Compute Units per second if positive, "+
 			"or KV Compute Units per second per CPU if negative",
@@ -77,6 +78,7 @@ var (
 	)
 
 	kvcuBurstLimitSeconds = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.burst_limit_seconds",
 		"per-tenant burst limit as a multiplier of the rate",
 		10,
@@ -84,6 +86,7 @@ var (
 	)
 
 	readRequestCost = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.read_request_cost",
 		"base cost of a read request in KV Compute Units",
 		0.7,
@@ -91,6 +94,7 @@ var (
 	)
 
 	readCostPerMB = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.read_cost_per_megabyte",
 		"cost of a read in KV Compute Units per MB",
 		10.0,
@@ -98,6 +102,7 @@ var (
 	)
 
 	writeRequestCost = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.write_request_cost",
 		"base cost of a write request in KV Compute Units",
 		1.0,
@@ -105,6 +110,7 @@ var (
 	)
 
 	writeCostPerMB = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"kv.tenant_rate_limiter.write_cost_per_megabyte",
 		"cost of a write in KV Compute Units per MB",
 		400.0,

--- a/pkg/multitenant/tenantcostmodel/settings.go
+++ b/pkg/multitenant/tenantcostmodel/settings.go
@@ -27,6 +27,7 @@ import (
 // from the host cluster.
 var (
 	readRequestCost = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.kv_read_request_cost",
 		"base cost of a read request in Request Units",
 		0.6993,
@@ -34,6 +35,7 @@ var (
 	)
 
 	readCostPerMB = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.kv_read_cost_per_megabyte",
 		"cost of a read in Request Units per MB",
 		107.6563,
@@ -41,6 +43,7 @@ var (
 	)
 
 	writeRequestCost = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.kv_write_request_cost",
 		"base cost of a write request in Request Units",
 		5.7733,
@@ -48,6 +51,7 @@ var (
 	)
 
 	writeCostPerMB = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.kv_write_cost_per_megabyte",
 		"cost of a write in Request Units per MB",
 		2026.3021,
@@ -55,6 +59,7 @@ var (
 	)
 
 	podCPUSecondCost = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.pod_cpu_second_cost",
 		"cost of a CPU-second on the tenant POD in Request Units",
 		1000.0,
@@ -62,6 +67,7 @@ var (
 	)
 
 	pgwireEgressCostPerMB = settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"tenant_cost_model.pgwire_egress_cost_per_megabyte",
 		"cost of client <-> SQL ingress/egress per MB",
 		878.9063,

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -85,6 +85,7 @@ func HashPassword(ctx context.Context, password string) ([]byte, error) {
 // AutoDetectPasswordHashes is the cluster setting that configures whether
 // the server recognizes pre-hashed passwords.
 var AutoDetectPasswordHashes = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"server.user_login.store_client_pre_hashed_passwords.enabled",
 	"whether the server accepts to store passwords pre-hashed by clients",
 	true,
@@ -159,6 +160,7 @@ func CheckPasswordHashValidity(
 // MinPasswordLength is the cluster setting that configures the
 // minimum SQL password length.
 var MinPasswordLength = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"server.user_login.min_password_length",
 	"the minimum length accepted for passwords set in cleartext via SQL. "+
 		"Note that a value lower than 1 is ignored: passwords cannot be empty in any case.",

--- a/pkg/security/tls_settings.go
+++ b/pkg/security/tls_settings.go
@@ -33,7 +33,8 @@ type TLSSettings interface {
 	ocspTimeout() time.Duration
 }
 
-var ocspMode = settings.RegisterEnumSetting("security.ocsp.mode",
+var ocspMode = settings.RegisterEnumSetting(
+	settings.TenantWritable, "security.ocsp.mode",
 	"use OCSP to check whether TLS certificates are revoked. If the OCSP "+
 		"server is unreachable, in strict mode all certificates will be rejected "+
 		"and in lax mode all certificates will be accepted.",
@@ -42,7 +43,8 @@ var ocspMode = settings.RegisterEnumSetting("security.ocsp.mode",
 // TODO(bdarnell): 3 seconds is the same as base.NetworkTimeout, but
 // we can't use it here due to import cycles. We need a real
 // no-dependencies base package for constants like this.
-var ocspTimeout = settings.RegisterDurationSetting("security.ocsp.timeout",
+var ocspTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable, "security.ocsp.timeout",
 	"timeout before considering the OCSP server unreachable",
 	3*time.Second,
 	settings.NonNegativeDuration,

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -87,6 +87,7 @@ var ConfigureOIDC = func(
 }
 
 var webSessionTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"server.web_session_timeout",
 	"the duration that a newly created web session will be valid",
 	7*24*time.Hour,

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -53,7 +53,8 @@ const Endpoint = "/debug/"
 var _ = func() *settings.StringSetting {
 	// This setting definition still exists so as to not break
 	// deployment scripts that set it unconditionally.
-	v := settings.RegisterStringSetting("server.remote_debugging.mode", "unused", "local")
+	v := settings.RegisterStringSetting(
+		settings.TenantWritable, "server.remote_debugging.mode", "unused", "local")
 	v.SetRetired()
 	return v
 }()

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -57,6 +57,7 @@ type NodeStatusGenerator interface {
 }
 
 var reportFrequency = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"diagnostics.reporting.interval",
 	"interval at which diagnostics data should be reported",
 	time.Hour,

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	queryWait = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.shutdown.query_wait",
 		"the server will wait for at least this amount of time for active queries to finish "+
 			"(note that the --drain-wait parameter for cockroach node drain may need adjustment "+
@@ -35,6 +36,7 @@ var (
 	).WithPublic()
 
 	drainWait = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.shutdown.drain_wait",
 		"the amount of time a server waits in an unready state before proceeding with the rest "+
 			"of the shutdown process "+

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -34,12 +34,14 @@ const (
 
 var (
 	numGoroutinesThreshold = settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"server.goroutine_dump.num_goroutines_threshold",
 		"a threshold beyond which if number of goroutines increases, "+
 			"then goroutine dump can be triggered",
 		1000,
 	)
 	totalDumpSizeLimit = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"server.goroutine_dump.total_dump_size_limit",
 		"total size of goroutine dumps to be kept. "+
 			"Dumps are GC'ed in the order of creation time. The latest dump is "+

--- a/pkg/server/heapprofiler/cluster_settings.go
+++ b/pkg/server/heapprofiler/cluster_settings.go
@@ -21,7 +21,8 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 // Note: this feature only works for nodes running on unix hosts with cgroups
 // enabled.
 var ActiveQueryDumpsEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
 	"diagnostics.active_query_dumps.enabled",
 	"experimental: enable dumping of anonymized active queries to disk when node is under memory pressure",
 	true,
-).WithPublic().WithSystemOnly()
+).WithPublic()

--- a/pkg/server/heapprofiler/profilestore.go
+++ b/pkg/server/heapprofiler/profilestore.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	maxProfiles = settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"server.mem_profile.max_profiles",
 		"maximum number of profiles to be kept per ramp-up of memory usage. "+
 			"A ramp-up is defined as a sequence of profiles with increasing usage.",
@@ -35,6 +36,7 @@ var (
 	)
 
 	maxCombinedFileSize = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"server.mem_profile.total_dump_size_limit",
 		"maximum combined disk size of preserved memory profiles",
 		128<<20, // 128MiB
@@ -43,10 +45,12 @@ var (
 
 func init() {
 	s := settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"server.heap_profile.max_profiles", "use server.mem_profile.max_profiles instead", 5)
 	s.SetRetired()
 
 	b := settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"server.heap_profile.total_dump_size_limit",
 		"use server.mem_profile.total_dump_size_limit instead",
 		128<<20, // 128MiB

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -134,12 +134,14 @@ This metric is thus not an indicator of KV health.`,
 var (
 	// graphiteEndpoint is host:port, if any, of Graphite metrics server.
 	graphiteEndpoint = settings.RegisterStringSetting(
+		settings.TenantWritable,
 		"external.graphite.endpoint",
 		"if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port",
 		"",
 	).WithPublic()
 	// graphiteInterval is how often metrics are pushed to Graphite, if enabled.
 	graphiteInterval = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		graphiteIntervalKey,
 		"the interval at which metrics are pushed to Graphite (if enabled)",
 		10*time.Second,

--- a/pkg/server/purge_auth_session.go
+++ b/pkg/server/purge_auth_session.go
@@ -25,12 +25,14 @@ import (
 
 var (
 	webSessionPurgeTTL = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.web_session.purge.ttl",
 		"if nonzero, entries in system.web_sessions older than this duration are periodically purged",
 		time.Hour,
 	).WithPublic()
 
 	webSessionAutoLogoutTimeout = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.web_session.auto_logout.timeout",
 		"the duration that web sessions will survive before being periodically purged, since they were last used",
 		7*24*time.Hour,
@@ -38,6 +40,7 @@ var (
 	).WithPublic()
 
 	webSessionPurgePeriod = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.web_session.purge.period",
 		"the time until old sessions are deleted",
 		time.Hour,
@@ -45,6 +48,7 @@ var (
 	).WithPublic()
 
 	webSessionPurgeLimit = settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"server.web_session.purge.max_deletions_per_cycle",
 		"the maximum number of old sessions to delete for each purge",
 		10,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -118,12 +118,14 @@ var (
 	gzipResponseWriterPool sync.Pool
 
 	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"server.clock.forward_jump_check_enabled",
 		"if enabled, forward clock jumps > max_offset/2 will cause a panic",
 		false,
 	).WithPublic()
 
 	persistHLCUpperBoundInterval = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.clock.persist_upper_bound_interval",
 		"the interval between persisting the wall time upper bound of the clock. The clock "+
 			"does not generate a wall time greater than the persisted timestamp and will panic if "+

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -36,6 +36,7 @@ var (
 	// rangeLogTTL is the TTL for rows in system.rangelog. If non zero, range log
 	// entries are periodically garbage collected.
 	rangeLogTTL = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.rangelog.ttl",
 		fmt.Sprintf(
 			"if nonzero, range log entries older than this duration are deleted every %s. "+
@@ -48,6 +49,7 @@ var (
 	// eventLogTTL is the TTL for rows in system.eventlog. If non zero, event log
 	// entries are periodically garbage collected.
 	eventLogTTL = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.eventlog.ttl",
 		fmt.Sprintf(
 			"if nonzero, entries in system.eventlog older than this duration are deleted every %s. "+

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -33,32 +33,37 @@ const durationKey = "testing.duration"
 const byteSizeKey = "testing.bytesize"
 const enumKey = "testing.enum"
 
-var strA = settings.RegisterValidatedStringSetting(strKey, "desc", "<default>", func(sv *settings.Values, v string) error {
-	if len(v) > 15 {
-		return errors.Errorf("can't set %s to string longer than 15: %s", strKey, v)
-	}
-	return nil
-})
-var intA = settings.RegisterIntSetting(intKey, "desc", 1, func(v int64) error {
-	if v < 0 {
-		return errors.Errorf("can't set %s to a negative value: %d", intKey, v)
-	}
-	return nil
+var strA = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable, strKey, "desc", "<default>", func(sv *settings.Values, v string) error {
+		if len(v) > 15 {
+			return errors.Errorf("can't set %s to string longer than 15: %s", strKey, v)
+		}
+		return nil
+	})
+var intA = settings.RegisterIntSetting(
+	settings.TenantWritable, intKey, "desc", 1, func(v int64) error {
+		if v < 0 {
+			return errors.Errorf("can't set %s to a negative value: %d", intKey, v)
+		}
+		return nil
 
-})
-var durationA = settings.RegisterDurationSetting(durationKey, "desc", time.Minute, func(v time.Duration) error {
-	if v < 0 {
-		return errors.Errorf("can't set %s to a negative duration: %s", durationKey, v)
-	}
-	return nil
-})
-var byteSizeA = settings.RegisterByteSizeSetting(byteSizeKey, "desc", 1024*1024, func(v int64) error {
-	if v < 0 {
-		return errors.Errorf("can't set %s to a negative value: %d", byteSizeKey, v)
-	}
-	return nil
-})
-var enumA = settings.RegisterEnumSetting(enumKey, "desc", "foo", map[int64]string{1: "foo", 2: "bar"})
+	})
+var durationA = settings.RegisterDurationSetting(
+	settings.TenantWritable, durationKey, "desc", time.Minute, func(v time.Duration) error {
+		if v < 0 {
+			return errors.Errorf("can't set %s to a negative duration: %s", durationKey, v)
+		}
+		return nil
+	})
+var byteSizeA = settings.RegisterByteSizeSetting(
+	settings.TenantWritable, byteSizeKey, "desc", 1024*1024, func(v int64) error {
+		if v < 0 {
+			return errors.Errorf("can't set %s to a negative value: %d", byteSizeKey, v)
+		}
+		return nil
+	})
+var enumA = settings.RegisterEnumSetting(
+	settings.TenantWritable, enumKey, "desc", "foo", map[int64]string{1: "foo", 2: "bar"})
 
 func TestSettingsRefresh(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -87,7 +87,8 @@ type storeMetrics interface {
 	Registry() *metric.Registry
 }
 
-var childMetricsEnabled = settings.RegisterBoolSetting("server.child_metrics.enabled",
+var childMetricsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable, "server.child_metrics.enabled",
 	"enables the exporting of child metrics, additional prometheus time series with extra labels",
 	false)
 

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -34,6 +34,7 @@ const (
 
 var (
 	totalDumpSizeLimit = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
 		"server.job_trace.total_dump_size_limit",
 		"total size of job trace dumps to be kept. "+
 			"Dumps are GC'ed in the order of creation time. The latest dump is "+

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -92,15 +92,9 @@ func (b *BoolSetting) WithPublic() *BoolSetting {
 	return b
 }
 
-// WithSystemOnly marks this setting as system-only and can be chained.
-func (b *BoolSetting) WithSystemOnly() *BoolSetting {
-	b.common.systemOnly = true
-	return b
-}
-
 // RegisterBoolSetting defines a new setting with type bool.
-func RegisterBoolSetting(key, desc string, defaultValue bool) *BoolSetting {
+func RegisterBoolSetting(class Class, key, desc string, defaultValue bool) *BoolSetting {
 	setting := &BoolSetting{defaultValue: defaultValue}
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -39,16 +39,10 @@ func (b *ByteSizeSetting) WithPublic() *ByteSizeSetting {
 	return b
 }
 
-// WithSystemOnly marks this setting as system-only and can be chained.
-func (b *ByteSizeSetting) WithSystemOnly() *ByteSizeSetting {
-	b.common.systemOnly = true
-	return b
-}
-
 // RegisterByteSizeSetting defines a new setting with type bytesize and any
 // supplied validation function(s).
 func RegisterByteSizeSetting(
-	key, desc string, defaultValue int64, validateFns ...func(int64) error,
+	class Class, key, desc string, defaultValue int64, validateFns ...func(int64) error,
 ) *ByteSizeSetting {
 
 	var validateFn func(int64) error
@@ -72,6 +66,6 @@ func RegisterByteSizeSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}}
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -18,19 +18,17 @@ import (
 // common implements basic functionality used by all setting types.
 type common struct {
 	description string
+	class       Class
 	visibility  Visibility
-	systemOnly  bool
 	// Each setting has a slotIdx which is used as a handle with Values.
 	slotIdx       int
 	nonReportable bool
 	retired       bool
 }
 
-func (i *common) isRetired() bool {
-	return i.retired
-}
-
-func (i *common) setSlotIdx(slotIdx int) {
+// init must be called to initialize the fields that don't have defaults.
+func (i *common) init(class Class, slotIdx int, description string) {
+	i.class = class
 	if slotIdx < 1 {
 		panic(fmt.Sprintf("Invalid slot index %d", slotIdx))
 	}
@@ -38,25 +36,27 @@ func (i *common) setSlotIdx(slotIdx int) {
 		panic("too many settings; increase MaxSettings")
 	}
 	i.slotIdx = slotIdx
-}
-func (i *common) getSlotIdx() int {
-	return i.slotIdx
+	i.description = description
 }
 
-func (i *common) setDescription(s string) {
-	i.description = s
+func (i *common) isRetired() bool {
+	return i.retired
+}
+
+func (i *common) getSlotIdx() int {
+	return i.slotIdx
 }
 
 func (i common) Description() string {
 	return i.description
 }
 
-func (i common) Visibility() Visibility {
-	return i.visibility
+func (i common) Class() Class {
+	return i.class
 }
 
-func (i common) SystemOnly() bool {
-	return i.systemOnly
+func (i common) Visibility() Visibility {
+	return i.visibility
 }
 
 func (i common) isReportable() bool {
@@ -103,10 +103,9 @@ func (i *common) SetOnChange(sv *Values, fn func(ctx context.Context)) {
 type internalSetting interface {
 	NonMaskedSetting
 
+	init(class Class, slotIdx int, desc string)
 	isRetired() bool
 	setToDefault(ctx context.Context, sv *Values)
-	setDescription(desc string)
-	setSlotIdx(slotIdx int)
 	getSlotIdx() int
 	// isReportable indicates whether the value of the setting can be
 	// included in user-facing reports such as that produced by SHOW ALL

--- a/pkg/settings/doc.go
+++ b/pkg/settings/doc.go
@@ -27,7 +27,10 @@ setting is to be used. For example, to add an "enterprise" flag, adding into
 license_check.go:
 
 var enterpriseEnabled = settings.RegisterBoolSetting(
-  "enterprise.enabled", "some doc for the setting", false,
+	settings.TenantWritable,
+	"enterprise.enabled",
+	"some doc for the setting",
+	false,
 )
 
 Then use with `if enterpriseEnabled.Get() ...`

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -120,18 +120,12 @@ func (d *DurationSetting) WithPublic() *DurationSetting {
 	return d
 }
 
-// WithSystemOnly marks this setting as system-only and can be chained.
-func (d *DurationSetting) WithSystemOnly() *DurationSetting {
-	d.common.systemOnly = true
-	return d
-}
-
-// Defeat the linter.
-var _ = (*DurationSetting).WithSystemOnly
-
 // RegisterDurationSetting defines a new setting with type duration.
 func RegisterDurationSetting(
-	key, desc string, defaultValue time.Duration, validateFns ...func(time.Duration) error,
+	class Class,
+	key, desc string,
+	defaultValue time.Duration,
+	validateFns ...func(time.Duration) error,
 ) *DurationSetting {
 	var validateFn func(time.Duration) error
 	if len(validateFns) > 0 {
@@ -154,7 +148,7 @@ func RegisterDurationSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }
 
@@ -162,7 +156,7 @@ func RegisterDurationSetting(
 // public setting with type duration which requires an explicit unit when being
 // set.
 func RegisterPublicDurationSettingWithExplicitUnit(
-	key, desc string, defaultValue time.Duration, validateFn func(time.Duration) error,
+	class Class, key, desc string, defaultValue time.Duration, validateFn func(time.Duration) error,
 ) *DurationSettingWithExplicitUnit {
 	var fn func(time.Duration) error
 
@@ -179,7 +173,7 @@ func RegisterPublicDurationSettingWithExplicitUnit(
 		},
 	}
 	setting.SetVisibility(Public)
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }
 

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -110,18 +110,9 @@ func (e *EnumSetting) WithPublic() *EnumSetting {
 	return e
 }
 
-// WithSystemOnly indicates system-usage only and can be chained.
-func (e *EnumSetting) WithSystemOnly() *EnumSetting {
-	e.common.systemOnly = true
-	return e
-}
-
-// Defeat the linter.
-var _ = (*EnumSetting).WithSystemOnly
-
 // RegisterEnumSetting defines a new setting with type int.
 func RegisterEnumSetting(
-	key, desc string, defaultValue string, enumValues map[int64]string,
+	class Class, key, desc string, defaultValue string, enumValues map[int64]string,
 ) *EnumSetting {
 	enumValuesLower := make(map[int64]string)
 	var i int64
@@ -143,6 +134,6 @@ func RegisterEnumSetting(
 		enumValues: enumValuesLower,
 	}
 
-	register(key, fmt.Sprintf("%s %s", desc, enumValuesToDesc(enumValues)), setting)
+	register(class, key, fmt.Sprintf("%s %s", desc, enumValuesToDesc(enumValues)), setting)
 	return setting
 }

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -109,18 +109,9 @@ func (f *FloatSetting) WithPublic() *FloatSetting {
 	return f
 }
 
-// WithSystemOnly indicates system-usage only and can be chained.
-func (f *FloatSetting) WithSystemOnly() *FloatSetting {
-	f.common.systemOnly = true
-	return f
-}
-
-// Defeat the linter.
-var _ = (*FloatSetting).WithSystemOnly
-
 // RegisterFloatSetting defines a new setting with type float.
 func RegisterFloatSetting(
-	key, desc string, defaultValue float64, validateFns ...func(float64) error,
+	class Class, key, desc string, defaultValue float64, validateFns ...func(float64) error,
 ) *FloatSetting {
 	var validateFn func(float64) error
 	if len(validateFns) > 0 {
@@ -143,7 +134,7 @@ func RegisterFloatSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }
 

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -103,7 +103,7 @@ func (i *IntSetting) setToDefault(ctx context.Context, sv *Values) {
 // RegisterIntSetting defines a new setting with type int with a
 // validation function.
 func RegisterIntSetting(
-	key, desc string, defaultValue int64, validateFns ...func(int64) error,
+	class Class, key, desc string, defaultValue int64, validateFns ...func(int64) error,
 ) *IntSetting {
 	var composed func(int64) error
 	if len(validateFns) > 0 {
@@ -125,7 +125,7 @@ func RegisterIntSetting(
 		defaultValue: defaultValue,
 		validateFn:   composed,
 	}
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }
 
@@ -134,15 +134,6 @@ func (i *IntSetting) WithPublic() *IntSetting {
 	i.SetVisibility(Public)
 	return i
 }
-
-// WithSystemOnly system-only usage and can be chained.
-func (i *IntSetting) WithSystemOnly() *IntSetting {
-	i.common.systemOnly = true
-	return i
-}
-
-// Defeat the linter.
-var _ = (*IntSetting).WithSystemOnly
 
 // PositiveInt can be passed to RegisterIntSetting
 func PositiveInt(v int64) error {

--- a/pkg/settings/masked.go
+++ b/pkg/settings/masked.go
@@ -48,9 +48,9 @@ func (s *MaskedSetting) Typ() string {
 	return s.setting.Typ()
 }
 
-// SystemOnly returns the underlying setting's SystemOnly.
-func (s *MaskedSetting) SystemOnly() bool {
-	return s.setting.SystemOnly()
+// Class returns the class for the underlying setting.
+func (s *MaskedSetting) Class() Class {
+	return s.setting.Class()
 }
 
 // TestingIsReportable is used in testing for reportability.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -117,7 +117,7 @@ var retiredSettings = map[string]struct{}{
 }
 
 // register adds a setting to the registry.
-func register(key, desc string, s internalSetting) {
+func register(class Class, key, desc string, s internalSetting) {
 	if _, ok := retiredSettings[key]; ok {
 		panic(fmt.Sprintf("cannot reuse previously defined setting name: %s", key))
 	}
@@ -142,9 +142,9 @@ func register(key, desc string, s internalSetting) {
 			))
 		}
 	}
-	s.setDescription(desc)
 	registry[key] = s
-	s.setSlotIdx(len(registry))
+	slotIdx := len(registry)
+	s.init(class, slotIdx, desc)
 }
 
 // NumRegisteredSettings returns the number of registered settings.

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -102,14 +102,14 @@ func (s *StringSetting) WithPublic() *StringSetting {
 }
 
 // RegisterStringSetting defines a new setting with type string.
-func RegisterStringSetting(key, desc string, defaultValue string) *StringSetting {
-	return RegisterValidatedStringSetting(key, desc, defaultValue, nil)
+func RegisterStringSetting(class Class, key, desc string, defaultValue string) *StringSetting {
+	return RegisterValidatedStringSetting(class, key, desc, defaultValue, nil)
 }
 
 // RegisterValidatedStringSetting defines a new setting with type string with a
 // validation function.
 func RegisterValidatedStringSetting(
-	key, desc string, defaultValue string, validateFn func(*Values, string) error,
+	class Class, key, desc string, defaultValue string, validateFn func(*Values, string) error,
 ) *StringSetting {
 	if validateFn != nil {
 		if err := validateFn(nil, defaultValue); err != nil {
@@ -124,6 +124,6 @@ func RegisterValidatedStringSetting(
 	// PII and are thus non-reportable (to exclude them from telemetry
 	// reports).
 	setting.SetReportable(false)
-	register(key, desc, setting)
+	register(class, key, desc, setting)
 	return setting
 }

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -165,14 +165,6 @@ func (v *VersionSetting) setToDefault(ctx context.Context, sv *Values) {}
 
 // RegisterVersionSetting adds the provided version setting to the global
 // registry.
-func RegisterVersionSetting(key, desc string, setting *VersionSetting) {
-	register(key, desc, setting)
-}
-
-// TestingRegisterVersionSetting is like RegisterVersionSetting,
-// but it takes a VersionSettingImpl.
-func TestingRegisterVersionSetting(key, desc string, impl VersionSettingImpl) *VersionSetting {
-	setting := MakeVersionSetting(impl)
-	register(key, desc, &setting)
-	return &setting
+func RegisterVersionSetting(class Class, key, desc string, setting *VersionSetting) {
+	register(class, key, desc, setting)
 }

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -34,6 +34,7 @@ import (
 // spanconfig.experimental_reconciliation.enabled is configured. For host
 // tenants, COCKROACH_EXPERIMENTAL_SPAN_CONFIGS needs to be additionally set.
 var checkReconciliationJobInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"spanconfig.experimental_reconciliation_job.check_interval",
 	"the frequency at which to check if the span config reconciliation job exists (and to start it if not)",
 	10*time.Minute,
@@ -45,6 +46,7 @@ var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 // For the host tenant it has no effect unless
 // COCKROACH_EXPERIMENTAL_SPAN_CONFIGS is also set.
 var jobEnabledSetting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"spanconfig.experimental_reconciliation_job.enabled",
 	"enable the use of the kv accessor", false)
 

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -31,10 +31,11 @@ import (
 // infrastructure. It has no effect unless COCKROACH_EXPERIMENTAL_SPAN_CONFIGS
 // is set.
 var EnabledSetting = settings.RegisterBoolSetting(
+	settings.SystemOnly,
 	"spanconfig.experimental_store.enabled",
 	`use the span config infrastructure in KV instead of the system config span`,
 	false,
-).WithSystemOnly()
+)
 
 // Store is an in-memory data structure to store and retrieve span configs.
 // Internally it makes use of an interval tree to store non-overlapping span

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -286,6 +286,7 @@ type alterDatabaseDropRegionNode struct {
 }
 
 var allowDropFinalRegion = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.multiregion.drop_primary_region.enabled",
 	"allows dropping the PRIMARY REGION of a database if it is the last region",
 	true,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -77,6 +77,7 @@ const (
 // entries for before we attempt to fill in a single index batch before queueing
 // it up for ingestion and progress reporting in the index backfiller processor.
 var indexBackfillBatchSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"bulkio.index_backfill.batch_size",
 	"the number of rows for which we construct index entries in a single batch",
 	50000,
@@ -85,6 +86,7 @@ var indexBackfillBatchSize = settings.RegisterIntSetting(
 
 // indexBackfillCheckpointInterval is the duration between backfill detail updates.
 var indexBackfillCheckpointInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"bulkio.index_backfill.checkpoint_interval",
 	"the amount of time between index backfill checkpoint updates",
 	30*time.Second,
@@ -94,6 +96,7 @@ var indexBackfillCheckpointInterval = settings.RegisterDurationSetting(
 // columnBackfillBatchSize is the maximum number of rows we update at once when
 // adding or removing columns.
 var columnBackfillBatchSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"bulkio.column_backfill.batch_size",
 	"the number of rows updated at a time to add/remove columns",
 	200,

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -203,6 +203,7 @@ func (tc *Collection) AddUncommittedDescriptor(desc catalog.MutableDescriptor) e
 // ValidateOnWriteEnabled is the cluster setting used to enable or disable
 // validating descriptors prior to writing.
 var ValidateOnWriteEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.catalog.descs.validate_on_write.enabled",
 	"set to true to validate descriptors prior to writing, false to disable; default is true",
 	true, /* defaultValue */

--- a/pkg/sql/catalog/hydratedtables/hydratedcache.go
+++ b/pkg/sql/catalog/hydratedtables/hydratedcache.go
@@ -98,6 +98,7 @@ var (
 
 // CacheSize controls the size of the LRU cache.
 var CacheSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.catalog.hydrated_tables.cache_size",
 	"number of table descriptor versions retained in the hydratedtables LRU cache",
 	128,

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -55,6 +55,7 @@ var errReadOlderVersion = errors.New("read older descriptor version from store")
 
 // LeaseDuration controls the duration of sql descriptor leases.
 var LeaseDuration = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.catalog.descriptor_lease_duration",
 	"mean duration of sql descriptor leases, this actual duration is jitterred",
 	base.DefaultDescriptorLeaseDuration)
@@ -68,6 +69,7 @@ func between0and1inclusive(f float64) error {
 
 // LeaseJitterFraction controls the percent jitter around sql lease durations
 var LeaseJitterFraction = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"sql.catalog.descriptor_lease_jitter_fraction",
 	"mean duration of sql descriptor leases, this actual duration is jitterred",
 	base.DefaultDescriptorLeaseJitterFraction,
@@ -1135,6 +1137,7 @@ func (m *Manager) watchForUpdates(ctx context.Context, descUpdateCh chan<- *desc
 // leaseRefreshLimit is the upper-limit on the number of descriptor leases
 // that will continuously have their lease refreshed.
 var leaseRefreshLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.tablecache.lease.refresh_limit",
 	"maximum number of descriptors to periodically refresh leases for",
 	500,

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -62,6 +62,7 @@ type storage struct {
 // LeaseRenewalDuration controls the default time before a lease expires when
 // acquisition to renew the lease begins.
 var LeaseRenewalDuration = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.catalog.descriptor_lease_renewal_fraction",
 	"controls the default time before a lease expires when acquisition to renew the lease begins",
 	base.DefaultDescriptorLeaseRenewalTimeout)

--- a/pkg/sql/colexec/external_hash_aggregator.go
+++ b/pkg/sql/colexec/external_hash_aggregator.go
@@ -104,6 +104,7 @@ const HashAggregationDiskSpillingEnabledSettingName = "sql.distsql.temp_storage.
 // HashAggregationDiskSpillingEnabled is a cluster setting that allows to
 // disable hash aggregator disk spilling.
 var HashAggregationDiskSpillingEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	HashAggregationDiskSpillingEnabledSettingName,
 	"set to false to disable hash aggregator disk spilling "+
 		"(this will improve performance, but the query might hit the memory limit)",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -476,6 +476,7 @@ CREATE TABLE crdb_internal.tables (
 // is used to define the AS OF time for querying the system.table_statistics
 // table when building crdb_internal.table_row_statistics.
 var statsAsOfTimeClusterMode = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.crdb_internal.table_row_statistics.as_of_time",
 	"historical query time used to build the crdb_internal.table_row_statistics table",
 	-10*time.Second,

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -46,6 +46,7 @@ import (
 // createStatsPostEvents controls the cluster setting for logging
 // automatic table statistics collection to the event log.
 var createStatsPostEvents = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.stats.post_events.enabled",
 	"if set, an event is logged for every CREATE STATISTICS job",
 	false,
@@ -54,6 +55,7 @@ var createStatsPostEvents = settings.RegisterBoolSetting(
 // featureStatsEnabled is used to enable and disable the CREATE STATISTICS and
 // ANALYZE features.
 var featureStatsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.stats.enabled",
 	"set to true to enable CREATE STATISTICS/ANALYZE, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -21,6 +21,7 @@ import (
 )
 
 var showEstimatedRowCountClusterSetting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.show_tables.estimated_row_count.enabled",
 	"whether the estimated_row_count is shown on SHOW TABLES. Turning this off "+
 		"will improve SHOW TABLES performance.",

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -356,6 +356,7 @@ const DefaultPrimaryRegionClusterSettingName = "sql.defaults.primary_region"
 
 // DefaultPrimaryRegion is a cluster setting that contains the default primary region.
 var DefaultPrimaryRegion = settings.RegisterStringSetting(
+	settings.TenantWritable,
 	DefaultPrimaryRegionClusterSettingName,
 	`if not empty, all databases created without a PRIMARY REGION will `+
 		`implicitly have the given PRIMARY REGION`,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1357,6 +1357,7 @@ const defaultLocalScansConcurrencyLimit = 1024
 // "additional" we mean having more processors than one in the same stage of the
 // physical plan.
 var localScansConcurrencyLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.local_scans.concurrency_limit",
 	"maximum number of additional goroutines for performing scans in local plans",
 	defaultLocalScansConcurrencyLimit,

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -47,6 +47,7 @@ const histogramSamples = 10000
 // The lowest TTL we recommend is 10 minutes. This value must be lower than
 // that.
 var maxTimestampAge = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.stats.max_timestamp_age",
 	"maximum age of timestamp during table statistics collection",
 	5*time.Minute,

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -374,6 +374,7 @@ func LogEventForJobs(
 }
 
 var eventLogSystemTableEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"server.eventlog.enabled",
 	"if set, logged notable events are also stored in the table system.eventlog",
 	true,

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -66,12 +66,14 @@ import (
 // logStatementsExecuteEnabled causes the Executor to log executed
 // statements and, if any, resulting errors.
 var logStatementsExecuteEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.trace.log_statement_execute",
 	"set to true to enable logging of executed statements",
 	false,
 ).WithPublic()
 
 var slowQueryLogThreshold = settings.RegisterPublicDurationSettingWithExplicitUnit(
+	settings.TenantWritable,
 	"sql.log.slow_query.latency_threshold",
 	"when set to non-zero, log statements whose service latency exceeds "+
 		"the threshold to a secondary logger on each node",
@@ -80,6 +82,7 @@ var slowQueryLogThreshold = settings.RegisterPublicDurationSettingWithExplicitUn
 )
 
 var slowInternalQueryLogEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.log.slow_query.internal_queries.enabled",
 	"when set to true, internal queries which exceed the slow query log threshold "+
 		"are logged to a separate log. Must have the slow query log enabled for this "+
@@ -88,6 +91,7 @@ var slowInternalQueryLogEnabled = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var slowQueryLogFullTableScans = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.log.slow_query.experimental_full_table_scans.enabled",
 	"when set to true, statements that perform a full table/index scan will be logged to the "+
 		"slow query log even if they do not meet the latency threshold. Must have the slow query "+
@@ -96,18 +100,21 @@ var slowQueryLogFullTableScans = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var unstructuredQueryLog = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.log.unstructured_entries.enabled",
 	"when set, SQL execution and audit logs use the pre-v21.1 unstrucured format",
 	false,
 )
 
 var adminAuditLogEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.log.admin_audit.enabled",
 	"when set, log SQL queries that are executed by a user with admin privileges",
 	false,
 )
 
 var telemetryLoggingEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.telemetry.query_sampling.enabled",
 	"when set to true, executed queries will emit an event on the telemetry logging channel",
 	// Note: Usage of an env var here makes it possible to set a default without

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -104,6 +104,7 @@ import (
 
 // ClusterOrganization is the organization name.
 var ClusterOrganization = settings.RegisterStringSetting(
+	settings.TenantWritable,
 	"cluster.organization",
 	"organization name",
 	"",
@@ -119,6 +120,7 @@ func ClusterIsInternal(sv *settings.Values) bool {
 // non-reportable.
 var ClusterSecret = func() *settings.StringSetting {
 	s := settings.RegisterStringSetting(
+		settings.TenantWritable,
 		"cluster.secret",
 		"cluster specific secret",
 		"",
@@ -135,6 +137,7 @@ var ClusterSecret = func() *settings.StringSetting {
 // TODO(bob): Remove or n-op this in v2.4: https://github.com/cockroachdb/cockroach/issues/32844
 var defaultIntSize = func() *settings.IntSetting {
 	s := settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"sql.defaults.default_int_size",
 		"the size, in bytes, of an INT type", 8, func(i int64) error {
 			if i != 4 && i != 8 {
@@ -149,6 +152,7 @@ var defaultIntSize = func() *settings.IntSetting {
 const allowCrossDatabaseFKsSetting = "sql.cross_db_fks.enabled"
 
 var allowCrossDatabaseFKs = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	allowCrossDatabaseFKsSetting,
 	"if true, creating foreign key references across databases is allowed",
 	false,
@@ -157,6 +161,7 @@ var allowCrossDatabaseFKs = settings.RegisterBoolSetting(
 const allowCrossDatabaseViewsSetting = "sql.cross_db_views.enabled"
 
 var allowCrossDatabaseViews = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	allowCrossDatabaseViewsSetting,
 	"if true, creating views that refer to other databases is allowed",
 	false,
@@ -165,6 +170,7 @@ var allowCrossDatabaseViews = settings.RegisterBoolSetting(
 const allowCrossDatabaseSeqOwnerSetting = "sql.cross_db_sequence_owners.enabled"
 
 var allowCrossDatabaseSeqOwner = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	allowCrossDatabaseSeqOwnerSetting,
 	"if true, creating sequences owned by tables from other databases is allowed",
 	false,
@@ -173,6 +179,7 @@ var allowCrossDatabaseSeqOwner = settings.RegisterBoolSetting(
 const allowCrossDatabaseSeqReferencesSetting = "sql.cross_db_sequence_references.enabled"
 
 var allowCrossDatabaseSeqReferences = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	allowCrossDatabaseSeqReferencesSetting,
 	"if true, sequences referenced by tables from other databases are allowed",
 	false,
@@ -185,6 +192,7 @@ const secondaryTenantsZoneConfigsEnabledSettingName = "sql.zone_configs.experime
 //
 // This setting has no effect on zone configurations that have already been set.
 var secondaryTenantZoneConfigsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	secondaryTenantsZoneConfigsEnabledSettingName,
 	"allow secondary tenants to set zone configurations; does not affect the system tenant",
 	false,
@@ -198,6 +206,7 @@ var secondaryTenantZoneConfigsEnabled = settings.RegisterBoolSetting(
 // all execution because traces are gathered for all transactions even
 // if they are not output.
 var traceTxnThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.trace.txn.enable_threshold",
 	"duration beyond which all transactions are traced (set to 0 to "+
 		"disable). This setting is coarser grained than"+
@@ -210,6 +219,7 @@ var traceTxnThreshold = settings.RegisterDurationSetting(
 // to be able to reduce the noise associated with a larger transaction (e.g.
 // round trips to client).
 var traceStmtThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.trace.stmt.enable_threshold",
 	"duration beyond which all statements are traced (set to 0 to disable). "+
 		"This applies to individual statements within a transaction and is therefore "+
@@ -222,6 +232,7 @@ var traceStmtThreshold = settings.RegisterDurationSetting(
 // non-trivial performance impact and also reveals SQL statements
 // which may be a privacy concern.
 var traceSessionEventLogEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.trace.session_eventlog.enabled",
 	"set to true to enable session tracing. "+
 		"Note that enabling this may have a non-trivial negative performance impact.",
@@ -235,6 +246,7 @@ const ReorderJoinsLimitClusterSettingName = "sql.defaults.reorder_joins_limit"
 // ReorderJoinsLimitClusterValue controls the cluster default for the maximum
 // number of joins reordered.
 var ReorderJoinsLimitClusterValue = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	ReorderJoinsLimitClusterSettingName,
 	"default number of joins to reorder",
 	opt.DefaultJoinOrderLimit,
@@ -251,12 +263,14 @@ var ReorderJoinsLimitClusterValue = settings.RegisterIntSetting(
 ).WithPublic()
 
 var requireExplicitPrimaryKeysClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.require_explicit_primary_keys.enabled",
 	"default value for requiring explicit primary keys in CREATE TABLE statements",
 	false,
 ).WithPublic()
 
 var placementEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.multiregion_placement_policy.enabled",
 	"default value for enable_multiregion_placement_policy;"+
 		" allows for use of PLACEMENT RESTRICTED",
@@ -264,6 +278,7 @@ var placementEnabledClusterMode = settings.RegisterBoolSetting(
 )
 
 var autoRehomingEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_auto_rehoming.enabled",
 	"default value for experimental_enable_auto_rehoming;"+
 		" allows for rows in REGIONAL BY ROW tables to be auto-rehomed on UPDATE",
@@ -271,6 +286,7 @@ var autoRehomingEnabledClusterMode = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var onUpdateRehomeRowEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.on_update_rehome_row.enabled",
 	"default value for on_update_rehome_row;"+
 		" enables ON UPDATE rehome_row() expressions to trigger on updates",
@@ -278,18 +294,21 @@ var onUpdateRehomeRowEnabledClusterMode = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var temporaryTablesEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_temporary_tables.enabled",
 	"default value for experimental_enable_temp_tables; allows for use of temporary tables by default",
 	false,
 ).WithPublic()
 
 var implicitColumnPartitioningEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_implicit_column_partitioning.enabled",
 	"default value for experimental_enable_temp_tables; allows for the use of implicit column partitioning",
 	false,
 ).WithPublic()
 
 var overrideMultiRegionZoneConfigClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.override_multi_region_zone_config.enabled",
 	"default value for override_multi_region_zone_config; "+
 		"allows for overriding the zone configs of a multi-region table or database",
@@ -297,18 +316,21 @@ var overrideMultiRegionZoneConfigClusterMode = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var hashShardedIndexesEnabledClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_hash_sharded_indexes.enabled",
 	"default value for experimental_enable_hash_sharded_indexes; allows for creation of hash sharded indexes by default",
 	false,
 ).WithPublic()
 
 var zigzagJoinClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.zigzag_join.enabled",
 	"default value for enable_zigzag_join session setting; allows use of zig-zag join by default",
 	true,
 ).WithPublic()
 
 var optDrivenFKCascadesClusterLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.foreign_key_cascades_limit",
 	"default value for foreign_key_cascades_limit session setting; limits the number of cascading operations that run as part of a single query",
 	10000,
@@ -316,6 +338,7 @@ var optDrivenFKCascadesClusterLimit = settings.RegisterIntSetting(
 ).WithPublic()
 
 var preferLookupJoinsForFKs = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.prefer_lookup_joins_for_fks.enabled",
 	"default value for prefer_lookup_joins_for_fks session setting; causes foreign key operations to use lookup joins when possible",
 	false,
@@ -328,6 +351,7 @@ var preferLookupJoinsForFKs = settings.RegisterBoolSetting(
 // haven't been collected. Collection of histograms is controlled by the
 // cluster setting sql.stats.histogram_collection.enabled.
 var optUseHistogramsClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.optimizer_use_histograms.enabled",
 	"default value for optimizer_use_histograms session setting; enables usage of histograms in the optimizer by default",
 	true,
@@ -340,6 +364,7 @@ var optUseHistogramsClusterMode = settings.RegisterBoolSetting(
 // if they haven't been collected. Collection of multi-column stats is
 // controlled by the cluster setting sql.stats.multi_column_collection.enabled.
 var optUseMultiColStatsClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.optimizer_use_multicol_stats.enabled",
 	"default value for optimizer_use_multicol_stats session setting; enables usage of multi-column stats in the optimizer by default",
 	true,
@@ -351,6 +376,7 @@ var optUseMultiColStatsClusterMode = settings.RegisterBoolSetting(
 // searched for matching rows before remote nodes, in the hope that the
 // execution engine can avoid visiting remote nodes.
 var localityOptimizedSearchMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.locality_optimized_partitioned_index_scan.enabled",
 	"default value for locality_optimized_partitioned_index_scan session setting; "+
 		"enables searching for rows in the current region before searching remote regions",
@@ -358,18 +384,21 @@ var localityOptimizedSearchMode = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var implicitSelectForUpdateClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.implicit_select_for_update.enabled",
 	"default value for enable_implicit_select_for_update session setting; enables FOR UPDATE locking during the row-fetch phase of mutation statements",
 	true,
 ).WithPublic()
 
 var insertFastPathClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.insert_fast_path.enabled",
 	"default value for enable_insert_fast_path session setting; enables a specialized insert path",
 	true,
 ).WithPublic()
 
 var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_alter_column_type.enabled",
 	"default value for experimental_alter_column_type session setting; "+
 		"enables the use of ALTER COLUMN TYPE for general conversions",
@@ -377,6 +406,7 @@ var experimentalAlterColumnTypeGeneralMode = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var clusterStatementTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.defaults.statement_timeout",
 	"default value for the statement_timeout; "+
 		"default value for the statement_timeout session setting; controls the "+
@@ -387,6 +417,7 @@ var clusterStatementTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 var clusterLockTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.defaults.lock_timeout",
 	"default value for the lock_timeout; "+
 		"default value for the lock_timeout session setting; controls the "+
@@ -398,6 +429,7 @@ var clusterLockTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.defaults.idle_in_session_timeout",
 	"default value for the idle_in_session_timeout; "+
 		"default value for the idle_in_session_timeout session setting; controls the "+
@@ -408,6 +440,7 @@ var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 var clusterIdleInTransactionSessionTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.defaults.idle_in_transaction_session_timeout",
 	"default value for the idle_in_transaction_session_timeout; controls the "+
 		"duration a session is permitted to idle in a transaction before the "+
@@ -419,6 +452,7 @@ var clusterIdleInTransactionSessionTimeout = settings.RegisterDurationSetting(
 // TODO(rytaft): remove this once unique without index constraints are fully
 // supported.
 var experimentalUniqueWithoutIndexConstraintsMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_enable_unique_without_index_constraints.enabled",
 	"default value for experimental_enable_unique_without_index_constraints session setting;"+
 		"disables unique without index constraints by default",
@@ -426,6 +460,7 @@ var experimentalUniqueWithoutIndexConstraintsMode = settings.RegisterBoolSetting
 ).WithPublic()
 
 var experimentalUseNewSchemaChanger = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_new_schema_changer.enabled",
 	"default value for experimental_use_new_schema_changer session setting;"+
 		"disables new schema changer by default",
@@ -439,6 +474,7 @@ var experimentalUseNewSchemaChanger = settings.RegisterEnumSetting(
 ).WithPublic()
 
 var experimentalStreamReplicationEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_stream_replication.enabled",
 	"default value for experimental_stream_replication session setting;"+
 		"enables the ability to setup a replication stream",
@@ -446,12 +482,14 @@ var experimentalStreamReplicationEnabled = settings.RegisterBoolSetting(
 ).WithPublic()
 
 var stubCatalogTablesEnabledClusterValue = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	`sql.defaults.stub_catalog_tables.enabled`,
 	`default value for stub_catalog_tables session setting`,
 	true,
 ).WithPublic()
 
 var experimentalComputedColumnRewrites = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
 	"sql.defaults.experimental_computed_column_rewrites",
 	"allows rewriting computed column expressions in CREATE TABLE and ALTER TABLE statements; "+
 		"the format is: '(before expression) -> (after expression) [, (before expression) -> (after expression) ...]'",
@@ -463,6 +501,7 @@ var experimentalComputedColumnRewrites = settings.RegisterValidatedStringSetting
 )
 
 var propagateInputOrdering = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	`sql.defaults.propagate_input_ordering.enabled`,
 	`default value for the experimental propagate_input_ordering session variable`,
 	false,
@@ -471,6 +510,7 @@ var propagateInputOrdering = settings.RegisterBoolSetting(
 // settingWorkMemBytes is a cluster setting that determines the maximum amount
 // of RAM that a processor can use.
 var settingWorkMemBytes = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.distsql.temp_storage.workmem",
 	"maximum amount of memory in bytes a processor can use before falling back to temp storage",
 	execinfra.DefaultMemoryLimit, /* 64MiB */
@@ -484,6 +524,7 @@ const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental
 // optimizer-driven DistSQL planning that sidesteps intermediate planNode
 // transition when going from opt.Expr to DistSQL processor specs.
 var experimentalDistSQLPlanningClusterMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	ExperimentalDistSQLPlanningClusterSettingName,
 	"default experimental_distsql_planning mode; enables experimental opt-driven DistSQL planning",
 	"off",
@@ -500,6 +541,7 @@ const VectorizeClusterSettingName = "sql.defaults.vectorize"
 // VectorizeClusterMode controls the cluster default for when automatic
 // vectorization is enabled.
 var VectorizeClusterMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	VectorizeClusterSettingName,
 	"default vectorize mode",
 	"on",
@@ -513,6 +555,7 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 
 // DistSQLClusterExecMode controls the cluster default for when DistSQL is used.
 var DistSQLClusterExecMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"sql.defaults.distsql",
 	"default distributed SQL execution mode",
 	"auto",
@@ -527,6 +570,7 @@ var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 // SerialNormalizationMode controls how the SERIAL type is interpreted in table
 // definitions.
 var SerialNormalizationMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"sql.defaults.serial_normalization",
 	"default handling of SERIAL in table definitions",
 	"rowid",
@@ -540,6 +584,7 @@ var SerialNormalizationMode = settings.RegisterEnumSetting(
 ).WithPublic()
 
 var disallowFullTableScans = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	`sql.defaults.disallow_full_table_scans.enabled`,
 	"setting to true rejects queries that have planned a full table scan",
 	false,
@@ -547,6 +592,7 @@ var disallowFullTableScans = settings.RegisterBoolSetting(
 
 // intervalStyle controls intervals representation.
 var intervalStyle = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"sql.defaults.intervalstyle",
 	"default value for IntervalStyle session setting",
 	strings.ToLower(duration.IntervalStyle_POSTGRES.String()),
@@ -567,6 +613,7 @@ var dateStyleEnumMap = map[int64]string{
 
 // dateStyle controls dates representation.
 var dateStyle = settings.RegisterEnumSetting(
+	settings.TenantWritable,
 	"sql.defaults.datestyle",
 	"default value for DateStyle session setting",
 	pgdate.DefaultDateStyle().SQLString(),
@@ -579,6 +626,7 @@ const intervalStyleEnabledClusterSetting = "sql.defaults.intervalstyle.enabled"
 // TODO(#sql-experience): remove session setting in v22.1 and have this
 // always enabled.
 var intervalStyleEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	intervalStyleEnabledClusterSetting,
 	"default value for intervalstyle_enabled session setting",
 	false,
@@ -590,12 +638,14 @@ const dateStyleEnabledClusterSetting = "sql.defaults.datestyle.enabled"
 // TODO(#sql-experience): remove session setting in v22.1 and have this
 // always enabled.
 var dateStyleEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	dateStyleEnabledClusterSetting,
 	"default value for datestyle_enabled session setting",
 	false,
 ).WithPublic()
 
 var txnRowsWrittenLog = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.transaction_rows_written_log",
 	"the threshold for the number of rows written by a SQL transaction "+
 		"which - once exceeded - will trigger a logging event to SQL_PERF (or "+
@@ -605,6 +655,7 @@ var txnRowsWrittenLog = settings.RegisterIntSetting(
 ).WithPublic()
 
 var txnRowsWrittenErr = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.transaction_rows_written_err",
 	"the limit for the number of rows written by a SQL transaction which - "+
 		"once exceeded - will fail the transaction (or will trigger a logging "+
@@ -614,6 +665,7 @@ var txnRowsWrittenErr = settings.RegisterIntSetting(
 ).WithPublic()
 
 var txnRowsReadLog = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.transaction_rows_read_log",
 	"the threshold for the number of rows read by a SQL transaction "+
 		"which - once exceeded - will trigger a logging event to SQL_PERF (or "+
@@ -623,6 +675,7 @@ var txnRowsReadLog = settings.RegisterIntSetting(
 ).WithPublic()
 
 var txnRowsReadErr = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.transaction_rows_read_err",
 	"the limit for the number of rows read by a SQL transaction which - "+
 		"once exceeded - will fail the transaction (or will trigger a logging "+
@@ -634,6 +687,7 @@ var txnRowsReadErr = settings.RegisterIntSetting(
 // This is a float setting (rather than an int setting) because the optimizer
 // uses floating point for calculating row estimates.
 var largeFullScanRows = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"sql.defaults.large_full_scan_rows",
 	"default value for large_full_scan_rows session setting which determines "+
 		"the maximum table size allowed for a full scan when disallow_full_table_scans "+

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -93,6 +93,7 @@ const parquetSuffix = "parquet"
 
 // featureExportEnabled is used to enable and disable the EXPORT feature.
 var featureExportEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.export.enabled",
 	"set to true to enable exports, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -40,6 +40,7 @@ func IsNoInboundStreamConnectionError(err error) bool {
 // SettingFlowStreamTimeout is a cluster setting that sets the default flow
 // stream timeout.
 var SettingFlowStreamTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.distsql.flow_stream_timeout",
 	"amount of time incoming streams wait for a flow to be set up before erroring out",
 	10*time.Second,

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -42,6 +42,7 @@ const flowDoneChanSize = 8
 // TODO(yuzefovich): we probably want to remove / disable this limit completely
 // when we enable the admission control.
 var settingMaxRunningFlows = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.distsql.max_running_flows",
 	"the value - when positive - used as is, or the value - when negative - "+
 		"multiplied by the number of CPUs on a node, to determine the "+

--- a/pkg/sql/idxusage/cluster_settings.go
+++ b/pkg/sql/idxusage/cluster_settings.go
@@ -14,5 +14,6 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 
 // Enable determines whether to collect per-index usage statistics.
 var Enable = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.metrics.index_usage_stats.enabled", "collect per index usage statistics", true, /* defaultValue */
 ).WithPublic()

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -40,6 +40,7 @@ import (
 )
 
 var collectTxnStatsSampleRate = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"sql.txn_stats.sample_rate",
 	"the probability that a given transaction will collect execution statistics (displayed in the DB Console)",
 	0.01,

--- a/pkg/sql/join_token.go
+++ b/pkg/sql/join_token.go
@@ -27,6 +27,7 @@ import (
 // FeatureTLSAutoJoinEnabled is used to enable and disable the TLS auto-join
 // feature.
 var FeatureTLSAutoJoinEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.tls_auto_join.enabled",
 	"set to true to enable tls auto join through join tokens, false to disable; default is false",
 	false,

--- a/pkg/sql/notice.go
+++ b/pkg/sql/notice.go
@@ -22,6 +22,7 @@ import (
 // NoticesEnabled is the cluster setting that allows users
 // to enable notices.
 var NoticesEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.notices.enabled",
 	"enable notices in the server/client protocol being sent",
 	true,

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -25,6 +25,7 @@ import (
 // UniquenessChecksForGenRandomUUIDClusterMode controls the cluster setting for
 // enabling uniqueness checks for UUID columns set to gen_random_uuid().
 var UniquenessChecksForGenRandomUUIDClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled",
 	"if enabled, uniqueness checks may be planned for mutations of UUID columns updated with"+
 		" gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability",

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -28,6 +28,7 @@ import (
 )
 
 var multipleModificationsOfTableEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.multiple_modifications_of_table.enabled",
 	"if true, allow statements containing multiple INSERT ON CONFLICT, UPSERT, UPDATE, or DELETE "+
 		"subqueries modifying the same table, at the risk of data corruption if the same row is "+

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -72,6 +72,7 @@ const serverHBAConfSetting = "server.host_based_authentication.configuration"
 // configuration.
 var connAuthConf = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		serverHBAConfSetting,
 		"host-based authentication configuration to use during connection authentication",
 		"",

--- a/pkg/sql/pgwire/ident_map_conf.go
+++ b/pkg/sql/pgwire/ident_map_conf.go
@@ -26,6 +26,7 @@ const serverIdentityMapSetting = "server.identity_map.configuration"
 
 var connIdentityMapConf = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
+		settings.TenantWritable,
 		serverIdentityMapSetting,
 		"system-identity to database-username mappings",
 		"",

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -52,6 +52,7 @@ const readBufferMaxMessageSizeClusterSettingName = "sql.conn.max_read_buffer_mes
 // ReadBufferMaxMessageSizeClusterSetting is the cluster setting for configuring
 // ReadBuffer default message sizes.
 var ReadBufferMaxMessageSizeClusterSetting = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	readBufferMaxMessageSizeClusterSettingName,
 	"maximum buffer size to allow for ingesting sql statements. Connections must be restarted for this to take effect.",
 	defaultMaxReadBufferMessageSize,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -59,6 +59,7 @@ import (
 // The "results_buffer_size" connection parameter can be used to override this
 // default for an individual connection.
 var connResultsBufferSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.defaults.results_buffer.size",
 	"default size of the buffer that accumulates results for a statement or a batch "+
 		"of statements before they are sent to the client. This can be overridden on "+
@@ -73,11 +74,13 @@ var connResultsBufferSize = settings.RegisterByteSizeSetting(
 ).WithPublic()
 
 var logConnAuth = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	sql.ConnAuditingClusterSettingName,
 	"if set, log SQL client connect and disconnect events (note: may hinder performance on loaded nodes)",
 	false).WithPublic()
 
 var logSessionAuth = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	sql.AuthAuditingClusterSettingName,
 	"if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)",
 	false).WithPublic()

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -37,6 +37,7 @@ import (
 )
 
 var queryCacheEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.query_cache.enabled", "enable the query cache", true,
 )
 

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -32,6 +32,7 @@ const RevertTableDefaultBatchSize = 500000
 // useTBIForRevertRange is a cluster setting that controls if the time-bound
 // iterator optimization is used when processing a revert range request.
 var useTBIForRevertRange = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"kv.bulk_io_write.revert_range_time_bound_iterator.enabled",
 	"use the time-bound iterator optimization when processing a revert range request",
 	true,

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -43,6 +43,7 @@ const (
 )
 
 var maxRowSizeLog = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.guardrails.max_row_size_log",
 	"maximum size of row (or column family if multiple column families are in use) that SQL can "+
 		"write to the database, above which an event is logged to SQL_PERF (or SQL_INTERNAL_PERF "+
@@ -65,6 +66,7 @@ var maxRowSizeLog = settings.RegisterByteSizeSetting(
 ).WithPublic()
 
 var maxRowSizeErr = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.guardrails.max_row_size_err",
 	"maximum size of row (or column family if multiple column families are in use) that SQL can "+
 		"write to the database, above which an error is returned; use 0 to disable",

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -47,6 +47,7 @@ var _ chunkBackfiller = &columnBackfiller{}
 // Each function retains a reference to its corresponding TxnCoordSender, so we
 // need to be careful not to accumulate an unbounded number of these functions.
 var backfillerMaxCommitWaitFns = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"schemachanger.backfiller.max_commit_wait_fns",
 	"the maximum number of commit-wait functions that the columnBackfiller will accumulate before consuming them to reclaim memory",
 	128,

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -58,18 +58,22 @@ type indexBackfiller struct {
 var _ execinfra.Processor = &indexBackfiller{}
 
 var backfillerBufferSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"schemachanger.backfiller.buffer_size", "the initial size of the BulkAdder buffer handling index backfills", 32<<20,
 )
 
 var backfillerMaxBufferSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"schemachanger.backfiller.max_buffer_size", "the maximum size of the BulkAdder buffer handling index backfills", 512<<20,
 )
 
 var backfillerBufferIncrementSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"schemachanger.backfiller.buffer_increment", "the size by which the BulkAdder attempts to grow its buffer before flushing", 32<<20,
 )
 
 var backillerSSTSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"schemachanger.backfiller.max_sst_size", "target size for ingested files during backfills", 16<<20,
 )
 

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -208,6 +208,7 @@ const joinReaderProcName = "join reader"
 // ParallelizeMultiKeyLookupJoinsEnabled determines whether the joinReader
 // parallelizes KV batches in all cases.
 var ParallelizeMultiKeyLookupJoinsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.distsql.parallelize_multi_key_lookup_joins.enabled",
 	"determines whether KV batches are executed in parallel for lookup joins in all cases. "+
 		"Enabling this will increase the speed of lookup joins when each input row might get "+

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -509,6 +509,7 @@ const joinReaderOrderingStrategyBatchSizeDefault = 10 << 10 /* 10 KiB */
 // JoinReaderOrderingStrategyBatchSize determines the size of input batches used
 // to construct a single lookup KV batch by joinReaderOrderingStrategy.
 var JoinReaderOrderingStrategyBatchSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.distsql.join_reader_ordering_strategy.batch_size",
 	"size limit on the input rows to construct a single lookup KV batch",
 	joinReaderOrderingStrategyBatchSizeDefault,

--- a/pkg/sql/schema_change_cluster_setting.go
+++ b/pkg/sql/schema_change_cluster_setting.go
@@ -22,6 +22,7 @@ import (
 // any features that require schema changes. Documentation for which features
 // are covered TBD.
 var featureSchemaChangeEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"feature.schema_change.enabled",
 	"set to true to enable schema changes, false to disable; default is true",
 	featureflag.FeatureFlagEnabledDefault,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2637,6 +2637,7 @@ var CmpOps = cmpOpFixups(map[ComparisonOperatorSymbol]cmpOpOverload{
 const experimentalBox2DClusterSettingName = "sql.spatial.experimental_box2d_comparison_operators.enabled"
 
 var experimentalBox2DClusterSetting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	experimentalBox2DClusterSettingName,
 	"enables the use of certain experimental box2d comparison operators",
 	false,

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -50,6 +50,7 @@ var virtualSequenceOpts = tree.SequenceOptions{
 // cachedSequencesCacheSize is the default cache size used when
 // SessionNormalizationMode is SerialUsesCachedSQLSequences.
 var cachedSequencesCacheSizeSetting = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.defaults.serial_sequences_cache_size",
 	"the default cache size when the session's serial normalization mode is set to cached sequences"+
 		"A cache size of 1 means no caching. Any cache size less than 1 is invalid.",

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -35,6 +35,7 @@ var CacheEnabledSettingName = "server.authentication_cache.enabled"
 // CacheEnabled is a cluster setting that determines if the
 // sessioninit.Cache and associated logic is enabled.
 var CacheEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	CacheEnabledSettingName,
 	"enables a cache used during authentication to avoid lookups to system tables "+
 		"when retrieving per-user authentication-related information",

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -96,7 +96,7 @@ func (p *planner) SetClusterSetting(
 		return nil, errors.AssertionFailedf("expected writable setting, got %T", v)
 	}
 
-	if setting.SystemOnly() && !p.execCfg.Codec.ForSystemTenant() {
+	if setting.Class() == settings.SystemOnly && !p.execCfg.Codec.ForSystemTenant() {
 		return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
 			"setting %s is only settable in the system tenant", name)
 	}

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -33,6 +33,7 @@ import (
 var (
 	// DefaultTTL specifies the time to expiration when a session is created.
 	DefaultTTL = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.sqlliveness.ttl",
 		"default sqlliveness session ttl",
 		40*time.Second,
@@ -40,6 +41,7 @@ var (
 	)
 	// DefaultHeartBeat specifies the period between attempts to extend a session.
 	DefaultHeartBeat = settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"server.sqlliveness.heartbeat",
 		"duration heart beats to push session expiration further out in time",
 		5*time.Second,

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -40,6 +40,7 @@ import (
 // GCInterval specifies duration between attempts to delete extant
 // sessions that have expired.
 var GCInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"server.sqlliveness.gc_interval",
 	"duration between attempts to delete extant sessions that have expired",
 	20*time.Second,
@@ -51,6 +52,7 @@ var GCInterval = settings.RegisterDurationSetting(
 //
 // [(1-GCJitter) * GCInterval, (1+GCJitter) * GCInterval]
 var GCJitter = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"server.sqlliveness.gc_jitter",
 	"jitter fraction on the duration between attempts to delete extant sessions that have expired",
 	.15,
@@ -69,6 +71,7 @@ var GCJitter = settings.RegisterFloatSetting(
 // increasing the cache size dynamically. The entries are just bytes each so
 // this should not be a big deal.
 var CacheSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"server.sqlliveness.storage_session_cache_size",
 	"number of session entries to store in the LRU",
 	1024)

--- a/pkg/sql/sqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/cluster_settings.go
@@ -18,6 +18,7 @@ import (
 
 // StmtStatsEnable determines whether to collect per-statement statistics.
 var StmtStatsEnable = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.metrics.statement_details.enabled", "collect per-statement query statistics", true,
 ).WithPublic()
 
@@ -25,6 +26,7 @@ var StmtStatsEnable = settings.RegisterBoolSetting(
 // transactions statistics for a single transaction. This defaults to 1000, and
 // currently is non-configurable (hidden setting).
 var TxnStatsNumStmtFingerprintIDsToRecord = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.transaction_details.max_statement_ids",
 	"max number of statement fingerprint IDs to store for transaction statistics",
 	1000,
@@ -34,12 +36,14 @@ var TxnStatsNumStmtFingerprintIDsToRecord = settings.RegisterIntSetting(
 // TxnStatsEnable determines whether to collect per-application transaction
 // statistics.
 var TxnStatsEnable = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.metrics.transaction_details.enabled", "collect per-application transaction statistics", true,
 ).WithPublic()
 
 // StatsCollectionLatencyThreshold specifies the minimum amount of time
 // consumed by a SQL statement before it is collected for statistics reporting.
 var StatsCollectionLatencyThreshold = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.metrics.statement_details.threshold",
 	"minimum execution time to cause statement statistics to be collected. "+
 		"If configured, no transaction stats are collected.",
@@ -49,6 +53,7 @@ var StatsCollectionLatencyThreshold = settings.RegisterDurationSetting(
 // DumpStmtStatsToLogBeforeReset specifies whether we dump the statements
 // statistics to logs before being reset.
 var DumpStmtStatsToLogBeforeReset = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.metrics.statement_details.dump_to_logs",
 	"dump collected statement statistics to node logs when periodically cleared",
 	false,
@@ -57,6 +62,7 @@ var DumpStmtStatsToLogBeforeReset = settings.RegisterBoolSetting(
 // SampleLogicalPlans specifies whether we periodically sample the logical plan
 // for each fingerprint.
 var SampleLogicalPlans = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.metrics.statement_details.plan_collection.enabled",
 	"periodically save a logical plan for each fingerprint",
 	true,
@@ -65,6 +71,7 @@ var SampleLogicalPlans = settings.RegisterBoolSetting(
 // LogicalPlanCollectionPeriod specifies the interval between collections of
 // logical plans for each fingerprint.
 var LogicalPlanCollectionPeriod = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.metrics.statement_details.plan_collection.period",
 	"the time until a new logical plan is collected",
 	5*time.Minute,
@@ -74,6 +81,7 @@ var LogicalPlanCollectionPeriod = settings.RegisterDurationSetting(
 // MaxMemSQLStatsStmtFingerprints specifies the maximum of unique statement
 // fingerprints we store in memory.
 var MaxMemSQLStatsStmtFingerprints = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.max_mem_stmt_fingerprints",
 	"the maximum number of statement fingerprints stored in memory",
 	100000,
@@ -82,6 +90,7 @@ var MaxMemSQLStatsStmtFingerprints = settings.RegisterIntSetting(
 // MaxMemSQLStatsTxnFingerprints specifies the maximum of unique transaction
 // fingerprints we store in memory.
 var MaxMemSQLStatsTxnFingerprints = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.max_mem_txn_fingerprints",
 	"the maximum number of transaction fingerprints stored in memory",
 	100000,
@@ -90,6 +99,7 @@ var MaxMemSQLStatsTxnFingerprints = settings.RegisterIntSetting(
 // MaxMemReportedSQLStatsStmtFingerprints specifies the maximum of unique statement
 // fingerprints we store in memory.
 var MaxMemReportedSQLStatsStmtFingerprints = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.max_mem_reported_stmt_fingerprints",
 	"the maximum number of reported statement fingerprints stored in memory",
 	100000,
@@ -98,6 +108,7 @@ var MaxMemReportedSQLStatsStmtFingerprints = settings.RegisterIntSetting(
 // MaxMemReportedSQLStatsTxnFingerprints specifies the maximum of unique transaction
 // fingerprints we store in memory.
 var MaxMemReportedSQLStatsTxnFingerprints = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.max_mem_reported_txn_fingerprints",
 	"the maximum number of reported transaction fingerprints stored in memory",
 	100000,
@@ -132,6 +143,7 @@ var MaxMemReportedSQLStatsTxnFingerprints = settings.RegisterIntSetting(
 // The total amount of memory consumed will still be constrained by the
 // top-level memory monitor created for SQL Stats.
 var MaxSQLStatsStmtFingerprintsPerExplicitTxn = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.metrics.max_stmt_fingerprints_per_explicit_txn",
 	"the maximum number of statement fingerprints stored per explicit transaction",
 	2000,
@@ -140,6 +152,7 @@ var MaxSQLStatsStmtFingerprintsPerExplicitTxn = settings.RegisterIntSetting(
 // MaxSQLStatReset is the cluster setting that controls at what interval SQL
 // statement statistics must be flushed within.
 var MaxSQLStatReset = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"diagnostics.forced_sql_stat_reset.interval",
 	"interval after which the reported SQL Stats are reset even "+
 		"if not collected by telemetry reporter. It has a max value of 24H.",

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -21,6 +21,7 @@ import (
 // SQLStatsFlushInterval is the cluster setting that controls how often the SQL
 // stats are flushed to system table.
 var SQLStatsFlushInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.stats.flush.interval",
 	"the interval at which SQL execution statistics are flushed to disk",
 	time.Hour,
@@ -30,6 +31,7 @@ var SQLStatsFlushInterval = settings.RegisterDurationSetting(
 // SQLStatsFlushEnabled is the cluster setting that controls if the sqlstats
 // subsystem persists the statistics into system table.
 var SQLStatsFlushEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.stats.flush.enabled",
 	"if set, SQL execution statistics are periodically flushed to disk",
 	true, /* defaultValue */
@@ -41,6 +43,7 @@ var SQLStatsFlushEnabled = settings.RegisterBoolSetting(
 // [(1 - SQLStatsFlushJitter) * SQLStatsFlushInterval),
 //  (1 + SQLStatsFlushJitter) * SQLStatsFlushInterval)]
 var SQLStatsFlushJitter = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"sql.stats.flush.jitter",
 	"jitter fraction on the duration between sql stats flushes",
 	0.15,
@@ -55,6 +58,7 @@ var SQLStatsFlushJitter = settings.RegisterFloatSetting(
 // SQLStatsMaxPersistedRows specifies maximum number of rows that will be
 // retained in system.statement_statistics and system.transaction_statistics.
 var SQLStatsMaxPersistedRows = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.stats.persisted_rows.max",
 	"maximum number of rows of statement and transaction"+
 		" statistics that will be persisted in the system tables",
@@ -64,6 +68,7 @@ var SQLStatsMaxPersistedRows = settings.RegisterIntSetting(
 // SQLStatsCleanupRecurrence is the cron-tab string specifying the recurrence
 // for SQL Stats cleanup job.
 var SQLStatsCleanupRecurrence = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
 	"sql.stats.cleanup.recurrence",
 	"cron-tab recurrence for SQL Stats cleanup job",
 	"@hourly", /* defaultValue */

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -41,6 +41,7 @@ const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	AutoStatsClusterSettingName,
 	"automatic statistics collection mode",
 	true,
@@ -49,6 +50,7 @@ var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
 // MultiColumnStatisticsClusterMode controls the cluster setting for enabling
 // automatic collection of multi-column statistics.
 var MultiColumnStatisticsClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.stats.multi_column_collection.enabled",
 	"multi-column statistics collection mode",
 	true,
@@ -59,6 +61,7 @@ var MultiColumnStatisticsClusterMode = settings.RegisterBoolSetting(
 // statistics (in high load scenarios). This value can be tuned to trade off
 // the runtime vs performance impact of automatic stats.
 var AutomaticStatisticsMaxIdleTime = settings.RegisterFloatSetting(
+	settings.TenantWritable,
 	"sql.stats.automatic_collection.max_fraction_idle",
 	"maximum fraction of time that automatic statistics sampler processors are idle",
 	0.9,
@@ -77,6 +80,7 @@ var AutomaticStatisticsMaxIdleTime = settings.RegisterFloatSetting(
 // AutomaticStatisticsMinStaleRows.
 var AutomaticStatisticsFractionStaleRows = func() *settings.FloatSetting {
 	s := settings.RegisterFloatSetting(
+		settings.TenantWritable,
 		"sql.stats.automatic_collection.fraction_stale_rows",
 		"target fraction of stale rows per table that will trigger a statistics refresh",
 		0.2,
@@ -91,6 +95,7 @@ var AutomaticStatisticsFractionStaleRows = func() *settings.FloatSetting {
 // addition to the fraction AutomaticStatisticsFractionStaleRows.
 var AutomaticStatisticsMinStaleRows = func() *settings.IntSetting {
 	s := settings.RegisterIntSetting(
+		settings.TenantWritable,
 		"sql.stats.automatic_collection.min_stale_rows",
 		"target minimum number of stale rows per table that will trigger a statistics refresh",
 		500,

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -26,6 +26,7 @@ import (
 // HistogramClusterMode controls the cluster setting for enabling
 // histogram collection.
 var HistogramClusterMode = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"sql.stats.histogram_collection.enabled",
 	"histogram collection mode",
 	true,

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -36,11 +36,13 @@ import (
 )
 
 var pollingInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.stmt_diagnostics.poll_interval",
 	"rate at which the stmtdiagnostics.Registry polls for requests, set to zero to disable",
 	10*time.Second)
 
 var bundleChunkSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.stmt_diagnostics.bundle_chunk_size",
 	"chunk size for statement diagnostic bundles",
 	1024*1024,

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -145,6 +145,7 @@ type tableWriterBase struct {
 }
 
 var maxBatchBytes = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
 	"sql.mutations.mutation_batch_byte_size",
 	"byte size - in key and value lengths -- for mutation batches",
 	4<<20,

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -24,6 +24,7 @@ import (
 const defaultMaxEventFrequency = 10
 
 var telemetryMaxEventFrequency = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.telemetry.query_sampling.max_event_frequency",
 	"the max event frequency at which we sample queries for telemetry",
 	defaultMaxEventFrequency,

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -50,6 +50,7 @@ import (
 // TempObjectCleanupInterval is a ClusterSetting controlling how often
 // temporary objects get cleaned up.
 var TempObjectCleanupInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.temp_object_cleaner.cleanup_interval",
 	"how often to clean up orphaned temporary objects",
 	30*time.Minute,
@@ -58,6 +59,7 @@ var TempObjectCleanupInterval = settings.RegisterDurationSetting(
 // TempObjectWaitInterval is a ClusterSetting controlling how long
 // after a creation a temporary object will be cleaned up.
 var TempObjectWaitInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"sql.temp_object_cleaner.wait_interval",
 	"how long after creation a temporary object will be cleaned up",
 	30*time.Minute,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -152,6 +152,7 @@ func (t *truncateNode) Close(context.Context)        {}
 // split points that we re-create on a table after a truncate. It's scaled by
 // the number of nodes in the cluster.
 var PreservedSplitCountMultiple = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"sql.truncate.preserved_split_count_multiple",
 	"set to non-zero to cause TRUNCATE to preserve range splits from the "+
 		"table's indexes. The multiple given will be multiplied with the number of "+

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -370,6 +370,7 @@ WHERE
 }
 
 var userLoginTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"server.user_login.timeout",
 	"timeout after which client authentication times out if some system range is unavailable (0 = no timeout)",
 	10*time.Second,

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1013,12 +1013,14 @@ func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Ke
 }
 
 var ingestDelayL0Threshold = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"rocksdb.ingest_backpressure.l0_file_count_threshold",
 	"number of L0 files after which to backpressure SST ingestions",
 	20,
 )
 
 var ingestDelayTime = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"rocksdb.ingest_backpressure.max_delay",
 	"maximum amount of time to backpressure a single SST ingestion",
 	time.Second*5,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -66,6 +66,7 @@ var (
 )
 
 var minWALSyncInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"rocksdb.min_wal_sync_interval",
 	"minimum duration between syncs of the RocksDB WAL",
 	0*time.Millisecond,
@@ -75,6 +76,7 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 // WriteIntentError in operations that return multiple intents per error.
 // Currently it is used in Scan, ReverseScan, and ExportToSST.
 var MaxIntentsPerWriteIntentError = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"storage.mvcc.max_intents_per_error",
 	"maximum number of intents returned in error during export of scan requests",
 	maxIntentsPerWriteIntentErrorDefault)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -62,6 +62,7 @@ var maxSyncDurationDefault = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_
 // MaxSyncDuration is the threshold above which an observed engine sync duration
 // triggers either a warning or a fatal error.
 var MaxSyncDuration = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"storage.max_sync_duration",
 	"maximum duration for disk operations; any operations that take longer"+
 		" than this setting trigger a warning log entry or process crash",
@@ -71,6 +72,7 @@ var MaxSyncDuration = settings.RegisterDurationSetting(
 // MaxSyncDurationFatalOnExceeded governs whether disk stalls longer than
 // MaxSyncDuration fatal the Cockroach process. Defaults to true.
 var MaxSyncDurationFatalOnExceeded = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"storage.max_sync_duration.fatal.enabled",
 	"if true, fatal the process when a disk operation exceeds storage.max_sync_duration",
 	maxSyncDurationFatalOnExceededDefault,

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -40,6 +40,7 @@ var (
 
 // TimeseriesStorageEnabled controls whether to store timeseries data to disk.
 var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"timeseries.storage.enabled",
 	"if set, periodic timeseries data is stored within the cluster; disabling is not recommended "+
 		"unless you are storing the data elsewhere",
@@ -50,6 +51,7 @@ var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
 // at he 10 second resolution. Data older than this is subject to being "rolled
 // up" into the 30 minute resolution and then deleted.
 var Resolution10sStorageTTL = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"timeseries.storage.resolution_10s.ttl",
 	"the maximum age of time series data stored at the 10 second resolution. Data older than this "+
 		"is subject to rollup and deletion.",
@@ -59,6 +61,7 @@ var Resolution10sStorageTTL = settings.RegisterDurationSetting(
 // deprecatedResolution30StoreDuration is retained for backward compatibility during a version upgrade.
 var deprecatedResolution30StoreDuration = func() *settings.DurationSetting {
 	s := settings.RegisterDurationSetting(
+		settings.TenantWritable,
 		"timeseries.storage.30m_resolution_ttl", "replaced by timeseries.storage.resolution_30m.ttl",
 		resolution30mDefaultPruneThreshold,
 	)
@@ -77,6 +80,7 @@ func init() {
 // retained at he 30 minute resolution. Data older than this is subject to
 // deletion.
 var Resolution30mStorageTTL = settings.RegisterDurationSetting(
+	settings.TenantWritable,
 	"timeseries.storage.resolution_30m.ttl",
 	"the maximum age of time series data stored at the 30 minute resolution. Data older than this "+
 		"is subject to deletion.",

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -30,6 +30,7 @@ import (
 // which the CPU will be considered overloaded, when running in a node that
 // executes KV operations.
 var KVSlotAdjusterOverloadThreshold = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"admission.kv_slot_adjuster.overload_threshold",
 	"when the number of runnable goroutines per CPU is greater than this threshold, the "+
 		"slot adjuster considers the cpu to be overloaded",
@@ -38,6 +39,7 @@ var KVSlotAdjusterOverloadThreshold = settings.RegisterIntSetting(
 // L0FileCountOverloadThreshold sets a file count threshold that signals an
 // overloaded store.
 var L0FileCountOverloadThreshold = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"admission.l0_file_count_overload_threshold",
 	"when the L0 file count exceeds this theshold, the store is considered overloaded",
 	l0FileCountOverloadThreshold, settings.PositiveInt)
@@ -45,6 +47,7 @@ var L0FileCountOverloadThreshold = settings.RegisterIntSetting(
 // L0SubLevelCountOverloadThreshold sets a sub-level count threshold that
 // signals an overloaded store.
 var L0SubLevelCountOverloadThreshold = settings.RegisterIntSetting(
+	settings.TenantWritable,
 	"admission.l0_sub_level_count_overload_threshold",
 	"when the L0 sub-level count exceeds this threshold, the store is considered overloaded",
 	l0SubLevelCountOverloadThreshold, settings.PositiveInt)

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -34,6 +34,7 @@ import (
 // KVAdmissionControlEnabled controls whether KV server-side admission control
 // is enabled.
 var KVAdmissionControlEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"admission.kv.enabled",
 	"when true, work performed by the KV layer is subject to admission control",
 	true).WithPublic()
@@ -41,6 +42,7 @@ var KVAdmissionControlEnabled = settings.RegisterBoolSetting(
 // SQLKVResponseAdmissionControlEnabled controls whether response processing
 // in SQL, for KV requests, is enabled.
 var SQLKVResponseAdmissionControlEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"admission.sql_kv_response.enabled",
 	"when true, work performed by the SQL layer when receiving a KV response is subject to "+
 		"admission control",
@@ -49,6 +51,7 @@ var SQLKVResponseAdmissionControlEnabled = settings.RegisterBoolSetting(
 // SQLSQLResponseAdmissionControlEnabled controls whether response processing
 // in SQL, for DistSQL requests, is enabled.
 var SQLSQLResponseAdmissionControlEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"admission.sql_sql_response.enabled",
 	"when true, work performed by the SQL layer when receiving a DistSQL response is subject "+
 		"to admission control",

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -52,6 +52,7 @@ var (
 	// Doing this, rather than just using a default of `true`, means that a node
 	// will not errantly send a report using a default before loading settings.
 	DiagnosticsReportingEnabled = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"diagnostics.reporting.enabled",
 		"enable reporting diagnostic metrics to cockroach labs",
 		false,
@@ -59,6 +60,7 @@ var (
 
 	// CrashReports wraps "diagnostics.reporting.send_crash_reports".
 	CrashReports = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"diagnostics.reporting.send_crash_reports",
 		"send crash and panic reports",
 		true,
@@ -66,6 +68,7 @@ var (
 
 	// PanicOnAssertions wraps "debug.panic_on_failed_assertions"
 	PanicOnAssertions = settings.RegisterBoolSetting(
+		settings.TenantWritable,
 		"debug.panic_on_failed_assertions",
 		"panic when an assertion fails rather than reporting",
 		false,

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -92,6 +92,7 @@ const (
 // resolved via #58610, this setting can be removed so that all traces
 // have redactability enabled.
 var enableTraceRedactable = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"trace.redactable.enabled",
 	"set to true to enable redactability for unstructured events "+
 		"in traces and to redact traces sent to tenants. "+
@@ -101,12 +102,14 @@ var enableTraceRedactable = settings.RegisterBoolSetting(
 )
 
 var enableNetTrace = settings.RegisterBoolSetting(
+	settings.TenantWritable,
 	"trace.debug.enable",
 	"if set, traces for recent requests can be seen at https://<ui>/debug/requests",
 	false,
 ).WithPublic()
 
 var openTelemetryCollector = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
 	"trace.opentelemetry.collector",
 	"address of an OpenTelemetry trace collector to receive "+
 		"traces using the otel gRPC protocol, as <host>:<port>. "+
@@ -122,6 +125,7 @@ var openTelemetryCollector = settings.RegisterValidatedStringSetting(
 ).WithPublic()
 
 var jaegerAgent = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
 	"trace.jaeger.agent",
 	"the address of a Jaeger agent to receive traces using the "+
 		"Jaeger UDP Thrift protocol, as <host>:<port>. "+
@@ -139,6 +143,7 @@ var jaegerAgent = settings.RegisterValidatedStringSetting(
 // ZipkinCollector is the cluster setting that specifies the Zipkin instance
 // to send traces to, if any.
 var ZipkinCollector = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
 	"trace.zipkin.collector",
 	"the address of a Zipkin instance to receive traces, as <host>:<port>. "+
 		"If no port is specified, 9411 will be used.",


### PR DESCRIPTION
This commit introduces the three setting classes in the RFC (#73349):
`SystemOnly`, `TenantReadOnly`, and `TenantWritable`. The `SystemOnly`
class replaces the existing `WithSystemOnly()`.

In this change we don't yet implement the advertised semantics. We
mechanically use `TenantWritable` for all settings except those that
were using `WithSystemOnly()` which use `SystemOnly`; this should not
change any existing behavior. The classes will be revisited in a
separate change, after we implement the semantics.

Release note: None