### PR TITLE
sql: add assignment casts for DEFAULT and computed columns for INSERTs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -265,6 +265,90 @@ PREPARE insert_s AS INSERT INTO assn_cast(s) VALUES ($1)
 statement error expected EXECUTE parameter expression to have type string, but \'1\' has type int
 EXECUTE insert_s(1)
 
+# Tests for assignment casts of DEFAULT expressions.
+subtest assignment_casts_default
+
+statement ok
+CREATE TABLE assn_cast_int_default (
+  k INT,
+  -- TODO(mgartner): This should not cause the CREATE TABLE statement to fail.
+  -- See #74090.
+  -- i1 INT2 DEFAULT 9999999,
+  i2 INT2 DEFAULT 9999999::INT
+)
+
+statement error integer out of range for type int2
+INSERT INTO assn_cast_int_default(k) VALUES (1)
+
+statement ok
+CREATE TABLE assn_cast_char_default (
+  c CHAR DEFAULT 'foo'::TEXT,
+  c2 CHAR(2) DEFAULT 'bar',
+  qc "char" DEFAULT 'baz'
+)
+
+# The default value of c is too long.
+statement error value too long for type CHAR
+INSERT INTO assn_cast_char_default(c2) VALUES ('ab')
+
+# The default value of c2 is too long.
+statement error value too long for type CHAR\(2\)
+INSERT INTO assn_cast_char_default(c) VALUES ('a')
+
+# The default value of qc is truncated when inserted.
+statement ok
+INSERT INTO assn_cast_char_default(c, c2) VALUES ('a', 'ab')
+
+query TTT
+SELECT * FROM assn_cast_char_default
+----
+a ab b
+
+statement ok
+CREATE TABLE assn_cast_dec_default (
+  k INT,
+  d DECIMAL(10, 0) DEFAULT 1.56::DECIMAL(10, 2),
+  d1 DECIMAL(10, 1) DEFAULT 1.58
+)
+
+statement ok
+INSERT INTO assn_cast_dec_default(k) VALUES (1)
+
+query IRR
+SELECT * FROM assn_cast_dec_default
+----
+1  2  1.6
+
+# Tests for assignment casts of computed columns.
+subtest assignment_casts_computed
+
+statement ok
+CREATE TABLE assn_cast_comp (
+  i INT,
+  i2 INT2 AS (i + 9999999) STORED,
+  t TEXT,
+  c CHAR AS (t) STORED,
+  d DECIMAL(10, 0),
+  d_comp DECIMAL(10, 2) AS (d) STORED,
+  d2 DECIMAL(10, 2),
+  d2_comp DECIMAL(10, 0) AS (d2) STORED
+)
+
+statement error integer out of range for type int2
+INSERT INTO assn_cast_comp(i) VALUES (1)
+
+statement error value too long for type CHAR
+INSERT INTO assn_cast_comp(t) VALUES ('foo')
+
+statement ok
+INSERT INTO assn_cast_comp(d, d2) VALUES (1.56, 2.78)
+
+query RRRR
+SELECT d, d_comp, d2, d2_comp FROM assn_cast_comp
+----
+2  2.00  2.78  3
+
+# Regression tests.
 subtest regressions
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -19,16 +19,16 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (crdb_internal_a_shard_11_comp, column1, check1)
+    │ columns: (column7, column1, check1)
     │ estimated row count: 2
-    │ render check1: crdb_internal_a_shard_11_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    │ render check1: column7 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     │ render column1: column1
-    │ render crdb_internal_a_shard_11_comp: crdb_internal_a_shard_11_comp
+    │ render column7: column7
     │
     └── • render
-        │ columns: (crdb_internal_a_shard_11_comp, column1)
+        │ columns: (column7, column1)
         │ estimated row count: 2
-        │ render crdb_internal_a_shard_11_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 11)::INT4
+        │ render column7: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 11), NULL::INT4)
         │ render column1: column1
         │
         └── • values
@@ -53,17 +53,17 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (column1, crdb_internal_a_shard_12_comp, rowid_default, check1)
+    │ columns: (column1, column9, rowid_default, check1)
     │ estimated row count: 2
-    │ render check1: crdb_internal_a_shard_12_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    │ render check1: column9 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
     │ render column1: column1
     │ render rowid_default: rowid_default
-    │ render crdb_internal_a_shard_12_comp: crdb_internal_a_shard_12_comp
+    │ render column9: column9
     │
     └── • render
-        │ columns: (crdb_internal_a_shard_12_comp, rowid_default, column1)
+        │ columns: (column9, rowid_default, column1)
         │ estimated row count: 2
-        │ render crdb_internal_a_shard_12_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 12)::INT4
+        │ render column9: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 12), NULL::INT4)
         │ render rowid_default: unique_rowid()
         │ render column1: column1
         │

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -45,31 +45,26 @@ insert abcde
       │    ├── fd: ()-->(14,16)
       │    ├── prune: (10,14-16)
       │    ├── interesting orderings: (+10 opt(14,16))
-      │    ├── project
-      │    │    ├── columns: y:10(int!null)
+      │    ├── limit
+      │    │    ├── columns: y:10(int!null) z:11(float)
+      │    │    ├── internal-ordering: +10,+11
       │    │    ├── cardinality: [0 - 10]
-      │    │    ├── prune: (10)
-      │    │    ├── interesting orderings: (+10)
-      │    │    └── limit
-      │    │         ├── columns: y:10(int!null) z:11(float)
-      │    │         ├── internal-ordering: +10,+11
-      │    │         ├── cardinality: [0 - 10]
-      │    │         ├── interesting orderings: (+10,+11)
-      │    │         ├── sort
-      │    │         │    ├── columns: y:10(int!null) z:11(float)
-      │    │         │    ├── ordering: +10,+11
-      │    │         │    ├── limit hint: 10.00
-      │    │         │    ├── prune: (10,11)
-      │    │         │    └── project
-      │    │         │         ├── columns: y:10(int!null) z:11(float)
-      │    │         │         ├── prune: (10,11)
-      │    │         │         └── scan xyz
-      │    │         │              ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
-      │    │         │              ├── key: (9)
-      │    │         │              ├── fd: (9)-->(10-13)
-      │    │         │              ├── prune: (9-13)
-      │    │         │              └── interesting orderings: (+9)
-      │    │         └── const: 10 [type=int]
+      │    │    ├── interesting orderings: (+10,+11)
+      │    │    ├── sort
+      │    │    │    ├── columns: y:10(int!null) z:11(float)
+      │    │    │    ├── ordering: +10,+11
+      │    │    │    ├── limit hint: 10.00
+      │    │    │    ├── prune: (10,11)
+      │    │    │    └── project
+      │    │    │         ├── columns: y:10(int!null) z:11(float)
+      │    │    │         ├── prune: (10,11)
+      │    │    │         └── scan xyz
+      │    │    │              ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
+      │    │    │              ├── key: (9)
+      │    │    │              ├── fd: (9)-->(10-13)
+      │    │    │              ├── prune: (9-13)
+      │    │    │              └── interesting orderings: (+9)
+      │    │    └── const: 10 [type=int]
       │    └── projections
       │         ├── const: 10 [as=c_default:14, type=int]
       │         ├── function: unique_rowid [as=rowid_default:15, type=int, volatile]
@@ -118,31 +113,26 @@ project
            │    ├── fd: ()-->(14,16)
            │    ├── prune: (10,14-16)
            │    ├── interesting orderings: (+10 opt(14,16))
-           │    ├── project
-           │    │    ├── columns: y:10(int!null)
+           │    ├── limit
+           │    │    ├── columns: y:10(int!null) z:11(float)
+           │    │    ├── internal-ordering: +10,+11
            │    │    ├── cardinality: [0 - 10]
-           │    │    ├── prune: (10)
-           │    │    ├── interesting orderings: (+10)
-           │    │    └── limit
-           │    │         ├── columns: y:10(int!null) z:11(float)
-           │    │         ├── internal-ordering: +10,+11
-           │    │         ├── cardinality: [0 - 10]
-           │    │         ├── interesting orderings: (+10,+11)
-           │    │         ├── sort
-           │    │         │    ├── columns: y:10(int!null) z:11(float)
-           │    │         │    ├── ordering: +10,+11
-           │    │         │    ├── limit hint: 10.00
-           │    │         │    ├── prune: (10,11)
-           │    │         │    └── project
-           │    │         │         ├── columns: y:10(int!null) z:11(float)
-           │    │         │         ├── prune: (10,11)
-           │    │         │         └── scan xyz
-           │    │         │              ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
-           │    │         │              ├── key: (9)
-           │    │         │              ├── fd: (9)-->(10-13)
-           │    │         │              ├── prune: (9-13)
-           │    │         │              └── interesting orderings: (+9)
-           │    │         └── const: 10 [type=int]
+           │    │    ├── interesting orderings: (+10,+11)
+           │    │    ├── sort
+           │    │    │    ├── columns: y:10(int!null) z:11(float)
+           │    │    │    ├── ordering: +10,+11
+           │    │    │    ├── limit hint: 10.00
+           │    │    │    ├── prune: (10,11)
+           │    │    │    └── project
+           │    │    │         ├── columns: y:10(int!null) z:11(float)
+           │    │    │         ├── prune: (10,11)
+           │    │    │         └── scan xyz
+           │    │    │              ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
+           │    │    │              ├── key: (9)
+           │    │    │              ├── fd: (9)-->(10-13)
+           │    │    │              ├── prune: (9-13)
+           │    │    │              └── interesting orderings: (+9)
+           │    │    └── const: 10 [type=int]
            │    └── projections
            │         ├── const: 10 [as=c_default:14, type=int]
            │         ├── function: unique_rowid [as=rowid_default:15, type=int, volatile]
@@ -186,17 +176,14 @@ project
            │    ├── fd: ()-->(14,16)
            │    ├── prune: (10,14-16)
            │    ├── project
-           │    │    ├── columns: y:10(int!null)
-           │    │    ├── prune: (10)
-           │    │    └── project
-           │    │         ├── columns: y:10(int!null) z:11(float)
-           │    │         ├── prune: (10,11)
-           │    │         └── scan xyz
-           │    │              ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
-           │    │              ├── key: (9)
-           │    │              ├── fd: (9)-->(10-13)
-           │    │              ├── prune: (9-13)
-           │    │              └── interesting orderings: (+9)
+           │    │    ├── columns: y:10(int!null) z:11(float)
+           │    │    ├── prune: (10,11)
+           │    │    └── scan xyz
+           │    │         ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
+           │    │         ├── key: (9)
+           │    │         ├── fd: (9)-->(10-13)
+           │    │         ├── prune: (9-13)
+           │    │         └── interesting orderings: (+9)
            │    └── projections
            │         ├── const: 10 [as=c_default:14, type=int]
            │         ├── function: unique_rowid [as=rowid_default:15, type=int, volatile]
@@ -240,21 +227,15 @@ insert abcde
       │    ├── key: ()
       │    ├── fd: ()-->(9-13)
       │    ├── prune: (9-13)
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9(int!null) column2:10(int!null)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(9,10)
       │    │    ├── prune: (9,10)
-      │    │    └── values
-      │    │         ├── columns: column1:9(int!null) column2:10(int!null)
-      │    │         ├── cardinality: [1 - 1]
-      │    │         ├── key: ()
-      │    │         ├── fd: ()-->(9,10)
-      │    │         ├── prune: (9,10)
-      │    │         └── tuple [type=tuple{int, int}]
-      │    │              ├── const: 1 [type=int]
-      │    │              └── const: 2 [type=int]
+      │    │    └── tuple [type=tuple{int, int}]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 2 [type=int]
       │    └── projections
       │         ├── const: 10 [as=c_default:11, type=int]
       │         ├── function: unique_rowid [as=rowid_default:12, type=int, volatile]
@@ -298,36 +279,31 @@ project
            │    ├── fd: ()-->(10,15,17)
            │    ├── prune: (10,14-17)
            │    ├── project
-           │    │    ├── columns: y:10(int!null) int8:14(int)
+           │    │    ├── columns: int8:14(int) y:10(int!null)
            │    │    ├── immutable
            │    │    ├── fd: ()-->(10)
            │    │    ├── prune: (10,14)
