### PR TITLE
build: removing `--roachprod` from roachtest invocations

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -17,9 +17,9 @@ run build/builder.sh make build &> artifacts/roachtests-compile.log || (cat arti
 rm artifacts/roachtests-compile.log
 tc_end_block "Compile CockroachDB"
 
-tc_start_block "Compile roachprod/workload/roachtest"
-run build/builder.sh make bin/roachprod bin/workload bin/roachtest
-tc_end_block "Compile roachprod/workload/roachtest"
+tc_start_block "Compile workload/roachtest"
+run build/builder.sh make bin/workload bin/roachtest
+tc_end_block "Compile workload/roachtest"
 
 tc_start_block "Run local roachtests"
 # TODO(peter,dan): curate a suite of the tests that works locally.
@@ -38,7 +38,6 @@ build/builder.sh env \
   --local \
   --parallelism=1 \
   --cockroach "cockroach" \
-  --roachprod "bin/roachprod" \
   --workload "bin/workload" \
   --artifacts artifacts \
   --teamcity

--- a/build/teamcity-nightly-pebble-common.sh
+++ b/build/teamcity-nightly-pebble-common.sh
@@ -32,7 +32,7 @@ build_tag=$(git describe --abbrev=0 --tags --match=v[0-9]*)
 export build_tag
 
 # Build the roachtest binary.
-make bin/roachprod bin/roachtest
+make bin/roachtest
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
 # against the tip of the 'master' branch.

--- a/build/teamcity-nightly-pebble-write-throughput.sh
+++ b/build/teamcity-nightly-pebble-write-throughput.sh
@@ -26,7 +26,6 @@ if ! timeout -s INT 12h bin/roachtest run \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
   --cloud "gce" \
   --cockroach "true" \
-  --roachprod "$PWD/bin/roachprod" \
   --workload "true" \
   --artifacts "$artifacts" \
   --parallelism 2 \

--- a/build/teamcity-nightly-pebble-ycsb.sh
+++ b/build/teamcity-nightly-pebble-ycsb.sh
@@ -25,7 +25,6 @@ if ! timeout -s INT $((1000*60)) bin/roachtest run \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
   --cloud "aws" \
   --cockroach "true" \
-  --roachprod "$PWD/bin/roachprod" \
   --workload "true" \
   --artifacts "$artifacts" \
   --parallelism 3 \

--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -20,7 +20,7 @@ chmod o+rwx "${artifacts}"
 # Disable global -json flag.
 export PATH=$PATH:$(GOFLAGS=; go env GOPATH)/bin
 
-build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest bin/roachprod \
+build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest \
   > "${artifacts}/build.txt" 2>&1 || (cat "${artifacts}/build.txt"; false)
 
 # Set up GCE authentication, artifact upload logic, and the PARALLELISM/CPUQUOTA/TESTS env variables.

--- a/build/teamcity-roachtest-invoke.sh
+++ b/build/teamcity-roachtest-invoke.sh
@@ -6,7 +6,6 @@ set +e
 # passed by the caller, the passed one takes precedence.
 bin/roachtest run \
   --teamcity \
-  --roachprod="${PWD}/bin/roachprod" \
   --workload="${PWD}/bin/workload" \
   --os-volume-size=32 \
   "$@"

--- a/build/teamcity-roachtest-stress.sh
+++ b/build/teamcity-roachtest-stress.sh
@@ -14,7 +14,7 @@ export GCE_PROJECT=${GCE_PROJECT-cockroach-roachstress}
 
 mkdir -p artifacts
 
-build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest bin/roachprod \
+build/builder/mkrelease.sh amd64-linux-gnu build bin/workload bin/roachtest \
   > artifacts/build.txt 2>&1 || (cat artifacts/build.txt; false)
 
 build/teamcity-roachtest-invoke.sh \

--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -21,7 +21,7 @@ git checkout master
 git pull origin master
 
 git rev-parse HEAD
-build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest bin/roachprod
+build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest
 
 # release-2.0 names the cockroach binary differently.
 if [[ -f cockroach-linux-2.6.32-gnu-amd64 ]]; then
@@ -54,7 +54,6 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --cockroach "$PWD/cockroach.linux-2.6.32-gnu-amd64" \
-  --roachprod "$PWD/bin/roachprod" \
   --workload "$PWD/bin/workload" \
   --artifacts "$artifacts" \
   --parallelism 5 \

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 bazel build --config=crosslinux --config=ci //pkg/cmd/cockroach-short \
-      //pkg/cmd/roachprod \
       //pkg/cmd/roachtest \
       //pkg/cmd/workload
 
@@ -12,7 +11,6 @@ $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/b
   --local \
   --parallelism=1 \
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
-  --roachprod "$BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts /artifacts \
   --teamcity

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -4,16 +4,15 @@
 
 bazel build --config crosslinux --config ci --config with_ui -c opt \
       //pkg/cmd/cockroach //pkg/cmd/workload //pkg/cmd/roachtest \
-      //pkg/cmd/roachprod //c-deps:libgeos
+      //c-deps:libgeos
 BAZEL_BIN=$(bazel info bazel-bin --config crosslinux --config ci --config with_ui -c opt)
 # Move this stuff to bin for simplicity.
 mkdir -p bin
 chmod o+rwx bin
 cp $BAZEL_BIN/pkg/cmd/cockroach/cockroach_/cockroach bin
-cp $BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod bin
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin
-chmod a+w bin/cockroach bin/roachprod bin/roachtest bin/workload
+chmod a+w bin/cockroach bin/roachtest bin/workload
 # Stage the geos libs in the appropriate spot.
 mkdir -p lib.docker_amd64
 chmod o+rwx lib.docker_amd64

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -48,7 +48,6 @@ timeout -s INT $((7800*60)) bin/roachtest run \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --cockroach "$PWD/bin/cockroach" \
-  --roachprod "$PWD/bin/roachprod" \
   --workload "$PWD/bin/workload" \
   --artifacts "/artifacts/${artifacts_subdir}" \
   --artifacts-literal="${artifacts}" \

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -2,7 +2,7 @@
 
 `roachtest` is a tool for performing large-scale (multi-machine)
 automated tests. It relies on the concurrently-developed (but
-separate) tool `roachprod`.
+separate) library `roachprod`.
 
 # Setup
 
