### PR TITLE
roachtest: use parallelism with local clusters

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
@@ -26,7 +26,7 @@ $BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod destroy --all-local
 
 $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
   --local \
-  --parallelism=1 \
+  --parallelism=3 \
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts /artifacts \

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -23,7 +23,7 @@ $BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod destroy --all-local
 
 $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
   --local \
-  --parallelism=1 \
+  --parallelism=3 \
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts /artifacts \

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -76,7 +76,7 @@ func parseCreateOpts(flags *pflag.FlagSet, opts *vm.CreateOpts) {
 func main() {
 	rand.Seed(timeutil.Now().UnixNano())
 	username := os.Getenv("ROACHPROD_USER")
-	parallelism := 10
+	parallelism := 0
 	var cpuQuota int
 	// Path to a local dir where the test logs and artifacts collected from
 	// cluster will be placed.
@@ -429,9 +429,13 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 		bindTo = "localhost"
 
 		fmt.Printf("--local specified. Binding http listener to localhost only")
-		if cfg.parallelism != 1 {
-			fmt.Printf("--local specified. Overriding --parallelism to 1.\n")
+	}
+	if cfg.parallelism == 0 {
+		// No custom value was passed for parallelism so set the default values.
+		if local {
 			cfg.parallelism = 1
+		} else {
+			cfg.parallelism = 10
 		}
 	}
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -244,9 +244,6 @@ func (r *testRunner) Run(
 		if clustersOpt.clusterName != "" {
 			return fmt.Errorf("--cluster incompatible with --parallelism. Use --parallelism=1")
 		}
-		if clustersOpt.typ == localCluster {
-			return fmt.Errorf("--local incompatible with --parallelism. Use --parallelism=1")
-		}
 	}
 
 	if name := clustersOpt.clusterName; name != "" {

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -26,7 +26,7 @@ func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 	u := newVersionUpgradeTest(c,
 		uploadVersionStep(allNodes, clusterupgrade.MainVersion),
 		startVersion(allNodes, clusterupgrade.MainVersion),
-		fullyDecommissionStep(2, 2, clusterupgrade.MainVersion),
+		fullyDecommissionStep(2, 2, clusterupgrade.MainVersion, t.L()),
 		func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 			// Stop n2 and exclude it from post-test consistency checks,
 			// as this node can't contact cluster any more and operations


### PR DESCRIPTION
We can run multiple local roachprod clusters now, so this patch
integrates this change into roachtest by allowing it to run  with
both `--local` and `parallelism > 1`.

Release note: None