### PR TITLE
sqlsmith: make `makeStringComparison` great again

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -655,8 +655,7 @@ func makeStringComparison(s *Smither, typ *types.T, refs colRefs) (tree.TypedExp
 		}
 	}
 	switch typ.Family() {
-	case types.BoolFamily, types.AnyFamily:
-	default:
+	case types.AnyFamily, types.VoidFamily:
 		return nil, false
 	}
 	return tree.NewTypedComparisonExpr(

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -604,8 +604,7 @@ func makeExists(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 
 func makeIn(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 	switch typ.Family() {
-	case types.BoolFamily, types.AnyFamily:
-	default:
+	case types.AnyFamily, types.VoidFamily:
 		return nil, false
 	}
 


### PR DESCRIPTION
Previously this basically always dropped everything except bools (the
only available scalar). I think it was intended to be otherwise.

Release note: None