### PR TITLE
sql: perform incremental memory accounting for subquery result

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1260,6 +1260,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if err := subqueryRowReceiver.Err(); err != nil {
 		return err
 	}
+	var alreadyAccountedFor int64
 	switch subqueryPlan.execMode {
 	case rowexec.SubqueryExecModeExists:
 		// For EXISTS expressions, all we want to know if there is at least one row.
@@ -1267,8 +1268,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		subqueryPlans[planIdx].result = tree.MakeDBool(tree.DBool(hasRows))
 	case rowexec.SubqueryExecModeAllRows, rowexec.SubqueryExecModeAllRowsNormalized:
 		// TODO(yuzefovich): this is unfortunate - we're materializing all
-		// buffered rows into a single tuple kept in memory without any memory
-		// accounting. Refactor it.
+		// buffered rows into a single tuple kept in memory. Refactor it.
 		var result tree.DTuple
 		iterator := newRowContainerIterator(ctx, rows, typs)
 		defer iterator.Close()
@@ -1280,18 +1280,33 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 			if row == nil {
 				break
 			}
+			var toAppend tree.Datum
 			if row.Len() == 1 {
 				// This seems hokey, but if we don't do this then the subquery expands
 				// to a tuple of tuples instead of a tuple of values and an expression
 				// like "k IN (SELECT foo FROM bar)" will fail because we're comparing
 				// a single value against a tuple.
-				result.D = append(result.D, row[0])
+				toAppend = row[0]
 			} else {
-				result.D = append(result.D, &tree.DTuple{D: row})
+				toAppend = &tree.DTuple{D: row}
 			}
+			// Perform memory accounting for this datum. We do this in an
+			// incremental fashion since we might be materializing a lot of data
+			// into a single result tuple, and the memory accounting below might
+			// come too late.
+			size := int64(toAppend.Size())
+			alreadyAccountedFor += size
+			if err = subqueryResultMemAcc.Grow(ctx, size); err != nil {
+				return err
+			}
+			result.D = append(result.D, toAppend)
 		}
 
 		if subqueryPlan.execMode == rowexec.SubqueryExecModeAllRowsNormalized {
+			// During the normalization, we will remove duplicate elements which
+			// we've already accounted for. That's ok because below we will
+			// reconcile the incremental accounting with the final result's
+			// memory footprint.
 			result.Normalize(&evalCtx.EvalContext)
 		}
 		subqueryPlans[planIdx].result = &result
@@ -1324,8 +1339,16 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	}
 	// Account for the result of the subquery using the separate memory account
 	// since it outlives the execution of the subquery itself.
-	if err := subqueryResultMemAcc.Grow(ctx, int64(subqueryPlans[planIdx].result.Size())); err != nil {
-		return err
+	actualSize := int64(subqueryPlans[planIdx].result.Size())
+	if actualSize >= alreadyAccountedFor {
+		if err := subqueryResultMemAcc.Grow(ctx, actualSize-alreadyAccountedFor); err != nil {
+			return err
+		}
+	} else {
+		// We've accounted for more than the actual result needs. For example,
+		// this could occur in rowexec.SubqueryExecModeAllRowsNormalized mode
+		// with many duplicate elements.
+		subqueryResultMemAcc.Shrink(ctx, alreadyAccountedFor-actualSize)
 	}
 	return nil
 }


### PR DESCRIPTION
In two modes of the subquery execution we materialize the full result
into a single tuple in-memory. Previously, that possibly-large tuple
would get memory accounting only after it was fully populated; however,
that might be too late since a subquery can return arbitrarily large
result. This commit fixes this omission by performing the memory
accounting in an incremental fashion. Care needs to be taken for the
accounting to not introduce any drift, so we reconcile the incremental
estimate with the actual footprint in the end.

Release note: None