### PR TITLE
sql: deprecate "GRANT" privilege

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2303,6 +2303,20 @@ func (c *clusterImpl) ConnE(ctx context.Context, node int) (*gosql.DB, error) {
 	return db, nil
 }
 
+// ConnEAsUser returns a SQL connection to the specified node as a specific user
+func (c *clusterImpl) ConnEAsUser(ctx context.Context, node int, user string) (*gosql.DB, error) {
+	urls, err := c.ExternalPGUrl(ctx, c.Node(node))
+	if err != nil {
+		return nil, err
+	}
+	dataSourceName := strings.Replace(urls[0], "root", user, 1)
+	db, err := gosql.Open("postgres", dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
 func (c *clusterImpl) MakeNodes(opts ...option.Option) string {
 	var r option.NodeListOption
 	for _, o := range opts {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -71,6 +71,7 @@ type Cluster interface {
 
 	Conn(ctx context.Context, node int) *gosql.DB
 	ConnE(ctx context.Context, node int) (*gosql.DB, error)
+	ConnEAsUser(ctx context.Context, node int, user string) (*gosql.DB, error)
 
 	// URLs for the Admin UI.
 

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -115,6 +115,7 @@ func RegisterTests(r registry.Registry) {
 	registerKVBench(r)
 	registerTypeORM(r)
 	registerLoadSplits(r)
+	registerValidateGrantOption(r)
 	registerVersion(r)
 	registerYCSB(r)
 	registerTPCHBench(r)

--- a/pkg/cmd/roachtest/tests/validate_grant_option.go
+++ b/pkg/cmd/roachtest/tests/validate_grant_option.go
@@ -1,0 +1,161 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/stretchr/testify/require"
+)
+
+func registerValidateGrantOption(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:    "sql-experience/validate-grant-option",
+		Owner:   registry.OwnerSQLExperience,
+		Cluster: r.MakeClusterSpec(3),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runRegisterValidateGrantOption(ctx, t, c, *t.BuildVersion())
+		},
+	})
+}
+
+// execSQL executes the SQL statement as "root".
+func execSQL(sqlStatement string, expectedErrText string, node int) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		conn, err := u.c.ConnE(ctx, node)
+		require.NoError(t, err)
+		_, err = conn.Exec(sqlStatement)
+		if len(expectedErrText) == 0 {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+			if err.Error() != expectedErrText {
+				fmt.Println("expected error was ", expectedErrText, "but received ", err.Error())
+				t.FailNow()
+			}
+		}
+	}
+}
+
+// execSQLAsUser executes the SQL statement as the specified user.
+func execSQLAsUser(sqlStatement string, user string, expectedErrText string, node int) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		conn, err := u.c.ConnEAsUser(ctx, node, user)
+		require.NoError(t, err)
+		_, err = conn.Exec(sqlStatement)
+		if len(expectedErrText) == 0 {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+			if err.Error() != expectedErrText {
+				fmt.Println("expected error was ", expectedErrText, "but received ", err.Error())
+				t.FailNow()
+			}
+		}
+	}
+}
+
+func runRegisterValidateGrantOption(
+	ctx context.Context, t test.Test, c cluster.Cluster, buildVersion version.Version,
+) {
+	const mainVersion = ""
+	predecessorVersion, err := PredecessorVersion(buildVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u := newVersionUpgradeTest(c,
+		uploadAndStart(c.All(), predecessorVersion),
+		waitForUpgradeStep(c.All()),
+		preventAutoUpgradeStep(1),
+		preventAutoUpgradeStep(2),
+		preventAutoUpgradeStep(3),
+
+		// No nodes have been upgraded; any user can grant or revoke a privilege that they hold (grant options
+		// are ignored).
+		execSQL("CREATE USER foo;", "", 1),
+		execSQL("CREATE USER foo2;", "", 2),
+		execSQL("CREATE USER foo3;", "", 2),
+		execSQL("CREATE USER foo4;", "", 2),
+		execSQL("CREATE USER target;", "", 1),
+
+		execSQL("CREATE DATABASE d;", "", 2),
+		execSQL("CREATE SCHEMA s;", "", 3),
+		execSQL("CREATE TABLE t1();", "", 2),
+		execSQL("CREATE TYPE ty AS ENUM();", "", 3),
+
+		execSQL("GRANT ALL PRIVILEGES ON DATABASE d TO foo;", "", 1),
+		execSQL("GRANT ALL PRIVILEGES ON SCHEMA s TO foo2;", "", 3),
+		execSQL("GRANT ALL PRIVILEGES ON TABLE t1 TO foo3;", "", 1),
+		execSQL("GRANT ALL PRIVILEGES ON TYPE ty TO foo4;", "", 1),
+
+		execSQLAsUser("SELECT * FROM t1;", "foo3", "", 2),
+		execSQLAsUser("GRANT CREATE ON DATABASE d TO target;", "foo", "", 1),
+		execSQLAsUser("GRANT USAGE ON SCHEMA s TO target;", "foo2", "", 3),
+		execSQLAsUser("GRANT SELECT ON TABLE t1 TO target;", "foo3", "", 1),
+		execSQLAsUser("GRANT USAGE ON TYPE ty TO target;", "foo4", "", 1),
+
+		// Node 1 is upgraded; because nodes 2 and 3 are on the previous version, any user can still grant
+		// or revoke a privilege that they hold (grant options are ignored).
+		binaryUpgradeStep(c.Node(1), mainVersion),
+		allowAutoUpgradeStep(1),
+		execSQLAsUser("GRANT CREATE ON DATABASE d TO target;", "foo", "", 1),
+		execSQLAsUser("GRANT USAGE ON SCHEMA s TO target;", "foo2", "", 3),
+		execSQLAsUser("GRANT INSERT ON TABLE t1 TO target;", "foo3", "", 2),
+		execSQLAsUser("GRANT GRANT ON TYPE ty TO target;", "foo4", "", 2),
+
+		// Node 2 is upgraded; because node 3 is on the previous version, any user can still grant or revoke
+		// a privilege that they hold (grant options are ignored).
+		binaryUpgradeStep(c.Node(2), mainVersion),
+		allowAutoUpgradeStep(2),
+		execSQLAsUser("GRANT ALL PRIVILEGES ON DATABASE d TO target;", "foo", "", 3),
+		execSQLAsUser("GRANT ALL PRIVILEGES ON SCHEMA s TO target;", "foo2", "", 2),
+		execSQLAsUser("GRANT ALL PRIVILEGES ON TABLE t1 TO target;", "foo3", "", 1),
+		execSQLAsUser("GRANT ALL PRIVILEGES ON TYPE ty TO target;", "foo4", "", 1),
+		execSQLAsUser("GRANT GRANT ON DATABASE d TO foo2;", "foo", "", 1),
+		execSQLAsUser("GRANT GRANT ON SCHEMA s TO foo3;", "foo2", "", 1),
+		execSQLAsUser("GRANT GRANT, SELECT ON TABLE t1 TO foo4;", "foo3", "", 2),
+		execSQLAsUser("GRANT DELETE ON TABLE t1 TO foo4;", "foo3", "", 2),
+
+		// Node 3 is upgraded; because all the nodes have been upgraded, the migration will begin running after
+		// allowAutoUpgradeStep(3). The roachtest will ensure that the migration will be complete before moving
+		// beyond waitForUpgradeStep(c.All()).
+		binaryUpgradeStep(c.Node(3), mainVersion),
+		allowAutoUpgradeStep(3),
+		waitForUpgradeStep(c.All()),
+
+		// All the nodes have been upgraded and the migration has finished; existing users will have had their grant
+		// option bits set equal to their privilege bits if they hold "GRANT" or "ALL" privileges. Grant options will
+		// now be enforced (an error will be returned if a user tries to grant a privilege they do not hold grant
+		// options for, which corresponds to "true" in the errorExpected field).
+		execSQLAsUser("GRANT DELETE ON TABLE t1 TO foo2;", "foo3", "", 3),
+		execSQLAsUser("GRANT ALL PRIVILEGES ON SCHEMA s TO foo3;", "target", "", 2),
+		execSQLAsUser("GRANT CREATE ON DATABASE d TO foo3;", "foo2", "pq: user foo2 does not have CREATE privilege on database d", 2),
+		execSQLAsUser("GRANT USAGE ON SCHEMA s TO foo;", "foo3", "pq: missing WITH GRANT OPTION privilege type USAGE", 2),
+		execSQLAsUser("GRANT INSERT ON TABLE t1 TO foo;", "foo4", "pq: user foo4 does not have INSERT privilege on relation t1", 1),
+		execSQLAsUser("GRANT SELECT ON TABLE t1 TO foo;", "foo4", "", 1),
+		execSQLAsUser("GRANT DELETE ON TABLE t1 TO foo;", "foo4", "", 1),
+
+		execSQL("CREATE USER foo5;", "", 2),
+		execSQL("CREATE USER foo6;", "", 2),
+		execSQL("CREATE TABLE t2();", "", 3),
+		execSQL("GRANT ALL PRIVILEGES ON TABLE t2 TO foo5;", "", 1),
+		execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo5", "pq: missing WITH GRANT OPTION privilege type DELETE", 2),
+		execSQL("GRANT ALL PRIVILEGES ON TABLE t2 TO foo6 WITH GRANT OPTION;", "", 1),
+		execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo6", "", 3),
+	)
+	u.run(ctx, t)
+}

--- a/pkg/cmd/roachtest/tests/validate_grant_option.go
+++ b/pkg/cmd/roachtest/tests/validate_grant_option.go
@@ -144,7 +144,7 @@ func runRegisterValidateGrantOption(
 		execSQLAsUser("GRANT DELETE ON TABLE t1 TO foo2;", "foo3", "", 3),
 		execSQLAsUser("GRANT ALL PRIVILEGES ON SCHEMA s TO foo3;", "target", "", 2),
 		execSQLAsUser("GRANT CREATE ON DATABASE d TO foo3;", "foo2", "pq: user foo2 does not have CREATE privilege on database d", 2),
-		execSQLAsUser("GRANT USAGE ON SCHEMA s TO foo;", "foo3", "pq: missing WITH GRANT OPTION privilege type USAGE", 2),
+		//execSQLAsUser("GRANT USAGE ON SCHEMA s TO foo;", "foo3", "pq: missing WITH GRANT OPTION privilege type USAGE", 2),
 		execSQLAsUser("GRANT INSERT ON TABLE t1 TO foo;", "foo4", "pq: user foo4 does not have INSERT privilege on relation t1", 1),
 		execSQLAsUser("GRANT SELECT ON TABLE t1 TO foo;", "foo4", "", 1),
 		execSQLAsUser("GRANT DELETE ON TABLE t1 TO foo;", "foo4", "", 1),
@@ -153,9 +153,23 @@ func runRegisterValidateGrantOption(
 		execSQL("CREATE USER foo6;", "", 2),
 		execSQL("CREATE TABLE t2();", "", 3),
 		execSQL("GRANT ALL PRIVILEGES ON TABLE t2 TO foo5;", "", 1),
-		execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo5", "pq: missing WITH GRANT OPTION privilege type DELETE", 2),
+		//execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo5", "pq: missing WITH GRANT OPTION privilege type DELETE", 2),
+		execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo5", "", 2),
 		execSQL("GRANT ALL PRIVILEGES ON TABLE t2 TO foo6 WITH GRANT OPTION;", "", 1),
 		execSQLAsUser("GRANT DELETE ON TABLE t2 TO foo2;", "foo6", "", 3),
+
+		// This section below exists solely for version 22.1 (GRANT privilege deprecation), delete once removed in 22.2
+		execSQL("CREATE USER foo7;", "", 2),
+		execSQL("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo7;", "", 1),
+		execSQLAsUser("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo2;", "foo7", "pq: missing WITH GRANT OPTION privilege type SELECT", 3),
+		execSQL("GRANT GRANT ON TABLE t2 TO foo7;", "", 1),
+		execSQLAsUser("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo2;", "foo7", "", 3),
+		execSQL("REVOKE GRANT OPTION FOR GRANT ON TABLE t2 FROM foo7;", "", 1),
+		execSQLAsUser("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo2;", "foo7", "", 3),
+		execSQL("REVOKE GRANT ON TABLE t2 FROM foo7;", "", 1),
+		execSQLAsUser("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo2;", "foo7", "pq: missing WITH GRANT OPTION privilege type SELECT", 2),
+		execSQL("GRANT ALL PRIVILEGES ON TABLE t2 TO foo7;", "", 1),
+		execSQLAsUser("GRANT SELECT, INSERT, DELETE ON TABLE t2 TO foo2;", "foo7", "", 3),
 	)
 	u.run(ctx, t)
 }

--- a/pkg/migration/migrations/grant_option_migration.go
+++ b/pkg/migration/migrations/grant_option_migration.go
@@ -1,0 +1,156 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/migration"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+func maybeAddGrantOptions(b catalog.DescriptorBuilder) {
+	switch b.DescriptorType() {
+	case catalog.Database:
+		dbdesc.MaybeAddGrantOptionsDatabase(b.(dbdesc.DatabaseDescriptorBuilder))
+	case catalog.Schema:
+		schemadesc.MaybeAddGrantOptionsSchema(b.(schemadesc.SchemaDescriptorBuilder))
+	case catalog.Table:
+		tabledesc.MaybeAddGrantOptionsTable(b.(tabledesc.TableDescriptorBuilder))
+	case catalog.Type:
+		typedesc.MaybeAddGrantOptionsType(b.(typedesc.TypeDescriptorBuilder))
+	}
+}
+
+// grantOptionMigration iterates through every descriptor and sets a user's grant option bits
+// equal to its privilege bits if it holds the "GRANT" privilege.
+func grantOptionMigration(
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.TenantDeps, _ *jobs.Job,
+) error {
+	query := `SELECT id, descriptor, crdb_internal_mvcc_timestamp FROM system.descriptor ORDER BY ID ASC`
+	rows, err := d.InternalExecutor.QueryIterator(
+		ctx, "retrieve-grant-options", nil /* txn */, query,
+	)
+	if err != nil {
+		return err
+	}
+
+	addGrantOptionFunc := func(ids []descpb.ID, descs []descpb.Descriptor, timestamps []hlc.Timestamp) error {
+		var modifiedDescs []catalog.MutableDescriptor
+		for i, id := range ids {
+			b := catalogkv.NewBuilderWithMVCCTimestamp(&descs[i], timestamps[i])
+			if b == nil {
+				return errors.Newf("unable to find descriptor for id %d", id)
+			}
+
+			err := b.RunMigrationChanges(maybeAddGrantOptions)
+			if err != nil {
+				return err
+			}
+			mutableDesc := b.BuildExistingMutable()
+
+			modifiedDescs = append(modifiedDescs, mutableDesc)
+		}
+		if err := writeModifiedDescriptors(ctx, d, modifiedDescs); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return addGrantOptionMigration(ctx, rows, addGrantOptionFunc, 1<<19 /* 512 KiB batch size */)
+}
+
+// addGrantOptionFunction is used in addGrantOptionMigration to maybe add grant options
+// of descriptors specified by the id.
+type addGrantOptionFunction func(ids []descpb.ID, descs []descpb.Descriptor, timestamps []hlc.Timestamp) error
+
+// addGrantOptionMigration is an abstraction for adding grant options.
+// The rows provided should be the result of a select ID, descriptor, crdb_internal_mvcc_timestamp
+// from system.descriptor table.
+// The datums returned from the query are parsed to grab the descpb.Descriptor
+// and addGrantOptionFunction is called on the desc.
+// If minBatchSizeInBytes is specified, fixDescriptors will only be called once the
+// size of the descriptors in the id array surpasses minBatchSizeInBytes.
+func addGrantOptionMigration(
+	ctx context.Context,
+	rows sqlutil.InternalRows,
+	grantOptionFunc addGrantOptionFunction,
+	minBatchSizeInBytes int,
+) error {
+	defer func() { _ = rows.Close() }()
+	ok, err := rows.Next(ctx)
+	if err != nil {
+		return err
+	}
+	currSize := 0 // in bytes.
+	var ids []descpb.ID
+	var descs []descpb.Descriptor
+	var timestamps []hlc.Timestamp
+	for ; ok; ok, err = rows.Next(ctx) {
+		if err != nil {
+			return err
+		}
+		datums := rows.Cur()
+		id, desc, ts, err := unmarshalDescFromDescriptorRow(datums)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		descs = append(descs, desc)
+		timestamps = append(timestamps, ts)
+		currSize += desc.Size()
+		if currSize > minBatchSizeInBytes || minBatchSizeInBytes == 0 {
+			err = grantOptionFunc(ids, descs, timestamps)
+			if err != nil {
+				return err
+			}
+			// Reset size and id array after the batch is fixed.
+			currSize = 0
+			ids = nil
+			descs = nil
+			timestamps = nil
+		}
+	}
+	// Fix remaining descriptors.
+	return grantOptionFunc(ids, descs, timestamps)
+}
+
+// writeModifiedDescriptors writes the descriptors that we have given grant option privileges
+// to back to batch
+func writeModifiedDescriptors(
+	ctx context.Context, d migration.TenantDeps, modifiedDescs []catalog.MutableDescriptor,
+) error {
+	return d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+	) error {
+		batch := txn.NewBatch()
+		for _, desc := range modifiedDescs {
+			err := catalogkv.WriteDescToBatch(ctx, false, d.Settings, batch, d.Codec, desc.GetID(), desc)
+			if err != nil {
+				return err
+			}
+		}
+		return txn.Run(ctx, batch)
+	})
+}

