### PR TITLE
opt: fix like escape processing for span constraints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -254,7 +254,7 @@ statement ok
 CREATE TABLE str (k INT PRIMARY KEY, v STRING, INDEX(v))
 
 statement ok
-INSERT INTO str VALUES (1, 'A'), (4, 'AB'), (2, 'ABC'), (5, 'ABCD'), (3, 'ABCDEZ'), (9, 'ABD')
+INSERT INTO str VALUES (1, 'A'), (4, 'AB'), (2, 'ABC'), (5, 'ABCD'), (3, 'ABCDEZ'), (9, 'ABD'), (10, '\CBA'), (11, 'A%'), (12, 'CAB.*'), (13, 'CABD')
 
 query IT rowsort
 SELECT k, v FROM str WHERE v LIKE 'ABC%'
@@ -264,7 +264,37 @@ SELECT k, v FROM str WHERE v LIKE 'ABC%'
 3  ABCDEZ
 
 query IT rowsort
+SELECT k, v FROM str WHERE v LIKE '\ABC%'
+----
+2  ABC
+5  ABCD
+3  ABCDEZ
+
+statement error LIKE regexp compilation failed: LIKE pattern must not end with escape character
+SELECT k, v FROM str WHERE v LIKE 'ABC\'
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE '\\CBA%'
+----
+10 \CBA
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE 'A\%'
+----
+11  A%
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE 'CAB.*'
+----
+12  CAB.*
+
+query IT rowsort
 SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
+----
+3  ABCDEZ
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE '\ABCDE_'
 ----
 3  ABCDEZ
 

--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -1,4 +1,81 @@
 index-constraints vars=(a string) index=a
+a LIKE 'ABC'
+----
+[/'ABC' - /'ABC']
+
+# A backslash that isn't escaping anything is just removed from pattern.
+index-constraints vars=(a string) index=a
+a LIKE '\aABC%'
+----
+[/'aABC' - /'aABD')
+
+# A backslash that isn't escaping anything is just removed from pattern.
+index-constraints vars=(a string) index=a
+a LIKE 'A\BC%'
+----
+[/'ABC' - /'ABD')
+
+# Currently we punt on custom ESCAPE clauses.
+index-constraints vars=(a string) index=a
+a LIKE '\aABC%' ESCAPE '|'
+----
+[ - ]
+Remaining filter: like_escape(a, e'\\aABC%', '|')
+
+# Single char wildcard requires remaining filter.
+index-constraints vars=(a string) index=a
+a LIKE '\aABC_'
+----
+[/'aABC' - /'aABD')
+Remaining filter: a LIKE e'\\aABC_'
+
+# Ending with wildcard with other wildcards present isn't tight.
+index-constraints vars=(a string) index=a
+a LIKE 'AB_C%'
+----
+[/'AB' - /'AC')
+Remaining filter: a LIKE 'AB_C%'
+
+# Ignore zero prefix (wildcard at beginning).
+index-constraints vars=(a string) index=a
+a LIKE '%ABC'
+----
+(/NULL - ]
+Remaining filter: a LIKE '%ABC'
+
+# Ignore zero prefix (wildcard at beginning).
+index-constraints vars=(a string) index=a
+a LIKE '_ABC'
+----
+(/NULL - ]
+Remaining filter: a LIKE '_ABC'
+
+# A backslash that is escaping a wildcard becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE 'ABC\%'
+----
+[/'ABC%' - /'ABC%']
+
+# A backslash that is escaping a wildcard becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE 'ABC\_'
+----
+[/'ABC_' - /'ABC_']
+
+# A backslash that is escaping a wildcard becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE 'ABC\_Z'
+----
+[/'ABC_Z' - /'ABC_Z']
+
+# Invalid pattern does not generate index constraints.
+index-constraints vars=(a string) index=a
+a LIKE 'ABC\'
+----
+(/NULL - ]
+Remaining filter: a LIKE e'ABC\\'
+
+index-constraints vars=(a string) index=a
 a LIKE 'ABC%'
 ----
 [/'ABC' - /'ABD')
@@ -59,6 +136,18 @@ a SIMILAR TO 'ABC.*Z'
 ----
 [/'ABC' - /'ABD')
 Remaining filter: a SIMILAR TO 'ABC.*Z'
+
+index-constraints vars=(a string) index=(a)
+a SIMILAR TO 'ABC%Z'
+----
+[/'ABC' - /'ABD')
+Remaining filter: a SIMILAR TO 'ABC%Z'
+
+index-constraints vars=(a string) index=(a)
+a SIMILAR TO 'ABC_Z'
+----
+[/'ABC' - /'ABD')
+Remaining filter: a SIMILAR TO 'ABC_Z'
 
 index-constraints vars=(a string) index=(a)
 a SIMILAR TO 'ABC'

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1054,6 +1054,47 @@ select
            └── const: 'ABC%' [type=string]
 
 opt
+SELECT * FROM kuv WHERE v LIKE '\ABC%'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
+           ├── variable: v:3 [type=string]
+           └── const: e'\\ABC%' [type=string]
+
+# Like doesn't support RE syntax.
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC.*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1 opt(3))
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC.*' - /'ABC.*']; tight), fd=()-->(3)]
+           ├── variable: v:3 [type=string]
+           └── const: 'ABC.*' [type=string]
+
+opt
 SELECT * FROM kuv WHERE v LIKE 'ABC_'
 ----
 select

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4976,6 +4976,13 @@ type likeKey struct {
 	escape          rune
 }
 
+// LikeEscape converts a like pattern to a regexp pattern.
+func LikeEscape(pattern string) (string, error) {
+	key := likeKey{s: pattern, caseInsensitive: false, escape: '\\'}
+	re, err := key.patternNoAnchor()
+	return re, err
+}
+
 // unescapePattern unescapes a pattern for a given escape token.
 // It handles escaped escape tokens properly by maintaining them as the escape
 // token in the return string.
@@ -5335,11 +5342,7 @@ func calculateLengthAfterReplacingCustomEscape(s string, escape rune) (bool, int
 	return changed, retLen, nil
 }
 
-// Pattern implements the RegexpCacheKey interface.
-// The strategy for handling custom escape character
-// is to convert all unescaped escape character into '\'.
-// k.escape can either be empty or a single character.
-func (k likeKey) Pattern() (string, error) {
+func (k likeKey) patternNoAnchor() (string, error) {
 	// QuoteMeta escapes all regexp metacharacters (`\.+*?()|[]{}^$`) with a `\`.
 	pattern := regexp.QuoteMeta(k.s)
 	var err error
@@ -5416,6 +5419,18 @@ func (k likeKey) Pattern() (string, error) {
 		}
 	}
 
+	return pattern, nil
+}
+
+// Pattern implements the RegexpCacheKey interface.
+// The strategy for handling custom escape character
+// is to convert all unescaped escape character into '\'.
+// k.escape can either be empty or a single character.
+func (k likeKey) Pattern() (string, error) {
+	pattern, err := k.patternNoAnchor()
+	if err != nil {
+		return "", err
+	}
 	return anchorPattern(pattern, k.caseInsensitive), nil
 }
 


### PR DESCRIPTION
Fixes: #44123

Previously no attempt was made to properly handle escape ('\\') sequence
in like patterns being turned into constraints. Refactor code used to
process like at runtime to generate a regexp and use that to properly
handle index constraint generation.

Release note (sql change): Escape character processing was missing from
constraint span generation which resulted in incorrect results when
doing escaped like lookups.