### PR TITLE
bazel: fix `errcheck` error location as reported by `nogo`

### DIFF
--- a/build/patches/com_github_kisielk_errcheck.patch
+++ b/build/patches/com_github_kisielk_errcheck.patch
@@ -1,8 +1,11 @@
 diff -urN a/errcheck/analyzer.go b/errcheck/analyzer.go
 --- a/errcheck/analyzer.go
 +++ b/errcheck/analyzer.go
-@@ -6,6 +6,7 @@ import (
- 	"go/token"
+@@ -3,9 +3,9 @@ package errcheck
+ import (
+ 	"fmt"
+ 	"go/ast"
+-	"go/token"
  	"reflect"
  	"regexp"
 +	"strings"
@@ -41,3 +44,16 @@ diff -urN a/errcheck/analyzer.go b/errcheck/analyzer.go
  		excludes, err := ReadExcludes(argExcludeFile)
  		if err != nil {
  			return nil, fmt.Errorf("Could not read exclude file: %v\n", err)
+--- a/errcheck/analyzer.go
++++ b/errcheck/analyzer.go
+@@ -65,8 +65,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
+ 		ast.Walk(v, f)
+ 
+ 		for _, err := range v.errors {
++			fsetFile := pass.Fset.File(f.Pos())
+ 			pass.Report(analysis.Diagnostic{
+-				Pos:     token.Pos(int(f.Pos()) + err.Pos.Offset),
++				Pos:     fsetFile.Pos(err.Pos.Offset),
+ 				Message: "unchecked error",
+ 			})
+ 		}


### PR DESCRIPTION
`errcheck` uses the following logic to compute the `token.Pos` position
of each reported diagnostic:

    int(file.Pos()) + err.Pos.Offset

This would be correct if `file.Pos()` returned the position of the
BEGINNING of the file, but in practice when run by `nogo` it returns
the position of the `package` statement at the beginning of the file. I
have not checked whether this behavior on `nogo`'s part is correct or
not. Either way, we replace it with
`pass.Fset.File(file.Pos()).Pos(err.Pos.Offset)`, which gives the
correct result regardless.

Closes #74182.

Release note: None