### PR TITLE
roachpb: InternalServer API for tenant settings

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -100,6 +100,12 @@ func (m *mockServer) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
+func (m *mockServer) TenantSettings(
+	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
+) error {
+	panic("unimplemented")
+}
+
 func gossipEventForClusterID(clusterID uuid.UUID) *roachpb.GossipSubscriptionEvent {
 	return &roachpb.GossipSubscriptionEvent{
 		Key:            gossip.KeyClusterID,

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -91,6 +91,12 @@ func (n Node) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
+func (n Node) TenantSettings(
+	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
+) error {
+	panic("unimplemented")
+}
+
 // TestSendToOneClient verifies that Send correctly sends a request
 // to one server using the heartbeat RPC.
 func TestSendToOneClient(t *testing.T) {

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -208,3 +208,9 @@ func (m *mockInternalClient) UpdateSpanConfigs(
 ) (*roachpb.UpdateSpanConfigsResponse, error) {
 	return nil, fmt.Errorf("unsupported UpdateSpanConfigs call")
 }
+
+func (m *mockInternalClient) TenantSettings(
+	context.Context, *roachpb.TenantSettingsRequest, ...grpc.CallOption,
+) (roachpb.Internal_TenantSettingsClient, error) {
+	return nil, fmt.Errorf("unsupported TenantSettings call")
+}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1677,3 +1677,19 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 func (s *ScanStats) String() string {
 	return redact.StringWithoutMarkers(s)
 }
+
+// TenantSettingsPrecedence identifies the precedence of a set of setting
+// overrides. It is used by the TenantSettings API which supports passing
+// multiple overrides for the same setting.
+type TenantSettingsPrecedence uint32
+
+const (
+	// SpecificTenantOverrides is the high precedence for tenant setting overrides.
+	// These overrides take precedence over AllTenantsOverrides.
+	SpecificTenantOverrides TenantSettingsPrecedence = 1 + iota
+
+	// AllTenantsOverrides is the low precedence for tenant setting overrides.
+	// These overrides are only effectual for a tenant if there is no override
+	// with the SpecificTenantOverrides precedence..
+	AllTenantsOverrides
+)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2610,6 +2610,60 @@ message GossipSubscriptionEvent {
   kv.kvpb.Error error = 4;
 }
 
+// TenantSettingsRequest establishes an indefinite stream that provides
+// up-to-date overrides for tenant settings.
+//
+// Upon establishment of the stream, the current overrides are returned as an
+// event, and any time the overrides change a new event is generated.
+message TenantSettingsRequest {
+  TenantID tenant_id = 1 [(gogoproto.customname) = "TenantID", (gogoproto.nullable) = false];
+}
+
+// TenantSettingsEvent is used to report changes to setting overrides for a
+// particular tenant.
+//
+// Each event pertains to a certain precedence value (see
+// TenantSettingsPrecedence).
+//
+// Note: this API is designed to allow flexibility of implementation on the
+// server side (e.g. to make it maintain very little state per tenant).
+message TenantSettingsEvent {
+  // Precedence must be a valid TenantSettingsPrecedence value.
+  uint32 precedence = 1 [(gogoproto.casttype) = "TenantSettingsPrecedence"];
+
+  // Incremental is true if the list of overrides is a list of changes since the
+  // last event. In that case, any overrides that have been removed are returned
+  // as TenantSettings with empty RawValue and ValueType fields.
+  //
+  // When Incremental is false, the overrides contains the complete list of
+  // current overrides for this precedence.
+  //
+  // The first event for a precedence is never incremental.
+  bool incremental = 2;
+
+  // Overrides contains:
+  //  - all current setting overrides for the given precedence if Incremental is
+  //    false; or
+  //  - the changed overrides since the last event for the precedence if
+  //    Incremental is true (removed overrides have empty RawValue and ValueType
+  //    fields).
+  repeated TenantSetting overrides = 3;
+
+  // If non-nil, the other fields will be empty and this will be the final event
+  // sent on the stream before it is terminated.
+  errorspb.EncodedError error = 4 [(gogoproto.nullable) = false];
+}
+
+// TenantSetting contains the name and value of a tenant setting.
+//
+// The value representation is the same as that used by the system.settings
+// table (value and valueType columns).
+message TenantSetting {
+  string name = 1;
+  string raw_value = 2;
+  string value_type = 3;
+}
+
 // TenantConsumption contains information about resource utilization by a
 // tenant, which directly factors into their bill.
 message TenantConsumption {
@@ -2743,6 +2797,10 @@ service Internal {
   // UpdateSpanConfigs is used to update the span configurations over given
   // keyspans.
   rpc UpdateSpanConfigs (UpdateSpanConfigsRequest) returns (UpdateSpanConfigsResponse) { }
+
+  // TenantSettings is used by tenants to obtain and stay up to date with tenant
+  // setting overrides.
+  rpc TenantSettings (TenantSettingsRequest) returns (stream TenantSettingsEvent) { }
 }
 
 // ContentionEvent is a message that will be attached to BatchResponses

--- a/pkg/roachpb/mocks_generated.go
+++ b/pkg/roachpb/mocks_generated.go
@@ -176,6 +176,26 @@ func (mr *MockInternalClientMockRecorder) ResetQuorum(arg0, arg1 interface{}, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetQuorum", reflect.TypeOf((*MockInternalClient)(nil).ResetQuorum), varargs...)
 }
 
+// TenantSettings mocks base method.
+func (m *MockInternalClient) TenantSettings(arg0 context.Context, arg1 *TenantSettingsRequest, arg2 ...grpc.CallOption) (Internal_TenantSettingsClient, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TenantSettings", varargs...)
+	ret0, _ := ret[0].(Internal_TenantSettingsClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TenantSettings indicates an expected call of TenantSettings.
+func (mr *MockInternalClientMockRecorder) TenantSettings(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantSettings", reflect.TypeOf((*MockInternalClient)(nil).TenantSettings), varargs...)
+}
+
 // TokenBucket mocks base method.
 func (m *MockInternalClient) TokenBucket(arg0 context.Context, arg1 *TokenBucketRequest, arg2 ...grpc.CallOption) (*TokenBucketResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -276,6 +276,12 @@ func (*internalServer) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
+func (*internalServer) TenantSettings(
+	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
+) error {
+	panic("unimplemented")
+}
+
 // TestInternalServerAddress verifies that RPCContext uses AdvertiseAddr, not Addr, to
 // determine whether to apply the local server optimization.
 //

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -597,3 +597,9 @@ func (*internalServer) UpdateSpanConfigs(
 ) (*roachpb.UpdateSpanConfigsResponse, error) {
 	panic("unimplemented")
 }
+
+func (*internalServer) TenantSettings(
+	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
+) error {
+	panic("unimplemented")
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1375,6 +1375,13 @@ func (n *Node) GossipSubscription(
 	}
 }
 
+// TenantSettings implements the roachpb.InternalServer interface.
+func (n *Node) TenantSettings(
+	args *roachpb.TenantSettingsRequest, stream roachpb.Internal_TenantSettingsServer,
+) error {
+	return errors.AssertionFailedf("not implemented")
+}
+
 // Join implements the roachpb.InternalServer service. This is the
 // "connectivity" API; individual CRDB servers are passed in a --join list and
 // the join targets are addressed through this API.


### PR DESCRIPTION
This commit introduces the API that the tenants will use to obtain and
list for updates to tenant setting overrides. The API was designed to
allow for maximum flexibility on the server side so that it can be
implemented as a range feed without any extra state (if necessary).

Release note: None