### PR TITLE
backupccl: add more logging on sink close error condition

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -122,6 +122,7 @@ go_library(
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//types",
         "@com_github_gorhill_cronexpr//:cronexpr",
+        "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/kr/pretty"
 )
 
 var backupOutputTypes = []*types.T{}
@@ -534,7 +535,7 @@ func runBackupProcessor(
 			err := sink.Close()
 			err = errors.CombineErrors(storage.Close(), err)
 			if err != nil {
-				log.Warningf(ctx, "failed to close backup sink(s): %+v", err)
+				log.Warningf(ctx, "failed to close backup sink(s): % #v", pretty.Formatter(err))
 			}
 		}()
 
@@ -650,6 +651,7 @@ func (s *sstSink) flushFile(ctx context.Context) error {
 		return err
 	}
 	if err := s.out.Close(); err != nil {
+		log.Warningf(ctx, "failed to close write in sstSink: % #v", pretty.Formatter(err))
 		return errors.Wrap(err, "writing SST")
 	}
 	s.outName = ""


### PR DESCRIPTION
This change adds a log line to print the error on sink close
as go source, in an attempt to get more information about
a 503 error we are seeing in our backup/2TB roachtest. This
has not been easily reproducible.

Informs: #73331

Release note: None