### PR TITLE
util/log: fix data race in `TestRedactedDecodeFile`

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -86,12 +86,39 @@ func capture() func() {
 
 // resetCaptured erases the logging output captured so far.
 func resetCaptured() {
-	debugLog.getFileSink().mu.file.(*flushBuffer).Buffer.Reset()
+	fs := debugLog.getFileSink()
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.mu.file.(*flushBuffer).Buffer.Reset()
 }
 
 // contents returns the specified log value as a string.
 func contents() string {
-	return debugLog.getFileSink().mu.file.(*flushBuffer).Buffer.String()
+	fs := debugLog.getFileSink()
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	return fs.mu.file.(*flushBuffer).Buffer.String()
+}
+
+func (l *fileSink) getDir() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.mu.logDir
+}
+
+func getDebugLogFileName(t *testing.T) string {
+	fs := debugLog.getFileSink()
+	return fs.getFileName(t)
+}
+
+func (l *fileSink) getFileName(t *testing.T) string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	sb, ok := l.mu.file.(*syncBuffer)
+	if !ok {
+		t.Fatalf("buffer wasn't created")
+	}
+	return sb.file.Name()
 }
 
 // contains reports whether the string is contained in the log.
@@ -290,17 +317,14 @@ func TestListLogFiles(t *testing.T) {
 
 	Info(context.Background(), "x")
 
-	sb, ok := debugLog.getFileSink().mu.file.(*syncBuffer)
-	if !ok {
-		t.Fatalf("buffer wasn't created")
-	}
+	fileName := getDebugLogFileName(t)
 
 	results, err := ListLogFiles()
 	if err != nil {
 		t.Fatalf("error in ListLogFiles: %v", err)
 	}
 
-	expectedName := filepath.Base(sb.file.Name())
+	expectedName := filepath.Base(fileName)
 	foundExpected := false
 	for i := range results {
 		if results[i].Name == expectedName {
@@ -325,17 +349,14 @@ func TestFilePermissions(t *testing.T) {
 
 	Info(context.Background(), "x")
 
-	sb, ok := debugLog.getFileSink().mu.file.(*syncBuffer)
-	if !ok {
-		t.Fatalf("buffer wasn't created")
-	}
+	fileName := fs.getFileName(t)
 
 	results, err := ListLogFiles()
 	if err != nil {
 		t.Fatalf("error in ListLogFiles: %v", err)
 	}
 
-	expectedName := filepath.Base(sb.file.Name())
+	expectedName := filepath.Base(fileName)
 	foundExpected := false
 	for _, r := range results {
 		if r.Name != expectedName {
@@ -382,12 +403,8 @@ func TestGetLogReader(t *testing.T) {
 
 	// Force creation of a file on the default sink.
 	Info(context.Background(), "x")
-	fs := debugLog.getFileSink()
-	info, ok := fs.mu.file.(*syncBuffer)
-	if !ok {
-		t.Fatalf("buffer wasn't created")
-	}
-	infoName := filepath.Base(info.file.Name())
+	fileName := getDebugLogFileName(t)
+	infoName := filepath.Base(fileName)
 
 	// Create some relative path. We'll check below these cannot be
 	// accessed.
@@ -395,13 +412,13 @@ func TestGetLogReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	relPathFromCurDir, err := filepath.Rel(curDir, info.file.Name())
+	relPathFromCurDir, err := filepath.Rel(curDir, fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Directory for the default sink.
-	dir := fs.mu.logDir
+	dir := debugLog.getFileSink().getDir()
 	if dir == "" {
 		t.Fatal(errDirectoryNotSet)
 	}
@@ -445,7 +462,7 @@ func TestGetLogReader(t *testing.T) {
 		// File is not specified (trying to open a directory instead).
 		{dir, "pathnames must be basenames"},
 		// Absolute filename is specified.
-		{info.file.Name(), "pathnames must be basenames"},
+		{fileName, "pathnames must be basenames"},
 		// Symlink to a log file.
 		{filepath.Join(dir, fileNameConstants.program+".log"), "pathnames must be basenames"},
 		// Symlink relative to logDir.
@@ -496,14 +513,10 @@ func TestRollover(t *testing.T) {
 	debugFileSink.logFileMaxSize = 2048
 
 	Info(context.Background(), "x") // Be sure we have a file.
-	info, ok := debugFileSink.mu.file.(*syncBuffer)
-	if !ok {
-		t.Fatal("info wasn't created")
-	}
 	if err != nil {
 		t.Fatalf("info has initial error: %v", err)
 	}
-	fname0 := info.file.Name()
+	fname0 := debugFileSink.getFileName(t)
 	Infof(context.Background(), "%s", strings.Repeat("x", int(debugFileSink.logFileMaxSize))) // force a rollover
 	if err != nil {
 		t.Fatalf("info has error after big write: %v", err)
@@ -516,6 +529,12 @@ func TestRollover(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error after rotation: %v", err)
 	}
+
+	fs := debugLog.getFileSink()
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	info := fs.mu.file.(*syncBuffer)
+
 	fname1 := info.file.Name()
 	if fname0 == fname1 {
 		t.Errorf("info.f.Name did not change: %v", fname0)
@@ -592,7 +611,7 @@ func TestFd2Capture(t *testing.T) {
 	const stderrText = "hello stderr"
 	fmt.Fprint(os.Stderr, stderrText)
 
-	contents, err := ioutil.ReadFile(logging.testingFd2CaptureLogger.getFileSink().mu.file.(*syncBuffer).file.Name())
+	contents, err := ioutil.ReadFile(logging.testingFd2CaptureLogger.getFileSink().getFileName(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +638,7 @@ func TestFileSeverityFilter(t *testing.T) {
 	Flush()
 
 	debugFileSink := debugFileSinkInfo.sink.(*fileSink)
-	contents, err := ioutil.ReadFile(debugFileSink.mu.file.(*syncBuffer).file.Name())
+	contents, err := ioutil.ReadFile(debugFileSink.getFileName(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -82,8 +82,7 @@ func TestFormatRedaction(t *testing.T) {
 							Infof(ctx, "safe2 %s", "secret3")
 							Flush()
 
-							debugFileSink := debugLog.getFileSink()
-							contents, err := ioutil.ReadFile(debugFileSink.mu.file.(*syncBuffer).file.Name())
+							contents, err := ioutil.ReadFile(getDebugLogFileName(t))
 							require.NoError(t, err)
 							require.Greater(t, len(contents), 0)
 							lastLineStart := bytes.LastIndexByte(contents[:len(contents)-1], '\n')

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -119,14 +119,14 @@ func TestRedactedDecodeFile(t *testing.T) {
 			Infof(context.Background(), "marker: this is safe, stray marks ‹›, %s", "this is not safe")
 
 			// Retrieve the log writer and log location for this test.
-			info, ok := debugLog.getFileSink().mu.file.(*syncBuffer)
+			debugSink := debugLog.getFileSink()
+			info, ok := debugSink.mu.file.(*syncBuffer)
 			if !ok {
 				t.Fatalf("buffer wasn't created")
 			}
+
 			// Ensure our log message above made it to the file.
-			if err := info.Flush(); err != nil {
-				t.Fatal(err)
-			}
+			debugSink.flushAndMaybeSyncLocked(false)
 
 			// Prepare reading the entries from the file.
 			infoName := filepath.Base(info.file.Name())

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -120,16 +120,13 @@ func TestRedactedDecodeFile(t *testing.T) {
 
 			// Retrieve the log writer and log location for this test.
 			debugSink := debugLog.getFileSink()
-			info, ok := debugSink.mu.file.(*syncBuffer)
-			if !ok {
-				t.Fatalf("buffer wasn't created")
-			}
+			fileName := debugSink.getFileName(t)
 
 			// Ensure our log message above made it to the file.
 			debugSink.flushAndMaybeSyncLocked(false)
 
 			// Prepare reading the entries from the file.
-			infoName := filepath.Base(info.file.Name())
+			infoName := filepath.Base(fileName)
 			reader, err := GetLogReader(infoName)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -76,7 +76,7 @@ func TestSecondaryLog(t *testing.T) {
 
 	// Check that the messages indeed made it to different files.
 
-	bcontents, err := ioutil.ReadFile(debugLog.getFileSink().mu.file.(*syncBuffer).file.Name())
+	bcontents, err := ioutil.ReadFile(getDebugLogFileName(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,8 @@ func TestSecondaryLog(t *testing.T) {
 	}
 
 	l := logging.getLogger(channel.SESSIONS)
-	bcontents, err = ioutil.ReadFile(l.getFileSink().mu.file.(*syncBuffer).file.Name())
+	fsFileName := l.getFileSink().getFileName(t)
+	bcontents, err = ioutil.ReadFile(fsFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestRedirectStderrWithSecondaryLoggersActive(t *testing.T) {
 
 	// Check the stderr log file: we want our stderr text there.
 	stderrLog := logging.testingFd2CaptureLogger
-	contents, err := ioutil.ReadFile(stderrLog.getFileSink().mu.file.(*syncBuffer).file.Name())
+	contents, err := ioutil.ReadFile(stderrLog.getFileSink().getFileName(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +133,7 @@ func TestRedirectStderrWithSecondaryLoggersActive(t *testing.T) {
 
 	// Check the secondary log file: we don't want our stderr text there.
 	l := logging.getLogger(channel.SESSIONS)
-	contents2, err := ioutil.ReadFile(l.getFileSink().mu.file.(*syncBuffer).file.Name())
+	contents2, err := ioutil.ReadFile(l.getFileSink().getFileName(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +160,7 @@ func TestListLogFilesIncludeSecondaryLogs(t *testing.T) {
 	}
 
 	l := logging.getLogger(channel.SESSIONS)
-	expectedName := filepath.Base(l.getFileSink().mu.file.(*syncBuffer).file.Name())
+	expectedName := filepath.Base(l.getFileSink().getFileName(t))
 	foundExpected := false
 	for i := range results {
 		if results[i].Name == expectedName {


### PR DESCRIPTION
Fixes #71902

It's racy to call `Flush()` on the `*syncBuffer` directly, because of
the async flusher.

Release note: None