### PR TITLE
cdc: bounded cache for avro encoders

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -992,7 +992,7 @@ func (r *avroEnvelopeRecord) BinaryFromRow(
 }
 
 // Refresh the metadata for user-defined types on a cached schema
-// The only user-defined type is enum, so this is usually a no-op
+// The only user-defined type is enum, so this is usually a no-op.
 func (r *avroDataRecord) refreshTypeMetadata(tbl catalog.TableDescriptor) {
 	for _, col := range tbl.UserDefinedTypeColumns() {
 		if fieldIdx, ok := r.fieldIdxByColIdx[col.Ordinal()]; ok {


### PR DESCRIPTION
closes #73856. Removes another place where in theory
we leak memory during schema changes. Also recklessly
removing a TODO to bound a per-topic cache because
that's already inherently bounded.

Release note: None