### PR TITLE
dev: port testing flags to `dev testlogic`

### DIFF
--- a/pkg/cmd/dev/logic.go
+++ b/pkg/cmd/dev/logic.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -37,9 +38,16 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 		RunE: runE,
 	}
 	testLogicCmd.Flags().Duration(timeoutFlag, 0*time.Minute, "timeout for test")
+	testLogicCmd.Flags().BoolP(vFlag, "v", false, "show testing process output")
+	testLogicCmd.Flags().BoolP(showLogsFlag, "", false, "show crdb logs in-line")
 	testLogicCmd.Flags().String(filesFlag, "", "run logic tests for files matching this regex")
 	testLogicCmd.Flags().String(subtestsFlag, "", "run logic test subtests matching this regex")
 	testLogicCmd.Flags().String(configFlag, "", "run logic tests under the specified config")
+	testLogicCmd.Flags().Bool(ignoreCacheFlag, false, "ignore cached test runs")
+	testLogicCmd.Flags().String(rewriteFlag, "", "argument to pass to underlying (only applicable for certain tests, e.g. logic and datadriven tests). If unspecified, -rewrite will be passed to the test binary.")
+	testLogicCmd.Flags().String(rewriteArgFlag, "", "additional argument to pass to -rewrite (implies --rewrite)")
+	testLogicCmd.Flags().Lookup(rewriteFlag).NoOptDefVal = "-rewrite"
+
 	addCommonBuildFlags(testLogicCmd)
 	return testLogicCmd
 }
@@ -47,14 +55,22 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	choices, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
-	files := mustGetFlagString(cmd, filesFlag)
-	subtests := mustGetFlagString(cmd, subtestsFlag)
-	config := mustGetFlagString(cmd, configFlag)
-	timeout := mustGetFlagDuration(cmd, timeoutFlag)
+
+	var (
+		config      = mustGetFlagString(cmd, configFlag)
+		files       = mustGetFlagString(cmd, filesFlag)
+		ignoreCache = mustGetFlagBool(cmd, ignoreCacheFlag)
+		rewrite     = mustGetFlagString(cmd, rewriteFlag)
+		rewriteArg  = mustGetFlagString(cmd, rewriteArgFlag)
+		showLogs    = mustGetFlagBool(cmd, showLogsFlag)
+		subtests    = mustGetFlagString(cmd, subtestsFlag)
+		timeout     = mustGetFlagDuration(cmd, timeoutFlag)
+		verbose     = mustGetFlagBool(cmd, vFlag)
+	)
 
 	validChoices := []string{"base", "ccl", "opt"}
 	if len(choices) == 0 {
-		// Default to ALL
+		// Default to all targets.
 		choices = append(choices, validChoices...)
 	}
 	for _, choice := range choices {
@@ -70,42 +86,77 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	}
 
 	for _, choice := range choices {
-		args := []string{"test"}
-		var target, selectorPrefix string
+		var testTarget, selectorPrefix string
 		switch choice {
 		case "base":
-			target = "//pkg/sql/logictest:logictest_test"
+			testTarget = "//pkg/sql/logictest:logictest_test"
 			selectorPrefix = "TestLogic"
 		case "ccl":
-			target = "//pkg/ccl/logictestccl:logictestccl_test"
+			testTarget = "//pkg/ccl/logictestccl:logictestccl_test"
 			selectorPrefix = "TestCCLLogic"
 		case "opt":
-			target = "//pkg/sql/opt/exec/execbuilder:execbuilder_test"
+			testTarget = "//pkg/sql/opt/exec/execbuilder:execbuilder_test"
 			selectorPrefix = "TestExecBuild"
 		}
-		selector := fmt.Sprintf(
-			"%s/%s/%s/%s",
-			selectorPrefix,
-			maybeAddBeginEndMarkers(config),
-			maybeAddBeginEndMarkers(files),
-			subtests)
-		args = append(args, target)
-		args = append(args, "--test_filter", selector)
-		args = append(args, "--test_arg", "-test.v")
+
+		var args []string
+		args = append(args, "test")
+		args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
+		args = append(args, "--test_env=GOTRACEBACK=all")
+		if numCPUs != 0 {
+			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+		}
+		if ignoreCache {
+			args = append(args, "--nocache_test_results")
+		}
+		if verbose {
+			args = append(args, "--test_arg", "-test.v")
+		}
+		if showLogs {
+			args = append(args, "--test_arg", "-show-logs")
+		}
+		if timeout > 0 {
+			args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
+		}
 		if len(files) > 0 {
 			args = append(args, "--test_arg", "-show-sql")
 		}
 		if len(config) > 0 {
 			args = append(args, "--test_arg", "-config", "--test_arg", config)
 		}
-		if timeout > 0 {
-			args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
+
+		if verbose || showLogs {
+			args = append(args, "--test_output", "all")
+		} else {
+			args = append(args, "--test_output", "errors")
 		}
-		if numCPUs != 0 {
-			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+
+		if rewrite != "" {
+			workspace, err := d.getWorkspace(ctx)
+			if err != nil {
+				return err
+			}
+
+			args = append(args, fmt.Sprintf("--test_env=COCKROACH_WORKSPACE=%s", workspace))
+			args = append(args, "--test_arg", rewrite)
+			if rewriteArg != "" {
+				args = append(args, "--test_arg", rewriteArg)
+			}
+
+			dir := getDirectoryFromTarget(testTarget)
+			args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir)))
 		}
