### PR TITLE
sql: support RULE privilege for compatibility

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -2055,3 +2055,8 @@ GRANT SELECT ON system.lease TO testuser
 
 statement error pq: cannot REVOKE on system object
 REVOKE SELECT ON system.lease FROM testuser
+
+# Postgres does a no-op here, but since the RULE privilege is very legacy,
+# we error explicitly instead of getting 100% compatibility.
+statement error invalid privilege type RULE for table
+GRANT RULE ON t TO testuser

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -834,43 +834,46 @@ NULL
 
 ## has_table_privilege
 
-query BBBBBBB
+query BBBBBBBB
 SELECT has_table_privilege(12345, 'SELECT'),
        has_table_privilege(12345, 'INSERT'),
        has_table_privilege(12345, 'UPDATE'),
        has_table_privilege(12345, 'DELETE'),
        has_table_privilege(12345, 'TRUNCATE'),
        has_table_privilege(12345, 'REFERENCES'),
-       has_table_privilege(12345, 'TRIGGER')
+       has_table_privilege(12345, 'TRIGGER'),
+       has_table_privilege(12345, 'RULE')
 ----
-NULL  NULL  NULL  NULL  NULL  NULL  NULL
+NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
-query BBBBBBB
+query BBBBBBBB
 SELECT has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'SELECT'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'INSERT'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'UPDATE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'DELETE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'TRUNCATE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'REFERENCES'),
-       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'TRIGGER')
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'TRIGGER'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'RULE')
 ----
-true  false  false  false  false  true  false
+true  false  false  false  false  true  false  false
 
-query BBBBBBB
+query BBBBBBBB
 SELECT has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'SELECT'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'INSERT'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'UPDATE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'DELETE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'TRUNCATE'),
        has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'REFERENCES'),
-       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'TRIGGER')
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'TRIGGER'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'RULE')
 ----
-true  true  true  true  true  true  true
+true  true  true  true  true  true  true  false
 
 query error pgcode 42P01 relation "does_not_exist" does not exist
 SELECT has_table_privilege('does_not_exist', 'SELECT')
 
-query BBBBBBBBBB
+query BBBBBBBBBBB
 SELECT has_table_privilege('pg_type', 'SELECT'),
        has_table_privilege('pg_type', 'INSERT'),
        has_table_privilege('pg_type', 'UPDATE'),
@@ -880,11 +883,12 @@ SELECT has_table_privilege('pg_type', 'SELECT'),
        has_table_privilege('pg_type', 'TRIGGER'),
        has_table_privilege('pg_type', 'SELECT, INSERT, UPDATE'),
        has_table_privilege('pg_type', 'SELECT, TRUNCATE'),
-       has_table_privilege('pg_type', 'INSERT, UPDATE')
+       has_table_privilege('pg_type', 'INSERT, UPDATE'),
+       has_table_privilege('pg_type', 'RULE')
 ----
-true  false  false  false  false  true  false  true  true  false
+true  false  false  false  false  true  false  true  true  false  false
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('t', 'SELECT'),
        has_table_privilege('t', 'INSERT'),
        has_table_privilege('t', 'UPDATE'),
@@ -893,11 +897,12 @@ SELECT has_table_privilege('t', 'SELECT'),
        has_table_privilege('t', 'REFERENCES'),
        has_table_privilege('t', 'TRIGGER'),
        has_table_privilege('t', 'SELECT, INSERT, UPDATE'),
-       has_table_privilege('t', 'SELECT, TRUNCATE')
+       has_table_privilege('t', 'SELECT, TRUNCATE'),
+       has_table_privilege('t', 'RULE')
 ----