--- a/pkg/migration/migrations/grant_option_migration_external_test.go
+++ b/pkg/migration/migrations/grant_option_migration_external_test.go
@@ -1,0 +1,217 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations_test
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantOptionMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Test when a user holds privileges on a database, schema, and table
+	/*
+			   CREATE USER testuser;
+				 CREATE DATABASE db;
+				 GRANT CREATE ON DATABASE db TO testuser;
+				 USE db;
+				 CREATE SCHEMA s;
+				 CREATE TABLE t1();
+		     GRANT CREATE ON SCHEMA s TO testuser;
+				 GRANT INSERT, SELECT ON TABLE t1 TO testuser;
+
+			   	The descriptors were then extracted using:
+
+			   	SELECT encode(descriptor, 'hex') AS descriptor
+			     FROM system.descriptor
+			    WHERE id
+			          IN (
+			               SELECT id
+			                 FROM system.namespace
+			                WHERE "parentID"
+			                      = (
+			                           SELECT id
+			                             FROM system.namespace
+			                            WHERE "parentID" = 0 AND name = 'db'
+			                       )
+			                   OR "parentID" = 0 AND name = 'db'
+			           );
+
+	*/
+	const objectTest = `
+124e0a02646210341a310a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100418001204726f6f741802220028033a090a017312040835100040004a005a00
+22420834120173183522310a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100418001204726f6f7418022a00300240004a00
+0aab020a0274311836203428023a00423a0a05726f77696410011a0c08011040180030005014600020002a0e756e697175655f726f77696428293001680070007800800100880100980100480252500a0774315f706b6579100118012205726f776964300140004a10080010001a00200028003000380040005a007a0408002000800100880100900104980101a20106080012001800a80100b20100ba010060026a310a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572106418001204726f6f741802800101880103980100b201160a077072696d61727910001a05726f77696420012800b80101c20100e80100f2010408001200f801008002009202009a020a08d8bfcfc594a985dc16b20200b80200c0021dc80200e00200f00200
+`
+
+	// Check that descriptors for multiple users are pulled and updated when
+	// creating schemas and tables within those schemas
+	/*
+		   	CREATE USER testuser;
+				CREATE USER testuser2;
+				CREATE DATABASE db;
+				USE db;
+				GRANT ALL PRIVILEGES ON DATABASE db TO testuser;
+				CREATE schema s;
+				CREATE table s.t1();
+				CREATE table s.t2();
+				GRANT GRANT, CREATE ON SCHEMA s TO testuser2;
+				GRANT SELECT, DELETE ON TABLE s.t1 TO testuser2;
+				GRANT ALL PRIVILEGES ON TABLE s.t2 TO testuser2;
+
+		   	The descriptors were then extracted using:
+
+		   	SELECT encode(descriptor, 'hex') AS descriptor
+		     FROM system.descriptor
+		    WHERE id
+		          IN (
+		               SELECT id
+		                 FROM system.namespace
+		                WHERE "parentID"
+		                      = (
+		                           SELECT id
+		                             FROM system.namespace
+		                            WHERE "parentID" = 0 AND name = 'db'
+		                       )
+		                   OR "parentID" = 0 AND name = 'db'
+		           );
+
+	*/
+	const multipleUsersTest = `
+124e0a02646210341a310a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100218021204726f6f741802220028033a090a017312040835100040004a005a00
+22530834120173183522420a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100218020a0f0a09746573747573657232101418001204726f6f7418022a00300240004a00
+0abd020a0274311836203428023a00423a0a05726f77696410011a0c08011040180030005014600020002a0e756e697175655f726f77696428293001680070007800800100880100980100480252500a0774315f706b6579100118012205726f776964300140004a10080010001a00200028003000380040005a007a0408002000800100880100900104980101a20106080012001800a80100b20100ba010060026a430a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100218020a100a0974657374757365723210a00118001204726f6f741802800101880103980100b201160a077072696d61727910001a05726f77696420012800b80101c20100e80100f2010408001200f801008002009202009a020a08b8b091afa2d484dc16b20200b80200c00235c80200e00200f00200
+0abc020a0274321837203428023a00423a0a05726f77696410011a0c08011040180030005014600020002a0e756e697175655f726f77696428293001680070007800800100880100980100480252500a0774325f706b6579100118012205726f776964300140004a10080010001a00200028003000380040005a007a0408002000800100880100900104980101a20106080012001800a80100b20100ba010060026a420a0b0a0561646d696e100218020a0a0a04726f6f74100218020a0e0a087465737475736572100218020a0f0a09746573747573657232100218001204726f6f741802800101880103980100b201160a077072696d61727910001a05726f77696420012800b80101c20100e80100f2010408001200f801008002009202009a020a08d8efb894b8d484dc16b20200b80200c00235c80200e00200f00200
+`
+
+	// Test the migration for types
+	/*
+			   CREATE USER testuser;
+				 CREATE DATABASE db;
+				 USE db;
+				 CREATE schema s;
+				 CREATE TYPE ty AS ENUM();
+		     CREATE TYPE s.ty2 AS ENUM();
+				 GRANT USAGE ON TYPE ty TO testuser;
+				 GRANT ALL PRIVILEGES ON TYPE s.ty2 TO testuser;
+
+			   	The descriptors were then extracted using:
+
+			   	SELECT encode(descriptor, 'hex') AS descriptor
+			     FROM system.descriptor
+			    WHERE id
+			          IN (
+			               SELECT id
+			                 FROM system.namespace
+			                WHERE "parentID"
+			                      = (
+			                           SELECT id
+			                             FROM system.namespace
+			                            WHERE "parentID" = 0 AND name = 'db'
+			                       )
+			                   OR "parentID" = 0 AND name = 'db'
+			           );
+
+	*/
+	const typesTest = `
+123e0a02646210341a210a0b0a0561646d696e100218020a0a0a04726f6f74100218021204726f6f741802220028023a090a017312040835100040004a005a00
+22320834120173183522210a0b0a0561646d696e100218020a0a0a04726f6f74100218021204726f6f7418022a00300140004a00
+1a590834101d1a02747920362800403748025200680072410a0b0a0561646d696e100218020a0d0a067075626c696310800418000a0a0a04726f6f74100218020a0f0a08746573747573657210800418001204726f6f7418027a00
+1a710834101d1a035f7479203728013a26080f100018003000381850d78d065a14081810001800300050d68d0660007a0410d78d066000400048015200680072300a0b0a0561646d696e100218020a0d0a067075626c696310800418000a0a0a04726f6f74100218021204726f6f7418027a00
+1a59083410351a0374793220382800403948025200680072400a0b0a0561646d696e100218020a0d0a067075626c696310800418000a0a0a04726f6f74100218020a0e0a087465737475736572100218001204726f6f7418027a00
+1a72083410351a045f747932203928013a26080f100018003000381850d98d065a14081810001800300050d88d0660007a0410d98d066000400048015200680072300a0b0a0561646d696e100218020a0d0a067075626c696310800418000a0a0a04726f6f74100218021204726f6f7418027a00
+`
+
+	testCases := []string{
+		objectTest,
+		multipleUsersTest,
+		typesTest,
+	}
+	for _, descriptorStringsToInject := range testCases {
+		var descriptorsToInject []*descpb.Descriptor
+		for _, s := range strings.Split(strings.TrimSpace(descriptorStringsToInject), "\n") {
+			encoded, err := hex.DecodeString(s)
+			require.NoError(t, err)
+			var desc descpb.Descriptor
+			require.NoError(t, protoutil.Unmarshal(encoded, &desc))
+			descriptorsToInject = append(descriptorsToInject, &desc)
+		}
+
+		ctx := context.Background()
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						DisableAutomaticVersionUpgrade: 1,
+						BinaryVersionOverride:          clusterversion.ByKey(clusterversion.ValidateGrantOption - 1), // changed cluster version
+					},
+				},
+			},
+		})
+
+		db := tc.ServerConn(0)
+		kvDB := tc.Server(0).DB()
+		require.NoError(t, sqlutils.InjectDescriptors(
+			ctx, db, descriptorsToInject, true, /* force */
+		))
+
+		_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+			clusterversion.ByKey(clusterversion.ValidateGrantOption).String())
+		require.NoError(t, err)
+
+		err = kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// GetAllDescriptors calls PrivilegeDescriptor.Validate, all the invalid
+			// descriptors should be updated.
+			descs, err := catalogkv.GetAllDescriptors(ctx, txn, keys.SystemSQLCodec, false /* shouldRunPostDeserializationChanges */)
+			if err != nil {
+				return err
+			}
+
+			for _, desc := range descs {
+				privilegeDesc := desc.GetPrivileges()
+				for _, u := range privilegeDesc.Users {
+					if privilege.GRANT.IsSetIn(u.Privileges) || privilege.ALL.IsSetIn(u.Privileges) {
+						if u.UserProto.Decode().IsAdminRole() || u.UserProto.Decode().IsRootUser() || u.UserProto.Decode().IsNodeUser() {
+							continue
+						}
+
+						if u.Privileges != u.WithGrantOption {
+							return errors.Newf("grant options not updated properly for %d, Privileges: %d, Grant Option: %d", u.User(), u.Privileges, u.WithGrantOption)
+						}
+					}
+				}
+
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		tc.Stopper().Stop(ctx)
+	}
+}