@@ -31,10 +31,9 @@ acceptance/cli/node-status [server]
 
 To run a test, the `roachtest run` command is used. Since a test typically
 deploys a CockroachDB cluster, `roachtest` needs to know which cockroach binary
-to use. It also needs to know where to find `roachprod`, and also generically
-requires the `workload` binary which is used by many tests to deploy load
-against the cluster. To that effect, `roachtest run` takes the `--cockroach`,
-`--roachprod`, and `--workload` flags. The default values for these are set up
+to use. It also generically requires the `workload` binary which is used by many 
+tests to deploy load against the cluster. To that effect, `roachtest run` takes 
+the `--cockroach`, and `--workload` flags. The default values for these are set up
 so that they do not need to be specified in the common case. Besides, when
 the binaries have nonstandard names, it is often more convenient to move them
 to the location `roachtest` expects (it will tell you) rather than to specify
@@ -59,7 +58,7 @@ where `roachtest` will find them:
 `roachtest` will look first in `$PATH`, then (except when `--local` is
 specified) in `bin.docker_amd64` in the repo root, followed by `bin`. This
 is complicated enough to be surprising, which might be another reason to
-pass the `--cockroach`, `--workload`, `--roachprod` flags explicitly.
+pass the `--cockroach` and  `--workload` flags explicitly.
 
 Some roachtests can also be run with the `--local` flag, i.e. will use a
 cluster on the local machine created via `roachprod create local`. In that
@@ -108,7 +107,7 @@ $ roachtest run acceptance/build-info
 
 If this doesn't work, the output should tell you why. Perhaps the binaries you
 use are not in the canonical locations and need to be specified via the
-`--cockroach`, `--workload`, `--roachprod` flags. Common other errors include
+`--cockroach` and `--workload` flags. Common other errors include
 not having set up roachprod properly (does `roachprod create -n 1 $USER-foo &&
 roachprod destroy $USER-foo` work?), or having the binaries for the wrong
 architecture in place (reminder: `roachtest` and `roachprod` run on your own

--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -127,7 +127,6 @@ trap 'echo Build artifacts dir is ${abase}' EXIT
 
 # Locations of the binaries.
 rt="${abase}/roachtest"
-rp="${abase}/roachprod"
 wl="${abase}/workload${local}"
 cr="${abase}/cockroach${local}"
 
@@ -154,8 +153,7 @@ if [ ! -f "${wl}" ] || [ "${force_build}" = "y" ]; then
     make bin/workload
     cp bin/workload "${wl}"
   fi
-  make bin/roach{prod,test}
-  cp bin/roachprod "${rp}"
+  make bin/roachtest
   cp bin/roachtest "${rt}"
 fi
 
@@ -167,7 +165,6 @@ trap 'echo Find run artifacts in ${a}' EXIT
 args=(
   "run" "${test}"
   "--port" "$((8080+RANDOM % 1000))"
-  "--roachprod" "${rp}"
   "--workload" "${wl}"
   "--cockroach" "${cr}"
   "--artifacts" "${a}"


### PR DESCRIPTION
`--roachprod` flag is now deprecated.

Release note: None