### PR TITLE
jobs,schemachanges: return error when waiting on paused job

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1154,6 +1154,9 @@ func (sc *SchemaChanger) distIndexBackfill(
 	g.GoCtx(func(ctx context.Context) error {
 		defer close(stopProgress)
 		defer close(stopJobDetailsUpdate)
+		if err := sc.jobRegistry.CheckPausepoint("indexbackfill.before_flow"); err != nil {
+			return err
+		}
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := evalCtx
 		sc.distSQLPlanner.Run(

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -230,3 +230,17 @@ CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)
 
 statement error index with name "'t1-esc-index'" already exists
 CREATE INDEX "'t1-esc-index'" ON "'t1-esc'"(name)
+
+subtest pause
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'indexbackfill.before_flow'
+
+statement ok
+CREATE TABLE tbl (i INT PRIMARY KEY, j INT NOT NULL)
+
+statement ok
+INSERT INTO tbl VALUES (1, 100), (2, 200), (3, 300);
+
+statement error job .* was paused before it completed with reason: pause point "indexbackfill.before_flow" hit
+CREATE INDEX idx ON tbl(j);


### PR DESCRIPTION
This changes the 'wait for jobs to finish' stage of running a
schema change to consider a job that moved from a running state
to a paused state as cause to stop waiting and return an error,
as at this point the job is no longer running / making progress
to completion, just as if it moved to cancelled or failed. While
it is true that the job could be resumed and then succeed later,
it could just as easily not be resumed as well, so treating this
state the same as terminal makes sense.

Release note (sql change): clients waiting for a schema change job will now receive an error if the job they are waiting for is paused.