### PR TITLE
roachtest: don't use envutil

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/testutils/skip",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
-        "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/quotapool",
         "//pkg/util/stop",

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -923,11 +922,11 @@ func (r *testRunner) maybePostGithubIssue(
 		projColID = teams[sl[0]].TriageColumnID
 	}
 
-	branch := "<unknown branch>"
-
-	if b := envutil.EnvOrDefaultString("TC_BUILD_BRANCH", ""); b != "" {
-		branch = b
+	branch := os.Getenv("TC_BUILD_BRANCH")
+	if branch == "" {
+		branch = "<unknown branch>"
 	}
+
 	msg := fmt.Sprintf("The test failed on branch=%s, cloud=%s:\n%s",
 		branch, t.Spec().(*registry.TestSpec).Cluster.Cloud, output)
 	artifacts := fmt.Sprintf("/%s", t.Name())


### PR DESCRIPTION
envutil is for use with CRDB only. It has strong opinions about what
constitutes a valid env var and will fatal when handed anything else,
such as `TC_BUILD_BRANCH`.

This fixes the roachtest nightlies by fixng this problem:
https://cockroachlabs.slack.com/archives/C026MSSL926/p1640244136067300

Release note: None
