### PR TITLE
tracing: various cleanup and small memory re-use improvement

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -633,16 +633,14 @@ func (s *crdbSpan) addChildLocked(child *crdbSpan, collectChildRec bool) bool {
 func (s *crdbSpan) childFinished(child *crdbSpan) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var childIdx int
-	found := false
+	childIdx := -1
 	for i, c := range s.mu.openChildren {
 		if c.crdbSpan == child {
 			childIdx = i
-			found = true
 			break
 		}
 	}
-	if !found {
+	if childIdx == -1 {
 		panic("child not present in parent")
 	}
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -43,8 +43,8 @@ const (
 // The CockroachDB-internal Span (crdbSpan) is more complex because
 // rather than reporting to some external sink, the caller's "owner"
 // must propagate the trace data back across process boundaries towards
-// the root of the trace span tree; see WithParent
-// and WithRemoteParent, respectively.
+// the root of the trace span tree; see WithParent and WithRemoteParent,
+// respectively.
 //
 // Additionally, the internal span type also supports turning on, stopping,
 // and restarting its data collection (see Span.StartRecording), and this is
@@ -78,7 +78,7 @@ func (sp *Span) IsNoop() bool {
 // been configured to not tolerate use-after-Finish, it crashes.
 //
 // Exported methods on Span are supposed to call this and short-circuit if true
-// is returrned.
+// is returned.
 func (sp *Span) detectUseAfterFinish() bool {
 	if sp == nil {
 		return true
@@ -116,7 +116,7 @@ func (sp *Span) Redactable() bool {
 	return sp.Tracer().Redactable()
 }
 
-// Finish marks the Span as completed. Its illegal to use a Span after calling
+// Finish marks the Span as completed. It's illegal to use a Span after calling
 // Finish().
 //
 // Finishing a nil *Span is a noop.

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -337,7 +337,7 @@ func WithRecording(recType RecordingType) SpanOption {
 	case RecordingOff:
 		panic("invalid recording option: RecordingOff")
 	default:
-		recCpy := recType // copy excaping to the heap
+		recCpy := recType // copy escaping to the heap
 		panic(fmt.Sprintf("invalid recording option: %d", recCpy))
 	}
 }


### PR DESCRIPTION
This commit contains a collection of small cleanups that I stumbled upon
while getting familiar with this package, in preparation to give #73883
a code review.

Most of the changes are minor, though there is one more involved tweak
to use the `optsPool` in more places.

During the code walkthrough, I also noticed two different possible areas
to improve performance. These were based on code inspection alone, not on
any runtime measurements, so take them with a grain of salt.
1. the `TraceInfo_OtelInfo` struct incurs unnecessary cost by storing
   its fixed-size `TraceID` and `SpanID` in byte slices. Can these be
   inlined into the `TraceInfo_OtelInfo` struct as arrays? Ironically,
   the slice headers (24-bytes) are actually larger than the slices
   themselves, so this would actually reduce the size of `TraceInfo_OtelInfo`
   and avoid any indirection or extra heap allocation.
2. the `WithParent` function does a nice job avoid heap allocations.
   Unfortunately, this is not the case for the `WithRemoteParent` function,
   which does heap allocate. Can we avoid this? Taking a `SpanMeta` by pointer
   seems to just shift the problem, because now we need a heap-allocated
   `SpanMeta`. But maybe we can address this by lazily decoding `SpanMeta`
   objects. Instead of decoding a SpanMeta and passing that in to
   `WithRemoteParent`, we could introduce a `SpanMetaSource` interface that
   is implemented on `*tracingpb.TraceInfo` and `*Tracer`. We can then pass
   these heap-allocated references in to `WithRemoteParent`.

In general, the code in the package is clean and I was impressed by the
degree to which we try to batch heap allocations in `startSpanGeneric`.