-true  true  true  true  true  true  true  true  true
+true  true  true  true  true  true  true  true  true  false
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('t', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('t', 'INSERT WITH GRANT OPTION'),
        has_table_privilege('t', 'UPDATE WITH GRANT OPTION'),
@@ -906,11 +911,12 @@ SELECT has_table_privilege('t', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('t', 'REFERENCES WITH GRANT OPTION'),
        has_table_privilege('t', 'TRIGGER WITH GRANT OPTION'),
        has_table_privilege('t', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
-       has_table_privilege('t', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION')
+       has_table_privilege('t', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION'),
+       has_table_privilege('t', 'RULE WITH GRANT OPTION')
 ----
-true  true  true  true  true  true  true  true  true
+true  true  true  true  true  true  true  true  true  false
 
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('t'::Name, 'SELECT'),
        has_table_privilege('t'::Name, 'INSERT'),
        has_table_privilege('t'::Name, 'UPDATE'),
@@ -919,12 +925,13 @@ SELECT has_table_privilege('t'::Name, 'SELECT'),
        has_table_privilege('t'::Name, 'REFERENCES'),
        has_table_privilege('t'::Name, 'TRIGGER'),
        has_table_privilege('t'::Name, 'SELECT, INSERT, UPDATE'),
-       has_table_privilege('t'::Name, 'SELECT, TRUNCATE')
+       has_table_privilege('t'::Name, 'SELECT, TRUNCATE'),
+       has_table_privilege('t'::Name, 'RULE')
 ----
-true  true  true  true  true  true  true  true  true
+true  true  true  true  true  true  true  true  true  false
 
 # has_table_privilege works with sequences as well.
-query BBBBBBBBB
+query BBBBBBBBBB
 SELECT has_table_privilege('seq', 'SELECT'),
        has_table_privilege('seq', 'INSERT'),
        has_table_privilege('seq', 'UPDATE'),
@@ -933,9 +940,10 @@ SELECT has_table_privilege('seq', 'SELECT'),
        has_table_privilege('seq', 'REFERENCES'),
        has_table_privilege('seq', 'TRIGGER'),
        has_table_privilege('seq', 'SELECT, INSERT, UPDATE'),
-       has_table_privilege('seq', 'SELECT, TRUNCATE')
+       has_table_privilege('seq', 'SELECT, TRUNCATE'),
+       has_table_privilege('seq', 'RULE')
 ----
-true  true  true  true  true  true  true  true  true
+true  true  true  true  true  true  true  true  true  false
 
 query error pgcode 22023 unrecognized privilege type: "USAGE"
 SELECT has_table_privilege('t', 'USAGE')
@@ -946,7 +954,7 @@ SELECT has_table_privilege('t', 'SELECT, USAGE')
 query error pgcode 42704 role 'no_user' does not exist
 SELECT has_table_privilege('no_user', 't', 'SELECT')
 
-query BBBBBBBBBB
+query BBBBBBBBBBB
 SELECT has_table_privilege('bar', 't', 'SELECT'),
        has_table_privilege('bar', 't', 'INSERT'),
        has_table_privilege('bar', 't', 'UPDATE'),
@@ -956,11 +964,12 @@ SELECT has_table_privilege('bar', 't', 'SELECT'),
        has_table_privilege('bar', 't', 'TRIGGER'),
        has_table_privilege('bar', 't', 'SELECT, INSERT, UPDATE'),
        has_table_privilege('bar', 't', 'SELECT, TRUNCATE'),
-       has_table_privilege('bar', 't', 'INSERT, UPDATE')
+       has_table_privilege('bar', 't', 'INSERT, UPDATE'),
+       has_table_privilege('bar', 't', 'RULE')
 ----
-false  false  false  true  true  false  true  false  true  false
+false  false  false  true  true  false  true  false  true  false  false
 
-query BBBBBBBBBB
+query BBBBBBBBBBB
 SELECT has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'UPDATE WITH GRANT OPTION'),
@@ -970,9 +979,10 @@ SELECT has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'TRIGGER WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
        has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION'),
-       has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+       has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'RULE WITH GRANT OPTION')
 ----
-false  false  false  true  true  false  true  false  true  false
+false  false  false  true  true  false  true  false  true  false  false
 
 
 ## has_tablespace_privilege

--- a/pkg/sql/privilege/kind_string.go
+++ b/pkg/sql/privilege/kind_string.go
@@ -19,11 +19,12 @@ func _() {
 	_ = x[USAGE-9]
 	_ = x[ZONECONFIG-10]
 	_ = x[CONNECT-11]
+	_ = x[RULE-12]
 }
 
-const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATEUSAGEZONECONFIGCONNECT"
+const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATEUSAGEZONECONFIGCONNECTRULE"
 
-var _Kind_index = [...]uint8{0, 3, 9, 13, 18, 24, 30, 36, 42, 47, 57, 64}
+var _Kind_index = [...]uint8{0, 3, 9, 13, 18, 24, 30, 36, 42, 47, 57, 64, 68}
 
 func (i Kind) String() string {
 	i -= 1

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -42,6 +42,7 @@ const (
 	USAGE      Kind = 9
 	ZONECONFIG Kind = 10
 	CONNECT    Kind = 11
+	RULE       Kind = 12
 )
 
 // ObjectType represents objects that can have privileges.
@@ -97,7 +98,7 @@ func (k Kind) IsSetIn(bits uint32) bool {
 
 // ByValue is just an array of privilege kinds sorted by value.
 var ByValue = [...]Kind{
-	ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG, CONNECT,
+	ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG, CONNECT, RULE,
 }
 
 // ByName is a map of string -> kind value.
@@ -113,6 +114,7 @@ var ByName = map[string]Kind{
 	"UPDATE":     UPDATE,
 	"ZONECONFIG": ZONECONFIG,
 	"USAGE":      USAGE,
+	"RULE":       RULE,
 }
 
 // List is a list of privileges.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -326,6 +326,13 @@ func (p *planner) HasPrivilege(
 		return true, nil
 	}
 
+	if kind == privilege.RULE {
+		// RULE was only added for compatibility with Postgres, and Postgres
+		// never allows RULE to be granted, even if the user has ALL privileges.
+		// See https://www.postgresql.org/docs/8.1/sql-grant.html
+		// and https://www.postgresql.org/docs/release/8.2.0/.
+		return false, nil
+	}
 	hasPrivilege, err := hasPrivilegeFunc(privilege.ALL)
 	if err != nil {
 		return false, err

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1888,6 +1888,8 @@ SELECT description
 				"REFERENCES WITH GRANT OPTION": {privilege.SELECT, true},
 				"TRIGGER":                      {privilege.CREATE, false},
 				"TRIGGER WITH GRANT OPTION":    {privilege.CREATE, true},
+				"RULE":                         {privilege.RULE, false},
+				"RULE WITH GRANT OPTION":       {privilege.RULE, true},
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
fixes #72832

The RULE privilege is legacy in Postgres, but some tools expect
the has_table_privilege function to work.

Release note (sql change): The RULE privilege was added for compatbility
with Postgres. It is impossible to grant it, but it is supported as a
parameter of the has_table_privilege function.