### PR TITLE
kv/kvclient: don't let request direction switch while splitting partial batches

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -777,6 +777,7 @@ func (ds *DistSender) Send(
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
+		isReverse := ba.IsReverse()
 
 		// Determine whether this part of the BatchRequest contains a committing
 		// EndTxn request.
@@ -790,9 +791,9 @@ func (ds *DistSender) Send(
 		var rpl *roachpb.BatchResponse
 		var pErr *roachpb.Error
 		if withParallelCommit {
-			rpl, pErr = ds.divideAndSendParallelCommit(ctx, ba, rs, 0 /* batchIdx */)
+			rpl, pErr = ds.divideAndSendParallelCommit(ctx, ba, rs, isReverse, 0 /* batchIdx */)
 		} else {
-			rpl, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, withCommit, 0 /* batchIdx */)
+			rpl, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, isReverse, withCommit, 0 /* batchIdx */)
 		}
 
 		if pErr == errNo1PCTxn {
@@ -884,7 +885,7 @@ type response struct {
 // method is never invoked recursively, but it is exposed to maintain symmetry
 // with divideAndSendBatchToRanges.
 func (ds *DistSender) divideAndSendParallelCommit(
-	ctx context.Context, ba roachpb.BatchRequest, rs roachpb.RSpan, batchIdx int,
+	ctx context.Context, ba roachpb.BatchRequest, rs roachpb.RSpan, isReverse bool, batchIdx int,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	// Search backwards, looking for the first pre-commit QueryIntent.
 	swapIdx := -1
@@ -899,7 +900,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	}
 	if swapIdx == -1 {
 		// No pre-commit QueryIntents. Nothing to split.
-		return ds.divideAndSendBatchToRanges(ctx, ba, rs, true /* withCommit */, batchIdx)
+		return ds.divideAndSendBatchToRanges(ctx, ba, rs, isReverse, true /* withCommit */, batchIdx)
 	}
 
 	// Swap the EndTxn request and the first pre-commit QueryIntent. This
@@ -926,6 +927,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	if err != nil {
 		return br, roachpb.NewError(err)
 	}
+	qiIsReverse := qiBa.IsReverse()
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
 	qiBaCopy := qiBa // avoids escape to heap
@@ -955,7 +957,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 
 		// Send the batch with withCommit=true since it will be inflight
 		// concurrently with the EndTxn batch below.
-		reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, true /* withCommit */, qiBatchIdx)
+		reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, qiIsReverse, true /* withCommit */, qiBatchIdx)
 		qiResponseCh <- response{reply: reply, positions: positions, pErr: pErr}
 	}); err != nil {
 		return nil, roachpb.NewError(err)
@@ -969,7 +971,8 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
-	br, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, true /* withCommit */, batchIdx)
+	isReverse = ba.IsReverse()
+	br, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, isReverse, true /* withCommit */, batchIdx)
 
 	// Wait for the QueryIntent-only batch to complete and stitch
 	// the responses together.
