### PR TITLE
server: start protectedts before modeOperational

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1736,6 +1736,19 @@ func (s *Server) PreStart(ctx context.Context) error {
 		}
 	})
 
+	// Start the protected timestamp subsystem. Note that this needs to happen
+	// before the modeOperational switch below, as the protected timestamps
+	// subsystem will crash if accessed before being Started (and serving general
+	// traffic may access it).
+	//
+	// See https://github.com/cockroachdb/cockroach/issues/73897.
+	if err := s.protectedtsProvider.Start(ctx, s.stopper); err != nil {
+		return err
+	}
+	if err := s.protectedtsReconciler.Start(ctx, s.stopper); err != nil {
+		return err
+	}
+
 	// After setting modeOperational, we can block until all stores are fully
 	// initialized.
 	s.grpc.setMode(modeOperational)
@@ -1779,14 +1792,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 	// Begin recording status summaries.
 	if err := s.node.startWriteNodeStatus(base.DefaultMetricsSampleInterval); err != nil {
-		return err
-	}
-
-	// Start the protected timestamp subsystem.
-	if err := s.protectedtsProvider.Start(ctx, s.stopper); err != nil {
-		return err
-	}
-	if err := s.protectedtsReconciler.Start(ctx, s.stopper); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Access to `protectedts.Provider` before `.Start()` is
called causes NPEs. We were previously allowing these
to happen as a server in `modeOperational` serves KV
traffic which may access protected timestamps.

Touches #73897 (needs backport)

Release note: None
