### PR TITLE
ui: resize the information on Statement Details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -561,13 +561,13 @@ export class StatementDetails extends React.Component<
         activeKey={currentTab}
       >
         <TabPane tab="Overview" key="overview">
-          <Row gutter={16}>
-            <Col className="gutter-row" span={16}>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={24}>
               <SqlBox value={statement} />
             </Col>
           </Row>
-          <Row gutter={16}>
-            <Col className="gutter-row" span={8}>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
                 <Row>
                   <Col>
@@ -670,7 +670,7 @@ export class StatementDetails extends React.Component<
                 </Row>
               </SummaryCard>
             </Col>
-            <Col className="gutter-row" span={8}>
+            <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Statement details</Heading>
                 <div className={summaryCardStylesCx("summary--card__item")}>


### PR DESCRIPTION
Previously, the size of columns on Overview tab of the
Statement Details page were not using the full size like
other tabs on that page. This commit changes the content
to full size.

Partially addresses #70783

Before
<img width="1644" alt="Screen Shot 2021-12-17 at 5 39 19 PM" src="https://user-images.githubusercontent.com/1017486/146616379-85768c3c-6c09-4c90-841f-44b50d0d2bd4.png">


After
<img width="1743" alt="Screen Shot 2021-12-17 at 5 40 11 PM" src="https://user-images.githubusercontent.com/1017486/146616387-e93753d2-dcad-46c3-857e-74053ce4fdff.png">


Release note: None