### PR TITLE
git: clean untracked files when switching branches

### DIFF
--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -2,5 +2,6 @@
 set -e
 
 if [ "$1" != "$2" ]; then # previous ref != new ref.
+  git clean pkg -fd
   exec git submodule update --init --recursive
 fi


### PR DESCRIPTION
As our set of gitignored files change, switching to older branches can
often lead to untracked files left around that need manual cleanup. We
could perhaps do this automatically.

Release note: None