### PR TITLE
roachtest: make crdb crash on span-use-after-Finish

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -45,7 +45,14 @@ var (
 	secure                = false
 	extraSSHOptions       = ""
 	nodeEnv               = []string{
+		// NOTE: The defaults are also copied in roachtest's invocation of roachprod
+		// (which overrides the default). On changes, consider updating that one
+		// too.
+
+		// RPC compressions costs around 5% on kv95, so we disable it. It might help
+		// when moving snapshots around, though.
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
+		// Get rid of an annoying popup in the UI.
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
 	}
 	tag           string


### PR DESCRIPTION
This patch makes roachtest pass an env var to crdb asking it to panic on
mis-use of tracing spans. I've been battling such bugs, which become
more problematic as I'm trying to introduce span reuse. In production
we'll probably continue tolerating such bugs for the time being, but I
want tests to yell. Unit tests are already running with this
use-after-Finish detection, and so far so good. I've done a manual run
of all the roachtests in this configuration and nothing crashed, so I
don't expect a tragedy.

Release note: None