### PR TITLE
ui: fix flaky test for "query" sagas

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/queryManager/saga.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/queryManager/saga.spec.ts
@@ -143,7 +143,7 @@ describe("Query Management Saga", function() {
         let queryCalled = 0;
         const selfStopQuery = {
           id: "selfStopQuery",
-          refreshInterval: moment.duration(50),
+          refreshInterval: moment.duration(5),
           querySaga: function*(): IterableIterator<void> {
             queryCalled++;
             if (queryCalled > 3) {
@@ -156,9 +156,9 @@ describe("Query Management Saga", function() {
           .dispatch(autoRefresh(selfStopQuery))
           .dispatch(autoRefresh(selfStopQuery))
           .dispatch(autoRefresh(selfStopQuery))
-          .silentRun(250)
+          .silentRun()
           .then(() => {
-            assert.equal(queryCalled, 5);
+            assert.equal(queryCalled, 6);
           });
       });
       it("Uses retry delay when errors are encountered", function() {


### PR DESCRIPTION
Initially, test logic was defined in a way that query
should be auto refreshed every 50ms and `silentRun` limited
saga execution time to 250ms only, so it was enough to queue
tasks and auto-refresh it maximum 5 times due to timing limitation
but not because of business logic.
Sometimes this test failed when task was executed 6 times and it
is valid expected result, possibly due to asynchronous nature of
sagas and how it waits for next actions.

Now, this test modified to have small `refreshInterval` value
and it allows to run all tasks in queue before timeout.

Expected value is changed to 6 because:
- `queryCalled` is incremented 3 times when `autoRefresh` action
is dispatched 3 times in a row manually
- and then it is called 3 times for every `stopAutoRefresh` action
respectively

Release note: None