-           │    │    └── project
-           │    │         ├── columns: int8:14(int) y:10(int!null)
-           │    │         ├── immutable
-           │    │         ├── fd: ()-->(10)
-           │    │         ├── prune: (10,14)
-           │    │         ├── select
-           │    │         │    ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
-           │    │         │    ├── key: (9)
-           │    │         │    ├── fd: ()-->(10), (9)-->(11-13)
-           │    │         │    ├── prune: (9,11-13)
-           │    │         │    ├── interesting orderings: (+9 opt(10))
-           │    │         │    ├── scan xyz
-           │    │         │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
-           │    │         │    │    ├── key: (9)
-           │    │         │    │    ├── fd: (9)-->(10-13)
-           │    │         │    │    ├── prune: (9-13)
-           │    │         │    │    └── interesting orderings: (+9)
-           │    │         │    └── filters
-           │    │         │         └── eq [type=bool, outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
-           │    │         │              ├── variable: y:10 [type=int]
-           │    │         │              └── const: 1 [type=int]
-           │    │         └── projections
-           │    │              └── cast: INT8 [as=int8:14, type=int, outer=(11), immutable]
-           │    │                   └── plus [type=float]
-           │    │                        ├── variable: z:11 [type=float]
-           │    │                        └── const: 1.0 [type=float]
+           │    │    ├── select
+           │    │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
+           │    │    │    ├── key: (9)
+           │    │    │    ├── fd: ()-->(10), (9)-->(11-13)
+           │    │    │    ├── prune: (9,11-13)
+           │    │    │    ├── interesting orderings: (+9 opt(10))
+           │    │    │    ├── scan xyz
+           │    │    │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float) xyz.crdb_internal_mvcc_timestamp:12(decimal) xyz.tableoid:13(oid)
+           │    │    │    │    ├── key: (9)
+           │    │    │    │    ├── fd: (9)-->(10-13)
+           │    │    │    │    ├── prune: (9-13)
+           │    │    │    │    └── interesting orderings: (+9)
+           │    │    │    └── filters
+           │    │    │         └── eq [type=bool, outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
+           │    │    │              ├── variable: y:10 [type=int]
+           │    │    │              └── const: 1 [type=int]
+           │    │    └── projections
+           │    │         └── cast: INT8 [as=int8:14, type=int, outer=(11), immutable]
+           │    │              └── plus [type=float]
+           │    │                   ├── variable: z:11 [type=float]
+           │    │                   └── const: 1.0 [type=float]
            │    └── projections
            │         ├── const: 10 [as=c_default:15, type=int]
            │         ├── function: unique_rowid [as=rowid_default:16, type=int, volatile]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -291,20 +291,13 @@ project
            │    │    │    │    │    │    │    │    ├── prune: (7,8)
            │    │    │    │    │    │    │    │    ├── interesting orderings: (+7) (+8)
            │    │    │    │    │    │    │    │    ├── unfiltered-cols: (7-11)
-           │    │    │    │    │    │    │    │    └── project
-           │    │    │    │    │    │    │    │         ├── columns: x:7(int!null) y:8(int)
+           │    │    │    │    │    │    │    │    └── scan xyz
+           │    │    │    │    │    │    │    │         ├── columns: x:7(int!null) y:8(int) z:9(int) xyz.crdb_internal_mvcc_timestamp:10(decimal) xyz.tableoid:11(oid)
            │    │    │    │    │    │    │    │         ├── key: (7)
-           │    │    │    │    │    │    │    │         ├── fd: (7)-->(8)
-           │    │    │    │    │    │    │    │         ├── prune: (7,8)
-           │    │    │    │    │    │    │    │         ├── interesting orderings: (+7) (+8)
-           │    │    │    │    │    │    │    │         ├── unfiltered-cols: (7-11)
-           │    │    │    │    │    │    │    │         └── scan xyz
-           │    │    │    │    │    │    │    │              ├── columns: x:7(int!null) y:8(int) z:9(int) xyz.crdb_internal_mvcc_timestamp:10(decimal) xyz.tableoid:11(oid)
-           │    │    │    │    │    │    │    │              ├── key: (7)
-           │    │    │    │    │    │    │    │              ├── fd: (7)-->(8-11), (8,9)~~>(7,10,11)
-           │    │    │    │    │    │    │    │              ├── prune: (7-11)
-           │    │    │    │    │    │    │    │              ├── interesting orderings: (+7) (+8,+9,+7) (+9,+8,+7)
-           │    │    │    │    │    │    │    │              └── unfiltered-cols: (7-11)
+           │    │    │    │    │    │    │    │         ├── fd: (7)-->(8-11), (8,9)~~>(7,10,11)
+           │    │    │    │    │    │    │    │         ├── prune: (7-11)
+           │    │    │    │    │    │    │    │         ├── interesting orderings: (+7) (+8,+9,+7) (+9,+8,+7)
+           │    │    │    │    │    │    │    │         └── unfiltered-cols: (7-11)
            │    │    │    │    │    │    │    └── projections
            │    │    │    │    │    │    │         └── function: unique_rowid [as=rowid_default:12, type=int, volatile]
            │    │    │    │    │    │    └── projections

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -56,25 +56,21 @@ with &1
  │         ├── columns: a:6(int!null) b:7(string!null) c:8(float)
  │         ├── stats: [rows=200, distinct(6)=200, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=130.264312, null(8)=2]
  │         ├── fd: ()-->(7), (6)-->(8)
- │         └── project
- │              ├── columns: a:6(int!null) b:7(string!null) c:8(float)
+ │         └── select
+ │              ├── columns: a:6(int!null) b:7(string!null) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
  │              ├── stats: [rows=200, distinct(6)=200, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=130.264312, null(8)=2]
- │              ├── fd: ()-->(7), (6)-->(8)
- │              └── select
- │                   ├── columns: a:6(int!null) b:7(string!null) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
- │                   ├── stats: [rows=200, distinct(6)=200, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=130.264312, null(8)=2]
- │                   ├── key: (9)
- │                   ├── fd: ()-->(7), (9)-->(6,8,10,11), (6)-->(8)
- │                   ├── scan abc
- │                   │    ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
- │                   │    ├── computed column expressions
- │                   │    │    └── c:8
- │                   │    │         └── a:6::FLOAT8 [type=float]
- │                   │    ├── stats: [rows=2000, distinct(6)=2000, null(6)=0, distinct(7)=10, null(7)=0, distinct(8)=200, null(8)=20, distinct(9)=2000, null(9)=0]
- │                   │    ├── key: (9)
- │                   │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
- │                   └── filters
- │                        └── b:7 = 'foo' [type=bool, outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
+ │              ├── key: (9)
+ │              ├── fd: ()-->(7), (9)-->(6,8,10,11), (6)-->(8)
+ │              ├── scan abc
+ │              │    ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
+ │              │    ├── computed column expressions
+ │              │    │    └── c:8
+ │              │    │         └── a:6::FLOAT8 [type=float]
+ │              │    ├── stats: [rows=2000, distinct(6)=2000, null(6)=0, distinct(7)=10, null(7)=0, distinct(8)=200, null(8)=20, distinct(9)=2000, null(9)=0]
+ │              │    ├── key: (9)
+ │              │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
+ │              └── filters
+ │                   └── b:7 = 'foo' [type=bool, outer=(7), constraints=(/7: [/'foo' - /'foo']; tight), fd=()-->(7)]
  └── select
       ├── columns: x:12(string!null) y:13(int!null) z:14(float!null)
       ├── stats: [rows=66.5105818, distinct(14)=43.4214373, null(14)=0]
@@ -109,24 +105,19 @@ insert xyz
       ├── cardinality: [0 - 0]
       ├── stats: [rows=0]
       ├── fd: (6)-->(8)
-      └── project
-           ├── columns: a:6(int!null) b:7(string) c:8(float)
+      └── select
+           ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
            ├── cardinality: [0 - 0]
            ├── stats: [rows=0]
-           ├── fd: (6)-->(8)
-           └── select
-                ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
-                ├── cardinality: [0 - 0]
-                ├── stats: [rows=0]
-                ├── key: (9)
-                ├── fd: (9)-->(6-8,10,11), (6)-->(8)
-                ├── scan abc
-                │    ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
-                │    ├── computed column expressions
-                │    │    └── c:8
-                │    │         └── a:6::FLOAT8 [type=float]
-                │    ├── stats: [rows=2000]
-                │    ├── key: (9)
-                │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
-                └── filters
-                     └── false [type=bool, constraints=(contradiction; tight)]
+           ├── key: (9)
+           ├── fd: (9)-->(6-8,10,11), (6)-->(8)
+           ├── scan abc
+           │    ├── columns: a:6(int!null) b:7(string) c:8(float) rowid:9(int!null) abc.crdb_internal_mvcc_timestamp:10(decimal) abc.tableoid:11(oid)
+           │    ├── computed column expressions
+           │    │    └── c:8
+           │    │         └── a:6::FLOAT8 [type=float]
+           │    ├── stats: [rows=2000]
+           │    ├── key: (9)
+           │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
+           └── filters
+                └── false [type=bool, constraints=(contradiction; tight)]

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -665,10 +665,13 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert(isUpsert bool) {
 		false, /* applyOnUpdate */
 	)
 
-	// Possibly round DECIMAL-related columns containing insertion values (whether
-	// synthesized or not).
 	if isUpsert {
+		// Possibly round DECIMAL-related columns containing insertion values (whether
+		// synthesized or not).
 		mb.roundDecimalValues(mb.insertColIDs, false /* roundComputedCols */)
+	} else {
+		// Add assignment casts for default column values.
+		mb.addAssignmentCasts(mb.insertColIDs)
 	}
 
 	// Now add all computed columns.
@@ -677,6 +680,9 @@ func (mb *mutationBuilder) addSynthesizedColsForInsert(isUpsert bool) {
 	// Possibly round DECIMAL-related computed columns.
 	if isUpsert {
 		mb.roundDecimalValues(mb.insertColIDs, true /* roundComputedCols */)
+	} else {
+		// Add assignment casts for computed column values.
+		mb.addAssignmentCasts(mb.insertColIDs)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -460,7 +460,7 @@ func (s *scope) resolveAndRequireType(expr tree.Expr, desired *types.T) tree.Typ
 	if err != nil {
 		panic(err)
 	}
-	return tree.ReType(s.ensureNullType(texpr, desired), desired)
+	return s.ensureNullType(texpr, desired)
 }
 
 // ensureNullType tests the type of the given expression. If types.Unknown, then

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -15,12 +15,10 @@ insert child
  │    ├── column1:5 => c:1
  │    └── column2:6 => child.p:2
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:5!null column2:6!null
- │    └── values
- │         ├── columns: column1:5!null column2:6!null
- │         ├── (100, 1)
- │         └── (200, 1)
+ │    ├── (100, 1)
+ │    └── (200, 1)
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
@@ -49,12 +47,10 @@ insert child
  │    ├── grouping columns: column1:5!null
  │    ├── anti-join (hash)
  │    │    ├── columns: column1:5!null column2:6!null
- │    │    ├── project
+ │    │    ├── values
  │    │    │    ├── columns: column1:5!null column2:6!null
- │    │    │    └── values
- │    │    │         ├── columns: column1:5!null column2:6!null
- │    │    │         ├── (100, 1)
- │    │    │         └── (200, 1)
+ │    │    │    ├── (100, 1)
+ │    │    │    └── (200, 1)
  │    │    ├── scan child
  │    │    │    └── columns: c:7!null child.p:8!null
  │    │    └── filters
@@ -91,10 +87,8 @@ insert child
  ├── input binding: &1
  ├── project
  │    ├── columns: x:5 y:6
- │    └── project
- │         ├── columns: x:5 y:6
- │         └── scan xy
- │              └── columns: x:5 y:6 rowid:7!null xy.crdb_internal_mvcc_timestamp:8 xy.tableoid:9
+ │    └── scan xy
+ │         └── columns: x:5 y:6 rowid:7!null xy.crdb_internal_mvcc_timestamp:8 xy.tableoid:9
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
@@ -123,12 +117,10 @@ insert child_nullable
  │    ├── column1:5 => c:1
  │    └── column2:6 => child_nullable.p:2
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:5!null column2:6
- │    └── values
- │         ├── columns: column1:5!null column2:6
- │         ├── (100, 1)
- │         └── (200, NULL::INT8)
+ │    ├── (100, 1)
+ │    └── (200, NULL::INT8)
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join (hash)
@@ -157,12 +149,10 @@ insert child_nullable
  │    ├── column1:5 => c:1
  │    └── column2:6 => child_nullable.p:2
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:5!null column2:6!null
- │    └── values
- │         ├── columns: column1:5!null column2:6!null
- │         ├── (100, 1)
- │         └── (200, 1)
+ │    ├── (100, 1)
+ │    └── (200, 1)
  └── f-k-checks
       └── f-k-checks-item: child_nullable(p) -> parent(p)
            └── anti-join (hash)
@@ -204,12 +194,10 @@ insert child_nullable
  │    └── p_default:6 => p:2
  └── project
       ├── columns: p_default:6 column1:5!null
-      ├── project
+      ├── values
       │    ├── columns: column1:5!null
-      │    └── values
-      │         ├── columns: column1:5!null
-      │         ├── (100,)
-      │         └── (200,)
+      │    ├── (100,)
+      │    └── (200,)
       └── projections
            └── NULL::INT8 [as=p_default:6]
 
@@ -228,12 +216,10 @@ insert child_nullable_full
  │    ├── column1:5 => c:1
  │    └── column2:6 => child_nullable_full.p:2
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:5!null column2:6
- │    └── values
- │         ├── columns: column1:5!null column2:6
- │         ├── (100, 1)
- │         └── (200, NULL::INT8)
+ │    ├── (100, 1)
+ │    └── (200, NULL::INT8)
  └── f-k-checks
       └── f-k-checks-item: child_nullable_full(p) -> parent(p)
            └── anti-join (hash)
@@ -262,12 +248,10 @@ insert child_nullable_full
  │    └── p_default:6 => p:2
  └── project
       ├── columns: p_default:6 column1:5!null
-      ├── project
+      ├── values
       │    ├── columns: column1:5!null
-      │    └── values
-      │         ├── columns: column1:5!null
-      │         ├── (100,)
-      │         └── (200,)
+      │    ├── (100,)
+      │    └── (200,)
       └── projections
            └── NULL::INT8 [as=p_default:6]
 
@@ -296,12 +280,10 @@ insert multi_col_child
  │    ├── column3:9 => multi_col_child.q:3
  │    └── column4:10 => multi_col_child.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9 column4:10
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9 column4:10
- │         ├── (4, NULL::INT8, NULL::INT8, NULL::INT8)
- │         └── (5, 1, 2, 3)
+ │    ├── (4, NULL::INT8, NULL::INT8, NULL::INT8)
+ │    └── (5, 1, 2, 3)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -337,12 +319,10 @@ insert multi_col_child
  │    ├── column3:9 => multi_col_child.q:3
  │    └── column4:10 => multi_col_child.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9 column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9 column4:10!null
- │         ├── (2, NULL::INT8, 20, 20)
- │         └── (3, 20, NULL::INT8, 20)
+ │    ├── (2, NULL::INT8, 20, 20)
+ │    └── (3, 20, NULL::INT8, 20)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -377,11 +357,9 @@ insert multi_col_child
  │    ├── column3:9 => multi_col_child.q:3
  │    └── column4:10 => multi_col_child.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │         └── (1, 10, 10, 10)
+ │    └── (1, 10, 10, 10)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -436,12 +414,10 @@ insert multi_col_child_full
  │    ├── column3:9 => multi_col_child_full.q:3
  │    └── column4:10 => multi_col_child_full.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9 column4:10
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9 column4:10
- │         ├── (4, NULL::INT8, NULL::INT8, NULL::INT8)
- │         └── (5, 1, 2, 3)
+ │    ├── (4, NULL::INT8, NULL::INT8, NULL::INT8)
+ │    └── (5, 1, 2, 3)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -475,12 +451,10 @@ insert multi_col_child_full
  │    ├── column3:9 => multi_col_child_full.q:3
  │    └── column4:10 => multi_col_child_full.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9 column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9 column4:10!null
- │         ├── (2, NULL::INT8, 20, 20)
- │         └── (3, 20, NULL::INT8, 20)
+ │    ├── (2, NULL::INT8, 20, 20)
+ │    └── (3, 20, NULL::INT8, 20)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -510,11 +484,9 @@ insert multi_col_child_full
  │    ├── column3:9 => multi_col_child_full.q:3
  │    └── column4:10 => multi_col_child_full.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │         └── (1, 10, 10, 10)
+ │    └── (1, 10, 10, 10)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -562,11 +534,9 @@ insert multi_col_child_full
  │    ├── column3:9 => multi_col_child_full.q:3
  │    └── column4:10 => multi_col_child_full.r:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9!null column4:10
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9!null column4:10
- │         └── (1, NULL::INT8, 2, NULL::INT8)
+ │    └── (1, NULL::INT8, 2, NULL::INT8)
  └── f-k-checks
       └── f-k-checks-item: multi_col_child_full(p,q,r) -> multi_col_parent(p,q,r)
            └── anti-join (hash)
@@ -614,13 +584,11 @@ insert multi_ref_child
  │    ├── column3:9 => multi_ref_child.b:3
  │    └── column4:10 => multi_ref_child.c:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8 column3:9 column4:10
- │    └── values
- │         ├── columns: column1:7!null column2:8 column3:9 column4:10
- │         ├── (1, 1, NULL::INT8, NULL::INT8)
- │         ├── (2, NULL::INT8, 2, NULL::INT8)
- │         └── (3, NULL::INT8, NULL::INT8, 3)
+ │    ├── (1, 1, NULL::INT8, NULL::INT8)
+ │    ├── (2, NULL::INT8, 2, NULL::INT8)
+ │    └── (3, NULL::INT8, NULL::INT8, 3)
  └── f-k-checks
       ├── f-k-checks-item: multi_ref_child(a) -> multi_ref_parent_a(a)
       │    └── anti-join (hash)
@@ -682,12 +650,10 @@ insert child
  │    ├── column1:5 => c:1
  │    └── column2:6 => child.p:2
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:5!null column2:6!null
- │    └── values
- │         ├── columns: column1:5!null column2:6!null
- │         ├── (100, 1)
- │         └── (200, 1)
+ │    ├── (100, 1)
+ │    └── (200, 1)
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1192,32 +1192,42 @@ insert decimals
  ├── insert-mapping:
  │    ├── column9:9 => a:1
  │    ├── column10:10 => b:2
- │    ├── c_default:11 => c:3
- │    └── d_comp:12 => d:4
- ├── check columns: check1:13 check2:14
+ │    ├── column12:12 => c:3
+ │    └── column14:14 => d:4
+ ├── check columns: check1:15 check2:16
  └── project
-      ├── columns: check1:13 check2:14 column9:9!null column10:10 c_default:11!null d_comp:12!null
+      ├── columns: check1:15 check2:16 column9:9!null column10:10 column12:12!null column14:14!null
       ├── project
-      │    ├── columns: d_comp:12!null column9:9!null column10:10 c_default:11!null
+      │    ├── columns: column14:14!null column9:9!null column10:10 column12:12!null
       │    ├── project
-      │    │    ├── columns: c_default:11!null column9:9!null column10:10
+      │    │    ├── columns: d_comp:13!null column9:9!null column10:10 column12:12!null
       │    │    ├── project
-      │    │    │    ├── columns: column9:9!null column10:10
-      │    │    │    ├── values
-      │    │    │    │    ├── columns: column1:7!null column2:8
-      │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
+      │    │    │    ├── columns: column12:12!null column9:9!null column10:10
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: c_default:11!null column9:9!null column10:10
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column9:9!null column10:10
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null column2:8
+      │    │    │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         ├── assignment-cast: DECIMAL(10) [as=column9:9]
+      │    │    │    │    │         │    └── column1:7
+      │    │    │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=column10:10]
+      │    │    │    │    │              └── column2:8
+      │    │    │    │    └── projections
+      │    │    │    │         └── 1.23 [as=c_default:11]
       │    │    │    └── projections
-      │    │    │         ├── assignment-cast: DECIMAL(10) [as=column9:9]
-      │    │    │         │    └── column1:7
-      │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=column10:10]
-      │    │    │              └── column2:8
+      │    │    │         └── assignment-cast: DECIMAL(10,1) [as=column12:12]
+      │    │    │              └── c_default:11
       │    │    └── projections
-      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:11]
+      │    │         └── column9:9::DECIMAL + column12:12::DECIMAL [as=d_comp:13]
       │    └── projections
