### PR TITLE
*: future proof tests for span configs

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -177,7 +177,6 @@ go_test(
         "//pkg/server/status",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
-        "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3578,8 +3578,8 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 		func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
 			defer close(done)
 			sqlDB := sqlutils.MakeSQLRunner(db)
-			sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 1`)
-			sqlDB.Exec(t, `ALTER RANGE system CONFIGURE ZONE USING gc.ttlseconds = 1`)
+			sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 100`)
+			sqlDB.Exec(t, `ALTER RANGE system CONFIGURE ZONE USING gc.ttlseconds = 100`)
 			sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 			sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b'), (4, 'c'), (7, 'd'), (8, 'e')`)
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -329,7 +328,6 @@ func startTestFullServer(
 	knobs := base.TestingKnobs{
 		DistSQL:          &execinfra.TestingKnobs{Changefeed: &TestingKnobs{}},
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
-		SpanConfig:       &spanconfig.TestingKnobs{ManagerDisableJobCreation: true},
 	}
 	if options.knobsFn != nil {
 		options.knobsFn(&knobs)

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
@@ -15,7 +15,7 @@ INSERT INTO t VALUES (1);
 # read, we should always be looking at the leaseholder in the nearest_only=False
 # case. We always do bounded staleness reads from node_idx 2, as node_idx 0 in a
 # TestCluster is always the leaseholder.
-query idx=2
+query idx=2 wait-until-match
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1μs') WHERE pk = 1
 ----
 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,7 +1,7 @@
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 statement ok
-SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true
 
 query TTTT
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -293,7 +293,7 @@ public       regional_by_row_table_explicit_crdb_region_column  table  root   0 
 
 # Add a gc.ttlseconds to a partition and ensure it displays.
 statement ok
-SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true;
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true;
 ALTER PARTITION "us-east-1" OF INDEX public.regional_by_row_table@regional_by_row_table_a_idx
 CONFIGURE ZONE USING gc.ttlseconds = 10
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
@@ -4,11 +4,14 @@
 statement ok
 CREATE TABLE t();
 
+statement ok
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = false
+
 statement error pq: unimplemented: operation is unsupported in multi-tenancy mode
 ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5;
 
 statement ok
-SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true
 
 statement ok
 ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5;

--- a/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
@@ -52,7 +52,17 @@ func TestPreSeedSpanConfigsWrittenWhenActive(t *testing.T) {
 	ts := tc.Server(0)
 
 	tenantID := roachpb.MakeTenantID(10)
-	_, err := ts.StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
+	_, err := ts.StartTenant(ctx, base.TestTenantArgs{
+		TenantID: tenantID,
+		TestingKnobs: base.TestingKnobs{
+			SpanConfig: &spanconfig.TestingKnobs{
+				// Disable the tenant's span config reconciliation process,
+				// it'll muck with the tenant's span configs that we check
+				// below.
+				ManagerDisableJobCreation: true,
+			},
+		},
+	})
 	require.NoError(t, err)
 
 	scKVAccessor := ts.SpanConfigKVAccessor().(spanconfig.KVAccessor)
@@ -101,7 +111,17 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 	tenantSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()}
 	tenantSeedSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.Next()}
 	{
-		_, err := ts.StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
+		_, err := ts.StartTenant(ctx, base.TestTenantArgs{
+			TenantID: tenantID,
+			TestingKnobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// Disable the tenant's span config reconciliation process,
+					// it'll muck with the tenant's span configs that we check
+					// below.
+					ManagerDisableJobCreation: true,
+				},
+			},
+		})
 		require.NoError(t, err)
 	}
 
@@ -159,7 +179,17 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 	tenantSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()}
 	tenantSeedSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.Next()}
 	{
-		_, err := ts.StartTenant(ctx, base.TestTenantArgs{TenantID: tenantID})
+		_, err := ts.StartTenant(ctx, base.TestTenantArgs{
+			TenantID: tenantID,
+			TestingKnobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// Disable the tenant's span config reconciliation process,
+					// it'll muck with the tenant's span configs that we check
+					// below.
+					ManagerDisableJobCreation: true,
+				},
+			},
+		})
 		require.NoError(t, err)
 	}
 

