### PR TITLE
internal/sqlsmith: remove vectorized-specific things

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -305,12 +305,9 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 			register(setup, setting)
 		}
 	}
-	setups["seed-vec"] = sqlsmith.Setups["seed-vec"]
 	setups["seed-multi-region"] = sqlsmith.Setups["seed-multi-region"]
 	settings["ddl-nodrop"] = sqlsmith.Settings["ddl-nodrop"]
-	settings["vec"] = sqlsmith.SettingVectorize
 	settings["multi-region"] = sqlsmith.Settings["multi-region"]
-	register("seed-vec", "vec")
 	register("tpcc", "ddl-nodrop")
 	register("seed-multi-region", "multi-region")
 }

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -135,9 +135,6 @@ func makeCaseExpr(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool)
 }
 
 func makeCoalesceExpr(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	if s.vectorizable {
-		return nil, false
-	}
 	typ = s.pickAnyType(typ)
 	firstExpr := makeScalar(s, typ, refs)
 	secondExpr := makeScalar(s, typ, refs)
@@ -177,11 +174,7 @@ func makeConstExpr(s *Smither, typ *types.T, refs colRefs) tree.TypedExpr {
 func makeConstDatum(s *Smither, typ *types.T) tree.Datum {
 	var datum tree.Datum
 	s.lock.Lock()
-	nullChance := 6
-	if s.vectorizable {
-		nullChance = 0
-	}
-	datum = randgen.RandDatumWithNullChance(s.rnd, typ, nullChance)
+	datum = randgen.RandDatumWithNullChance(s.rnd, typ, 6)
 	if f := datum.ResolvedType().Family(); f != types.UnknownFamily && s.simpleDatums {
 		datum = randgen.RandDatumSimple(s.rnd, typ)
 	}
@@ -252,9 +245,6 @@ func makeAnd(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 }
 
 func makeNot(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	if s.vectorizable {
-		return nil, false
-	}
 	switch typ.Family() {
 	case types.BoolFamily, types.AnyFamily:
 	default:
@@ -285,19 +275,9 @@ func makeCompareOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool
 	if _, ok := tree.CmpOps[op].LookupImpl(typ, typ); !ok {
 		return nil, false
 	}
-	if s.vectorizable && (op == tree.IsDistinctFrom || op == tree.IsNotDistinctFrom) {
-		return nil, false
-	}
 	left := makeScalar(s, typ, refs)
 	right := makeScalar(s, typ, refs)
 	return typedParen(tree.NewTypedComparisonExpr(tree.MakeComparisonOperator(op), left, right), typ), true
-}
-
-var vecBinOps = map[tree.BinaryOperatorSymbol]bool{
-	tree.Plus:  true,
-	tree.Minus: true,
-	tree.Mult:  true,
-	tree.Div:   true,
 }
 
 func makeBinOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
@@ -308,9 +288,6 @@ func makeBinOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 	}
 	n := s.rnd.Intn(len(ops))
 	op := ops[n]
-	if s.vectorizable && !vecBinOps[op.Operator.Symbol] {
-		return nil, false
-	}
 	if s.postgres {
 		if ignorePostgresBinOps[binOpTriple{
 			op.LeftType.Family(),
@@ -382,9 +359,6 @@ var postgresBinOpTransformations = map[binOpTriple]binOpOperands{
 }
 
 func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	if s.vectorizable {
-		return nil, false
-	}
 	typ = s.pickAnyType(typ)
 
 	class := ctx.fnClass
@@ -580,9 +554,6 @@ func makeWindowFrame(s *Smither, refs colRefs, orderTypes []*types.T) *tree.Wind
 }
 
 func makeExists(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	if s.vectorizable {
-		return nil, false
-	}
 	switch typ.Family() {
 	case types.BoolFamily, types.AnyFamily:
 	default:
@@ -611,7 +582,7 @@ func makeIn(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 
 	t := s.randScalarType()
 	var rhs tree.TypedExpr
-	if s.vectorizable || s.coin() {
+	if s.coin() {
 		rhs = makeTuple(s, t, refs)
 	} else {
 		selectStmt, _, ok := s.makeSelect([]*types.T{t}, refs)
@@ -646,14 +617,6 @@ func makeIn(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 
 func makeStringComparison(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 	stringComparison := s.randStringComparison()
-	if s.vectorizable {
-		// Vectorized supports only tree.Like and tree.NotLike.
-		if s.coin() {
-			stringComparison = tree.MakeComparisonOperator(tree.Like)
-		} else {
-			stringComparison = tree.MakeComparisonOperator(tree.NotLike)
-		}
-	}
 	switch typ.Family() {
 	case types.BoolFamily, types.AnyFamily:
 	default:
@@ -669,12 +632,12 @@ func makeStringComparison(s *Smither, typ *types.T, refs colRefs) (tree.TypedExp
 func makeTuple(s *Smither, typ *types.T, refs colRefs) *tree.Tuple {
 	n := s.rnd.Intn(5)
 	// Don't allow empty tuples in simple/postgres mode.
-	if n == 0 && (s.simpleDatums || s.vectorizable) {
+	if n == 0 && s.simpleDatums {
 		n++
 	}
 	exprs := make(tree.Exprs, n)
 	for i := range exprs {
-		if s.vectorizable || s.d9() == 1 {
+		if s.d9() == 1 {
 			exprs[i] = makeConstDatum(s, typ)
 		} else {
 			exprs[i] = makeScalar(s, typ, refs)
@@ -684,9 +647,6 @@ func makeTuple(s *Smither, typ *types.T, refs colRefs) *tree.Tuple {
 }
 
 func makeScalarSubquery(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
-	if s.vectorizable {
-		return nil, false
-	}
 	if s.disableLimits {
 		// This query must use a LIMIT, so bail if they are disabled.
 		return nil, false

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -84,7 +84,6 @@ type Smither struct {
 	disableWindowFuncs bool
 	simpleDatums       bool
 	avoidConsts        bool
-	vectorizable       bool
 	outputSort         bool
 	postgres           bool
 	ignoreFNs          []*regexp.Regexp
@@ -333,23 +332,6 @@ var AvoidConsts = simpleOption("avoid consts", func(s *Smither) {
 var DisableWindowFuncs = simpleOption("disable window funcs", func(s *Smither) {
 	s.disableWindowFuncs = true
 })
-
-// Vectorizable causes the Smither to limit query generation to queries
-// supported by vectorized execution.
-var Vectorizable = multiOption(
-	"Vectorizable",
-	DisableMutations(),
-	DisableWith(),
-	DisableWindowFuncs(),
-	AvoidConsts(),
-	// This must be last so it can make the final changes to table
-	// exprs and statements.
-	simpleOption("vectorizable", func(s *Smither) {
-		s.vectorizable = true
-		s.stmtWeights = nonMutatingStatements
-		s.tableExprWeights = vectorizableTableExprs
-	})(),
-)
 
 // OutputSort adds a top-level ORDER BY on all columns.
 var OutputSort = simpleOption("output sort", func(s *Smither) {

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -27,11 +26,10 @@ import (
 )
 
 var (
-	flagExec     = flag.Bool("ex", false, "execute (instead of just parse) generated statements")
-	flagNum      = flag.Int("num", 100, "number of statements to generate")
-	flagSetup    = flag.String("setup", "", "setup for TestGenerateParse, empty for random")
-	flagSetting  = flag.String("setting", "", "setting for TestGenerateParse, empty for random")
-	flagCheckVec = flag.Bool("check-vec", false, "fail if a generated statement cannot be vectorized")
+	flagExec    = flag.Bool("ex", false, "execute (instead of just parse) generated statements")
+	flagNum     = flag.Int("num", 100, "number of statements to generate")
+	flagSetup   = flag.String("setup", "", "setup for TestGenerateParse, empty for random")
+	flagSetting = flag.String("setting", "", "setting for TestGenerateParse, empty for random")
 )
 
 // TestSetups verifies that all setups generate executable SQL.
@@ -191,34 +189,6 @@ func TestGenerateParse(t *testing.T) {
 		}
 		stmt = prettyCfg.Pretty(parsed.AST)
 		fmt.Print("STMT: ", i, "\n", stmt, ";\n\n")
-		if *flagCheckVec {
-			if _, err := sqlDB.Exec(fmt.Sprintf("EXPLAIN (vec) %s", stmt)); err != nil {
-				es := err.Error()
-				ok := false
-				// It is hard to make queries that can always
-				// be vectorized. Hard code a list of error
-				// messages we are ok with.
-				for _, s := range []string{
-					// If the optimizer removes stuff due
-					// to something like a `WHERE false`,
-					// vec will fail with an error message
-					// like this. This is hard to fix
-					// because things like `WHERE true AND
-					// false` similarly remove rows but are
-					// harder to detect.
-					"num_rows:0",
-					"unsorted distinct",
-				} {
-					if strings.Contains(es, s) {
-						ok = true
-						break
-					}
-				}
-				if !ok {
-					t.Fatal(err)
-				}
-			}
-		}
 		if *flagExec {
 			db.Exec(t, `SET statement_timeout = '9s'`)
 			if _, err := sqlDB.Exec(stmt); err != nil {


### PR DESCRIPTION
It is no longer useful to have some vectorized-specific things since the
vectorized engine now supports everything (either natively or by
wrapping a row-by-row processor).

Release note: None