### PR TITLE
sql: run lazy virtual table generators in the right ctx

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -359,7 +359,7 @@ CREATE TABLE crdb_internal.tables (
 )`,
 	generator: func(ctx context.Context, p *planner, dbDesc catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 14)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			descs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 			if err != nil {
 				return err
@@ -2536,7 +2536,7 @@ CREATE TABLE crdb_internal.table_columns (
 `,
 	generator: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 8)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
 				func(db catalog.DatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
 					tableID := tree.NewDInt(tree.DInt(table.GetID()))
@@ -2597,7 +2597,7 @@ CREATE TABLE crdb_internal.table_indexes (
 		primary := tree.NewDString("primary")
 		secondary := tree.NewDString("secondary")
 		row := make(tree.Datums, 7)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
 				func(db catalog.DatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
 					tableID := tree.NewDInt(tree.DInt(table.GetID()))
@@ -4012,7 +4012,7 @@ CREATE TABLE crdb_internal.partitions (
 		if dbContext != nil {
 			dbName = dbContext.GetName()
 		}
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual, /* virtual tables have no partitions*/
 				func(db catalog.DatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
 					return catalog.ForEachIndex(table, catalog.IndexOpts{
@@ -4964,7 +4964,7 @@ CREATE TABLE crdb_internal.index_usage_statistics (
 		indexStats := idxusage.NewLocalIndexUsageStatsFromExistingStats(&idxusage.Config{}, stats.Statistics)
 
 		row := make(tree.Datums, 4 /* number of columns for this virtual table */)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
 				func(db catalog.DatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
 					tableID := table.GetID()
@@ -5046,7 +5046,7 @@ CREATE TABLE crdb_internal.statement_statistics (
 		}, memSQLStats)
 
 		row := make(tree.Datums, 8 /* number of columns for this virtual table */)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return sqlStats.IterateStatementStats(ctx, &sqlstats.IteratorOptions{
 				SortedAppNames: true,
 				SortedKey:      true,
@@ -5194,7 +5194,7 @@ CREATE TABLE crdb_internal.transaction_statistics (
 		}, memSQLStats)
 
 		row := make(tree.Datums, 5 /* number of columns for this virtual table */)
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return sqlStats.IterateTransactionStats(ctx, &sqlstats.IteratorOptions{
 				SortedAppNames: true,
 				SortedKey:      true,

--- a/pkg/sql/virtual_table_test.go
+++ b/pkg/sql/virtual_table_test.go
@@ -30,7 +30,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 	t.Run("test cleanup", func(t *testing.T) {
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
 				return err
 			}
@@ -53,7 +53,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 
 	t.Run("test worker error", func(t *testing.T) {
 		// Test that if the worker returns an error we catch it.
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
 				return err
 			}
@@ -75,7 +75,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 
 	t.Run("test no next", func(t *testing.T) {
 		// Test we don't leak anything if we call cleanup before next.
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			return nil
 		}
 		_, cleanup, setupError := setupGenerator(ctx, worker, stopper)
@@ -86,7 +86,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 	t.Run("test context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// Test cancellation before asking for any rows.
-		worker := func(pusher rowPusher) error {
+		worker := func(ctx context.Context, pusher rowPusher) error {
 			if err := pusher.pushRow(tree.NewDInt(1)); err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func BenchmarkVirtualTableGenerators(b *testing.B) {
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
-	worker := func(pusher rowPusher) error {
+	worker := func(ctx context.Context, pusher rowPusher) error {
 		for {
 			if err := pusher.pushRow(tree.NewDInt(tree.DInt(1))); err != nil {
 				return err


### PR DESCRIPTION
Before this patch, the closures generating virtual tables lazily were
capturing and using the wrong context. They were capturing the ctx
passed to the factory function `generator`, even though they're running
in an async task. Now they'll use the context set up by the RunAsyncTask
in `setupGenerator()`. Beyond the general issue that capturing contexts
is usually a bad idea, the problem with the context passes to the
generator is that the lifetime is wrong: the span in that ctx can end
while the async task is running, leading to a span-use-after-Finish
crash.
This patch fixes it by plumbing the task's ctx to the closures. Now that
the task's ctx is actually used, I had to switch its relationship with
the parent from a FollowsFrom to a regular child, so that the child is
included in the parent's trace.

Release note: None