### PR TITLE
sql: fix kvtrace on table with not null virtual computed columns

### DIFF
--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -419,11 +419,6 @@ func NewColIndexJoin(
 	if err != nil {
 		return nil, err
 	}
-	if idxMap != nil {
-		// The index join is fetching from the primary index, so there should be
-		// no mapping needed.
-		return nil, errors.AssertionFailedf("unexpectedly non-nil idx map for the index join")
-	}
 
 	// Retrieve the set of columns that the index join needs to fetch.
 	var neededColumns []uint32

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1241,3 +1241,22 @@ query ITI
 SELECT * FROM t73372
 ----
 0  foo  0
+
+# Regression test for #73745. Cfetcher should never try to fetch virtual
+# computed columns from a primary index.
+subtest 73745
+
+statement ok
+CREATE TABLE t73745 (
+  i INT PRIMARY KEY,
+  v INT NOT NULL AS ((i * 2)) VIRTUAL
+)
+
+statement ok
+INSERT INTO t73745 VALUES (1), (2), (3);
+
+# Use kvtrace to simulate \set auto_trace=on,kv.
+query T kvtrace
+SELECT * FROM t73745
+----
+Scan /Table/87/{1-2}


### PR DESCRIPTION
This commit fixes a bug caused by cfetcher trying to fetch virtual
computed columns from a primary index. Under normal operation, this bug
had no effect because cfetch only fetches columns that the optimizer
instructs it to. The optimizer is aware that virtual columns are not
present in primary indexes. However, when KV tracing is enabled,
cfetcher attempts to fetch all columns. The bug is fixed by pruning
virtual columns when fetching from a primary index.

Fixes #73745

Release note (bug fix): A bug has been fixed that caused internal errors
when querying tables with not null virtual computed columns while KV
tracing was enabled (for example `\set autotrace=on,kv`). This bug was
present since virtual computed columns were released in version 21.1.