### PR TITLE
streamingccl: Ensure appropriate privileges when replicating.

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
@@ -1,0 +1,11 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package streamproducer


### PR DESCRIPTION
Add checks to replication stream manager to ensure appropriate privileges
and require enterprise license when executing streaming replication.

Release Notes: None