### PR TITLE
Revert "colrpc: propagate the flow cancellation as ungraceful for FlowStream RPC"

### DIFF
--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -78,9 +78,6 @@ type Inbox struct {
 	// goroutine should exit while waiting for a stream.
 	timeoutCh chan error
 
-	// flowCtxDone is the Done() channel of the flow context of the Inbox host.
-	flowCtxDone <-chan struct{}
-
 	// errCh is the channel that RunWithStream will block on, waiting until the
 	// Inbox does not need a stream any more. An error will only be sent on this
 	// channel in the event of a cancellation or a non-io.EOF error originating
@@ -158,33 +155,16 @@ func NewInbox(
 	return i, nil
 }
 
-// NewInboxWithFlowCtxDone creates a new Inbox when the done channel of the flow
-// context is available.
-func NewInboxWithFlowCtxDone(
-	allocator *colmem.Allocator,
-	typs []*types.T,
-	streamID execinfrapb.StreamID,
-	flowCtxDone <-chan struct{},
-) (*Inbox, error) {
-	i, err := NewInbox(allocator, typs, streamID)
-	if err != nil {
-		return nil, err
-	}
-	i.flowCtxDone = flowCtxDone
-	return i, nil
-}
-
 // NewInboxWithAdmissionControl creates a new Inbox that does admission
 // control on responses received from DistSQL.
 func NewInboxWithAdmissionControl(
 	allocator *colmem.Allocator,
 	typs []*types.T,
 	streamID execinfrapb.StreamID,
-	flowCtxDone <-chan struct{},
 	admissionQ *admission.WorkQueue,
 	admissionInfo admission.WorkInfo,
 ) (*Inbox, error) {
-	i, err := NewInboxWithFlowCtxDone(allocator, typs, streamID, flowCtxDone)
+	i, err := NewInbox(allocator, typs, streamID)
 	if err != nil {
 		return nil, err
 	}
@@ -205,22 +185,15 @@ func (i *Inbox) close() {
 	}
 }
 
-// checkFlowCtxCancellation returns an error if the flow context has already
-// been canceled.
-func (i *Inbox) checkFlowCtxCancellation() error {
-	select {
-	case <-i.flowCtxDone:
-		return cancelchecker.QueryCanceledError
-	default:
-		return nil
-	}
-}
-
 // RunWithStream sets the Inbox's stream and waits until either streamCtx is
-// canceled, the Inbox's host cancels the flow context, a caller of Next cancels
-// the context passed into Init, or any error is encountered on the stream by
-// the Next goroutine.
-func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
+// canceled, a caller of Next cancels the context passed into Init, or any error
+// is encountered on the stream by the Next goroutine.
+//
+// flowCtxDone is listened on only during the setup of the handler, before the
+// readerCtx is received. This is needed in case Inbox.Init is never called.
+func (i *Inbox) RunWithStream(
+	streamCtx context.Context, stream flowStreamServer, flowCtxDone <-chan struct{},
+) error {
 	streamCtx = logtags.AddTag(streamCtx, "streamID", i.streamID)
 	log.VEvent(streamCtx, 2, "Inbox handling stream")
 	defer log.VEvent(streamCtx, 2, "Inbox exited stream handler")
@@ -236,7 +209,7 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
 	case <-streamCtx.Done():
 		return errors.Wrap(streamCtx.Err(), "streamCtx error while waiting for reader (remote client canceled)")
-	case <-i.flowCtxDone:
+	case <-flowCtxDone:
 		// The flow context of the inbox host has been canceled. This can occur
 		// e.g. when the query is canceled, or when another stream encountered
 		// an unrecoverable error forcing it to shutdown the flow.
@@ -246,21 +219,18 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 	// Now wait for one of the events described in the method comment. If a
 	// cancellation is encountered, nothing special must be done to cancel the
 	// reader goroutine as returning from the handler will close the stream.
+	//
+	// Note that we don't listen for cancellation on flowCtxDone because
+	// readerCtx must be the child of the flow context.
 	select {
 	case err := <-i.errCh:
 		// nil will be read from errCh when the channel is closed.
 		return err
-	case <-i.flowCtxDone:
-		// The flow context of the inbox host has been canceled. This can occur
-		// e.g. when the query is canceled, or when another stream encountered
-		// an unrecoverable error forcing it to shutdown the flow.
-		return cancelchecker.QueryCanceledError
 	case <-readerCtx.Done():
-		// readerCtx is canceled, but we don't know whether it was because the
-		// flow context was canceled or for other reason. In the former case we
-		// have an ungraceful shutdown whereas in the latter case we have a
-		// graceful one.
-		return i.checkFlowCtxCancellation()
+		// The reader canceled the stream meaning that it no longer needs any
+		// more data from the outbox. This is a graceful termination, so we
+		// return nil.
+		return nil
 	case <-streamCtx.Done():
 		// The client canceled the stream.
 		return errors.Wrap(streamCtx.Err(), "streamCtx error in Inbox stream handler (remote client canceled)")
@@ -290,15 +260,12 @@ func (i *Inbox) Init(ctx context.Context) {
 		case err := <-i.timeoutCh:
 			i.errCh <- errors.Wrap(err, "remote stream arrived too late")
 			return err
-		case <-i.flowCtxDone:
-			i.errCh <- cancelchecker.QueryCanceledError
-			return cancelchecker.QueryCanceledError
 		case <-i.Ctx.Done():
-			if err := i.checkFlowCtxCancellation(); err != nil {
-				// This is an ungraceful termination because the flow context
-				// has been canceled.
-				i.errCh <- err
-			}
+			// Our reader canceled the context meaning that it no longer needs
+			// any more data from the outbox. This is a graceful termination, so
+			// we don't send any error on errCh and only return an error. This
+			// will close the inbox (making the stream handler exit gracefully)
+			// and will stop the current goroutine from proceeding further.
 			return i.Ctx.Err()
 		}
 

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -70,7 +70,7 @@ func TestInboxCancellation(t *testing.T) {
 		err = colexecerror.CatchVectorizedRuntimeError(func() { inbox.Init(ctx) })
 		require.True(t, testutils.IsError(err, "context canceled"), err)
 		// Now, the remote stream arrives.
-		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
+		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{}, make(<-chan struct{}))
 		// We expect no error from the stream handler since we canceled it
 		// ourselves (a graceful termination).
 		require.Nil(t, err)

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -289,7 +289,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					doneFn := func() { close(serverStreamNotification.Donec) }
 					wg.Add(1)
 					go func(id int, stream execinfrapb.DistSQL_FlowStreamServer, doneFn func()) {
-						handleStreamErrCh[id] <- inbox.RunWithStream(stream.Context(), stream)
+						handleStreamErrCh[id] <- inbox.RunWithStream(stream.Context(), stream, make(<-chan struct{}))
 						doneFn()
 						wg.Done()
 					}(id, serverStream, doneFn)

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -52,11 +52,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 }
 
 func (c callbackRemoteComponentCreator) newInbox(
-	allocator *colmem.Allocator,
-	typs []*types.T,
-	streamID execinfrapb.StreamID,
-	_ <-chan struct{},
-	_ admissionOptions,
+	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID, _ admissionOptions,
 ) (*colrpc.Inbox, error) {
 	return c.newInboxFn(allocator, typs, streamID)
 }


### PR DESCRIPTION
There appears to be some fallout from this change that I need to investigate,
but in the meantime let's revert it.

This reverts commit 2203baea4d66c93a3c5631b97c1b1b4072c8418e.