### PR TITLE
opt: remove outdated TODO in inverted-join test

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -146,9 +146,8 @@ project
       └── filters
            └── t1.j:2 @> t2.j:9 [type=bool, outer=(2,9), immutable]
 
-# TODO(rytaft): The following two inverted joins have the same estimated row
-# count even though the first one has an extra conjunct in the inverted
-# expression. The first one should have a lower estimated row count.
+# Of the following two join expressions, the first one has an extra conjunct in
+# the inverted expression, so it should have a lower estimated row count.
 opt
 SELECT *
 FROM json_arr1 AS t1


### PR DESCRIPTION
There was a TODO about how the row size estimate of two join queries in
the `stats/inverted-join` test should be different. It appears that the
row sizes are different now, so the TODO has been removed and replaced
with a comment about why they should be different.

Release note: None