### PR TITLE
release-21.1: kv: remove dependency on ticks from maybeDropMsgApp

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -207,6 +207,9 @@ type Replica struct {
 	// The writes to this key happen in Replica.setStartKeyLocked.
 	startKey roachpb.RKey
 
+	// creationTime is the time that the Replica struct was initially constructed.
+	creationTime time.Time
+
 	store     *Store
 	abortSpan *abortspan.AbortSpan // Avoids anomalous reads after abort
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -70,6 +70,7 @@ func newUnloadedReplica(
 	r := &Replica{
 		AmbientContext: store.cfg.AmbientCtx,
 		RangeID:        desc.RangeID,
+		creationTime:   timeutil.Now(),
 		store:          store,
 		abortSpan:      abortspan.New(desc.RangeID),
 		concMgr: concurrency.NewManager(concurrency.Config{

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -32,18 +32,20 @@ func (rd *replicaMsgAppDropper) Args() (initialized bool, ticks int) {
 	return initialized, ticks
 }
 
-func (rd *replicaMsgAppDropper) ShouldDrop(startKey roachpb.RKey) (fmt.Stringer, bool) {
+func (rd *replicaMsgAppDropper) ShouldDrop(
+	ctx context.Context, startKey roachpb.RKey,
+) (fmt.Stringer, bool) {
 	lhsRepl := (*Replica)(rd).store.LookupReplica(startKey)
 	if lhsRepl == nil {
 		return nil, false
 	}
-	lhsRepl.store.replicaGCQueue.AddAsync(context.Background(), lhsRepl, replicaGCPriorityDefault)
+	lhsRepl.store.replicaGCQueue.AddAsync(ctx, lhsRepl, replicaGCPriorityDefault)
 	return lhsRepl, true
 }
 
 type msgAppDropper interface {
 	Args() (initialized bool, ticks int)
-	ShouldDrop(key roachpb.RKey) (fmt.Stringer, bool)
+	ShouldDrop(ctx context.Context, key roachpb.RKey) (fmt.Stringer, bool)
 }
 
 // maybeDropMsgApp returns true if the incoming Raft message should be dropped.
@@ -130,7 +132,7 @@ func maybeDropMsgApp(
 
 	// NB: the caller is likely holding r.raftMu, but that's OK according to
 	// the lock order. We're not allowed to hold r.mu, but we don't.
-	lhsRepl, drop := r.ShouldDrop(startKey)
+	lhsRepl, drop := r.ShouldDrop(ctx, startKey)
 	if !drop {
 		return false
 	}

--- a/pkg/kv/kvserver/split_trigger_helper_test.go
+++ b/pkg/kv/kvserver/split_trigger_helper_test.go
@@ -36,7 +36,9 @@ func (td *testMsgAppDropper) Args() (initialized bool, ticks int) {
 	return td.initialized, td.ticks
 }
 
-func (td *testMsgAppDropper) ShouldDrop(startKey roachpb.RKey) (fmt.Stringer, bool) {
+func (td *testMsgAppDropper) ShouldDrop(
+	ctx context.Context, startKey roachpb.RKey,
+) (fmt.Stringer, bool) {
 	if len(startKey) == 0 {
 		panic("empty startKey")
 	}

--- a/pkg/kv/kvserver/split_trigger_helper_test.go
+++ b/pkg/kv/kvserver/split_trigger_helper_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -26,14 +27,14 @@ import (
 
 type testMsgAppDropper struct {
 	initialized bool
-	ticks       int
+	age         time.Duration
 	lhs         bool
 
 	startKey string // set by ShouldDrop
 }
 
-func (td *testMsgAppDropper) Args() (initialized bool, ticks int) {
-	return td.initialized, td.ticks
+func (td *testMsgAppDropper) Args() (initialized bool, age time.Duration) {
+	return td.initialized, td.age
 }
 
 func (td *testMsgAppDropper) ShouldDrop(
@@ -58,9 +59,9 @@ func TestMaybeDropMsgApp(t *testing.T) {
 		// Drop message to wait for trigger.
 		{initialized: false, lhs: true}: true,
 		// Drop message to wait for trigger.
-		{initialized: false, lhs: true, ticks: maxDelaySplitTriggerTicks}: true,
+		{initialized: false, lhs: true, age: maxDelaySplitTriggerDur}: true,
 		// Escape hatch fires.
-		{initialized: false, lhs: true, ticks: maxDelaySplitTriggerTicks + 1}: false,
+		{initialized: false, lhs: true, age: maxDelaySplitTriggerDur + 1}: false,
 	}
 
 	msgHeartbeat := &raftpb.Message{


### PR DESCRIPTION
Backport 2/2 commits from #74108.

/cc @cockroachdb/release

Release justification: bug fix

---

Related to #73838.

In d77bee9, we stopped ticking uninitialized replicas, so we can no longer use ticks as a proxy for the age of a replica in the escape hatch of `maybeDropMsgApp`.  Instead, we now use the age of the replica directly. We hit the escape hatch for any replica that is older than 20s, which corresponds to the 100 ticks we used before.
