### PR TITLE
release-21.1: kvserver: throttle `AddSSTable` requests with `IngestAsWrites`

### DIFF
--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -34,10 +34,11 @@ import (
 
 // Limiters is the collection of per-store limits used during cmd evaluation.
 type Limiters struct {
-	BulkIOWriteRate              *rate.Limiter
-	ConcurrentImportRequests     limit.ConcurrentRequestLimiter
-	ConcurrentExportRequests     limit.ConcurrentRequestLimiter
-	ConcurrentAddSSTableRequests limit.ConcurrentRequestLimiter
+	BulkIOWriteRate                      *rate.Limiter
+	ConcurrentImportRequests             limit.ConcurrentRequestLimiter
+	ConcurrentExportRequests             limit.ConcurrentRequestLimiter
+	ConcurrentAddSSTableRequests         limit.ConcurrentRequestLimiter
+	ConcurrentAddSSTableAsWritesRequests limit.ConcurrentRequestLimiter
 	// concurrentRangefeedIters is a semaphore used to limit the number of
 	// rangefeeds in the "catch-up" state across the store. The "catch-up" state
 	// is a temporary state at the beginning of a rangefeed which is expensive

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -263,15 +263,12 @@ func (s *Store) maybeThrottleBatch(
 
 	switch t := ba.Requests[0].GetInner().(type) {
 	case *roachpb.AddSSTableRequest:
-		// Limit the number of concurrent AddSSTable requests, since they're
-		// expensive and block all other writes to the same span. However, don't
-		// limit AddSSTable requests that are going to ingest as a WriteBatch.
+		limiter := s.limiters.ConcurrentAddSSTableRequests
 		if t.IngestAsWrites {
-			return nil, nil
+			limiter = s.limiters.ConcurrentAddSSTableAsWritesRequests
 		}
-
 		before := timeutil.Now()
-		res, err := s.limiters.ConcurrentAddSSTableRequests.Begin(ctx)
+		res, err := limiter.Begin(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #73904.

/cc @cockroachdb/release

---

`Store.Send()` limits the number of concurrent `AddSSTable` requests
and delays them depending on LSM health via `Engine.PreIngestDelay`, to
prevent overwhelming Pebble. However, requests with `IngestAsWrites`
were not throttled, which has been seen to cause significant read
amplification.

This patch subjects `IngestAsWrites` requests to `Engine.PreIngestDelay`
as well, and adds a separate limit for `IngestAsWrites` requests
controlled via the cluster setting
`kv.bulk_io_write.concurrent_addsstable_as_writes_requests` (default
10). Since these requests are generally small, and will end up in the
Pebble memtable before being flushed to disk, we can tolerate a larger
limit for these requests than regular `AddSSTable` requests (1).

Release note (performance improvement): Bulk ingestion of small write
batches (e.g. index backfill into a large number of ranges) is now
throttled, to avoid buildup of read amplification and associated
performance degradation. Concurrency is controlled by the new cluster
setting `kv.bulk_io_write.concurrent_addsstable_as_writes_requests`.

----

Release justification: prevents pathological performance degradation.