### PR TITLE
kv: Annotate rangefeed stacks with labels.

### DIFF
--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -34,6 +34,7 @@ type config struct {
 	onUnrecoverableError OnUnrecoverableError
 	onCheckpoint         OnCheckpoint
 	onFrontierAdvance    OnFrontierAdvance
+	extraPProfLabels     []string
 }
 
 type scanConfig struct {
@@ -207,5 +208,13 @@ const (
 func WithScanRetryBehavior(b ScanRetryBehavior) Option {
 	return optionFunc(func(c *config) {
 		c.retryBehavior = b
+	})
+}
+
+// WithPProfLabel configures rangefeed to annotate go routines started by range feed
+// with the specified key=value label.
+func WithPProfLabel(key, value string) Option {
+	return optionFunc(func(c *config) {
+		c.extraPProfLabels = append(c.extraPProfLabels, key, value)
 	})
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -13,6 +13,7 @@ package rangefeed
 import (
 	"context"
 	"fmt"
+	"runtime/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -203,6 +204,12 @@ func (f *RangeFeed) Start(ctx context.Context, spans []roachpb.Span) error {
 	})
 
 	runWithFrontier := func(ctx context.Context) {
+		// pprof.Do function does exactly what we do here, but it also results in
+		// pprof.Do function showing up in the stack traces -- so, just set and reset
+		// labels manually.
+		defer pprof.SetGoroutineLabels(ctx)
+		ctx = pprof.WithLabels(ctx, pprof.Labels(append(f.extraPProfLabels, "rangefeed", f.name)...))
+		pprof.SetGoroutineLabels(ctx)
 		f.run(ctx, frontier)
 	}
 


### PR DESCRIPTION
Rangefeed library is a library that's starting to see more
use cases in the code base.  The feeds managed by this library
are intented to be long running processes -- most of the time,
running for the entirety of the node lifetime.
However, starting rangefeed tasks with `stopper.RunAsyncTask`
makes it hard to determine which rangefeeed instances is responsible
for a particular stack.

This change annotates each rangefeed with a pprof label identifying
rangefeed name.  In addition, allow the callers to specify additional
list of labels to apply to rangefeed initiated go routines.

After this change stack traces are easily identifyable.
<img width="842" alt="Screen Shot 2021-12-18 at 2 30 10 PM" src="https://user-images.githubusercontent.com/54641364/146653810-3280a62d-ce19-46ab-8912-3767987f7527.png">


Release Notes: None