### PR TITLE
setting: prevent use of SystemOnly settings from tenant code

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/distsql",
-        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -23,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -86,7 +86,9 @@ func TestTenantCannotSetClusterSetting(t *testing.T) {
 	var pqErr *pq.Error
 	ok := errors.As(err, &pqErr)
 	require.True(t, ok, "expected err to be a *pq.Error but is of type %T. error is: %v", err)
-	require.Equal(t, pq.ErrorCode(pgcode.InsufficientPrivilege.String()), pqErr.Code, "err %v has unexpected code", err)
+	if !strings.Contains(pqErr.Message, "unknown cluster setting") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestTenantCanUseEnterpriseFeatures(t *testing.T) {

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -211,8 +211,8 @@ Output the list of cluster settings known to this binary.
 		settings.NewUpdater(&s.SV).ResetRemaining(context.Background())
 
 		var rows [][]string
-		for _, name := range settings.Keys() {
-			setting, ok := settings.Lookup(name, settings.LookupForLocalAccess)
+		for _, name := range settings.Keys(settings.ForSystemTenant) {
+			setting, ok := settings.Lookup(name, settings.LookupForLocalAccess, settings.ForSystemTenant)
 			if !ok {
 				panic(fmt.Sprintf("could not find setting %q", name))
 			}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1662,7 +1662,7 @@ func (s *adminServer) Settings(
 ) (*serverpb.SettingsResponse, error) {
 	keys := req.Keys
 	if len(keys) == 0 {
-		keys = settings.Keys()
+		keys = settings.Keys(settings.ForSystemTenant)
 	}
 
 	_, isAdmin, err := s.getUserAndRole(ctx)
@@ -1686,7 +1686,7 @@ func (s *adminServer) Settings(
 
 	resp := serverpb.SettingsResponse{KeyValues: make(map[string]serverpb.SettingsResponse_Value)}
 	for _, k := range keys {
-		v, ok := settings.Lookup(k, lookupPurpose)
+		v, ok := settings.Lookup(k, lookupPurpose, settings.ForSystemTenant)
 		if !ok {
 			continue
 		}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1074,10 +1074,10 @@ func TestAdminAPISettings(t *testing.T) {
 	// Any bool that defaults to true will work here.
 	const settingKey = "sql.metrics.statement_details.enabled"
 	st := s.ClusterSettings()
-	allKeys := settings.Keys()
+	allKeys := settings.Keys(settings.ForSystemTenant)
 
 	checkSetting := func(t *testing.T, k string, v serverpb.SettingsResponse_Value) {
-		ref, ok := settings.Lookup(k, settings.LookupForReporting)
+		ref, ok := settings.Lookup(k, settings.LookupForReporting, settings.ForSystemTenant)
 		if !ok {
 			t.Fatalf("%s: not found after initial lookup", k)
 		}

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -209,7 +209,9 @@ func (r *Reporter) CreateReport(
 		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 			row := it.Cur()
 			name := string(tree.MustBeDString(row[0]))
-			info.AlteredSettings[name] = settings.RedactedValue(name, &r.Settings.SV)
+			info.AlteredSettings[name] = settings.RedactedValue(
+				name, &r.Settings.SV, r.TenantID == roachpb.SystemTenantID,
+			)
 		}
 		if err != nil {
 			// No need to clear AlteredSettings map since we only make best

--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/settings",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/buildutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
@@ -35,6 +36,7 @@ go_test(
     deps = [
         ":settings",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -24,7 +24,7 @@ var _ internalSetting = &BoolSetting{}
 
 // Get retrieves the bool value in the setting.
 func (b *BoolSetting) Get(sv *Values) bool {
-	return sv.getInt64(b.slotIdx) != 0
+	return sv.getInt64(b.slot) != 0
 }
 
 func (b *BoolSetting) String(sv *Values) string {
@@ -65,7 +65,7 @@ func (b *BoolSetting) Override(ctx context.Context, sv *Values, v bool) {
 	if v {
 		vInt = 1
 	}
-	sv.setDefaultOverrideInt64(b.slotIdx, vInt)
+	sv.setDefaultOverrideInt64(b.slot, vInt)
 }
 
 func (b *BoolSetting) set(ctx context.Context, sv *Values, v bool) {
@@ -73,12 +73,12 @@ func (b *BoolSetting) set(ctx context.Context, sv *Values, v bool) {
 	if v {
 		vInt = 1
 	}
-	sv.setInt64(ctx, b.slotIdx, vInt)
+	sv.setInt64(ctx, b.slot, vInt)
 }
 
 func (b *BoolSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
-	ok, val, _ := sv.getDefaultOverride(b.slotIdx)
+	ok, val, _ := sv.getDefaultOverride(b.slot)
 	if ok {
 		b.set(ctx, sv, val > 0)
 		return

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -17,59 +17,60 @@ import (
 
 // common implements basic functionality used by all setting types.
 type common struct {
-	key         string
-	description string
-	class       Class
-	visibility  Visibility
-	// Each setting has a slotIdx which is used as a handle with Values.
-	slotIdx       int
+	class         Class
+	key           string
+	description   string
+	visibility    Visibility
+	slot          slotIdx
 	nonReportable bool
 	retired       bool
 }
 
+// slotIdx is an integer in the range [0, MaxSetting) which is uniquely
+// associated with a registered setting. Slot indexes are used as "handles" for
+// manipulating the setting values. They are generated sequentially, in the
+// order of registration.
+type slotIdx int32
+
 // init must be called to initialize the fields that don't have defaults.
-func (i *common) init(class Class, slotIdx int, key string, description string) {
-	i.class = class
-	if slotIdx < 1 {
-		panic(fmt.Sprintf("Invalid slot index %d", slotIdx))
+func (c *common) init(class Class, key string, description string, slot slotIdx) {
+	c.class = class
+	c.key = key
+	c.description = description
+	if slot < 0 {
+		panic(fmt.Sprintf("Invalid slot index %d", slot))
 	}
-	if slotIdx > MaxSettings {
+	if slot >= MaxSettings {
 		panic("too many settings; increase MaxSettings")
 	}
-	i.slotIdx = slotIdx
-	i.key = key
-	i.description = description
+	c.slot = slot
 }
 
-func (i *common) isRetired() bool {
-	return i.retired
+func (c common) Class() Class {
+	return c.class
 }
 
-func (i *common) getSlotIdx() int {
-	return i.slotIdx
+func (c common) Key() string {
+	return c.key
 }
 
-func (i common) Key() string {
-	return i.key
+func (c common) Description() string {
+	return c.description
 }
 
-func (i common) Description() string {
-	return i.description
+func (c common) Visibility() Visibility {
+	return c.visibility
 }
 
-func (i common) Class() Class {
-	return i.class
+func (c common) isReportable() bool {
+	return !c.nonReportable
 }
 
-func (i common) Visibility() Visibility {
-	return i.visibility
+func (c *common) isRetired() bool {
+	return c.retired
 }
 
-func (i common) isReportable() bool {
-	return !i.nonReportable
-}
-
-func (i *common) ErrorHint() (bool, string) {
+func (c *common) ErrorHint() (bool, string) {
 	return false, ""
 }
 
@@ -83,36 +84,36 @@ func (i *common) ErrorHint() (bool, string) {
 //
 // All string settings are also non-reportable by default and must be
 // opted in to reports manually with SetReportable(true).
-func (i *common) SetReportable(reportable bool) {
-	i.nonReportable = !reportable
+func (c *common) SetReportable(reportable bool) {
+	c.nonReportable = !reportable
 }
 
 // SetVisibility customizes the visibility of a setting.
-func (i *common) SetVisibility(v Visibility) {
-	i.visibility = v
+func (c *common) SetVisibility(v Visibility) {
+	c.visibility = v
 }
 
 // SetRetired marks the setting as obsolete. It also hides
 // it from the output of SHOW CLUSTER SETTINGS.
-func (i *common) SetRetired() {
-	i.description = "do not use - " + i.description
-	i.retired = true
+func (c *common) SetRetired() {
+	c.description = "do not use - " + c.description
+	c.retired = true
 }
 
 // SetOnChange installs a callback to be called when a setting's value changes.
 // `fn` should avoid doing long-running or blocking work as it is called on the
 // goroutine which handles all settings updates.
-func (i *common) SetOnChange(sv *Values, fn func(ctx context.Context)) {
-	sv.setOnChange(i.slotIdx, fn)
+func (c *common) SetOnChange(sv *Values, fn func(ctx context.Context)) {
+	sv.setOnChange(c.slot, fn)
 }
 
 type internalSetting interface {
 	NonMaskedSetting
 
-	init(class Class, slotIdx int, key string, desc string)
+	init(class Class, key, description string, slot slotIdx)
 	isRetired() bool
 	setToDefault(ctx context.Context, sv *Values)
-	getSlotIdx() int
+
 	// isReportable indicates whether the value of the setting can be
 	// included in user-facing reports such as that produced by SHOW ALL
 	// CLUSTER SETTINGS.
@@ -126,5 +127,5 @@ type internalSetting interface {
 // numericSetting is used for settings that can be set using an integer value.
 type numericSetting interface {
 	internalSetting
-	set(ctx context.Context, sv *Values, i int64) error
+	set(ctx context.Context, sv *Values, value int64) error
 }

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -43,7 +43,7 @@ func (d *DurationSettingWithExplicitUnit) ErrorHint() (bool, string) {
 
 // Get retrieves the duration value in the setting.
 func (d *DurationSetting) Get(sv *Values) time.Duration {
-	return time.Duration(sv.getInt64(d.slotIdx))
+	return time.Duration(sv.getInt64(d.slot))
 }
 
 func (d *DurationSetting) String(sv *Values) string {
@@ -88,21 +88,21 @@ func (d *DurationSetting) Validate(v time.Duration) error {
 //
 // For testing usage only.
 func (d *DurationSetting) Override(ctx context.Context, sv *Values, v time.Duration) {
-	sv.setInt64(ctx, d.slotIdx, int64(v))
-	sv.setDefaultOverrideInt64(d.slotIdx, int64(v))
+	sv.setInt64(ctx, d.slot, int64(v))
+	sv.setDefaultOverrideInt64(d.slot, int64(v))
 }
 
 func (d *DurationSetting) set(ctx context.Context, sv *Values, v time.Duration) error {
 	if err := d.Validate(v); err != nil {
 		return err
 	}
-	sv.setInt64(ctx, d.slotIdx, int64(v))
+	sv.setInt64(ctx, d.slot, int64(v))
 	return nil
 }
 
 func (d *DurationSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
-	ok, val, _ := sv.getDefaultOverride(d.slotIdx)
+	ok, val, _ := sv.getDefaultOverride(d.slot)
 	if ok {
 		// As per the semantics of override, these values don't go through
 		// validation.

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -30,7 +30,7 @@ var _ internalSetting = &FloatSetting{}
 
 // Get retrieves the float value in the setting.
 func (f *FloatSetting) Get(sv *Values) float64 {
-	return math.Float64frombits(uint64(sv.getInt64(f.slotIdx)))
+	return math.Float64frombits(uint64(sv.getInt64(f.slot)))
 }
 
 func (f *FloatSetting) String(sv *Values) string {
@@ -68,7 +68,7 @@ func (f *FloatSetting) Override(ctx context.Context, sv *Values, v float64) {
 	if err := f.set(ctx, sv, v); err != nil {
 		panic(err)
 	}
-	sv.setDefaultOverrideInt64(f.slotIdx, int64(math.Float64bits(v)))
+	sv.setDefaultOverrideInt64(f.slot, int64(math.Float64bits(v)))
 }
 
 // Validate that a value conforms with the validation function.
@@ -85,13 +85,13 @@ func (f *FloatSetting) set(ctx context.Context, sv *Values, v float64) error {
 	if err := f.Validate(v); err != nil {
 		return err
 	}
-	sv.setInt64(ctx, f.slotIdx, int64(math.Float64bits(v)))
+	sv.setInt64(ctx, f.slot, int64(math.Float64bits(v)))
 	return nil
 }
 
 func (f *FloatSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
-	ok, val, _ := sv.getDefaultOverride(f.slotIdx)
+	ok, val, _ := sv.getDefaultOverride(f.slot)
 	if ok {
 		// As per the semantics of override, these values don't go through
 		// validation.

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -29,7 +29,7 @@ var _ numericSetting = &IntSetting{}
 
 // Get retrieves the int value in the setting.
 func (i *IntSetting) Get(sv *Values) int64 {
-	return sv.container.getInt64(i.slotIdx)
+	return sv.container.getInt64(i.slot)
 }
 
 func (i *IntSetting) String(sv *Values) string {
@@ -74,21 +74,21 @@ func (i *IntSetting) Validate(v int64) error {
 //
 // For testing usage only.
 func (i *IntSetting) Override(ctx context.Context, sv *Values, v int64) {
-	sv.setInt64(ctx, i.slotIdx, v)
-	sv.setDefaultOverrideInt64(i.slotIdx, v)
+	sv.setInt64(ctx, i.slot, v)
+	sv.setDefaultOverrideInt64(i.slot, v)
 }
 
 func (i *IntSetting) set(ctx context.Context, sv *Values, v int64) error {
 	if err := i.Validate(v); err != nil {
 		return err
 	}
-	sv.setInt64(ctx, i.slotIdx, v)
+	sv.setInt64(ctx, i.slot, v)
 	return nil
 }
 
 func (i *IntSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
-	ok, val, _ := sv.getDefaultOverride(i.slotIdx)
+	ok, val, _ := sv.getDefaultOverride(i.slot)
 	if ok {
 		// As per the semantics of override, these values don't go through
 		// validation.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -142,9 +142,9 @@ func register(class Class, key, desc string, s internalSetting) {
 			))
 		}
 	}
+	slot := slotIdx(len(registry))
+	s.init(class, key, desc, slot)
 	registry[key] = s
-	slotIdx := len(registry)
-	s.init(class, slotIdx, key, desc)
 }
 
 // NumRegisteredSettings returns the number of registered settings.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -27,6 +27,10 @@ import (
 // read concurrently by different callers.
 var registry = make(map[string]internalSetting)
 
+// slotTable stores the same settings as the registry, but accessible by the
+// slot index.
+var slotTable [MaxSettings]internalSetting
+
 // TestingSaveRegistry can be used in tests to save/restore the current
 // contents of the registry.
 func TestingSaveRegistry() func() {
@@ -145,16 +149,20 @@ func register(class Class, key, desc string, s internalSetting) {
 	slot := slotIdx(len(registry))
 	s.init(class, key, desc, slot)
 	registry[key] = s
+	slotTable[slot] = s
 }
 
 // NumRegisteredSettings returns the number of registered settings.
 func NumRegisteredSettings() int { return len(registry) }
 
 // Keys returns a sorted string array with all the known keys.
-func Keys() (res []string) {
+func Keys(forSystemTenant bool) (res []string) {
 	res = make([]string, 0, len(registry))
-	for k := range registry {
-		if registry[k].isRetired() {
+	for k, v := range registry {
+		if v.isRetired() {
+			continue
+		}
+		if !forSystemTenant && v.Class() == SystemOnly {
 			continue
 		}
 		res = append(res, k)
@@ -166,13 +174,18 @@ func Keys() (res []string) {
 // Lookup returns a Setting by name along with its description.
 // For non-reportable setting, it instantiates a MaskedSetting
 // to masquerade for the underlying setting.
-func Lookup(name string, purpose LookupPurpose) (Setting, bool) {
-	v, ok := registry[name]
-	var setting Setting = v
-	if ok && purpose == LookupForReporting && !v.isReportable() {
-		setting = &MaskedSetting{setting: v}
+func Lookup(name string, purpose LookupPurpose, forSystemTenant bool) (Setting, bool) {
+	s, ok := registry[name]
+	if !ok {
+		return nil, false
 	}
-	return setting, ok
+	if !forSystemTenant && s.Class() == SystemOnly {
+		return nil, false
+	}
+	if purpose == LookupForReporting && !s.isReportable() {
+		return &MaskedSetting{setting: s}, true
+	}
+	return s, true
 }
 
 // LookupPurpose indicates what is being done with the setting.
@@ -187,6 +200,10 @@ const (
 	// all values should be accessible
 	LookupForLocalAccess
 )
+
+// ForSystemTenant can be passed to Lookup for code that runs only on the system
+// tenant.
+const ForSystemTenant = true
 
 // ReadableTypes maps our short type identifiers to friendlier names.
 var ReadableTypes = map[string]string{
@@ -204,8 +221,8 @@ var ReadableTypes = map[string]string{
 // RedactedValue returns a string representation of the value for settings
 // types the are not considered sensitive (numbers, bools, etc) or
 // <redacted> for those with values could store sensitive things (i.e. strings).
-func RedactedValue(name string, values *Values) string {
-	if setting, ok := Lookup(name, LookupForReporting); ok {
+func RedactedValue(name string, values *Values, forSystemTenant bool) string {
+	if setting, ok := Lookup(name, LookupForReporting, forSystemTenant); ok {
 		return setting.String(values)
 	}
 	return "<unknown>"

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -22,6 +22,12 @@ import (
 // multiple "instances" (values) for each setting (e.g. for multiple test
 // servers in the same process).
 type Setting interface {
+	// Class returns the scope of the setting in multi-tenant scenarios.
+	Class() Class
+
+	// Key returns the name of the specific cluster setting.
+	Key() string
+
 	// Typ returns the short (1 char) string denoting the type of setting.
 	Typ() string
 
@@ -29,9 +35,6 @@ type Setting interface {
 	// It's used when materializing results for `SHOW CLUSTER SETTINGS` or `SHOW
 	// CLUSTER SETTING <setting-name>`.
 	String(sv *Values) string
-
-	// Key returns the name of the specific cluster setting.
-	Key() string
 
 	// Description contains a helpful text explaining what the specific cluster
 	// setting is for.
@@ -41,9 +44,6 @@ type Setting interface {
 	// Reserved settings are still accessible to users, but they don't get listed
 	// out when retrieving all settings.
 	Visibility() Visibility
-
-	// Class returns the scope of the setting in multi-tenant scenarios.
-	Class() Class
 }
 
 // NonMaskedSetting is the exported interface of non-masked settings.

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -56,7 +56,7 @@ var _ = (*StringSetting).Default
 
 // Get retrieves the string value in the setting.
 func (s *StringSetting) Get(sv *Values) string {
-	loaded := sv.getGeneric(s.slotIdx)
+	loaded := sv.getGeneric(s.slot)
 	if loaded == nil {
 		return ""
 	}
@@ -84,7 +84,7 @@ func (s *StringSetting) set(ctx context.Context, sv *Values, v string) error {
 		return err
 	}
 	if s.Get(sv) != v {
-		sv.setGeneric(ctx, s.slotIdx, v)
+		sv.setGeneric(ctx, s.slot, v)
 	}
 	return nil
 }

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -136,6 +136,10 @@ func (u updater) Set(ctx context.Context, key, rawValue string, vt string) error
 // ResetRemaining sets all settings not updated by the updater to their default values.
 func (u updater) ResetRemaining(ctx context.Context) {
 	for k, v := range registry {
+		if u.sv.NonSystemTenant() && v.Class() == SystemOnly {
+			// Don't try to reset system settings on a non-system tenant.
+			continue
+		}
 		if _, ok := u.m[k]; !ok {
 			v.setToDefault(ctx, u.sv)
 		}

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -34,7 +34,7 @@ type Values struct {
 		// Override()).
 		defaultOverrides valuesContainer
 		// setOverrides is the list of slots with values in defaultOverrides.
-		setOverrides map[int]struct{}
+		setOverrides map[slotIdx]struct{}
 	}
 
 	changeMu struct {
@@ -53,12 +53,12 @@ type valuesContainer struct {
 	genericVals [MaxSettings]atomic.Value
 }
 
-func (c *valuesContainer) setGenericVal(slotIdx int, newVal interface{}) {
-	c.genericVals[slotIdx].Store(newVal)
+func (c *valuesContainer) setGenericVal(slot slotIdx, newVal interface{}) {
+	c.genericVals[slot].Store(newVal)
 }
 
-func (c *valuesContainer) setInt64Val(slotIdx int, newVal int64) bool {
-	return atomic.SwapInt64(&c.intVals[slotIdx], newVal) != newVal
+func (c *valuesContainer) setInt64Val(slot slotIdx, newVal int64) bool {
+	return atomic.SwapInt64(&c.intVals[slot], newVal) != newVal
 }
 
 type testOpaqueType struct{}
@@ -83,44 +83,44 @@ func (sv *Values) Opaque() interface{} {
 	return sv.opaque
 }
 
-func (sv *Values) settingChanged(ctx context.Context, slotIdx int) {
+func (sv *Values) settingChanged(ctx context.Context, slot slotIdx) {
 	sv.changeMu.Lock()
-	funcs := sv.changeMu.onChange[slotIdx-1]
+	funcs := sv.changeMu.onChange[slot]
 	sv.changeMu.Unlock()
 	for _, fn := range funcs {
 		fn(ctx)
 	}
 }
 
-func (c *valuesContainer) getInt64(slotIdx int) int64 {
-	return atomic.LoadInt64(&c.intVals[slotIdx-1])
+func (c *valuesContainer) getInt64(slot slotIdx) int64 {
+	return atomic.LoadInt64(&c.intVals[slot])
 }
 
-func (c *valuesContainer) getGeneric(slotIdx int) interface{} {
-	return c.genericVals[slotIdx-1].Load()
+func (c *valuesContainer) getGeneric(slot slotIdx) interface{} {
+	return c.genericVals[slot].Load()
 }
 
-func (sv *Values) setInt64(ctx context.Context, slotIdx int, newVal int64) {
-	if sv.container.setInt64Val(slotIdx-1, newVal) {
-		sv.settingChanged(ctx, slotIdx)
+func (sv *Values) setInt64(ctx context.Context, slot slotIdx, newVal int64) {
+	if sv.container.setInt64Val(slot, newVal) {
+		sv.settingChanged(ctx, slot)
 	}
 }
 
 // setDefaultOverrideInt64 overrides the default value for the respective
 // setting to newVal.
-func (sv *Values) setDefaultOverrideInt64(slotIdx int, newVal int64) {
+func (sv *Values) setDefaultOverrideInt64(slot slotIdx, newVal int64) {
 	sv.overridesMu.Lock()
 	defer sv.overridesMu.Unlock()
-	sv.overridesMu.defaultOverrides.setInt64Val(slotIdx-1, newVal)
-	sv.setDefaultOverrideLocked(slotIdx)
+	sv.overridesMu.defaultOverrides.setInt64Val(slot, newVal)
+	sv.setDefaultOverrideLocked(slot)
 }
 
-// setDefaultOverrideLocked marks slotIdx-1 as having an overridden default value.
-func (sv *Values) setDefaultOverrideLocked(slotIdx int) {
+// setDefaultOverrideLocked marks the slot as having an overridden default value.
+func (sv *Values) setDefaultOverrideLocked(slot slotIdx) {
 	if sv.overridesMu.setOverrides == nil {
-		sv.overridesMu.setOverrides = make(map[int]struct{})
+		sv.overridesMu.setOverrides = make(map[slotIdx]struct{})
 	}
-	sv.overridesMu.setOverrides[slotIdx-1] = struct{}{}
+	sv.overridesMu.setOverrides[slot] = struct{}{}
 }
 
 // getDefaultOverrides checks whether there's a default override for slotIdx-1.
@@ -128,36 +128,35 @@ func (sv *Values) setDefaultOverrideLocked(slotIdx int) {
 // true, the second is the int64 override and the last is a pointer to the
 // generic value override. Callers are expected to only use the override value
 // corresponding to their setting type.
-func (sv *Values) getDefaultOverride(slotIdx int) (bool, int64, *atomic.Value) {
-	slotIdx--
+func (sv *Values) getDefaultOverride(slot slotIdx) (bool, int64, *atomic.Value) {
 	sv.overridesMu.Lock()
 	defer sv.overridesMu.Unlock()
-	if _, ok := sv.overridesMu.setOverrides[slotIdx]; !ok {
+	if _, ok := sv.overridesMu.setOverrides[slot]; !ok {
 		return false, 0, nil
 	}
 	return true,
-		sv.overridesMu.defaultOverrides.intVals[slotIdx],
-		&sv.overridesMu.defaultOverrides.genericVals[slotIdx]
+		sv.overridesMu.defaultOverrides.intVals[slot],
+		&sv.overridesMu.defaultOverrides.genericVals[slot]
 }
 
-func (sv *Values) setGeneric(ctx context.Context, slotIdx int, newVal interface{}) {
-	sv.container.setGenericVal(slotIdx-1, newVal)
-	sv.settingChanged(ctx, slotIdx)
+func (sv *Values) setGeneric(ctx context.Context, slot slotIdx, newVal interface{}) {
+	sv.container.setGenericVal(slot, newVal)
+	sv.settingChanged(ctx, slot)
 }
 
-func (sv *Values) getInt64(slotIdx int) int64 {
-	return sv.container.getInt64(slotIdx)
+func (sv *Values) getInt64(slot slotIdx) int64 {
+	return sv.container.getInt64(slot)
 }
 
-func (sv *Values) getGeneric(slotIdx int) interface{} {
-	return sv.container.getGeneric(slotIdx)
+func (sv *Values) getGeneric(slot slotIdx) interface{} {
+	return sv.container.getGeneric(slot)
 }
 
 // setOnChange installs a callback to be called when a setting's value changes.
 // `fn` should avoid doing long-running or blocking work as it is called on the
 // goroutine which handles all settings updates.
-func (sv *Values) setOnChange(slotIdx int, fn func(ctx context.Context)) {
+func (sv *Values) setOnChange(slot slotIdx, fn func(ctx context.Context)) {
 	sv.changeMu.Lock()
-	sv.changeMu.onChange[slotIdx-1] = append(sv.changeMu.onChange[slotIdx-1], fn)
+	sv.changeMu.onChange[slot] = append(sv.changeMu.onChange[slot], fn)
 	sv.changeMu.Unlock()
 }

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -140,19 +140,19 @@ func (v *VersionSetting) EncodedDefault() string {
 func (v *VersionSetting) Get(sv *Values) string {
 	encV := v.GetInternal(sv)
 	if encV == nil {
-		panic(fmt.Sprintf("missing value for version setting in slot %d", v.getSlotIdx()))
+		panic(fmt.Sprintf("missing value for version setting in slot %d", v.slot))
 	}
 	return string(encV.([]byte))
 }
 
 // GetInternal returns the setting's current value.
 func (v *VersionSetting) GetInternal(sv *Values) interface{} {
-	return sv.getGeneric(v.getSlotIdx())
+	return sv.getGeneric(v.slot)
 }
 
 // SetInternal updates the setting's value in the provided Values container.
 func (v *VersionSetting) SetInternal(ctx context.Context, sv *Values, newVal interface{}) {
-	sv.setGeneric(ctx, v.getSlotIdx(), newVal)
+	sv.setGeneric(ctx, v.slot, newVal)
 }
 
 // setToDefault is part of the extendingSetting interface. This is a no-op for

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1411,11 +1411,13 @@ CREATE TABLE crdb_internal.cluster_settings (
 						"crdb_internal.cluster_settings", roleoption.MODIFYCLUSTERSETTING)
 			}
 		}
-		for _, k := range settings.Keys() {
+		for _, k := range settings.Keys(p.ExecCfg().Codec.ForSystemTenant()) {
 			if !hasAdmin && settings.AdminOnly(k) {
 				continue
 			}
-			setting, _ := settings.Lookup(k, settings.LookupForLocalAccess)
+			setting, _ := settings.Lookup(
+				k, settings.LookupForLocalAccess, p.ExecCfg().Codec.ForSystemTenant(),
+			)
 			strVal := setting.String(&p.ExecCfg().Settings.SV)
 			isPublic := setting.Visibility() == settings.Public
 			desc := setting.Description()

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -98,3 +98,21 @@ query B
 SHOW CLUSTER SETTING sql.defaults.stub_catalog_tables.enabled
 ----
 true
+
+skipif config 3node-tenant
+statement ok
+SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '10Mib'
+
+skipif config 3node-tenant
+query T
+SHOW CLUSTER SETTING kv.snapshot_rebalance.max_rate
+----
+10 MiB
+
+onlyif config 3node-tenant
+statement error unknown cluster setting
+SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '10Mib'
+
+onlyif config 3node-tenant
+statement error unknown setting
+SHOW CLUSTER SETTING kv.snapshot_rebalance.max_rate

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -82,7 +82,7 @@ func (p *planner) SetClusterSetting(
 ) (planNode, error) {
 	name := strings.ToLower(n.Name)
 	st := p.EvalContext().Settings
-	v, ok := settings.Lookup(name, settings.LookupForLocalAccess)
+	v, ok := settings.Lookup(name, settings.LookupForLocalAccess, p.ExecCfg().Codec.ForSystemTenant())
 	if !ok {
 		return nil, errors.Errorf("unknown cluster setting '%s'", name)
 	}

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -119,7 +119,9 @@ func (p *planner) ShowClusterSetting(
 ) (planNode, error) {
 	name := strings.ToLower(n.Name)
 	st := p.ExecCfg().Settings
-	val, ok := settings.Lookup(name, settings.LookupForLocalAccess)
+	val, ok := settings.Lookup(
+		name, settings.LookupForLocalAccess, p.ExecCfg().Codec.ForSystemTenant(),
+	)
 	if !ok {
 		return nil, errors.Errorf("unknown setting: %q", name)
 	}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1509,6 +1509,7 @@ func TestLint(t *testing.T) {
 				case strings.HasSuffix(s, "protoutil"):
 				case strings.HasSuffix(s, "testutils"):
 				case strings.HasSuffix(s, "syncutil"):
+				case strings.HasSuffix(s, "buildutil"):
 				case strings.HasSuffix(s, settingsPkgPrefix):
 				default:
 					t.Errorf("%s <- please don't add CRDB dependencies to settings pkg", s)

--- a/pkg/testutils/skip/BUILD.bazel
+++ b/pkg/testutils/skip/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/build/bazel",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/syncutil",
     ],

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -133,6 +134,14 @@ func UnderMetamorphic(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if util.IsMetamorphicBuild() {
 		t.Skip(append([]interface{}{"disabled under metamorphic"}, args...))
+	}
+}
+
+// UnderNonTestBuild skips this test if the build does not have the crdb_test
+// tag.
+func UnderNonTestBuild(t SkippableTest) {
+	if !buildutil.CrdbTestBuild {
+		t.Skip("crdb_test tag required for this test")
 	}
 }
 


### PR DESCRIPTION
#### setting: clean up slot indexes

The internal setting code passes around slot indexes as bare integers,
and there are confusingly two variants: one is 1-indexed, another is
0-indexed.

This change makes all slot indexes 0-indexed and adds a `slotIdx`
type.

Note: the 1-indexed choice was perhaps useful at the time to help find
code paths where the slot index is not initialized, but now the slot
index is set along with other mandatory fields by `init()`.

Release note: None

#### setting: prevent use of SystemOnly settings from tenant code

This change implements the `system-only` semantics in the RFC
(#73349).

All SystemOnly setting values are now invisible from tenant code. If
tenant code attempts to get or set a SystemOnly setting by handle, it
results in panics in test builds; in non-test builds, these settings
always report the default value.

Release note (sql change): System-only cluster settings are no longer
visible for non-system tenants.