-      │         └── (column9:9::DECIMAL + c_default:11::DECIMAL)::DECIMAL(10,1) [as=d_comp:12]
+      │         └── assignment-cast: DECIMAL(10,1) [as=column14:14]
+      │              └── d_comp:13
       └── projections
-           ├── round(column9:9) = column9:9 [as=check1:13]
-           └── column10:10[0] > 1 [as=check2:14]
+           ├── round(column9:9) = column9:9 [as=check1:15]
+           └── column10:10[0] > 1 [as=check2:16]
 
 assign-placeholders-build query-args=(1.1, (ARRAY[0.95, NULL, 15]))
 INSERT INTO decimals (a, b) VALUES ($1, $2)
@@ -1227,32 +1237,42 @@ insert decimals
  ├── insert-mapping:
  │    ├── column9:9 => a:1
  │    ├── column10:10 => b:2
- │    ├── c_default:11 => c:3
- │    └── d_comp:12 => d:4
- ├── check columns: check1:13 check2:14
+ │    ├── column12:12 => c:3
+ │    └── column14:14 => d:4
+ ├── check columns: check1:15 check2:16
  └── project
-      ├── columns: check1:13 check2:14 column9:9!null column10:10!null c_default:11!null d_comp:12!null
+      ├── columns: check1:15 check2:16 column9:9!null column10:10!null column12:12!null column14:14!null
       ├── project
-      │    ├── columns: d_comp:12!null column9:9!null column10:10!null c_default:11!null
+      │    ├── columns: column14:14!null column9:9!null column10:10!null column12:12!null
       │    ├── project
-      │    │    ├── columns: c_default:11!null column9:9!null column10:10!null
+      │    │    ├── columns: d_comp:13!null column9:9!null column10:10!null column12:12!null
       │    │    ├── project
-      │    │    │    ├── columns: column9:9!null column10:10!null
-      │    │    │    ├── values
-      │    │    │    │    ├── columns: column1:7!null column2:8!null
-      │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
+      │    │    │    ├── columns: column12:12!null column9:9!null column10:10!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: c_default:11!null column9:9!null column10:10!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column9:9!null column10:10!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null
+      │    │    │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         ├── assignment-cast: DECIMAL(10) [as=column9:9]
+      │    │    │    │    │         │    └── column1:7
+      │    │    │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=column10:10]
+      │    │    │    │    │              └── column2:8
+      │    │    │    │    └── projections
+      │    │    │    │         └── 1.23 [as=c_default:11]
       │    │    │    └── projections
-      │    │    │         ├── assignment-cast: DECIMAL(10) [as=column9:9]
-      │    │    │         │    └── column1:7
-      │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=column10:10]
-      │    │    │              └── column2:8
+      │    │    │         └── assignment-cast: DECIMAL(10,1) [as=column12:12]
+      │    │    │              └── c_default:11
       │    │    └── projections
-      │    │         └── 1.23::DECIMAL(10,1) [as=c_default:11]
+      │    │         └── column9:9::DECIMAL + column12:12::DECIMAL [as=d_comp:13]
       │    └── projections
-      │         └── (column9:9::DECIMAL + c_default:11::DECIMAL)::DECIMAL(10,1) [as=d_comp:12]
+      │         └── assignment-cast: DECIMAL(10,1) [as=column14:14]
+      │              └── d_comp:13
       └── projections
-           ├── round(column9:9) = column9:9 [as=check1:13]
-           └── column10:10[0] > 1 [as=check2:14]
+           ├── round(column9:9) = column9:9 [as=check1:15]
+           └── column10:10[0] > 1 [as=check2:16]
 
 build
 INSERT INTO assn_cast (c, qc, i, s) VALUES (' ', 'foo', '1', 2)
@@ -1308,6 +1328,105 @@ insert assn_cast
       └── projections
            ├── NULL::STRING [as=s_default:13]
            └── unique_rowid() [as=rowid_default:14]
+
+exec-ddl
+CREATE TABLE assn_cast_default (
+    k INT PRIMARY KEY,
+    i2 INT2 DEFAULT 10::INT,
+    c1 CHAR DEFAULT 'foo',
+    c2 CHAR DEFAULT 'bar'::TEXT,
+    d1 DECIMAL(10, 0) DEFAULT 1.23,
+    d2 DECIMAL(10, 0) DEFAULT 4.56::DECIMAL(10, 2),
+    s TEXT DEFAULT NULL
+)
+----
+
+build
+INSERT INTO assn_cast_default (k) VALUES (1)
+----
+insert assn_cast_default
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:10 => k:1
+ │    ├── column17:17 => i2:2
+ │    ├── column18:18 => c1:3
+ │    ├── column19:19 => c2:4
+ │    ├── column20:20 => d1:5
+ │    ├── column21:21 => d2:6
+ │    └── s_default:16 => s:7
+ └── project
+      ├── columns: column17:17!null column18:18!null column19:19!null column20:20!null column21:21!null column1:10!null s_default:16
+      ├── project
+      │    ├── columns: i2_default:11!null c1_default:12!null c2_default:13!null d1_default:14!null d2_default:15!null s_default:16 column1:10!null
+      │    ├── values
+      │    │    ├── columns: column1:10!null
+      │    │    └── (1,)
+      │    └── projections
+      │         ├── 10 [as=i2_default:11]
+      │         ├── 'foo' [as=c1_default:12]
+      │         ├── 'bar' [as=c2_default:13]
+      │         ├── 1.23 [as=d1_default:14]
+      │         ├── 4.56::DECIMAL(10,2) [as=d2_default:15]
+      │         └── NULL::STRING [as=s_default:16]
+      └── projections
+           ├── assignment-cast: INT2 [as=column17:17]
+           │    └── i2_default:11
+           ├── assignment-cast: CHAR [as=column18:18]
+           │    └── c1_default:12
+           ├── assignment-cast: CHAR [as=column19:19]
+           │    └── c2_default:13
+           ├── assignment-cast: DECIMAL(10) [as=column20:20]
+           │    └── d1_default:14
+           └── assignment-cast: DECIMAL(10) [as=column21:21]
+                └── d2_default:15
+
+exec-ddl
+CREATE TABLE assn_cast_comp (
+    k INT PRIMARY KEY,
+    i INT,
+    i_comp INT2 AS (i + 10) STORED,
+    t TEXT,
+    c_comp CHAR AS (t) STORED,
+    d DECIMAL(10, 0),
+    d_comp DECIMAL(10, 0) AS (d + 2.5) STORED
+)
+----
+
+build
+INSERT INTO assn_cast_comp (k, i, t, d) VALUES (1, 2, 'foo', 1.56)
+----
+insert assn_cast_comp
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:10 => k:1
+ │    ├── column2:11 => i:2
+ │    ├── column17:17 => i_comp:3
+ │    ├── column3:12 => t:4
+ │    ├── column18:18 => c_comp:5
+ │    ├── column14:14 => d:6
+ │    └── column19:19 => d_comp:7
+ └── project
+      ├── columns: column17:17!null column18:18!null column19:19!null column1:10!null column2:11!null column3:12!null column14:14!null
+      ├── project
+      │    ├── columns: i_comp_comp:15!null d_comp_comp:16!null column1:10!null column2:11!null column3:12!null column14:14!null
+      │    ├── project
+      │    │    ├── columns: column14:14!null column1:10!null column2:11!null column3:12!null
+      │    │    ├── values
+      │    │    │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null
+      │    │    │    └── (1, 2, 'foo', 1.56)
+      │    │    └── projections
+      │    │         └── assignment-cast: DECIMAL(10) [as=column14:14]
+      │    │              └── column4:13
+      │    └── projections
+      │         ├── column2:11 + 10 [as=i_comp_comp:15]
+      │         └── column14:14::DECIMAL + 2.5 [as=d_comp_comp:16]
+      └── projections
+           ├── assignment-cast: INT2 [as=column17:17]
+           │    └── i_comp_comp:15
+           ├── assignment-cast: CHAR [as=column18:18]
+           │    └── column3:12
+           └── assignment-cast: DECIMAL(10) [as=column19:19]
+                └── d_comp_comp:16
 
 # Regression test for #38293; the default values should be separate projections.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -103,11 +103,9 @@ insert abcde
       ├── columns: d_comp:13!null column1:9!null column2:10!null column3:11!null rowid_default:12
       ├── project
       │    ├── columns: rowid_default:12 column1:9!null column2:10!null column3:11!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null column2:10!null column3:11!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null column2:10!null column3:11!null
-      │    │         └── (1, 2, 3)
+      │    │    └── (1, 2, 3)
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:12]
       └── projections
@@ -130,11 +128,9 @@ insert abcde
       ├── columns: d_comp:13 column1:9!null b_default:10 c_default:11!null rowid_default:12
       ├── project
       │    ├── columns: b_default:10 c_default:11!null rowid_default:12 column1:9!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null
