### PR TITLE
ui: unset windowEnd value to enable continuous updates for Timescale

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timescale/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timescale/index.tsx
@@ -51,7 +51,7 @@ const TimeScaleDropdownWithSearchParams = (
       ) {
         timeScale.key = "Custom";
       }
-      timeScale.windowEnd = end;
+      timeScale.windowEnd = null;
       timeScale.windowSize = moment.duration(end.diff(start));
       props.setTimeScale(timeScale);
     };


### PR DESCRIPTION
Timescale component and its initial values rely on URL path and
provided time window to select. During "componentDidMount" lifecycle
hook, `windowEnd` value was set to value from URL path or to the current
date as a fallback value in case nothing was provided in URL path and
this fallback option caused an issue that prevented to set `windowEnd` to
NULL value that is an indicator for moving time window with windowEnd equal
to current time.

This change resolves regression after component refactoring and
now it should work as before.

Release note: None

Video below shows that timewindow is incremented on one minute automatically

https://user-images.githubusercontent.com/3106437/147110232-541e7d9c-a6ca-438f-bbf3-8647bbc8a603.mov

