### PR TITLE
roachtest: avoid mutating spec in RoachprodOpts

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -174,6 +174,7 @@ func (s *ClusterSpec) RoachprodOpts(
 
 	createVMOpts.GeoDistributed = s.Geo
 	machineType := s.InstanceType
+	ssdCount := s.SSDs
 	if s.CPUs != 0 {
 		// Default to the user-supplied machine type, if any.
 		// Otherwise, pick based on requested CPU count.
@@ -196,8 +197,8 @@ func (s *ClusterSpec) RoachprodOpts(
 		// - on AWS, if the machine type supports it.
 		if s.PreferLocalSSD && s.VolumeSize == 0 && (s.Cloud != AWS || awsMachineSupportsSSD(machineType)) {
 			// Ensure SSD count is at least 1 if UseLocalSSD is true.
-			if s.SSDs == 0 {
-				s.SSDs = 1
+			if ssdCount == 0 {
+				ssdCount = 1
 			}
 			createVMOpts.SSDOpts.UseLocalSSD = true
 			createVMOpts.SSDOpts.NoExt4Barrier = !useIOBarrier
@@ -232,7 +233,7 @@ func (s *ClusterSpec) RoachprodOpts(
 	case AWS:
 		providerOpts = getAWSOpts(machineType, zones, createVMOpts.SSDOpts.UseLocalSSD)
 	case GCE:
-		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, s.SSDs, createVMOpts.SSDOpts.UseLocalSSD, s.RAID0)
+		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, ssdCount, createVMOpts.SSDOpts.UseLocalSSD, s.RAID0)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, zones)
 	}


### PR DESCRIPTION
Previously, this code mutated the spec's SSD count inside
RoachprodOpts. This mutation could lead to failures on retry since we
also assert the SSD count is 0 for some providers. Now, the code
avoids mutating the SSD count since the value was only ever used
locally to the function.

Further, I've hoisted the loop-invariant parts of this option creation
outside of the loop.

Fixes #73902

Release note: None