-      │    │         └── (1,)
+      │    │    └── (1,)
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:10]
       │         ├── 10 [as=c_default:11]
@@ -159,20 +155,18 @@ insert abcde
       ├── columns: d_comp:17 y:10 b_default:14 c_default:15!null rowid_default:16
       ├── project
       │    ├── columns: b_default:14 c_default:15!null rowid_default:16 y:10
-      │    ├── project
-      │    │    ├── columns: y:10
-      │    │    └── limit
-      │    │         ├── columns: y:10 z:11
-      │    │         ├── internal-ordering: +10,+11
-      │    │         ├── sort
-      │    │         │    ├── columns: y:10 z:11
-      │    │         │    ├── ordering: +10,+11
-      │    │         │    ├── limit hint: 10.00
-      │    │         │    └── project
-      │    │         │         ├── columns: y:10 z:11
-      │    │         │         └── scan xyz
-      │    │         │              └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
-      │    │         └── 10
+      │    ├── limit
+      │    │    ├── columns: y:10 z:11
+      │    │    ├── internal-ordering: +10,+11
+      │    │    ├── sort
+      │    │    │    ├── columns: y:10 z:11
+      │    │    │    ├── ordering: +10,+11
+      │    │    │    ├── limit hint: 10.00
+      │    │    │    └── project
+      │    │    │         ├── columns: y:10 z:11
+      │    │    │         └── scan xyz
+      │    │    │              └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
+      │    │    └── 10
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:14]
       │         ├── 10 [as=c_default:15]
@@ -198,11 +192,9 @@ insert abcde
       ├── project
       │    ├── columns: b_default:14 c_default:15!null rowid_default:16 y:10
       │    ├── project
-      │    │    ├── columns: y:10
-      │    │    └── project
-      │    │         ├── columns: y:10 z:11
-      │    │         └── scan xyz
-      │    │              └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
+      │    │    ├── columns: y:10 z:11
+      │    │    └── scan xyz
+      │    │         └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:14]
       │         ├── 10 [as=c_default:15]
@@ -220,11 +212,9 @@ insert xyz
  │    ├── column1:6 => x:1
  │    ├── column2:7 => y:2
  │    └── column3:8 => z:3
- └── project
+ └── values
       ├── columns: column1:6 column2:7 column3:8
-      └── values
-           ├── columns: column1:6 column2:7 column3:8
-           └── ($1, $2, $3)
+      └── ($1, $2, $3)
 
 # Null expressions.
 build
@@ -243,11 +233,9 @@ insert abcde
       ├── columns: d_comp:13 column1:9!null column2:10 column3:11 rowid_default:12
       ├── project
       │    ├── columns: rowid_default:12 column1:9!null column2:10 column3:11
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null column2:10 column3:11
-      │    │    └── values
-      │    │         ├── columns: column1:9!null column2:10 column3:11
-      │    │         └── (2, NULL::INT8, NULL::INT8)
+      │    │    └── (2, NULL::INT8, NULL::INT8)
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:12]
       └── projections
@@ -272,13 +260,11 @@ insert abcde
       │    ├── columns: rowid_default:11 "?column?":9!null "?column?":10
       │    ├── project
       │    │    ├── columns: "?column?":9!null "?column?":10
-      │    │    └── project
-      │    │         ├── columns: "?column?":9!null "?column?":10
-      │    │         ├── values
-      │    │         │    └── ()
-      │    │         └── projections
-      │    │              ├── 2 [as="?column?":9]
-      │    │              └── $1 + 1 [as="?column?":10]
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── projections
+      │    │         ├── 2 [as="?column?":9]
+      │    │         └── $1 + 1 [as="?column?":10]
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:11]
       └── projections
@@ -320,14 +306,12 @@ insert abcde
       ├── columns: d_comp:13 column1:9!null column2:10 column3:11!null rowid_default:12
       ├── project
       │    ├── columns: rowid_default:12 column1:9!null column2:10 column3:11!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null column2:10 column3:11!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null column2:10 column3:11!null
-      │    │         ├── (1, NULL::INT8, 2)
-      │    │         ├── (2, 3, 4)
-      │    │         ├── (3, 2, 10)
-      │    │         └── (4, NULL::INT8, 10)
+      │    │    ├── (1, NULL::INT8, 2)
+      │    │    ├── (2, 3, 4)
+      │    │    ├── (3, 2, 10)
+      │    │    └── (4, NULL::INT8, 10)
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:12]
       └── projections
@@ -366,12 +350,10 @@ project
            │    ├── columns: b_default:10 c_default:11!null rowid_default:12 "?column?":9!null
            │    ├── project
            │    │    ├── columns: "?column?":9!null
-           │    │    └── project
-           │    │         ├── columns: "?column?":9!null
-           │    │         ├── values
-           │    │         │    └── ()
-           │    │         └── projections
-           │    │              └── 1 [as="?column?":9]
+           │    │    ├── values
+           │    │    │    └── ()
+           │    │    └── projections
+           │    │         └── 1 [as="?column?":9]
            │    └── projections
            │         ├── NULL::INT8 [as=b_default:10]
            │         ├── 10 [as=c_default:11]
@@ -400,12 +382,10 @@ project
  │         │    ├── columns: b_default:10 c_default:11!null rowid_default:12 "?column?":9!null
  │         │    ├── project
  │         │    │    ├── columns: "?column?":9!null
- │         │    │    └── project
- │         │    │         ├── columns: "?column?":9!null
- │         │    │         ├── values
- │         │    │         │    └── ()
- │         │    │         └── projections
- │         │    │              └── 1 [as="?column?":9]
+ │         │    │    ├── values
+ │         │    │    │    └── ()
+ │         │    │    └── projections
+ │         │    │         └── 1 [as="?column?":9]
  │         │    └── projections
  │         │         ├── NULL::INT8 [as=b_default:10]
  │         │         ├── 10 [as=c_default:11]
@@ -437,11 +417,9 @@ with &1
  │              ├── columns: d_comp:13 column1:9!null b_default:10 c_default:11!null rowid_default:12
  │              ├── project
  │              │    ├── columns: b_default:10 c_default:11!null rowid_default:12 column1:9!null
- │              │    ├── project
+ │              │    ├── values
  │              │    │    ├── columns: column1:9!null
- │              │    │    └── values
- │              │    │         ├── columns: column1:9!null
- │              │    │         └── (1,)
+ │              │    │    └── (1,)
  │              │    └── projections
  │              │         ├── NULL::INT8 [as=b_default:10]
  │              │         ├── 10 [as=c_default:11]
@@ -499,13 +477,11 @@ with &1 (a)
            ├── columns: d_comp:19 y:15 "?column?":16 c_default:17!null rowid_default:18
            ├── project
            │    ├── columns: c_default:17!null rowid_default:18 y:15 "?column?":16
-           │    ├── project
+           │    ├── with-scan &1 (a)
            │    │    ├── columns: y:15 "?column?":16
-           │    │    └── with-scan &1 (a)
-           │    │         ├── columns: y:15 "?column?":16
-           │    │         └── mapping:
-           │    │              ├──  xyz.y:2 => y:15
-           │    │              └──  "?column?":6 => "?column?":16
+           │    │    └── mapping:
+           │    │         ├──  xyz.y:2 => y:15
+           │    │         └──  "?column?":6 => "?column?":16
            │    └── projections
            │         ├── 10 [as=c_default:17]
            │         └── unique_rowid() [as=rowid_default:18]
@@ -544,22 +520,20 @@ with &1 (a)
                 ├── columns: d_comp:29 y:25 "?column?":26 c_default:27!null rowid_default:28
                 ├── project
                 │    ├── columns: c_default:27!null rowid_default:28 y:25 "?column?":26
-                │    ├── project
+                │    ├── union
                 │    │    ├── columns: y:25 "?column?":26
-                │    │    └── union
-                │    │         ├── columns: y:25 "?column?":26
-                │    │         ├── left columns: y:21 "?column?":22
-                │    │         ├── right columns: "?column?":23 y:24
-                │    │         ├── with-scan &1 (a)
-                │    │         │    ├── columns: y:21 "?column?":22
-                │    │         │    └── mapping:
-                │    │         │         ├──  xyz.y:2 => y:21
-                │    │         │         └──  "?column?":6 => "?column?":22
-                │    │         └── with-scan &2 (b)
-                │    │              ├── columns: "?column?":23 y:24
-                │    │              └── mapping:
-                │    │                   ├──  "?column?":12 => "?column?":23
-                │    │                   └──  xyz.y:8 => y:24
+                │    │    ├── left columns: y:21 "?column?":22
+                │    │    ├── right columns: "?column?":23 y:24
+                │    │    ├── with-scan &1 (a)
+                │    │    │    ├── columns: y:21 "?column?":22
+                │    │    │    └── mapping:
+                │    │    │         ├──  xyz.y:2 => y:21
+                │    │    │         └──  "?column?":6 => "?column?":22
+                │    │    └── with-scan &2 (b)
+                │    │         ├── columns: "?column?":23 y:24
+                │    │         └── mapping:
+                │    │              ├──  "?column?":12 => "?column?":23
+                │    │              └──  xyz.y:8 => y:24
                 │    └── projections
                 │         ├── 10 [as=c_default:27]
                 │         └── unique_rowid() [as=rowid_default:28]
@@ -586,11 +560,9 @@ with &1
  │              ├── columns: d_comp:13 column1:9!null b_default:10 c_default:11!null rowid_default:12
  │              ├── project
  │              │    ├── columns: b_default:10 c_default:11!null rowid_default:12 column1:9!null
- │              │    ├── project
+ │              │    ├── values
  │              │    │    ├── columns: column1:9!null
- │              │    │    └── values
- │              │    │         ├── columns: column1:9!null
- │              │    │         └── (1,)
+ │              │    │    └── (1,)
  │              │    └── projections
  │              │         ├── NULL::INT8 [as=b_default:10]
  │              │         ├── 10 [as=c_default:11]
@@ -621,11 +593,9 @@ with &1
                 ├── columns: d_comp:31 column1:27!null b_default:28 c_default:29!null rowid_default:30
                 ├── project
                 │    ├── columns: b_default:28 c_default:29!null rowid_default:30 column1:27!null
-                │    ├── project
+                │    ├── values
                 │    │    ├── columns: column1:27!null
-                │    │    └── values
-                │    │         ├── columns: column1:27!null
-                │    │         └── (1,)
+                │    │    └── (1,)
                 │    └── projections
                 │         ├── NULL::INT8 [as=b_default:28]
                 │         ├── 10 [as=c_default:29]
@@ -666,11 +636,9 @@ insert abcde
       ├── columns: d_comp:13!null column1:9!null column2:10!null column3:11!null rowid_default:12
       ├── project
       │    ├── columns: rowid_default:12 column1:9!null column2:10!null column3:11!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null column2:10!null column3:11!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null column2:10!null column3:11!null
-      │    │         └── (1, 2, 3)
+      │    │    └── (1, 2, 3)
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:12]
       └── projections
@@ -693,11 +661,9 @@ insert abcde
       ├── columns: d_comp:13 column1:9!null b_default:10 c_default:11!null rowid_default:12
       ├── project
       │    ├── columns: b_default:10 c_default:11!null rowid_default:12 column1:9!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null
-      │    │         └── (1,)
+      │    │    └── (1,)
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:10]
       │         ├── 10 [as=c_default:11]
@@ -724,11 +690,9 @@ project
            ├── columns: d_comp:13 column1:9!null column2:10!null b_default:11 c_default:12!null
            ├── project
            │    ├── columns: b_default:11 c_default:12!null column1:9!null column2:10!null
-           │    ├── project
+           │    ├── values
            │    │    ├── columns: column1:9!null column2:10!null
-           │    │    └── values
-           │    │         ├── columns: column1:9!null column2:10!null
-           │    │         └── (1, 2)
+           │    │    └── (1, 2)
            │    └── projections
            │         ├── NULL::INT8 [as=b_default:11]
            │         └── 10 [as=c_default:12]
@@ -752,13 +716,11 @@ insert abcde
  │    └── column4:12 => rowid:6
  └── project
       ├── columns: d_comp:13 column1:9!null column2:10 column3:11!null column4:12
-      ├── project
+      ├── values
       │    ├── columns: column1:9!null column2:10 column3:11!null column4:12
-      │    └── values
-      │         ├── columns: column1:9!null column2:10 column3:11!null column4:12
-      │         ├── (10, NULL::INT8, 1, unique_rowid())
-      │         ├── (3, 2, 1, unique_rowid())
-      │         └── (10, NULL::INT8, 2, 100)
+      │    ├── (10, NULL::INT8, 1, unique_rowid())
+      │    ├── (3, 2, 1, unique_rowid())
+      │    └── (10, NULL::INT8, 2, 100)
       └── projections
            └── (column2:10 + column1:9) + 1 [as=d_comp:13]
 
@@ -780,11 +742,9 @@ insert abcde
       ├── columns: d_comp:13 column1:9 b_default:10 c_default:11!null rowid_default:12
       ├── project
       │    ├── columns: b_default:10 c_default:11!null rowid_default:12 column1:9
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9
-      │    │    └── values
-      │    │         ├── columns: column1:9
-      │    │         └── (NULL::INT8,)
+      │    │    └── (NULL::INT8,)
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:10]
       │         ├── 10 [as=c_default:11]
@@ -872,13 +832,11 @@ project
            ├── project
            │    ├── columns: c_default:15!null rowid_default:16 y:10 x:14!null
            │    ├── project
