### PR TITLE
bench/rttanalysis: allow roundtrips to be off by 1

### DIFF
--- a/pkg/bench/rttanalysis/validate_benchmark_data.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data.go
@@ -319,7 +319,10 @@ func (b benchmarkExpectations) find(name string) (benchmarkExpectation, bool) {
 }
 
 func (e benchmarkExpectation) matches(roundTrips int) bool {
-	return e.min <= roundTrips && roundTrips <= e.max
+	// Either the value falls within the expected range, or
+	return (e.min <= roundTrips && roundTrips <= e.max) ||
+		// the expectation isn't a range, so give it a leeway of one.
+		e.min == e.max && (roundTrips == e.min-1 || roundTrips == e.min+1)
 }
 
 func (e benchmarkExpectation) String() string {


### PR DESCRIPTION
If we don't have a range, let the currently estimate be wrong by 1.
We mostly care about the ballpark and the growth rate. I'm sick of
these flakes.

Fixes #73884.

Release note: None