### PR TITLE
roachprod: fixing nil/inactive providerOpts and empty zones issues

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -146,7 +146,9 @@ if the user would like to update the keys on the remote hosts.
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		zonesMap := make(map[string][]string)
 		// Only adding aws zones because only aws.ConfigSSH uses it.
-		zonesMap[aws.ProviderName] = providerOptsContainer[aws.ProviderName].(*aws.ProviderOpts).CreateZones
+		if vm.Providers[aws.ProviderName].Active() {
+			zonesMap[aws.ProviderName] = providerOptsContainer[aws.ProviderName].(*aws.ProviderOpts).CreateZones
+		}
 		return roachprod.SetupSSH(args[0], zonesMap)
 	}),
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1135,7 +1135,9 @@ func Create(
 	}
 	zonesMap := make(map[string][]string)
 	// Only adding aws zones because only aws.ConfigSSH uses it.
-	zonesMap[aws.ProviderName] = providerOptsContainer[aws.ProviderName].(*aws.ProviderOpts).CreateZones
+	if vm.Providers[aws.ProviderName].Active() {
+		zonesMap[aws.ProviderName] = providerOptsContainer[aws.ProviderName].(*aws.ProviderOpts).CreateZones
+	}
 	return SetupSSH(clusterName, zonesMap)
 }
 

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -202,6 +202,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		RemoteUserName:   "ubuntu",
 		DefaultEBSVolume: defaultEBSVolumeValue,
 		CreateRateLimit:  2,
+		CreateZones:      defaultCreateZones,
 	}
 }
 
@@ -387,6 +388,7 @@ func (p *Provider) Create(
 	names []string, opts vm.CreateOpts, vmProviderOpts vm.ProviderOpts,
 ) error {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
+	fmt.Println(providerOpts.CreateZones)
 	// We need to make sure that the SSH keys have been distributed to all regions
 	if err := p.ConfigSSH(providerOpts.CreateZones); err != nil {
 		return err


### PR DESCRIPTION
Merging #73964 introduced two issues. The first issue involved
casting nil providerOpts (for aws) when the provider is inactive.
This patch fixes the first issue by checking if the provider is
active before casting providerOpts. The second issue was caused
by not assigning default zones when creating default providerOpts.
This was only caught recently because #73964 was the first time we
try to use default zones directly from providerOpts. This was fixed
by simply making defaultProviderOpts assign default zones to providerOpts.

Release note: None