### PR TITLE
util/log: de-flake `TestRedactedDecodeFile` for realz this time

### DIFF
--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -123,7 +123,7 @@ func TestRedactedDecodeFile(t *testing.T) {
 			fileName := debugSink.getFileName(t)
 
 			// Ensure our log message above made it to the file.
-			debugSink.flushAndMaybeSyncLocked(false)
+			debugSink.lockAndFlushAndMaybeSync(false)
 
 			// Prepare reading the entries from the file.
 			infoName := filepath.Base(fileName)


### PR DESCRIPTION
Fixes #74201.

To avoid the race we need to lock first... 🤦

Release note: None