### PR TITLE
colbuilder: fix window functions planning

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4301,3 +4301,34 @@ SELECT x, y, first_value(y) OVER (PARTITION BY x ROWS BETWEEN CURRENT ROW AND CU
 2  NotNull  NotNull
 2  NotNull  NotNull
 2  NotNull  NotNull
+
+# Regression test for incorrect type schema setup in the vectorized engine with
+# multiple window functions (#74087).
+statement ok
+CREATE TABLE t74087 AS
+  SELECT
+    g::INT2 AS _int2, g::INT4 AS _int4
+  FROM
+    ROWS FROM (generate_series(1, 5)) AS g;
+
+query IIIIIIIIIRRI rowsort
+SELECT
+  lag(_int2, _int4, _int2) OVER w,
+  lead(_int4, _int2, _int4) OVER w,
+  first_value(_int2) OVER w,
+  last_value(_int4) OVER w,
+  nth_value(_int2, _int4) OVER w,
+  min(_int4) OVER w,
+  row_number() OVER w,
+  rank() OVER w,
+  dense_rank() OVER w,
+  percent_rank() OVER w,
+  cume_dist() OVER w,
+  ntile(_int2) OVER w
+FROM t74087 WINDOW w AS (ORDER BY _int4);
+----
+1  2  1  1  1  1  1  1  1  0     0.2  1
+2  4  1  2  2  1  2  2  2  0.25  0.4  1
+3  3  1  3  3  1  3  3  3  0.5   0.6  1
+4  4  1  4  4  1  4  4  4  0.75  0.8  1
+5  5  1  5  5  1  5  5  5  1     1    1


### PR DESCRIPTION
The problem with integer widths bites us again - in the vectorized
window functions planning we could mistakenly think that the window
function returns INT8 when it actually returned INT2 or INT4. This would
result in an internal error if there was another window function on top
of the "broken" one with the same PARTITION BY clause.

Fixes: #74087.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when executing queries with multiple window functions and
when one of those functions returned INT2 or INT4 type.