-           │    │    ├── columns: y:10 x:14!null
-           │    │    └── project
-           │    │         ├── columns: x:14!null y:10
-           │    │         ├── scan xyz
-           │    │         │    └── columns: xyz.x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
-           │    │         └── projections
-           │    │              └── xyz.x:9::INT8 [as=x:14]
+           │    │    ├── columns: x:14!null y:10
+           │    │    ├── scan xyz
+           │    │    │    └── columns: xyz.x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
+           │    │    └── projections
+           │    │         └── xyz.x:9::INT8 [as=x:14]
            │    └── projections
            │         ├── 10 [as=c_default:15]
            │         └── unique_rowid() [as=rowid_default:16]
@@ -902,11 +860,9 @@ insert abcde
       ├── columns: d_comp:13 column1:9!null column2:10!null b_default:11 c_default:12!null
       ├── project
       │    ├── columns: b_default:11 c_default:12!null column1:9!null column2:10!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:9!null column2:10!null
-      │    │    └── values
-      │    │         ├── columns: column1:9!null column2:10!null
-      │    │         └── (1, 2)
+      │    │    └── (1, 2)
       │    └── projections
       │         ├── NULL::INT8 [as=b_default:11]
       │         └── 10 [as=c_default:12]
@@ -935,13 +891,11 @@ with &1
  │              ├── project
  │              │    ├── columns: c_default:15!null rowid_default:16 y:10 "?column?":14
  │              │    ├── project
- │              │    │    ├── columns: y:10 "?column?":14
- │              │    │    └── project
- │              │    │         ├── columns: "?column?":14 y:10
- │              │    │         ├── scan xyz
- │              │    │         │    └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
- │              │    │         └── projections
- │              │    │              └── y:10 + 1 [as="?column?":14]
+ │              │    │    ├── columns: "?column?":14 y:10
+ │              │    │    ├── scan xyz
+ │              │    │    │    └── columns: x:9!null y:10 z:11 xyz.crdb_internal_mvcc_timestamp:12 xyz.tableoid:13
+ │              │    │    └── projections
+ │              │    │         └── y:10 + 1 [as="?column?":14]
  │              │    └── projections
  │              │         ├── 10 [as=c_default:15]
  │              │         └── unique_rowid() [as=rowid_default:16]
@@ -970,11 +924,9 @@ insert xyz
  │    ├── column1:6 => x:1
  │    ├── column2:7 => y:2
  │    └── column3:8 => z:3
- └── project
+ └── values
       ├── columns: column1:6 column2:7 column3:8
-      └── values
-           ├── columns: column1:6 column2:7 column3:8
-           └── ($1, $2 + 1, $3 + 1.0)
+      └── ($1, $2 + 1, $3 + 1.0)
 
 # Propagate types to VALUES (named columns).
 build
@@ -986,11 +938,9 @@ insert xyz
  │    ├── column3:8 => x:1
  │    ├── column2:7 => y:2
  │    └── column1:6 => z:3
- └── project
+ └── values
       ├── columns: column1:6 column2:7 column3:8
-      └── values
-           ├── columns: column1:6 column2:7 column3:8
-           └── ($1 + 1.0, $2 + 1, $3)
+      └── ($1 + 1.0, $2 + 1, $3)
 
 # Propagate types to projection list.
 build
@@ -1004,14 +954,12 @@ insert xyz
  │    └── "?column?":8 => z:3
  └── project
       ├── columns: "?column?":6 "?column?":7 "?column?":8
-      └── project
-           ├── columns: "?column?":6 "?column?":7 "?column?":8
-           ├── values
-           │    └── ()
-           └── projections
-                ├── $1 [as="?column?":6]
-                ├── $2 + 1 [as="?column?":7]
-                └── $3 + 1.0 [as="?column?":8]
+      ├── values
+      │    └── ()
+      └── projections
+           ├── $1 [as="?column?":6]
+           ├── $2 + 1 [as="?column?":7]
+           └── $3 + 1.0 [as="?column?":8]
 
 # Propagate types to projection list (named columns).
 build
@@ -1025,14 +973,12 @@ insert xyz
  │    └── "?column?":8 => z:3
  └── project
       ├── columns: "?column?":6 "?column?":7 "?column?":8
-      └── project
-           ├── columns: "?column?":6 "?column?":7 "?column?":8
-           ├── values
-           │    └── ()
-           └── projections
-                ├── $1 [as="?column?":6]
-                ├── $2 + 1 [as="?column?":7]
-                └── $3 + 1.0 [as="?column?":8]
+      ├── values
+      │    └── ()
+      └── projections
+           ├── $1 [as="?column?":6]
+           ├── $2 + 1 [as="?column?":7]
+           └── $3 + 1.0 [as="?column?":8]
 
 # Propagate types to UNION.
 build
@@ -1044,28 +990,26 @@ insert xyz
  │    ├── "?column?":12 => x:1
  │    ├── "?column?":13 => y:2
  │    └── "?column?":14 => z:3
- └── project
+ └── union-all
       ├── columns: "?column?":12 "?column?":13 "?column?":14
-      └── union-all
-           ├── columns: "?column?":12 "?column?":13 "?column?":14
-           ├── left columns: "?column?":6 "?column?":7 "?column?":8
-           ├── right columns: "?column?":9 "?column?":10 "?column?":11
-           ├── project
-           │    ├── columns: "?column?":6 "?column?":7 "?column?":8
-           │    ├── values
-           │    │    └── ()
-           │    └── projections
-           │         ├── $1 [as="?column?":6]
-           │         ├── $2 + 1 [as="?column?":7]
-           │         └── $3 + 1.0 [as="?column?":8]
-           └── project
-                ├── columns: "?column?":9 "?column?":10 "?column?":11
-                ├── values
-                │    └── ()
-                └── projections
-                     ├── $1 [as="?column?":9]
-                     ├── $2 + 1 [as="?column?":10]
-                     └── $3 + 1.0 [as="?column?":11]
+      ├── left columns: "?column?":6 "?column?":7 "?column?":8
+      ├── right columns: "?column?":9 "?column?":10 "?column?":11
+      ├── project
+      │    ├── columns: "?column?":6 "?column?":7 "?column?":8
+      │    ├── values
+      │    │    └── ()
+      │    └── projections
+      │         ├── $1 [as="?column?":6]
+      │         ├── $2 + 1 [as="?column?":7]
+      │         └── $3 + 1.0 [as="?column?":8]
+      └── project
+           ├── columns: "?column?":9 "?column?":10 "?column?":11
+           ├── values
+           │    └── ()
+           └── projections
+                ├── $1 [as="?column?":9]
+                ├── $2 + 1 [as="?column?":10]
+                └── $3 + 1.0 [as="?column?":11]
 
 # Propagate types to UNION (named columns).
 build
@@ -1077,28 +1021,26 @@ insert xyz
  │    ├── "?column?":12 => x:1
  │    ├── "?column?":14 => y:2
  │    └── "?column?":13 => z:3
- └── project
+ └── union-all
       ├── columns: "?column?":12 "?column?":13 "?column?":14
-      └── union-all
-           ├── columns: "?column?":12 "?column?":13 "?column?":14
-           ├── left columns: "?column?":6 "?column?":7 "?column?":8
-           ├── right columns: "?column?":9 "?column?":10 "?column?":11
-           ├── project
-           │    ├── columns: "?column?":6 "?column?":7 "?column?":8
-           │    ├── values
-           │    │    └── ()
-           │    └── projections
-           │         ├── $1 [as="?column?":6]
-           │         ├── $2 + 1.0 [as="?column?":7]
-           │         └── $3 + 1 [as="?column?":8]
-           └── project
-                ├── columns: "?column?":9 "?column?":10 "?column?":11
-                ├── values
-                │    └── ()
-                └── projections
-                     ├── $1 [as="?column?":9]
-                     ├── $2 + 1.0 [as="?column?":10]
-                     └── $3 + 1 [as="?column?":11]
+      ├── left columns: "?column?":6 "?column?":7 "?column?":8
+      ├── right columns: "?column?":9 "?column?":10 "?column?":11
+      ├── project
+      │    ├── columns: "?column?":6 "?column?":7 "?column?":8
+      │    ├── values
+      │    │    └── ()
+      │    └── projections
+      │         ├── $1 [as="?column?":6]
+      │         ├── $2 + 1.0 [as="?column?":7]
+      │         └── $3 + 1 [as="?column?":8]
+      └── project
+           ├── columns: "?column?":9 "?column?":10 "?column?":11
+           ├── values
+           │    └── ()
+           └── projections
+                ├── $1 [as="?column?":9]
+                ├── $2 + 1.0 [as="?column?":10]
+                └── $3 + 1 [as="?column?":11]
 
 # ------------------------------------------------------------------------------
 # Tests with mutation columns.
@@ -1122,11 +1064,9 @@ insert mutation
       │    ├── columns: p_comp:11!null column1:8!null column2:9!null o_default:10!null
       │    ├── project
       │    │    ├── columns: o_default:10!null column1:8!null column2:9!null
-      │    │    ├── project
+      │    │    ├── values
       │    │    │    ├── columns: column1:8!null column2:9!null
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:8!null column2:9!null
-      │    │    │         └── (1, 2)
+      │    │    │    └── (1, 2)
       │    │    └── projections
       │    │         └── 10 [as=o_default:10]
       │    └── projections
@@ -1152,11 +1092,9 @@ insert mutation
       │    ├── columns: p_comp:11!null column1:8!null column2:9!null o_default:10!null
       │    ├── project
       │    │    ├── columns: o_default:10!null column1:8!null column2:9!null
-      │    │    ├── project
+      │    │    ├── values
       │    │    │    ├── columns: column1:8!null column2:9!null
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:8!null column2:9!null
-      │    │    │         └── (1, 2)
+      │    │    │    └── (1, 2)
       │    │    └── projections
       │    │         └── 10 [as=o_default:10]
       │    └── projections
@@ -1202,11 +1140,9 @@ insert checks
       ├── columns: check1:11!null check2:12!null column1:7!null column2:8!null column3:9!null d_comp:10!null
       ├── project
       │    ├── columns: d_comp:10!null column1:7!null column2:8!null column3:9!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:7!null column2:8!null column3:9!null
-      │    │    └── values
-      │    │         ├── columns: column1:7!null column2:8!null column3:9!null
-      │    │         └── (1, 2, 3)
+      │    │    └── (1, 2, 3)
       │    └── projections
       │         └── column3:9 + 1 [as=d_comp:10]
       └── projections
@@ -1231,15 +1167,13 @@ insert checks
       │    ├── columns: d_comp:15 abcde.a:7!null abcde.b:8 abcde.c:9
       │    ├── project
       │    │    ├── columns: abcde.a:7!null abcde.b:8 abcde.c:9
-      │    │    └── project
-      │    │         ├── columns: abcde.a:7!null abcde.b:8 abcde.c:9
-      │    │         └── scan abcde
-      │    │              ├── columns: abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 e:11 rowid:12!null abcde.crdb_internal_mvcc_timestamp:13 abcde.tableoid:14
-      │    │              └── computed column expressions
-      │    │                   ├── abcde.d:10
-      │    │                   │    └── (abcde.b:8 + abcde.c:9) + 1
-      │    │                   └── e:11
-      │    │                        └── abcde.a:7
+      │    │    └── scan abcde
+      │    │         ├── columns: abcde.a:7!null abcde.b:8 abcde.c:9 abcde.d:10 e:11 rowid:12!null abcde.crdb_internal_mvcc_timestamp:13 abcde.tableoid:14
+      │    │         └── computed column expressions
+      │    │              ├── abcde.d:10
+      │    │              │    └── (abcde.b:8 + abcde.c:9) + 1
+      │    │              └── e:11
+      │    │                   └── abcde.a:7
       │    └── projections
       │         └── abcde.c:9 + 1 [as=d_comp:15]
       └── projections
@@ -1395,11 +1329,9 @@ insert defvals
  │    └── arr2_default:8 => arr2:3
  └── project
       ├── columns: arr1_default:7!null arr2_default:8!null column1:6!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null
-      │    └── values
-      │         ├── columns: column1:6!null
-      │         └── (1,)
+      │    └── (1,)
       └── projections
            ├── ARRAY[] [as=arr1_default:7]
            └── ARRAY[] [as=arr2_default:8]
@@ -1423,11 +1355,9 @@ insert defvals2
  │    └── arr2_default:8 => arr2:3
  └── project
       ├── columns: arr1_default:7 arr2_default:8 column1:6!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null
-      │    └── values
-      │         ├── columns: column1:6!null
-      │         └── (1,)
+      │    └── (1,)
       └── projections
            ├── ARRAY[NULL] [as=arr1_default:7]
            └── ARRAY[NULL] [as=arr2_default:8]
@@ -1457,11 +1387,9 @@ insert t67100
       ├── columns: check1:7!null check2:8!null check3:9!null column1:5!null rowid_default:6
       ├── project
       │    ├── columns: rowid_default:6 column1:5!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:5!null
-      │    │    └── values
-      │    │         ├── columns: column1:5!null
-      │    │         └── (1,)
+      │    │    └── (1,)
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:6]
       └── projections
@@ -1484,11 +1412,9 @@ insert on_update_bare
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: rowid_default:8 column1:6!null column2:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null
-      │         └── (1, 2)
+      │    └── (1, 2)
       └── projections
            └── unique_rowid() [as=rowid_default:8]
 
@@ -1503,11 +1429,9 @@ insert on_update_bare
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: v_default:7 rowid_default:8 column1:6!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null
-      │    └── values
-      │         ├── columns: column1:6!null
-      │         └── (1,)
+      │    └── (1,)
       └── projections
            ├── NULL::INT8 [as=v_default:7]
            └── unique_rowid() [as=rowid_default:8]
@@ -1524,11 +1448,9 @@ insert on_update_with_default
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: rowid_default:8 column1:6!null column2:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null
-      │         └── (1, 2)
+      │    └── (1, 2)
       └── projections
            └── unique_rowid() [as=rowid_default:8]
 
