### PR TITLE
kv: treat empty transaction deadlines identically to nil deadlines

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -442,7 +442,7 @@ func (tc *TxnCoordSender) finalizeNonLockingTxnLocked(
 	et := ba.Requests[0].GetEndTxn()
 	if et.Commit {
 		deadline := et.Deadline
-		if deadline != nil && deadline.LessEq(tc.mu.txn.WriteTimestamp) {
+		if deadline != nil && !deadline.IsEmpty() && deadline.LessEq(tc.mu.txn.WriteTimestamp) {
 			txn := tc.mu.txn.Clone()
 			pErr := generateTxnDeadlineExceededErr(txn, *deadline)
 			// We need to bump the epoch and transform this retriable error.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -313,7 +313,7 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 	// transaction is trying to commit.
 	if et.Commit {
 		deadline := et.Deadline
-		if deadline != nil && deadline.LessEq(br.Txn.WriteTimestamp) {
+		if deadline != nil && !deadline.IsEmpty() && deadline.LessEq(br.Txn.WriteTimestamp) {
 			return nil, generateTxnDeadlineExceededErr(ba.Txn, *deadline)
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -391,7 +391,7 @@ func EndTxn(
 // commit timestamp exceeded its deadline. If so, the transaction should not be
 // allowed to commit.
 func IsEndTxnExceedingDeadline(commitTS hlc.Timestamp, deadline *hlc.Timestamp) bool {
-	return deadline != nil && deadline.LessEq(commitTS)
+	return deadline != nil && !deadline.IsEmpty() && deadline.LessEq(commitTS)
 }
 
 // IsEndTxnTriggeringRetryError returns true if the EndTxnRequest cannot be

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1054,7 +1054,7 @@ func TestTransactionDeadline(t *testing.T) {
 
 		if args, ok := ba.GetArg(roachpb.EndTxn); ok {
 			et := args.(*roachpb.EndTxnRequest)
-			if et.Deadline == nil {
+			if et.Deadline == nil || et.Deadline.IsEmpty() {
 				return nil
 			}
 			mu.txnDeadline = *et.Deadline


### PR DESCRIPTION
This is as much as we can do for #74224 this release (v22.1). It sets us up to do the rest in the following release (v22.2).