### PR TITLE
sql : sequence value out of bounds

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2029,3 +2029,48 @@ CREATE SEQUENCE seqas_error
   INCREMENT BY 1
   MAXVALUE 123456
   CACHE 1
+
+###### check the value out of bounds
+## cache = 1
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_1 INCREMENT  BY 3  MINVALUE 6 MAXVALUE 10
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+6
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+9
+
+query error pq: nextval\(\): reached maximum value of sequence "customer_seq_check_cache_and_bounds_1" \(10\)
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+
+query I
+SELECT last_value from customer_seq_check_cache_and_bounds_1
+----
+12
+
+## cache = 2
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_2 MINVALUE -2 MAXVALUE 2 START WITH 1 CACHE 5 INCREMENT BY -2
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+1
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+-1
+
+query error pq: nextval\(\): reached minimum value of sequence "customer_seq_check_cache_and_bounds_2" \(-2\)
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+
+query I
+SELECT last_value from customer_seq_check_cache_and_bounds_2
+----
+-17

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -153,11 +153,14 @@ func (p *planner) incrementSequenceUsingCache(
 			return 0, 0, 0, err
 		}
 
+		incrementAmount = seqOpts.Increment
+		lastEndValue := endValue - incrementAmount*cacheSize
+		beginValue := endValue - incrementAmount*(cacheSize-1)
 		// This sequence has exceeded its bounds after performing this increment.
 		if endValue > seqOpts.MaxValue || endValue < seqOpts.MinValue {
-			// If the sequence exceeded its bounds prior to the increment, then return an error.
-			if (seqOpts.Increment > 0 && endValue-seqOpts.Increment*cacheSize >= seqOpts.MaxValue) ||
-				(seqOpts.Increment < 0 && endValue-seqOpts.Increment*cacheSize <= seqOpts.MinValue) {
+			// If the first sequence value in this cache exceeded its bounds, then return an error.
+			if (seqOpts.Increment > 0 && beginValue > seqOpts.MaxValue) ||
+				(seqOpts.Increment < 0 && beginValue < seqOpts.MinValue) {
 				return 0, 0, 0, boundsExceededError(descriptor)
 			}
 			// Otherwise, values between the limit and the value prior to incrementing can be cached.
@@ -171,13 +174,12 @@ func (p *planner) incrementSequenceUsingCache(
 				}
 				return i
 			}
-			currentValue = endValue - seqOpts.Increment*(cacheSize-1)
-			incrementAmount = seqOpts.Increment
-			sizeOfCache = abs(limit-(endValue-seqOpts.Increment*cacheSize)) / abs(seqOpts.Increment)
-			return currentValue, incrementAmount, sizeOfCache, nil
+			sizeOfCache = abs(limit-lastEndValue) / abs(seqOpts.Increment)
+		} else {
+			sizeOfCache = cacheSize
 		}
 
-		return endValue - seqOpts.Increment*(cacheSize-1), seqOpts.Increment, cacheSize, nil
+		return beginValue, incrementAmount, sizeOfCache, nil
 	}
 
 	var val int64


### PR DESCRIPTION
Previously, an additional out-of-range sequence value may have been
generated.
The original criterion was whether the previous endSequence value exceeded the limit.
However, when the current endSequence is 1, the increment is 2 and the MaxValue is 2,
the previous endSequence value is 1 and the program does not report an error.
However, when the current endSequenceValue 3 exceeds the limit, an error should be reported

In incrementSequenceUsingCache, the criterion for determining whether a cache's data is eligible is modified to whether the first data that may be stored in the cache exceeds the limit.

Fixes #74127.

Release note: None