@@ -1544,11 +1466,9 @@ insert on_update_with_default
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: v_default:7!null rowid_default:8 column1:6!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null
-      │    └── values
-      │         ├── columns: column1:6!null
-      │         └── (1,)
+      │    └── (1,)
       └── projections
            ├── 3 [as=v_default:7]
            └── unique_rowid() [as=rowid_default:8]
@@ -1590,11 +1510,9 @@ insert generated_as_identity
  │    └── rowid_default:10 => rowid:4
  └── project
       ├── columns: b_default:9 rowid_default:10 column1:7!null column2:8!null
-      ├── project
+      ├── values
       │    ├── columns: column1:7!null column2:8!null
-      │    └── values
-      │         ├── columns: column1:7!null column2:8!null
-      │         └── (1, 10)
+      │    └── (1, 10)
       └── projections
            ├── nextval('t.public.generated_as_identity_b_seq') [as=b_default:9]
            └── unique_rowid() [as=rowid_default:10]
@@ -1611,11 +1529,9 @@ insert generated_as_identity
  │    └── rowid_default:10 => rowid:4
  └── project
       ├── columns: b_default:8 c_default:9 rowid_default:10 column1:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:7!null
-      │    └── values
-      │         ├── columns: column1:7!null
-      │         └── (2,)
+      │    └── (2,)
       └── projections
            ├── nextval('t.public.generated_as_identity_b_seq') [as=b_default:8]
            ├── nextval('t.public.generated_as_identity_c_seq') [as=c_default:9]
@@ -1640,11 +1556,9 @@ insert serial_t
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: a_default:7 rowid_default:8 column1:6!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null
-      │    └── values
-      │         ├── columns: column1:6!null
-      │         └── (2,)
+      │    └── (2,)
       └── projections
            ├── unique_rowid() [as=a_default:7]
            └── unique_rowid() [as=rowid_default:8]

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -46,11 +46,9 @@ insert kj
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    └── column2:7 => j:2
- └── project
+ └── values
       ├── columns: column1:6!null column2:7!null
-      └── values
-           ├── columns: column1:6!null column2:7!null
-           └── (1, '{"a": 2}')
+      └── (1, '{"a": 2}')
 
 build
 UPSERT INTO kj VALUES (1, '{"a": 2}')
@@ -99,11 +97,9 @@ insert kj
       ├── grouping columns: column1:6!null
       ├── anti-join (hash)
       │    ├── columns: column1:6!null column2:7!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null
-      │    │    └── values
-      │    │         ├── columns: column1:6!null column2:7!null
-      │    │         └── (1, '{"a": 2}')
+      │    │    └── (1, '{"a": 2}')
       │    ├── scan kj
       │    │    └── columns: k:8!null j:9
       │    └── filters

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -103,11 +103,9 @@ insert partial_indexes
  ├── partial index put columns: partial_index_put1:9 partial_index_put2:10 partial_index_put3:11 partial_index_put4:12
  └── project
       ├── columns: partial_index_put1:9!null partial_index_put2:10!null partial_index_put3:11!null partial_index_put4:12!null column1:6!null column2:7!null column3:8!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │         └── (2, 1, 'bar')
+      │    └── (2, 1, 'bar')
       └── projections
            ├── column3:8 = 'foo' [as=partial_index_put1:9]
            ├── (column1:6 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:10]
@@ -134,11 +132,9 @@ insert ambig
       │    ├── columns: check1:11!null column1:7!null column2:8!null column3:9!null rowid_default:10
       │    ├── project
       │    │    ├── columns: rowid_default:10 column1:7!null column2:8!null column3:9!null
-      │    │    ├── project
+      │    │    ├── values
       │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:7!null column2:8!null column3:9!null
-      │    │    │         └── (1, 2, 3)
+      │    │    │    └── (1, 2, 3)
       │    │    └── projections
       │    │         └── unique_rowid() [as=rowid_default:10]
       │    └── projections
@@ -164,11 +160,9 @@ insert comp
       ├── columns: partial_index_put1:13 partial_index_put2:14 column1:8!null column2:9!null column3:10!null d_comp:11 e_comp:12
       ├── project
       │    ├── columns: d_comp:11 e_comp:12 column1:8!null column2:9!null column3:10!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    └── values
-      │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │         └── (2, 1, 'Foo')
+      │    │    └── (2, 1, 'Foo')
       │    └── projections
       │         ├── lower(column3:10) [as=d_comp:11]
       │         └── upper(column3:10) [as=e_comp:12]
@@ -195,11 +189,9 @@ insert t52546
  ├── partial index put columns: column2:7
  └── project
       ├── columns: rowid_default:8 column1:6!null column2:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null
-      │         └── (1, true)
+      │    └── (1, true)
       └── projections
            └── unique_rowid() [as=rowid_default:8]
 
@@ -618,11 +610,9 @@ insert partial_indexes
       │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    ├── anti-join (hash)
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    ├── project
+      │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    └── values
-      │    │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │         └── (2, 1, 'bar')
+      │    │    │    │    │    └── (2, 1, 'bar')
       │    │    │    │    ├── scan partial_indexes
       │    │    │    │    │    ├── columns: a:9!null b:10 c:11
       │    │    │    │    │    └── partial index predicates
@@ -818,11 +808,9 @@ insert comp
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null d_comp:11 e_comp:12
       │    │    ├── project
       │    │    │    ├── columns: d_comp:11 e_comp:12 column1:8!null column2:9!null column3:10!null
-      │    │    │    ├── project
+      │    │    │    ├── values
       │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │    └── values
-      │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │         └── (2, 1, 'Foo')
+      │    │    │    │    └── (2, 1, 'Foo')
       │    │    │    └── projections
       │    │    │         ├── lower(column3:10) [as=d_comp:11]
       │    │    │         └── upper(column3:10) [as=e_comp:12]
@@ -1044,11 +1032,9 @@ insert uniq
       │         │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │    │    ├── anti-join (hash)
       │         │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │    │    │    ├── project
+      │         │    │    │    │    ├── values
       │         │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │    │    │    │    └── values
-      │         │    │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │    │    │    │         └── (1, 1, 'bar')
+      │         │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │    │    │    ├── scan uniq
       │         │    │    │    │    │    ├── columns: a:9!null b:10 c:11
       │         │    │    │    │    │    └── partial index predicates
@@ -1119,11 +1105,9 @@ insert uniq
       │         │    │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │         │    │    ├── anti-join (hash)
       │         │    │         │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    ├── project
+      │         │    │         │    │    │    ├── values
       │         │    │         │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    │    └── values
-      │         │    │         │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    │         └── (1, 1, 'bar')
+      │         │    │         │    │    │    │    └── (1, 1, 'bar')
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: a:9!null b:10 c:11!null
       │         │    │         │    │    │    │    ├── scan uniq
@@ -1203,11 +1187,9 @@ insert uniq
       │    ├── grouping columns: column2:7!null
       │    ├── anti-join (hash)
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    ├── project
+      │    │    ├── values
       │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │         └── (1, 1, 'bar')
+      │    │    │    └── (1, 1, 'bar')
       │    │    ├── scan uniq
       │    │    │    ├── columns: a:9!null b:10 c:11
       │    │    │    └── partial index predicates
@@ -1476,11 +1458,9 @@ insert comp
       │         │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null d_comp:11 e_comp:12
       │         │    │    │    │    ├── project
       │         │    │    │    │    │    ├── columns: d_comp:11 e_comp:12 column1:8!null column2:9!null column3:10!null
-      │         │    │    │    │    │    ├── project
+      │         │    │    │    │    │    ├── values
       │         │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │         │    │    │    │    │    │    └── values
-      │         │    │    │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │         │    │    │    │    │    │         └── (1, 1, 'bar')
+      │         │    │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │    │    │    │    └── projections
       │         │    │    │    │    │         ├── lower(column3:10) [as=d_comp:11]
       │         │    │    │    │    │         └── upper(column3:10) [as=e_comp:12]
@@ -1594,11 +1574,9 @@ insert comp
       │         │    │         │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null d_comp:11 e_comp:12
       │         │    │         │    │    │    ├── project
       │         │    │         │    │    │    │    ├── columns: d_comp:11 e_comp:12 column1:8!null column2:9!null column3:10!null
-      │         │    │         │    │    │    │    ├── project
+      │         │    │         │    │    │    │    ├── values
       │         │    │         │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │         │    │         │    │    │    │    │    └── values
-      │         │    │         │    │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │         │    │         │    │    │    │    │         └── (1, 1, 'bar')
+      │         │    │         │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │         │    │    │    │    └── projections
       │         │    │         │    │    │    │         ├── lower(column3:10) [as=d_comp:11]
       │         │    │         │    │    │    │         └── upper(column3:10) [as=e_comp:12]
@@ -1720,11 +1698,9 @@ insert comp
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null d_comp:11 e_comp:12
       │    │    ├── project
       │    │    │    ├── columns: d_comp:11 e_comp:12 column1:8!null column2:9!null column3:10!null
-      │    │    │    ├── project
+      │    │    │    ├── values
       │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │    └── values
-      │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │         └── (1, 1, 'bar')
+      │    │    │    │    └── (1, 1, 'bar')
       │    │    │    └── projections
       │    │    │         ├── lower(column3:10) [as=d_comp:11]
       │    │    │         └── upper(column3:10) [as=e_comp:12]

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -91,11 +91,9 @@ insert ab
  │    └── rowid_default:8 => rowid:3
  └── project
       ├── columns: rowid_default:8 column1:6 column2:7
-      ├── project
+      ├── values
       │    ├── columns: column1:6 column2:7
-      │    └── values
-      │         ├── columns: column1:6 column2:7
-      │         └── (random(), random())
+      │    └── (random(), random())
       └── projections
            └── unique_rowid() [as=rowid_default:8]
 
@@ -117,11 +115,9 @@ insert abcd
  │    └── rowid_default:12 => rowid:5
  └── project
       ├── columns: c_default:10 d_default:11 rowid_default:12 column1:8!null column2:9!null
-      ├── project
+      ├── values
       │    ├── columns: column1:8!null column2:9!null
-      │    └── values
-      │         ├── columns: column1:8!null column2:9!null
-      │         └── (1.0, 1.0)
+      │    └── (1.0, 1.0)
       └── projections
            ├── random() [as=c_default:10]
            ├── random() [as=d_default:11]
@@ -140,11 +136,9 @@ insert abcd
  │    └── rowid_default:12 => rowid:5
  └── project
       ├── columns: c_default:10 d_default:11 rowid_default:12 column1:8 column2:9
-      ├── project
+      ├── values
       │    ├── columns: column1:8 column2:9
-      │    └── values
-      │         ├── columns: column1:8 column2:9
-      │         └── (random(), random())
+      │    └── (random(), random())
       └── projections
            ├── random() [as=c_default:10]
            ├── random() [as=d_default:11]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1265,11 +1265,9 @@ with &1
  │    │    └── b_default:7 => abc.c:3
  │    └── project
  │         ├── columns: b_default:7 column1:6!null
- │         ├── project
+ │         ├── values
  │         │    ├── columns: column1:6!null
- │         │    └── values
- │         │         ├── columns: column1:6!null
- │         │         └── (1,)
+ │         │    └── (1,)
  │         └── projections
  │              └── NULL::INT8 [as=b_default:7]
  └── with &2 (cte)
@@ -1322,11 +1320,9 @@ with &1
  │         │    ├── column1:6 => abc.a:1
  │         │    ├── column2:7 => b:2
  │         │    └── column3:8 => c:3
- │         └── project
+ │         └── values
  │              ├── columns: column1:6!null column2:7!null column3:8!null
- │              └── values
- │                   ├── columns: column1:6!null column2:7!null column3:8!null
- │                   └── (1, 2, 3)
+ │              └── (1, 2, 3)
  └── with-scan &1
       ├── columns: a:9!null
       └── mapping:
@@ -1447,11 +1443,9 @@ insert inaccessible
  │    └── v_default:6 => v:2
  └── project
       ├── columns: v_default:6 column1:5!null
-      ├── project
+      ├── values
       │    ├── columns: column1:5!null
-      │    └── values
-      │         ├── columns: column1:5!null
-      │         └── (1,)
+      │    └── (1,)
       └── projections
            └── NULL::INT8 [as=v_default:6]
 

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -22,12 +22,10 @@ insert uniq
  │    ├── column4:11 => uniq.x:4
  │    └── column5:12 => uniq.y:5
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │    └── values
- │         ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │         ├── (1, 1, 1, 1, 1)
- │         └── (2, 2, 2, 2, 2)
+ │    ├── (1, 1, 1, 1, 1)
+ │    └── (2, 2, 2, 2, 2)
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -80,13 +78,11 @@ insert uniq
  │    ├── column4:11 => uniq.x:4
  │    └── column5:12 => uniq.y:5
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:8!null column2:9 column3:10 column4:11 column5:12!null
- │    └── values
- │         ├── columns: column1:8!null column2:9 column3:10 column4:11 column5:12!null
- │         ├── (1, 1, 1, 1, 1)
- │         ├── (2, 2, 2, 2, 2)
- │         └── (3, NULL::INT8, NULL::INT8, NULL::INT8, 3)
+ │    ├── (1, 1, 1, 1, 1)
+ │    ├── (2, 2, 2, 2, 2)
+ │    └── (3, NULL::INT8, NULL::INT8, NULL::INT8, 3)
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -290,11 +286,9 @@ insert uniq
       │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
       │    │    │    │    │    │    ├── anti-join (hash)
       │    │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
-      │    │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
-      │    │    │    │    │    │    │    │    └── values
-      │    │    │    │    │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
-      │    │    │    │    │    │    │    │         └── (1, 2, 3, 4, 5)
+      │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
       │    │    │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    │    │    └── columns: k:13!null v:14 w:15 x:16 y:17
       │    │    │    │    │    │    │    └── filters
@@ -366,11 +360,9 @@ insert uniq
  │    ├── grouping columns: column3:10!null
  │    ├── anti-join (hash)
  │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │    │    ├── project
