### PR TITLE
sql/pgwire: fix extended protocol autocommit behavior

### DIFF
--- a/pkg/server/purge_auth_session.go
+++ b/pkg/server/purge_auth_session.go
@@ -124,7 +124,7 @@ RETURNING 1
 		autoLogoutTime = currTime.Add(autoLogoutTimeout * time.Duration(-1))
 	)
 
-	if _, err := internalExecutor.QueryRowEx(
+	if _, err := internalExecutor.ExecEx(
 		ctx,
 		"delete-old-expired-sessions",
 		nil, /* txn */
@@ -136,7 +136,7 @@ RETURNING 1
 		log.Errorf(ctx, "error while deleting old expired web sessions: %+v", err)
 	}
 
-	if _, err := internalExecutor.QueryRowEx(
+	if _, err := internalExecutor.ExecEx(
 		ctx,
 		"delete-old-revoked-sessions",
 		nil, /* txn */
@@ -148,7 +148,7 @@ RETURNING 1
 		log.Errorf(ctx, "error while deleting old revoked web sessions: %+v", err)
 	}
 
-	if _, err := internalExecutor.QueryRowEx(
+	if _, err := internalExecutor.ExecEx(
 		ctx,
 		"delete-sessions-timeout",
 		nil, /* txn */

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -694,7 +694,12 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.stmt = stmt
 	p.cancelChecker.Reset(ctx)
-	p.autoCommit = os.ImplicitTxn.Get() && !ex.server.cfg.TestingKnobs.DisableAutoCommit
+
+	// We need to turn off autocommit behavior here so that the "insert fast path"
+	// does not get triggered. The postgres docs say that commands in the extended
+	// protocol are all treated as an implicit transaction that does not get
+	// committed until a Sync message is received.
+	p.autoCommit = os.ImplicitTxn.Get() && !isExtendedProtocol && !ex.server.cfg.TestingKnobs.DisableAutoCommit
 
 	var stmtThresholdSpan *tracing.Span
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -1048,3 +1048,98 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS portal_sync_test"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE portal_sync_test (a FLOAT CHECK(a > 1))"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Name": "s15", "Query": "INSERT INTO portal_sync_test VALUES($1);"}
+Describe {"ObjectType": "S", "Name": "s15"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[701]}
+{"Type":"NoData"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that the "insert fast path" does not cause an auto-commit before
+# the Sync message is handled. This also tests behavior with the unnamed
+# portal.
+send
+Bind {"PreparedStatement": "s15", "Parameters": [{"text":"2"}]}
+Describe {"ObjectType": "P"}
+Execute
+Bind {"PreparedStatement": "s15", "Parameters": [{"text":"3"}]}
+Describe {"ObjectType": "P"}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that an error during the implicit transaction causes both
+# INSERTs to be rolled back.
+send
+Bind {"PreparedStatement": "s15", "Parameters": [{"text":"4"}]}
+Describe {"ObjectType": "P"}
+Execute
+Bind {"PreparedStatement": "s15", "Parameters": [{"text":"0"}]}
+Describe {"ObjectType": "P"}
+Execute
+Sync
+----
+
+until ignore_constraint_name
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"BindComplete"}
+{"Type":"NoData"}
+{"Type":"ErrorResponse","Code":"23514"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT * FROM portal_sync_test ORDER BY a;"}
+----
+
+until ignore_table_oids
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"a","TableOID":0,"TableAttributeNumber":1,"DataTypeOID":701,"DataTypeSize":8,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"DataRow","Values":[{"text":"3"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -181,6 +181,12 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 					}
 				}
 			}
+		case "ignore_constraint_name":
+			for _, msg := range msgs {
+				if m, ok := msg.(*pgproto3.ErrorResponse); ok {
+					m.ConstraintName = ""
+				}
+			}
 		case "ignore":
 			for _, typ := range arg.Vals {
 				ignore[fmt.Sprintf("*pgproto3.%s", typ)] = true


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/74279
fixes https://github.com/cockroachdb/cockroach/issues/74276
maybe fixes https://github.com/cockroachdb/cockroach/issues/74280

A recent commit (1ef5c75c8c539e8f6375ecdf87a24d9004e2d872) added the correct behavior for transactions in the
extended protocol. The transaction is not supposed to be committed until
Sync is received. However, it missed one case -- for certain statements
a "fast path" could get triggered that autocommits the statement as soon
as it's executed.

This change disables that fast path behavior for the extended protocol.

No release note since this bug was never released.

Release note: None