### PR TITLE
sql/pgwire: correct implicit txn behavior in extended protocol

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -454,13 +454,6 @@ func (r *limitedCommandResult) SupportsAddBatch() bool {
 // requests for rows from the active portal, during the "execute portal" flow
 // when a limit has been specified.
 func (r *limitedCommandResult) moreResultsNeeded(ctx context.Context) error {
-	// In an implicit transaction, a portal suspension is immediately
-	// followed by closing the portal.
-	if r.implicitTxn {
-		r.typ = noCompletionMsg
-		return sql.ErrLimitedResultClosed
-	}
-
 	// Keep track of the previous CmdPos so we can rewind if needed.
 	prevPos := r.conn.stmtBuf.AdvanceOne()
 	for {
@@ -491,6 +484,11 @@ func (r *limitedCommandResult) moreResultsNeeded(ctx context.Context) error {
 			r.rowsAffected = 0
 			return nil
 		case sql.Sync:
+			if r.implicitTxn {
+				// Implicit transactions should treat a Sync as an auto-commit. This
+				// needs to be handled in conn_executor.
+				return r.rewindAndClosePortal(ctx, prevPos)
+			}
 			// The client wants to see a ready for query message
 			// back. Send it then run the for loop again.
 			r.conn.stmtBuf.AdvanceOne()
@@ -498,9 +496,8 @@ func (r *limitedCommandResult) moreResultsNeeded(ctx context.Context) error {
 			// here as the conn_executor cleanup is not executed because of the
 			// limitedCommandResult side state machine.
 			r.conn.stmtBuf.Ltrim(ctx, prevPos)
-			// We can hard code InTxnBlock here because we don't
-			// support implicit transactions, so we know we're in
-			// a transaction.
+			// We can hard code InTxnBlock here because implicit transactions are
+			// handled above.
 			r.conn.bufferReadyForQuery(byte(sql.InTxnBlock))
 			if err := r.conn.Flush(r.pos); err != nil {
 				return err

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -932,3 +932,119 @@ ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"ROLLBACK"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test that we can use a portal with MaxRows from an implicit transaction.
+send
+Parse {"Name": "s12", "Query": "SELECT * FROM generate_series(1, 10)"}
+Bind {"DestinationPortal": "C_1", "PreparedStatement": "s12"}
+Execute {"Portal": "C_1", "MaxRows": 2}
+Execute {"Portal": "C_1", "MaxRows": 2}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"PortalSuspended"}
+{"Type":"DataRow","Values":[{"text":"3"}]}
+{"Type":"DataRow","Values":[{"text":"4"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# We can reuse the portal name, but not the statement name.
+# This also tests that when the rows are fully consumed, reading from the
+# portal returns 0 rows.
+send
+Parse {"Name": "s13", "Query": "SELECT * FROM generate_series(1, 7)"}
+Bind {"DestinationPortal": "C_1", "PreparedStatement": "s13"}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"DataRow","Values":[{"text":"3"}]}
+{"Type":"PortalSuspended"}
+{"Type":"DataRow","Values":[{"text":"4"}]}
+{"Type":"DataRow","Values":[{"text":"5"}]}
+{"Type":"DataRow","Values":[{"text":"6"}]}
+{"Type":"PortalSuspended"}
+{"Type":"DataRow","Values":[{"text":"7"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS portal_sync_test"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE portal_sync_test (a FLOAT)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test that Sync is treated as an auto-commit and that it can deal with
+# errors during the implicit transaction.
+send
+Parse {"Name": "s14", "Query": "INSERT INTO portal_sync_test VALUES(1.0/0);"}
+Bind {"DestinationPortal": "C_1", "PreparedStatement": "s14"}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Execute {"Portal": "C_1", "MaxRows": 3}
+Sync
+----
+
+# CockroachDB sends a BindComplete here, but PostgreSQL does not.
+until keepErrMessage ignore=BindComplete
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"22012","Message":"division by zero"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "INSERT INTO portal_sync_test VALUES(1);"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT * FROM portal_sync_test;"}
+----
+
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":701,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes #74187

The PostgreSQL docs say:

```
At completion of each series of extended-query messages, the frontend should
issue a Sync message. This parameterless message causes the backend to close
the current transaction if it's not inside a BEGIN/COMMIT transaction block.
```

This behavior was not implemented in CockroachDB -- previously we were
performing the auto-commit when the Execute message was handled, rather
than when Sync was handled.

This divergence also was preventing CockroachDB from being able to
handle portals correctly when used in an implicit transaction. Portals
are supposed to be closed when the transaction ends. But since we were
ending the transaction to early, it meant that a portal could not be
read multiple times in an implicit transaction.

Release note (bug fix): Portals in the extended protocol of the Postgres
wire protocol can now be used from implicit transactions and can be
executed multiple times if there is a row-count limit applied to the
portal. Previously, trying to execute the same portal twice would result
in an "unknown portal" error.