### PR TITLE
dev: add `--show-logs` to `dev test`

### DIFF
--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -41,7 +41,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
+bazel test //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_arg -test.v --test_arg -show-logs --test_output all
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:
@@ -110,7 +110,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -13,10 +13,10 @@ dev test pkg/util/tracing -f TestStartChild*
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
 bazel test //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_output errors
 
-dev test pkg/util/tracing -f TestStartChild* -v
+dev test pkg/util/tracing -f TestStartChild* -v --show-logs
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_output all --test_arg -test.v
+bazel test //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_arg -test.v --test_arg -show-logs --test_output all
 
 dev test pkg/util/tracing -f TestStartChild* --remote-cache 127.0.0.1:9092
 ----
@@ -41,7 +41,7 @@ bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled //pkg/util
 dev test --stress pkg/util/tracing --filter TestStartChild* --timeout=10s -v
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
 
 dev test //pkg/testutils --timeout=10s
 ----


### PR DESCRIPTION
Go's test runner runs tests in sub-processes; the stderr/stdout data
from the test process is first swallowed by go test and then only
conditionally released to the invoking user depending on flags passed to
`go test`. The `-v` switch controls whether `go test` shows the test
process' output (which test is being run, how long it took, etc.)
always, or only on failures. `-show-logs` by contrast is a flag for the
process under test, controlling whether the process-internal logs are
made visible.

Release note: None