--- a/pkg/migration/migrations/migrations.go
+++ b/pkg/migration/migrations/migrations.go
@@ -142,6 +142,12 @@ var migrations = []migration.Migration{
 		NoPrecondition,
 		alterSystemStmtDiagReqs,
 	),
+	migration.NewTenantMigration(
+		"track grant options on users and enable granting/revoking with them",
+		toCV(clusterversion.ValidateGrantOption),
+		NoPrecondition,
+		grantOptionMigration,
+	),
 }
 
 func init() {

--- a/pkg/sql/catalog/catprivilege/fix.go
+++ b/pkg/sql/catalog/catprivilege/fix.go
@@ -138,3 +138,43 @@ func MaybeFixPrivileges(
 	}
 	return changed
 }
+
+// MaybeUpdateGrantOptions iterates over the users of the descriptor and checks
+// if they have the GRANT privilege - if so, then set the user's grant option
+// bits equal to the privilege bits.
+func MaybeUpdateGrantOptions(ptr **descpb.PrivilegeDescriptor) bool {
+	p := *ptr
+	changed := false
+	if p.Version >= descpb.GrantOptionVersion {
+		// do not apply changes because the grant bits will have already been set.
+		return changed
+	}
+
+	for i := range p.Users {
+		u := &p.Users[i]
+
+		if u.User().IsRootUser() || u.User().IsAdminRole() {
+			// we've already checked superusers.
+			continue
+		}
+
+		if privilege.ALL.IsSetIn(u.Privileges) {
+			if !privilege.ALL.IsSetIn(u.WithGrantOption) {
+				changed = true
+			}
+			u.WithGrantOption = privilege.ALL.Mask()
+			continue
+		}
+		if privilege.GRANT.IsSetIn(u.Privileges) {
+			if u.Privileges != u.WithGrantOption {
+				changed = true
+			}
+			u.WithGrantOption |= u.Privileges
+		}
+	}
+
+	p.SetVersion(descpb.GrantOptionVersion)
+	changed = true
+
+	return changed
+}

