### PR TITLE
sql: don't allow public role to have grant options

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -19,6 +19,9 @@ GRANT ALL PRIVILEGES ON table t to testuser2
 # switch to root
 user root
 
+statement error grant options cannot be granted to "public" role
+GRANT ALL PRIVILEGES ON TABLE t TO public WITH GRANT OPTION
+
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 


### PR DESCRIPTION
fixes #73998

No release note since this behavior is new in v22.1

Release note: None