+
+		// TODO(irfansharif): Is this right? --config and --files is optional.
+		selector := fmt.Sprintf(
+			"%s/%s/%s/%s",
+			selectorPrefix,
+			maybeAddBeginEndMarkers(config),
+			maybeAddBeginEndMarkers(files),
+			subtests)
+		args = append(args, testTarget)
+		args = append(args, "--test_filter", selector)
 		args = append(args, additionalBazelArgs...)
-		args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 		logCommand("bazel", args...)
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -74,9 +74,6 @@ func makeTestCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Comm
 	return testCmd
 }
 
-// TODO(irfansharif): Add tests for the various bazel commands that get
-// generated from the set of provided user flags.
-
 func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	pkgs, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
@@ -93,9 +90,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		verbose     = mustGetFlagBool(cmd, vFlag)
 		showLogs    = mustGetFlagBool(cmd, showLogsFlag)
 	)
-	if rewriteArg != "" && rewrite == "" {
-		rewrite = "-rewrite"
-	}
 
 	var args []string
 	args = append(args, "test")

--- a/pkg/cmd/dev/testdata/logic.txt
+++ b/pkg/cmd/dev/testdata/logic.txt
@@ -1,9 +1,14 @@
 dev testlogic
 ----
-bazel test //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_arg -test.v
-bazel test //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic/// --test_arg -test.v
-bazel test //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_arg -test.v
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/logictest:logictest_test --test_filter TestLogic///
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic///
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild///
 
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local
 ----
-bazel test //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_arg -test.v --test_arg -show-sql --test_arg -config --test_arg local
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local --test_output errors //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042'
+
+dev testlogic base --files=auto_span_config_reconciliation_job --config=local -v --show-logs --timeout=50s --rewrite
+----
+bazel info workspace --color=no
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_timeout=50 --test_arg -show-sql --test_arg -config --test_arg local --test_output all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/sql/logictest //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation_job$/'

--- a/pkg/cmd/dev/testdata/recording/logic.txt
+++ b/pkg/cmd/dev/testdata/recording/logic.txt
@@ -1,11 +1,18 @@
-bazel test //pkg/sql/logictest:logictest_test --test_filter TestLogic/// --test_arg -test.v
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/logictest:logictest_test --test_filter TestLogic///
 ----
 
-bazel test //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic/// --test_arg -test.v
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic///
 ----
 
-bazel test //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild/// --test_arg -test.v
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild///
 ----
 
-bazel test //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042' --test_arg -test.v --test_arg -show-sql --test_arg -config --test_arg local
+bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local --test_output errors //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042'
+----
+
+bazel info workspace --color=no
+----
+go/src/github.com/cockroachdb/cockroach
+
+bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_timeout=50 --test_arg -show-sql --test_arg -config --test_arg local --test_output all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/sql/logictest //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation_job$/'
 ----


### PR DESCRIPTION
We were missing a few: -v, --show-logs, --ignore-cache, --rewrite. It's
a bit unfortunate how much duplication there is here with the canonical
test command implementation, but this commit does not attempt to unify
the codepaths.

Release note: None

---

First commit is from #73999.