### PR TITLE
sql: add tests for UPSERT with ON UPDATE columns without target columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/on_update
+++ b/pkg/sql/logictest/testdata/logic_test/on_update
@@ -62,6 +62,17 @@ SELECT p, j, k FROM test_upsert ORDER BY p
 pk1  val2  regress
 pk2  val3  def
 
+# If there are no explicit target columns, UPSERT sets all columns to their
+# DEFAULT value. Therefore, the ON UPDATE value is not used. See #73984.
+statement ok
+UPSERT INTO test_upsert VALUES ('pk1', 'val20'), ('pk2', 'val30')
+
+query TTT
+SELECT p, j, k FROM test_upsert ORDER BY p
+----
+pk1  val20  def
+pk2  val30  def
+
 # ON UPDATE usage by running ALTER TABLE
 subtest OnUpdateAlterTable
 

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2008,6 +2008,24 @@ upsert on_update_bare
       ├── columns: column1:5!null column2:6!null
       └── (1, 2)
 
+# If there are no explicit target columns, UPSERT sets all columns to their
+# DEFAULT value. Therefore, the ON UPDATE value is not used. See #73984.
+build
+UPSERT INTO on_update_bare VALUES (1)
+----
+upsert on_update_bare
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:5 => a:1
+ │    └── v_default:6 => v:2
+ └── project
+      ├── columns: v_default:6 column1:5!null
+      ├── values
+      │    ├── columns: column1:5!null
+      │    └── (1,)
+      └── projections
+           └── NULL::INT8 [as=v_default:6]
+
 build
 UPSERT INTO on_update_bare (a) VALUES (1)
 ----


### PR DESCRIPTION
This commit adds tests so that the behavior of UPSERT is well defined
when it has no explicit target columns and the target table has an ON
UPDATE column.

Informs #73984

Release note: None