@@ -1125,16 +1128,27 @@ func mergeErrors(pErr1, pErr2 *roachpb.Error) *roachpb.Error {
 // is trimmed against each range which is part of the span and sent
 // either serially or in parallel, if possible.
 //
-// batchIdx indicates which partial fragment of the larger batch is
-// being processed by this method. It's specified as non-zero when
-// this method is invoked recursively.
+// isReverse indicates the direction that the provided span should be
+// iterated over while sending requests. It is passed in by callers
+// instead of being recomputed based on the requests in the batch to
+// prevent the iteration direction from switching midway through a
+// batch, in cases where partial batches recurse into this function.
 //
 // withCommit indicates that the batch contains a transaction commit
 // or that a transaction commit is being run concurrently with this
 // batch. Either way, if this is true then sendToReplicas will need
 // to handle errors differently.
+//
+// batchIdx indicates which partial fragment of the larger batch is
+// being processed by this method. It's specified as non-zero when
+// this method is invoked recursively.
 func (ds *DistSender) divideAndSendBatchToRanges(
-	ctx context.Context, ba roachpb.BatchRequest, rs roachpb.RSpan, withCommit bool, batchIdx int,
+	ctx context.Context,
+	ba roachpb.BatchRequest,
+	rs roachpb.RSpan,
+	isReverse bool,
+	withCommit bool,
+	batchIdx int,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	// Clone the BatchRequest's transaction so that future mutations to the
 	// proto don't affect the proto in this batch.
@@ -1144,7 +1158,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 	// Get initial seek key depending on direction of iteration.
 	var scanDir ScanDirection
 	var seekKey roachpb.RKey
-	if !ba.IsReverse() {
+	if !isReverse {
 		scanDir = Ascending
 		seekKey = rs.Key
 	} else {
@@ -1159,7 +1173,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 	// Take the fast path if this batch fits within a single range.
 	if !ri.NeedAnother(rs) {
 		resp := ds.sendPartialBatch(
-			ctx, ba, rs, ri.Token(), withCommit, batchIdx, false, /* needsTruncate */
+			ctx, ba, rs, isReverse, withCommit, batchIdx, ri.Token(), false, /* needsTruncate */
 		)
 		return resp.reply, resp.pErr
 	}
@@ -1317,11 +1331,11 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		// If we can reserve one of the limited goroutines available for parallel
 		// batch RPCs, send asynchronously.
 		if canParallelize && !lastRange && !ds.disableParallelBatches &&
-			ds.sendPartialBatchAsync(ctx, ba, rs, ri.Token(), withCommit, batchIdx, responseCh) {
+			ds.sendPartialBatchAsync(ctx, ba, rs, isReverse, withCommit, batchIdx, ri.Token(), responseCh) {
 			// Sent the batch asynchronously.
 		} else {
 			resp := ds.sendPartialBatch(
-				ctx, ba, rs, ri.Token(), withCommit, batchIdx, true, /* needsTruncate */
+				ctx, ba, rs, isReverse, withCommit, batchIdx, ri.Token(), true, /* needsTruncate */
 			)
 			responseCh <- resp
 			if resp.pErr != nil {
@@ -1410,9 +1424,10 @@ func (ds *DistSender) sendPartialBatchAsync(
 	ctx context.Context,
 	ba roachpb.BatchRequest,
 	rs roachpb.RSpan,
-	routing rangecache.EvictionToken,
+	isReverse bool,
 	withCommit bool,
 	batchIdx int,
+	routing rangecache.EvictionToken,
 	responseCh chan response,
 ) bool {
 	if err := ds.rpcContext.Stopper.RunAsyncTaskEx(
@@ -1426,7 +1441,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 		func(ctx context.Context) {
 			ds.metrics.AsyncSentCount.Inc(1)
 			responseCh <- ds.sendPartialBatch(
-				ctx, ba, rs, routing, withCommit, batchIdx, true, /* needsTruncate */
+				ctx, ba, rs, isReverse, withCommit, batchIdx, routing, true, /* needsTruncate */
 			)
 		},
 	); err != nil {
@@ -1472,9 +1487,10 @@ func (ds *DistSender) sendPartialBatch(
 	ctx context.Context,
 	ba roachpb.BatchRequest,
 	rs roachpb.RSpan,
-	routingTok rangecache.EvictionToken,
+	isReverse bool,
 	withCommit bool,
 	batchIdx int,
+	routingTok rangecache.EvictionToken,
 	needsTruncate bool,
 ) response {
 	if batchIdx == 1 {
@@ -1486,8 +1502,6 @@ func (ds *DistSender) sendPartialBatch(
 	var pErr *roachpb.Error
 	var err error
 	var positions []int
-
-	isReverse := ba.IsReverse()
 
 	if needsTruncate {
 		// Truncate the request to range descriptor.
@@ -1536,7 +1550,7 @@ func (ds *DistSender) sendPartialBatch(
 				continue
 			}
 
-			// See if the range shrunk. If it has, we need to to sub-divide the
+			// See if the range shrunk. If it has, we need to sub-divide the
 			// request. Note that for the resending, we use the already truncated
 			// batch, so that we know that the response to it matches the positions
 			// into our batch (using the full batch here would give a potentially
@@ -1547,7 +1561,7 @@ func (ds *DistSender) sendPartialBatch(
 			}
 			if !intersection.Equal(rs) {
 				log.Eventf(ctx, "range shrunk; sub-dividing the request")
-				reply, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, withCommit, batchIdx)
+				reply, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, isReverse, withCommit, batchIdx)
 				return response{reply: reply, positions: positions, pErr: pErr}
 			}
 		}
@@ -1654,7 +1668,7 @@ func (ds *DistSender) sendPartialBatch(
 			// batch here would give a potentially larger response slice
 			// with unknown mapping to our truncated reply).
 			log.VEventf(ctx, 1, "likely split; will resend. Got new descriptors: %s", tErr.Ranges)
-			reply, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, withCommit, batchIdx)
+			reply, pErr = ds.divideAndSendBatchToRanges(ctx, ba, rs, isReverse, withCommit, batchIdx)
 			return response{reply: reply, positions: positions, pErr: pErr}
 		}
 		break

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4194,130 +4194,307 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	tr := tracing.NewTracer()
-	stopper := stop.NewStopper(stop.WithTracer(tr))
-	defer stopper.Stop(ctx)
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+	splitKey := keys.MustAddr(keyB)
 
-	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
-	g := makeGossip(t, stopper, rpcContext)
-
-	// First request will be sent to an unsplit descriptor.
-	var initialDesc = roachpb.RangeDescriptor{
-		RangeID:    roachpb.RangeID(1),
-		Generation: 1,
-		StartKey:   roachpb.RKeyMin,
-		EndKey:     roachpb.RKeyMax,
-		InternalReplicas: []roachpb.ReplicaDescriptor{
-			{
-				NodeID:  1,
-				StoreID: 1,
-			},
-		},
+	get := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewGet(k, false /* forUpdate */)
+	}
+	scan := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewScan(k, k.Next(), false /* forUpdate */)
+	}
+	revScan := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewReverseScan(k, k.Next(), false /* forUpdate */)
 	}
 
-	// But the 2nd attempt will use the split ones.
-	splitKey := roachpb.RKey("b")
-	splitDescs := []roachpb.RangeDescriptor{{
-		RangeID:    roachpb.RangeID(1),
-		Generation: 2,
-		StartKey:   roachpb.RKeyMin,
-		EndKey:     splitKey,
-		InternalReplicas: []roachpb.ReplicaDescriptor{
-			{
+	for _, tc := range []struct {
+		req1, req2 func(roachpb.Key) roachpb.Request
+	}{
+		{get, get},
+		{scan, get},
+		{get, scan},
+		{scan, scan},
+		{revScan, get},
+		{get, revScan},
+		{revScan, revScan},
+	} {
+		name := fmt.Sprintf("%s %s", tc.req1(nil).Method(), tc.req2(nil).Method())
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			tr := tracing.NewTracer()
+			stopper := stop.NewStopper(stop.WithTracer(tr))
+			defer stopper.Stop(ctx)
+
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+			g := makeGossip(t, stopper, rpcContext)
+
+			// First request will be sent to an unsplit descriptor.
+			repls := []roachpb.ReplicaDescriptor{{
 				NodeID:  1,
 				StoreID: 1,
-			},
-		},
-	}, {
-		RangeID:    roachpb.RangeID(2),
-		Generation: 2,
-		StartKey:   splitKey,
-		EndKey:     roachpb.RKeyMax,
-		InternalReplicas: []roachpb.ReplicaDescriptor{
-			{
-				NodeID:  1,
-				StoreID: 1,
-			},
-		},
-	}}
+			}}
+			initDesc := roachpb.RangeDescriptor{
+				RangeID:          roachpb.RangeID(1),
+				Generation:       1,
+				StartKey:         roachpb.RKeyMin,
+				EndKey:           roachpb.RKeyMax,
+				InternalReplicas: repls,
+			}
+			// But the 2nd attempt will use the split ones.
+			splitDescs := []roachpb.RangeDescriptor{{
+				RangeID:          roachpb.RangeID(1),
+				Generation:       2,
+				StartKey:         roachpb.RKeyMin,
+				EndKey:           splitKey,
+				InternalReplicas: repls,
+			}, {
+				RangeID:          roachpb.RangeID(2),
+				Generation:       2,
+				StartKey:         splitKey,
+				EndKey:           roachpb.RKeyMax,
+				InternalReplicas: repls,
+			}}
 
-	initialRDB := MockRangeDescriptorDB(func(key roachpb.RKey, reverse bool) (
-		[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
-	) {
-		return []roachpb.RangeDescriptor{initialDesc}, nil, nil
-	})
-	splitRDB := MockRangeDescriptorDB(func(key roachpb.RKey, reverse bool) (
-		[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
-	) {
-		if key.Less(splitKey) {
-			return splitDescs[0:1], nil, nil
-		}
-		return splitDescs[1:], nil, nil
-	})
+			initialRDB := mockRangeDescriptorDBForDescs(initDesc)
+			splitRDB := mockRangeDescriptorDBForDescs(splitDescs...)
 
-	returnErr := true
-	var switchToSplitDesc func()
-	transportFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
-		if returnErr {
-			// First time around we return an RPC error. Next time around, make sure
-			// the DistSender tries gets the split descriptors.
-			if len(ba.Requests) != 2 {
-				// Sanity check - first attempt should have the unsplit batch.
+			var rc *rangecache.RangeCache
+			switchToSplitDesc := func() {
+				rc.TestingSetDB(splitRDB)
+			}
+
+			returnErr := true
+			transportFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+				if returnErr {
+					// First time around we return an RPC error. Next time around, make sure
+					// the DistSender tries gets the split descriptors.
+					if len(ba.Requests) != 2 {
+						// Sanity check - first attempt should have the unsplit batch.
+						rep := ba.CreateReply()
+						rep.Error = roachpb.NewErrorf("expected divided batches with one request each, got: %s", ba)
+						return rep, nil
+					}
+					switchToSplitDesc()
+					returnErr = false
+					return nil, errors.New("boom")
+				}
 				rep := ba.CreateReply()
-				rep.Error = roachpb.NewErrorf("expected divided batches with one request each, got: %s", ba)
+				if len(ba.Requests) != 1 {
+					rep.Error = roachpb.NewErrorf("expected divided batches with one request each, got: %s", ba)
+				}
 				return rep, nil
 			}
-			switchToSplitDesc()
-			returnErr = false
-			return nil, errors.New("boom")
-		}
-		rep := ba.CreateReply()
-		if len(ba.Requests) != 1 {
-			rep.Error = roachpb.NewErrorf("expected divided batches with one request each, got: %s", ba)
-		}
-		return rep, nil
+
+			cfg := DistSenderConfig{
+				AmbientCtx:        log.AmbientContext{Tracer: tr},
+				Clock:             clock,
+				NodeDescs:         g,
+				RPCContext:        rpcContext,
+				RangeDescriptorDB: initialRDB,
+				TestingKnobs: ClientTestingKnobs{
+					TransportFactory: adaptSimpleTransport(transportFn),
+				},
+				Settings: cluster.MakeTestingClusterSettings(),
+			}
+
+			ds := NewDistSender(cfg)
+			rc = ds.rangeCache
+
+			// We're going to send a batch with two reqs, on different sides of the split.
+			// The DistSender will first use the unsplit descriptor, and we'll inject an
+			// RPC error which will cause the eviction of the descriptor from the cache.
+			// Then, we'll switch the descriptor db that the DistSender uses to the
+			// version that returns a split descriptor (see switchToSplitDesc). From this
+			// moment on, we check that the sent batches only consist of single requests -
+			// which proves that the original batch was split.
+
+			var ba roachpb.BatchRequest
+			ba.Add(tc.req1(keyA), tc.req2(keyC))
+			// Inconsistent read because otherwise the batch will ask to be re-sent in a
+			// txn when split.
+			ba.ReadConsistency = roachpb.INCONSISTENT
+
+			_, pErr := ds.Send(ctx, ba)
+			require.Nil(t, pErr)
+		})
+	}
+}
+
+// TestDescriptorChangeAfterRequestSubdivision is similar to
+// TestRequestSubdivisionAfterDescriptorChange, but it exercises a scenario
+// where the request is subdivided before observing a descriptor change. After
+// the request is divided in half, both halves are issued concurrently and both
+// hit sendErrors that cause them to refresh their descriptors and observe range
+// splits. The test checks that the partial requests are then sent to only the
+// new descriptors that overlap the requests.
+//
+// This acts as a regression test against #73710, where such a scenario could
+// cause the partial batches to send requests to ranges that did not overlap
+// their request span.
+func TestDescriptorChangeAfterRequestSubdivision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+	keyD := roachpb.Key("d")
+	keyE := roachpb.Key("e")
+	initSplitKey := keys.MustAddr(keyC)
+	laterSplitKey1 := keys.MustAddr(keyB)
+	laterSplitKey2 := keys.MustAddr(keyD)
+
+	get := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewGet(k, false /* forUpdate */)
+	}
+	scan := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewScan(k, k.Next(), false /* forUpdate */)
+	}
+	revScan := func(k roachpb.Key) roachpb.Request {
+		return roachpb.NewReverseScan(k, k.Next(), false /* forUpdate */)
 	}
 
-	cfg := DistSenderConfig{
-		AmbientCtx:        log.AmbientContext{Tracer: tr},
-		Clock:             clock,
-		NodeDescs:         g,
-		RPCContext:        rpcContext,
-		RangeDescriptorDB: initialRDB,
-		TestingKnobs: ClientTestingKnobs{
-			TransportFactory: adaptSimpleTransport(transportFn),
-		},
-		Settings: cluster.MakeTestingClusterSettings(),
-	}
+	for _, tc := range []struct {
+		req1, req2 func(roachpb.Key) roachpb.Request
+	}{
+		{get, get},
+		{scan, get},
+		{get, scan},
+		{scan, scan},
+		{revScan, get},
+		{get, revScan},
+		{revScan, revScan},
+	} {
+		name := fmt.Sprintf("%s %s", tc.req1(nil).Method(), tc.req2(nil).Method())
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			tr := tracing.NewTracer()
+			stopper := stop.NewStopper(stop.WithTracer(tr))
+			defer stopper.Stop(ctx)
 
-	ds := NewDistSender(cfg)
-	switchToSplitDesc = func() {
-		ds.rangeCache.TestingSetDB(splitRDB)
-	}
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			rpcContext := rpc.NewInsecureTestingContext(clock, stopper)
+			g := makeGossip(t, stopper, rpcContext)
 
-	// We're going to send a batch with two gets, on different sides of the split.
-	// The DistSender will first use the unsplit descriptor, and we'll inject an
-	// RPC error which will cause the eviction of the descriptor from the cache.
-	// Then, we'll switch the descriptor db that the DistSender uses to the
-	// version that returns a split descriptor (see switchToSplitDesc). From this
-	// moment on, we check that the sent batches only consist of single requests -
-	// which proves that the original batch was split.
+			// Requests will be initially split across two descriptors.
+			repls := []roachpb.ReplicaDescriptor{{
+				NodeID:  1,
+				StoreID: 1,
+			}}
+			initDescs := []roachpb.RangeDescriptor{
+				{
+					RangeID:          roachpb.RangeID(1),
+					Generation:       1,
+					StartKey:         roachpb.RKeyMin,
+					EndKey:           initSplitKey,
+					InternalReplicas: repls,
+				},
+				{
+					RangeID:          roachpb.RangeID(2),
+					Generation:       1,
+					StartKey:         initSplitKey,
+					EndKey:           roachpb.RKeyMax,
+					InternalReplicas: repls,
+				},
+			}
+			// But those requests will be rejected, and they will find new descriptors
+			// upon a subsequent range descriptor lookup.
+			splitDescs := []roachpb.RangeDescriptor{
+				{
+					RangeID:          roachpb.RangeID(1),
+					Generation:       2,
+					StartKey:         roachpb.RKeyMin,
+					EndKey:           laterSplitKey1,
+					InternalReplicas: repls,
+				},
+				{
+					RangeID:          roachpb.RangeID(3),
+					Generation:       2,
+					StartKey:         laterSplitKey1,
+					EndKey:           initSplitKey,
+					InternalReplicas: repls,
+				},
+				{
+					RangeID:          roachpb.RangeID(2),
+					Generation:       2,
+					StartKey:         initSplitKey,
+					EndKey:           laterSplitKey2,
+					InternalReplicas: repls,
+				},
+				{
+					RangeID:          roachpb.RangeID(4),
+					Generation:       2,
+					StartKey:         laterSplitKey2,
+					EndKey:           roachpb.RKeyMax,
+					InternalReplicas: repls,
+				},
+			}
 
-	var ba roachpb.BatchRequest
-	get := &roachpb.GetRequest{}
-	get.Key = roachpb.Key("a")
-	ba.Add(get)
-	get = &roachpb.GetRequest{}
-	get.Key = roachpb.Key("c")
-	ba.Add(get)
-	// Inconsistent read because otherwise the batch will ask to be re-sent in a
-	// txn when split.
-	ba.ReadConsistency = roachpb.INCONSISTENT
+			initialRDB := mockRangeDescriptorDBForDescs(initDescs...)
+			splitRDB := mockRangeDescriptorDBForDescs(splitDescs...)
 
-	if _, pErr := ds.Send(ctx, ba); pErr != nil {
-		t.Fatal(pErr)
+			var rc *rangecache.RangeCache
+			var wg sync.WaitGroup
+			var once sync.Once
+			wg.Add(2)
+			waitThenSwitchToSplitDesc := func() {
+				// Wait for both partial requests to be sent.
+				wg.Done()
+				wg.Wait()
+				// Switch out the RangeDescriptorDB.
+				once.Do(func() { rc.TestingSetDB(splitRDB) })
+			}
+
+			var successes int32
+			transportFn := func(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+				require.Len(t, ba.Requests, 1)
+				switch ba.ClientRangeInfo.DescriptorGeneration {
+				case 1:
+					waitThenSwitchToSplitDesc()
+					return nil, errors.New("boom")
+				case 2:
+					atomic.AddInt32(&successes, 1)
+					return ba.CreateReply(), nil
+				default:
+					require.Fail(t, "unexpected desc generation")
+					return nil, nil
+				}
+			}
+
+			cfg := DistSenderConfig{
+				AmbientCtx:        log.AmbientContext{Tracer: tr},
+				Clock:             clock,
+				NodeDescs:         g,
+				RPCContext:        rpcContext,
+				RangeDescriptorDB: initialRDB,
+				TestingKnobs: ClientTestingKnobs{
+					TransportFactory: adaptSimpleTransport(transportFn),
+				},
+				Settings: cluster.MakeTestingClusterSettings(),
+			}
+
+			ds := NewDistSender(cfg)
+			rc = ds.rangeCache
+
+			// We're going to send a batch with two reqs, on different sides of the split.
+			// The DistSender will first split the requests across ranges. We'll inject an
+			// RPC error on each side, which will cause the eviction of the descriptors
+			// from the cache. Then, we'll switch the descriptor db that the DistSender
+			// uses to the version that returns four ranges.
+
+			var ba roachpb.BatchRequest
+			ba.Add(tc.req1(keyA), tc.req2(keyE))
+			// Inconsistent read because otherwise the batch will ask to be re-sent in a
+			// txn when split.
+			ba.ReadConsistency = roachpb.INCONSISTENT
+
+			_, pErr := ds.Send(ctx, ba)
+			require.Nil(t, pErr)
+			require.Equal(t, int32(2), atomic.LoadInt32(&successes))
+		})
 	}
 }
 

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -39,7 +39,6 @@ func TestKVNemesisSingleNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
-	skip.WithIssue(t, 73722)
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
@@ -74,7 +73,6 @@ func TestKVNemesisMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
-	skip.WithIssue(t, 73710)
 
 	// 4 nodes so we have somewhere to move 3x replicated ranges to.
 	const numNodes = 4


### PR DESCRIPTION
Fixes #73710.
Fixes #73722.

This commit fixes the error observed in #73710 and described in https://github.com/cockroachdb/cockroach/issues/73710#issuecomment-994308896.

It fixes this by using a consistent request direction across an entire batch, instead of recomputing the direction based on the requests in a sub-batch when recursing into `divideAndSendBatchToRanges`.

The commit adds a new test called `TestDescriptorChangeAfterRequestSubdivision`. Before the fix, the `ReverseScan_Get` subtest would hit the `truncation resulted in empty batch` error we saw in #73710.