### PR TITLE
sql: deflake TestCancelQueryPermissions

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -243,7 +242,6 @@ GRANT admin TO has_admin2;
 
 func TestCancelQueryPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 73544, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// getQueryIDs retrieves the IDs of any currently running queries for the
@@ -365,6 +363,8 @@ GRANT admin TO has_admin2;
 			}
 		}()
 	}
+	// Give the cancel queries a chance to propagate before stopping the cluster.
+	time.Sleep(time.Second)
 	testCluster.Stopper().Stop(ctx)
 	wg.Wait()
 }


### PR DESCRIPTION
Added a sleep between running the last cancel query test case and
stopping the test cluster in order to give the cancel queries a chance
to propagate before shutting down the cluster.

The issue took ~11K runs to reproduce. After adding the sleep, no
failures reproduced in >14K runs.

Fixes: 73544

Release note: None