### PR TITLE
log,*: remove Tracer from AmbientContext

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -384,7 +384,7 @@ func TestOracle(t *testing.T) {
 	current := clock.Now()
 	future := clock.Now().Add(2*clock.MaxOffset().Nanoseconds(), 0)
 
-	c := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), kv.MockTxnSenderFactory{}, clock, stopper)
+	c := kv.NewDB(log.MakeTestingAmbientContext(), kv.MockTxnSenderFactory{}, clock, stopper)
 	staleTxn := kv.NewTxn(ctx, c, 0)
 	require.NoError(t, staleTxn.SetFixedTimestamp(ctx, stale))
 	currentTxn := kv.NewTxn(ctx, c, 0)

--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -176,7 +176,7 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := kvtenant.ConnectorConfig{
-		AmbientCtx:      log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx:      log.MakeTestingAmbientContext(),
 		RPCContext:      rpcContext,
 		RPCRetryOptions: rpcRetryOpts,
 	}
@@ -301,7 +301,7 @@ func TestConnectorRangeLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := kvtenant.ConnectorConfig{
-		AmbientCtx:      log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx:      log.MakeTestingAmbientContext(),
 		RPCContext:      rpcContext,
 		RPCRetryOptions: rpcRetryOpts,
 	}
@@ -400,7 +400,7 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 
 	// Add listen address into list of other bogus addresses.
 	cfg := kvtenant.ConnectorConfig{
-		AmbientCtx:      log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx:      log.MakeTestingAmbientContext(),
 		RPCContext:      rpcContext,
 		RPCRetryOptions: rpcRetryOpts,
 	}