+ │    │    ├── values
  │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │    │    │    └── values
- │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
- │    │    │         └── (1, 2, 3, 4, 5)
+ │    │    │    └── (1, 2, 3, 4, 5)
  │    │    ├── scan uniq
  │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  │    │    └── filters
@@ -424,10 +416,8 @@ insert uniq
  ├── input binding: &1
  ├── project
  │    ├── columns: other.k:8 other.v:9 other.w:10!null other.x:11 other.y:12
- │    └── project
- │         ├── columns: other.k:8 other.v:9 other.w:10!null other.x:11 other.y:12
- │         └── scan other
- │              └── columns: other.k:8 other.v:9 other.w:10!null other.x:11 other.y:12 rowid:13!null other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
+ │    └── scan other
+ │         └── columns: other.k:8 other.v:9 other.w:10!null other.x:11 other.y:12 rowid:13!null other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -495,12 +485,10 @@ insert uniq_overlaps_pk
  │    ├── column3:9 => uniq_overlaps_pk.c:3
  │    └── column4:10 => uniq_overlaps_pk.d:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │         ├── (1, 1, 1, 1)
- │         └── (2, 2, 2, 2)
+ │    ├── (1, 1, 1, 1)
+ │    └── (2, 2, 2, 2)
  └── unique-checks
       ├── unique-checks-item: uniq_overlaps_pk(b,c)
       │    └── project
@@ -572,10 +560,8 @@ insert uniq_overlaps_pk
  ├── input binding: &1
  ├── project
  │    ├── columns: k:7 v:8 x:10 y:11
- │    └── project
- │         ├── columns: k:7 v:8 x:10 y:11
- │         └── scan other
- │              └── columns: k:7 v:8 w:9!null x:10 y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+ │    └── scan other
+ │         └── columns: k:7 v:8 w:9!null x:10 y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
  └── unique-checks
       ├── unique-checks-item: uniq_overlaps_pk(b,c)
       │    └── project
@@ -659,12 +645,10 @@ insert uniq_hidden_pk
  ├── input binding: &1
  ├── project
  │    ├── columns: rowid_default:12 column1:8!null column2:9!null column3:10!null column4:11!null
- │    ├── project
+ │    ├── values
  │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
- │    │    └── values
- │    │         ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
- │    │         ├── (1, 1, 1, 1)
- │    │         └── (2, 2, 2, 2)
+ │    │    ├── (1, 1, 1, 1)
+ │    │    └── (2, 2, 2, 2)
  │    └── projections
  │         └── unique_rowid() [as=rowid_default:12]
  └── unique-checks
@@ -744,10 +728,8 @@ insert uniq_hidden_pk
  │    ├── columns: rowid_default:16 k:8 v:9 x:11 y:12
  │    ├── project
  │    │    ├── columns: k:8 v:9 x:11 y:12
- │    │    └── project
- │    │         ├── columns: k:8 v:9 x:11 y:12
- │    │         └── scan other
- │    │              └── columns: k:8 v:9 w:10!null x:11 y:12 other.rowid:13!null other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
+ │    │    └── scan other
+ │    │         └── columns: k:8 v:9 w:10!null x:11 y:12 other.rowid:13!null other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
  │    └── projections
  │         └── unique_rowid() [as=rowid_default:16]
  └── unique-checks
@@ -829,12 +811,10 @@ insert uniq_partial
  │    ├── column2:7 => uniq_partial.a:2
  │    └── column3:8 => uniq_partial.b:3
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:6!null column2:7!null column3:8!null
- │    └── values
- │         ├── columns: column1:6!null column2:7!null column3:8!null
- │         ├── (1, 1, 1)
- │         └── (2, 2, 2)
+ │    ├── (1, 1, 1)
+ │    └── (2, 2, 2)
  └── unique-checks
       └── unique-checks-item: uniq_partial(a)
            └── project
@@ -866,13 +846,11 @@ insert uniq_partial
  │    ├── column2:7 => uniq_partial.a:2
  │    └── column3:8 => uniq_partial.b:3
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:6!null column2:7 column3:8!null
- │    └── values
- │         ├── columns: column1:6!null column2:7 column3:8!null
- │         ├── (1, 1, 1)
- │         ├── (2, 2, 2)
- │         └── (3, NULL::INT8, 3)
+ │    ├── (1, 1, 1)
+ │    ├── (2, 2, 2)
+ │    └── (3, NULL::INT8, 3)
  └── unique-checks
       └── unique-checks-item: uniq_partial(a)
            └── project
@@ -937,12 +915,10 @@ insert uniq_partial
            │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
            │    │    │    ├── anti-join (hash)
            │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    │    │    ├── project
+           │    │    │    │    ├── values
            │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    │    │    │    └── values
-           │    │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    │    │    │         ├── (1, 2, 3)
-           │    │    │    │    │         └── (2, 2, 3)
+           │    │    │    │    │    ├── (1, 2, 3)
+           │    │    │    │    │    └── (2, 2, 3)
            │    │    │    │    ├── scan uniq_partial
            │    │    │    │    │    └── columns: k:9!null a:10 b:11
            │    │    │    │    └── filters
@@ -996,11 +972,9 @@ insert uniq_partial
            │    ├── columns: arbiter_unique_a_distinct:14 column1:6!null column2:7!null column3:8!null
            │    ├── anti-join (hash)
            │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    ├── project
+           │    │    ├── values
            │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    │    └── values
-           │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-           │    │    │         └── (1, 2, 3)
+           │    │    │    └── (1, 2, 3)
            │    │    ├── select
            │    │    │    ├── columns: k:9!null a:10 b:11!null
            │    │    │    ├── scan uniq_partial
@@ -1031,10 +1005,8 @@ insert uniq_partial
  ├── input binding: &1
  ├── project
  │    ├── columns: other.k:6 v:7 w:8!null
- │    └── project
- │         ├── columns: other.k:6 v:7 w:8!null
- │         └── scan other
- │              └── columns: other.k:6 v:7 w:8!null x:9 y:10 rowid:11!null other.crdb_internal_mvcc_timestamp:12 other.tableoid:13
+ │    └── scan other
+ │         └── columns: other.k:6 v:7 w:8!null x:9 y:10 rowid:11!null other.crdb_internal_mvcc_timestamp:12 other.tableoid:13
  └── unique-checks
       └── unique-checks-item: uniq_partial(a)
            └── project
@@ -1084,12 +1056,10 @@ insert uniq_partial_overlaps_pk
  │    ├── column3:9 => uniq_partial_overlaps_pk.c:3
  │    └── column4:10 => uniq_partial_overlaps_pk.d:4
  ├── input binding: &1
- ├── project
+ ├── values
  │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │    └── values
- │         ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
- │         ├── (1, 1, 1, 1)
- │         └── (2, 2, 2, 2)
+ │    ├── (1, 1, 1, 1)
+ │    └── (2, 2, 2, 2)
  └── unique-checks
       ├── unique-checks-item: uniq_partial_overlaps_pk(c)
       │    └── project
@@ -1166,10 +1136,8 @@ insert uniq_partial_overlaps_pk
  ├── input binding: &1
  ├── project
  │    ├── columns: k:7 v:8 x:10 y:11
- │    └── project
- │         ├── columns: k:7 v:8 x:10 y:11
- │         └── scan other
- │              └── columns: k:7 v:8 w:9!null x:10 y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+ │    └── scan other
+ │         └── columns: k:7 v:8 w:9!null x:10 y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
  └── unique-checks
       ├── unique-checks-item: uniq_partial_overlaps_pk(c)
       │    └── project
@@ -1254,12 +1222,10 @@ insert uniq_partial_hidden_pk
  ├── input binding: &1
  ├── project
  │    ├── columns: c_default:9 rowid_default:10 column1:7!null column2:8!null
- │    ├── project
+ │    ├── values
  │    │    ├── columns: column1:7!null column2:8!null
- │    │    └── values
- │    │         ├── columns: column1:7!null column2:8!null
- │    │         ├── (1, 1)
- │    │         └── (2, 2)
+ │    │    ├── (1, 1)
+ │    │    └── (2, 2)
  │    └── projections
  │         ├── NULL::INT8 [as=c_default:9]
  │         └── unique_rowid() [as=rowid_default:10]
@@ -1300,10 +1266,8 @@ insert uniq_partial_hidden_pk
  │    ├── columns: c_default:15 rowid_default:16 k:7 v:8
  │    ├── project
  │    │    ├── columns: k:7 v:8
- │    │    └── project
- │    │         ├── columns: k:7 v:8
- │    │         └── scan other
- │    │              └── columns: k:7 v:8 w:9!null x:10 y:11 other.rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
+ │    │    └── scan other
+ │    │         └── columns: k:7 v:8 w:9!null x:10 y:11 other.rowid:12!null other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
  │    └── projections
  │         ├── NULL::INT8 [as=c_default:15]
  │         └── unique_rowid() [as=rowid_default:16]
@@ -1490,11 +1454,9 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │         │    │    ├── anti-join (hash)
       │         │    │         │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    ├── project
+      │         │    │         │    │    │    ├── values
       │         │    │         │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    │    └── values
-      │         │    │         │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │         │    │         │    │    │    │         └── (1, 1, 1)
+      │         │    │         │    │    │    │    └── (1, 1, 1)
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: k:9!null a:10 b:11!null
       │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
@@ -1573,12 +1535,10 @@ insert uniq_computed_pk
  ├── input binding: &1
  ├── project
  │    ├── columns: c_i_expr_comp:13!null c_d_expr_comp:14!null column1:10!null column2:11!null column3:12!null
- │    ├── project
+ │    ├── values
  │    │    ├── columns: column1:10!null column2:11!null column3:12!null
- │    │    └── values
- │    │         ├── columns: column1:10!null column2:11!null column3:12!null
- │    │         ├── (1, 'a', 1.0)
- │    │         └── (2, 'b', 2.0)
+ │    │    ├── (1, 'a', 1.0)
+ │    │    └── (2, 'b', 2.0)
  │    └── projections
  │         ├── CASE WHEN column1:10 < 0 THEN 'foo' ELSE 'bar' END [as=c_i_expr_comp:13]
  │         └── column3:12::STRING [as=c_d_expr_comp:14]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1642,7 +1642,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── (a:7::DECIMAL + c:9::DECIMAL)::DECIMAL(10,1)
+      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15] [as=b_new:14]
@@ -1650,7 +1650,7 @@ update decimals
       │    │    │         ├── crdb_internal.round_decimal_values(a_new:13, 0) [as=a_new:15]
       │    │    │         └── crdb_internal.round_decimal_values(b_new:14, 1) [as=b_new:16]
       │    │    └── projections
-      │    │         └── (a_new:15 + c:9::DECIMAL)::DECIMAL(10,1) [as=d_comp:17]
+      │    │         └── a_new:15 + c:9::DECIMAL [as=d_comp:17]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(d_comp:17, 1) [as=d_comp:18]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -2,6 +2,8 @@ exec-ddl
 create table t (a int2, b int2, c int2 as (a + b) virtual)
 ----
 
+# TODO(mgartner): An assignment cast should be added so that the type of the
+# insert column for c is int2, not int.
 build format=show-types
 update t set a = (with cte as (select 1:::int8) select t.c from cte limit 1)
 ----
@@ -19,7 +21,7 @@ with &1 (cte)
       │    ├── a_new:16 => a:1
       │    └── c_comp:17 => t.c:3
       └── project
-           ├── columns: c_comp:17(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid) a_new:16(int2)
+           ├── columns: c_comp:17(int) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid) a_new:16(int2)
            ├── project
            │    ├── columns: a_new:16(int2) a:7(int2) b:8(int2) t.c:9(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    ├── project
@@ -28,9 +30,9 @@ with &1 (cte)
            │    │    │    ├── columns: a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    │    │    └── computed column expressions
            │    │    │         └── t.c:9
-           │    │    │              └── (a:7::INT8 + b:8::INT8)::INT2 [type=int2]
+           │    │    │              └── a:7::INT8 + b:8::INT8 [type=int]
            │    │    └── projections
-           │    │         └── (a:7::INT8 + b:8::INT8)::INT2 [as=t.c:9, type=int2]
+           │    │         └── a:7::INT8 + b:8::INT8 [as=t.c:9, type=int]
            │    └── projections
            │         └── subquery [as=a_new:16, type=int2]
            │              └── max1-row
@@ -49,4 +51,4 @@ with &1 (cte)
            │                        │         └── t.c:9 [as=c:15, type=int2]
            │                        └── 1 [type=int]
            └── projections
-                └── (a_new:16::INT8 + b:8::INT8)::INT2 [as=c_comp:17, type=int2]
+                └── a_new:16::INT8 + b:8::INT8 [as=c_comp:17, type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1737,13 +1737,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8
       │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=c_default:9]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:9]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:7, 0) [as=a:10]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:8, 1) [as=b:11]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:9, 1) [as=c_default:12]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── (a:10 + c_default:12::DECIMAL)::DECIMAL(10,1) [as=d_comp:13]
+      │    │    │    │    │    │         └── a:10 + c_default:12 [as=d_comp:13]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:13, 1) [as=d_comp:14]
       │    │    │    │    └── aggregations
@@ -1757,11 +1757,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:15!null decimals.b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:18
-      │    │    │    │              └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1)
+      │    │    │    │              └── decimals.a:15::DECIMAL + c:17::DECIMAL
       │    │    │    └── filters
       │    │    │         └── a:10 = decimals.a:15
       │    │    └── projections
-      │    │         └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1) [as=d_comp:21]
+      │    │         └── decimals.a:15::DECIMAL + c:17::DECIMAL [as=d_comp:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN a:10 ELSE decimals.a:15 END [as=upsert_a:22]
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN c_default:12 ELSE c:17 END [as=upsert_c:23]
@@ -1809,13 +1809,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    └── (1.1,)
       │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=b_default:8]