--- a/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
@@ -110,7 +110,7 @@ func TestDataDriven(t *testing.T) {
 			tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		}
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		kvSubscriber := tc.Server(0).SpanConfigKVSubscriber().(spanconfig.KVSubscriber)

--- a/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
@@ -182,7 +182,7 @@ func TestDataDriven(t *testing.T) {
 			switch d.Cmd {
 			case "initialize":
 				secondaryTenant := spanConfigTestCluster.InitializeTenant(ctx, tenantID)
-				secondaryTenant.Exec(`SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true`)
+				secondaryTenant.Exec(`SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`)
 
 			case "exec-sql":
 				// Run under an explicit transaction -- we rely on having a

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -128,7 +128,7 @@ func TestDataDriven(t *testing.T) {
 			switch d.Cmd {
 			case "initialize":
 				secondaryTenant := spanConfigTestCluster.InitializeTenant(ctx, tenantID)
-				secondaryTenant.Exec(`SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true`)
+				secondaryTenant.Exec(`SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`)
 
 			case "exec-sql":
 				// Run under an explicit transaction -- we rely on having a

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -103,7 +103,7 @@ func TestDataDriven(t *testing.T) {
 			tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		}
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		systemTenant := spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -88,7 +88,7 @@ func TestDataDriven(t *testing.T) {
 		})
 		defer tc.Stopper().Stop(ctx)
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		var tenant *spanconfigtestcluster.Tenant

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -94,7 +94,7 @@ func TestDataDriven(t *testing.T) {
 		var tenant *spanconfigtestcluster.Tenant
 		if strings.Contains(path, "tenant") {
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, roachpb.MakeTenantID(10))
-			tenant.Exec(`SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true`)
+			tenant.Exec(`SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`)
 		} else {
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)
 		}

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
@@ -21,21 +21,10 @@ DROP TABLE db.t1;
 # We should no longer see the dropped table's spans.
 translate database=db
 ----
-/Tenant/10/Table/5{6-7}                    ttl_seconds=1
 /Tenant/10/Table/5{7-8}                    range default
 
 # Same as above, except this time the translation starts from the table's ID.
-translate id=53
-----
-
-# By now t1's descriptor should have been deleted.
-translate database=db
-----
-/Tenant/10/Table/5{6-7}                    ttl_seconds=1
-/Tenant/10/Table/5{7-8}                    range default
-
-# This no longer exists, so no span configuration should be generated.
-translate id=53
+translate id=56
 ----
 
 # Mark table t2 as offline, we should still be able to generate a span
@@ -51,7 +40,6 @@ translate database=db table=t2
 
 translate database=db
 ----
-/Tenant/10/Table/5{6-7}                    ttl_seconds=1
 /Tenant/10/Table/5{7-8}                    range default
 
 
@@ -69,19 +57,21 @@ CREATE SCHEMA db.sc;
 CREATE TYPE db.typ AS ENUM();
 ----
 
+translate database=db
+----
+/Tenant/10/Table/5{7-8}                    range default
+
 # Schema.
-translate id=55
+translate id=58
 ----
 
 # Enum.
-translate id=56
+translate id=59
 ----
-/Tenant/10/Table/5{6-7}                    ttl_seconds=1
 
 # Array type alias.
-translate id=57
+translate id=60
 ----
-/Tenant/10/Table/5{7-8}                    range default
 
 # Test that non-existent IDs do not generate span configurations either.
 translate id=500

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5576,14 +5576,20 @@ func TestElectionAfterRestart(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tc.WaitForFullReplication())
 
-		for _, row := range sqlutils.MakeSQLRunner(tc.Conns[0]).QueryStr(
-			t, `SELECT range_id FROM crdb_internal.ranges_no_leases WHERE table_name = 't';`,
-		) {
-			n, err := strconv.Atoi(row[0])
-			require.NoError(t, err)
-			rangeIDs[roachpb.RangeID(n)] = 0
-		}
-		require.Len(t, rangeIDs, numRanges)
+		testutils.SucceedsSoon(t, func() error {
+			for _, row := range sqlutils.MakeSQLRunner(tc.Conns[0]).QueryStr(
+				t, `SELECT range_id FROM crdb_internal.ranges_no_leases WHERE table_name = 't';`,
+			) {
+				n, err := strconv.Atoi(row[0])
+				require.NoError(t, err)
+				rangeIDs[roachpb.RangeID(n)] = 0
+			}
+			if len(rangeIDs) != numRanges {
+				return errors.Newf("expected %d ranges, found %d", numRanges, len(rangeIDs))
+			}
+			return nil
+		})
+
 		t.Logf("created %d ranges", numRanges)
 
 		// Make sure that the ranges have all followers fully caught up. Otherwise,

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -59,7 +59,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 
 	_, err := s.InternalExecutor().(sqlutil.InternalExecutor).ExecEx(ctx, "inline-exec", nil,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-		`SET CLUSTER SETTING spanconfig.experimental_store.enabled = true`)
+		`SET CLUSTER SETTING spanconfig.store.enabled = true`)
 	require.NoError(t, err)
 
 	key, err := s.ScratchRange()

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -41,9 +41,6 @@ go_test(
     embed = [":liveness"],
     deps = [
         "//pkg/base",
-        "//pkg/config",
-        "//pkg/config/zonepb",
-        "//pkg/keys",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb:with-mocks",
@@ -63,7 +60,6 @@ go_test(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
-        "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -19,9 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -36,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
-	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,14 +170,9 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 	ctx = logtags.AddTag(ctx, "in test", nil)
 
 	log.Infof(ctx, "setting zone config to disable replication")
-	// Allow for inserting zone configs without having to go through (or
-	// duplicate the logic from) the CLI.
-	config.TestingSetupZoneConfigHook(tc.Stopper())
-	zoneConfig := zonepb.DefaultZoneConfig()
-	// Force just one replica per range to ensure that we can shut down
-	// nodes without endangering the liveness range.
-	zoneConfig.NumReplicas = proto.Int32(1)
-	config.TestingSetZoneConfig(keys.MetaRangesID, zoneConfig)
+	if _, err := tc.Conns[0].Exec(`ALTER RANGE meta CONFIGURE ZONE using num_replicas = 1`); err != nil {
+		t.Fatal(err)
+	}
 
 	log.Infof(ctx, "starting 3 more nodes")
 	tc.AddAndStartServer(t, serverArgs)

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -31,11 +31,11 @@ import (
 // checkReconciliationJobInterval is a cluster setting to control how often we
 // check if the span config reconciliation job exists. If it's not found, it
 // will be started. It has no effect unless
-// spanconfig.experimental_reconciliation.enabled is configured. For host
+// spanconfig.reconciliation_job.enabled is configured. For host
 // tenants, COCKROACH_EXPERIMENTAL_SPAN_CONFIGS needs to be additionally set.
 var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
-	"spanconfig.experimental_reconciliation_job.check_interval",
+	"spanconfig.reconciliation_job.check_interval",
 	"the frequency at which to check if the span config reconciliation job exists (and to start it if not)",
 	10*time.Minute,
 	settings.NonNegativeDuration,
@@ -45,9 +45,12 @@ var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 //
 // For the host tenant it has no effect unless
 // COCKROACH_EXPERIMENTAL_SPAN_CONFIGS is also set.
+//
+// TODO(irfansharif): This should be a tenant read-only setting once the work
+// for #73349 is completed.
 var jobEnabledSetting = settings.RegisterBoolSetting(
 	settings.TenantWritable,
-	"spanconfig.experimental_reconciliation_job.enabled",
+	"spanconfig.reconciliation_job.enabled",
 	"enable the use of the kv accessor", false)
 
 // Manager is the coordinator of the span config subsystem. It ensures that

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -201,7 +201,7 @@ func TestManagerCheckJobConditions(t *testing.T) {
 
 	ts := tc.Server(0)
 	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
-	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.enabled = false;`)
+	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = false;`)
 
 	var interceptCount int32
 	checkInterceptCountGreaterThan := func(min int32) int32 {
@@ -233,9 +233,9 @@ func TestManagerCheckJobConditions(t *testing.T) {
 	require.NoError(t, manager.Start(ctx))
 	currentCount = checkInterceptCountGreaterThan(currentCount) // wait for an initial check
 
-	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.enabled = true;`)
+	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = true;`)
 	currentCount = checkInterceptCountGreaterThan(currentCount) // the job enablement setting triggers a check
 
-	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.check_interval = '25m'`)
+	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.check_interval = '25m'`)
 	_ = checkInterceptCountGreaterThan(currentCount) // the job check interval setting triggers a check
 }

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -32,7 +32,7 @@ import (
 // is set.
 var EnabledSetting = settings.RegisterBoolSetting(
 	settings.SystemOnly,
-	"spanconfig.experimental_store.enabled",
+	"spanconfig.store.enabled",
 	`use the span config infrastructure in KV instead of the system config span`,
 	false,
 )

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
@@ -140,6 +140,7 @@ func (s *Tenant) LookupTableByName(
 					CommonLookupFlags: tree.CommonLookupFlags{
 						Required:       true,
 						IncludeOffline: true,
+						AvoidLeased:    true,
 					},
 				},
 			)
@@ -164,6 +165,7 @@ func (s *Tenant) LookupDatabaseByName(
 				tree.DatabaseLookupFlags{
 					Required:       true,
 					IncludeOffline: true,
+					AvoidLeased:    true,
 				},
 			)
 			if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -185,12 +185,15 @@ var allowCrossDatabaseSeqReferences = settings.RegisterBoolSetting(
 	false,
 ).WithPublic()
 
-const secondaryTenantsZoneConfigsEnabledSettingName = "sql.zone_configs.experimental_allow_for_secondary_tenant.enabled"
+const secondaryTenantsZoneConfigsEnabledSettingName = "sql.zone_configs.allow_for_secondary_tenant.enabled"
 
 // secondaryTenantZoneConfigsEnabled controls if secondary tenants are allowed
 // to set zone configurations. It has no effect for the system tenant.
 //
 // This setting has no effect on zone configurations that have already been set.
+//
+// TODO(irfansharif): This should be a tenant-readonly setting, possible after
+// the work for #73349 is completed.
 var secondaryTenantZoneConfigsEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	secondaryTenantsZoneConfigsEnabledSettingName,

--- a/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
+++ b/pkg/sql/logictest/testdata/logic_test/auto_span_config_reconciliation_job
@@ -1,7 +1,7 @@
 # cluster-opt: enable-span-configs
 
 statement ok
-SET CLUSTER SETTING spanconfig.experimental_reconciliation_job.enabled = true;
+SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = true;
 
 # Ensure there's a single auto span config reconciliation job in the system,
 # and that it's running.

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,7 +1,7 @@
 # As these tests are run for both the system tenant and secondary tenants, we
 # turn on the setting that gates setting zone configs for system tenants.
 statement ok
-SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = true
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true
 
 # Check that we can alter the default zone config.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -9,7 +9,7 @@ ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5;
 
 # Should have no effect on the system tenant.
 statement ok
-SET CLUSTER SETTING sql.zone_configs.experimental_allow_for_secondary_tenant.enabled = false
+SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = false
 
 statement ok
 ALTER TABLE t CONFIGURE ZONE USING num_replicas = 3;


### PR DESCRIPTION
This PR is a (mostly) test-only change that paves the way for enabling span
configs by default (#73876). Various tests throughout CRDB rely on timing
assumptions with respect to how quickly splits are induced or configs applied,
assumptions that are no longer true with the span configs infrastructure
because:
- updated descriptors/zone configs make its way to the global span config
   state `system.span_configurations` asynchronously, and
- kv learns about learns about these updates asynchronously.

Consider TestTruncatePreservesSplitPoints for example, which relied on range
split decisions to happen near-instantaneously (especially for the single node
variant) -- a fair assumption with the gossiped SystemConfigSpan, but no longer
applicable.

Another example is TestChangefeedProtectedTimestamps, where we use an
extremely low gc.ttlseconds. Given span configs makes use of rangefeeds
internally, feeds that error out if started at timestamps already GC-ed, we
need to ensure a sufficiently lax GC TTL.

For most of these tests, making them agnostic to either subsystem is just a
matter of throwing in a SucceedsSoon block at the right places. See individual
commits/commentary for the individual test changes.

Release note: None

---

First commit is from #74171 and should be reviewed there.