### PR TITLE
protoreflect: add shorthands for names of common persisted messages

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -8,7 +8,10 @@
 
 package backupccl
 
-import descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+import (
+	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+)
 
 // GetTenants retrieves the tenant information from the manifest. It should be
 // used instead of Tenants to support older versions of the manifest which used
@@ -30,4 +33,8 @@ func (m *BackupManifest) GetTenants() []descpb.TenantInfoWithUsage {
 // HasTenants returns true if the manifest contains (non-system) tenant data.
 func (m *BackupManifest) HasTenants() bool {
 	return len(m.Tenants) > 0 || len(m.TenantsDeprecated) > 0
+}
+
+func init() {
+	protoreflect.RegisterShorthands((*BackupManifest)(nil), "backup", "backup_manifest")
 }

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -344,4 +344,9 @@ func init() {
 		panic(fmt.Errorf("NumJobTypes (%d) does not match generated job type name map length (%d)",
 			NumJobTypes, len(Type_name)))
 	}
+
+	protoreflect.RegisterShorthands((*Progress)(nil), "progress")
+	protoreflect.RegisterShorthands((*Payload)(nil), "payload")
+	protoreflect.RegisterShorthands((*ScheduleDetails)(nil), "schedule", "schedule_details")
+	protoreflect.RegisterShorthands((*ExecutionArguments)(nil), "exec_args", "execution_args", "schedule_args")
 }

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -13,6 +13,7 @@ package descpb
 import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -390,4 +391,8 @@ func (ni NameInfo) GetParentSchemaID() ID {
 // GetName implements the catalog.NameKeyHaver interface.
 func (ni NameInfo) GetName() string {
 	return ni.Name
+}
+
+func init() {
+	protoreflect.RegisterShorthands((*Descriptor)(nil), "descriptor", "desc")
 }

--- a/pkg/sql/protoreflect/utils.go
+++ b/pkg/sql/protoreflect/utils.go
@@ -21,13 +21,42 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+var shorthands map[string]protoutil.Message = map[string]protoutil.Message{}
+
+// RegisterShorthands registers a shorthand alias for a given message type which
+// can be used by NewMessage to look up that message type, when it fails to find
+// a message type with that name in the fully-qualified global registry first.
+// Aliases are folded to lower-case with any '_'s removed prior to registration
+// and when being searched.
+func RegisterShorthands(msg protoutil.Message, names ...string) {
+	for _, name := range names {
+		name = foldShorthand(name)
+		if existing, ok := shorthands[name]; ok {
+			panic(errors.AssertionFailedf("shorthand %s already registered to %T", name, existing))
+		}
+		shorthands[name] = msg
+	}
+}
+
+func foldShorthand(name string) string {
+	return strings.ReplaceAll(strings.ToLower(name), "_", "")
+}
+
 // NewMessage creates a new protocol message object, given its fully
-// qualified name.
+// qualified name, or an alias previously registered via RegisterShorthands.
 func NewMessage(name string) (protoutil.Message, error) {
 	// Get the reflected type of the protocol message.
 	rt := proto.MessageType(name)
 	if rt == nil {
-		return nil, errors.Newf("unknown proto message type %s", name)
+		if msg, ok := shorthands[foldShorthand(name)]; ok {
+			fullName := proto.MessageName(msg)
+			rt = proto.MessageType(fullName)
+			if rt == nil {
+				return nil, errors.Newf("unknown proto message type %s", fullName)
+			}
+		} else {
+			return nil, errors.Newf("unknown proto message type %s", name)
+		}
 	}
 
 	// If the message is known, we should get the pointer to our message.


### PR DESCRIPTION
This adds a mechanism for registering shorthand aliases for the names of
messages that are most often persisted including∑ jobspb.Progress,
jobspb.Payload, descpb.Descriptor, etc.

These shorthands are then consulted when looking up a message type by
name, such as when using pb_to_json or json_to_pb, if the provided name
is not found in the existing global registry that contains only the
fully qualified (by proto import path) names. Shorthands are folded to
lower case and any '_'s are removed for search. Thus, with this change,
one can use `crdb_internal.pb_to_json('desc', descriptor)` in place of
`crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)`.

Release note: none.