-      │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=c_default:9]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:9]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:7, 0) [as=a:10]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(b_default:8, 1) [as=b_default:11]
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:9, 1) [as=c_default:12]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── (a:10 + c_default:12::DECIMAL)::DECIMAL(10,1) [as=d_comp:13]
+      │    │    │    │    │    │         └── a:10 + c_default:12 [as=d_comp:13]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:13, 1) [as=d_comp:14]
       │    │    │    │    └── aggregations
@@ -1829,11 +1829,11 @@ upsert decimals
       │    │    │    │    ├── columns: decimals.a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:18
-      │    │    │    │              └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1)
+      │    │    │    │              └── decimals.a:15::DECIMAL + c:17::DECIMAL
       │    │    │    └── filters
       │    │    │         └── a:10 = decimals.a:15
       │    │    └── projections
-      │    │         └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1) [as=d_comp:21]
+      │    │         └── decimals.a:15::DECIMAL + c:17::DECIMAL [as=d_comp:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN a:10 ELSE decimals.a:15 END [as=upsert_a:22]
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN b_default:11 ELSE b:16 END [as=upsert_b:23]
@@ -1889,13 +1889,13 @@ upsert decimals
       │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8
       │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         └── 1.23::DECIMAL(10,1) [as=c_default:9]
+      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:9]
       │    │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:7, 0) [as=a:10]
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:8, 1) [as=b:11]
       │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:9, 1) [as=c_default:12]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── (a:10 + c_default:12::DECIMAL)::DECIMAL(10,1) [as=d_comp:13]
+      │    │    │    │    │    │    │    │         └── a:10 + c_default:12 [as=d_comp:13]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:13, 1) [as=d_comp:14]
       │    │    │    │    │    │    └── aggregations
@@ -1909,7 +1909,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: decimals.a:15!null decimals.b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── d:18
-      │    │    │    │    │    │              └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1)
+      │    │    │    │    │    │              └── decimals.a:15::DECIMAL + c:17::DECIMAL
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a:10 = decimals.a:15
       │    │    │    │    └── projections
@@ -1917,7 +1917,7 @@ upsert decimals
       │    │    │    └── projections
       │    │    │         └── crdb_internal.round_decimal_values(b_new:21, 1) [as=b_new:22]
       │    │    └── projections
-      │    │         └── (decimals.a:15::DECIMAL + c:17::DECIMAL)::DECIMAL(10,1) [as=d_comp:23]
+      │    │         └── decimals.a:15::DECIMAL + c:17::DECIMAL [as=d_comp:23]
       │    └── projections
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN a:10 ELSE decimals.a:15 END [as=upsert_a:24]
       │         ├── CASE WHEN decimals.a:15 IS NULL THEN b:11 ELSE b_new:22 END [as=upsert_b:25]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -576,12 +576,10 @@ insert xyz
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    │    ├── anti-join (hash)
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    ├── project
+      │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    │    └── values
-      │    │    │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    │         ├── (1, 2, 3)
-      │    │    │    │    │    │         └── (4, 5, 6)
+      │    │    │    │    │    │    ├── (1, 2, 3)
+      │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    └── columns: x:9!null y:10 z:11
       │    │    │    │    │    └── filters
@@ -626,12 +624,10 @@ insert xyz
       ├── grouping columns: column2:7!null column3:8!null
       ├── anti-join (hash)
       │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    └── values
-      │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │         ├── (1, 2, 3)
-      │    │         └── (4, 5, 6)
+      │    │    ├── (1, 2, 3)
+      │    │    └── (4, 5, 6)
       │    ├── scan xyz
       │    │    └── columns: x:9!null y:10 z:11
       │    └── filters
@@ -667,13 +663,11 @@ insert uniq
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    │    ├── anti-join (hash)
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    ├── project
+      │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    │    └── values
-      │    │    │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null
-      │    │    │    │    │    │         ├── ('x2', 'y1', 'z2')
-      │    │    │    │    │    │         ├── ('x2', 'y2', 'z2')
-      │    │    │    │    │    │         └── ('x2', 'y2', 'z2')
+      │    │    │    │    │    │    ├── ('x2', 'y1', 'z2')
+      │    │    │    │    │    │    ├── ('x2', 'y2', 'z2')
+      │    │    │    │    │    │    └── ('x2', 'y2', 'z2')
       │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    └── columns: x:9!null y:10 z:11
       │    │    │    │    │    └── filters
@@ -1473,11 +1467,9 @@ insert checks
       │    │    │    ├── columns: d_comp:10 column1:7!null column2:8!null c_default:9
       │    │    │    ├── project
       │    │    │    │    ├── columns: c_default:9 column1:7!null column2:8!null
-      │    │    │    │    ├── project
+      │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:7!null column2:8!null
-      │    │    │    │    │    └── values
-      │    │    │    │    │         ├── columns: column1:7!null column2:8!null
-      │    │    │    │    │         └── (1, 2)
+      │    │    │    │    │    └── (1, 2)
       │    │    │    │    └── projections
       │    │    │    │         └── NULL::INT8 [as=c_default:9]
       │    │    │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -100,11 +100,9 @@ insert t
  │    └── v_comp:8 => v:3
  └── project
       ├── columns: v_comp:8!null column1:6!null column2:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null
-      │         └── (1, 1)
+      │    └── (1, 1)
       └── projections
            └── column1:6 + column2:7 [as=v_comp:8]
 
@@ -121,11 +119,9 @@ insert t
       ├── columns: v_comp:8 column1:6!null b_default:7
       ├── project
       │    ├── columns: b_default:7 column1:6!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:6!null
-      │    │    └── values
-      │    │         ├── columns: column1:6!null
-      │    │         └── (1,)
+      │    │    └── (1,)
       │    └── projections
       │         └── NULL::INT8 [as=b_default:7]
       └── projections
@@ -149,11 +145,9 @@ project
       │    └── v_comp:8 => v:3
       └── project
            ├── columns: v_comp:8!null column1:6!null column2:7!null
-           ├── project
+           ├── values
            │    ├── columns: column1:6!null column2:7!null
-           │    └── values
-           │         ├── columns: column1:6!null column2:7!null
-           │         └── (1, 1)
+           │    └── (1, 1)
            └── projections
                 └── column1:6 + column2:7 [as=v_comp:8]
 
@@ -168,11 +162,9 @@ insert t_idx
  │    └── v_comp:8 => v:3
  └── project
       ├── columns: v_comp:8!null column1:6!null column2:7!null
-      ├── project
+      ├── values
       │    ├── columns: column1:6!null column2:7!null
-      │    └── values
-      │         ├── columns: column1:6!null column2:7!null
-      │         └── (1, 1)
+      │    └── (1, 1)
       └── projections
            └── column1:6 + column2:7 [as=v_comp:8]
 
@@ -191,11 +183,9 @@ insert t_check
       ├── columns: check1:11!null check2:12!null column1:7!null column2:8!null v_comp:9!null w_comp:10!null
       ├── project
       │    ├── columns: v_comp:9!null w_comp:10!null column1:7!null column2:8!null
-      │    ├── project
+      │    ├── values
       │    │    ├── columns: column1:7!null column2:8!null
-      │    │    └── values
-      │    │         ├── columns: column1:7!null column2:8!null
-      │    │         └── (1, 1)
+      │    │    └── (1, 1)
       │    └── projections
       │         ├── column1:7 + column2:8 [as=v_comp:9]
       │         └── column1:7 * column2:8 [as=w_comp:10]
@@ -842,11 +832,9 @@ project
            │    ├── columns: column1:6!null column2:7!null v_comp:8!null
            │    ├── project
            │    │    ├── columns: v_comp:8!null column1:6!null column2:7!null
-           │    │    ├── project
+           │    │    ├── values
            │    │    │    ├── columns: column1:6!null column2:7!null
-           │    │    │    └── values
-           │    │    │         ├── columns: column1:6!null column2:7!null
-           │    │    │         └── (1, 1)
+           │    │    │    └── (1, 1)
            │    │    └── projections
            │    │         └── column1:6 + column2:7 [as=v_comp:8]
            │    ├── project
@@ -885,11 +873,9 @@ insert t_idx2
       │    ├── columns: column1:8!null column2:9!null column3:10!null v_comp:11!null w_comp:12!null
       │    ├── project
       │    │    ├── columns: v_comp:11!null w_comp:12!null column1:8!null column2:9!null column3:10!null
-      │    │    ├── project
+      │    │    ├── values
       │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    └── values
-      │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │         └── (1, 1, 1)
+      │    │    │    └── (1, 1, 1)
       │    │    └── projections
       │    │         ├── column1:8 + column2:9 [as=v_comp:11]
       │    │         └── column3:10 + 1 [as=w_comp:12]
@@ -941,11 +927,9 @@ insert t_idx2
       │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null v_comp:11!null w_comp:12!null
       │    │    │    ├── project
       │    │    │    │    ├── columns: v_comp:11!null w_comp:12!null column1:8!null column2:9!null column3:10!null
-      │    │    │    │    ├── project
+      │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │    │    └── values
-      │    │    │    │    │         ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    │    │    │         └── (1, 1, 1)
+      │    │    │    │    │    └── (1, 1, 1)
       │    │    │    │    └── projections
       │    │    │    │         ├── column1:8 + column2:9 [as=v_comp:11]
       │    │    │    │         └── column3:10 + 1 [as=w_comp:12]

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -667,14 +667,12 @@ with &1 (t)
                 ├── columns: b_default:13 rowid_default:14 "?column?":12
                 ├── project
                 │    ├── columns: "?column?":12
-                │    └── project
-                │         ├── columns: "?column?":12
-                │         ├── with-scan &1 (t)
-                │         │    ├── columns: a:11
-                │         │    └── mapping:
-                │         │         └──  x.a:1 => a:11
-                │         └── projections
-                │              └── a:11 + 20 [as="?column?":12]
+                │    ├── with-scan &1 (t)
+                │    │    ├── columns: a:11
+                │    │    └── mapping:
+                │    │         └──  x.a:1 => a:11
+                │    └── projections
+                │         └── a:11 + 20 [as="?column?":12]
                 └── projections
                      ├── NULL::INT8 [as=b_default:13]
                      └── unique_rowid() [as=rowid_default:14]
@@ -1448,12 +1446,10 @@ with &2
  │         │    └── rowid_default:14 => rowid:9
  │         └── project
  │              ├── columns: rowid_default:14 column1:12!null column2:13!null
- │              ├── project
+ │              ├── values
  │              │    ├── columns: column1:12!null column2:13!null
- │              │    └── values
- │              │         ├── columns: column1:12!null column2:13!null
- │              │         ├── (1, 1)
- │              │         └── (2, 2)
+ │              │    ├── (1, 1)
+ │              │    └── (2, 2)
  │              └── projections
  │                   └── unique_rowid() [as=rowid_default:14]
  └── with &3 (cte)
@@ -1675,11 +1671,9 @@ explain
       │         │    └── rowid_default:6 => rowid:2
       │         └── project
       │              ├── columns: rowid_default:6 column1:5!null
-      │              ├── project
+      │              ├── values
       │              │    ├── columns: column1:5!null
-      │              │    └── values
-      │              │         ├── columns: column1:5!null
-      │              │         └── (1,)
+      │              │    └── (1,)
       │              └── projections
       │                   └── unique_rowid() [as=rowid_default:6]
       └── with-scan &1 (foo)
@@ -1710,14 +1704,12 @@ with &1 (b)
            ├── columns: rowid_default:8 w:7!null
            ├── project
            │    ├── columns: w:7!null
-           │    └── project
-           │         ├── columns: w:7!null
-           │         ├── with-scan &1 (b)
-           │         │    ├── columns: z:6!null
-           │         │    └── mapping:
-           │         │         └──  column1:5 => z:6
-           │         └── projections
-           │              └── z:6 + 1 [as=w:7]
+           │    ├── with-scan &1 (b)
+           │    │    ├── columns: z:6!null
+           │    │    └── mapping:
+           │    │         └──  column1:5 => z:6
+           │    └── projections
+           │         └── z:6 + 1 [as=w:7]
            └── projections
                 └── unique_rowid() [as=rowid_default:8]
 

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1592,7 +1592,7 @@ update cardsinfo [as=ci]
       │         └── const-agg [as=q:37, outer=(37)]
       │              └── q:37
       └── projections
-           ├── crdb_internal.round_decimal_values((buyprice:23::DECIMAL - discount:25::DECIMAL)::DECIMAL(10,4), 4) [as=discountbuyprice_comp:53, outer=(23,25), immutable]
+           ├── crdb_internal.round_decimal_values(buyprice:23::DECIMAL - discount:25::DECIMAL, 4) [as=discountbuyprice_comp:53, outer=(23,25), immutable]
            ├── CAST(NULL AS STRING) [as=notes_default:50]
            ├── 0 [as=oldinventory_default:51]
            └── COALESCE(sum_int:47, 0) [as=actualinventory_new:49, outer=(47)]


### PR DESCRIPTION
#### opt: do not add empty project when no assignment casts are necessary

This commit prevents optbuilder from building empty project expressions
when no assignment casts are necessary.

It also fixes a minor bug with the scope of assignment cast projections.
Rather than pushing a new scope onto `mb.outScope` for assignment casts,
it replaces `mb.outScope` with a new scope. This bug causes no
observable effect with the current assignment code-paths, but would
cause problems as more assignment cast support is added.

Release note: None

#### sql: add assignment casts for DEFAULT and computed columns for INSERTs

This commit adds assignment casts to INSERTS for DEFAULT and computed
column expressions when the type of the expression is not identical to
the column's type.

This change required removing `tree.ReType` from
`scope.resolveAndRequireType`, which causes a regression of the
`update-col-cast-bug` test. This will be fixed in a future commit when
assignment casts are added for UPDATEs.

Release note: None
