### PR TITLE
bazel: expose `devdarwinx86_64` toolchain via `platform` rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,7 +37,7 @@ build:crosslinuxarm '--workspace_status_command=./build/bazelutil/stamp.sh aarch
 build:crosslinuxarm --config=cross
 
 # developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
-build:devdarwinx86_64 --crosstool_top=@toolchain_dev_darwin_x86-64//:suite
+build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
 # NOTE(ricky): This is consumed in `BUILD` files (see
 # `build/toolchains/BUILD.bazel`).
 build:devdarwinx86_64 --config=dev

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -370,6 +370,7 @@ register_toolchains(
     "//build/toolchains:cross_linux_arm_toolchain",
     "//build/toolchains:cross_macos_toolchain",
     "//build/toolchains:cross_windows_toolchain",
+    "//build/toolchains:dev_darwin_x86_64_toolchain",
 )
 
 http_archive(

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -86,6 +86,31 @@ platform(
     ],
 )
 
+toolchain(
+    name = "dev_darwin_x86_64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    target_settings = [
+        ":dev",
+    ],
+    toolchain = "@toolchain_dev_darwin_x86-64//:toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+platform(
+    name = "darwin_x86_64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 config_setting(
     name = "dbg_crdb_test",
     define_values = {


### PR DESCRIPTION
This becomes necessary after #73819, which sets
`--incompatible_enable_cc_toolchain_resolution` for builds. The problem
is that this flag causes Bazel to ignore `--crosstool_top` in favor of
what toolchain it selects via [toolchain resolution](https://docs.bazel.build/versions/main/toolchains.html#toolchain-resolution).
Therefore we update `.bazelrc` to specify the `--platforms` instead of
`--crosstool_top`, and add an appropriate `toolchain` in
`build/toolchains`.

Release note: None