### PR TITLE
bulk,backup,import: add Write-at-now settings for RESTORE and IMPORT

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -109,6 +109,7 @@ func MakeBulkAdder(
 			disallowShadowingBelow: opts.DisallowShadowingBelow,
 			splitAfter:             opts.SplitAndScatterAfter,
 			batchTS:                opts.BatchTimestamp,
+			writeAtBatchTS:         opts.WriteAtRequestTime,
 		},
 		timestamp:           timestamp,
 		curBufferSize:       opts.MinBufferSize,

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -330,7 +330,14 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if _, err := bulk.AddSSTable(
-		ctx, mock, start, end, sst, hlc.Timestamp{}, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(), hlc.Timestamp{},
+		ctx, mock,
+		start, end,
+		sst,
+		hlc.Timestamp{},
+		enginepb.MVCCStats{},
+		cluster.MakeTestingClusterSettings(),
+		hlc.Timestamp{},
+		false,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -67,6 +67,10 @@ type BulkAdderOptions struct {
 	// different from the timestamp used to construct the adder which is what is
 	// actually applied to each key).
 	BatchTimestamp hlc.Timestamp
+
+	// WriteAtRequestTime is used to set the corresponding field when sending
+	// constructed SSTables to AddSSTable. See roachpb.AddSSTableRequest.
+	WriteAtRequestTime bool
 }
 
 // DisableExplicitSplits can be returned by a SplitAndScatterAfter function to


### PR DESCRIPTION
This adds a new arguemnt to MakeSSTBatcher to cause the returned batcher to send
its AddSSTableRequests with the WriteAtBatchTS argument as specified, and a new
special timestamp value to kvserverbase along side the interface for BulkAdder
that can be passed as the WriteTimestamp to when making a BulkAdder (BufferingAdder)
to cause it to, while using that timestamp to construct SSTs as usual, additionally
set the WriteAtBatchTS flag when those SSTs are flushed by its backing sst batcher.

These new options are then used by RESTORE and IMPORT, by enabling the settings
'bulkio.restore_at_current_time.enabled' or 'bulkio.import_at_current_time.enabled'
respectively. These currently default to off, but will be enabled in the near future.

Release note: none.