### PR TITLE
kv: add replicas.uninitialized metric

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3901,6 +3901,85 @@ func TestTenantID(t *testing.T) {
 
 }
 
+// TestUninitializedMetric ensures that uninitialized replicas are reflected in the UninitializedCount store metric.
+func TestUninitializedMetric(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs:      base.TestServerArgs{Insecure: true},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	scratchKey := tc.ScratchRange(t)
+	_, repl := getFirstStoreReplica(t, tc.Server(0), scratchKey)
+	sawSnapshot := make(chan struct{}, 1)
+	blockSnapshot := make(chan struct{})
+	tc.AddAndStartServer(t, base.TestServerArgs{
+		Insecure: true,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				BeforeSnapshotSSTIngestion: func(
+					snapshot kvserver.IncomingSnapshot,
+					_ kvserver.SnapshotRequest_Type,
+					_ []string,
+				) error {
+					if snapshot.Desc.RangeID == repl.RangeID {
+						select {
+						case sawSnapshot <- struct{}{}:
+						default:
+						}
+						<-blockSnapshot
+					}
+					return nil
+				},
+			},
+		},
+	})
+
+	// We're going to block the snapshot. We need to retry adding the replica
+	// to the second node as under stressrace, failures can occur due to
+	// networking handshake timeouts.
+	addReplicaErr := make(chan error)
+	addReplica := func() {
+		_, err := tc.AddVoters(scratchKey, tc.Target(1))
+		addReplicaErr <- err
+	}
+	go addReplica()
+	if err := retry.ForDuration(3*time.Minute, func() error {
+		select {
+		case <-sawSnapshot:
+			return nil
+		case err := <-addReplicaErr:
+			go addReplica()
+			return err
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	targetStore := tc.GetFirstStoreFromServer(t, 1)
+
+	// Force the store to compute the replica metrics
+	require.NoError(t, targetStore.ComputeMetrics(ctx, 0))
+
+	// Blocked snapshot on the second server (1) should realize 1 uninitialized replica.
+	require.Equal(t, int64(1), targetStore.Metrics().UninitializedCount.Value())
+
+	// Unblock snapshot on the second server (1), this should initialize replica.
+	close(blockSnapshot)
+	require.NoError(t, <-addReplicaErr)
+
+	// Again force the store to compute metrics, increment tick counter 0 -> 1
+	require.NoError(t, targetStore.ComputeMetrics(ctx, 1))
+
+	// There should now be no uninitialized replicas in the recorded metrics
+	require.Equal(t, int64(0), targetStore.Metrics().UninitializedCount.Value())
+}
+
 // TestRangeMigration tests the below-raft migration infrastructure. It checks
 // to see that the version recorded as part of the in-memory ReplicaState
 // is up to date, and in-sync with the persisted state. It also checks to see

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -68,6 +68,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaUninitializedCount = metric.Metadata{
+		Name:        "replicas.uninitialized",
+		Help:        "Number of uninitialized replicas, this does not include uninitialized replicas that can lie dormant in a persistent state.",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Range metrics.
 	metaRangeCount = metric.Metadata{
@@ -1253,6 +1259,7 @@ type StoreMetrics struct {
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
+	UninitializedCount            *metric.Gauge
 
 	// Range metrics.
 	RangeCount                *metric.Gauge
@@ -1685,6 +1692,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
+		UninitializedCount:            metric.NewGauge(metaUninitializedCount),
 
 		// Range metrics.
 		RangeCount:                metric.NewGauge(metaRangeCount),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1593,6 +1593,7 @@ var charts = []sectionDescription{
 				Title: "Count",
 				Metrics: []string{
 					"replicas.quiescent",
+					"replicas.uninitialized",
 					"replicas",
 					"replicas.reserved",
 				},


### PR DESCRIPTION
This change adds `replicas.unitialized` metric, tracking the number of non-init replicas on a store. 

Note that this metric doesn't give the exact number of uninitialized replicas because, after a process restart, uninitialized replicas can remain on disk without an in memory representation.

resolves  #73368

