### PR TITLE
bazel: require setting `cockroach_cross=y` to opt into cross toolchains

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -8,6 +8,9 @@ toolchain(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+    target_settings = [
+        ":cross",
+    ],
     toolchain = "@toolchain_cross_x86_64-unknown-linux-gnu//:toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
@@ -29,6 +32,9 @@ toolchain(
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
+    ],
+    target_settings = [
+        ":cross",
     ],
     toolchain = "@toolchain_cross_x86_64-w64-mingw32//:toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
@@ -52,6 +58,9 @@ toolchain(
         "@platforms//os:macos",
         "@platforms//cpu:x86_64",
     ],
+    target_settings = [
+        ":cross",
+    ],
     toolchain = "@toolchain_cross_x86_64-apple-darwin19//:toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
@@ -73,6 +82,9 @@ toolchain(
     target_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
+    ],
+    target_settings = [
+        ":cross",
     ],
     toolchain = "@toolchain_cross_aarch64-unknown-linux-gnu//:toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
@@ -135,6 +147,13 @@ config_setting(
     name = "dev",
     define_values = {
         "cockroach_bazel_dev": "y",
+    },
+)
+
+config_setting(
+    name = "cross",
+    define_values = {
+        "cockroach_cross": "y",
     },
 )
 

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -294,6 +294,11 @@ func main() {
 					}
 				}
 				args = append(args, "--")
+				if target == "stressrace" {
+					args = append(args, "--config=race")
+				} else {
+					args = append(args, "--test_sharding_strategy=disabled")
+				}
 				var filters []string
 				for _, test := range pkg.tests {
 					filters = append(filters, "^"+test+"$")
@@ -304,11 +309,6 @@ func main() {
 				// Give the entire test 1 more minute than the duration to wrap up.
 				args = append(args, fmt.Sprintf("--test_timeout=%d", int((duration+1*time.Minute).Seconds())))
 				args = append(args, "--run_under", fmt.Sprintf("%s -stderr -maxfails 1 -maxtime %s -p %d", bazelStressTarget, duration, parallelism))
-				if target == "stressrace" {
-					args = append(args, "--config=race")
-				} else {
-					args = append(args, "--test_sharding_strategy=disabled")
-				}
 				// NB: bazci is expected to be put in `PATH` by the caller.
 				cmd := exec.Command("bazci", args...)
 				cmd.Stdout = os.Stdout


### PR DESCRIPTION
With `--incompatible_enable_cc_toolchain_resolution` set in #73819, now
Bazel selects the appropriate toolchain for you. Bazel was selecting the
`cross_linux_toolchain` when building for the host platform on Linux,
resulting in link errors when trying to compile `stress` under `race`.
We update the toolchains to instead require opting into the cross
toolchains by defining `cockroach_cross=y`.

Closes #73997.

Release note: None