### PR TITLE
release-21.2: ui: update ellipsis icon

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -27,6 +27,8 @@ import { TerminateQueryModalRef } from "./terminateQueryModal";
 import { ColumnDescriptor, SortedTable } from "src/sortedtable/sortedtable";
 
 import { Icon } from "antd";
+import { Ellipsis } from "@cockroachlabs/icons";
+
 import {
   Dropdown,
   DropdownOption as DropdownItem,
@@ -227,7 +229,7 @@ export function makeSessionsColumns(
       const renderDropdownToggleButton: JSX.Element = (
         <>
           <Button type="secondary" size="small">
-            <Icon type="ellipsis" />
+            <Icon component={Ellipsis} />
           </Button>
         </>
       );


### PR DESCRIPTION
Backport 1/1 commits from #74001.

/cc @cockroachdb/release

---

Previously, the ellipsis icon on the Sessions page were
not matching the ellipsis being used on the other places
of the console. This commit changes that icon to use
the same as other pages.

Partially addresses #67774

Before
<img width="936" alt="Screen Shot 2021-12-17 at 5 14 08 PM" src="https://user-images.githubusercontent.com/1017486/146614574-7f05a897-587b-4f08-9874-6885a4195573.png">


After
<img width="945" alt="Screen Shot 2021-12-17 at 5 11 40 PM" src="https://user-images.githubusercontent.com/1017486/146614560-f94f6ce3-d911-4c99-a4fa-21683e1f0dcc.png">

Release note: None

Release Justification: Category 4