--- a/pkg/sql/catalog/descpb/privilege.go
+++ b/pkg/sql/catalog/descpb/privilege.go
@@ -41,6 +41,11 @@ const (
 	// These descriptors should have all the correct privileges and the owner field
 	// explicitly set. These descriptors should be strictly validated.
 	Version21_2
+
+	// GrantOptionVersion corresponds to descriptors created in 22.1 and onwards.
+	// These descriptors should have grant options for all their privileges
+	// if they have the GRANT or ALL were created prior to 22.1.
+	GrantOptionVersion
 )
 
 // Owner accesses the owner field.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -64,6 +64,10 @@ const (
 	IncludeConstraints = 0
 )
 
+// MigrationWorkFunc represents the work that is applied when
+// RunMigrationOnlyChanges() is called
+type MigrationWorkFunc = func(b DescriptorBuilder)
+
 // DescriptorBuilder interfaces are used to build catalog.Descriptor
 // objects.
 type DescriptorBuilder interface {
@@ -79,6 +83,13 @@ type DescriptorBuilder interface {
 	// argument is a DescGetter and a nil value will cause table foreign-key
 	// representation upgrades to be skipped.
 	RunPostDeserializationChanges(ctx context.Context, dg DescGetter) error
+
+	// RunMigrationChanges also attempts to perform post-deserialization
+	// changes to the descriptor being built, similar to RunPostDeserializationChanges
+	// above. The difference is that these changes will only ever be run during the
+	// migration in grant_option_migration.go and will stop once all nodes are upgraded
+	// and waitForUpgradeStep(c.All()) is called.
+	RunMigrationChanges(workFuncs ...MigrationWorkFunc) error
 
 	// BuildImmutable returns an immutable Descriptor.
 	BuildImmutable() Descriptor

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -338,6 +338,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		n.dbDesc.GetID(),
 		params.SessionData().User(), tree.Tables, n.dbDesc.GetPrivileges(),
 	)
+
 	var desc *tabledesc.Mutable
 	var affected map[descpb.ID]*tabledesc.Mutable
 	// creationTime is initialized to a zero value and populated at read time.

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
@@ -1,4 +1,13 @@
+# TODO(jack.wu): Replace these tests once the GRANT privilege is removed in 22.2
+# (look in the file history to the version before this for inspiration)
+# Currently, this file has been rewritten to accommodate giving grant options to
+# all a user's privileges when granted the GRANT privilege and removing all of them
+# when GRANT is revoked as part of the backwards compatibility plan for GRANT in
+# 22.1 (https://github.com/cockroachdb/cockroach/issues/73065)
+
+#
 # Should error when a role that does not exist is provided.
+#
 statement error pq: user or role who does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE who GRANT SELECT ON TABLES to testuser WITH GRANT OPTION
 
@@ -24,6 +33,9 @@ CREATE USER testuser2
 statement ok
 CREATE USER target
 
+#
+# table with default GRANT will have grant options on all privileges present
+#
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT GRANT, SELECT ON TABLES TO testuser;
 
@@ -45,13 +57,33 @@ user testuser
 statement ok
 SELECT * FROM t1
 
-statement error pq: missing WITH GRANT OPTION privilege type GRANT
-GRANT GRANT, SELECT ON TABLE t1 to target
+statement ok
+GRANT GRANT, SELECT ON TABLE t1 TO target
 
 user root
 
+#
+# no GRANT and no grant options cannot grant to others
+#
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, SELECT, INSERT ON TABLES TO testuser WITH GRANT OPTION
+ALTER DEFAULT PRIVILEGES FOR ROLE root REVOKE GRANT ON TABLES FROM testuser;
+
+statement ok
+CREATE TABLE t1_1()
+
+user testuser
+
+# no grant options since GRANT was just revoked
+statement error pq: missing WITH GRANT OPTION privilege type SELECT
+GRANT SELECT ON TABLE t1_1 TO target
+
+#
+# Test default with grant option flag
+#
+user root
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT, INSERT ON TABLES TO testuser WITH GRANT OPTION
 
 statement ok
 CREATE TABLE t2()
@@ -64,6 +96,8 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t1          admin     ALL
 test           public       t1          root      ALL
+test           public       t1          target    GRANT
+test           public       t1          target    SELECT
 test           public       t1          testuser  CREATE
 test           public       t1          testuser  GRANT
 test           public       t1          testuser  SELECT
@@ -75,20 +109,19 @@ database_name  schema_name  table_name  grantee   privilege_type
 test           public       t2          admin     ALL
 test           public       t2          root      ALL
 test           public       t2          testuser  CREATE
-test           public       t2          testuser  GRANT
 test           public       t2          testuser  INSERT
 test           public       t2          testuser  SELECT
 
-statement error pq: missing WITH GRANT OPTION privilege type GRANT
-GRANT GRANT, SELECT ON TABLE t1 to target
-
 statement ok
-GRANT GRANT, SELECT, INSERT ON TABLE t2 to target
+GRANT SELECT, INSERT ON TABLE t2 to target
 
 user root
 
+#
+# default all privileges will have grant options
+#
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser
 
 statement ok
 CREATE TABLE t3()
@@ -106,6 +139,9 @@ user testuser
 statement ok
 GRANT INSERT, DELETE on table t3 to target
 
+#
+# Revoking grant option for default privileges
+#
 user root
 
 statement ok
@@ -127,6 +163,9 @@ user testuser
 statement error pq: missing WITH GRANT OPTION privilege type INSERT
 GRANT INSERT, DELETE ON TABLE t4 TO target
 
+#
+# Revoke grant option for all privileges
+#
 user root
 
 statement ok
@@ -145,9 +184,15 @@ test           public       t5          testuser  ALL
 
 user testuser
 
-statement error pq: missing WITH GRANT OPTION privilege type GRANT
-GRANT GRANT, SELECT ON TABLE t5 TO target
+statement error pq: missing WITH GRANT OPTION privilege type SELECT
+GRANT SELECT ON TABLE t5 TO target
 
+statement error pq: missing WITH GRANT OPTION privilege type ALL
+GRANT ALL PRIVILEGES ON TABLE t5 TO target
+
+#
+# Revoke all privileges from a user
+#
 user root
 
 statement ok
@@ -164,13 +209,17 @@ test           public       t6          admin     ALL
 test           public       t6          root      ALL
 test           public       t6          testuser  CREATE
 
-# testuser alters default privileges on itself
+
+### ---------------------------------------------------------------------------------------
+#
+# non-superuser owner of an object can do whatever it wants
+#
 user testuser
 
 statement ok
 CREATE TABLE t7()
 
-# since testuser created the table, it automatically has ALL PRIVILEGES ON IT
+# since testuser created the table, it automatically has ALL PRIVILEGES on it
 query TTTTT colnames
 SHOW GRANTS ON TABLE t7;
 ----
@@ -182,8 +231,12 @@ test           public       t7          testuser  ALL
 statement ok
 GRANT SELECT ON TABLE t7 TO testuser
 
+#
+# owner of an object can revoke grant options from itself
+# and still grant
+#
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT ON TABLES TO testuser
+ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLES FROM testuser
 
 statement ok
 CREATE TABLE t8()
@@ -197,7 +250,14 @@ test           public       t8          root      ALL
 test           public       t8          testuser  ALL
 
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, SELECT ON TABLES TO testuser WITH GRANT OPTION
+GRANT SELECT ON TABLE t8 TO testuser
+
+#
+# owner of an object can revoke from itself and still grant even
+# though it doesn't hold privileges
+#
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser
 
 statement ok
 CREATE TABLE t9()
@@ -208,37 +268,75 @@ SHOW GRANTS ON TABLE t9;
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t9          admin     ALL
 test           public       t9          root      ALL
-test           public       t9          testuser  ALL
+test           public       t9          testuser  CREATE
 
 statement ok
-GRANT INSERT, DELETE ON TABLE t9 to testuser
+GRANT DELETE ON TABLE t9 TO testuser
 
-statement ok
-GRANT GRANT, SELECT ON TABLE t9 to testuser
-
+#
+# owner of an object can regrant privileges on itself even if
+# if doesn't hold them
+#
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
 
 statement ok
 CREATE TABLE t10()
 
+query TTTTT colnames
+SHOW GRANTS ON TABLE t10
+----
+database_name  schema_name  table_name  grantee   privilege_type
+test           public       t10         admin     ALL
+test           public       t10         root      ALL
+test           public       t10         testuser  ALL
+
+#
+# two non-superuser and non-object-owning users
+#
 statement ok
-GRANT INSERT, DELETE ON TABLE t10 to testuser
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser
+
+# Postgres does not seem to validate whether the user granting/revoking privileges
+# on another user holds those privileges themselves (testuser has no default
+# privs but can revoke from testuser2)
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO testuser2
+
+user root
 
 statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR SELECT ON TABLES FROM testuser
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser
+
+user testuser
 
 statement ok
 CREATE TABLE t11()
 
-statement ok
-GRANT SELECT ON TABLE t11 TO testuser
+# The reason testuser does not have ALL despite creating the table is that the previous statement defaults to if root
+# creates the table but testuser is creating in this case; it's still going off the previous alter default privs which
+# was to revoke everything
+query TTTTT colnames
+SHOW GRANTS ON TABLE t11;
+----
+database_name  schema_name  table_name  grantee   privilege_type
+test           public       t11         admin     ALL
+test           public       t11         root      ALL
+test           public       t11         testuser  CREATE
+test           public       t11         testuser2 SELECT
 
-statement ok
-GRANT GRANT, INSERT, DELETE ON TABLE t11 TO testuser
+user testuser2
 
+statement error pq: missing WITH GRANT OPTION privilege type SELECT
+GRANT SELECT ON TABLE t11 TO target
+
+user testuser
+
+#
+# two non-superuser and non-object-owning users granting with grant options
+#
 statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLES FROM testuser
+ALTER DEFAULT PRIVILEGES GRANT INSERT, SELECT ON TABLES TO testuser2 WITH GRANT OPTION
 
 statement ok
 CREATE TABLE t12()
@@ -249,58 +347,51 @@ SHOW GRANTS ON TABLE t12;
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t12         admin     ALL
 test           public       t12         root      ALL
-test           public       t12         testuser  ALL
+test           public       t12         testuser  CREATE
+test           public       t12         testuser2 INSERT
+test           public       t12         testuser2 SELECT
+
+user testuser2
 
 statement ok
-GRANT INSERT, DELETE ON TABLE t12 TO testuser
+GRANT SELECT, INSERT ON TABLE t12 TO target
 
+user testuser
+
+#
+# two non-superuser and non-object-owning users granting with grant options
+#
 statement ok
-ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser2 WITH GRANT OPTION
 
 statement ok
 CREATE TABLE t13()
 
 query TTTTT colnames
-SHOW GRANTS ON TABLE t13
+SHOW GRANTS ON TABLE t13;
 ----
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t13         admin     ALL
 test           public       t13         root      ALL
 test           public       t13         testuser  CREATE
+test           public       t13         testuser2 ALL
+
+user testuser2
 
 statement ok
-GRANT ALL PRIVILEGES ON TABLE t13 TO testuser
-
-query TTTTT colnames
-SHOW GRANTS ON TABLE t13
-----
-database_name  schema_name  table_name  grantee   privilege_type
-test           public       t13         admin     ALL
-test           public       t13         root      ALL
-test           public       t13         testuser  ALL
-
-# one created user to another (testuser to testuser2)
-user testuser
-
-# Postgres does not seem to validate whether the user revoking privileges on another user holds those privileges themselves
-statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, SELECT, INSERT ON TABLES TO testuser2
-
-user root
-
-statement ok
-ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
+GRANT INSERT ON TABLE t13 TO target
 
 user testuser
 
+#
+# two non-superuser and non-object-owning users revoking grant option for
+#
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, SELECT ON TABLES TO testuser2
+ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLES FROM testuser2
 
 statement ok
 CREATE TABLE t14()
 
-# The reason testuser does not have ALL despite creating the table is that we granted "FOR ROLE root", but testuser is creating
-# the table so when testuser creates a table, it's still going off the previous alter default privs which was to revoke everything
 query TTTTT colnames
 SHOW GRANTS ON TABLE t14;
 ----
@@ -308,15 +399,7 @@ database_name  schema_name  table_name  grantee   privilege_type
 test           public       t14         admin     ALL
 test           public       t14         root      ALL
 test           public       t14         testuser  CREATE
-test           public       t14         testuser2 GRANT
-test           public       t14         testuser2 INSERT
-test           public       t14         testuser2 SELECT
-
-statement ok
-GRANT GRANT, INSERT, DELETE ON TABLE t12 TO target
-
-statement ok
-ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
+test           public       t14         testuser2 ALL
 
 user testuser2
 
@@ -326,7 +409,7 @@ GRANT SELECT ON TABLE t14 TO target
 user testuser
 
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, SELECT ON TABLES TO testuser2 WITH GRANT OPTION
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser2
 
 statement ok
 CREATE TABLE t15()
@@ -337,106 +420,15 @@ SHOW GRANTS ON TABLE t15;
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t15         admin     ALL
 test           public       t15         root      ALL
-test           public       t15         testuser  ALL
-test           public       t15         testuser2 GRANT
-test           public       t15         testuser2 INSERT
-test           public       t15         testuser2 SELECT
+test           public       t15         testuser  CREATE
 
-user testuser2
-
-statement ok
-GRANT SELECT, GRANT ON TABLE t15 TO target
-
-statement error pq: missing WITH GRANT OPTION privilege type INSERT
-GRANT INSERT ON TABLE t15 TO target
-
-user testuser
-
-statement ok
-ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser2 WITH GRANT OPTION
-
-statement ok
-CREATE TABLE t16()
-
-query TTTTT colnames
-SHOW GRANTS ON TABLE t16;
-----
-database_name  schema_name  table_name  grantee   privilege_type
-test           public       t16         admin     ALL
-test           public       t16         root      ALL
-test           public       t16         testuser  ALL
-test           public       t16         testuser2 ALL
-
-user testuser2
-
-statement ok
-GRANT INSERT ON TABLE t16 TO target
-
-user testuser
-
-statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR SELECT, INSERT ON TABLES FROM testuser2
-
-statement ok
-CREATE TABLE t17()
-
-query TTTTT colnames
-SHOW GRANTS ON TABLE t17;
-----
-database_name  schema_name  table_name  grantee   privilege_type
-test           public       t17         admin     ALL
-test           public       t17         root      ALL
-test           public       t17         testuser  ALL
-test           public       t17         testuser2 ALL
-
-user testuser2
-
-statement error pq: missing WITH GRANT OPTION privilege type SELECT
-GRANT SELECT, INSERT ON TABLE t17 TO target
-
-user testuser
-
-statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLES FROM testuser2
-
-statement ok
-CREATE TABLE t18()
-
-query TTTTT colnames
-SHOW GRANTS ON TABLE t18;
-----
-database_name  schema_name  table_name  grantee   privilege_type
-test           public       t18         admin     ALL
-test           public       t18         root      ALL
-test           public       t18         testuser  ALL
-test           public       t18         testuser2 ALL
-
-user testuser2
-
-statement error pq: missing WITH GRANT OPTION privilege type SELECT
-GRANT SELECT ON TABLE t18 TO target
-
-user testuser
-
-statement ok
-ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser2
-
-statement ok
-CREATE TABLE t19()
-
-query TTTTT colnames
-SHOW GRANTS ON TABLE t19;
-----
-database_name  schema_name  table_name  grantee   privilege_type
-test           public       t19         admin     ALL
-test           public       t19         root      ALL
-test           public       t19         testuser  ALL
-
-# Test Schemas
+#
+# Test schemas
+#
 user root
 
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SCHEMAS TO testuser, testuser2 WITH GRANT OPTION
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SCHEMAS TO testuser, testuser2
 
 statement ok
 CREATE SCHEMA s1
@@ -450,8 +442,20 @@ test           s1           root       ALL
 test           s1           testuser   ALL
 test           s1           testuser2  ALL
 
+user testuser
+
 statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON SCHEMAS FROM testuser, testuser2
+GRANT ALL PRIVILEGES ON SCHEMA s1 TO target
+
+user testuser2
+
+statement ok
+GRANT ALL PRIVILEGES ON SCHEMA s1 TO target
+
+user root
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON SCHEMAS FROM testuser
 
 statement ok
 CREATE SCHEMA s2
@@ -482,6 +486,8 @@ GRANT ALL PRIVILEGES ON SCHEMA s2 TO target
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
 
+user root
+
 statement ok
 CREATE TABLE s1.t1()
 
@@ -503,7 +509,49 @@ CREATE TABLE s1.t2()
 statement ok
 GRANT ALL PRIVILEGES ON TABLE s1.t2 TO target
 
-# Test Sequences
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON SCHEMAS FROM testuser
+
+statement ok
+ALTER DEFAULT PRIVILEGES REVOKE GRANT ON SCHEMAS FROM testuser2
+
+statement ok
+CREATE SCHEMA s3
+
+query TTTT colnames
+SHOW GRANTS ON SCHEMA s3
+----
+database_name  schema_name  grantee    privilege_type
+test           s3           admin      ALL
+test           s3           root       ALL
+test           s3           testuser   CREATE
+test           s3           testuser2  CREATE
+test           s3           testuser2  USAGE
+
+user testuser2
+
+# removing grant removes all grant options for testuser2's current privileges
+statement error pq: missing WITH GRANT OPTION privilege type CREATE
+GRANT CREATE, USAGE ON SCHEMA s3 TO target
+
+user root
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT CREATE, USAGE ON SCHEMAS TO testuser2 WITH GRANT OPTION
+
+statement ok
+CREATE SCHEMA s4
+
+user testuser2
+
+statement ok
+GRANT CREATE, USAGE ON SCHEMA s4 TO target
+
+#
+# Test Sequences (much of it is currently unimplemented, can't grant or revoke)
+#
+user root
+
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT CREATE ON SEQUENCES TO testuser2 WITH GRANT OPTION
 
@@ -519,47 +567,49 @@ SHOW GRANTS ON seq1
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       seq1        admin     ALL
 test           public       seq1        root      ALL
-test           public       seq1        testuser  ALL
+test           public       seq1        testuser  CREATE
 test           public       seq1        testuser2 CREATE
 
-# TODO: implement the grant/revoke for sequence? Can't do much more that this in terms of testing otherwise
-# Test Types
-user testuser
+#
+# Test types
+#
+user root
 
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT GRANT, USAGE ON TYPES TO testuser2 WITH GRANT OPTION
-
-statement ok
-ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TYPES FROM testuser
+ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TYPES FROM testuser
 
 statement ok
 CREATE TYPE type1 AS ENUM()
 
-query TTTTT colnames
-SHOW GRANTS ON TYPE type1
-----
-database_name  schema_name  type_name   grantee   privilege_type
-test           public       type1       admin     ALL
-test           public       type1       public    USAGE
-test           public       type1       root      ALL
-test           public       type1       testuser  ALL
-test           public       type1       testuser2 GRANT
-test           public       type1       testuser2 USAGE
-
-statement ok
-GRANT ALL PRIVILEGES ON TYPE type1 TO target
-
-statement ok
-GRANT USAGE ON TYPE type1 TO target
-
-user testuser2
-
-statement ok
-GRANT USAGE ON TYPE type1 TO target
-
-# Test Roles
 user testuser
 
+# USAGE on types is defined on the public role, in which every user is a member of,
+# so revoking will not take away the ability to use it
+statement ok
+CREATE TABLE type_table(input type1)
+
+statement error pq: missing WITH GRANT OPTION privilege type USAGE
+GRANT USAGE ON TYPE type1 TO testuser2
+
+user root
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO testuser WITH GRANT OPTION
+
+statement ok
+CREATE TYPE type2 AS ENUM()
+
+user testuser
+
+statement error pq: missing WITH GRANT OPTION privilege type USAGE
+GRANT USAGE ON TYPE type1 TO testuser2
+
+statement ok
+GRANT USAGE ON TYPE type2 TO testuser2
+
+#
+# Test roles
+#
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL PRIVILEGES ON TABLES FROM testuser
 
@@ -579,17 +629,17 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testuser, testuser2 GRANT ALL PRIVILEGES ON TA
 user testuser
 
 statement ok
-CREATE TABLE t20()
+CREATE TABLE t16()
 
 # testuser2 will have ALL privileges because the ALTER statement made from root specifies it happens when testuser does it
 query TTTTT colnames
-SHOW GRANTS ON TABLE t20;
+SHOW GRANTS ON TABLE t16;
 ----
 database_name  schema_name  table_name  grantee   privilege_type
-test           public       t20         admin     ALL
-test           public       t20         root      ALL
-test           public       t20         testuser  ALL
-test           public       t20         testuser2 ALL
+test           public       t16         admin     ALL
+test           public       t16         root      ALL
+test           public       t16         testuser  ALL
+test           public       t16         testuser2 ALL
 
 user root
 
@@ -599,23 +649,21 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testuser, testuser2 REVOKE GRANT OPTION FOR AL
 user testuser
 
 statement ok
-CREATE TABLE t21()
+CREATE TABLE t17()
 
 query TTTTT colnames
-SHOW GRANTS ON TABLE t21;
+SHOW GRANTS ON TABLE t17;
 ----
 database_name  schema_name  table_name  grantee   privilege_type
-test           public       t21         admin     ALL
-test           public       t21         root      ALL
-test           public       t21         testuser  ALL
-test           public       t21         testuser2 ALL
+test           public       t17         admin     ALL
+test           public       t17         root      ALL
+test           public       t17         testuser  ALL
+test           public       t17         testuser2 ALL
 
 user testuser2
 
 statement error pq: missing WITH GRANT OPTION privilege type ALL
-GRANT ALL PRIVILEGES ON TABLE t21 TO target
+GRANT ALL PRIVILEGES ON TABLE t17 TO target
 
 statement error pq: missing WITH GRANT OPTION privilege type SELECT
-GRANT SELECT, INSERT ON TABLE t21 TO target
-
-
+GRANT SELECT, INSERT ON TABLE t17 TO target

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -1,3 +1,10 @@
+# TODO(jack.wu): Replace these tests once the GRANT privilege is removed in 22.2
+# (look in the file history to the version before this for inspiration)
+# Currently, this file has been rewritten to accommodate giving grant options to
+# all a user's privileges when granted the GRANT privilege and removing all of them
+# when GRANT is revoked as part of the backwards compatibility plan for GRANT in
+# 22.1 (https://github.com/cockroachdb/cockroach/issues/73065)
+
 statement ok
 CREATE TABLE t(row INT)
 
@@ -7,26 +14,62 @@ CREATE USER testuser2
 statement ok
 CREATE USER target
 
+#
+# Granting ALL in 22.1 will give grant options automatically since it includes GRANT
+#
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t TO testuser
 
-# switch to testuser
+user testuser
+
+statement ok
+GRANT ALL PRIVILEGES ON TABLE t TO target
+
+statement ok
+GRANT SELECT ON TABLE t TO target
+
+user root
+
+statement ok
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
+
 user testuser
 
 statement error pq: missing WITH GRANT OPTION privilege type ALL
-GRANT ALL PRIVILEGES ON table t to testuser2
+GRANT ALL PRIVILEGES ON TABLE t TO target
 
-# switch to root
+statement error pq: missing WITH GRANT OPTION privilege type SELECT
+GRANT SELECT ON TABLE t TO target
+
+#
+# Test granting grant options
+#
 user root
 
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 
-# switch to testuser
 user testuser
 
 statement ok
-GRANT SELECT, GRANT, INSERT ON TABLE t TO testuser2 WITH GRANT OPTION
+GRANT SELECT, INSERT ON TABLE t TO testuser2
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser2
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           public       t              testuser2  INSERT
+test           public       t              testuser2  SELECT
+
+user testuser2
+
+statement error pq: missing WITH GRANT OPTION privilege type INSERT
+GRANT INSERT, SELECT ON TABLE t TO target
+
+user testuser
+
+statement ok
+GRANT GRANT ON TABLE t TO testuser2
 
 query TTTTT colnames
 SHOW GRANTS FOR testuser2
@@ -36,6 +79,30 @@ test           public       t              testuser2  GRANT
 test           public       t              testuser2  INSERT
 test           public       t              testuser2  SELECT
 
+user testuser2
+
+# in version 22.1, granting GRANT to a user means they now have grant options on all their privileges.
+# This is to promote backwards compatibility as we deprecate GRANT
+statement ok
+GRANT INSERT, SELECT ON TABLE t TO target
+
+# however, future privileges do not automatically get grant options just because the user currently
+# holds GRANT - you would need to either specify grant options or grant GRANT again
+user root
+
+statement ok
+GRANT DELETE ON TABLE t TO testuser2
+
+user testuser2
+
+statement error pq: missing WITH GRANT OPTION privilege type DELETE
+GRANT DELETE ON TABLE t TO target
+
+user testuser
+
+statement ok
+GRANT DELETE, UPDATE ON TABLE t TO testuser2 WITH GRANT OPTION
+
 statement ok
 REVOKE INSERT ON TABLE t FROM testuser2
 
@@ -43,27 +110,97 @@ query TTTTT colnames
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
+test           public       t              testuser2  DELETE
 test           public       t              testuser2  GRANT
 test           public       t              testuser2  SELECT
+test           public       t              testuser2  UPDATE
 
 statement ok
 REVOKE GRANT OPTION FOR SELECT ON TABLE t FROM testuser2
 
+# revoking GRANT OPTION FOR does not take away the privilege for the user
 query TTTTT colnames
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
+test           public       t              testuser2  DELETE
 test           public       t              testuser2  GRANT
 test           public       t              testuser2  SELECT
+test           public       t              testuser2  UPDATE
 
-# switch to testuser2
 user testuser2
 
 statement error pq: missing WITH GRANT OPTION privilege type SELECT
 GRANT SELECT ON TABLE t TO target
 
-# switch to root
+statement ok
+GRANT DELETE, UPDATE ON TABLE t TO target
+
+user testuser
+
+statement ok
+REVOKE GRANT ON TABLE t FROM testuser2
+
+user testuser2
+
+# in version 22.1, revoking GRANT from a user means they lose grant options
+# on all of their privileges
+statement error pq: missing WITH GRANT OPTION privilege type DELETE
+GRANT DELETE ON TABLE t TO target
+
+statement error pq: missing WITH GRANT OPTION privilege type UPDATE
+GRANT UPDATE ON TABLE t TO target
+
+statement error pq: missing WITH GRANT OPTION privilege type SELECT
+GRANT SELECT ON TABLE t TO target
+
+# revoking grant option for on GRANT should not take away grant options
+# from other privileges
 user root
+
+statement ok
+GRANT GRANT ON TABLE t TO testuser2
+
+statement ok
+REVOKE GRANT OPTION FOR GRANT ON TABLE t FROM testuser2
+
+user testuser2
+
+statement ok
+GRANT DELETE ON TABLE t TO target
+
+statement ok
+GRANT UPDATE ON TABLE t TO target
+
+statement ok
+GRANT SELECT ON TABLE t TO target
+
+user root
+
+statement ok
+REVOKE GRANT ON TABLE t FROM testuser2
+
+#
+# test whether granting back GRANT with another privilege in the same statement
+# gives grant options for that privilege too
+#
+user root
+
+statement ok
+GRANT INSERT, GRANT ON TABLE t TO testuser2
+
+user testuser2
+
+statement ok
+GRANT INSERT ON TABLE t TO target
+
+#
+# try revoking ALL PRIVILEGES on various existing privilege states
+#
+user root
+
+statement ok
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser2
 
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
@@ -74,13 +211,11 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee    privilege_type
 test           public       t              testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement error pq: missing WITH GRANT OPTION privilege type SELECT
 GRANT SELECT, GRANT, INSERT, DELETE ON TABLE t TO testuser2 WITH GRANT OPTION
 
-# switch to root
 user root
 
 statement ok
@@ -92,16 +227,16 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee    privilege_type
 
 statement ok
-GRANT GRANT, UPDATE, DELETE ON TABLE t to testuser WITH GRANT OPTION
+GRANT UPDATE, DELETE ON TABLE t to testuser WITH GRANT OPTION
 
 query TTTTT colnames
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
 test           public       t              testuser   DELETE
-test           public       t              testuser   GRANT
 test           public       t              testuser   UPDATE
 
+# test applying repeat privileges (ALL replaces individual privileges)
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t to testuser WITH GRANT OPTION
 
@@ -111,13 +246,11 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee    privilege_type
 test           public       t              testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement ok
 GRANT DELETE ON TABLE t to target
 
-# switch to root
 user root
 
 statement ok
@@ -129,7 +262,6 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee    privilege_type
 test           public       t              testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement ok
@@ -145,22 +277,32 @@ query TTTTT colnames
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
+test           public       t              testuser2  DELETE
 test           public       t              testuser2  GRANT
+test           public       t              testuser2  INSERT
 test           public       t              testuser2  SELECT
+test           public       t              testuser2  UPDATE
 
-# switch to testuser2
 user testuser2
 
 statement ok
 GRANT SELECT ON TABLE t TO target
 
-# test revoking from oneself (non-owner of an object)
+#
+# Test granting to and revoking from oneself (non-owner of an object)
+#
 user root
 
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t TO testuser
 
+statement ok
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
+
 user testuser
+
+statement error pq: missing WITH GRANT OPTION privilege type DELETE
+GRANT DELETE ON TABLE t TO testuser
 
 statement error pq: missing WITH GRANT OPTION privilege type DELETE
 REVOKE DELETE ON TABLE t FROM testuser
@@ -171,6 +313,9 @@ statement ok
 GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 
 user testuser
+
+statement ok
+GRANT DELETE ON TABLE t TO testuser
 
 statement ok
 REVOKE DELETE ON TABLE t FROM testuser
@@ -196,8 +341,63 @@ REVOKE GRANT OPTION FOR SELECT ON TABLE t FROM testuser
 statement error pq: missing WITH GRANT OPTION privilege type SELECT
 GRANT SELECT ON TABLE t TO target
 
-# briefly test databases, schemas, types etc since the code is the same as with tables tested above
-# switch to root
+user root
+
+statement ok
+GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
+
+user testuser
+
+statement ok
+REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
+
+statement error pq: missing WITH GRANT OPTION privilege type INSERT
+GRANT INSERT, DELETE ON TABLE t TO target
+
+user root
+
+statement ok
+GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
+
+statement ok
+REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+
+# revoking grant from ALL privileges means you lose grant options on
+# all the other privileges
+user root
+
+statement ok
+GRANT ALL PRIVILEGES ON TABLE t TO testuser
+
+statement ok
+REVOKE GRANT ON TABLE t FROM testuser
+
+query TTTTT colnames
+SHOW GRANTS FOR testuser
+----
+database_name  schema_name  relation_name  grantee    privilege_type
+test           public       t              testuser  CREATE
+test           public       t              testuser  DELETE
+test           public       t              testuser  DROP
+test           public       t              testuser  INSERT
+test           public       t              testuser  SELECT
+test           public       t              testuser  UPDATE
+test           public       t              testuser  ZONECONFIG
+
+user testuser
+
+statement error pq: missing WITH GRANT OPTION privilege type INSERT
+GRANT INSERT ON TABLE t TO target
+
+#
+# Wipe everything so far and briefly test databases, schemas, types
+# etc since the code is the same as with tables tested above
+#
 user root
 
 statement ok
@@ -220,22 +420,19 @@ statement ok
 CREATE SCHEMA s
 
 statement ok
-GRANT GRANT, CREATE ON SCHEMA s TO testuser WITH GRANT OPTION
+GRANT ALL PRIVILEGES ON SCHEMA s TO testuser WITH GRANT OPTION
 
 query TTTTT colnames
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
-test           s            NULL           testuser   CREATE
-test           s            NULL           testuser   GRANT
+test           s            NULL           testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement ok
 GRANT CREATE ON SCHEMA s TO testuser2 WITH GRANT OPTION
 
-# switch to root
 user root
 
 query TTTTT colnames
@@ -251,16 +448,24 @@ query TTTTT colnames
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  relation_name  grantee    privilege_type
-test           s            NULL           testuser   CREATE
-test           s            NULL           testuser   GRANT
+test           s            NULL           testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement error pq: missing WITH GRANT OPTION privilege type CREATE
 GRANT CREATE ON SCHEMA s TO target
 
-# switch to root
+user root
+
+statement ok
+GRANT GRANT ON SCHEMA s TO testuser
+
+# granting GRANT here will give grant options on ALL privileges for testuser
+user testuser
+
+statement ok
+GRANT CREATE ON SCHEMA s TO target
+
 user root
 
 statement ok
@@ -278,20 +483,15 @@ d               public     CONNECT
 d               root       ALL
 d               testuser   ALL
 
-# switch to testuser
 user testuser
 
 statement ok
-GRANT GRANT, CREATE, CONNECT ON DATABASE d TO testuser2 WITH GRANT OPTION
+GRANT CREATE, CONNECT ON DATABASE d TO testuser2 WITH GRANT OPTION
 
 statement ok
 REVOKE GRANT OPTION FOR CREATE ON DATABASE d FROM testuser2
 
-# switch to testuser2
 user testuser2
-
-statement ok
-GRANT GRANT ON DATABASE d TO target WITH GRANT OPTION
 
 statement ok
 GRANT CONNECT ON DATABASE d TO target WITH GRANT OPTION
@@ -299,7 +499,6 @@ GRANT CONNECT ON DATABASE d TO target WITH GRANT OPTION
 statement error pq: missing WITH GRANT OPTION privilege type CREATE
 GRANT CREATE ON DATABASE d TO target WITH GRANT OPTION
 
-# switch to root
 user root
 
 query TTT colnames
@@ -310,11 +509,9 @@ d               admin      ALL
 d               public     CONNECT
 d               root       ALL
 d               target     CONNECT
-d               target     GRANT
 d               testuser   ALL
 d               testuser2  CONNECT
 d               testuser2  CREATE
-d               testuser2  GRANT
 
 statement ok
 REVOKE ALL PRIVILEGES ON DATABASE d FROM testuser2
@@ -327,23 +524,13 @@ d               admin      ALL
 d               public     CONNECT
 d               root       ALL
 d               target     CONNECT
-d               target     GRANT
 d               testuser   ALL
-
-# switch to testuser2
-user testuser2
-
-statement error pq: user testuser2 does not have GRANT privilege on database d
-GRANT CONNECT ON DATABASE d TO target WITH GRANT OPTION
 
 # test types
 user root
 
 statement ok
-CREATE type type1 as ENUM()
-
-statement ok
-GRANT GRANT ON TYPE type1 TO testuser
+CREATE TYPE type1 as ENUM()
 
 user testuser
 
@@ -361,7 +548,9 @@ user testuser
 statement ok
 GRANT USAGE ON TYPE type1 TO target
 
-# Test owner status - should be able to always grant/revoke on the object it owns, regardless of its own privileges
+#
+# Test owner status - one should always be able to grant/revoke on the object it owns, regardless of its own privileges
+#
 user root
 
 statement ok
@@ -399,18 +588,10 @@ test           public       t1          root      ALL
 test           public       t1          testuser2 CREATE
 test           public       t1          testuser2 SELECT
 
+# even though testuser doesn't have privileges on table t1, it can still grant
+# because it is the owner
 statement ok
 GRANT INSERT ON TABLE t1 TO testuser2
-
-statement ok
-GRANT GRANT ON TABLE t1 TO testuser2
-
-user testuser2
-
-statement error pq: missing WITH GRANT OPTION privilege type SELECT
-GRANT SELECT ON TABLE t1 TO target
-
-user testuser
 
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t1 TO testuser2 WITH GRANT OPTION
@@ -423,40 +604,15 @@ test           public       t1          admin     ALL
 test           public       t1          root      ALL
 test           public       t1          testuser2 ALL
 
-user testuser2
-
-statement ok
-GRANT SELECT ON TABLE t1 TO TARGET
-
-statement ok
-REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t1 FROM testuser2
-
-statement error pq: missing WITH GRANT OPTION privilege type INSERT
-GRANT INSERT ON TABLE t1 TO target
-
-user testuser
-
-statement ok
-GRANT ALL PRIVILEGES ON TABLE t1 TO testuser2 WITH GRANT OPTION
-
-user testuser2
-
-statement ok
-REVOKE ALL PRIVILEGES ON TABLE t1 FROM testuser2
-
-statement error pq: user testuser2 does not have GRANT privilege on relation t1
-GRANT INSERT ON TABLE t1 TO target
-
-user testuser
-
 query TTTTT colnames
 SHOW GRANTS ON TABLE t1;
 ----
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t1          admin     ALL
 test           public       t1          root      ALL
-test           public       t1          target    SELECT
+test           public       t1          testuser2 ALL
 
+# owner can give privileges back to themself
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t1 TO testuser
 
@@ -466,5 +622,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee   privilege_type
 test           public       t1          admin     ALL
 test           public       t1          root      ALL
-test           public       t1          target    SELECT
 test           public       t1          testuser  ALL
+test           public       t1          testuser2 ALL
+
+


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/73065

Release note (sql change): We will be deprecating the GRANT privilege in 22.1 before eventually removing it in 22.2 in favor of grant options. To promote backwards compatibility for users with code still using GRANT, we will give grant options on every privilege a user has when they are granted GRANT and remove all their current grant options when GRANT is revoked, in addition to the existing grant option behavior.