### PR TITLE
bazel: pass path argument to `find`

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -53,7 +53,7 @@ fi
 
 bazel run //:gazelle
 
-if files_unchanged_from_upstream $(find -name BUILD.bazel) $(find -name '*.bzl'); then
+if files_unchanged_from_upstream $(find ./pkg -name BUILD.bazel) $(find ./pkg -name '*.bzl'); then
   echo "Skipping //pkg/cmd/generate-test-suites (relevant files are unchanged from upstream)."
 else
   CONTENTS=$(bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && ")


### PR DESCRIPTION
The bare `find -name ...` invocation without a path argument fails on
some versions of `find`, namely the one installed on macOS machines.

Release note: None