@@ -509,7 +509,7 @@ func TestConnectorRetriesError(t *testing.T) {
 
 			// Add listen address into list of other bogus addresses.
 			cfg := kvtenant.ConnectorConfig{
-				AmbientCtx:      log.MakeTestingAmbientContext(stopper.Tracer()),
+				AmbientCtx:      log.MakeTestingAmbientContext(),
 				RPCContext:      rpcContext,
 				RPCRetryOptions: rpcRetryOpts,
 			}

--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -85,7 +85,7 @@ func TestTenantReport(t *testing.T) {
 	require.NotZero(t, len(last.FeatureUsage))
 
 	// Call PeriodicallyReportDiagnostics and ensure it sends out a report.
-	reporter.PeriodicallyReportDiagnostics(ctx, rt.server.Stopper())
+	reporter.PeriodicallyReportDiagnostics(ctx)
 	testutils.SucceedsSoon(t, func() error {
 		if rt.diagServer.NumRequests() != 2 {
 			return errors.Errorf("did not receive a diagnostics report")

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -92,7 +92,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer stopper.Stop(ctx)
-	stopper.SetTracer(serverCfg.BaseConfig.AmbientCtx.Tracer)
+	stopper.SetTracer(serverCfg.Tracer)
 
 	st := serverCfg.BaseConfig.Settings
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -421,8 +421,9 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// infrastructure below.  This span concludes when the startup
 	// goroutine started below has completed.  TODO(andrei): we don't
 	// close the span on the early returns below.
+	ctx = ambientCtx.AnnotateCtx(ctx)
 	var startupSpan *tracing.Span
-	ctx, startupSpan = ambientCtx.AnnotateCtxWithSpan(ctx, "server start")
+	ctx, startupSpan = serverCfg.Tracer.EnsureChildSpan(ctx, "server start")
 
 	// Set up the logging and profiling output.
 	//
@@ -701,7 +702,8 @@ If problems persist, please see %s.`
 	// We'll want to log any shutdown activity against a separate span.
 	// We cannot use s.AnnotateCtx here because s might not have
 	// been assigned yet (the goroutine above runs asynchronously).
-	shutdownCtx, shutdownSpan := ambientCtx.AnnotateCtxWithSpan(context.Background(), "server shutdown")
+	shutdownCtx := ambientCtx.AnnotateCtx(context.Background())
+	shutdownCtx, shutdownSpan := serverCfg.Tracer.EnsureChildSpan(shutdownCtx, "server shutdown")
 	defer shutdownSpan.Finish()
 
 	stopWithoutDrain := make(chan struct{}) // closed if interrupted very early

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -187,7 +187,7 @@ func TestClientGossip(t *testing.T) {
 	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 	disconnected := make(chan *client, 1)
-	c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), remote.GetNodeAddr(), makeMetrics())
+	c := newClient(log.MakeTestingAmbientContext(), remote.GetNodeAddr(), makeMetrics())
 
 	defer func() {
 		stopper.Stop(ctx)
@@ -239,7 +239,7 @@ func TestClientGossipMetrics(t *testing.T) {
 	gossipSucceedsSoon(
 		t, stopper, clusterID, make(chan *client, 2),
 		map[*client]*Gossip{
-			newClient(log.MakeTestingAmbientCtxWithNewTracer(), local.GetNodeAddr(), remote.nodeMetrics): remote,
+			newClient(log.MakeTestingAmbientContext(), local.GetNodeAddr(), remote.nodeMetrics): remote,
 		},
 		func() error {
 			// Infos/Bytes Sent/Received should not be zero.
@@ -297,7 +297,7 @@ func TestClientNodeID(t *testing.T) {
 	// Use an insecure context. We're talking to tcp socket which are not in the certs.
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 
-	c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), &remote.nodeAddr, makeMetrics())
+	c := newClient(log.MakeTestingAmbientContext(), &remote.nodeAddr, makeMetrics())
 	disconnected <- c
 
 	defer func() {
@@ -521,7 +521,7 @@ func TestClientForwardUnresolved(t *testing.T) {
 	local := startGossip(uuid.Nil, nodeID, stopper, t, metric.NewRegistry())
 	addr := local.GetNodeAddr()
 
-	client := newClient(log.MakeTestingAmbientCtxWithNewTracer(), addr, makeMetrics()) // never started
+	client := newClient(log.MakeTestingAmbientContext(), addr, makeMetrics()) // never started
 
 	newAddr := util.UnresolvedAddr{
 		NetworkField: "tcp",

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -486,7 +486,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	}
 
 	for _, peer := range peers {
-		c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), local.GetNodeAddr(), makeMetrics())
+		c := newClient(log.MakeTestingAmbientContext(), local.GetNodeAddr(), makeMetrics())
 
 		testutils.SucceedsSoon(t, func() error {
 			conn, err := peer.rpcContext.GRPCUnvalidatedDial(c.addr.String()).Connect(ctx)
@@ -522,7 +522,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 
 		for {
 			localAddr := local.GetNodeAddr()
-			c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), localAddr, makeMetrics())
+			c := newClient(log.MakeTestingAmbientContext(), localAddr, makeMetrics())
 			peer.mu.Lock()
 			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker(""))
 			peer.mu.Unlock()

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -36,7 +36,7 @@ func newTestInfoStore() (*infoStore, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	nc := &base.NodeIDContainer{}
 	nc.Set(context.Background(), 1)
-	is := newInfoStore(log.MakeTestingAmbientCtxWithNewTracer(), nc, emptyAddr, stopper)
+	is := newInfoStore(log.MakeTestingAmbientContext(), nc, emptyAddr, stopper)
 	return is, stopper
 }
 

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -395,7 +395,7 @@ func (r *Registry) runJob(
 	// TODO(ajwerner): Move this writing up the trace ID down into
 	// stepThroughStateMachine where we're already often (and soon with
 	// exponential backoff, always) updating the job in that call.
-	ctx, span := r.ac.Tracer.StartSpanCtx(ctx, typ.String(), spanOptions...)
+	ctx, span := r.stopper.Tracer().StartSpanCtx(ctx, typ.String(), spanOptions...)
 	span.SetTag("job-id", attribute.Int64Value(int64(job.ID())))
 	defer span.Finish()
 	if span.TraceID() != 0 {

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -163,7 +163,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			// still handle an unexpected split, so we make our own range cache and
 			// only populate it with one of our two splits.
 			mockCache := rangecache.NewRangeCache(s.ClusterSettings(), nil,
-				func() int64 { return 2 << 10 }, s.Stopper(), s.TracerI().(*tracing.Tracer))
+				func() int64 { return 2 << 10 }, s.Stopper())
 			addr, err := keys.Addr(key(0))
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -768,7 +768,7 @@ func TestReadConsistencyTypes(t *testing.T) {
 				})
 
 			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-			db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+			db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 			prepWithRC := func() *kv.Batch {
 				b := &kv.Batch{}
@@ -918,7 +918,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 		}
 		dbCtx.NodeID = base.NewSQLIDContainerForNode(&c)
 
-		db := kv.NewDBWithContext(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, dbCtx)
+		db := kv.NewDBWithContext(log.MakeTestingAmbientContext(), factory, clock, dbCtx)
 		return db
 	}
 

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -265,6 +266,11 @@ type DB struct {
 	SQLKVResponseAdmissionQ *admission.WorkQueue
 }
 
+// Tracer retrieves the Tracer instance for this DB handle.
+func (db *DB) Tracer() *tracing.Tracer {
+	return db.ctx.Stopper.Tracer()
+}
+
 // NonTransactionalSender returns a Sender that can be used for sending
 // non-transactional requests. The Sender is capable of transparently wrapping
 // non-transactional requests that span ranges in transactions.
@@ -296,8 +302,8 @@ func NewDB(
 func NewDBWithContext(
 	actx log.AmbientContext, factory TxnSenderFactory, clock *hlc.Clock, ctx DBContext,
 ) *DB {
-	if actx.Tracer == nil {
-		panic("no tracer set in AmbientCtx")
+	if ctx.Stopper.Tracer() == nil {
+		panic("no tracer set in stopper")
 	}
 	db := &DB{
 		AmbientContext: actx,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -59,7 +59,7 @@ func (ds *DistSender) RangeFeed(
 	}
 
 	ctx = ds.AnnotateCtx(ctx)
-	ctx, sp := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender")
+	ctx, sp := tracing.EnsureChildSpan(ctx, ds.rpcContext.Stopper.Tracer(), "dist sender")
 	defer sp.Finish()
 
 	rr := newRangeFeedRegistry(ctx, startFrom, withDiff)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -127,7 +127,7 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 			}
 
 			ds := NewDistSender(DistSenderConfig{
-				AmbientCtx:      log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx:      log.MakeTestingAmbientContext(),
 				Clock:           clock,
 				NodeDescs:       g,
 				RPCRetryOptions: &retry.Options{MaxRetries: 10},

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1722,7 +1722,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	}
 	n.Start()
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:         log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx:         log.MakeTestingAmbientContext(),
 		NodeDescs:          n.Nodes[0].Gossip,
 		RPCContext:         n.RPCContext,
 		NodeDialer:         nodedialer.New(n.RPCContext, gossip.AddressResolver(n.Nodes[0].Gossip)),
@@ -2164,7 +2164,7 @@ func TestMultiRangeGapReverse(t *testing.T) {
 	})
 
 	cfg := DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
@@ -2492,7 +2492,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -2619,7 +2619,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientContext(stopper.Tracer()),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -3461,7 +3461,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 				}
 
 				cfg := DistSenderConfig{
-					AmbientCtx: log.MakeTestingAmbientContext(stopper.Tracer()),
+					AmbientCtx: log.MakeTestingAmbientContext(),
 					Clock:      clock,
 					NodeDescs:  g,
 					RPCContext: rpcContext,
@@ -4313,7 +4313,7 @@ func TestRequestSubdivisionAfterDescriptorChange(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx:        log.AmbientContext{Tracer: tr},
+				AmbientCtx:        log.AmbientContext{},
 				Clock:             clock,
 				NodeDescs:         g,
 				RPCContext:        rpcContext,
@@ -4489,7 +4489,7 @@ func TestDescriptorChangeAfterRequestSubdivision(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx:        log.AmbientContext{Tracer: tr},
+				AmbientCtx:        log.AmbientContext{},
 				Clock:             clock,
 				NodeDescs:         g,
 				RPCContext:        rpcContext,
@@ -4599,11 +4599,10 @@ func TestSendToReplicasSkipsStaleReplicas(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
-			tr := tracing.NewTracer()
 			getRangeDescCacheSize := func() int64 {
 				return 1 << 20
 			}
-			rc := rangecache.NewRangeCache(st, nil /* db */, getRangeDescCacheSize, stopper, tr)
+			rc := rangecache.NewRangeCache(st, nil /* db */, getRangeDescCacheSize, stopper)
 			rc.Insert(ctx, roachpb.RangeInfo{
 				Desc: desc,
 				Lease: roachpb.Lease{
@@ -4644,7 +4643,7 @@ func TestSendToReplicasSkipsStaleReplicas(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientContext(tr),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  ns,
 				RPCContext: rpcContext,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -373,7 +373,7 @@ func TestSendRPCOrder(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -531,7 +531,7 @@ func TestImmutableBatchArgs(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -658,7 +658,7 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -748,7 +748,7 @@ func TestBackoffOnNotLeaseHolderErrorDuringTransfer(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -841,7 +841,7 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 		}
 	}
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -937,7 +937,7 @@ func TestDistSenderMovesOnFromReplicaWithStaleLease(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1027,7 +1027,7 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -1131,7 +1131,7 @@ func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1189,7 +1189,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1265,7 +1265,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 	})
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1413,7 +1413,7 @@ func TestEvictCacheOnError(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -1486,7 +1486,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1586,7 +1586,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1687,7 +1687,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1811,7 +1811,7 @@ func TestSendRPCRetry(t *testing.T) {
 		return batchReply, nil
 	}
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -1934,7 +1934,7 @@ func TestDistSenderDescriptorUpdatesOnSuccessfulRPCs(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -2050,7 +2050,7 @@ func TestSendRPCRangeNotFoundError(t *testing.T) {
 		return br, nil
 	}
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -2085,7 +2085,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:         log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:         log.MakeTestingAmbientContext(),
 		Clock:              clock,
 		NodeDescs:          g,
 		RPCContext:         rpcContext,
@@ -2269,7 +2269,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		return batchReply, nil
 	}
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -2318,7 +2318,7 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -2358,7 +2358,7 @@ func TestClockUpdateOnResponse(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	cfg := DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
@@ -2810,7 +2810,7 @@ func TestMultiRangeWithEndTxn(t *testing.T) {
 		}
 
 		cfg := DistSenderConfig{
-			AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+			AmbientCtx: log.MakeTestingAmbientContext(),
 			Clock:      clock,
 			NodeDescs:  g,
 			RPCContext: rpcContext,
@@ -2943,7 +2943,7 @@ func TestParallelCommitSplitFromQueryIntents(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -3072,7 +3072,7 @@ func TestParallelCommitsDetectIntentMissingCause(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -3158,7 +3158,7 @@ func TestCountRanges(t *testing.T) {
 	// Mock out descriptor DB and sender function.
 	descDB := mockRangeDescriptorDBForDescs(append(descriptors[:], testMetaRangeDescriptor)...)
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -3250,7 +3250,7 @@ func TestGatewayNodeID(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -3600,7 +3600,7 @@ func TestErrorIndexAlignment(t *testing.T) {
 			}
 
 			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				AmbientCtx: log.MakeTestingAmbientContext(),
 				Clock:      clock,
 				NodeDescs:  g,
 				RPCContext: rpcContext,
@@ -3681,7 +3681,7 @@ func TestCanSendToFollower(t *testing.T) {
 		return ba.CreateReply(), nil
 	}
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -3901,7 +3901,7 @@ func TestEvictMetaRange(t *testing.T) {
 		}
 
 		cfg := DistSenderConfig{
-			AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+			AmbientCtx: log.MakeTestingAmbientContext(),
 			Clock:      clock,
 			NodeDescs:  g,
 			RPCContext: rpcContext,
@@ -4007,7 +4007,7 @@ func TestConnectionClass(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -4145,7 +4145,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  g,
 		RPCContext: rpcContext,
@@ -4758,7 +4758,7 @@ func TestDistSenderDescEvictionAfterLeaseUpdate(t *testing.T) {
 
 	rangeLookups := 0
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  ns,
 		RPCContext: rpcContext,
@@ -4837,7 +4837,7 @@ func TestDistSenderRPCMetrics(t *testing.T) {
 	}
 
 	cfg := DistSenderConfig{
-		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx: log.MakeTestingAmbientContext(),
 		Clock:      clock,
 		NodeDescs:  ns,
 		RPCContext: rpcContext,

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -59,7 +59,7 @@ func InitFactoryForLocalTestCluster(
 ) kv.TxnSenderFactory {
 	return NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
-			AmbientCtx: log.MakeTestingAmbientContext(tracer),
+			AmbientCtx: log.MakeTestingAmbientContext(),
 			Settings:   st,
 			Clock:      clock,
 			Stopper:    stopper,
@@ -85,7 +85,7 @@ func NewDistSenderForLocalTestCluster(
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	senderTransportFactory := SenderTransportFactory(tracer, stores)
 	return NewDistSender(DistSenderConfig{
-		AmbientCtx:         log.MakeTestingAmbientContext(tracer),
+		AmbientCtx:         log.MakeTestingAmbientContext(),
 		Settings:           st,
 		Clock:              clock,
 		NodeDescs:          g,

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -61,7 +61,7 @@ func TestRangeIterForward(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
@@ -97,7 +97,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
@@ -136,7 +136,7 @@ func TestRangeIterReverse(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,
@@ -172,7 +172,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	g := makeGossip(t, stopper, rpcContext)
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:        log.MakeTestingAmbientContext(),
 		Clock:             clock,
 		NodeDescs:         g,
 		RPCContext:        rpcContext,

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -340,7 +340,7 @@ func sendBatch(
 	}
 
 	ds := NewDistSender(DistSenderConfig{
-		AmbientCtx:         log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientCtx:         log.MakeTestingAmbientContext(),
 		Settings:           cluster.MakeTestingClusterSettings(),
 		NodeDescs:          g,
 		RPCContext:         rpcContext,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -486,7 +486,8 @@ func (tc *TxnCoordSender) Send(
 		return nil, tc.finalizeNonLockingTxnLocked(ctx, ba)
 	}
 
-	ctx, sp := tc.AnnotateCtxWithSpan(ctx, OpTxnCoordSender)
+	ctx = tc.AnnotateCtx(ctx)
+	ctx, sp := tc.stopper.Tracer().EnsureChildSpan(ctx, OpTxnCoordSender)
 	defer sp.Finish()
 
 	// Associate the txnID with the trace.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -180,7 +180,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 		NewDistSenderForLocalTestCluster(
 			ctx,
 			s.Cfg.Settings, &roachpb.NodeDescriptor{NodeID: 1},
-			ambient.Tracer, s.Clock, s.Latency, s.Stores, s.Stopper(), s.Gossip,
+			s.Stopper().Tracer(), s.Clock, s.Latency, s.Stores, s.Stopper(), s.Gossip,
 		),
 	)
 	quickHeartbeatDB := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -770,7 +770,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				}
 				return reply, pErr
 			}
-			ambient := log.MakeTestingAmbientCtxWithNewTracer()
+			ambient := log.MakeTestingAmbientContext()
 			tsf := NewTxnCoordSenderFactory(
 				TxnCoordSenderFactoryConfig{
 					AmbientCtx: ambient,
@@ -907,7 +907,7 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 		}
 		return br, nil
 	}
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 
 	factory := NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
@@ -1453,7 +1453,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				}
 				return br, nil
 			}
-			ambient := log.MakeTestingAmbientCtxWithNewTracer()
+			ambient := log.MakeTestingAmbientContext()
 			factory := NewTxnCoordSenderFactory(
 				TxnCoordSenderFactoryConfig{
 					AmbientCtx: ambient,
@@ -1530,14 +1530,14 @@ func TestRollbackErrorStopsHeartbeat(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
 	factory := NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
-			AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+			AmbientCtx: log.MakeTestingAmbientContext(),
 			Clock:      clock,
 			Stopper:    stopper,
 			Settings:   cluster.MakeTestingClusterSettings(),
@@ -1598,14 +1598,14 @@ func TestOnePCErrorTracking(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
 	factory := NewTxnCoordSenderFactory(
 		TxnCoordSenderFactoryConfig{
-			AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+			AmbientCtx: log.MakeTestingAmbientContext(),
 			Clock:      clock,
 			Stopper:    stopper,
 			Settings:   cluster.MakeTestingClusterSettings(),
@@ -1683,7 +1683,7 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -1706,7 +1706,7 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "explicit txn", func(t *testing.T, explicitTxn bool) {
 		testutils.RunTrueAndFalse(t, "with get", func(t *testing.T, withGet bool) {
 			calls = nil
-			db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+			db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 			if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				b := txn.NewBatch()
 				if withGet {
@@ -1738,7 +1738,7 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -1815,7 +1815,7 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	for i, test := range testArgs {
 		t.Run(test.expMethod.String(), func(t *testing.T) {
 			calls = nil
-			db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+			db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 			if err := db.Txn(ctx, test.f); err != nil {
 				t.Fatalf("%d: unexpected error on commit: %s", i, err)
 			}
@@ -1838,7 +1838,7 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -1858,7 +1858,7 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 	if err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		return errors.New("foo")
 	}); err == nil {
@@ -1879,7 +1879,7 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -1915,7 +1915,7 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 	testutils.RunTrueAndFalse(t, "write", func(t *testing.T, write bool) {
 		testutils.RunTrueAndFalse(t, "success", func(t *testing.T, success bool) {
@@ -1963,7 +1963,7 @@ func TestTransactionKeyNotChangedInRestart(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2007,7 +2007,7 @@ func TestTransactionKeyNotChangedInRestart(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 	if err := db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 		defer func() { attempt++ }()
@@ -2030,7 +2030,7 @@ func TestSequenceNumbers(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2063,7 +2063,7 @@ func TestSequenceNumbers(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 	for i := 0; i < 5; i++ {
@@ -2084,7 +2084,7 @@ func TestConcurrentTxnRequestsProhibited(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2141,7 +2141,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2155,7 +2155,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 	curReq := 0
 	requests := []struct {
@@ -2206,7 +2206,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	sender := &mockSender{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -2231,7 +2231,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 		},
 		sender,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 	// We're going to run two tests: one where the EndTxn is by itself in a
 	// batch, one where it is not. As of June 2018, the EndTxn is elided in
@@ -2350,7 +2350,7 @@ func TestAnchorKey(t *testing.T) {
 	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
@@ -2380,7 +2380,7 @@ func TestAnchorKey(t *testing.T) {
 		},
 		senderFn,
 	)
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		ba := txn.NewBatch()
@@ -2736,7 +2736,7 @@ func TestTxnManualRefresh(t *testing.T) {
 				return nil, roachpb.NewError(ctx.Err())
 			}
 		}
-		ambient := log.MakeTestingAmbientCtxWithNewTracer()
+		ambient := log.MakeTestingAmbientContext()
 		tsf := NewTxnCoordSenderFactory(
 			TxnCoordSenderFactoryConfig{
 				AmbientCtx:        ambient,

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -297,7 +297,7 @@ func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) {
 	timer := time.AfterFunc(h.loopInterval, func() {
 		const taskName = "kv.TxnCoordSender: heartbeat loop"
 		var span *tracing.Span
-		hbCtx, span = h.AmbientContext.Tracer.StartSpanCtx(hbCtx, taskName)
+		hbCtx, span = h.stopper.Tracer().StartSpanCtx(hbCtx, taskName)
 		defer span.Finish()
 
 		// Only errors on quiesce, which is safe to ignore.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
@@ -34,7 +34,7 @@ func makeMockTxnHeartbeater(
 	mockSender, mockGatekeeper = &mockLockedSender{}, &mockLockedSender{}
 	manual := hlc.NewManualClock(123)
 	th.init(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		log.MakeTestingAmbientContext(),
 		stop.NewStopper(),
 		hlc.NewClock(manual.UnixNano, time.Nanosecond),
 		new(TxnMetrics),

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -1570,7 +1570,7 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 		}
 		return resp, nil
 	}
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	ds := NewDistSender(DistSenderConfig{
 		AmbientCtx: ambient,
 		Clock:      s.Clock,

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -176,13 +176,9 @@ func makeLookupRequestKey(
 // NewRangeCache returns a new RangeCache which uses the given RangeDescriptorDB
 // as the underlying source of range descriptors.
 func NewRangeCache(
-	st *cluster.Settings,
-	db RangeDescriptorDB,
-	size func() int64,
-	stopper *stop.Stopper,
-	tracer *tracing.Tracer,
+	st *cluster.Settings, db RangeDescriptorDB, size func() int64, stopper *stop.Stopper,
 ) *RangeCache {
-	rdc := &RangeCache{st: st, db: db, stopper: stopper, tracer: tracer}
+	rdc := &RangeCache{st: st, db: db, stopper: stopper, tracer: stopper.Tracer()}
 	rdc.rangeCache.cache = cache.NewOrderedCache(cache.Config{
 		Policy: cache.CacheLRU,
 		ShouldEvict: func(n int, _, _ interface{}) bool {

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -55,7 +55,7 @@ func (a *Applier) Apply(ctx context.Context, step *Step) (trace tracing.Recordin
 	db, step.DBID = a.getNextDBRoundRobin()
 
 	step.Before = db.Clock().Now()
-	recCtx, collectAndFinish := tracing.ContextWithRecordingSpan(ctx, db.Tracer, "txn step")
+	recCtx, collectAndFinish := tracing.ContextWithRecordingSpan(ctx, db.Tracer(), "txn step")
 	defer func() {
 		step.After = db.Clock().Now()
 		if p := recover(); p != nil {

--- a/pkg/kv/kvserver/addressing_test.go
+++ b/pkg/kv/kvserver/addressing_test.go
@@ -135,7 +135,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		// interface without sending through a TxnCoordSender (which initializes a
 		// transaction id). Also, we need the TxnCoordSender to clean up the
 		// intents, otherwise the MVCCScan that the test does below fails.
-		actx := log.MakeTestingAmbientCtxWithNewTracer()
+		actx := log.MakeTestingAmbientContext()
 		tcsf := kvcoord.NewTxnCoordSenderFactory(
 			kvcoord.TxnCoordSenderFactoryConfig{
 				AmbientCtx: actx,

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -7335,7 +7335,6 @@ func TestAllocatorFullDisks(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()
-	tr := tracing.NewTracer()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 
 	// Model a set of stores in a cluster doing rebalancing, with ranges being
@@ -7359,7 +7358,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 
 	mockNodeLiveness := newMockNodeLiveness(livenesspb.NodeLivenessStatus_LIVE)
 	sp := NewStorePool(
-		log.MakeTestingAmbientContext(tr),
+		log.MakeTestingAmbientContext(),
 		st,
 		g,
 		clock,
@@ -7483,7 +7482,7 @@ func Example_rebalancing() {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
+	ambientCtx := log.MakeTestingAmbientContext()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 
 	// Model a set of stores in a cluster,

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -795,7 +795,7 @@ func newIntentResolverWithSendFuncs(
 			f := sf.popLocked()
 			return f(ba)
 		})
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), txnSenderFactory, c.Clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), txnSenderFactory, c.Clock, stopper)
 	c.DB = db
 	c.MaxGCBatchWait = time.Nanosecond
 	return New(c)

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
     ],
 )

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -920,7 +920,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 		return nil
 	}
 
-	ctx, span := tracing.EnsureChildSpan(ctx, bq.Tracer, bq.processOpName())
+	ctx, span := tracing.EnsureChildSpan(ctx, bq.store.stopper.Tracer(), bq.processOpName())
 	defer span.Finish()
 	return contextutil.RunWithTimeout(ctx, fmt.Sprintf("%s queue process replica %d", bq.name, repl.GetRangeID()),
 		bq.processTimeoutFunc(bq.store.ClusterSettings(), repl), func(ctx context.Context) error {

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -71,7 +71,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 	store := &Store{
 		cfg: StoreConfig{
 			Clock:             hlc.NewClock(hlc.UnixNano, time.Second),
-			AmbientCtx:        log.MakeTestingAmbientContext(tr),
+			AmbientCtx:        log.MakeTestingAmbientContext(),
 			DefaultSpanConfig: roachpb.TestingDefaultSpanConfig(),
 		},
 	}

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -170,7 +170,7 @@ func NewDummyRaftTransport(st *cluster.Settings, tracer *tracing.Tracer) *RaftTr
 	resolver := func(roachpb.NodeID) (net.Addr, error) {
 		return nil, errors.New("dummy resolver")
 	}
-	return NewRaftTransport(log.MakeTestingAmbientContext(tracer), st,
+	return NewRaftTransport(log.MakeTestingAmbientContext(), st,
 		nodedialer.New(nil, resolver), nil, nil)
 }
 

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -160,7 +160,7 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 ) (*kvserver.RaftTransport, net.Addr) {
 	grpcServer := rpc.NewServer(rttc.nodeRPCContext)
 	transport := kvserver.NewRaftTransport(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		log.MakeTestingAmbientContext(),
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(rttc.nodeRPCContext, gossip.AddressResolver(rttc.gossip)),
 		grpcServer,

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -67,7 +67,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	}
 
 	tp := NewRaftTransport(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		log.MakeTestingAmbientContext(),
 		cluster.MakeTestingClusterSettings(),
 		nodedialer.New(rpcC, resolver),
 		grpcServer,

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -144,7 +144,7 @@ func newTestProcessorWithTxnPusher(
 	}
 
 	p := NewProcessor(Config{
-		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		AmbientContext:       log.MakeTestingAmbientContext(),
 		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 		TxnPusher:            txnPusher,

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -143,13 +143,13 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 		} else if cmd.raftCmd.TraceData != nil {
 			// The proposal isn't local, and trace data is available. Extract
 			// the remote span and start a server-side span that follows from it.
-			spanMeta, err := d.r.AmbientContext.Tracer.ExtractMetaFrom(tracing.MapCarrier{
+			spanMeta, err := d.r.store.stopper.Tracer().ExtractMetaFrom(tracing.MapCarrier{
 				Map: cmd.raftCmd.TraceData,
 			})
 			if err != nil {
 				log.Errorf(ctx, "unable to extract trace data from raft command: %s", err)
 			} else {
-				cmd.ctx, cmd.sp = d.r.AmbientContext.Tracer.StartSpanCtx(
+				cmd.ctx, cmd.sp = d.r.store.stopper.Tracer().StartSpanCtx(
 					ctx,
 					opName,
 					// NB: Nobody is collecting the recording of this span; we have no

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -913,6 +913,6 @@ func (r *Replica) getTraceData(ctx context.Context) map[string]string {
 	traceCarrier := tracing.MapCarrier{
 		Map: make(map[string]string),
 	}
-	r.AmbientContext.Tracer.InjectMetaInto(sp.Meta(), traceCarrier)
+	r.store.stopper.Tracer().InjectMetaInto(sp.Meta(), traceCarrier)
 	return traceCarrier.Map
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	"go.etcd.io/etcd/raft/v3"
+	raft "go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -412,6 +412,7 @@ func (r *Replica) raftSnapshotLocked() (raftpb.Snapshot, error) {
 func (r *Replica) GetSnapshot(
 	ctx context.Context, snapType SnapshotRequest_Type, recipientStore roachpb.StoreID,
 ) (_ *OutgoingSnapshot, err error) {
+	ctx = r.AnnotateCtx(ctx)
 	snapUUID := uuid.MakeV4()
 	// Get a snapshot while holding raftMu to make sure we're not seeing "half
 	// an AddSSTable" (i.e. a state in which an SSTable has been linked in, but
@@ -442,7 +443,7 @@ func (r *Replica) GetSnapshot(
 	rangeID := r.RangeID
 
 	startKey := r.mu.state.Desc.StartKey
-	ctx, sp := r.AnnotateCtxWithSpan(ctx, "snapshot")
+	ctx, sp := r.store.stopper.Tracer().EnsureChildSpan(ctx, "snapshot")
 	defer sp.Finish()
 
 	log.Eventf(ctx, "new engine snapshot for replica %s", r)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -61,7 +61,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	"go.etcd.io/etcd/raft/v3"
+	raft "go.etcd.io/etcd/raft/v3"
 )
 
 var leaseStatusLogLimiter = func() *log.EveryN {
@@ -319,7 +319,7 @@ func (p *pendingLeaseRequest) requestLeaseAsync(
 	// cancel function that must be called; calling just cancel is insufficient.
 	ctx := p.repl.AnnotateCtx(context.Background())
 	const opName = "request range lease"
-	tr := p.repl.AmbientContext.Tracer
+	tr := p.repl.store.stopper.Tracer()
 	tagsOpt := tracing.WithLogTags(logtags.FromContext(parentCtx))
 	var sp *tracing.Span
 	if parentSp := tracing.SpanFromContext(parentCtx); parentSp != nil {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -660,7 +660,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 		// Ignore the result of DoChan since, to keep this all async, it always
 		// returns nil and any errors are logged by the closure passed to the
 		// `DoChan` call.
-		taskCtx, sp := tracing.EnsureForkSpan(ctx, r.AmbientContext.Tracer, key)
+		taskCtx, sp := tracing.EnsureForkSpan(ctx, r.store.stopper.Tracer(), key)
 		_, leader := m.RangeFeedSlowClosedTimestampNudge.DoChan(key, func() (interface{}, error) {
 			defer sp.Finish()
 			// Also ignore the result of RunTask, since it only returns errors when

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -744,7 +744,7 @@ func (r *Replica) executeAdminBatch(
 
 	args := ba.Requests[0].GetInner()
 
-	ctx, sp := tracing.EnsureChildSpan(ctx, r.AmbientContext.Tracer, reflect.TypeOf(args).String())
+	ctx, sp := tracing.EnsureChildSpan(ctx, r.store.stopper.Tracer(), reflect.TypeOf(args).String())
 	defer sp.Finish()
 
 	// Verify that the batch can be executed, which includes verifying that the

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -584,7 +584,7 @@ func testRaftSSTableSideloadingProposal(t *testing.T, eng storage.Engine) {
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
 
-	tr := tc.store.cfg.AmbientCtx.Tracer
+	tr := stopper.Tracer()
 	tr.TestingRecordAsyncSpans() // we assert on async span traces in this test
 	ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 	defer getRecAndFinish()

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func makeAmbCtx() log.AmbientContext {
-	return log.MakeTestingAmbientCtxWithNewTracer()
+	return log.MakeTestingAmbientContext()
 }
 
 // Test implementation of a range set backed by btree.BTree.

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -236,7 +236,7 @@ func TestSchedulerLoop(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(), m, p, 1)
 
 	s.Start(stopper)
 	s.EnqueueRaftTicks(1, 2, 3)
@@ -264,7 +264,7 @@ func TestSchedulerBuffering(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(), m, p, 1)
 	s.Start(stopper)
 
 	testCases := []struct {

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -102,7 +102,7 @@ func createTestStorePool(
 	mc := hlc.NewManualClock(123)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	st := cluster.MakeTestingClusterSettings()
-	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
+	ambientCtx := log.MakeTestingAmbientContext()
 	rpcContext := rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
@@ -635,7 +635,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	cfg := TestStoreConfig(clock)
-	cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	cfg.Transport = NewDummyRaftTransport(cfg.Settings, stopper.Tracer())
 	store := NewStore(ctx, cfg, eng, &node)
 	// Fake an ident because this test doesn't want to start the store
 	// but without an Ident there will be NPEs.

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -36,7 +36,7 @@ func newStores(ambientCtx log.AmbientContext, clock *hlc.Clock) *Stores {
 func TestStoresAddStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	ls := newStores(log.MakeTestingAmbientContext(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	store := Store{
 		Ident: &roachpb.StoreIdent{StoreID: 123},
 	}
@@ -52,7 +52,7 @@ func TestStoresAddStore(t *testing.T) {
 func TestStoresRemoveStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	ls := newStores(log.MakeTestingAmbientContext(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 
 	storeID := roachpb.StoreID(89)
 
@@ -68,7 +68,7 @@ func TestStoresRemoveStore(t *testing.T) {
 func TestStoresGetStoreCount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	ls := newStores(log.MakeTestingAmbientContext(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	if ls.GetStoreCount() != 0 {
 		t.Errorf("expected 0 stores in new local sender")
 	}
@@ -85,7 +85,7 @@ func TestStoresGetStoreCount(t *testing.T) {
 func TestStoresVisitStores(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	ls := newStores(log.MakeTestingAmbientContext(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	numStores := 10
 	for i := 0; i < numStores; i++ {
 		ls.AddStore(&Store{Ident: &roachpb.StoreIdent{StoreID: roachpb.StoreID(i)}})
@@ -120,7 +120,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), clock)
+	ls := newStores(log.MakeTestingAmbientContext(), clock)
 	numStores := 10
 	for i := 1; i <= numStores; i++ {
 		storeID := roachpb.StoreID(i)
@@ -190,7 +190,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 func TestStoresGetStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	ls := newStores(log.MakeTestingAmbientContext(), hlc.NewClock(hlc.UnixNano, time.Nanosecond))
 	store := Store{Ident: &roachpb.StoreIdent{StoreID: 1}}
 	replica := roachpb.ReplicaDescriptor{StoreID: store.Ident.StoreID}
 	s, pErr := ls.GetStore(replica.StoreID)
@@ -217,7 +217,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	stopper := stop.NewStopper()
 	manual := hlc.NewManualClock(123)
 	cfg := TestStoreConfig(hlc.NewClock(manual.UnixNano, time.Nanosecond))
-	ls := newStores(log.MakeTestingAmbientCtxWithNewTracer(), cfg.Clock)
+	ls := newStores(log.MakeTestingAmbientContext(), cfg.Clock)
 
 	// Create two stores with ranges we care about.
 	stores := []*Store{}
@@ -272,7 +272,7 @@ func TestStoresGossipStorage(t *testing.T) {
 	ls.AddStore(stores[1])
 
 	// Create a new stores object to verify read.
-	ls2 := newStores(log.MakeTestingAmbientCtxWithNewTracer(), ls.clock)
+	ls2 := newStores(log.MakeTestingAmbientContext(), ls.clock)
 	ls2.AddStore(stores[1])
 	var verifyBI gossip.BootstrapInfo
 	if err := ls2.ReadBootstrapInfo(&verifyBI); err != nil {
@@ -313,7 +313,7 @@ func TestStoresGossipStorageReadLatest(t *testing.T) {
 	// Create a new stores object to freshly read. Should get latest
 	// version from store 1.
 	manual.Increment(1)
-	ls2 := newStores(log.MakeTestingAmbientCtxWithNewTracer(), ls.clock)
+	ls2 := newStores(log.MakeTestingAmbientContext(), ls.clock)
 	ls2.AddStore(stores[0])
 	ls2.AddStore(stores[1])
 	var verifyBI gossip.BootstrapInfo
@@ -326,7 +326,7 @@ func TestStoresGossipStorageReadLatest(t *testing.T) {
 
 	// Verify that stores[0], which had old info, was updated with
 	// latest bootstrap info during the read.
-	ls3 := newStores(log.MakeTestingAmbientCtxWithNewTracer(), ls.clock)
+	ls3 := newStores(log.MakeTestingAmbientContext(), ls.clock)
 	ls3.AddStore(stores[0])
 	verifyBI.Reset()
 	if err := ls3.ReadBootstrapInfo(&verifyBI); err != nil {
@@ -353,7 +353,7 @@ func TestClusterVersionWriteSynthesize(t *testing.T) {
 	minV := v1_0
 
 	makeStores := func() *Stores {
-		ls := NewStores(log.MakeTestingAmbientCtxWithNewTracer(), stores[0].Clock())
+		ls := NewStores(log.MakeTestingAmbientContext(), stores[0].Clock())
 		return ls
 	}
 

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -131,7 +131,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		stopper.AddCloser(memEngine)
 
 		cfg := TestStoreConfig(clock)
-		cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+		cfg.Transport = NewDummyRaftTransport(cfg.Settings, stopper.Tracer())
 
 		store := NewStore(ctx, cfg, memEngine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Fake-set an ident. This is usually read from the engine on store.Start()
@@ -222,7 +222,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	// Create two stores with ranges we care about.
 	stores := []*Store{}
 	for i := 0; i < count; i++ {
-		cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+		cfg.Transport = NewDummyRaftTransport(cfg.Settings, stopper.Tracer())
 		eng := storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(eng)
 		s := NewStore(context.Background(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})

--- a/pkg/kv/kvserver/txnrecovery/manager_test.go
+++ b/pkg/kv/kvserver/txnrecovery/manager_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func makeManager(s *kv.Sender) (Manager, *hlc.Clock, *stop.Stopper) {
-	ac := log.MakeTestingAmbientCtxWithNewTracer()
+	ac := log.MakeTestingAmbientContext()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	stopper := stop.NewStopper()
 	db := kv.NewDB(ac, kv.NonTransactionalFactoryFunc(func(

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -175,7 +175,7 @@ func makeConfig(s kv.SenderFunc, stopper *stop.Stopper) Config {
 	cfg.Metrics = NewMetrics(time.Minute)
 	if s != nil {
 		factory := kv.NonTransactionalFactoryFunc(s)
-		cfg.DB = kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, cfg.Clock, stopper)
+		cfg.DB = kv.NewDB(log.MakeTestingAmbientContext(), factory, cfg.Clock, stopper)
 	}
 	return cfg
 }

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -46,7 +46,7 @@ func TestTxnVerboseTrace(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(nil), clock, stopper)
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(nil), clock, stopper)
 
 	if err := db.Txn(ctx, func(ctx context.Context, txn *Txn) error {
 		log.Event(ctx, "inside txn")
@@ -141,7 +141,7 @@ func TestInitPut(t *testing.T) {
 	// TODO(vivekmenezes): update test or remove when InitPut is being
 	// considered sufficiently tested and this path exercised.
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		br := ba.CreateReply()
 		return br, nil
 	}), clock, stopper)
@@ -166,7 +166,7 @@ func TestTransactionConfig(t *testing.T) {
 	dbCtx := DefaultDBContext(stopper)
 	dbCtx.UserPriority = 101
 	db := NewDBWithContext(
-		log.MakeTestingAmbientCtxWithNewTracer(),
+		log.MakeTestingAmbientContext(),
 		newTestTxnFactory(nil), clock, dbCtx)
 	for _, tc := range []struct {
 		label               string
@@ -210,7 +210,7 @@ func TestCommitTransactionOnce(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	count := 0
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		count++
 		return ba.CreateReply(), nil
 	}), clock, stopper)
@@ -236,7 +236,7 @@ func TestAbortMutatingTransaction(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var calls []roachpb.Method
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		calls = append(calls, ba.Methods()...)
 		if et, ok := ba.GetArg(roachpb.EndTxn); ok && et.(*roachpb.EndTxnRequest).Commit {
 			t.Errorf("expected commit to be false")
@@ -288,7 +288,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(ctx)
 			count := 0
-			db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(
+			db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(
 				func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 
 					if _, ok := ba.GetArg(roachpb.Put); ok {
@@ -348,7 +348,7 @@ func TestTransactionStatus(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(nil), clock, stopper)
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(nil), clock, stopper)
 	for _, write := range []bool{true, false} {
 		for _, commit := range []bool{true, false} {
 			txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
@@ -388,7 +388,7 @@ func TestCommitInBatchWrongTxn(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(nil), clock, stopper)
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(nil), clock, stopper)
 	txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 	b1 := &Batch{}
@@ -413,7 +413,7 @@ func TestSetPriority(t *testing.T) {
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var expected roachpb.UserPriority
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(
 		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			if ba.UserPriority != expected {
 				pErr := roachpb.NewErrorf("Priority not set correctly in the batch! "+
@@ -454,7 +454,7 @@ func TestWrongTxnRetry(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(nil), clock, stopper)
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(nil), clock, stopper)
 
 	var retries int
 	txnClosure := func(ctx context.Context, outerTxn *Txn) error {
@@ -484,7 +484,7 @@ func TestBatchMixRawRequest(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), newTestTxnFactory(nil), clock, stopper)
+	db := NewDB(log.MakeTestingAmbientContext(), newTestTxnFactory(nil), clock, stopper)
 
 	b := &Batch{}
 	b.AddRawRequest(&roachpb.EndTxnRequest{})
@@ -503,7 +503,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 
 	mc := hlc.NewManualClock(1)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), MakeMockTxnSenderFactory(
+	db := NewDB(log.MakeTestingAmbientContext(), MakeMockTxnSenderFactory(
 		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
@@ -549,7 +549,7 @@ func TestAnchoringErrorNoTrigger(t *testing.T) {
 
 	mc := hlc.NewManualClock(1)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), MakeMockTxnSenderFactory(
+	db := NewDB(log.MakeTestingAmbientContext(), MakeMockTxnSenderFactory(
 		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
@@ -589,7 +589,7 @@ func TestTxnNegotiateAndSend(t *testing.T) {
 			br.Timestamp = ts20
 			return br, nil
 		})
-		db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), txnSender, clock, stopper)
+		db := NewDB(log.MakeTestingAmbientContext(), txnSender, clock, stopper)
 		txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 		var ba roachpb.BatchRequest
@@ -699,7 +699,7 @@ func TestTxnNegotiateAndSendWithDeadline(t *testing.T) {
 				br.Timestamp = minTSBound
 				return br, nil
 			})
-			db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), txnSender, clock, stopper)
+			db := NewDB(log.MakeTestingAmbientContext(), txnSender, clock, stopper)
 			txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
 			require.NoError(t, txn.UpdateDeadline(ctx, test.txnDeadline))
 
@@ -771,7 +771,7 @@ func TestTxnNegotiateAndSendWithResumeSpan(t *testing.T) {
 			scanResp.ResumeReason = roachpb.RESUME_KEY_LIMIT
 			return br, nil
 		})
-		db := NewDB(log.MakeTestingAmbientCtxWithNewTracer(), txnSender, clock, stopper)
+		db := NewDB(log.MakeTestingAmbientContext(), txnSender, clock, stopper)
 		txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
 		var ba roachpb.BatchRequest

--- a/pkg/migration/migrations/separated_intents_test.go
+++ b/pkg/migration/migrations/separated_intents_test.go
@@ -207,7 +207,7 @@ func TestRunSeparatedIntentsMigration(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), mockSender, hlcClock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), mockSender, hlcClock, stopper)
 
 	datadriven.RunTest(t, "testdata/separated_intents",
 		func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -318,7 +318,8 @@ func TestAdminAPIDatabases(t *testing.T) {
 	ts := s.(*TestServer)
 
 	ac := ts.AmbientCtx()
-	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
+	ctx := ac.AnnotateCtx(context.Background())
+	ctx, span := s.Stopper().Tracer().EnsureChildSpan(ctx, "test")
 	defer span.Finish()
 
 	const testdb = "test"
@@ -656,7 +657,8 @@ func TestAdminAPITableDetails(t *testing.T) {
 			schemaName := "testschema"
 
 			ac := ts.AmbientCtx()
-			ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
+			ctx := ac.AnnotateCtx(context.Background())
+			ctx, span := s.Stopper().Tracer().EnsureChildSpan(ctx, "test")
 			defer span.Finish()
 
 			tableSchema := `nulls_allowed INT8,
@@ -802,7 +804,8 @@ func TestAdminAPIZoneDetails(t *testing.T) {
 
 	// Create database and table.
 	ac := ts.AmbientCtx()
-	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
+	ctx := ac.AnnotateCtx(context.Background())
+	ctx, span := s.Stopper().Tracer().EnsureChildSpan(ctx, "test")
 	defer span.Finish()
 	setupQueries := []string{
 		"CREATE DATABASE test",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -197,7 +197,7 @@ func MakeBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 		idProvider:         idsProvider,
 		IDContainer:        idsProvider.serverID,
 		ClusterIDContainer: idsProvider.clusterID,
-		AmbientCtx:         log.MakeServerAmbientContext(tr, idsProvider),
+		AmbientCtx:         log.MakeServerAmbientContext(idsProvider),
 		Config:             new(base.Config),
 		Settings:           st,
 		MaxOffset:          MaxOffsetType(base.DefaultMaxClockOffset),

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -123,9 +123,7 @@ func TestReadEnvironmentVariables(t *testing.T) {
 
 	// Tracers store their stack trace in NewTracer, and this wouldn't match.
 	cfg.Tracer = nil
-	cfg.AmbientCtx.Tracer = nil
 	cfgExpected.Tracer = nil
-	cfgExpected.AmbientCtx.Tracer = nil
 	require.Equal(t, cfgExpected, cfg)
 
 	// Set all the environment variables to valid values and ensure they are set

--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -42,7 +42,8 @@ var _ serverpb.MigrationServer = &migrationServer{}
 func (m *migrationServer) ValidateTargetClusterVersion(
 	ctx context.Context, req *serverpb.ValidateTargetClusterVersionRequest,
 ) (*serverpb.ValidateTargetClusterVersionResponse, error) {
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, "validate-cluster-version")
+	ctx = m.server.AnnotateCtx(ctx)
+	ctx, span := m.server.stopper.Tracer().EnsureChildSpan(ctx, "validate-cluster-version")
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, "validate-cluster-version", nil)
 
@@ -89,7 +90,8 @@ func (m *migrationServer) BumpClusterVersion(
 	ctx context.Context, req *serverpb.BumpClusterVersionRequest,
 ) (*serverpb.BumpClusterVersionResponse, error) {
 	const opName = "bump-cluster-version"
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, opName)
+	ctx = m.server.AnnotateCtx(ctx)
+	ctx, span := m.server.stopper.Tracer().EnsureChildSpan(ctx, opName)
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 
@@ -156,7 +158,8 @@ func (m *migrationServer) SyncAllEngines(
 	ctx context.Context, _ *serverpb.SyncAllEnginesRequest,
 ) (*serverpb.SyncAllEnginesResponse, error) {
 	const opName = "sync-all-engines"
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, opName)
+	ctx = m.server.AnnotateCtx(ctx)
+	ctx, span := m.server.stopper.Tracer().EnsureChildSpan(ctx, opName)
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 
@@ -188,7 +191,8 @@ func (m *migrationServer) PurgeOutdatedReplicas(
 	ctx context.Context, req *serverpb.PurgeOutdatedReplicasRequest,
 ) (*serverpb.PurgeOutdatedReplicasResponse, error) {
 	const opName = "purged-outdated-replicas"
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, opName)
+	ctx = m.server.AnnotateCtx(ctx)
+	ctx, span := m.server.stopper.Tracer().EnsureChildSpan(ctx, opName)
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 
@@ -215,7 +219,8 @@ func (m *migrationServer) DeprecateBaseEncryptionRegistry(
 	ctx context.Context, req *serverpb.DeprecateBaseEncryptionRegistryRequest,
 ) (*serverpb.DeprecateBaseEncryptionRegistryResponse, error) {
 	const opName = "deprecate-base-encryption-registry"
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, opName)
+	ctx = m.server.AnnotateCtx(ctx)
+	ctx, span := m.server.stopper.Tracer().EnsureChildSpan(ctx, opName)
 	defer span.Finish()
 	ctx = logtags.AddTag(ctx, opName, nil)
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -390,13 +390,6 @@ func (n *Node) AnnotateCtx(ctx context.Context) context.Context {
 	return n.storeCfg.AmbientCtx.AnnotateCtx(ctx)
 }
 
-// AnnotateCtxWithSpan is a convenience wrapper; see AmbientContext.
-func (n *Node) AnnotateCtxWithSpan(
-	ctx context.Context, opName string,
-) (context.Context, *tracing.Span) {
-	return n.storeCfg.AmbientCtx.AnnotateCtxWithSpan(ctx, opName)
-}
-
 // start starts the node by registering the storage instance for the RPC
 // service "Node" and initializing stores for each specified engine.
 // Launches periodic store gossiping in a goroutine. A callback can
@@ -897,7 +890,8 @@ func (n *Node) recordJoinEvent(ctx context.Context) {
 	}
 
 	_ = n.stopper.RunAsyncTask(ctx, "record-join", func(bgCtx context.Context) {
-		ctx, span := n.AnnotateCtxWithSpan(bgCtx, "record-join-event")
+		ctx := n.AnnotateCtx(bgCtx)
+		ctx, span := n.stopper.Tracer().EnsureChildSpan(ctx, "record-join-event")
 		defer span.Finish()
 		retryOpts := base.DefaultRetryOptions()
 		retryOpts.Closer = n.stopper.ShouldQuiesce()
@@ -1047,7 +1041,7 @@ func (n *Node) Batch(
 func (n *Node) setupSpanForIncomingRPC(
 	ctx context.Context, tenID roachpb.TenantID, ba *roachpb.BatchRequest,
 ) (context.Context, func(context.Context, *roachpb.BatchResponse)) {
-	tr := n.storeCfg.AmbientCtx.Tracer
+	tr := n.stopper.Tracer()
 	var newSpan *tracing.Span
 	parentSpan := tracing.SpanFromContext(ctx)
 	localRequest := grpcutil.IsLocalRequestContext(ctx)
@@ -1381,7 +1375,8 @@ func (n *Node) GossipSubscription(
 func (n *Node) Join(
 	ctx context.Context, req *roachpb.JoinNodeRequest,
 ) (*roachpb.JoinNodeResponse, error) {
-	ctx, span := n.AnnotateCtxWithSpan(ctx, "alloc-{node,store}-id")
+	ctx = n.AnnotateCtx(ctx)
+	ctx, span := n.stopper.Tracer().EnsureChildSpan(ctx, "alloc-{node,store}-id")
 	defer span.Finish()
 
 	activeVersion := n.storeCfg.Settings.Version.ActiveVersion(ctx)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -257,8 +257,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	st := cfg.Settings
 
-	if cfg.AmbientCtx.Tracer == nil {
-		panic(errors.New("no tracer set in AmbientCtx"))
+	if cfg.Tracer == nil {
+		panic(errors.New("no tracer set in BaseConfig"))
 	}
 
 	var clock *hlc.Clock
@@ -278,8 +278,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	registry := metric.NewRegistry()
 	ruleRegistry := metric.NewRuleRegistry()
 	promRuleExporter := metric.NewPrometheusRuleExporter(ruleRegistry)
-	stopper.SetTracer(cfg.AmbientCtx.Tracer)
-	stopper.AddCloser(cfg.AmbientCtx.Tracer)
+	stopper.SetTracer(cfg.Tracer)
+	stopper.AddCloser(cfg.Tracer)
 
 	// Add a dynamic log tag value for the node ID.
 	//
@@ -511,6 +511,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	nodeLiveness := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
 		AmbientCtx:              cfg.AmbientCtx,
+		Tracer:                  stopper.Tracer(),
 		Clock:                   clock,
 		DB:                      db,
 		Gossip:                  g,
@@ -688,6 +689,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	updates := &diagnostics.UpdateChecker{
 		StartTime:     timeutil.Now(),
 		AmbientCtx:    &cfg.AmbientCtx,
+		Stopper:       stopper,
 		Config:        cfg.BaseConfig.Config,
 		Settings:      cfg.Settings,
 		ClusterID:     cfg.ClusterIDContainer.Get,
@@ -777,7 +779,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	kvProber := kvprober.NewProber(kvprober.Opts{
-		Tracer:                  cfg.AmbientCtx.Tracer,
+		Tracer:                  stopper.Tracer(),
 		DB:                      db,
 		Settings:                st,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
@@ -891,13 +893,6 @@ func (s *Server) ClusterSettings() *cluster.Settings {
 // AnnotateCtx is a convenience wrapper; see AmbientContext.
 func (s *Server) AnnotateCtx(ctx context.Context) context.Context {
 	return s.cfg.AmbientCtx.AnnotateCtx(ctx)
-}
-
-// AnnotateCtxWithSpan is a convenience wrapper; see AmbientContext.
-func (s *Server) AnnotateCtxWithSpan(
-	ctx context.Context, opName string,
-) (context.Context, *tracing.Span) {
-	return s.cfg.AmbientCtx.AnnotateCtxWithSpan(ctx, opName)
 }
 
 // ClusterID returns the ID of the cluster this server is a part of.
@@ -2805,7 +2800,7 @@ func (s *Server) PGServer() *pgwire.Server {
 // NOTE: This is not called in PreStart so that it's disabled by default for
 // testing.
 func (s *Server) StartDiagnostics(ctx context.Context) {
-	s.updates.PeriodicallyCheckForUpdates(ctx, s.stopper)
+	s.updates.PeriodicallyCheckForUpdates(ctx)
 	s.sqlServer.StartDiagnostics(ctx)
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -921,6 +921,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	reporter := &diagnostics.Reporter{
 		StartTime:     timeutil.Now(),
 		AmbientCtx:    &cfg.AmbientCtx,
+		Stopper:       cfg.stopper,
 		Config:        cfg.BaseConfig.Config,
 		Settings:      cfg.Settings,
 		ClusterID:     cfg.rpcContext.ClusterID.Get,
@@ -1204,7 +1205,7 @@ func (s *SQLServer) SQLInstanceID() base.SQLInstanceID {
 // NOTE: This is not called in preStart so that it's disabled by default for
 // testing.
 func (s *SQLServer) StartDiagnostics(ctx context.Context) {
-	s.diagnosticsReporter.PeriodicallyReportDiagnostics(ctx, s.stopper)
+	s.diagnosticsReporter.PeriodicallyReportDiagnostics(ctx)
 }
 
 // AnnotateCtx annotates the given context with the server tracer and tags.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1343,7 +1343,7 @@ func (ts *TestServer) TracerI() interface{} {
 
 // Tracer is like TracerI(), but returns the actual type.
 func (ts *TestServer) Tracer() *tracing.Tracer {
-	return ts.node.storeCfg.AmbientCtx.Tracer
+	return ts.node.stopper.Tracer()
 }
 
 // GCSystemLog deletes entries in the given system log table between

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -210,7 +210,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 		// Note: we create a fresh AmbientContext here, instead of using
 		// t.server.AmbientCtx(), because we want the lease manager to
 		// pretend to be a mock node with its own node ID.
-		ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
+		ambientCtx := log.MakeTestingAmbientContext()
 		ambientCtx.AddLogTag("n", nc)
 		// Hack the ExecutorConfig that we pass to the Manager to have a
 		// different node id.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -794,7 +794,7 @@ func (s *Server) newConnExecutor(
 			clock:        s.cfg.Clock,
 			// Future transaction's monitors will inherits from sessionRootMon.
 			connMon:          sessionRootMon,
-			tracer:           s.cfg.AmbientCtx.Tracer,
+			tracer:           s.cfg.Tracer(),
 			settings:         s.cfg.Settings,
 			execTestingKnobs: s.GetExecutorConfig().TestingKnobs,
 		},
@@ -1700,7 +1700,7 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 
 	// Ensure that every statement has a tracing span set up.
 	ctx, sp := tracing.EnsureChildSpan(
-		ctx, ex.server.cfg.AmbientCtx.Tracer,
+		ctx, ex.server.cfg.Tracer(),
 		// We print the type of command, not the String() which includes long
 		// statements.
 		cmd.command())

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -268,7 +268,7 @@ func startConnExecutor(
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
 		})
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 	st := cluster.MakeTestingClusterSettings()
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
@@ -278,7 +278,7 @@ func startConnExecutor(
 		return nil, nil, nil, nil, nil, err
 	}
 	defer tempEngine.Close()
-	ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
+	ambientCtx := log.MakeTestingAmbientContext()
 	cfg := &ExecutorConfig{
 		AmbientCtx:      ambientCtx,
 		Settings:        st,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1354,7 +1354,7 @@ CREATE TABLE crdb_internal.node_inflight_trace_spans (
 			return pgerror.Newf(pgcode.InsufficientPrivilege,
 				"only users with the admin role are allowed to read crdb_internal.node_inflight_trace_spans")
 		}
-		return p.ExecCfg().AmbientCtx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
+		return p.ExecCfg().Tracer().VisitSpans(func(span tracing.RegistrySpan) error {
 			for _, rec := range span.GetFullRecording(tracing.RecordingVerbose) {
 				traceID := rec.TraceID
 				parentSpanID := rec.ParentSpanID

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -67,7 +67,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 			Metrics:  &mt,
 			NodeID:   base.TestingIDContainer,
 		},
-		flowinfra.NewFlowScheduler(log.MakeTestingAmbientCtxWithNewTracer(), stopper, st),
+		flowinfra.NewFlowScheduler(log.MakeTestingAmbientContext(), stopper, st),
 	)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -53,7 +53,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -267,10 +266,9 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 
 	size := func() int64 { return 2 << 10 }
 	st := cluster.MakeTestingClusterSettings()
-	tr := tracing.NewTracer()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	rangeCache := rangecache.NewRangeCache(st, nil /* db */, size, stopper, tr)
+	rangeCache := rangecache.NewRangeCache(st, nil /* db */, size, stopper)
 	r := MakeDistSQLReceiver(
 		ctx,
 		&errOnlyResultWriter{}, /* resultWriter */

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1247,6 +1247,11 @@ type VersionUpgradeHook func(
 	updateSystemVersionSetting UpdateVersionSystemSettingHook,
 ) error
 
+// Tracer returns the tracer for this config.
+func (cfg *ExecutorConfig) Tracer() *tracing.Tracer {
+	return cfg.RPCContext.Stopper.Tracer()
+}
+
 // Organization returns the value of cluster.organization.
 func (cfg *ExecutorConfig) Organization() string {
 	return ClusterOrganization.Get(&cfg.Settings.SV)
@@ -2100,7 +2105,7 @@ func (st *SessionTracing) StartTracing(
 		opName := "session recording"
 		newConnCtx, st.connSpan = tracing.EnsureChildSpan(
 			connCtx,
-			st.ex.server.cfg.AmbientCtx.Tracer,
+			st.ex.server.cfg.Tracer(),
 			opName,
 			tracing.WithForceRealSpan(),
 		)
@@ -2121,7 +2126,7 @@ func (st *SessionTracing) StartTracing(
 		sp.Finish()
 
 		st.ex.state.Ctx, _ = tracing.EnsureChildSpan(
-			newConnCtx, st.ex.server.cfg.AmbientCtx.Tracer, "session tracing")
+			newConnCtx, st.ex.server.cfg.Tracer(), "session tracing")
 	}
 
 	st.enabled = true

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -106,7 +106,7 @@ func TestTraceAnalyzer(t *testing.T) {
 		colexecTraceAnalyzer *execstats.TraceAnalyzer
 	)
 	for _, vectorizeMode := range []sessiondatapb.VectorizeExecMode{sessiondatapb.VectorizeOff, sessiondatapb.VectorizeOn} {
-		execCtx, finishAndCollect := tracing.ContextWithRecordingSpan(ctx, execCfg.AmbientCtx.Tracer, t.Name())
+		execCtx, finishAndCollect := tracing.ContextWithRecordingSpan(ctx, execCfg.Tracer(), t.Name())
 		defer finishAndCollect()
 		ie := execCfg.InternalExecutor
 		ie.SetSessionData(

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -128,7 +128,7 @@ func TestFlowScheduler(t *testing.T) {
 	)
 	defer stopper.Stop(ctx)
 
-	scheduler := NewFlowScheduler(log.MakeTestingAmbientCtxWithNewTracer(), stopper, settings)
+	scheduler := NewFlowScheduler(log.MakeTestingAmbientContext(), stopper, settings)
 	scheduler.Init(&metrics)
 	scheduler.Start()
 	getNumRunning := func() int {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -224,7 +224,7 @@ func (ih *instrumentationHelper) Setup(
 			// If we need to collect stats, create a child span with structured
 			// recording. Stats will be added as structured metadata and processed in
 			// Finish.
-			newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement",
+			newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.Tracer(), "traced statement",
 				tracing.WithRecording(tracing.RecordingStructured))
 			ih.shouldFinishSpan = true
 			return newCtx, true
@@ -235,7 +235,7 @@ func (ih *instrumentationHelper) Setup(
 	ih.collectExecStats = true
 	ih.traceMetadata = make(execNodeTraceMetadata)
 	ih.evalCtx = p.EvalContext()
-	newCtx, ih.sp = tracing.StartVerboseTrace(ctx, cfg.AmbientCtx.Tracer, "traced statement")
+	newCtx, ih.sp = tracing.StartVerboseTrace(ctx, cfg.Tracer(), "traced statement")
 	ih.shouldFinishSpan = true
 	return newCtx, true
 }

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -651,7 +651,7 @@ func (ie *InternalExecutor) execInternal(
 	// an iterator is returned, then we transfer the responsibility of closing
 	// the span to the iterator. This is necessary so that the connExecutor
 	// exits before the span is finished.
-	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
+	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.Tracer(), opName)
 	stmtBuf := NewStmtBuf()
 	var wg sync.WaitGroup
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2181,7 +2181,7 @@ func (ot *OptTester) ExecBuild(f exec.Factory, mem *memo.Memo, expr opt.Expr) (e
 		factory := kv.MockTxnSenderFactory{}
 		clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 		stopper := stop.NewStopper()
-		db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+		db := kv.NewDB(log.MakeTestingAmbientContext(), factory, clock, stopper)
 		ot.evalCtx.Txn = kv.NewTxn(context.Background(), db, 1)
 	}
 	bld := execbuilder.New(f, ot.makeOptimizer(), mem, ot.catalog, expr, &ot.evalCtx, true)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -110,7 +110,7 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.ExecCfg = execCfg
 	evalCtx.Settings = execCfg.Settings
 	evalCtx.Codec = execCfg.Codec
-	evalCtx.Tracer = execCfg.AmbientCtx.Tracer
+	evalCtx.Tracer = execCfg.Tracer()
 	evalCtx.DB = execCfg.DB
 	evalCtx.SQLLivenessReader = execCfg.SQLLiveness
 	evalCtx.CompactEngineSpan = execCfg.CompactEngineSpanFunc

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -139,7 +139,7 @@ func TestTableReader(t *testing.T) {
 					Cfg: &execinfra.ServerConfig{
 						Settings: st,
 						RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,
-							func() int64 { return 2 << 10 }, s.Stopper(), s.TracerI().(*tracing.Tracer)),
+							func() int64 { return 2 << 10 }, s.Stopper()),
 					},
 					Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
 					NodeID: evalCtx.NodeID,
@@ -392,7 +392,7 @@ func TestLimitScans(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,
-				func() int64 { return 2 << 10 }, s.Stopper(), s.TracerI().(*tracing.Tracer)),
+				func() int64 { return 2 << 10 }, s.Stopper()),
 		},
 		Txn:    kv.NewTxn(ctx, kvDB, s.NodeID()),
 		NodeID: evalCtx.NodeID,
@@ -506,7 +506,7 @@ func BenchmarkTableReader(b *testing.B) {
 			Cfg: &execinfra.ServerConfig{
 				Settings: st,
 				RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,
-					func() int64 { return 2 << 10 }, s.Stopper(), s.TracerI().(*tracing.Tracer)),
+					func() int64 { return 2 << 10 }, s.Stopper()),
 			},
 			Txn:    kv.NewTxn(ctx, s.DB(), s.NodeID()),
 			NodeID: evalCtx.NodeID,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1978,7 +1978,7 @@ func createSchemaChangeEvalCtx(
 			NodeID:             execCfg.NodeID,
 			Codec:              execCfg.Codec,
 			Locality:           execCfg.Locality,
-			Tracer:             execCfg.AmbientCtx.Tracer,
+			Tracer:             execCfg.Tracer(),
 		},
 	}
 	// The backfill is going to use the current timestamp for the various

--- a/pkg/sql/sem/tree/timeconv_test.go
+++ b/pkg/sql/sem/tree/timeconv_test.go
@@ -52,7 +52,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			panic("unused")
 		})
-	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), senderFactory, clock, stopper)
+	db := kv.NewDB(log.MakeTestingAmbientContext(), senderFactory, clock, stopper)
 
 	for _, d := range testData {
 		ts := hlc.ClockTimestamp{WallTime: d.walltime, Logical: d.logical}

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -57,7 +57,7 @@ func makeTestContext(stopper *stop.Stopper) testContext {
 		})
 
 	settings := cluster.MakeTestingClusterSettings()
-	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ambient := log.MakeTestingAmbientContext()
 	return testContext{
 		manualClock: manual,
 		clock:       clock,

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -71,7 +71,7 @@ func makeTestContext(stopper *stop.Stopper) testContext {
 			1000, /* noteworthy */
 			settings,
 		),
-		tracer:   ambient.Tracer,
+		tracer:   stopper.Tracer(),
 		ctx:      context.Background(),
 		settings: settings,
 	}

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -195,7 +195,7 @@ func (p *poller) poll() {
 		}
 
 		const opName = "ts-poll"
-		ctx, span := p.AnnotateCtxWithSpan(ctx, opName)
+		ctx, span := p.stopper.Tracer().EnsureChildSpan(ctx, opName)
 		defer span.Finish()
 		if err := contextutil.RunWithTimeout(ctx, opName, storeDataTimeout,
 			func(ctx context.Context) error {

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -830,7 +830,7 @@ func TestDisableStorage(t *testing.T) {
 			},
 		}
 
-		ambient := log.MakeTestingAmbientCtxWithNewTracer()
+		ambient := log.MakeTestingAmbientContext()
 		tm.DB.PollSource(ambient, &testSource, time.Millisecond, Resolution10s, testSource.stopper)
 		select {
 		case <-testSource.stopper.IsStopped():

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -751,7 +751,7 @@ func TestStoreTimeSeries(t *testing.T) {
 func TestPollSource(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	runTestCaseMultipleFormats(t, func(t *testing.T, tm testModelRunner) {
-		tr := tm.Cfg.AmbientCtx.Tracer
+		tr := tm.Stopper().Tracer()
 		testSource := modelDataSource{
 			model:   tm,
 			r:       Resolution10s,
@@ -777,7 +777,7 @@ func TestPollSource(t *testing.T) {
 			},
 		}
 
-		ambient := log.MakeTestingAmbientContext(tr)
+		ambient := log.MakeTestingAmbientContext()
 		tm.DB.PollSource(ambient, &testSource, time.Millisecond, Resolution10s, testSource.stopper)
 		<-testSource.stopper.IsStopped()
 		if a, e := testSource.calledCount, 2; a != e {

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -47,13 +47,11 @@ import (
 //   })
 //
 //   // start a background operation
-//   ctx, span := s.AnnotateCtxWithSpan(context.Background(), "some-op")
+//   ctx := s.AnnotateCtx(context.Background())
+//   ctx, span := tracer.EnsureChildSpan(ctx, "some-op")
 //   defer span.Finish()
 //   ...
 type AmbientContext struct {
-	// Tracer is used to open spans (see AnnotateCtxWithSpan).
-	Tracer *tracing.Tracer
-
 	// ServerIDs will be embedded into contexts that don't already have
 	// one.
 	ServerIDs ServerIdentificationPayload
@@ -106,7 +104,8 @@ func (ac *AmbientContext) refreshCache() {
 //
 // For background operations, context.Background() should be passed; however, in
 // that case it is strongly recommended to open a span if possible (using
-// AnnotateCtxWithSpan).
+// tracing.EnsureChildSpan or the EnsureChildSpan on the nearest Tracer instance,
+// usually available via a Stopper).
 func (ac *AmbientContext) AnnotateCtx(ctx context.Context) context.Context {
 	switch ctx {
 	case context.TODO(), context.Background():
@@ -160,64 +159,20 @@ func (ac *AmbientContext) annotateCtxInternal(ctx context.Context) context.Conte
 	return ctx
 }
 
-// AnnotateCtxWithSpan annotates the given context with the information in
-// AmbientContext (see AnnotateCtx) and opens a span.
-//
-// If the given context has a span, the new span is a child of that span.
-// Otherwise, the Tracer in AmbientContext is used to create a new root span.
-//
-// The caller is responsible for closing the span (via Span.Finish).
-func (ac *AmbientContext) AnnotateCtxWithSpan(
-	ctx context.Context, opName string,
-) (context.Context, *tracing.Span) {
-	switch ctx {
-	case context.TODO(), context.Background():
-		// NB: context.TODO and context.Background are identical except for their
-		// names.
-		if ac.backgroundCtx != nil {
-			ctx = ac.backgroundCtx
-		}
-	default:
-		if ac.tags != nil {
-			ctx = logtags.AddTags(ctx, ac.tags)
-		}
-		if ac.ServerIDs != nil && ctx.Value(ServerIdentificationContextKey{}) == nil {
-			ctx = context.WithValue(ctx, ServerIdentificationContextKey{}, ac.ServerIDs)
-		}
-	}
-
-	return tracing.EnsureChildSpan(ctx, ac.Tracer, opName)
-}
-
 // MakeTestingAmbientContext creates an AmbientContext for use in tests,
 // when a test does not have sufficient details to instantiate a fully
 // fledged server AmbientContext.
-func MakeTestingAmbientContext(tracer *tracing.Tracer) AmbientContext {
-	return AmbientContext{Tracer: tracer}
+func MakeTestingAmbientContext() AmbientContext {
+	return AmbientContext{}
 }
 
-// MakeTestingAmbientCtxWithNewTracer is like MakeTestingAmbientContext() but it
-// also instantiates a new tracer.
-//
-// TODO(andrei): Remove this API.
-//
-// This is generally a bad idea because it creates a Tracer under the
-// hood, and if this Tracer ends up actually being used, chances are
-// it's going to crash because it'll end up mixing with some other
-// Tracer. When a test uses multiple tracers and does not crash,
-// either it's because one of the tracers is not being used (in which
-// case it'd be clearer to share the one being used using
-// MakeTestingAmbientContext), or, by happenstance, the trace in
-// question doesn't end up having more than one span. This is very
-// brittle.
+// MakeTestingAmbientCtxWithNewTracer should be removed.
 func MakeTestingAmbientCtxWithNewTracer() AmbientContext {
-	return MakeTestingAmbientContext(tracing.NewTracer())
+	return AmbientContext{}
 }
 
 // MakeServerAmbientContext creates an AmbientContext for use by
 // server processes.
-func MakeServerAmbientContext(
-	tracer *tracing.Tracer, idProvider ServerIdentificationPayload,
-) AmbientContext {
-	return AmbientContext{Tracer: tracer, ServerIDs: idProvider}
+func MakeServerAmbientContext(idProvider ServerIdentificationPayload) AmbientContext {
+	return AmbientContext{ServerIDs: idProvider}
 }

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -166,11 +166,6 @@ func MakeTestingAmbientContext() AmbientContext {
 	return AmbientContext{}
 }
 
-// MakeTestingAmbientCtxWithNewTracer should be removed.
-func MakeTestingAmbientCtxWithNewTracer() AmbientContext {
-	return AmbientContext{}
-}
-
 // MakeServerAmbientContext creates an AmbientContext for use by
 // server processes.
 func MakeServerAmbientContext(idProvider ServerIdentificationPayload) AmbientContext {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1269,6 +1269,14 @@ func EnsureChildSpan(
 	return ctx, sp
 }
 
+// EnsureChildSpan is a helper method that calls the
+// package-level EnsureChildSpan() with this tracer.
+func (t *Tracer) EnsureChildSpan(
+	ctx context.Context, name string, os ...SpanOption,
+) (context.Context, *Span) {
+	return EnsureChildSpan(ctx, t, name, os...)
+}
+
 var optsPool = sync.Pool{
 	New: func() interface{} {
 		// It is unusual to pass more than 5 SpanOptions.


### PR DESCRIPTION
Fixes #74291.
Will help simplify the tech note in the context of #73940.