### PR TITLE
opt: split a disjunction of equijoin predicates into a union of joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/disjunction_in_join
+++ b/pkg/sql/logictest/testdata/logic_test/disjunction_in_join
@@ -1,0 +1,968 @@
+# Test ORed ON clause predicates which may be split into unions or 
+# intersections.
+# Use tables both with and without a primary key, to test when PK columns are
+# not included and also to allow null values.
+
+statement ok
+CREATE TABLE a(a1 INT, a2 INT, a3 INT, a4 INT, PRIMARY KEY(a1, a2, a3, a4))
+
+statement ok
+CREATE TABLE b(b1 INT, b2 INT, b3 INT, b4 INT,
+               INDEX (b1, b2) STORING (b3, b4),
+               INDEX (b2) STORING (b1, b3, b4),
+               INDEX (b3) STORING (b1, b2, b4))
+
+statement ok
+CREATE TABLE c(c1 INT, c2 INT, c3 INT, c4 INT)
+
+statement ok
+CREATE TABLE d(d1 INT, d2 INT, d3 INT, d4 INT,
+               INDEX d (d1) STORING (d2, d3, d4))
+
+# shared column values
+statement ok
+INSERT INTO a VALUES (0, 0, 0, 0),(1, 10, 100, 1000);
+INSERT INTO b VALUES (0, 0, 0, 0),(1, 10, 100, 1000);
+INSERT INTO c VALUES (0, 0, 0, 0),(1, 10, 100, 1000);
+INSERT INTO d VALUES (0, 0, 0, 0),(1, 10, 100, 1000);
+
+# duplicate rows
+statement ok
+INSERT INTO a VALUES (11, 110, 1100, 11000);
+INSERT INTO b VALUES (11, 110, 1100, 11000), (11, 110, 1100, 11000);
+INSERT INTO c VALUES (11, 110, 1100, 11000), (11, 110, 1100, 11000), (11, 110, 1100, 11000);
+INSERT INTO d VALUES (11, 110, 1100, 11000), (11, 110, 1100, 11000), (11, 110, 1100, 11000), (11, 110, 1100, 11000);
+
+# null values
+statement ok
+INSERT INTO b VALUES (NULL, NULL, NULL, NULL), (NULL, NULL, NULL, NULL);
+INSERT INTO d VALUES (NULL, NULL, NULL, NULL), (NULL, NULL, NULL, NULL), (NULL, NULL, NULL, NULL), (NULL, NULL, NULL, NULL);
+
+# duplicates in first three columns
+statement ok
+INSERT INTO a VALUES (12, 120, 1200, 1), (12, 120, 1200, 2);
+INSERT INTO b VALUES (12, 120, 1200, 1), (12, 120, 1200, 2), (12, 120, 1200, 2);
+
+# nulls combined with the duplicates
+statement ok
+INSERT INTO b VALUES (NULL, 120, 1200, 1)   , (12, NULL, 1200, 2);
+INSERT INTO d VALUES (11, NULL, NULL, 11000), (NULL, 110, 1100, 11000);
+
+# partially shared combinations
+statement ok
+INSERT INTO a VALUES (2, 20, 200, 2000), (3, 30, 300, 3000), (4, 40, 400, 4000), (5, 50, 500, 5000), (6, 60, 600, 6000), (7, 70, 700, 7000);
+INSERT INTO b VALUES (2, 20, 200, 2000), (3, 30, 300, 3000),                     (5, 50, 500, 5000), (6, 60, 600, 6000)                    , (8, 80, 800, 8000), (9, 90, 900, 9000);
+INSERT INTO c VALUES (2, 20, 200, 2000),                                         (5, 50, 500, 5000)                                        , (8, 80, 800, 8000)                    , (10, 100, 1000, 10000);
+INSERT INTO d VALUES                                                             (5, 50, 500, 5000), (6, 60, 600, 6000), (7, 70, 700, 7000);
+
+# combinations with null values
+statement ok
+INSERT INTO b VALUES (2, NULL, 200, NULL), (3, 30, 300, NULL)    , (NULL, 40, 400, 4000)  , (NULL, NULL, NULL, 5000)                       , (7, NULL, 700, NULL);
+INSERT INTO b VALUES (2, 20, NULL, 200)  , (3, 30, 300, 3000)    , (4, NULL, NULL, NULL)  , (5, 50, NULL, 5000)                            , (7, NULL, 700, NULL);
+INSERT INTO c VALUES                       (3, 30, NULL, NULL)   , (NULL, NULL, 400, 4000), (5, 50, NULL, NULL), (6, NULL, NULL, 6000);
+INSERT INTO d VALUES                       (NULL, 30, NULL, 3000)                                                                                                , (NULL, 90, NULL, NULL);
+
+# combinations with null and unique values
+statement ok
+INSERT INTO b VALUES (82, NULL, 207, NULL), (NULL, 567, NULL, 789);
+INSERT INTO c VALUES (83, 208, NULL, NULL), (NULL, NULL, 84, 209);
+INSERT INTO d VALUES (85, NULL, NULL, 210), (NULL, 86, 211, NULL);
+
+# combinations with unique values
+statement ok
+INSERT INTO a VALUES (15,   55, 555, 5555), (15, 55,   500, 5555), (15, 50, 555,  5555);
+INSERT INTO b VALUES (17,   77, 777, 7777), (17, 77,   700, 7777), (17, 70, 777,  7777);
+INSERT INTO b VALUES (NULL, 77, 777, 7777), (17, NULL, 777, 7777), (17, 77, NULL, 7777);
+
+# cross column value matches (e.g. a1 = b2)
+statement ok
+INSERT INTO a VALUES (101, 200, 3000, 40);
+INSERT INTO a VALUES (102, 5, 60, 70);
+INSERT INTO a VALUES (103, 7, 8, 70);
+INSERT INTO a VALUES (104, 5, 5, 5);
+INSERT INTO a VALUES (50, 5, 5000, 500);
+INSERT INTO a VALUES (80, 11, 110, 11000);
+INSERT INTO b VALUES (30, 7, 40, 2);
+INSERT INTO b VALUES (120, 80, 90, 10);
+INSERT INTO c VALUES (1, 2, 3, 4);
+INSERT INTO d VALUES (5, 6, 7, 8), (9, 10, 11, 12);
+
+#############
+# InnerJoin #
+#############
+
+# The left AND right sides of the join already produce key columns
+query IIIIIIII rowsort
+SELECT t1.*, t2.* FROM a t1, a t2 WHERE t1.a1 = t2.a3 OR t1.a2 = t2.a4 OR t1.a1 = t2.a4
+----
+0    0   0     0     0    0    0     0
+1    10  100   1000  12   120  1200  1
+2    20  200   2000  12   120  1200  2
+4    40  400   4000  101  200  3000  40
+5    50  500   5000  104  5    5     5
+7    70  700   7000  102  5    60    70
+7    70  700   7000  103  7    8     70
+50   5   5000  500   104  5    5     5
+102  5   60    70    104  5    5     5
+104  5   5     5     104  5    5     5
+
+# Join of tables with compound primary keys
+query IIIIIIII rowsort
+SELECT * FROM a t1, a t2 WHERE (t1.a2 = t2.a2 OR t1.a3 = t2.a3) AND (t1.a1 = t2.a1 OR t1.a4 = t2.a4)
+----
+0    0    0     0      0    0    0     0
+1    10   100   1000   1    10   100   1000
+2    20   200   2000   2    20   200   2000
+3    30   300   3000   3    30   300   3000
+4    40   400   4000   4    40   400   4000
+5    50   500   5000   5    50   500   5000
+6    60   600   6000   6    60   600   6000
+7    70   700   7000   7    70   700   7000
+11   110  1100  11000  11   110  1100  11000
+12   120  1200  1      12   120  1200  1
+12   120  1200  1      12   120  1200  2
+12   120  1200  2      12   120  1200  1
+12   120  1200  2      12   120  1200  2
+15   50   555   5555   15   50   555   5555
+15   55   500   5555   15   55   500   5555
+15   55   500   5555   15   55   555   5555
+15   55   555   5555   15   55   500   5555
+15   55   555   5555   15   55   555   5555
+50   5    5000  500    50   5    5000  500
+80   11   110   11000  80   11   110   11000
+101  200  3000  40     101  200  3000  40
+102  5    60    70     102  5    60    70
+103  7    8     70     103  7    8     70
+104  5    5     5      104  5    5     5
+15   50   555   5555   15   55   555   5555
+15   55   555   5555   15   50   555   5555
+
+query IIIIIIII rowsort
+SELECT * FROM a, b WHERE (a2 = b2 OR a3 = b3) AND (a1 = b1 OR a4 = b4)
+----
+0   0    0     0      0     0     0     0
+1   10   100   1000   1     10    100   1000
+2   20   200   2000   2     20    200   2000
+2   20   200   2000   2     20    NULL  200
+3   30   300   3000   3     30    300   3000
+3   30   300   3000   3     30    300   3000
+3   30   300   3000   3     30    300   NULL
+4   40   400   4000   NULL  40    400   4000
+5   50   500   5000   5     50    500   5000
+5   50   500   5000   5     50    NULL  5000
+6   60   600   6000   6     60    600   6000
+11  110  1100  11000  11    110   1100  11000
+11  110  1100  11000  11    110   1100  11000
+12  120  1200  1      12    120   1200  1
+12  120  1200  1      NULL  120   1200  1
+12  120  1200  1      12    120   1200  2
+12  120  1200  1      12    120   1200  2
+12  120  1200  2      12    120   1200  1
+12  120  1200  2      12    120   1200  2
+12  120  1200  2      12    120   1200  2
+2   20   200   2000   2     NULL  200   NULL
+7   70   700   7000   7     NULL  700   NULL
+7   70   700   7000   7     NULL  700   NULL
+12  120  1200  1      12    NULL  1200  2
+12  120  1200  2      12    NULL  1200  2
+
+query III rowsort
+SELECT a1,a2,a3 FROM a,b WHERE (a1=b1 AND a2=b2 AND (a1=1 OR b1=1)) OR (a3=b3 AND a4=b4)
+----
+1   10   100
+0   0    0
+2   20   200
+3   30   300
+3   30   300
+4   40   400
+5   50   500
+6   60   600
+11  110  1100
+11  110  1100
+12  120  1200
+12  120  1200
+12  120  1200
+12  120  1200
+12  120  1200
+
+query III rowsort
+SELECT a1,a2,a3 FROM a,b WHERE a1=1 AND (a2=b2 OR a3=b3)
+----
+1  10  100
+
+# More than one disjunction in the filter
+query IIIIIIII rowsort
+SELECT * FROM a, c WHERE (a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+----
+0   0    0     0      0     0     0     0
+1   10   100   1000   1     10    100   1000
+1   10   100   1000   1     2     3     4
+2   20   200   2000   2     20    200   2000
+3   30   300   3000   3     30    NULL  NULL
+4   40   400   4000   NULL  NULL  400   4000
+5   50   500   5000   5     50    500   5000
+5   50   500   5000   5     50    NULL  NULL
+6   60   600   6000   6     NULL  NULL  6000
+11  110  1100  11000  11    110   1100  11000
+11  110  1100  11000  11    110   1100  11000
+11  110  1100  11000  11    110   1100  11000
+15  50   555   5555   5     50    500   5000
+15  50   555   5555   5     50    NULL  NULL
+15  55   500   5555   5     50    500   5000
+80  11   110   11000  11    110   1100  11000
+80  11   110   11000  11    110   1100  11000
+80  11   110   11000  11    110   1100  11000
+
+query IIIIIIII rowsort
+SELECT * FROM a, c WHERE (a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+----
+0    0   0     0      0   0    0     0
+1    10  100   1000   10  100  1000  10000
+2    20  200   2000   1   2    3     4
+50   5   5000  500    5   50   500   5000
+50   5   5000  500    5   50   NULL  NULL
+80   11  110   11000  11  110  1100  11000
+80   11  110   11000  11  110  1100  11000
+80   11  110   11000  11  110  1100  11000
+80   11  110   11000  8   80   800   8000
+102  5   60    70     5   50   500   5000
+102  5   60    70     5   50   NULL  NULL
+104  5   5     5      5   50   500   5000
+104  5   5     5      5   50   NULL  NULL
+
+# Equality filters that do not reference a column on each side of the join
+query IIIIIIII rowsort
+SELECT * FROM b, d WHERE (b1 = b2 OR b3 = d3)
+----
+0   0     0     0      0     0     0     0
+1   10    100   1000   1     10    100   1000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  NULL  110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  NULL  110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+11  110   1100  11000  11    110   1100  11000
+5   50    500   5000   5     50    500   5000
+6   60    600   6000   6     60    600   6000
+7   NULL  700   NULL   7     70    700   7000
+7   NULL  700   NULL   7     70    700   7000
+17  77    700   7777   7     70    700   7000
+0   0     0     0      1     10    100   1000
+0   0     0     0      11    110   1100  11000
+0   0     0     0      11    110   1100  11000
+0   0     0     0      11    110   1100  11000
+0   0     0     0      11    110   1100  11000
+0   0     0     0      NULL  NULL  NULL  NULL
+0   0     0     0      NULL  NULL  NULL  NULL
+0   0     0     0      NULL  NULL  NULL  NULL
+0   0     0     0      NULL  NULL  NULL  NULL
+0   0     0     0      11    NULL  NULL  11000
+0   0     0     0      NULL  110   1100  11000
+0   0     0     0      5     50    500   5000
+0   0     0     0      6     60    600   6000
+0   0     0     0      7     70    700   7000
+0   0     0     0      NULL  30    NULL  3000
+0   0     0     0      NULL  90    NULL  NULL
+0   0     0     0      85    NULL  NULL  210
+0   0     0     0      NULL  86    211   NULL
+0   0     0     0      5     6     7     8
+0   0     0     0      9     10    11    12
+
+query IIIIIIII rowsort
+SELECT * FROM b, d WHERE (b1 = b2 OR b3 = d3 OR b4 = d4 OR d1 = d2)
+----
+0     0     0     0      0     0     0     0
+0     0     0     0      1     10    100   1000
+0     0     0     0      11    110   1100  11000
+0     0     0     0      11    110   1100  11000
+0     0     0     0      11    110   1100  11000
+0     0     0     0      11    110   1100  11000
+0     0     0     0      NULL  NULL  NULL  NULL
+0     0     0     0      NULL  NULL  NULL  NULL
+0     0     0     0      NULL  NULL  NULL  NULL
+0     0     0     0      NULL  NULL  NULL  NULL
+0     0     0     0      11    NULL  NULL  11000
+0     0     0     0      NULL  110   1100  11000
+0     0     0     0      5     50    500   5000
+0     0     0     0      6     60    600   6000
+0     0     0     0      7     70    700   7000
+0     0     0     0      NULL  30    NULL  3000
+0     0     0     0      NULL  90    NULL  NULL
+0     0     0     0      85    NULL  NULL  210
+0     0     0     0      NULL  86    211   NULL
+0     0     0     0      5     6     7     8
+0     0     0     0      9     10    11    12
+1     10    100   1000   0     0     0     0
+1     10    100   1000   1     10    100   1000
+11    110   1100  11000  0     0     0     0
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    NULL  NULL  11000
+11    110   1100  11000  NULL  110   1100  11000
+11    110   1100  11000  0     0     0     0
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    110   1100  11000
+11    110   1100  11000  11    NULL  NULL  11000
+11    110   1100  11000  NULL  110   1100  11000
+NULL  NULL  NULL  NULL   0     0     0     0
+NULL  NULL  NULL  NULL   0     0     0     0
+12    120   1200  1      0     0     0     0
+12    120   1200  2      0     0     0     0
+12    120   1200  2      0     0     0     0
+NULL  120   1200  1      0     0     0     0
+12    NULL  1200  2      0     0     0     0
+2     20    200   2000   0     0     0     0
+3     30    300   3000   0     0     0     0
+3     30    300   3000   NULL  30    NULL  3000
+5     50    500   5000   0     0     0     0
+5     50    500   5000   5     50    500   5000
+6     60    600   6000   0     0     0     0
+6     60    600   6000   6     60    600   6000
+8     80    800   8000   0     0     0     0
+9     90    900   9000   0     0     0     0
+2     NULL  200   NULL   0     0     0     0
+3     30    300   NULL   0     0     0     0
+NULL  40    400   4000   0     0     0     0
+NULL  NULL  NULL  5000   0     0     0     0
+NULL  NULL  NULL  5000   5     50    500   5000
+7     NULL  700   NULL   0     0     0     0
+7     NULL  700   NULL   7     70    700   7000
+2     20    NULL  200    0     0     0     0
+3     30    300   3000   0     0     0     0
+3     30    300   3000   NULL  30    NULL  3000
+4     NULL  NULL  NULL   0     0     0     0
+5     50    NULL  5000   0     0     0     0
+5     50    NULL  5000   5     50    500   5000
+7     NULL  700   NULL   0     0     0     0
+7     NULL  700   NULL   7     70    700   7000
+82    NULL  207   NULL   0     0     0     0
+NULL  567   NULL  789    0     0     0     0
+17    77    777   7777   0     0     0     0
+17    77    700   7777   0     0     0     0
+17    77    700   7777   7     70    700   7000
+17    70    777   7777   0     0     0     0
+NULL  77    777   7777   0     0     0     0
+17    NULL  777   7777   0     0     0     0
+17    77    NULL  7777   0     0     0     0
+30    7     40    2      0     0     0     0
+120   80    90    10     0     0     0     0
+
+query IIIIIIII rowsort
+SELECT * FROM b, d WHERE (b1 = 0 OR b1 = d1)   AND
+                         (b1 = 0 OR b2 = 5)    AND
+                         (b2 = d1 OR b1 = d1)  AND
+                         (b2 = d1 OR b2 = 5)
+----
+0  0  0  0  0  0  0  0
+
+# ON filters that are a disjunction of equality filters AND And expressions
+query IIIIIIII rowsort
+SELECT * FROM c, d WHERE (c1 = d1 AND c2 = d2) OR c3 = d3
+----
+0   0    0     0      0     0    0     0
+1   10   100   1000   1     10   100   1000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+11  110  1100  11000  11    110  1100  11000
+5   50   500   5000   5     50   500   5000
+5   50   NULL  NULL   5     50   500   5000
+11  110  1100  11000  NULL  110  1100  11000
+11  110  1100  11000  NULL  110  1100  11000
+11  110  1100  11000  NULL  110  1100  11000
+
+query IIIIIIII rowsort
+SELECT * FROM a, d WHERE (a1 = d2 AND a2 = d1) OR (a3 = d4 AND a4 = d3)
+----
+0   0  0     0    0  0   0    0
+50  5  5000  500  5  50  500  5000
+
+#########################
+# Uncorrelated semijoin #
+#########################
+
+query IIII rowsort
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM d WHERE d1 = 4 OR d2 = 50)
+----
+0    0    0     0
+1    10   100   1000
+2    20   200   2000
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+11   110  1100  11000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+50   5    5000  500
+80   11   110   11000
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 HAVING sum(d4) > 40)
+----
+0    0    0     0
+1    10   100   1000
+2    20   200   2000
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+11   110  1100  11000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+50   5    5000  500
+80   11   110   11000
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE c1 = d2 or c2 = d1)
+----
+0    0    0     0
+1    10   100   1000
+2    20   200   2000
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+11   110  1100  11000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+50   5    5000  500
+80   11   110   11000
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)
+----
+0  0  0  0
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2 EXCEPT ALL
+                                   SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2)
+----
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+0  0  0  0
+
+query IIII rowsort
+SELECT * FROM b WHERE b1 NOT IN (SELECT c1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+
+query IIII rowsort
+SELECT * FROM b WHERE (b1, b2) NOT IN (SELECT c1, c2 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+
+#########################
+# Uncorrelated antijoin #
+#########################
+
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM b WHERE b1 = 4 OR b2 = 50)
+----
+
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 or d2+c3 > 5)
+----
+
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE c3 = d4 or c4 = d3)
+----
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)
+----
+1    10   100   1000
+2    20   200   2000
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+50   5    5000  500
+80   11   110   11000
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2 EXCEPT ALL
+                                       SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2)
+----
+0    0    0     0
+1    10   100   1000
+2    20   200   2000
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+11   110  1100  11000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+50   5    5000  500
+80   11   110   11000
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+
+#######################
+# Correlated semijoin #
+#######################
+
+query III rowsort
+SELECT a1,a2,a3 FROM a WHERE EXISTS (SELECT * FROM b WHERE a2 = b2 OR a3 = b3)
+----
+0    0    0
+1    10   100
+2    20   200
+3    30   300
+4    40   400
+5    50   500
+6    60   600
+7    70   700
+11   110  1100
+12   120  1200
+12   120  1200
+15   50   555
+103  7    8
+15   55   500
+
+query III rowsort
+SELECT a1,a2,a3 FROM a WHERE EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
+----
+0   0    0
+1   10   100
+2   20   200
+3   30   300
+4   40   400
+5   50   500
+6   60   600
+7   70   700
+11  110  1100
+12  120  1200
+12  120  1200
+50  5    5000
+80  11   110
+
+# The left side of the join already produces key columns
+# TODO: Enable this test once issue #74554 is fixed.
+# query IIII rowsort
+# SELECT * FROM a WHERE EXISTS (SELECT * FROM b WHERE a1 = b1 OR a2 = b2 OR a3 = b3 OR a4 = b4)
+# ----
+# 0    0    0     0
+# 1    10   100   1000
+# 2    20   200   2000
+# 3    30   300   3000
+# 4    40   400   4000
+# 5    50   500   5000
+# 6    60   600   6000
+# 7    70   700   7000
+# 11   110  1100  11000
+# 12   120  1200  1
+# 12   120  1200  2
+# 80   11   110   11000
+# 15   50   555   5555
+# 103  7    8     70
+# 15   55   500   5555
+
+# More than one disjunction in the filter
+# TODO: Enable this test once issue #74554 is fixed.
+# query IIII rowsort
+# SELECT * FROM a WHERE EXISTS (SELECT * FROM c WHERE a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+# ----
+# 0   0    0     0
+# 1   10   100   1000
+# 2   20   200   2000
+# 3   30   300   3000
+# 5   50   500   5000
+# 6   60   600   6000
+# 11  110  1100  11000
+# 4   40   400   4000
+# 80  11   110   11000
+# 15  50   555   5555
+# 15  55   500   5555
+
+# More than one disjunction in the filter
+# TODO: Enable this test once issue #74554 is fixed.
+# query IIII rowsort
+# SELECT * FROM a WHERE EXISTS (SELECT * FROM c WHERE a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+# ----
+# 0    0   0     0
+# 2    20  200   2000
+# 50   5   5000  500
+# 80   11  110   11000
+# 1    10  100   1000
+# 102  5   60    70
+# 104  5   5     5
+
+# IN subquery
+query I rowsort
+SELECT a1+a3-a2 FROM a WHERE a1 IN (SELECT b1 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
+----
+0
+91
+182
+273
+364
+455
+546
+637
+1001
+1092
+1092
+
+# IN subquery, 2 columns
+query I rowsort
+SELECT a1+a3-a2 FROM a WHERE (a1,a2) IN (SELECT b1,b2 FROM b WHERE
+                                            EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
+----
+0
+91
+182
+273
+455
+546
+1001
+1092
+1092
+
+# ANDed disjuncts
+query IIIIIII rowsort
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = a2) AND (a1 = c1 OR c1 = c2))
+----
+0   0    0     0   0    0     0
+1   10   100   1   10   100   1000
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+2   20   200   2   20   200   2000
+3   30   300   3   30   NULL  NULL
+5   50   500   5   50   500   5000
+5   50   500   5   50   NULL  NULL
+
+query IIIIIII rowsort
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b2) AND (c1 = b1 OR c1 = b2))
+----
+0   0    0     0   0    0     0
+1   10   100   1   10   100   1000
+2   20   200   2   20   200   2000
+3   30   300   3   30   NULL  NULL
+5   50   500   5   50   500   5000
+5   50   500   5   50   NULL  NULL
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+
+query IIIIIII rowsort
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b3) AND (a1 = c1 OR a1 = c3))
+----
+0   0    0     0   0    0     0
+1   10   100   1   10   100   1000
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+11  110  1100  11  110  1100  11000
+2   20   200   2   20   200   2000
+3   30   300   3   30   NULL  NULL
+5   50   500   5   50   500   5000
+5   50   500   5   50   NULL  NULL
+
+# Nested EXISTS
+query II rowsort
+SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE (a1=b1 OR a1=b2) AND EXISTS(SELECT 1 FROM c WHERE b1=c1))
+----
+0    0
+10   1000
+110  11000
+20   2000
+50   5000
+5    500
+11   11000
+30   3000
+60   6000
+
+# Two EXISTS at same nesting level; only one disjuction pair can be optimized
+query II rowsort
+SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2) AND
+                          EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2)
+----
+0    0
+10   1000
+110  11000
+20   2000
+50   5000
+5    500
+11   11000
+30   3000
+60   6000
+
+# Two EXISTS at same nesting level; only one disjuction chain can be optimized
+# TODO: Enable this test once issue #74554 is fixed.
+# query II rowsort
+# SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2 OR a1=b3 OR a1=b4) AND
+#                           EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2 OR a1=c3 OR a1=c4)
+# ----
+# 0    0
+# 10   1000
+# 110  11000
+# 20   2000
+# 50   5000
+# 5    500
+# 11   11000
+# 30   3000
+# 60   6000
+# 40   4000
+
+# Outer Select is Join
+query IIIIIIII rowsort
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c WHERE c1=b1))
+                       AS foo on a1=foo.b1 OR a2=foo.b2
+----
+1   10   100   1000   1   10    100   1000
+11  110  1100  11000  11  110   1100  11000
+11  110  1100  11000  11  110   1100  11000
+2   20   200   2000   2   NULL  200   NULL
+2   20   200   2000   2   20    NULL  200
+2   20   200   2000   2   20    200   2000
+5   50   500   5000   5   50    500   5000
+15  50   555   5555   5   50    NULL  5000
+15  50   555   5555   5   50    500   5000
+5   50   500   5000   5   50    NULL  5000
+3   30   300   3000   3   30    300   3000
+3   30   300   3000   3   30    300   3000
+3   30   300   3000   3   30    300   NULL
+6   60   600   6000   6   60    600   6000
+
+query IIIIIIII rowsort
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c WHERE c1=b1 or c2=b2))
+                       AS foo on a1=foo.b1
+----
+1   10   100   1000   1   10    100   1000
+2   20   200   2000   2   NULL  200   NULL
+2   20   200   2000   2   20    NULL  200
+2   20   200   2000   2   20    200   2000
+3   30   300   3000   3   30    300   3000
+3   30   300   3000   3   30    300   3000
+3   30   300   3000   3   30    300   NULL
+5   50   500   5000   5   50    500   5000
+5   50   500   5000   5   50    NULL  5000
+6   60   600   6000   6   60    600   6000
+11  110  1100  11000  11  110   1100  11000
+11  110  1100  11000  11  110   1100  11000
+
+#######################
+# Correlated antijoin #
+#######################
+
+query III rowsort
+SELECT a1,a2,a3 FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a2 = b2 OR a3 = b3)
+----
+15   55   555
+50   5    5000
+80   11   110
+101  200  3000
+102  5    60
+104  5    5
+
+query III rowsort
+SELECT a1,a2,a3 FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
+----
+15   50   555
+15   55   500
+15   55   555
+101  200  3000
+102  5    60
+103  7    8
+104  5    5
+
+# The left side of the join already produces key columns
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a1 = b1 OR a2 = b2 OR a3 = b3 OR a4 = b4)
+----
+15   55   555   5555
+50   5    5000  500
+101  200  3000  40
+102  5    60    70
+104  5    5     5
+
+# More than one disjunction in the filter
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM c WHERE a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+----
+7    70   700   7000
+12   120  1200  1
+12   120  1200  2
+15   55   555   5555
+50   5    5000  500
+101  200  3000  40
+102  5    60    70
+103  7    8     70
+104  5    5     5
+
+query IIII rowsort
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM c WHERE a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+----
+3    30   300   3000
+4    40   400   4000
+5    50   500   5000
+6    60   600   6000
+7    70   700   7000
+11   110  1100  11000
+12   120  1200  1
+12   120  1200  2
+15   50   555   5555
+15   55   500   5555
+15   55   555   5555
+101  200  3000  40
+103  7    8     70
+
+# Nested NOT EXISTS
+query II rowsort
+SELECT a2,a4 FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE (a1=b1 OR a1=b2) AND NOT EXISTS(SELECT 1 FROM c WHERE b1=c1))
+----
+0    0
+10   1000
+20   2000
+30   3000
+50   5000
+60   6000
+110  11000
+50   5555
+55   5555
+55   5555
+5    500
+200  40
+5    70
+7    70
+5    5
+
+# Two NOT EXISTS at same nesting level; only one disjuction pair can be optimized
+query II rowsort
+SELECT a2,a4 FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2) AND
+                          NOT EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2)
+----
+50   5555
+55   5555
+55   5555
+200  40
+5    70
+7    70
+5    5
+
+# Outer Select is Join
+query IIIIIIII rowsort
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND NOT EXISTS (SELECT 1 FROM c WHERE c1=b1))
+                       AS foo on a1=foo.b1 OR a2=foo.b2
+----
+4    40   400   4000  4   NULL  NULL  NULL
+7    70   700   7000  7   NULL  700   NULL
+7    70   700   7000  7   NULL  700   NULL
+7    70   700   7000  17  70    777   7777
+12   120  1200  1     12  NULL  1200  2
+12   120  1200  1     12  120   1200  1
+12   120  1200  1     12  120   1200  2
+12   120  1200  1     12  120   1200  2
+12   120  1200  2     12  NULL  1200  2
+12   120  1200  2     12  120   1200  1
+12   120  1200  2     12  120   1200  2
+12   120  1200  2     12  120   1200  2
+103  7    8     70    30  7     40    2
+
+query IIIIIIII rowsort
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND NOT EXISTS (SELECT 1 FROM c WHERE c1=b1 or c2=b2))
+                       AS foo on a1=foo.b1
+----
+4   40   400   4000  4   NULL  NULL  NULL
+7   70   700   7000  7   NULL  700   NULL
+7   70   700   7000  7   NULL  700   NULL
+12  120  1200  1     12  NULL  1200  2
+12  120  1200  1     12  120   1200  1
+12  120  1200  1     12  120   1200  2
+12  120  1200  1     12  120   1200  2
+12  120  1200  2     12  NULL  1200  2
+12  120  1200  2     12  120   1200  1
+12  120  1200  2     12  120   1200  2
+12  120  1200  2     12  120   1200  2
+
+# NOT IN subquery
+query III rowsort
+SELECT d3,d1,d2 FROM d WHERE d1 NOT IN (SELECT b1 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2=b2 OR c2=b3))
+----
+600   6   60
+700   7   70
+NULL  85  NULL
+11    9   10
+
+# NOT IN subquery, 2 columns
+query III rowsort
+SELECT d3,d1,d2 FROM d WHERE (d1,d3) NOT IN (SELECT b1,b2 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2=b2 OR c2=b3))
+----
+100   1     10
+1100  11    110
+1100  11    110
+1100  11    110
+1100  11    110
+1100  NULL  110
+500   5     50
+600   6     60
+700   7     70
+NULL  85    NULL
+211   NULL  86
+7     5     6
+11    9     10

--- a/pkg/sql/logictest/testdata/logic_test/inner-join
+++ b/pkg/sql/logictest/testdata/logic_test/inner-join
@@ -26,6 +26,33 @@ SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=d AND c=e)
 1  1  2
 2  1  1
 
+# Exists with primary key columns selected
+query III rowsort
+SELECT a, b, c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+1  1  2
+2  1  1
+2  2  NULL
+
+# Exists with primary key columns not selected
+query I rowsort
+SELECT c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+2
+1
+NULL
+
+# Not Exists with primary key columns selected
+query III rowsort
+SELECT a, b, c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+
+# Not Exists with primary key columns not selected
+query I rowsort
+SELECT c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+
+
 # A semi-join emits exactly one row for every matching row in the LHS.
 # The following test ensures that the SemiJoin doesn't commute into an
 # InnerJoin as that guarantee would be lost.
@@ -38,10 +65,27 @@ INSERT INTO abc VALUES (1, 1, 1)
 statement ok
 INSERT INTO def VALUES (1, 1, 1), (2, 1, 1)
 
+# Exists with primary key columns selected
 query III rowsort
 SELECT a, b, c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 ----
 1  1  1
+
+# Exists with primary key columns not selected
+query I rowsort
+SELECT c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+1
+
+# Not Exists with primary key columns selected
+query III rowsort
+SELECT a, b, c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+
+# Not Exists with primary key columns not selected
+query I rowsort
+SELECT c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
 
 # Given that we know the reason the above query would fail if an InnerJoin
 # was used - multiple rows emitted for each matching row in the LHS - we
@@ -58,6 +102,21 @@ SELECT a, b, c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 #
 # This tests that the InnerJoin commute rule for semi joins behaves sanely in
 # these cases.
+
+# InnerJoin with primary key columns selected
+query III rowsort
+SELECT a, b, c FROM abc, def WHERE a=d OR a=e
+----
+1  1  1
+1  1  1
+
+# InnerJoin with primary key columns not selected
+query I rowsort
+SELECT c FROM abc, def WHERE a=d OR a=e
+----
+1
+1
+
 statement ok
 CREATE TABLE abc_decimal (a DECIMAL, b DECIMAL, c DECIMAL);
 INSERT INTO abc_decimal VALUES (1, 1, 1), (1, 1, 1), (1.0, 1.0, 1.0), (1.00, 1.00, 1.00)
@@ -73,3 +132,23 @@ SELECT a, b, c FROM abc_decimal WHERE EXISTS (SELECT * FROM def_decimal WHERE a:
 1     1     1
 1.0   1.0   1.0
 1.00  1.00  1.00
+
+query RRR rowsort
+SELECT a, b, c FROM abc_decimal WHERE EXISTS (SELECT * FROM def_decimal WHERE a::string=d::string or a::string=e::string)
+----
+1     1     1
+1     1     1
+1.0   1.0   1.0
+1.00  1.00  1.00
+
+query RRR rowsort
+SELECT a, b, c FROM abc_decimal, def_decimal WHERE a::string=d::string or a::string=e::string
+----
+1     1     1
+1     1     1
+1.0   1.0   1.0
+1.00  1.00  1.00
+
+query RRR rowsort
+SELECT a, b, c FROM abc_decimal WHERE NOT EXISTS (SELECT * FROM def_decimal WHERE a::string=d::string or a::string=e::string)
+----

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -550,3 +550,118 @@ WHERE
   t.oid
   NOT IN (SELECT (ARRAY[704, 11676, 10005, 3912, 11765, 59410, 11397])[i] FROM generate_series(1, 376) AS i)
 ----
+
+statement ok
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["b"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+statement ok
+ALTER TABLE xyz INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+
+statement ok
+ALTER TABLE xyz INJECT STATISTICS '[
+  {
+    "columns": ["y"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+
+statement ok
+INSERT INTO xyz VALUES(5, 4, 7)
+
+statement ok
+INSERT INTO abc VALUES(12, 13, 14)
+
+statement ok
+CREATE INDEX abc_b ON abc(b)
+
+statement ok
+CREATE INDEX xyz_y ON xyz(y)
+
+### Split Disjunctions Tests
+query III rowsort
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.x OR abc.b = xyz.y)
+----
+4  5  6
+7  8  9
+2  5  6
+
+query III rowsort
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.y OR abc.b = xyz.x)
+----
+2   5   6
+4   5   6
+12  13  14
+
+query III rowsort
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x OR abc.b = xyz.y)and abc.a > 3 AND xyz.z > 10)
+----
+7  8  9
+
+query III rowsort
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.y OR abc.b = xyz.x) AND abc.a > 3 AND xyz.z > 10)
+----
+12  13  14
+
+query III rowsort
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.x OR abc.b = xyz.y)
+----
+12  13  14
+
+query III rowsort
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.y OR abc.b = xyz.x)
+----
+7  8  9
+
+query III rowsort
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x OR abc.b = xyz.y)and abc.a > 3 AND xyz.z > 10)
+----
+2   5   6
+4   5   6
+12  13  14
+
+query III rowsort
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.y OR abc.b = xyz.x) AND abc.a > 3 AND xyz.z > 10)
+----
+2  5  6
+4  5  6
+7  8  9
+
+query III rowsort
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x OR abc.b = xyz.y) AND (abc.a = xyz.y OR abc.b = xyz.y))
+----
+4  5  6
+2  5  6
+
+query III rowsort
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x OR abc.b = xyz.y) AND (abc.a = xyz.y OR abc.b = xyz.y))
+----
+7   8   9
+12  13  14
+
+### End Split Disjunctions Tests

--- a/pkg/sql/opt/exec/execbuilder/testdata/inner-join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inner-join
@@ -1,0 +1,251 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, b));
+
+statement ok
+CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (d, e));
+
+# Check that split join query plans are picked for qualifying queries
+# mirroring new additions to logic_test/inner-join
+
+# Exists with primary key columns selected
+query T
+EXPLAIN SELECT a, b, c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: a, b
+│
+└── • union all
+    │
+    ├── • merge join
+    │   │ equality: (a) = (d)
+    │   │ right cols are key
+    │   │
+    │   ├── • scan
+    │   │     missing stats
+    │   │     table: abc@abc_pkey
+    │   │     spans: FULL SCAN
+    │   │
+    │   └── • distinct
+    │       │ distinct on: d
+    │       │ order key: d
+    │       │
+    │       └── • scan
+    │             missing stats
+    │             table: def@def_pkey
+    │             spans: FULL SCAN
+    │
+    └── • hash join
+        │ equality: (a) = (e)
+        │ right cols are key
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@abc_pkey
+        │     spans: FULL SCAN
+        │
+        └── • distinct
+            │ distinct on: e
+            │
+            └── • scan
+                  missing stats
+                  table: def@def_pkey
+                  spans: FULL SCAN
+
+# Exists with primary key columns not selected
+query T
+EXPLAIN SELECT c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: a, b
+│
+└── • union all
+    │
+    ├── • merge join
+    │   │ equality: (a) = (d)
+    │   │ right cols are key
+    │   │
+    │   ├── • scan
+    │   │     missing stats
+    │   │     table: abc@abc_pkey
+    │   │     spans: FULL SCAN
+    │   │
+    │   └── • distinct
+    │       │ distinct on: d
+    │       │ order key: d
+    │       │
+    │       └── • scan
+    │             missing stats
+    │             table: def@def_pkey
+    │             spans: FULL SCAN
+    │
+    └── • hash join
+        │ equality: (a) = (e)
+        │ right cols are key
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@abc_pkey
+        │     spans: FULL SCAN
+        │
+        └── • distinct
+            │ distinct on: e
+            │
+            └── • scan
+                  missing stats
+                  table: def@def_pkey
+                  spans: FULL SCAN
+
+# Not Exists with primary key columns selected
+query T
+EXPLAIN SELECT a, b, c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+distribution: local
+vectorized: true
+·
+• intersect all
+│
+├── • merge join (anti)
+│   │ equality: (a) = (d)
+│   │
+│   ├── • scan
+│   │     missing stats
+│   │     table: abc@abc_pkey
+│   │     spans: FULL SCAN
+│   │
+│   └── • scan
+│         missing stats
+│         table: def@def_pkey
+│         spans: FULL SCAN
+│
+└── • hash join (anti)
+    │ equality: (a) = (e)
+    │
+    ├── • scan
+    │     missing stats
+    │     table: abc@abc_pkey
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: def@def_pkey
+          spans: FULL SCAN
+
+# Not Exists with primary key columns not selected
+query T
+EXPLAIN SELECT c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
+----
+distribution: local
+vectorized: true
+·
+• intersect all
+│
+├── • merge join (anti)
+│   │ equality: (a) = (d)
+│   │
+│   ├── • scan
+│   │     missing stats
+│   │     table: abc@abc_pkey
+│   │     spans: FULL SCAN
+│   │
+│   └── • scan
+│         missing stats
+│         table: def@def_pkey
+│         spans: FULL SCAN
+│
+└── • hash join (anti)
+    │ equality: (a) = (e)
+    │
+    ├── • scan
+    │     missing stats
+    │     table: abc@abc_pkey
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: def@def_pkey
+          spans: FULL SCAN
+
+# InnerJoin with primary key columns selected
+query T
+EXPLAIN SELECT a, b, c FROM abc, def WHERE a=d OR a=e
+----
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: a, b, d, e
+│
+└── • union all
+    │
+    ├── • merge join
+    │   │ equality: (a) = (d)
+    │   │
+    │   ├── • scan
+    │   │     missing stats
+    │   │     table: abc@abc_pkey
+    │   │     spans: FULL SCAN
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: def@def_pkey
+    │         spans: FULL SCAN
+    │
+    └── • hash join
+        │ equality: (a) = (e)
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@abc_pkey
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: def@def_pkey
+              spans: FULL SCAN
+
+# InnerJoin with primary key columns not selected
+query T
+EXPLAIN SELECT c FROM abc, def WHERE a=d OR a=e
+----
+distribution: local
+vectorized: true
+·
+• distinct
+│ distinct on: a, b, d, e
+│
+└── • union all
+    │
+    ├── • merge join
+    │   │ equality: (a) = (d)
+    │   │
+    │   ├── • scan
+    │   │     missing stats
+    │   │     table: abc@abc_pkey
+    │   │     spans: FULL SCAN
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: def@def_pkey
+    │         spans: FULL SCAN
+    │
+    └── • hash join
+        │ equality: (a) = (e)
+        │
+        ├── • scan
+        │     missing stats
+        │     table: abc@abc_pkey
+        │     spans: FULL SCAN
+        │
+        └── • scan
+              missing stats
+              table: def@def_pkey
+              spans: FULL SCAN
+

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -889,7 +889,8 @@ func (sb *statisticsBuilder) constrainScan(
 	// Calculate distinct counts and histograms for the partial index predicate
 	// ------------------------------------------------------------------------
 	if pred != nil {
-		predUnappliedConjucts, predConstrainedCols, predHistCols := sb.applyFilters(pred, scan, relProps)
+		predUnappliedConjucts, predConstrainedCols, predHistCols :=
+			sb.applyFilters(pred, scan, relProps, false /* skipOrTermAccounting */)
 		numUnappliedConjuncts += predUnappliedConjucts
 		constrainedCols.UnionWith(predConstrainedCols)
 		constrainedCols = sb.tryReduceCols(constrainedCols, s, MakeTableFuncDep(sb.md, scan.Table))
@@ -1214,7 +1215,8 @@ func (sb *statisticsBuilder) buildJoin(
 
 	// Calculate distinct counts for constrained columns in the ON conditions
 	// ----------------------------------------------------------------------
-	numUnappliedConjuncts, constrainedCols, histCols := sb.applyFilters(h.filters, join, relProps)
+	numUnappliedConjuncts, constrainedCols, histCols :=
+		sb.applyFilters(h.filters, join, relProps, true /* skipOrTermAccounting */)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -1241,6 +1243,10 @@ func (sb *statisticsBuilder) buildJoin(
 		s.ApplySelectivity(sb.selectivityFromEquivalenciesSemiJoin(
 			equivReps, h.leftProps.OutputCols, h.rightProps.OutputCols, &h.filtersFD, join, s,
 		))
+		var oredTermSelectivity props.Selectivity
+		oredTermSelectivity, numUnappliedConjuncts =
+			sb.selectivityFromOredEquivalencies(h, join, s, numUnappliedConjuncts, true /* semiJoin */)
+		s.ApplySelectivity(oredTermSelectivity)
 
 	default:
 		s.RowCount = leftStats.RowCount * rightStats.RowCount
@@ -1257,6 +1263,10 @@ func (sb *statisticsBuilder) buildJoin(
 		}
 
 		s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &h.filtersFD, join, s))
+		var oredTermSelectivity props.Selectivity
+		oredTermSelectivity, numUnappliedConjuncts =
+			sb.selectivityFromOredEquivalencies(h, join, s, numUnappliedConjuncts, false /* semiJoin */)
+		s.ApplySelectivity(oredTermSelectivity)
 	}
 
 	if join.Op() == opt.InvertedJoinOp || hasInvertedJoinCond(h.filters) {
@@ -1738,7 +1748,8 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	// to iterate through FixedCols here if we are already processing the ON
 	// clause.
 	// TODO(rytaft): use histogram for zig zag join.
-	numUnappliedConjuncts, constrainedCols, _ := sb.applyFilters(zigzag.On, zigzag, relProps)
+	numUnappliedConjuncts, constrainedCols, _ :=
+		sb.applyFilters(zigzag.On, zigzag, relProps, false /* skipOrTermAccounting */)
 
 	// Application of constraints on inverted indexes needs to be handled a
 	// little differently since a constraint on an inverted index key column
@@ -2954,7 +2965,8 @@ func (sb *statisticsBuilder) filterRelExpr(
 
 	// Calculate distinct counts and histograms for constrained columns
 	// ----------------------------------------------------------------
-	numUnappliedConjuncts, constrainedCols, histCols := sb.applyFilters(filters, e, relProps)
+	numUnappliedConjuncts, constrainedCols, histCols :=
+		sb.applyFilters(filters, e, relProps, false /* skipOrTermAccounting */)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -2981,11 +2993,12 @@ func (sb *statisticsBuilder) filterRelExpr(
 // applyFilters uses constraints to update the distinct counts and histograms
 // for the constrained columns in the filter. The changes in the distinct
 // counts and histograms will be used later to determine the selectivity of
-// the filter.
+// the filter. If skipOrTermAccounting is true, OrExpr filters are not counted
+// towards numUnappliedConjuncts.
 //
 // See applyFiltersItem for more details.
 func (sb *statisticsBuilder) applyFilters(
-	filters FiltersExpr, e RelExpr, relProps *props.Relational,
+	filters FiltersExpr, e RelExpr, relProps *props.Relational, skipOrTermAccounting bool,
 ) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
 	// Special hack for lookup and inverted joins. Add constant filters from the
 	// equality conditions.
@@ -3002,7 +3015,11 @@ func (sb *statisticsBuilder) applyFilters(
 	for i := range filters {
 		numUnappliedConjunctsLocal, constrainedColsLocal, histColsLocal :=
 			sb.applyFiltersItem(&filters[i], e, relProps)
-		numUnappliedConjuncts += numUnappliedConjunctsLocal
+		// Selectivity from OrExprs is computed elsewhere when skipOrTermAccounting
+		// is true.
+		if _, ok := filters[i].Condition.(*OrExpr); !skipOrTermAccounting || !ok {
+			numUnappliedConjuncts += numUnappliedConjunctsLocal
+		}
 		constrainedCols.UnionWith(constrainedColsLocal)
 		histCols.UnionWith(histColsLocal)
 	}
@@ -4070,6 +4087,177 @@ func (sb *statisticsBuilder) selectivityFromEquivalencies(
 	})
 
 	return selectivity
+}
+
+// selectivityFromOredEquivalencies determines the selectivity of all
+// disjunctions of equality constraints present in the array of conjuncts,
+// h.filters. For every conjunct that is an OrExpr chain in which at least one
+// disjunct exists with no column equivalency set, selectivity estimation is
+// skipped for that conjunct and numUnappliedConjuncts is incremented by 1.
+// If in the future the accuracy of inequality join predicate selectivity
+// estimation is improved, this method can be updated to handle those predicates
+// as well.
+func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
+	h *joinPropsHelper,
+	e RelExpr,
+	s *props.Statistics,
+	numUnappliedConjunctsIn float64,
+	semiJoin bool,
+) (selectivity props.Selectivity, numUnappliedConjuncts float64) {
+	numUnappliedConjuncts = numUnappliedConjunctsIn
+	selectivity = props.OneSelectivity
+	var conjunctSelectivity props.Selectivity
+
+	for f := 0; f < len(h.filters); f++ {
+		conjunctSelectivity = props.OneSelectivity
+		disjunction := h.filters[f]
+		var disjuncts []opt.ScalarExpr
+		if orExpr, ok := disjunction.Condition.(*OrExpr); !ok {
+			continue
+		} else {
+			disjuncts = CollectContiguousOrExprs(orExpr)
+		}
+		var filter FiltersItem
+		var filters FiltersExpr
+		var filtersFDs []props.FuncDepSet
+		var ok = true
+
+		for i := 0; ok && i < len(disjuncts); i++ {
+			var andFilters FiltersExpr
+			var filtersFD props.FuncDepSet
+
+			// Only handle ANDed equality expressions for which constructFiltersItem
+			// is able to build column equivalencies.
+			switch disjuncts[i].(type) {
+			case *EqExpr, *AndExpr:
+				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, e.Memo()); !ok {
+					numUnappliedConjuncts++
+					continue
+				}
+				e.Memo().logPropsBuilder.addFiltersToFuncDep(andFilters, &filtersFD)
+			default:
+				numUnappliedConjuncts++
+				ok = false
+				continue
+			}
+			// If no column equivalencies are found, we know nothing about this term,
+			// so should skip selectivity estimation on the entire conjunct.
+			if filtersFD.Empty() || filtersFD.EquivReps().Empty() {
+				numUnappliedConjuncts++
+				ok = false
+				break
+			}
+			filters = append(filters, filter)
+			filtersFDs = append(filtersFDs, filtersFD)
+		}
+		if !ok {
+			continue
+		}
+		var singleSelectivity props.Selectivity
+		var selectivities []props.Selectivity
+		for i := 0; i < len(filters); i++ {
+			FD := &filtersFDs[i]
+			equivReps := FD.EquivReps()
+			if semiJoin {
+				singleSelectivity = sb.selectivityFromEquivalenciesSemiJoin(
+					equivReps, h.leftProps.OutputCols, h.rightProps.OutputCols, FD, e, s,
+				)
+			} else {
+				singleSelectivity = sb.selectivityFromEquivalencies(equivReps, FD, e, s)
+			}
+			selectivities = append(selectivities, singleSelectivity)
+		}
+		if !ok {
+			continue
+		}
+		// Combine the selectivities of each ORed predicate to get the total
+		// combined selectivity of the entire OR expression.
+		conjunctSelectivity = combineOredSelectivities(selectivities)
+
+		// Combine this disjunction's selectivity with that of other disjunctions.
+		selectivity.Multiply(conjunctSelectivity)
+	}
+	return selectivity, numUnappliedConjuncts
+}
+
+// combineOredSelectivities iteratively applies the General Disjunction Rule
+// on a slice of 'selectivities' where each selectivity in the slice is the
+// selectivity of an individual ORed predicate.
+//
+// Given predicates A and B and probability function P:
+//     P(A or B) = P(A) + P(B) - P(A and B)
+// Continuation:
+//     P(A or B or C) = P(A or B) + P(C) - P((A or B) and C)
+//     P(A or B or C or D) = P(A or B or C) + P(D) - P((A or B or C) and D)
+//     ...
+//
+// This seems to be a standard approach in the database world.
+// The textbook solution is more complex:
+// https://www.thoughtco.com/probability-union-of-three-sets-more-3126263
+// https://stats.stackexchange.com/questions/87533/whats-the-general-disjunction-rule-for-n-events
+//
+// Q: Does the iterative approach do a good enough job of approximating
+//    the non-iterative textbook solution?
+//
+// In the formula we assume A and B are independent, so:
+//    P(A and B) = P(A) * P(B)
+// The independence assumption may not be correct in all cases.
+// Would using the full formula lead to more errors since the independence
+// assumption is used in more terms in that formula?
+// In any case, the runtime of computing the full formula for filters with
+// many predicates may be excessive due to combinatorial explosion.
+// That shouldn't apply to the ON clause because typically it would not have
+// hundreds of disjuncts, but may apply if this method were used for
+// single-table filter selectivity estimation.
+//
+// Possible improvement: Use multicolumn stats to estimate P(A and B)
+// instead of assuming full independence.
+func combineOredSelectivities(selectivities []props.Selectivity) props.Selectivity {
+	totalSelectivity := selectivities[0]
+	var combinedSel props.Selectivity
+	for i := 1; i < len(selectivities); i++ {
+		// combinedSel represents P(A and B)
+		combinedSel = props.MakeSelectivity((&totalSelectivity).AsFloat())
+		(&combinedSel).Multiply(selectivities[i])
+		totalSelectivity.UnsafeAdd(selectivities[i])
+		totalSelectivity.Subtract(combinedSel)
+	}
+	return totalSelectivity
+}
+
+// constructFiltersItem constructs an expression for the FiltersItem operator,
+// with identical behavior to the Factory method of the same name, but for use
+// in cases where the Factory is not accessible.
+func constructFiltersItem(condition opt.ScalarExpr, m *Memo) FiltersItem {
+	item := FiltersItem{Condition: condition}
+	item.PopulateProps(m)
+	return item
+}
+
+// addEqExprConjuncts recursively walks a scalar expression as long as it
+// continues to find nested And operators. It adds any equality expression
+// conjuncts to the given FiltersExpr and returns true.
+// This function is inspired by norm.CustomFuncs.addConjuncts, but serves
+// a different purpose.
+// The whole purpose of this new function is to enable the building of
+// functional dependencies based on equality predicates for selectivity
+// estimation purposes, so it is not important to traverse OrExpr expression
+// subtrees or make filters for any other expression type.
+func addEqExprConjuncts(
+	scalar opt.ScalarExpr, filters FiltersExpr, m *Memo,
+) (_ FiltersExpr, ok bool) {
+	switch t := scalar.(type) {
+	case *AndExpr:
+		var ok1, ok2 bool
+		filters, ok1 = addEqExprConjuncts(t.Left, filters, m)
+		filters, ok2 = addEqExprConjuncts(t.Right, filters, m)
+		return filters, ok1 || ok2
+	case *EqExpr:
+		filters = append(filters, constructFiltersItem(t, m))
+	default:
+		return nil, false
+	}
+	return filters, true
 }
 
 func (sb *statisticsBuilder) selectivityFromEquivalency(

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1662,3 +1662,316 @@ inner-join (cross)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
       └── (((s:3 = 'foo') AND (u:7 = 3)) AND (v:8 = 4)) OR (((s:3 = 'bar') AND (u:7 = 5)) AND (v:8 = 6)) [type=bool, outer=(3,7,8), constraints=(/3: [/'bar' - /'bar'] [/'foo' - /'foo']; /7: [/3 - /3] [/5 - /5]; /8: [/4 - /4] [/6 - /6])]
+
+# Test selectivity of ORed join predicates
+# Estimate of # rows should be low, and nowhere near the no-stats
+# cartesian join estimate of 1,000,000 rows.
+
+exec-ddl
+CREATE TABLE classes (classID int, description varchar(50))
+----
+
+exec-ddl
+CREATE TABLE classRequest (studentID int, firstChoiceClassID int, secondChoiceClassID int, thirdChoiceClassID int, primary key(studentID))
+----
+
+norm
+SELECT * FROM classes, classRequest WHERE classRequest.firstChoiceClassID = classes.classID OR
+                                          classRequest.secondChoiceClassID = classes.classID
+----
+inner-join (cross)
+ ├── columns: classid:1(int!null) description:2(varchar) studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=19701, distinct(1)=100, null(1)=0, avgsize(1)=4]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes, classRequest WHERE classRequest.firstChoiceClassID = classes.classID OR
+                                          classRequest.secondChoiceClassID = classes.classID OR
+                                          classRequest.thirdChoiceClassID = classes.classID
+----
+inner-join (cross)
+ ├── columns: classid:1(int!null) description:2(varchar) studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=29403.99, distinct(1)=100, null(1)=0, avgsize(1)=4]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4, distinct(9)=100, null(9)=10, avgsize(9)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── ((firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1)) OR (thirdchoiceclassid:9 = classid:1) [type=bool, outer=(1,7-9), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes LEFT OUTER JOIN classRequest ON
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = classes.classID
+----
+left-join (cross)
+ ├── columns: classid:1(int) description:2(varchar) studentid:6(int) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=19900]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+# Presence of a single-table join term brings the estimate back up to cartesian join territory.
+# Currently only ORed equijoin terms are handled. Otherwise we give up on trying to get accurate estimates.
+norm
+SELECT * FROM classes LEFT OUTER JOIN classRequest ON
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = 1
+----
+left-join (cross)
+ ├── columns: classid:1(int) description:2(varchar) studentid:6(int) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=333333.3]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = 1) [type=bool, outer=(1,7,8)]
+
+# Selectivity of each term is 1, so combined selectivity is 1 and 1000 rows
+# estimate is expected.
+norm
+SELECT * FROM classes WHERE EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = classes.classID)
+----
+semi-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
+ │    └── stats: [rows=1000, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4]
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes WHERE EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID  OR
+                      classRequest.secondChoiceClassID = classes.classID  OR
+                      classRequest.thirdChoiceClassID = classes.classID)
+----
+semi-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    └── stats: [rows=1000, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4, distinct(9)=100, null(9)=10, avgsize(9)=4]
+ └── filters
+      └── ((firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1)) OR (thirdchoiceclassid:9 = classid:1) [type=bool, outer=(1,7-9), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes WHERE NOT EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = classes.classID)
+----
+anti-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=1e-10]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
+ │    └── stats: [rows=1000, distinct(7)=100, null(7)=10, avgsize(7)=4, distinct(8)=100, null(8)=10, avgsize(8)=4]
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes WHERE EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = 5)
+----
+semi-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=333.3333]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=1000]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
+ │    └── stats: [rows=1000]
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = 5) [type=bool, outer=(1,7,8)]
+
+# Tests with real stats
+exec-ddl
+ALTER TABLE classes INJECT STATISTICS '[
+  {
+    "columns": ["classid"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 5000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE classRequest INJECT STATISTICS '[
+  {
+    "columns": ["firstchoiceclassid"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 500
+  },
+  {
+    "columns": ["secondchoiceclassid"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 50
+  },
+  {
+    "columns": ["thirdchoiceclassid"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 10
+  }
+]'
+----
+
+# Like the no-stats tests, these should show cardinalities much smaller than
+# the cross cardinality.
+norm
+SELECT * FROM classes, classRequest WHERE classRequest.firstChoiceClassID = classes.classID OR
+                                          classRequest.secondChoiceClassID = classes.classID
+----
+inner-join (cross)
+ ├── columns: classid:1(int!null) description:2(varchar) studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=1999.8, distinct(1)=1999.8, null(1)=0, avgsize(1)=4]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(8)=50, null(8)=0, avgsize(8)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes, classRequest WHERE classRequest.firstChoiceClassID = classes.classID OR
+                                          classRequest.thirdChoiceClassID = classes.classID
+----
+inner-join (cross)
+ ├── columns: classid:1(int!null) description:2(varchar) studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=1999.8, distinct(1)=1999.8, null(1)=0, avgsize(1)=4]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(9)=10, null(9)=0, avgsize(9)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (thirdchoiceclassid:9 = classid:1) [type=bool, outer=(1,7,9), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes, classRequest WHERE classRequest.firstChoiceClassID = classes.classID OR
+                                          classRequest.secondChoiceClassID = classes.classID OR
+                                          classRequest.thirdChoiceClassID = classes.classID
+----
+inner-join (cross)
+ ├── columns: classid:1(int!null) description:2(varchar) studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=2999.4, distinct(1)=2999.4, null(1)=0, avgsize(1)=4]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(8)=50, null(8)=0, avgsize(8)=4, distinct(9)=10, null(9)=0, avgsize(9)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── ((firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1)) OR (thirdchoiceclassid:9 = classid:1) [type=bool, outer=(1,7-9), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes LEFT OUTER JOIN classRequest ON
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = classes.classID
+----
+left-join (cross)
+ ├── columns: classid:1(int) description:2(varchar) studentid:6(int) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ ├── stats: [rows=5000]
+ ├── fd: (6)-->(7-9)
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
+ │    ├── stats: [rows=1000, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(8)=50, null(8)=0, avgsize(8)=4]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7-9)
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes WHERE EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID  OR
+                      classRequest.secondChoiceClassID = classes.classID)
+----
+semi-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=545, distinct(1)=545, null(1)=0, avgsize(1)=4]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
+ │    └── stats: [rows=1000, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(8)=50, null(8)=0, avgsize(8)=4]
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+norm
+SELECT * FROM classes WHERE NOT EXISTS (SELECT * FROM classRequest WHERE
+                      classRequest.firstChoiceClassID = classes.classID OR
+                      classRequest.secondChoiceClassID = classes.classID)
+----
+anti-join (cross)
+ ├── columns: classid:1(int) description:2(varchar)
+ ├── stats: [rows=4455]
+ ├── scan classes
+ │    ├── columns: classid:1(int) description:2(varchar)
+ │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0, avgsize(1)=4]
+ ├── scan classrequest
+ │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
+ │    └── stats: [rows=1000, distinct(7)=500, null(7)=0, avgsize(7)=4, distinct(8)=50, null(8)=0, avgsize(8)=4]
+ └── filters
+      └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = classid:1) [type=bool, outer=(1,7,8), constraints=(/1: (/NULL - ])]

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1068,3 +1068,12 @@ func (c *CustomFuncs) DuplicateScanPrivate(sp *memo.ScanPrivate) *memo.ScanPriva
 		Locking: sp.Locking,
 	}
 }
+
+// DuplicateJoinPrivate copies a JoinPrivate, preserving the Flags and
+// SkipReorderJoins field values.
+func (c *CustomFuncs) DuplicateJoinPrivate(jp *memo.JoinPrivate) *memo.JoinPrivate {
+	return &memo.JoinPrivate{
+		Flags:            jp.Flags,
+		SkipReorderJoins: jp.SkipReorderJoins,
+	}
+}

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -61,6 +61,20 @@ func (s *Selectivity) Add(other Selectivity) {
 	s.selectivity = selectivityInRange(s.selectivity + other.selectivity)
 }
 
+// Subtract finds the difference of two selectivities in the valid range and
+// modifies the selectivity specified in the receiver to equal the receiver
+// minus the operand.
+func (s *Selectivity) Subtract(other Selectivity) {
+	s.selectivity = selectivityInRange(s.selectivity - other.selectivity)
+}
+
+// UnsafeAdd finds the sum of two selectivities and modifies
+// the selectivity specified in the receiver to equal the sum.
+// It does not do a range check to make sure the result is between 0 and 1.
+func (s *Selectivity) UnsafeAdd(other Selectivity) {
+	s.selectivity = s.selectivity + other.selectivity
+}
+
 // Divide finds the quotient of two selectivities in the valid range and
 // modifies the selectivity specified in the receiver to equal the quotient.
 func (s *Selectivity) Divide(other Selectivity) {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1744,3 +1744,362 @@ func (c *CustomFuncs) splitValues(
 	}
 	return localVals, remoteVals
 }
+
+// splitDisjunctionForJoin finds the first disjunction in the ON clause that can
+// be split into an interesting pair of predicates. It returns the pair of
+// predicates and the Filters item they were a part of. If an "interesting"
+// disjunction is not found, ok=false is returned.
+//
+// It is expected that the left and right inputs to joinRel have been
+// pre-checked to be canonical scans, or Selects from canonical scans, and
+// origLeftScan and origRightScan refer to those scans.
+//
+// For details on what makes an "interesting" disjunction, see
+// findInterestingDisjunctionPairForJoin.
+func (c *CustomFuncs) splitDisjunctionForJoin(
+	joinRel memo.RelExpr,
+	filters memo.FiltersExpr,
+	origLeftScan *memo.ScanExpr,
+	origRightScan *memo.ScanExpr,
+) (
+	leftPreds opt.ScalarExpr,
+	rightPreds opt.ScalarExpr,
+	itemToReplace *memo.FiltersItem,
+	ok bool,
+) {
+	for i := range filters {
+		if filters[i].Condition.Op() == opt.OrOp {
+			if leftPreds, rightPreds, ok =
+				c.findInterestingDisjunctionPairForJoin(joinRel, &filters[i], origLeftScan, origRightScan); ok {
+				itemToReplace = &filters[i]
+				return leftPreds, rightPreds, itemToReplace, true
+			}
+		}
+	}
+	return nil, nil, nil, false
+}
+
+// makeFilteredSelectForJoin takes a scanPrivate and filters and constructs a
+// new SelectExpr from a ScanExpr with filter columns mapped from
+// origScanPrivate to the column IDs in the new scan.
+func (c *CustomFuncs) makeFilteredSelectForJoin(
+	filters memo.FiltersExpr, scanPrivate *memo.ScanPrivate, origScanPrivate *memo.ScanPrivate,
+) (newSelect memo.RelExpr) {
+	newScan := c.e.f.ConstructScan(scanPrivate)
+	newSelect =
+		c.e.f.ConstructSelect(
+			newScan,
+			c.RemapScanColsInFilter(filters, origScanPrivate, scanPrivate),
+		)
+	return newSelect
+}
+
+// SplitJoinWithEquijoinDisjuncts checks a join relation for a disjunction of
+// equijoin predicates in an InnerJoin, SemiJoin or AntiJoin. If present, and
+// the inputs to the join are canonical scans, or Selects from canonical scans,
+// it builds two new join relations of the same join type as the original, but
+// with one disjunct assigned to firstJoin and the remaining disjuncts assigned
+// to secondJoin.
+//
+// In the case of inner join, newRelationCols contains the column ids from the
+// original Scans in the left and right inputs plus primary key columns from
+// both input relations. For semijoin or antijoin, newRelationCols contains the
+// column ids from the original left Scan plus primary key columns from the left
+// relation.
+//
+// aggCols contains the non-key columns of the left and right inputs.
+// groupingCols contains the primary key columns of the left and right inputs,
+// needed for deduplicating results.
+// If there is no disjunction of equijoin predicates, or the join type is not
+// one of the supported join types listed above, ok=false is returned.
+func (c *CustomFuncs) SplitJoinWithEquijoinDisjuncts(
+	joinRel memo.RelExpr, joinFilters memo.FiltersExpr,
+) (
+	firstJoin memo.RelExpr,
+	secondJoin memo.RelExpr,
+	newRelationCols opt.ColSet,
+	aggCols opt.ColSet,
+	groupingCols opt.ColSet,
+	ok bool,
+) {
+	notOkSplitJoin := func() (memo.RelExpr, memo.RelExpr, opt.ColSet, opt.ColSet, opt.ColSet, bool) {
+		emptyColSet := opt.ColSet{}
+		return nil, nil, emptyColSet, emptyColSet, emptyColSet, false
+	}
+
+	var joinPrivate *memo.JoinPrivate
+	var leftInput memo.RelExpr
+	var rightInput memo.RelExpr
+
+	joinPrivate = joinRel.Private().(*memo.JoinPrivate)
+	leftInput = joinRel.Child(0).(memo.RelExpr)
+	rightInput = joinRel.Child(1).(memo.RelExpr)
+
+	switch joinRel.Op() {
+	case opt.InnerJoinOp, opt.SemiJoinOp, opt.AntiJoinOp:
+		// Do nothing
+	default:
+		panic(errors.AssertionFailedf("expected joinRel to be inner, semi, or anti-join"))
+	}
+
+	origLeftScan, leftFilters, ok := c.getfilteredCanonicalScan(leftInput)
+	if !ok {
+		return notOkSplitJoin()
+	}
+	origLeftScanPrivate := &origLeftScan.ScanPrivate
+	origRightScan, rightFilters, ok := c.getfilteredCanonicalScan(rightInput)
+	if !ok {
+		return notOkSplitJoin()
+	}
+	origRightScanPrivate := &origRightScan.ScanPrivate
+
+	// Look for a disjunction of equijoin predicates.
+	firstOnClause, secondOnClause, itemToReplace, ok :=
+		c.splitDisjunctionForJoin(joinRel, joinFilters, origLeftScan, origRightScan)
+	if !ok {
+		return notOkSplitJoin()
+	}
+
+	// Add in the primary key columns so the caller can group by them to
+	// deduplicate results.
+	var leftSP *memo.ScanPrivate
+	if c.PrimaryKeyCols(origLeftScanPrivate.Table).SubsetOf(origLeftScanPrivate.Cols) {
+		leftSP = origLeftScanPrivate
+	} else {
+		leftSP = c.AddPrimaryKeyColsToScanPrivate(origLeftScanPrivate)
+	}
+	var rightSP *memo.ScanPrivate
+	if joinRel.Op() == opt.InnerJoinOp {
+		if c.PrimaryKeyCols(origRightScanPrivate.Table).SubsetOf(origRightScanPrivate.Cols) {
+			rightSP = origRightScanPrivate
+		} else {
+			rightSP = c.AddPrimaryKeyColsToScanPrivate(origRightScanPrivate)
+		}
+	} else {
+		rightSP = origRightScanPrivate
+	}
+
+	// Make new column ids for the new scans which are input to the two
+	// new joins we're building.
+	leftFirstColID, _ := leftSP.Cols.Next(0)
+	rightFirstColID, _ := rightSP.Cols.Next(0)
+	var newLeftScanPrivate, newRightScanPrivate,
+		newLeftScanPrivate2, newRightScanPrivate2 *memo.ScanPrivate
+	// The UNION ALL and join operations treat the output columns in the output
+	// row as having the same order as the column id numbers. So, in order for the
+	// resulting row definition to have the same columns in the same positions as
+	// the join we're replacing, maintain this relative order. Follow a simple
+	// rule that the new duplicated left and right tables maintain the same column
+	// id order as the original scans. Scans allocate column ids in contiguous
+	// chunks, so if the first column id in the left is less than the first column
+	// id in the right, then all column ids in the left will be lower than all
+	// right column ids.
+	if leftFirstColID < rightFirstColID {
+		newLeftScanPrivate = c.DuplicateScanPrivate(leftSP)
+		newRightScanPrivate = c.DuplicateScanPrivate(rightSP)
+		newLeftScanPrivate2 = c.DuplicateScanPrivate(leftSP)
+		newRightScanPrivate2 = c.DuplicateScanPrivate(rightSP)
+	} else {
+		newRightScanPrivate = c.DuplicateScanPrivate(rightSP)
+		newLeftScanPrivate = c.DuplicateScanPrivate(leftSP)
+		newRightScanPrivate2 = c.DuplicateScanPrivate(rightSP)
+		newLeftScanPrivate2 = c.DuplicateScanPrivate(leftSP)
+	}
+
+	amendedLeftOrigCols := c.ScanPrivateCols(leftSP)
+	amendedRightOrigCols := c.ScanPrivateCols(rightSP)
+	amendedOrigCols := c.UnionCols(amendedLeftOrigCols, amendedRightOrigCols)
+
+	// Tell the caller what the complete set of column ids is for the new relation
+	// they are building (e.g., a UNION ALL of the 2 new joins).
+	if joinRel.Op() == opt.InnerJoinOp {
+		newRelationCols = amendedOrigCols
+	} else {
+		newRelationCols = amendedLeftOrigCols
+	}
+
+	// Build the new Selects for the first new join, with mapped filter columns.
+	newLeftSelect :=
+		c.makeFilteredSelectForJoin(leftFilters, newLeftScanPrivate, leftSP)
+	newRightSelect :=
+		c.makeFilteredSelectForJoin(rightFilters, newRightScanPrivate, rightSP)
+
+	// Assign the firstOnClause, which was built from splitting the disjunction,
+	// to the first new join.
+	newJoinFilters :=
+		c.remapJoinColsInFilter(
+			c.ReplaceFiltersItem(joinFilters, itemToReplace, firstOnClause),
+			leftSP, newLeftScanPrivate, rightSP, newRightScanPrivate,
+		)
+	newJoinPrivate := c.e.funcs.DuplicateJoinPrivate(joinPrivate)
+
+	// Build a new first join with an identical join type to the original join.
+	switch joinRel.Op() {
+	case opt.InnerJoinOp:
+		firstJoin = c.e.f.ConstructInnerJoin(newLeftSelect, newRightSelect, newJoinFilters, newJoinPrivate)
+	case opt.SemiJoinOp:
+		firstJoin = c.e.f.ConstructSemiJoin(newLeftSelect, newRightSelect, newJoinFilters, newJoinPrivate)
+	case opt.AntiJoinOp:
+		firstJoin = c.e.f.ConstructAntiJoin(newLeftSelect, newRightSelect, newJoinFilters, newJoinPrivate)
+	default:
+		panic(errors.AssertionFailedf("Unexpected join type while splitting disjuncted join predicates: %v",
+			joinRel.Op()))
+	}
+
+	// Build the new Selects for the second new join, with mapped filter columns.
+	newLeftSelect2 :=
+		c.makeFilteredSelectForJoin(leftFilters, newLeftScanPrivate2, leftSP)
+	newRightSelect2 :=
+		c.makeFilteredSelectForJoin(rightFilters, newRightScanPrivate2, rightSP)
+
+	// Assign the secondOnClause, which was built from splitting the disjunction,
+	// to the second new join.
+	newJoinFilters2 :=
+		c.remapJoinColsInFilter(
+			c.ReplaceFiltersItem(joinFilters, itemToReplace, secondOnClause),
+			leftSP, newLeftScanPrivate2, rightSP, newRightScanPrivate2,
+		)
+	newJoinPrivate2 := c.DuplicateJoinPrivate(joinPrivate)
+
+	// Build a new second join with an identical join type to the original join.
+	switch joinRel.Op() {
+	case opt.InnerJoinOp:
+		secondJoin = c.e.f.ConstructInnerJoin(newLeftSelect2, newRightSelect2, newJoinFilters2, newJoinPrivate2)
+	case opt.SemiJoinOp:
+		secondJoin = c.e.f.ConstructSemiJoin(newLeftSelect2, newRightSelect2, newJoinFilters2, newJoinPrivate2)
+	case opt.AntiJoinOp:
+		secondJoin = c.e.f.ConstructAntiJoin(newLeftSelect2, newRightSelect2, newJoinFilters2, newJoinPrivate2)
+	default:
+		panic(errors.AssertionFailedf("Unexpected join type while splitting disjuncted join predicates: %v",
+			joinRel.Op()))
+	}
+
+	// Build the PK/rowid grouping columns to allow the caller to remove duplicates.
+	switch joinRel.Op() {
+	case opt.InnerJoinOp:
+		allPKColsSet := c.UnionCols(
+			c.PrimaryKeyCols(origLeftScanPrivate.Table),
+			c.PrimaryKeyCols(origRightScanPrivate.Table))
+		allJoinColsSet := c.UnionCols(
+			origLeftScanPrivate.Cols,
+			origRightScanPrivate.Cols)
+		aggCols = c.DifferenceCols(allJoinColsSet, allPKColsSet)
+		groupingCols = allPKColsSet
+	case opt.SemiJoinOp, opt.AntiJoinOp:
+		projectedPKColsSet := c.PrimaryKeyCols(origLeftScanPrivate.Table)
+		projectedJoinColsSet := origLeftScanPrivate.Cols
+		aggCols = c.DifferenceCols(projectedJoinColsSet, projectedPKColsSet)
+		groupingCols = projectedPKColsSet
+	default:
+		panic(errors.AssertionFailedf("Unexpected join type while splitting disjuncted join predicates: %v",
+			joinRel.Op()))
+	}
+	return firstJoin, secondJoin, newRelationCols, aggCols, groupingCols, true
+}
+
+// getfilteredCanonicalScan looks at a *ScanExpr or *SelectExpr "relation" and
+// returns the input *ScanExpr and FiltersExpr, along with ok=true, if the Scan
+// is a canonical scan. If "relation" is a different type, or if it's a
+// *SelectExpr with an Input other than a *ScanExpr, ok=false is returned. Scans
+// or Selects with no filters may return filters as nil.
+func (c *CustomFuncs) getfilteredCanonicalScan(
+	relation memo.RelExpr,
+) (scanExpr *memo.ScanExpr, filters memo.FiltersExpr, ok bool) {
+	var selectExpr *memo.SelectExpr
+	if selectExpr, ok = relation.(*memo.SelectExpr); ok {
+		if scanExpr, ok = selectExpr.Input.(*memo.ScanExpr); !ok {
+			return nil, nil, false
+		}
+		filters = selectExpr.Filters
+	} else if scanExpr, ok = relation.(*memo.ScanExpr); !ok {
+		return nil, nil, false
+	}
+	scanPrivate := &scanExpr.ScanPrivate
+	if !c.IsCanonicalScan(scanPrivate) {
+		return nil, nil, false
+	}
+	return scanExpr, filters, true
+}
+
+// findInterestingDisjunctionPairForJoin groups disjunction subexpressions into
+// an "interesting" pair of join predicates.
+//
+// An "interesting" pair of predicates is one where one predicate is an
+// equality predicate which could enable more performant joins than cross join,
+// such as hash join or lookup join. At least one predicate in the disjunction
+// must be an equality join term referencing both input relations. When there
+// are more than two predicates, the deepest leaf node in the left depth OrExpr
+// tree is returned as "left" and the remaining predicates are built into a
+// brand new OrExpr chain and returned as "right".
+//
+// It is expected that the left and right inputs to joinRel have been
+// pre-checked to be canonical scans, or Selects from canonical scans, and
+// leftScan and rightScan refer to those scans.
+//
+// findInterestingDisjunctionPairForJoin returns an ok=false if at least one of
+// the ORed predicates is not an equality join term referencing both input
+// relations, or if joinRel is not a join relation.
+func (c *CustomFuncs) findInterestingDisjunctionPairForJoin(
+	joinRel memo.RelExpr, filter *memo.FiltersItem, leftScan *memo.ScanExpr, rightScan *memo.ScanExpr,
+) (left opt.ScalarExpr, right opt.ScalarExpr, ok bool) {
+	if !opt.IsJoinOp(joinRel) {
+		panic(errors.AssertionFailedf("expected joinRel to be a join operation"))
+	}
+
+	// isJoinPred tests if a predicate is a join predicate which references columns
+	// from both leftRelColSet and rightRelColSet, as indicated in the predicate's
+	// referenced columns, predCols.
+	isJoinPred := func(predCols, leftRelColSet, rightRelColSet opt.ColSet) bool {
+		return leftRelColSet.Intersects(predCols) && rightRelColSet.Intersects(predCols)
+	}
+
+	var leftExprs memo.ScalarListExpr
+	var rightExprs memo.ScalarListExpr
+	leftColSet := c.OutputCols(leftScan)
+	rightColSet := c.OutputCols(rightScan)
+
+	// An ANDed expression is interesting if it has at least one equality join
+	// predicate.
+	interesting := false
+	var hasJoinEquality func(opt.ScalarExpr) bool
+	hasJoinEquality = func(expr opt.ScalarExpr) bool {
+		switch t := expr.(type) {
+		case *memo.AndExpr:
+			return hasJoinEquality(t.Left) || hasJoinEquality(t.Right)
+		case *memo.EqExpr:
+			cols := c.OuterCols(expr)
+			return isJoinPred(cols, leftColSet, rightColSet)
+		default:
+			return false
+		}
+	}
+
+	// Traverse all adjacent OrExpr.
+	var collect func(opt.ScalarExpr)
+	collect = func(expr opt.ScalarExpr) {
+		interesting = false
+		switch t := expr.(type) {
+		case *memo.OrExpr:
+			collect(t.Left)
+			collect(t.Right)
+			return
+		default:
+			interesting = hasJoinEquality(expr)
+		}
+
+		if interesting && len(leftExprs) == 0 {
+			leftExprs = append(leftExprs, expr)
+		} else {
+			rightExprs = append(rightExprs, expr)
+		}
+	}
+
+	collect(filter.Condition)
+	// Return an empty pair if either of the expression lists is empty.
+	if len(leftExprs) == 0 ||
+		len(rightExprs) == 0 {
+		return nil, nil, false
+	}
+
+	return c.constructOr(leftExprs), c.constructOr(rightExprs), true
+}

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -124,6 +124,109 @@
     (OutputCols $left)
 )
 
+# SplitDisjunctionOfJoinTerms splits disjunctions (OR expressions) of ON clause
+# predicates of an inner or semi join into a Union of two Join expressions, the
+# first containing the left subexpression of the OR expression and the second
+# containing the right subexpression.
+# All other filter items in the original expression are preserved in the new
+# Join expressions. The logical Union is evaluated as a UNION ALL followed by a
+# distinct sort on the primary key columns of both the left and right input in
+# the case of inner join, or in the case or semijoin, the primary key columns
+# of the left.
+#
+# The call to SplitJoinWithEquijoinDisjuncts adds primary key columns to the
+# original Scan ColSet which the replace pattern removes by adding a Project as
+# the last operation.
+# Inclusion of the primary keys is required to prevent the generated Union from
+# duplicating rows that have the same selected values.
+#
+# This can produce better query plans in cases where indexes cover both sides of
+# the OR expression, or to enable hash-based join methods instead of cross join.
+# The execution plan can use both indexes to satisfy both sides of the
+# disjunction and union the results together.
+#
+# This rule is a reworking and combining of Select rules SplitDisjunction and
+# SplitDisjunctionAddKey, modified to handle joins and join predicates.
+[SplitDisjunctionOfJoinTerms, Explore]
+(InnerJoin | SemiJoin
+    *
+    *
+    $on:* &
+        (Let
+            (
+                $firstJoin
+                $secondJoin
+                $newRelationCols
+                $aggCols
+                $groupingCols
+                $ok
+            ):(SplitJoinWithEquijoinDisjuncts (Root) $on)
+            $ok
+        )
+    *
+)
+=>
+(Project
+    (DistinctOn
+        (UnionAll
+            $firstJoin
+            $secondJoin
+            (MakeSetPrivate
+                $firstJoinCols:(OutputCols $firstJoin)
+                $secondJoinCols:(OutputCols $secondJoin)
+                $newRelationCols
+            )
+        )
+        (MakeAggCols ConstAgg $aggCols)
+        (MakeGrouping $groupingCols (EmptyOrdering))
+    )
+    []
+    (OutputCols (Root))
+)
+
+# SplitDisjunctionOfAntiJoinTerms splits disjunctions (OR expressions) of ON
+# clause predicates of an antijoin into a Union of two AntiJoin expressions, the
+# first containing the left subexpression of the OR expression and the second
+# containing the right subexpression. This rule is identical to
+# SplitDisjunctionOfJoinTerms, except the INTERSECT ALL set operation is used
+# in place of UNION ALL.
+[SplitDisjunctionOfAntiJoinTerms, Explore]
+(AntiJoin
+    *
+    *
+    $on:* &
+        (Let
+            (
+                $firstJoin
+                $secondJoin
+                $newRelationCols
+                $aggCols
+                $groupingCols
+                $ok
+            ):(SplitJoinWithEquijoinDisjuncts (Root) $on)
+            $ok
+        )
+    *
+)
+=>
+(Project
+    (DistinctOn
+        (IntersectAll
+            $firstJoin
+            $secondJoin
+            (MakeSetPrivate
+                $firstJoinCols:(OutputCols $firstJoin)
+                $secondJoinCols:(OutputCols $secondJoin)
+                $newRelationCols
+            )
+        )
+        (MakeAggCols ConstAgg $aggCols)
+        (MakeGrouping $groupingCols (EmptyOrdering))
+    )
+    []
+    (OutputCols (Root))
+)
+
 # GenerateMergeJoins creates MergeJoin operators for the join, using the
 # interesting orderings property.
 [GenerateMergeJoins, Explore]

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -364,3 +364,8 @@ func (c *CustomFuncs) splitSpans(
 	remoteConstraint.Init(&keyCtx, &remoteSpans)
 	return localConstraint, remoteConstraint
 }
+
+// ScanPrivateCols returns the ColSet of a ScanPrivate.
+func (c *CustomFuncs) ScanPrivateCols(sp *memo.ScanPrivate) opt.ColSet {
+	return sp.Cols
+}

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -1,0 +1,3808 @@
+# Test ORed ON clause predicates which may be split into unions or 
+# intersections. The rewrite is cost-based, so may not always show up in the
+# query plan.
+# Use tables both with and without a primary key, to test when PK columns are
+# not included and also to allow null values.
+
+
+exec-ddl
+CREATE TABLE a(a1 INT, a2 INT, a3 INT, a4 INT, PRIMARY KEY(a1, a2, a3, a4))
+----
+
+exec-ddl
+CREATE TABLE b(b1 INT, b2 INT, b3 INT, b4 INT,
+               INDEX (b1, b2) STORING (b3, b4),
+               INDEX (b2) STORING (b1, b3, b4),
+               INDEX (b3) STORING (b1, b2, b4))
+----
+
+exec-ddl
+CREATE TABLE c(c1 INT, c2 INT, c3 INT, c4 INT)
+----
+
+exec-ddl
+CREATE TABLE d(d1 INT, d2 INT, d3 INT, d4 INT,
+               INDEX d (d1) STORING (d2, d3, d4))
+----
+
+# --------------------------------------------------
+# InnerJoin
+# --------------------------------------------------
+
+# The left AND right sides of the join already produce key columns
+build-cascades expect=SplitDisjunctionOfJoinTerms
+SELECT t1.*, t2.* FROM a t1, a t2 WHERE t1.a1 = t2.a3 OR t1.a2 = t2.a4 OR t1.a1 = t2.a4
+----
+root
+ └── project
+      ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+      ├── key: (1-4,7-10)
+      └── select
+           ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t1.crdb_internal_mvcc_timestamp:5 t1.tableoid:6 t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null t2.crdb_internal_mvcc_timestamp:11 t2.tableoid:12
+           ├── key: (1-4,7-10)
+           ├── fd: (1-4)-->(5,6), (7-10)-->(11,12)
+           ├── inner-join (cross)
+           │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t1.crdb_internal_mvcc_timestamp:5 t1.tableoid:6 t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null t2.crdb_internal_mvcc_timestamp:11 t2.tableoid:12
+           │    ├── key: (1-4,7-10)
+           │    ├── fd: (1-4)-->(5,6), (7-10)-->(11,12)
+           │    ├── scan a [as=t1]
+           │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t1.crdb_internal_mvcc_timestamp:5 t1.tableoid:6
+           │    │    ├── key: (1-4)
+           │    │    └── fd: (1-4)-->(5,6)
+           │    ├── scan a [as=t2]
+           │    │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null t2.crdb_internal_mvcc_timestamp:11 t2.tableoid:12
+           │    │    ├── key: (7-10)
+           │    │    └── fd: (7-10)-->(11,12)
+           │    └── filters (true)
+           └── filters
+                └── ((t1.a1:1 = t2.a3:9) OR (t1.a2:2 = t2.a4:10)) OR (t1.a1:1 = t2.a4:10) [outer=(1,2,9,10)]
+
+# Join of tables with compound primary keys
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (t1.a2 = t2.a2 OR t1.a3 = t2.a3) AND (t1.a1 = t2.a1 OR t1.a4 = t2.a4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── key: (1-4,7-10)
+ └── distinct-on
+      ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+      ├── grouping columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+      ├── key: (1-4,7-10)
+      └── union-all
+           ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+           ├── left columns: t1.a1:13 t1.a2:14 t1.a3:15 t1.a4:16 t2.a1:19 t2.a2:20 t2.a3:21 t2.a4:22
+           ├── right columns: t1.a1:25 t1.a2:26 t1.a3:27 t1.a4:28 t2.a1:31 t2.a2:32 t2.a3:33 t2.a4:34
+           ├── inner-join (hash)
+           │    ├── columns: t1.a1:13!null t1.a2:14!null t1.a3:15!null t1.a4:16!null t2.a1:19!null t2.a2:20!null t2.a3:21!null t2.a4:22!null
+           │    ├── key: (13,15,16,19-22)
+           │    ├── fd: (14)==(20), (20)==(14)
+           │    ├── scan a [as=t1]
+           │    │    ├── columns: t1.a1:13!null t1.a2:14!null t1.a3:15!null t1.a4:16!null
+           │    │    └── key: (13-16)
+           │    ├── scan a [as=t2]
+           │    │    ├── columns: t2.a1:19!null t2.a2:20!null t2.a3:21!null t2.a4:22!null
+           │    │    └── key: (19-22)
+           │    └── filters
+           │         ├── t1.a2:14 = t2.a2:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+           │         └── (t1.a1:13 = t2.a1:19) OR (t1.a4:16 = t2.a4:22) [outer=(13,16,19,22)]
+           └── inner-join (hash)
+                ├── columns: t1.a1:25!null t1.a2:26!null t1.a3:27!null t1.a4:28!null t2.a1:31!null t2.a2:32!null t2.a3:33!null t2.a4:34!null
+                ├── key: (25,26,28,31-34)
+                ├── fd: (27)==(33), (33)==(27)
+                ├── scan a [as=t1]
+                │    ├── columns: t1.a1:25!null t1.a2:26!null t1.a3:27!null t1.a4:28!null
+                │    └── key: (25-28)
+                ├── scan a [as=t2]
+                │    ├── columns: t2.a1:31!null t2.a2:32!null t2.a3:33!null t2.a4:34!null
+                │    └── key: (31-34)
+                └── filters
+                     ├── t1.a3:27 = t2.a3:33 [outer=(27,33), constraints=(/27: (/NULL - ]; /33: (/NULL - ]), fd=(27)==(33), (33)==(27)]
+                     └── (t1.a1:25 = t2.a1:31) OR (t1.a4:28 = t2.a4:34) [outer=(25,28,31,34)]
+
+# Join of tables with compound primary keys
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a, B WHERE (a2 = b2 OR a3 = b3) AND (a1 = b1 OR a4 = b4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10 rowid:11!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null rowid:11!null
+      ├── key: (1-4,11)
+      ├── fd: (1-4,11)-->(7-10)
+      ├── union-all
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10 rowid:11!null
+      │    ├── left columns: a1:14 a2:15 a3:16 a4:17 b1:20 b2:21 b3:22 b4:23 rowid:24
+      │    ├── right columns: a1:27 a2:28 a3:29 a4:30 b1:33 b2:34 b3:35 b4:36 rowid:37
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20 b2:21!null b3:22 b4:23 rowid:24!null
+      │    │    ├── key: (14,16,17,24)
+      │    │    ├── fd: (24)-->(20-23), (15)==(21), (21)==(15)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    │    └── key: (14-17)
+      │    │    ├── scan b
+      │    │    │    ├── columns: b1:20 b2:21 b3:22 b4:23 rowid:24!null
+      │    │    │    ├── key: (24)
+      │    │    │    └── fd: (24)-->(20-23)
+      │    │    └── filters
+      │    │         ├── a2:15 = b2:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
+      │    │         └── (a1:14 = b1:20) OR (a4:17 = b4:23) [outer=(14,17,20,23)]
+      │    └── inner-join (hash)
+      │         ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b1:33 b2:34 b3:35!null b4:36 rowid:37!null
+      │         ├── key: (27,28,30,37)
+      │         ├── fd: (37)-->(33-36), (29)==(35), (35)==(29)
+      │         ├── scan a
+      │         │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+      │         │    └── key: (27-30)
+      │         ├── scan b
+      │         │    ├── columns: b1:33 b2:34 b3:35 b4:36 rowid:37!null
+      │         │    ├── key: (37)
+      │         │    └── fd: (37)-->(33-36)
+      │         └── filters
+      │              ├── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+      │              └── (a1:27 = b1:33) OR (a4:30 = b4:36) [outer=(27,30,33,36)]
+      └── aggregations
+           ├── const-agg [as=b1:7, outer=(7)]
+           │    └── b1:7
+           ├── const-agg [as=b2:8, outer=(8)]
+           │    └── b2:8
+           ├── const-agg [as=b3:9, outer=(9)]
+           │    └── b3:9
+           └── const-agg [as=b4:10, outer=(10)]
+                └── b4:10
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (t1.a2 = t2.a2 OR t1.a3 = t2.a3) AND (t1.a1 = t2.a1 OR t1.a4 = t2.a4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── key: (1-4,7-10)
+ └── distinct-on
+      ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+      ├── grouping columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+      ├── key: (1-4,7-10)
+      └── union-all
+           ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+           ├── left columns: t1.a1:13 t1.a2:14 t1.a3:15 t1.a4:16 t2.a1:19 t2.a2:20 t2.a3:21 t2.a4:22
+           ├── right columns: t1.a1:25 t1.a2:26 t1.a3:27 t1.a4:28 t2.a1:31 t2.a2:32 t2.a3:33 t2.a4:34
+           ├── inner-join (hash)
+           │    ├── columns: t1.a1:13!null t1.a2:14!null t1.a3:15!null t1.a4:16!null t2.a1:19!null t2.a2:20!null t2.a3:21!null t2.a4:22!null
+           │    ├── key: (13,15,16,19-22)
+           │    ├── fd: (14)==(20), (20)==(14)
+           │    ├── scan a [as=t1]
+           │    │    ├── columns: t1.a1:13!null t1.a2:14!null t1.a3:15!null t1.a4:16!null
+           │    │    └── key: (13-16)
+           │    ├── scan a [as=t2]
+           │    │    ├── columns: t2.a1:19!null t2.a2:20!null t2.a3:21!null t2.a4:22!null
+           │    │    └── key: (19-22)
+           │    └── filters
+           │         ├── t1.a2:14 = t2.a2:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+           │         └── (t1.a1:13 = t2.a1:19) OR (t1.a4:16 = t2.a4:22) [outer=(13,16,19,22)]
+           └── inner-join (hash)
+                ├── columns: t1.a1:25!null t1.a2:26!null t1.a3:27!null t1.a4:28!null t2.a1:31!null t2.a2:32!null t2.a3:33!null t2.a4:34!null
+                ├── key: (25,26,28,31-34)
+                ├── fd: (27)==(33), (33)==(27)
+                ├── scan a [as=t1]
+                │    ├── columns: t1.a1:25!null t1.a2:26!null t1.a3:27!null t1.a4:28!null
+                │    └── key: (25-28)
+                ├── scan a [as=t2]
+                │    ├── columns: t2.a1:31!null t2.a2:32!null t2.a3:33!null t2.a4:34!null
+                │    └── key: (31-34)
+                └── filters
+                     ├── t1.a3:27 = t2.a3:33 [outer=(27,33), constraints=(/27: (/NULL - ]; /33: (/NULL - ]), fd=(27)==(33), (33)==(27)]
+                     └── (t1.a1:25 = t2.a1:31) OR (t1.a4:28 = t2.a4:34) [outer=(25,28,31,34)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3 FROM a,b WHERE (a1=b1 AND a2=b2 AND (a1=1 OR b1=1)) OR (a3=b3 AND a4=b4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10
+      └── distinct-on
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10 rowid:11!null
+           ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null rowid:11!null
+           ├── key: (1-4,11)
+           ├── fd: (1-4,11)-->(7-10)
+           ├── union-all
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b3:9 b4:10 rowid:11!null
+           │    ├── left columns: a1:14 a2:15 a3:16 a4:17 b1:20 b2:21 b3:22 b4:23 rowid:24
+           │    ├── right columns: a1:27 a2:28 a3:29 a4:30 b1:33 b2:34 b3:35 b4:36 rowid:37
+           │    ├── inner-join (merge)
+           │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20!null b2:21!null b3:22 b4:23 rowid:24!null
+           │    │    ├── left ordering: +15,+14
+           │    │    ├── right ordering: +21,+20
+           │    │    ├── key: (16,17,24)
+           │    │    ├── fd: ()-->(14,20), (24)-->(21-23), (14)==(20), (20)==(14), (15)==(21), (21)==(15)
+           │    │    ├── scan a
+           │    │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    │    │    ├── constraint: /14/15/16/17: [/1 - /1]
+           │    │    │    ├── key: (15-17)
+           │    │    │    ├── fd: ()-->(14)
+           │    │    │    └── ordering: +15 opt(14) [actual: +15]
+           │    │    ├── scan b@b_b1_b2_idx
+           │    │    │    ├── columns: b1:20!null b2:21 b3:22 b4:23 rowid:24!null
+           │    │    │    ├── constraint: /20/21/24: [/1 - /1]
+           │    │    │    ├── key: (24)
+           │    │    │    ├── fd: ()-->(20), (24)-->(21-23)
+           │    │    │    └── ordering: +21 opt(20) [actual: +21]
+           │    │    └── filters (true)
+           │    └── inner-join (hash)
+           │         ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b1:33 b2:34 b3:35!null b4:36!null rowid:37!null
+           │         ├── key: (27,28,37)
+           │         ├── fd: (37)-->(33-36), (29)==(35), (35)==(29), (30)==(36), (36)==(30)
+           │         ├── scan a
+           │         │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           │         │    └── key: (27-30)
+           │         ├── scan b
+           │         │    ├── columns: b1:33 b2:34 b3:35 b4:36 rowid:37!null
+           │         │    ├── key: (37)
+           │         │    └── fd: (37)-->(33-36)
+           │         └── filters
+           │              ├── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+           │              └── a4:30 = b4:36 [outer=(30,36), constraints=(/30: (/NULL - ]; /36: (/NULL - ]), fd=(30)==(36), (36)==(30)]
+           └── aggregations
+                ├── const-agg [as=b1:7, outer=(7)]
+                │    └── b1:7
+                ├── const-agg [as=b2:8, outer=(8)]
+                │    └── b2:8
+                ├── const-agg [as=b3:9, outer=(9)]
+                │    └── b3:9
+                └── const-agg [as=b4:10, outer=(10)]
+                     └── b4:10
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3 FROM a,b WHERE a1=1 AND (a2=b2 OR a3=b3)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ ├── fd: ()-->(1)
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null b2:8 b3:9
+      ├── fd: ()-->(1)
+      └── distinct-on
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b2:8 b3:9 rowid:11!null
+           ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null rowid:11!null
+           ├── key: (1-4,11)
+           ├── fd: (1-4,11)-->(8,9)
+           ├── union-all
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b2:8 b3:9 rowid:11!null
+           │    ├── left columns: a1:14 a2:15 a3:16 a4:17 b2:21 b3:22 rowid:24
+           │    ├── right columns: a1:27 a2:28 a3:29 a4:30 b2:34 b3:35 rowid:37
+           │    ├── inner-join (lookup b@b_b2_idx)
+           │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b2:21!null b3:22 rowid:24!null
+           │    │    ├── key columns: [15] = [21]
+           │    │    ├── key: (16,17,24)
+           │    │    ├── fd: ()-->(14), (24)-->(21,22), (15)==(21), (21)==(15)
+           │    │    ├── scan a
+           │    │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    │    │    ├── constraint: /14/15/16/17: [/1 - /1]
+           │    │    │    ├── key: (15-17)
+           │    │    │    └── fd: ()-->(14)
+           │    │    └── filters (true)
+           │    └── inner-join (lookup b@b_b3_idx)
+           │         ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b2:34 b3:35!null rowid:37!null
+           │         ├── key columns: [29] = [35]
+           │         ├── key: (28,30,37)
+           │         ├── fd: ()-->(27), (37)-->(34,35), (29)==(35), (35)==(29)
+           │         ├── scan a
+           │         │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           │         │    ├── constraint: /27/28/29/30: [/1 - /1]
+           │         │    ├── key: (28-30)
+           │         │    └── fd: ()-->(27)
+           │         └── filters (true)
+           └── aggregations
+                ├── const-agg [as=b2:8, outer=(8)]
+                │    └── b2:8
+                └── const-agg [as=b3:9, outer=(9)]
+                     └── b3:9
+
+# More than one disjunction in the filter
+build-cascades expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a, c WHERE (a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+----
+root
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8 c3:9 c4:10
+      └── select
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6 c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           ├── key: (1-4,11)
+           ├── fd: (1-4)-->(5,6), (11)-->(7-10,12,13)
+           ├── inner-join (cross)
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6 c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           │    ├── key: (1-4,11)
+           │    ├── fd: (1-4)-->(5,6), (11)-->(7-10,12,13)
+           │    ├── scan a
+           │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6
+           │    │    ├── key: (1-4)
+           │    │    └── fd: (1-4)-->(5,6)
+           │    ├── scan c
+           │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           │    │    ├── key: (11)
+           │    │    └── fd: (11)-->(7-10,12,13)
+           │    └── filters (true)
+           └── filters
+                └── (((a1:1 = c1:7) OR (a2:2 = c2:8)) OR (a3:3 = c3:9)) OR (a4:4 = c4:10) [outer=(1-4,7-10)]
+
+build-cascades expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a, c WHERE (a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+----
+root
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8 c3:9 c4:10
+      └── select
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6 c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           ├── key: (1-4,11)
+           ├── fd: (1-4)-->(5,6), (11)-->(7-10,12,13)
+           ├── inner-join (cross)
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6 c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           │    ├── key: (1-4,11)
+           │    ├── fd: (1-4)-->(5,6), (11)-->(7-10,12,13)
+           │    ├── scan a
+           │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6
+           │    │    ├── key: (1-4)
+           │    │    └── fd: (1-4)-->(5,6)
+           │    ├── scan c
+           │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 rowid:11!null c.crdb_internal_mvcc_timestamp:12 c.tableoid:13
+           │    │    ├── key: (11)
+           │    │    └── fd: (11)-->(7-10,12,13)
+           │    └── filters (true)
+           └── filters
+                └── (((a1:1 = c2:8) OR (a2:2 = c1:7)) OR (a3:3 = c4:10)) OR (a3:3 = c4:10) [outer=(1-3,7,8,10)]
+
+# Equality filters that do not reference a column on each side of the join
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM b, d WHERE (b1 = b2 OR b3 = d3)
+----
+project
+ ├── columns: b1:1 b2:2 b3:3 b4:4 d1:8 d2:9 d3:10 d4:11
+ └── distinct-on
+      ├── columns: b1:1 b2:2 b3:3 b4:4 b.rowid:5!null d1:8 d2:9 d3:10 d4:11 d.rowid:12!null
+      ├── grouping columns: b.rowid:5!null d.rowid:12!null
+      ├── key: (5,12)
+      ├── fd: (5,12)-->(1-4,8-11)
+      ├── union-all
+      │    ├── columns: b1:1 b2:2 b3:3 b4:4 b.rowid:5!null d1:8 d2:9 d3:10 d4:11 d.rowid:12!null
+      │    ├── left columns: b1:15 b2:16 b3:17 b4:18 b.rowid:19 d1:22 d2:23 d3:24 d4:25 d.rowid:26
+      │    ├── right columns: b1:29 b2:30 b3:31 b4:32 b.rowid:33 d1:36 d2:37 d3:38 d4:39 d.rowid:40
+      │    ├── inner-join (hash)
+      │    │    ├── columns: b1:15 b2:16 b3:17!null b4:18 b.rowid:19!null d1:22 d2:23 d3:24!null d4:25 d.rowid:26!null
+      │    │    ├── key: (19,26)
+      │    │    ├── fd: (19)-->(15-18), (26)-->(22-25), (17)==(24), (24)==(17)
+      │    │    ├── scan b
+      │    │    │    ├── columns: b1:15 b2:16 b3:17 b4:18 b.rowid:19!null
+      │    │    │    ├── key: (19)
+      │    │    │    └── fd: (19)-->(15-18)
+      │    │    ├── scan d
+      │    │    │    ├── columns: d1:22 d2:23 d3:24 d4:25 d.rowid:26!null
+      │    │    │    ├── key: (26)
+      │    │    │    └── fd: (26)-->(22-25)
+      │    │    └── filters
+      │    │         └── b3:17 = d3:24 [outer=(17,24), constraints=(/17: (/NULL - ]; /24: (/NULL - ]), fd=(17)==(24), (24)==(17)]
+      │    └── inner-join (cross)
+      │         ├── columns: b1:29!null b2:30!null b3:31 b4:32 b.rowid:33!null d1:36 d2:37 d3:38 d4:39 d.rowid:40!null
+      │         ├── key: (33,40)
+      │         ├── fd: (33)-->(29-32), (29)==(30), (30)==(29), (40)-->(36-39)
+      │         ├── scan d
+      │         │    ├── columns: d1:36 d2:37 d3:38 d4:39 d.rowid:40!null
+      │         │    ├── key: (40)
+      │         │    └── fd: (40)-->(36-39)
+      │         ├── select
+      │         │    ├── columns: b1:29!null b2:30!null b3:31 b4:32 b.rowid:33!null
+      │         │    ├── key: (33)
+      │         │    ├── fd: (33)-->(29-32), (29)==(30), (30)==(29)
+      │         │    ├── scan b@b_b1_b2_idx
+      │         │    │    ├── columns: b1:29!null b2:30 b3:31 b4:32 b.rowid:33!null
+      │         │    │    ├── constraint: /29/30/33: (/NULL - ]
+      │         │    │    ├── key: (33)
+      │         │    │    └── fd: (33)-->(29-32)
+      │         │    └── filters
+      │         │         └── b1:29 = b2:30 [outer=(29,30), constraints=(/29: (/NULL - ]; /30: (/NULL - ]), fd=(29)==(30), (30)==(29)]
+      │         └── filters (true)
+      └── aggregations
+           ├── const-agg [as=b1:1, outer=(1)]
+           │    └── b1:1
+           ├── const-agg [as=b2:2, outer=(2)]
+           │    └── b2:2
+           ├── const-agg [as=b3:3, outer=(3)]
+           │    └── b3:3
+           ├── const-agg [as=b4:4, outer=(4)]
+           │    └── b4:4
+           ├── const-agg [as=d1:8, outer=(8)]
+           │    └── d1:8
+           ├── const-agg [as=d2:9, outer=(9)]
+           │    └── d2:9
+           ├── const-agg [as=d3:10, outer=(10)]
+           │    └── d3:10
+           └── const-agg [as=d4:11, outer=(11)]
+                └── d4:11
+
+build-cascades expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM b, d WHERE (b1 = b2 OR b3 = d3 OR b4 = d4 OR d1 = d2)
+----
+root
+ └── project
+      ├── columns: b1:1 b2:2 b3:3 b4:4 d1:8 d2:9 d3:10 d4:11
+      └── select
+           ├── columns: b1:1 b2:2 b3:3 b4:4 b.rowid:5!null b.crdb_internal_mvcc_timestamp:6 b.tableoid:7 d1:8 d2:9 d3:10 d4:11 d.rowid:12!null d.crdb_internal_mvcc_timestamp:13 d.tableoid:14
+           ├── key: (5,12)
+           ├── fd: (5)-->(1-4,6,7), (12)-->(8-11,13,14)
+           ├── inner-join (cross)
+           │    ├── columns: b1:1 b2:2 b3:3 b4:4 b.rowid:5!null b.crdb_internal_mvcc_timestamp:6 b.tableoid:7 d1:8 d2:9 d3:10 d4:11 d.rowid:12!null d.crdb_internal_mvcc_timestamp:13 d.tableoid:14
+           │    ├── key: (5,12)
+           │    ├── fd: (5)-->(1-4,6,7), (12)-->(8-11,13,14)
+           │    ├── scan b
+           │    │    ├── columns: b1:1 b2:2 b3:3 b4:4 b.rowid:5!null b.crdb_internal_mvcc_timestamp:6 b.tableoid:7
+           │    │    ├── key: (5)
+           │    │    └── fd: (5)-->(1-4,6,7)
+           │    ├── scan d
+           │    │    ├── columns: d1:8 d2:9 d3:10 d4:11 d.rowid:12!null d.crdb_internal_mvcc_timestamp:13 d.tableoid:14
+           │    │    ├── key: (12)
+           │    │    └── fd: (12)-->(8-11,13,14)
+           │    └── filters (true)
+           └── filters
+                └── (((b1:1 = b2:2) OR (b3:3 = d3:10)) OR (b4:4 = d4:11)) OR (d1:8 = d2:9) [outer=(1-4,8-11)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM b, d WHERE (b1 = 0 OR b1 = d1)   AND
+                         (b1 = 0 OR b2 = 5)    AND
+                         (b2 = d1 OR b1 = d1)  AND
+                         (b2 = d1 OR b2 = 5)
+----
+project
+ ├── columns: b1:1!null b2:2!null b3:3 b4:4 d1:8!null d2:9 d3:10 d4:11
+ └── distinct-on
+      ├── columns: b1:1!null b2:2!null b3:3 b4:4 b.rowid:5!null d1:8!null d2:9 d3:10 d4:11 d.rowid:12!null
+      ├── grouping columns: b.rowid:5!null d.rowid:12!null
+      ├── key: (5,12)
+      ├── fd: (5,12)-->(1-4,8-11)
+      ├── union-all
+      │    ├── columns: b1:1!null b2:2!null b3:3 b4:4 b.rowid:5!null d1:8!null d2:9 d3:10 d4:11 d.rowid:12!null
+      │    ├── left columns: b1:29 b2:30 b3:31 b4:32 b.rowid:33 d1:36 d2:37 d3:38 d4:39 d.rowid:40
+      │    ├── right columns: b1:43 b2:44 b3:45 b4:46 b.rowid:47 d1:50 d2:51 d3:52 d4:53 d.rowid:54
+      │    ├── inner-join (lookup d@d)
+      │    │    ├── columns: b1:29!null b2:30!null b3:31 b4:32 b.rowid:33!null d1:36!null d2:37 d3:38 d4:39 d.rowid:40!null
+      │    │    ├── key columns: [29] = [36]
+      │    │    ├── key: (33,40)
+      │    │    ├── fd: (33)-->(29-32), (40)-->(36-39), (29)==(36), (36)==(29)
+      │    │    ├── distinct-on
+      │    │    │    ├── columns: b1:29!null b2:30!null b3:31 b4:32 b.rowid:33!null
+      │    │    │    ├── grouping columns: b.rowid:33!null
+      │    │    │    ├── key: (33)
+      │    │    │    ├── fd: (33)-->(29-32)
+      │    │    │    ├── union-all
+      │    │    │    │    ├── columns: b1:29!null b2:30!null b3:31 b4:32 b.rowid:33!null
+      │    │    │    │    ├── left columns: b1:57 b2:58 b3:59 b4:60 b.rowid:61
+      │    │    │    │    ├── right columns: b1:64 b2:65 b3:66 b4:67 b.rowid:68
+      │    │    │    │    ├── scan b@b_b1_b2_idx
+      │    │    │    │    │    ├── columns: b1:57!null b2:58!null b3:59 b4:60 b.rowid:61!null
+      │    │    │    │    │    ├── constraint: /57/58/61
+      │    │    │    │    │    │    ├── [/0/0 - /0/0]
+      │    │    │    │    │    │    └── [/0/5 - /0/5]
+      │    │    │    │    │    ├── key: (61)
+      │    │    │    │    │    └── fd: ()-->(57), (61)-->(58-60)
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: b1:64!null b2:65!null b3:66 b4:67 b.rowid:68!null
+      │    │    │    │         ├── key: (68)
+      │    │    │    │         ├── fd: ()-->(65), (68)-->(64,66,67)
+      │    │    │    │         ├── scan b@b_b2_idx
+      │    │    │    │         │    ├── columns: b1:64 b2:65!null b3:66 b4:67 b.rowid:68!null
+      │    │    │    │         │    ├── constraint: /65/68: [/5 - /5]
+      │    │    │    │         │    ├── key: (68)
+      │    │    │    │         │    └── fd: ()-->(65), (68)-->(64,66,67)
+      │    │    │    │         └── filters
+      │    │    │    │              └── (b1:64 = 5) OR ((b1:64 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) [outer=(64), constraints=(/64: (/NULL - ]; tight)]
+      │    │    │    └── aggregations
+      │    │    │         ├── const-agg [as=b1:29, outer=(29)]
+      │    │    │         │    └── b1:29
+      │    │    │         ├── const-agg [as=b2:30, outer=(30)]
+      │    │    │         │    └── b2:30
+      │    │    │         ├── const-agg [as=b3:31, outer=(31)]
+      │    │    │         │    └── b3:31
+      │    │    │         └── const-agg [as=b4:32, outer=(32)]
+      │    │    │              └── b4:32
+      │    │    └── filters (true)
+      │    └── project
+      │         ├── columns: b1:43!null b2:44!null b3:45 b4:46 b.rowid:47!null d1:50!null d2:51 d3:52 d4:53 d.rowid:54!null
+      │         ├── key: (47,54)
+      │         ├── fd: ()-->(43), (47)-->(44-46), (54)-->(50-53)
+      │         └── distinct-on
+      │              ├── columns: b1:43!null b2:44!null b3:45 b4:46 b.rowid:47!null d1:50!null d2:51 d3:52 d4:53 d.rowid:54!null
+      │              ├── grouping columns: b.rowid:47!null d.rowid:54!null
+      │              ├── key: (47,54)
+      │              ├── fd: (47,54)-->(43-46,50-53)
+      │              ├── union-all
+      │              │    ├── columns: b1:43!null b2:44!null b3:45 b4:46 b.rowid:47!null d1:50!null d2:51 d3:52 d4:53 d.rowid:54!null
+      │              │    ├── left columns: b1:71 b2:72 b3:73 b4:74 b.rowid:75 d1:78 d2:79 d3:80 d4:81 d.rowid:82
+      │              │    ├── right columns: b1:85 b2:86 b3:87 b4:88 b.rowid:89 d1:92 d2:93 d3:94 d4:95 d.rowid:96
+      │              │    ├── inner-join (lookup d@d)
+      │              │    │    ├── columns: b1:71!null b2:72!null b3:73 b4:74 b.rowid:75!null d1:78!null d2:79 d3:80 d4:81 d.rowid:82!null
+      │              │    │    ├── key columns: [72] = [78]
+      │              │    │    ├── key: (75,82)
+      │              │    │    ├── fd: ()-->(71), (75)-->(72-74), (82)-->(78-81), (72)==(78), (78)==(72)
+      │              │    │    ├── scan b@b_b1_b2_idx
+      │              │    │    │    ├── columns: b1:71!null b2:72!null b3:73 b4:74 b.rowid:75!null
+      │              │    │    │    ├── constraint: /71/72/75: (/0/NULL - /0]
+      │              │    │    │    ├── key: (75)
+      │              │    │    │    └── fd: ()-->(71), (75)-->(72-74)
+      │              │    │    └── filters
+      │              │    │         └── ((d1:78 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) OR (d1:78 = 5) [outer=(78), constraints=(/78: (/NULL - ]; tight)]
+      │              │    └── inner-join (lookup d@d)
+      │              │         ├── columns: b1:85!null b2:86!null b3:87 b4:88 b.rowid:89!null d1:92!null d2:93 d3:94 d4:95 d.rowid:96!null
+      │              │         ├── key columns: [85] = [92]
+      │              │         ├── key: (89,96)
+      │              │         ├── fd: ()-->(85,92), (89)-->(86-88), (96)-->(93-95), (85)==(92), (92)==(85)
+      │              │         ├── scan b@b_b1_b2_idx
+      │              │         │    ├── columns: b1:85!null b2:86!null b3:87 b4:88 b.rowid:89!null
+      │              │         │    ├── constraint: /85/86/89
+      │              │         │    │    ├── [/0/0 - /0/0]
+      │              │         │    │    └── [/0/5 - /0/5]
+      │              │         │    ├── key: (89)
+      │              │         │    └── fd: ()-->(85), (89)-->(86-88)
+      │              │         └── filters (true)
+      │              └── aggregations
+      │                   ├── const-agg [as=b1:43, outer=(43)]
+      │                   │    └── b1:43
+      │                   ├── const-agg [as=b2:44, outer=(44)]
+      │                   │    └── b2:44
+      │                   ├── const-agg [as=b3:45, outer=(45)]
+      │                   │    └── b3:45
+      │                   ├── const-agg [as=b4:46, outer=(46)]
+      │                   │    └── b4:46
+      │                   ├── const-agg [as=d1:50, outer=(50)]
+      │                   │    └── d1:50
+      │                   ├── const-agg [as=d2:51, outer=(51)]
+      │                   │    └── d2:51
+      │                   ├── const-agg [as=d3:52, outer=(52)]
+      │                   │    └── d3:52
+      │                   └── const-agg [as=d4:53, outer=(53)]
+      │                        └── d4:53
+      └── aggregations
+           ├── const-agg [as=b1:1, outer=(1)]
+           │    └── b1:1
+           ├── const-agg [as=b2:2, outer=(2)]
+           │    └── b2:2
+           ├── const-agg [as=b3:3, outer=(3)]
+           │    └── b3:3
+           ├── const-agg [as=b4:4, outer=(4)]
+           │    └── b4:4
+           ├── const-agg [as=d1:8, outer=(8)]
+           │    └── d1:8
+           ├── const-agg [as=d2:9, outer=(9)]
+           │    └── d2:9
+           ├── const-agg [as=d3:10, outer=(10)]
+           │    └── d3:10
+           └── const-agg [as=d4:11, outer=(11)]
+                └── d4:11
+
+# ON filters that are a disjunction of equality filters AND And expressions
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM c, d WHERE (c1 = d1 AND c2 = d2) OR c3 = d3
+----
+project
+ ├── columns: c1:1 c2:2 c3:3 c4:4 d1:8 d2:9 d3:10 d4:11
+ └── distinct-on
+      ├── columns: c1:1 c2:2 c3:3 c4:4 c.rowid:5!null d1:8 d2:9 d3:10 d4:11 d.rowid:12!null
+      ├── grouping columns: c.rowid:5!null d.rowid:12!null
+      ├── key: (5,12)
+      ├── fd: (5,12)-->(1-4,8-11)
+      ├── union-all
+      │    ├── columns: c1:1 c2:2 c3:3 c4:4 c.rowid:5!null d1:8 d2:9 d3:10 d4:11 d.rowid:12!null
+      │    ├── left columns: c1:15 c2:16 c3:17 c4:18 c.rowid:19 d1:22 d2:23 d3:24 d4:25 d.rowid:26
+      │    ├── right columns: c1:29 c2:30 c3:31 c4:32 c.rowid:33 d1:36 d2:37 d3:38 d4:39 d.rowid:40
+      │    ├── inner-join (hash)
+      │    │    ├── columns: c1:15!null c2:16!null c3:17 c4:18 c.rowid:19!null d1:22!null d2:23!null d3:24 d4:25 d.rowid:26!null
+      │    │    ├── key: (19,26)
+      │    │    ├── fd: (19)-->(15-18), (26)-->(22-25), (15)==(22), (22)==(15), (16)==(23), (23)==(16)
+      │    │    ├── scan c
+      │    │    │    ├── columns: c1:15 c2:16 c3:17 c4:18 c.rowid:19!null
+      │    │    │    ├── key: (19)
+      │    │    │    └── fd: (19)-->(15-18)
+      │    │    ├── scan d
+      │    │    │    ├── columns: d1:22 d2:23 d3:24 d4:25 d.rowid:26!null
+      │    │    │    ├── key: (26)
+      │    │    │    └── fd: (26)-->(22-25)
+      │    │    └── filters
+      │    │         ├── c1:15 = d1:22 [outer=(15,22), constraints=(/15: (/NULL - ]; /22: (/NULL - ]), fd=(15)==(22), (22)==(15)]
+      │    │         └── c2:16 = d2:23 [outer=(16,23), constraints=(/16: (/NULL - ]; /23: (/NULL - ]), fd=(16)==(23), (23)==(16)]
+      │    └── inner-join (hash)
+      │         ├── columns: c1:29 c2:30 c3:31!null c4:32 c.rowid:33!null d1:36 d2:37 d3:38!null d4:39 d.rowid:40!null
+      │         ├── key: (33,40)
+      │         ├── fd: (33)-->(29-32), (40)-->(36-39), (31)==(38), (38)==(31)
+      │         ├── scan c
+      │         │    ├── columns: c1:29 c2:30 c3:31 c4:32 c.rowid:33!null
+      │         │    ├── key: (33)
+      │         │    └── fd: (33)-->(29-32)
+      │         ├── scan d
+      │         │    ├── columns: d1:36 d2:37 d3:38 d4:39 d.rowid:40!null
+      │         │    ├── key: (40)
+      │         │    └── fd: (40)-->(36-39)
+      │         └── filters
+      │              └── c3:31 = d3:38 [outer=(31,38), constraints=(/31: (/NULL - ]; /38: (/NULL - ]), fd=(31)==(38), (38)==(31)]
+      └── aggregations
+           ├── const-agg [as=c1:1, outer=(1)]
+           │    └── c1:1
+           ├── const-agg [as=c2:2, outer=(2)]
+           │    └── c2:2
+           ├── const-agg [as=c3:3, outer=(3)]
+           │    └── c3:3
+           ├── const-agg [as=c4:4, outer=(4)]
+           │    └── c4:4
+           ├── const-agg [as=d1:8, outer=(8)]
+           │    └── d1:8
+           ├── const-agg [as=d2:9, outer=(9)]
+           │    └── d2:9
+           ├── const-agg [as=d3:10, outer=(10)]
+           │    └── d3:10
+           └── const-agg [as=d4:11, outer=(11)]
+                └── d4:11
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a, d WHERE (a1 = d2 AND a2 = d1) OR (a3 = d4 AND a4 = d3)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null d1:7 d2:8 d3:9 d4:10
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null d1:7 d2:8 d3:9 d4:10 rowid:11!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null rowid:11!null
+      ├── key: (1-4,11)
+      ├── fd: (1-4,11)-->(7-10)
+      ├── union-all
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null d1:7 d2:8 d3:9 d4:10 rowid:11!null
+      │    ├── left columns: a1:14 a2:15 a3:16 a4:17 d1:20 d2:21 d3:22 d4:23 rowid:24
+      │    ├── right columns: a1:27 a2:28 a3:29 a4:30 d1:33 d2:34 d3:35 d4:36 rowid:37
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null d1:20!null d2:21!null d3:22 d4:23 rowid:24!null
+      │    │    ├── key: (16,17,24)
+      │    │    ├── fd: (24)-->(20-23), (14)==(21), (21)==(14), (15)==(20), (20)==(15)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    │    └── key: (14-17)
+      │    │    ├── scan d
+      │    │    │    ├── columns: d1:20 d2:21 d3:22 d4:23 rowid:24!null
+      │    │    │    ├── key: (24)
+      │    │    │    └── fd: (24)-->(20-23)
+      │    │    └── filters
+      │    │         ├── a1:14 = d2:21 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
+      │    │         └── a2:15 = d1:20 [outer=(15,20), constraints=(/15: (/NULL - ]; /20: (/NULL - ]), fd=(15)==(20), (20)==(15)]
+      │    └── inner-join (hash)
+      │         ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null d1:33 d2:34 d3:35!null d4:36!null rowid:37!null
+      │         ├── key: (27,28,37)
+      │         ├── fd: (37)-->(33-36), (29)==(36), (36)==(29), (30)==(35), (35)==(30)
+      │         ├── scan a
+      │         │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+      │         │    └── key: (27-30)
+      │         ├── scan d
+      │         │    ├── columns: d1:33 d2:34 d3:35 d4:36 rowid:37!null
+      │         │    ├── key: (37)
+      │         │    └── fd: (37)-->(33-36)
+      │         └── filters
+      │              ├── a3:29 = d4:36 [outer=(29,36), constraints=(/29: (/NULL - ]; /36: (/NULL - ]), fd=(29)==(36), (36)==(29)]
+      │              └── a4:30 = d3:35 [outer=(30,35), constraints=(/30: (/NULL - ]; /35: (/NULL - ]), fd=(30)==(35), (35)==(30)]
+      └── aggregations
+           ├── const-agg [as=d1:7, outer=(7)]
+           │    └── d1:7
+           ├── const-agg [as=d2:8, outer=(8)]
+           │    └── d2:8
+           ├── const-agg [as=d3:9, outer=(9)]
+           │    └── d3:9
+           └── const-agg [as=d4:10, outer=(10)]
+                └── d4:10
+
+#########################
+# Uncorrelated semijoin #
+#########################
+
+# Join of tables with compound primary keys
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM d WHERE d1 = 4 OR d2 = 50)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── exists [subquery]
+           └── limit
+                ├── columns: d1:7 d2:8
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7,8)
+                ├── select
+                │    ├── columns: d1:7 d2:8
+                │    ├── limit hint: 1.00
+                │    ├── scan d
+                │    │    ├── columns: d1:7 d2:8
+                │    │    └── limit hint: 50.00
+                │    └── filters
+                │         └── (d1:7 = 4) OR (d2:8 = 50) [outer=(7,8)]
+                └── 1
+
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 HAVING sum(d4) > 40)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── immutable
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── exists [immutable, subquery]
+           └── select
+                ├── columns: sum:21!null
+                ├── cardinality: [0 - 1]
+                ├── immutable
+                ├── key: ()
+                ├── fd: ()-->(21)
+                ├── scalar-group-by
+                │    ├── columns: sum:21
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(21)
+                │    ├── inner-join (cross)
+                │    │    ├── columns: c2:8 d1:14 d4:17
+                │    │    ├── scan c
+                │    │    │    └── columns: c2:8
+                │    │    ├── scan d
+                │    │    │    └── columns: d1:14 d4:17
+                │    │    └── filters
+                │    │         └── (d1:14 = 4) OR (c2:8 = 50) [outer=(8,14)]
+                │    └── aggregations
+                │         └── sum [as=sum:21, outer=(17)]
+                │              └── d4:17
+                └── filters
+                     └── sum:21 > 40 [outer=(21), immutable, constraints=(/21: (/40 - ]; tight)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE c1 = d2 or c2 = d1)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── exists [subquery]
+           └── limit
+                ├── columns: c1:7 c2:8 d1:14 d2:15
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(7,8,14,15)
+                ├── project
+                │    ├── columns: c1:7 c2:8 d1:14 d2:15
+                │    ├── limit hint: 1.00
+                │    └── distinct-on
+                │         ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
+                │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+                │         ├── key: (11,18)
+                │         ├── fd: (11,18)-->(7,8,14,15)
+                │         ├── limit hint: 1.00
+                │         ├── union-all
+                │         │    ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
+                │         │    ├── left columns: c1:22 c2:23 c.rowid:26 d1:29 d2:30 d.rowid:33
+                │         │    ├── right columns: c1:36 c2:37 c.rowid:40 d1:43 d2:44 d.rowid:47
+                │         │    ├── limit hint: 1.20
+                │         │    ├── inner-join (hash)
+                │         │    │    ├── columns: c1:22!null c2:23 c.rowid:26!null d1:29 d2:30!null d.rowid:33!null
+                │         │    │    ├── key: (26,33)
+                │         │    │    ├── fd: (26)-->(22,23), (33)-->(29,30), (22)==(30), (30)==(22)
+                │         │    │    ├── limit hint: 1.20
+                │         │    │    ├── scan c
+                │         │    │    │    ├── columns: c1:22 c2:23 c.rowid:26!null
+                │         │    │    │    ├── key: (26)
+                │         │    │    │    └── fd: (26)-->(22,23)
+                │         │    │    ├── scan d
+                │         │    │    │    ├── columns: d1:29 d2:30 d.rowid:33!null
+                │         │    │    │    ├── key: (33)
+                │         │    │    │    └── fd: (33)-->(29,30)
+                │         │    │    └── filters
+                │         │    │         └── c1:22 = d2:30 [outer=(22,30), constraints=(/22: (/NULL - ]; /30: (/NULL - ]), fd=(22)==(30), (30)==(22)]
+                │         │    └── inner-join (hash)
+                │         │         ├── columns: c1:36 c2:37!null c.rowid:40!null d1:43!null d2:44 d.rowid:47!null
+                │         │         ├── key: (40,47)
+                │         │         ├── fd: (40)-->(36,37), (47)-->(43,44), (37)==(43), (43)==(37)
+                │         │         ├── limit hint: 1.20
+                │         │         ├── scan c
+                │         │         │    ├── columns: c1:36 c2:37 c.rowid:40!null
+                │         │         │    ├── key: (40)
+                │         │         │    └── fd: (40)-->(36,37)
+                │         │         ├── scan d
+                │         │         │    ├── columns: d1:43 d2:44 d.rowid:47!null
+                │         │         │    ├── key: (47)
+                │         │         │    └── fd: (47)-->(43,44)
+                │         │         └── filters
+                │         │              └── c2:37 = d1:43 [outer=(37,43), constraints=(/37: (/NULL - ]; /43: (/NULL - ]), fd=(37)==(43), (43)==(37)]
+                │         └── aggregations
+                │              ├── const-agg [as=c1:7, outer=(7)]
+                │              │    └── c1:7
+                │              ├── const-agg [as=c2:8, outer=(8)]
+                │              │    └── c2:8
+                │              ├── const-agg [as=d1:14, outer=(14)]
+                │              │    └── d1:14
+                │              └── const-agg [as=d2:15, outer=(15)]
+                │                   └── d2:15
+                └── 1
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)
+----
+semi-join (hash)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── project
+ │    ├── columns: c1:7 c3:9!null d1:14 d3:16 d4:17
+ │    └── distinct-on
+ │         ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
+ │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+ │         ├── key: (11,18)
+ │         ├── fd: (11,18)-->(7,9,14,16,17)
+ │         ├── union-all
+ │         │    ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
+ │         │    ├── left columns: c1:22 c3:24 c.rowid:26 d1:29 d3:31 d4:32 d.rowid:33
+ │         │    ├── right columns: c1:36 c3:38 c.rowid:40 d1:43 d3:45 d4:46 d.rowid:47
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: c1:22 c3:24!null c.rowid:26!null d1:29 d3:31!null d4:32 d.rowid:33!null
+ │         │    │    ├── key: (26,33)
+ │         │    │    ├── fd: (26)-->(22,24), (33)-->(29,31,32), (24)==(31), (31)==(24)
+ │         │    │    ├── scan c
+ │         │    │    │    ├── columns: c1:22 c3:24 c.rowid:26!null
+ │         │    │    │    ├── key: (26)
+ │         │    │    │    └── fd: (26)-->(22,24)
+ │         │    │    ├── scan d
+ │         │    │    │    ├── columns: d1:29 d3:31 d4:32 d.rowid:33!null
+ │         │    │    │    ├── key: (33)
+ │         │    │    │    └── fd: (33)-->(29,31,32)
+ │         │    │    └── filters
+ │         │    │         └── c3:24 = d3:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │         │    └── inner-join (hash)
+ │         │         ├── columns: c1:36 c3:38!null c.rowid:40!null d1:43 d3:45 d4:46!null d.rowid:47!null
+ │         │         ├── key: (40,47)
+ │         │         ├── fd: (40)-->(36,38), (47)-->(43,45,46), (38)==(46), (46)==(38)
+ │         │         ├── scan c
+ │         │         │    ├── columns: c1:36 c3:38 c.rowid:40!null
+ │         │         │    ├── key: (40)
+ │         │         │    └── fd: (40)-->(36,38)
+ │         │         ├── scan d
+ │         │         │    ├── columns: d1:43 d3:45 d4:46 d.rowid:47!null
+ │         │         │    ├── key: (47)
+ │         │         │    └── fd: (47)-->(43,45,46)
+ │         │         └── filters
+ │         │              └── c3:38 = d4:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
+ │         └── aggregations
+ │              ├── const-agg [as=c1:7, outer=(7)]
+ │              │    └── c1:7
+ │              ├── const-agg [as=c3:9, outer=(9)]
+ │              │    └── c3:9
+ │              ├── const-agg [as=d1:14, outer=(14)]
+ │              │    └── d1:14
+ │              ├── const-agg [as=d3:16, outer=(16)]
+ │              │    └── d3:16
+ │              └── const-agg [as=d4:17, outer=(17)]
+ │                   └── d4:17
+ └── filters
+      ├── c1:7 = a1:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+      └── d1:14 = a2:2 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2 EXCEPT ALL
+                                   SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2)
+----
+semi-join (hash)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── except-all
+ │    ├── columns: c1:7 d1:14
+ │    ├── left columns: c1:7 d1:14
+ │    ├── right columns: c1:21 d1:28
+ │    ├── project
+ │    │    ├── columns: c1:7 d1:14
+ │    │    └── project
+ │    │         ├── columns: c1:7 c2:8 c3:9 d1:14 d2:15 d3:16
+ │    │         └── distinct-on
+ │    │              ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
+ │    │              ├── grouping columns: c.rowid:11!null d.rowid:18!null
+ │    │              ├── key: (11,18)
+ │    │              ├── fd: (11,18)-->(7-9,14-16)
+ │    │              ├── union-all
+ │    │              │    ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
+ │    │              │    ├── left columns: c1:36 c2:37 c3:38 c.rowid:40 d1:43 d2:44 d3:45 d.rowid:47
+ │    │              │    ├── right columns: c1:50 c2:51 c3:52 c.rowid:54 d1:57 d2:58 d3:59 d.rowid:61
+ │    │              │    ├── inner-join (hash)
+ │    │              │    │    ├── columns: c1:36 c2:37 c3:38!null c.rowid:40!null d1:43 d2:44 d3:45!null d.rowid:47!null
+ │    │              │    │    ├── key: (40,47)
+ │    │              │    │    ├── fd: (40)-->(36-38), (47)-->(43-45), (38)==(45), (45)==(38)
+ │    │              │    │    ├── scan c
+ │    │              │    │    │    ├── columns: c1:36 c2:37 c3:38 c.rowid:40!null
+ │    │              │    │    │    ├── key: (40)
+ │    │              │    │    │    └── fd: (40)-->(36-38)
+ │    │              │    │    ├── scan d
+ │    │              │    │    │    ├── columns: d1:43 d2:44 d3:45 d.rowid:47!null
+ │    │              │    │    │    ├── key: (47)
+ │    │              │    │    │    └── fd: (47)-->(43-45)
+ │    │              │    │    └── filters
+ │    │              │    │         └── c3:38 = d3:45 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
+ │    │              │    └── inner-join (hash)
+ │    │              │         ├── columns: c1:50 c2:51!null c3:52 c.rowid:54!null d1:57 d2:58!null d3:59 d.rowid:61!null
+ │    │              │         ├── key: (54,61)
+ │    │              │         ├── fd: (54)-->(50-52), (61)-->(57-59), (51)==(58), (58)==(51)
+ │    │              │         ├── scan c
+ │    │              │         │    ├── columns: c1:50 c2:51 c3:52 c.rowid:54!null
+ │    │              │         │    ├── key: (54)
+ │    │              │         │    └── fd: (54)-->(50-52)
+ │    │              │         ├── scan d
+ │    │              │         │    ├── columns: d1:57 d2:58 d3:59 d.rowid:61!null
+ │    │              │         │    ├── key: (61)
+ │    │              │         │    └── fd: (61)-->(57-59)
+ │    │              │         └── filters
+ │    │              │              └── c2:51 = d2:58 [outer=(51,58), constraints=(/51: (/NULL - ]; /58: (/NULL - ]), fd=(51)==(58), (58)==(51)]
+ │    │              └── aggregations
+ │    │                   ├── const-agg [as=c1:7, outer=(7)]
+ │    │                   │    └── c1:7
+ │    │                   ├── const-agg [as=c2:8, outer=(8)]
+ │    │                   │    └── c2:8
+ │    │                   ├── const-agg [as=c3:9, outer=(9)]
+ │    │                   │    └── c3:9
+ │    │                   ├── const-agg [as=d1:14, outer=(14)]
+ │    │                   │    └── d1:14
+ │    │                   ├── const-agg [as=d2:15, outer=(15)]
+ │    │                   │    └── d2:15
+ │    │                   └── const-agg [as=d3:16, outer=(16)]
+ │    │                        └── d3:16
+ │    └── project
+ │         ├── columns: c1:21 d1:28
+ │         └── project
+ │              ├── columns: c1:21 c2:22 c3:23 d1:28 d2:29 d3:30
+ │              └── distinct-on
+ │                   ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
+ │                   ├── grouping columns: c.rowid:25!null d.rowid:32!null
+ │                   ├── key: (25,32)
+ │                   ├── fd: (25,32)-->(21-23,28-30)
+ │                   ├── union-all
+ │                   │    ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
+ │                   │    ├── left columns: c1:92 c2:93 c3:94 c.rowid:96 d1:99 d2:100 d3:101 d.rowid:103
+ │                   │    ├── right columns: c1:106 c2:107 c3:108 c.rowid:110 d1:113 d2:114 d3:115 d.rowid:117
+ │                   │    ├── inner-join (hash)
+ │                   │    │    ├── columns: c1:92 c2:93 c3:94!null c.rowid:96!null d1:99 d2:100 d3:101!null d.rowid:103!null
+ │                   │    │    ├── key: (96,103)
+ │                   │    │    ├── fd: (96)-->(92-94), (103)-->(99-101), (94)==(101), (101)==(94)
+ │                   │    │    ├── scan c
+ │                   │    │    │    ├── columns: c1:92 c2:93 c3:94 c.rowid:96!null
+ │                   │    │    │    ├── key: (96)
+ │                   │    │    │    └── fd: (96)-->(92-94)
+ │                   │    │    ├── scan d
+ │                   │    │    │    ├── columns: d1:99 d2:100 d3:101 d.rowid:103!null
+ │                   │    │    │    ├── key: (103)
+ │                   │    │    │    └── fd: (103)-->(99-101)
+ │                   │    │    └── filters
+ │                   │    │         └── c3:94 = d3:101 [outer=(94,101), constraints=(/94: (/NULL - ]; /101: (/NULL - ]), fd=(94)==(101), (101)==(94)]
+ │                   │    └── inner-join (hash)
+ │                   │         ├── columns: c1:106 c2:107!null c3:108 c.rowid:110!null d1:113 d2:114!null d3:115 d.rowid:117!null
+ │                   │         ├── key: (110,117)
+ │                   │         ├── fd: (110)-->(106-108), (117)-->(113-115), (107)==(114), (114)==(107)
+ │                   │         ├── scan c
+ │                   │         │    ├── columns: c1:106 c2:107 c3:108 c.rowid:110!null
+ │                   │         │    ├── key: (110)
+ │                   │         │    └── fd: (110)-->(106-108)
+ │                   │         ├── scan d
+ │                   │         │    ├── columns: d1:113 d2:114 d3:115 d.rowid:117!null
+ │                   │         │    ├── key: (117)
+ │                   │         │    └── fd: (117)-->(113-115)
+ │                   │         └── filters
+ │                   │              └── c2:107 = d2:114 [outer=(107,114), constraints=(/107: (/NULL - ]; /114: (/NULL - ]), fd=(107)==(114), (114)==(107)]
+ │                   └── aggregations
+ │                        ├── const-agg [as=c1:21, outer=(21)]
+ │                        │    └── c1:21
+ │                        ├── const-agg [as=c2:22, outer=(22)]
+ │                        │    └── c2:22
+ │                        ├── const-agg [as=c3:23, outer=(23)]
+ │                        │    └── c3:23
+ │                        ├── const-agg [as=d1:28, outer=(28)]
+ │                        │    └── d1:28
+ │                        ├── const-agg [as=d2:29, outer=(29)]
+ │                        │    └── d2:29
+ │                        └── const-agg [as=d3:30, outer=(30)]
+ │                             └── d3:30
+ └── filters
+      ├── c1:7 = a1:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+      └── d1:14 = a2:2 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── inner-join (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null d1:14!null
+      ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+      ├── key: (3,4,7,14)
+      ├── fd: (1)==(7), (7)==(1), (2)==(14), (14)==(2)
+      ├── distinct-on
+      │    ├── columns: c1:7 d1:14
+      │    ├── grouping columns: c1:7 d1:14
+      │    ├── key: (7,14)
+      │    └── distinct-on
+      │         ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
+      │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+      │         ├── key: (11,18)
+      │         ├── fd: (11,18)-->(7,14)
+      │         ├── union-all
+      │         │    ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
+      │         │    ├── left columns: c1:34 c.rowid:38 d1:41 d.rowid:45
+      │         │    ├── right columns: c1:48 c.rowid:52 d1:55 d.rowid:59
+      │         │    ├── inner-join (hash)
+      │         │    │    ├── columns: c1:34!null c.rowid:38!null d1:41!null d.rowid:45!null
+      │         │    │    ├── key: (38,45)
+      │         │    │    ├── fd: (38)-->(34), (45)-->(41), (34)==(41), (41)==(34)
+      │         │    │    ├── scan c
+      │         │    │    │    ├── columns: c1:34 c.rowid:38!null
+      │         │    │    │    ├── key: (38)
+      │         │    │    │    └── fd: (38)-->(34)
+      │         │    │    ├── scan d
+      │         │    │    │    ├── columns: d1:41 d.rowid:45!null
+      │         │    │    │    ├── key: (45)
+      │         │    │    │    └── fd: (45)-->(41)
+      │         │    │    └── filters
+      │         │    │         └── c1:34 = d1:41 [outer=(34,41), constraints=(/34: (/NULL - ]; /41: (/NULL - ]), fd=(34)==(41), (41)==(34)]
+      │         │    └── inner-join (cross)
+      │         │         ├── columns: c1:48 c.rowid:52!null d1:55 d.rowid:59!null
+      │         │         ├── key: (52,59)
+      │         │         ├── fd: ()-->(48), (59)-->(55)
+      │         │         ├── scan d
+      │         │         │    ├── columns: d1:55 d.rowid:59!null
+      │         │         │    ├── key: (59)
+      │         │         │    └── fd: (59)-->(55)
+      │         │         ├── select
+      │         │         │    ├── columns: c1:48 c.rowid:52!null
+      │         │         │    ├── key: (52)
+      │         │         │    ├── fd: ()-->(48)
+      │         │         │    ├── scan c
+      │         │         │    │    ├── columns: c1:48 c.rowid:52!null
+      │         │         │    │    ├── key: (52)
+      │         │         │    │    └── fd: (52)-->(48)
+      │         │         │    └── filters
+      │         │         │         └── c1:48 IS NULL [outer=(48), constraints=(/48: [/NULL - /NULL]; tight), fd=()-->(48)]
+      │         │         └── filters (true)
+      │         └── aggregations
+      │              ├── const-agg [as=c1:7, outer=(7)]
+      │              │    └── c1:7
+      │              └── const-agg [as=d1:14, outer=(14)]
+      │                   └── d1:14
+      ├── select
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    ├── key: (1-4)
+      │    ├── scan a
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    └── key: (1-4)
+      │    └── filters
+      │         └── (a1:1 IS NULL) OR (a1:1 = a2:2) [outer=(1,2)]
+      └── filters
+           ├── c1:7 = a1:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+           └── d1:14 = a2:2 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM b WHERE b1 NOT IN (SELECT c1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+anti-join (cross)
+ ├── columns: b1:1 b2:2 b3:3 b4:4
+ ├── scan b
+ │    └── columns: b1:1 b2:2 b3:3 b4:4
+ ├── project
+ │    ├── columns: c1:8 d1:15
+ │    └── distinct-on
+ │         ├── columns: c1:8 c.rowid:12!null d1:15 d.rowid:19!null
+ │         ├── grouping columns: c.rowid:12!null d.rowid:19!null
+ │         ├── key: (12,19)
+ │         ├── fd: (12,19)-->(8,15)
+ │         ├── union-all
+ │         │    ├── columns: c1:8 c.rowid:12!null d1:15 d.rowid:19!null
+ │         │    ├── left columns: c1:22 c.rowid:26 d1:29 d.rowid:33
+ │         │    ├── right columns: c1:36 c.rowid:40 d1:43 d.rowid:47
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: c1:22!null c.rowid:26!null d1:29!null d.rowid:33!null
+ │         │    │    ├── key: (26,33)
+ │         │    │    ├── fd: (26)-->(22), (33)-->(29), (22)==(29), (29)==(22)
+ │         │    │    ├── scan c
+ │         │    │    │    ├── columns: c1:22 c.rowid:26!null
+ │         │    │    │    ├── key: (26)
+ │         │    │    │    └── fd: (26)-->(22)
+ │         │    │    ├── scan d
+ │         │    │    │    ├── columns: d1:29 d.rowid:33!null
+ │         │    │    │    ├── key: (33)
+ │         │    │    │    └── fd: (33)-->(29)
+ │         │    │    └── filters
+ │         │    │         └── c1:22 = d1:29 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │         │    └── inner-join (cross)
+ │         │         ├── columns: c1:36 c.rowid:40!null d1:43 d.rowid:47!null
+ │         │         ├── key: (40,47)
+ │         │         ├── fd: ()-->(36), (47)-->(43)
+ │         │         ├── scan d
+ │         │         │    ├── columns: d1:43 d.rowid:47!null
+ │         │         │    ├── key: (47)
+ │         │         │    └── fd: (47)-->(43)
+ │         │         ├── select
+ │         │         │    ├── columns: c1:36 c.rowid:40!null
+ │         │         │    ├── key: (40)
+ │         │         │    ├── fd: ()-->(36)
+ │         │         │    ├── scan c
+ │         │         │    │    ├── columns: c1:36 c.rowid:40!null
+ │         │         │    │    ├── key: (40)
+ │         │         │    │    └── fd: (40)-->(36)
+ │         │         │    └── filters
+ │         │         │         └── c1:36 IS NULL [outer=(36), constraints=(/36: [/NULL - /NULL]; tight), fd=()-->(36)]
+ │         │         └── filters (true)
+ │         └── aggregations
+ │              ├── const-agg [as=c1:8, outer=(8)]
+ │              │    └── c1:8
+ │              └── const-agg [as=d1:15, outer=(15)]
+ │                   └── d1:15
+ └── filters
+      └── (b1:1 = c1:8) IS NOT false [outer=(1,8)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM b WHERE (b1, b2) NOT IN (SELECT c1, c2 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+anti-join (cross)
+ ├── columns: b1:1 b2:2 b3:3 b4:4
+ ├── immutable
+ ├── scan b
+ │    └── columns: b1:1 b2:2 b3:3 b4:4
+ ├── project
+ │    ├── columns: column22:22
+ │    ├── project
+ │    │    ├── columns: c1:8 c2:9 d1:15
+ │    │    └── distinct-on
+ │    │         ├── columns: c1:8 c2:9 c.rowid:12!null d1:15 d.rowid:19!null
+ │    │         ├── grouping columns: c.rowid:12!null d.rowid:19!null
+ │    │         ├── key: (12,19)
+ │    │         ├── fd: (12,19)-->(8,9,15)
+ │    │         ├── union-all
+ │    │         │    ├── columns: c1:8 c2:9 c.rowid:12!null d1:15 d.rowid:19!null
+ │    │         │    ├── left columns: c1:23 c2:24 c.rowid:27 d1:30 d.rowid:34
+ │    │         │    ├── right columns: c1:37 c2:38 c.rowid:41 d1:44 d.rowid:48
+ │    │         │    ├── inner-join (hash)
+ │    │         │    │    ├── columns: c1:23!null c2:24 c.rowid:27!null d1:30!null d.rowid:34!null
+ │    │         │    │    ├── key: (27,34)
+ │    │         │    │    ├── fd: (27)-->(23,24), (34)-->(30), (23)==(30), (30)==(23)
+ │    │         │    │    ├── scan c
+ │    │         │    │    │    ├── columns: c1:23 c2:24 c.rowid:27!null
+ │    │         │    │    │    ├── key: (27)
+ │    │         │    │    │    └── fd: (27)-->(23,24)
+ │    │         │    │    ├── scan d
+ │    │         │    │    │    ├── columns: d1:30 d.rowid:34!null
+ │    │         │    │    │    ├── key: (34)
+ │    │         │    │    │    └── fd: (34)-->(30)
+ │    │         │    │    └── filters
+ │    │         │    │         └── c1:23 = d1:30 [outer=(23,30), constraints=(/23: (/NULL - ]; /30: (/NULL - ]), fd=(23)==(30), (30)==(23)]
+ │    │         │    └── inner-join (cross)
+ │    │         │         ├── columns: c1:37 c2:38 c.rowid:41!null d1:44 d.rowid:48!null
+ │    │         │         ├── key: (41,48)
+ │    │         │         ├── fd: ()-->(37), (41)-->(38), (48)-->(44)
+ │    │         │         ├── scan d
+ │    │         │         │    ├── columns: d1:44 d.rowid:48!null
+ │    │         │         │    ├── key: (48)
+ │    │         │         │    └── fd: (48)-->(44)
+ │    │         │         ├── select
+ │    │         │         │    ├── columns: c1:37 c2:38 c.rowid:41!null
+ │    │         │         │    ├── key: (41)
+ │    │         │         │    ├── fd: ()-->(37), (41)-->(38)
+ │    │         │         │    ├── scan c
+ │    │         │         │    │    ├── columns: c1:37 c2:38 c.rowid:41!null
+ │    │         │         │    │    ├── key: (41)
+ │    │         │         │    │    └── fd: (41)-->(37,38)
+ │    │         │         │    └── filters
+ │    │         │         │         └── c1:37 IS NULL [outer=(37), constraints=(/37: [/NULL - /NULL]; tight), fd=()-->(37)]
+ │    │         │         └── filters (true)
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=c1:8, outer=(8)]
+ │    │              │    └── c1:8
+ │    │              ├── const-agg [as=c2:9, outer=(9)]
+ │    │              │    └── c2:9
+ │    │              └── const-agg [as=d1:15, outer=(15)]
+ │    │                   └── d1:15
+ │    └── projections
+ │         └── (c1:8, c2:9) [as=column22:22, outer=(8,9)]
+ └── filters
+      └── (column22:22 = (b1:1, b2:2)) IS NOT false [outer=(1,2,22), immutable]
+
+#########################
+# Uncorrelated antijoin #
+#########################
+
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM b WHERE b1 = 4 OR b2 = 50)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── not [subquery]
+           └── exists
+                └── limit
+                     ├── columns: b1:7 b2:8
+                     ├── cardinality: [0 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(7,8)
+                     ├── project
+                     │    ├── columns: b1:7 b2:8
+                     │    ├── limit hint: 1.00
+                     │    └── distinct-on
+                     │         ├── columns: b1:7 b2:8 rowid:11!null
+                     │         ├── grouping columns: rowid:11!null
+                     │         ├── key: (11)
+                     │         ├── fd: (11)-->(7,8)
+                     │         ├── limit hint: 1.00
+                     │         ├── union-all
+                     │         │    ├── columns: b1:7 b2:8 rowid:11!null
+                     │         │    ├── left columns: b1:15 b2:16 rowid:19
+                     │         │    ├── right columns: b1:22 b2:23 rowid:26
+                     │         │    ├── limit hint: 1.21
+                     │         │    ├── scan b@b_b1_b2_idx
+                     │         │    │    ├── columns: b1:15!null b2:16 rowid:19!null
+                     │         │    │    ├── constraint: /15/16/19: [/4 - /4]
+                     │         │    │    ├── key: (19)
+                     │         │    │    ├── fd: ()-->(15), (19)-->(16)
+                     │         │    │    └── limit hint: 1.21
+                     │         │    └── scan b@b_b2_idx
+                     │         │         ├── columns: b1:22 b2:23!null rowid:26!null
+                     │         │         ├── constraint: /23/26: [/50 - /50]
+                     │         │         ├── key: (26)
+                     │         │         ├── fd: ()-->(23), (26)-->(22)
+                     │         │         └── limit hint: 1.21
+                     │         └── aggregations
+                     │              ├── const-agg [as=b1:7, outer=(7)]
+                     │              │    └── b1:7
+                     │              └── const-agg [as=b2:8, outer=(8)]
+                     │                   └── b2:8
+                     └── 1
+
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 or d2+c3 > 5)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── immutable
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── not [immutable, subquery]
+           └── exists
+                └── limit
+                     ├── columns: c2:8 c3:9 d1:14 d2:15
+                     ├── cardinality: [0 - 1]
+                     ├── immutable
+                     ├── key: ()
+                     ├── fd: ()-->(8,9,14,15)
+                     ├── inner-join (cross)
+                     │    ├── columns: c2:8 c3:9 d1:14 d2:15
+                     │    ├── immutable
+                     │    ├── limit hint: 1.00
+                     │    ├── scan c
+                     │    │    └── columns: c2:8 c3:9
+                     │    ├── scan d
+                     │    │    └── columns: d1:14 d2:15
+                     │    └── filters
+                     │         └── ((d1:14 = 4) OR (c2:8 = 50)) OR ((d2:15 + c3:9) > 5) [outer=(8,9,14,15), immutable]
+                     └── 1
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE c3 = d4 or c4 = d3)
+----
+select
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ └── filters
+      └── not [subquery]
+           └── exists
+                └── limit
+                     ├── columns: c3:9 c4:10 d3:16 d4:17
+                     ├── cardinality: [0 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(9,10,16,17)
+                     ├── project
+                     │    ├── columns: c3:9 c4:10 d3:16 d4:17
+                     │    ├── limit hint: 1.00
+                     │    └── distinct-on
+                     │         ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
+                     │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+                     │         ├── key: (11,18)
+                     │         ├── fd: (11,18)-->(9,10,16,17)
+                     │         ├── limit hint: 1.00
+                     │         ├── union-all
+                     │         │    ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
+                     │         │    ├── left columns: c3:24 c4:25 c.rowid:26 d3:31 d4:32 d.rowid:33
+                     │         │    ├── right columns: c3:38 c4:39 c.rowid:40 d3:45 d4:46 d.rowid:47
+                     │         │    ├── limit hint: 1.20
+                     │         │    ├── inner-join (hash)
+                     │         │    │    ├── columns: c3:24!null c4:25 c.rowid:26!null d3:31 d4:32!null d.rowid:33!null
+                     │         │    │    ├── key: (26,33)
+                     │         │    │    ├── fd: (26)-->(24,25), (33)-->(31,32), (24)==(32), (32)==(24)
+                     │         │    │    ├── limit hint: 1.20
+                     │         │    │    ├── scan c
+                     │         │    │    │    ├── columns: c3:24 c4:25 c.rowid:26!null
+                     │         │    │    │    ├── key: (26)
+                     │         │    │    │    └── fd: (26)-->(24,25)
+                     │         │    │    ├── scan d
+                     │         │    │    │    ├── columns: d3:31 d4:32 d.rowid:33!null
+                     │         │    │    │    ├── key: (33)
+                     │         │    │    │    └── fd: (33)-->(31,32)
+                     │         │    │    └── filters
+                     │         │    │         └── c3:24 = d4:32 [outer=(24,32), constraints=(/24: (/NULL - ]; /32: (/NULL - ]), fd=(24)==(32), (32)==(24)]
+                     │         │    └── inner-join (hash)
+                     │         │         ├── columns: c3:38 c4:39!null c.rowid:40!null d3:45!null d4:46 d.rowid:47!null
+                     │         │         ├── key: (40,47)
+                     │         │         ├── fd: (40)-->(38,39), (47)-->(45,46), (39)==(45), (45)==(39)
+                     │         │         ├── limit hint: 1.20
+                     │         │         ├── scan c
+                     │         │         │    ├── columns: c3:38 c4:39 c.rowid:40!null
+                     │         │         │    ├── key: (40)
+                     │         │         │    └── fd: (40)-->(38,39)
+                     │         │         ├── scan d
+                     │         │         │    ├── columns: d3:45 d4:46 d.rowid:47!null
+                     │         │         │    ├── key: (47)
+                     │         │         │    └── fd: (47)-->(45,46)
+                     │         │         └── filters
+                     │         │              └── c4:39 = d3:45 [outer=(39,45), constraints=(/39: (/NULL - ]; /45: (/NULL - ]), fd=(39)==(45), (45)==(39)]
+                     │         └── aggregations
+                     │              ├── const-agg [as=c3:9, outer=(9)]
+                     │              │    └── c3:9
+                     │              ├── const-agg [as=c4:10, outer=(10)]
+                     │              │    └── c4:10
+                     │              ├── const-agg [as=d3:16, outer=(16)]
+                     │              │    └── d3:16
+                     │              └── const-agg [as=d4:17, outer=(17)]
+                     │                   └── d4:17
+                     └── 1
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)
+----
+anti-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── immutable
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── project
+ │    ├── columns: column21:21
+ │    ├── project
+ │    │    ├── columns: c1:7 c3:9!null d1:14 d3:16 d4:17
+ │    │    └── distinct-on
+ │    │         ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
+ │    │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+ │    │         ├── key: (11,18)
+ │    │         ├── fd: (11,18)-->(7,9,14,16,17)
+ │    │         ├── union-all
+ │    │         │    ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
+ │    │         │    ├── left columns: c1:22 c3:24 c.rowid:26 d1:29 d3:31 d4:32 d.rowid:33
+ │    │         │    ├── right columns: c1:36 c3:38 c.rowid:40 d1:43 d3:45 d4:46 d.rowid:47
+ │    │         │    ├── inner-join (hash)
+ │    │         │    │    ├── columns: c1:22 c3:24!null c.rowid:26!null d1:29 d3:31!null d4:32 d.rowid:33!null
+ │    │         │    │    ├── key: (26,33)
+ │    │         │    │    ├── fd: (26)-->(22,24), (33)-->(29,31,32), (24)==(31), (31)==(24)
+ │    │         │    │    ├── scan c
+ │    │         │    │    │    ├── columns: c1:22 c3:24 c.rowid:26!null
+ │    │         │    │    │    ├── key: (26)
+ │    │         │    │    │    └── fd: (26)-->(22,24)
+ │    │         │    │    ├── scan d
+ │    │         │    │    │    ├── columns: d1:29 d3:31 d4:32 d.rowid:33!null
+ │    │         │    │    │    ├── key: (33)
+ │    │         │    │    │    └── fd: (33)-->(29,31,32)
+ │    │         │    │    └── filters
+ │    │         │    │         └── c3:24 = d3:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │    │         │    └── inner-join (hash)
+ │    │         │         ├── columns: c1:36 c3:38!null c.rowid:40!null d1:43 d3:45 d4:46!null d.rowid:47!null
+ │    │         │         ├── key: (40,47)
+ │    │         │         ├── fd: (40)-->(36,38), (47)-->(43,45,46), (38)==(46), (46)==(38)
+ │    │         │         ├── scan c
+ │    │         │         │    ├── columns: c1:36 c3:38 c.rowid:40!null
+ │    │         │         │    ├── key: (40)
+ │    │         │         │    └── fd: (40)-->(36,38)
+ │    │         │         ├── scan d
+ │    │         │         │    ├── columns: d1:43 d3:45 d4:46 d.rowid:47!null
+ │    │         │         │    ├── key: (47)
+ │    │         │         │    └── fd: (47)-->(43,45,46)
+ │    │         │         └── filters
+ │    │         │              └── c3:38 = d4:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=c1:7, outer=(7)]
+ │    │              │    └── c1:7
+ │    │              ├── const-agg [as=c3:9, outer=(9)]
+ │    │              │    └── c3:9
+ │    │              ├── const-agg [as=d1:14, outer=(14)]
+ │    │              │    └── d1:14
+ │    │              ├── const-agg [as=d3:16, outer=(16)]
+ │    │              │    └── d3:16
+ │    │              └── const-agg [as=d4:17, outer=(17)]
+ │    │                   └── d4:17
+ │    └── projections
+ │         └── (c1:7, d1:14) [as=column21:21, outer=(7,14)]
+ └── filters
+      └── (column21:21 = (a1:1, a2:2)) IS NOT false [outer=(1,2,21), immutable]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2 EXCEPT ALL
+                                       SELECT c1, d1 FROM c, d WHERE c3 = d3 or c2 = d2)
+----
+anti-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── immutable
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── project
+ │    ├── columns: column35:35
+ │    ├── except-all
+ │    │    ├── columns: c1:7 d1:14
+ │    │    ├── left columns: c1:7 d1:14
+ │    │    ├── right columns: c1:21 d1:28
+ │    │    ├── project
+ │    │    │    ├── columns: c1:7 d1:14
+ │    │    │    └── project
+ │    │    │         ├── columns: c1:7 c2:8 c3:9 d1:14 d2:15 d3:16
+ │    │    │         └── distinct-on
+ │    │    │              ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
+ │    │    │              ├── grouping columns: c.rowid:11!null d.rowid:18!null
+ │    │    │              ├── key: (11,18)
+ │    │    │              ├── fd: (11,18)-->(7-9,14-16)
+ │    │    │              ├── union-all
+ │    │    │              │    ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
+ │    │    │              │    ├── left columns: c1:36 c2:37 c3:38 c.rowid:40 d1:43 d2:44 d3:45 d.rowid:47
+ │    │    │              │    ├── right columns: c1:50 c2:51 c3:52 c.rowid:54 d1:57 d2:58 d3:59 d.rowid:61
+ │    │    │              │    ├── inner-join (hash)
+ │    │    │              │    │    ├── columns: c1:36 c2:37 c3:38!null c.rowid:40!null d1:43 d2:44 d3:45!null d.rowid:47!null
+ │    │    │              │    │    ├── key: (40,47)
+ │    │    │              │    │    ├── fd: (40)-->(36-38), (47)-->(43-45), (38)==(45), (45)==(38)
+ │    │    │              │    │    ├── scan c
+ │    │    │              │    │    │    ├── columns: c1:36 c2:37 c3:38 c.rowid:40!null
+ │    │    │              │    │    │    ├── key: (40)
+ │    │    │              │    │    │    └── fd: (40)-->(36-38)
+ │    │    │              │    │    ├── scan d
+ │    │    │              │    │    │    ├── columns: d1:43 d2:44 d3:45 d.rowid:47!null
+ │    │    │              │    │    │    ├── key: (47)
+ │    │    │              │    │    │    └── fd: (47)-->(43-45)
+ │    │    │              │    │    └── filters
+ │    │    │              │    │         └── c3:38 = d3:45 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
+ │    │    │              │    └── inner-join (hash)
+ │    │    │              │         ├── columns: c1:50 c2:51!null c3:52 c.rowid:54!null d1:57 d2:58!null d3:59 d.rowid:61!null
+ │    │    │              │         ├── key: (54,61)
+ │    │    │              │         ├── fd: (54)-->(50-52), (61)-->(57-59), (51)==(58), (58)==(51)
+ │    │    │              │         ├── scan c
+ │    │    │              │         │    ├── columns: c1:50 c2:51 c3:52 c.rowid:54!null
+ │    │    │              │         │    ├── key: (54)
+ │    │    │              │         │    └── fd: (54)-->(50-52)
+ │    │    │              │         ├── scan d
+ │    │    │              │         │    ├── columns: d1:57 d2:58 d3:59 d.rowid:61!null
+ │    │    │              │         │    ├── key: (61)
+ │    │    │              │         │    └── fd: (61)-->(57-59)
+ │    │    │              │         └── filters
+ │    │    │              │              └── c2:51 = d2:58 [outer=(51,58), constraints=(/51: (/NULL - ]; /58: (/NULL - ]), fd=(51)==(58), (58)==(51)]
+ │    │    │              └── aggregations
+ │    │    │                   ├── const-agg [as=c1:7, outer=(7)]
+ │    │    │                   │    └── c1:7
+ │    │    │                   ├── const-agg [as=c2:8, outer=(8)]
+ │    │    │                   │    └── c2:8
+ │    │    │                   ├── const-agg [as=c3:9, outer=(9)]
+ │    │    │                   │    └── c3:9
+ │    │    │                   ├── const-agg [as=d1:14, outer=(14)]
+ │    │    │                   │    └── d1:14
+ │    │    │                   ├── const-agg [as=d2:15, outer=(15)]
+ │    │    │                   │    └── d2:15
+ │    │    │                   └── const-agg [as=d3:16, outer=(16)]
+ │    │    │                        └── d3:16
+ │    │    └── project
+ │    │         ├── columns: c1:21 d1:28
+ │    │         └── project
+ │    │              ├── columns: c1:21 c2:22 c3:23 d1:28 d2:29 d3:30
+ │    │              └── distinct-on
+ │    │                   ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
+ │    │                   ├── grouping columns: c.rowid:25!null d.rowid:32!null
+ │    │                   ├── key: (25,32)
+ │    │                   ├── fd: (25,32)-->(21-23,28-30)
+ │    │                   ├── union-all
+ │    │                   │    ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
+ │    │                   │    ├── left columns: c1:92 c2:93 c3:94 c.rowid:96 d1:99 d2:100 d3:101 d.rowid:103
+ │    │                   │    ├── right columns: c1:106 c2:107 c3:108 c.rowid:110 d1:113 d2:114 d3:115 d.rowid:117
+ │    │                   │    ├── inner-join (hash)
+ │    │                   │    │    ├── columns: c1:92 c2:93 c3:94!null c.rowid:96!null d1:99 d2:100 d3:101!null d.rowid:103!null
+ │    │                   │    │    ├── key: (96,103)
+ │    │                   │    │    ├── fd: (96)-->(92-94), (103)-->(99-101), (94)==(101), (101)==(94)
+ │    │                   │    │    ├── scan c
+ │    │                   │    │    │    ├── columns: c1:92 c2:93 c3:94 c.rowid:96!null
+ │    │                   │    │    │    ├── key: (96)
+ │    │                   │    │    │    └── fd: (96)-->(92-94)
+ │    │                   │    │    ├── scan d
+ │    │                   │    │    │    ├── columns: d1:99 d2:100 d3:101 d.rowid:103!null
+ │    │                   │    │    │    ├── key: (103)
+ │    │                   │    │    │    └── fd: (103)-->(99-101)
+ │    │                   │    │    └── filters
+ │    │                   │    │         └── c3:94 = d3:101 [outer=(94,101), constraints=(/94: (/NULL - ]; /101: (/NULL - ]), fd=(94)==(101), (101)==(94)]
+ │    │                   │    └── inner-join (hash)
+ │    │                   │         ├── columns: c1:106 c2:107!null c3:108 c.rowid:110!null d1:113 d2:114!null d3:115 d.rowid:117!null
+ │    │                   │         ├── key: (110,117)
+ │    │                   │         ├── fd: (110)-->(106-108), (117)-->(113-115), (107)==(114), (114)==(107)
+ │    │                   │         ├── scan c
+ │    │                   │         │    ├── columns: c1:106 c2:107 c3:108 c.rowid:110!null
+ │    │                   │         │    ├── key: (110)
+ │    │                   │         │    └── fd: (110)-->(106-108)
+ │    │                   │         ├── scan d
+ │    │                   │         │    ├── columns: d1:113 d2:114 d3:115 d.rowid:117!null
+ │    │                   │         │    ├── key: (117)
+ │    │                   │         │    └── fd: (117)-->(113-115)
+ │    │                   │         └── filters
+ │    │                   │              └── c2:107 = d2:114 [outer=(107,114), constraints=(/107: (/NULL - ]; /114: (/NULL - ]), fd=(107)==(114), (114)==(107)]
+ │    │                   └── aggregations
+ │    │                        ├── const-agg [as=c1:21, outer=(21)]
+ │    │                        │    └── c1:21
+ │    │                        ├── const-agg [as=c2:22, outer=(22)]
+ │    │                        │    └── c2:22
+ │    │                        ├── const-agg [as=c3:23, outer=(23)]
+ │    │                        │    └── c3:23
+ │    │                        ├── const-agg [as=d1:28, outer=(28)]
+ │    │                        │    └── d1:28
+ │    │                        ├── const-agg [as=d2:29, outer=(29)]
+ │    │                        │    └── d2:29
+ │    │                        └── const-agg [as=d3:30, outer=(30)]
+ │    │                             └── d3:30
+ │    └── projections
+ │         └── (c1:7, d1:14) [as=column35:35, outer=(7,14)]
+ └── filters
+      └── (column35:35 = (a1:1, a2:2)) IS NOT false [outer=(1,2,35), immutable]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c1 IS NULL OR c1 = d1)
+----
+anti-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── immutable
+ ├── key: (1-4)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── project
+ │    ├── columns: column21:21
+ │    ├── project
+ │    │    ├── columns: c1:7 d1:14
+ │    │    └── distinct-on
+ │    │         ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
+ │    │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+ │    │         ├── key: (11,18)
+ │    │         ├── fd: (11,18)-->(7,14)
+ │    │         ├── union-all
+ │    │         │    ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
+ │    │         │    ├── left columns: c1:22 c.rowid:26 d1:29 d.rowid:33
+ │    │         │    ├── right columns: c1:36 c.rowid:40 d1:43 d.rowid:47
+ │    │         │    ├── inner-join (hash)
+ │    │         │    │    ├── columns: c1:22!null c.rowid:26!null d1:29!null d.rowid:33!null
+ │    │         │    │    ├── key: (26,33)
+ │    │         │    │    ├── fd: (26)-->(22), (33)-->(29), (22)==(29), (29)==(22)
+ │    │         │    │    ├── scan c
+ │    │         │    │    │    ├── columns: c1:22 c.rowid:26!null
+ │    │         │    │    │    ├── key: (26)
+ │    │         │    │    │    └── fd: (26)-->(22)
+ │    │         │    │    ├── scan d
+ │    │         │    │    │    ├── columns: d1:29 d.rowid:33!null
+ │    │         │    │    │    ├── key: (33)
+ │    │         │    │    │    └── fd: (33)-->(29)
+ │    │         │    │    └── filters
+ │    │         │    │         └── c1:22 = d1:29 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │    │         │    └── inner-join (cross)
+ │    │         │         ├── columns: c1:36 c.rowid:40!null d1:43 d.rowid:47!null
+ │    │         │         ├── key: (40,47)
+ │    │         │         ├── fd: ()-->(36), (47)-->(43)
+ │    │         │         ├── scan d
+ │    │         │         │    ├── columns: d1:43 d.rowid:47!null
+ │    │         │         │    ├── key: (47)
+ │    │         │         │    └── fd: (47)-->(43)
+ │    │         │         ├── select
+ │    │         │         │    ├── columns: c1:36 c.rowid:40!null
+ │    │         │         │    ├── key: (40)
+ │    │         │         │    ├── fd: ()-->(36)
+ │    │         │         │    ├── scan c
+ │    │         │         │    │    ├── columns: c1:36 c.rowid:40!null
+ │    │         │         │    │    ├── key: (40)
+ │    │         │         │    │    └── fd: (40)-->(36)
+ │    │         │         │    └── filters
+ │    │         │         │         └── c1:36 IS NULL [outer=(36), constraints=(/36: [/NULL - /NULL]; tight), fd=()-->(36)]
+ │    │         │         └── filters (true)
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=c1:7, outer=(7)]
+ │    │              │    └── c1:7
+ │    │              └── const-agg [as=d1:14, outer=(14)]
+ │    │                   └── d1:14
+ │    └── projections
+ │         └── (c1:7, d1:14) [as=column21:21, outer=(7,14)]
+ └── filters
+      └── (column21:21 = (a1:1, a2:2)) IS NOT false [outer=(1,2,21), immutable]
+
+#######################
+# Correlated semijoin #
+#######################
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3 FROM a WHERE EXISTS (SELECT * FROM b WHERE a2 = b2 OR a3 = b3)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── key: (1-4)
+      └── union-all
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── left columns: a1:14 a2:15 a3:16 a4:17
+           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── project
+           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    ├── key: (14-17)
+           │    └── inner-join (hash)
+           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b2:21!null
+           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │         ├── key: (14,16,17,21)
+           │         ├── fd: (15)==(21), (21)==(15)
+           │         ├── scan a
+           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │         │    └── key: (14-17)
+           │         ├── distinct-on
+           │         │    ├── columns: b2:21
+           │         │    ├── grouping columns: b2:21
+           │         │    ├── internal-ordering: +21
+           │         │    ├── key: (21)
+           │         │    └── scan b@b_b2_idx
+           │         │         ├── columns: b2:21
+           │         │         └── ordering: +21
+           │         └── filters
+           │              └── a2:15 = b2:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
+           └── project
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── key: (27-30)
+                └── inner-join (hash)
+                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b3:35!null
+                     ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                     ├── key: (27,28,30,35)
+                     ├── fd: (29)==(35), (35)==(29)
+                     ├── scan a
+                     │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     │    └── key: (27-30)
+                     ├── distinct-on
+                     │    ├── columns: b3:35
+                     │    ├── grouping columns: b3:35
+                     │    ├── internal-ordering: +35
+                     │    ├── key: (35)
+                     │    └── scan b@b_b3_idx
+                     │         ├── columns: b3:35
+                     │         └── ordering: +35
+                     └── filters
+                          └── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3 FROM a WHERE EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── key: (1-4)
+      └── union-all
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── left columns: a1:14 a2:15 a3:16 a4:17
+           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── project
+           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    ├── key: (14-17)
+           │    └── inner-join (merge)
+           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20!null
+           │         ├── left ordering: +14
+           │         ├── right ordering: +20
+           │         ├── key: (15-17,20)
+           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── scan a
+           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │         │    ├── key: (14-17)
+           │         │    └── ordering: +14
+           │         ├── distinct-on
+           │         │    ├── columns: b1:20
+           │         │    ├── grouping columns: b1:20
+           │         │    ├── key: (20)
+           │         │    ├── ordering: +20
+           │         │    └── scan b@b_b1_b2_idx
+           │         │         ├── columns: b1:20
+           │         │         └── ordering: +20
+           │         └── filters (true)
+           └── project
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── key: (27-30)
+                └── inner-join (merge)
+                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b2:34!null
+                     ├── left ordering: +27
+                     ├── right ordering: +34
+                     ├── key: (28-30,34)
+                     ├── fd: (27)==(34), (34)==(27)
+                     ├── scan a
+                     │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     │    ├── key: (27-30)
+                     │    └── ordering: +27
+                     ├── distinct-on
+                     │    ├── columns: b2:34
+                     │    ├── grouping columns: b2:34
+                     │    ├── key: (34)
+                     │    ├── ordering: +34
+                     │    └── scan b@b_b2_idx
+                     │         ├── columns: b2:34
+                     │         └── ordering: +34
+                     └── filters (true)
+
+# The left side of the join already produces key columns
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT * FROM b WHERE a1 = b1 OR a2 = b2 OR a3 = b3 OR a4 = b4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── key: (1-4)
+      └── union-all
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── left columns: a1:14 a2:15 a3:16 a4:17
+           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── project
+           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    ├── key: (14-17)
+           │    └── inner-join (merge)
+           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20!null
+           │         ├── left ordering: +14
+           │         ├── right ordering: +20
+           │         ├── key: (15-17,20)
+           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── scan a
+           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │         │    ├── key: (14-17)
+           │         │    └── ordering: +14
+           │         ├── distinct-on
+           │         │    ├── columns: b1:20
+           │         │    ├── grouping columns: b1:20
+           │         │    ├── key: (20)
+           │         │    ├── ordering: +20
+           │         │    └── scan b@b_b1_b2_idx
+           │         │         ├── columns: b1:20
+           │         │         └── ordering: +20
+           │         └── filters (true)
+           └── project
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── key: (27-30)
+                └── distinct-on
+                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── key: (27-30)
+                     └── union-all
+                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                          ├── left columns: a1:274 a2:275 a3:276 a4:277
+                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── project
+                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │    ├── key: (274-277)
+                          │    └── inner-join (hash)
+                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null b4:283!null
+                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                          │         ├── key: (274-276,283)
+                          │         ├── fd: (277)==(283), (283)==(277)
+                          │         ├── scan a
+                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │         │    └── key: (274-277)
+                          │         ├── distinct-on
+                          │         │    ├── columns: b4:283
+                          │         │    ├── grouping columns: b4:283
+                          │         │    ├── key: (283)
+                          │         │    └── scan b
+                          │         │         └── columns: b4:283
+                          │         └── filters
+                          │              └── a4:277 = b4:283 [outer=(277,283), constraints=(/277: (/NULL - ]; /283: (/NULL - ]), fd=(277)==(283), (283)==(277)]
+                          └── project
+                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                               ├── key: (287-290)
+                               └── distinct-on
+                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── key: (287-290)
+                                    └── union-all
+                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
+                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── project
+                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │    ├── key: (430-433)
+                                         │    └── inner-join (hash)
+                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null b2:437!null
+                                         │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                         │         ├── key: (430,432,433,437)
+                                         │         ├── fd: (431)==(437), (437)==(431)
+                                         │         ├── scan a
+                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │         │    └── key: (430-433)
+                                         │         ├── distinct-on
+                                         │         │    ├── columns: b2:437
+                                         │         │    ├── grouping columns: b2:437
+                                         │         │    ├── internal-ordering: +437
+                                         │         │    ├── key: (437)
+                                         │         │    └── scan b@b_b2_idx
+                                         │         │         ├── columns: b2:437
+                                         │         │         └── ordering: +437
+                                         │         └── filters
+                                         │              └── a2:431 = b2:437 [outer=(431,437), constraints=(/431: (/NULL - ]; /437: (/NULL - ]), fd=(431)==(437), (437)==(431)]
+                                         └── project
+                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                              ├── key: (443-446)
+                                              └── inner-join (hash)
+                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null b3:451!null
+                                                   ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                                   ├── key: (443,444,446,451)
+                                                   ├── fd: (445)==(451), (451)==(445)
+                                                   ├── scan a
+                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                                   │    └── key: (443-446)
+                                                   ├── distinct-on
+                                                   │    ├── columns: b3:451
+                                                   │    ├── grouping columns: b3:451
+                                                   │    ├── internal-ordering: +451
+                                                   │    ├── key: (451)
+                                                   │    └── scan b@b_b3_idx
+                                                   │         ├── columns: b3:451
+                                                   │         └── ordering: +451
+                                                   └── filters
+                                                        └── a3:445 = b3:451 [outer=(445,451), constraints=(/445: (/NULL - ]; /451: (/NULL - ]), fd=(445)==(451), (451)==(445)]
+
+# More than one disjunction in the filter
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT * FROM c WHERE a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── key: (1-4)
+      └── union-all
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── left columns: a1:14 a2:15 a3:16 a4:17
+           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── project
+           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    ├── key: (14-17)
+           │    └── inner-join (hash)
+           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null c1:20!null
+           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │         ├── key: (15-17,20)
+           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── scan a
+           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │         │    └── key: (14-17)
+           │         ├── distinct-on
+           │         │    ├── columns: c1:20
+           │         │    ├── grouping columns: c1:20
+           │         │    ├── key: (20)
+           │         │    └── scan c
+           │         │         └── columns: c1:20
+           │         └── filters
+           │              └── a1:14 = c1:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+           └── project
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── key: (27-30)
+                └── distinct-on
+                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── key: (27-30)
+                     └── union-all
+                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                          ├── left columns: a1:274 a2:275 a3:276 a4:277
+                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── project
+                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │    ├── key: (274-277)
+                          │    └── inner-join (hash)
+                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null c4:283!null
+                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                          │         ├── key: (274-276,283)
+                          │         ├── fd: (277)==(283), (283)==(277)
+                          │         ├── scan a
+                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │         │    └── key: (274-277)
+                          │         ├── distinct-on
+                          │         │    ├── columns: c4:283
+                          │         │    ├── grouping columns: c4:283
+                          │         │    ├── key: (283)
+                          │         │    └── scan c
+                          │         │         └── columns: c4:283
+                          │         └── filters
+                          │              └── a4:277 = c4:283 [outer=(277,283), constraints=(/277: (/NULL - ]; /283: (/NULL - ]), fd=(277)==(283), (283)==(277)]
+                          └── project
+                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                               ├── key: (287-290)
+                               └── distinct-on
+                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── key: (287-290)
+                                    └── union-all
+                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
+                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── project
+                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │    ├── key: (430-433)
+                                         │    └── inner-join (hash)
+                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null c2:437!null
+                                         │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                         │         ├── key: (430,432,433,437)
+                                         │         ├── fd: (431)==(437), (437)==(431)
+                                         │         ├── scan a
+                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │         │    └── key: (430-433)
+                                         │         ├── distinct-on
+                                         │         │    ├── columns: c2:437
+                                         │         │    ├── grouping columns: c2:437
+                                         │         │    ├── key: (437)
+                                         │         │    └── scan c
+                                         │         │         └── columns: c2:437
+                                         │         └── filters
+                                         │              └── a2:431 = c2:437 [outer=(431,437), constraints=(/431: (/NULL - ]; /437: (/NULL - ]), fd=(431)==(437), (437)==(431)]
+                                         └── project
+                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                              ├── key: (443-446)
+                                              └── inner-join (hash)
+                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null c3:451!null
+                                                   ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                                   ├── key: (443,444,446,451)
+                                                   ├── fd: (445)==(451), (451)==(445)
+                                                   ├── scan a
+                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                                   │    └── key: (443-446)
+                                                   ├── distinct-on
+                                                   │    ├── columns: c3:451
+                                                   │    ├── grouping columns: c3:451
+                                                   │    ├── key: (451)
+                                                   │    └── scan c
+                                                   │         └── columns: c3:451
+                                                   └── filters
+                                                        └── a3:445 = c3:451 [outer=(445,451), constraints=(/445: (/NULL - ]; /451: (/NULL - ]), fd=(445)==(451), (451)==(445)]
+
+# More than one disjunction in the filter
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a WHERE EXISTS (SELECT * FROM c WHERE a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── distinct-on
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── key: (1-4)
+      └── union-all
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── left columns: a1:14 a2:15 a3:16 a4:17
+           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── project
+           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │    ├── key: (14-17)
+           │    └── inner-join (hash)
+           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null c2:21!null
+           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │         ├── key: (15-17,21)
+           │         ├── fd: (14)==(21), (21)==(14)
+           │         ├── scan a
+           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+           │         │    └── key: (14-17)
+           │         ├── distinct-on
+           │         │    ├── columns: c2:21
+           │         │    ├── grouping columns: c2:21
+           │         │    ├── key: (21)
+           │         │    └── scan c
+           │         │         └── columns: c2:21
+           │         └── filters
+           │              └── a1:14 = c2:21 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
+           └── project
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── key: (27-30)
+                └── distinct-on
+                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                     ├── key: (27-30)
+                     └── union-all
+                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                          ├── left columns: a1:274 a2:275 a3:276 a4:277
+                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── project
+                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │    ├── key: (274-277)
+                          │    └── inner-join (hash)
+                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null c4:283!null
+                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                          │         ├── key: (274,275,277,283)
+                          │         ├── fd: (276)==(283), (283)==(276)
+                          │         ├── scan a
+                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
+                          │         │    └── key: (274-277)
+                          │         ├── distinct-on
+                          │         │    ├── columns: c4:283
+                          │         │    ├── grouping columns: c4:283
+                          │         │    ├── key: (283)
+                          │         │    └── scan c
+                          │         │         └── columns: c4:283
+                          │         └── filters
+                          │              └── a3:276 = c4:283 [outer=(276,283), constraints=(/276: (/NULL - ]; /283: (/NULL - ]), fd=(276)==(283), (283)==(276)]
+                          └── project
+                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                               ├── key: (287-290)
+                               └── distinct-on
+                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                    ├── key: (287-290)
+                                    └── union-all
+                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
+                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
+                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── project
+                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │    ├── key: (430-433)
+                                         │    └── inner-join (hash)
+                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null c1:436!null
+                                         │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                         │         ├── key: (430,432,433,436)
+                                         │         ├── fd: (431)==(436), (436)==(431)
+                                         │         ├── scan a
+                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
+                                         │         │    └── key: (430-433)
+                                         │         ├── distinct-on
+                                         │         │    ├── columns: c1:436
+                                         │         │    ├── grouping columns: c1:436
+                                         │         │    ├── key: (436)
+                                         │         │    └── scan c
+                                         │         │         └── columns: c1:436
+                                         │         └── filters
+                                         │              └── a2:431 = c1:436 [outer=(431,436), constraints=(/431: (/NULL - ]; /436: (/NULL - ]), fd=(431)==(436), (436)==(431)]
+                                         └── project
+                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                              ├── key: (443-446)
+                                              └── inner-join (hash)
+                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null c4:452!null
+                                                   ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+                                                   ├── key: (443,444,446,452)
+                                                   ├── fd: (445)==(452), (452)==(445)
+                                                   ├── scan a
+                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
+                                                   │    └── key: (443-446)
+                                                   ├── distinct-on
+                                                   │    ├── columns: c4:452
+                                                   │    ├── grouping columns: c4:452
+                                                   │    ├── key: (452)
+                                                   │    └── scan c
+                                                   │         └── columns: c4:452
+                                                   └── filters
+                                                        └── a3:445 = c4:452 [outer=(445,452), constraints=(/445: (/NULL - ]; /452: (/NULL - ]), fd=(445)==(452), (452)==(445)]
+
+# IN subquery
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1+a3-a2 FROM a WHERE a1 IN (SELECT b1 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
+----
+project
+ ├── columns: "?column?":22!null
+ ├── immutable
+ ├── project
+ │    ├── columns: a1:1!null a2:2!null a3:3!null
+ │    └── inner-join (hash)
+ │         ├── columns: a1:1!null a2:2!null a3:3!null b1:7!null
+ │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         ├── fd: (1)==(7), (7)==(1)
+ │         ├── scan a
+ │         │    └── columns: a1:1!null a2:2!null a3:3!null
+ │         ├── distinct-on
+ │         │    ├── columns: b1:7
+ │         │    ├── grouping columns: b1:7
+ │         │    ├── key: (7)
+ │         │    └── project
+ │         │         ├── columns: b1:7 b2:8 b3:9
+ │         │         └── distinct-on
+ │         │              ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
+ │         │              ├── grouping columns: b.rowid:11!null
+ │         │              ├── key: (11)
+ │         │              ├── fd: (11)-->(7-9)
+ │         │              ├── union-all
+ │         │              │    ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
+ │         │              │    ├── left columns: b1:23 b2:24 b3:25 b.rowid:27
+ │         │              │    ├── right columns: b1:37 b2:38 b3:39 b.rowid:41
+ │         │              │    ├── project
+ │         │              │    │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
+ │         │              │    │    ├── key: (27)
+ │         │              │    │    ├── fd: (27)-->(23-25)
+ │         │              │    │    └── inner-join (hash)
+ │         │              │    │         ├── columns: b1:23 b2:24!null b3:25 b.rowid:27!null c2:31!null
+ │         │              │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │              │    │         ├── key: (27)
+ │         │              │    │         ├── fd: (27)-->(23-25), (24)==(31), (31)==(24)
+ │         │              │    │         ├── scan b
+ │         │              │    │         │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
+ │         │              │    │         │    ├── key: (27)
+ │         │              │    │         │    └── fd: (27)-->(23-25)
+ │         │              │    │         ├── distinct-on
+ │         │              │    │         │    ├── columns: c2:31
+ │         │              │    │         │    ├── grouping columns: c2:31
+ │         │              │    │         │    ├── key: (31)
+ │         │              │    │         │    └── scan c
+ │         │              │    │         │         └── columns: c2:31
+ │         │              │    │         └── filters
+ │         │              │    │              └── c2:31 = b2:24 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │         │              │    └── project
+ │         │              │         ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
+ │         │              │         ├── key: (41)
+ │         │              │         ├── fd: (41)-->(37-39)
+ │         │              │         └── distinct-on
+ │         │              │              ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
+ │         │              │              ├── grouping columns: b.rowid:41!null
+ │         │              │              ├── key: (41)
+ │         │              │              ├── fd: (41)-->(37-39)
+ │         │              │              ├── union-all
+ │         │              │              │    ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
+ │         │              │              │    ├── left columns: b1:191 b2:192 b3:193 b.rowid:195
+ │         │              │              │    ├── right columns: b1:205 b2:206 b3:207 b.rowid:209
+ │         │              │              │    ├── project
+ │         │              │              │    │    ├── columns: b1:191 b2:192 b3:193 b.rowid:195!null
+ │         │              │              │    │    ├── key: (195)
+ │         │              │              │    │    ├── fd: (195)-->(191-193)
+ │         │              │              │    │    └── inner-join (hash)
+ │         │              │              │    │         ├── columns: b1:191 b2:192 b3:193!null b.rowid:195!null c2:199!null
+ │         │              │              │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │              │              │    │         ├── key: (195)
+ │         │              │              │    │         ├── fd: (195)-->(191-193), (193)==(199), (199)==(193)
+ │         │              │              │    │         ├── scan b
+ │         │              │              │    │         │    ├── columns: b1:191 b2:192 b3:193 b.rowid:195!null
+ │         │              │              │    │         │    ├── key: (195)
+ │         │              │              │    │         │    └── fd: (195)-->(191-193)
+ │         │              │              │    │         ├── distinct-on
+ │         │              │              │    │         │    ├── columns: c2:199
+ │         │              │              │    │         │    ├── grouping columns: c2:199
+ │         │              │              │    │         │    ├── key: (199)
+ │         │              │              │    │         │    └── scan c
+ │         │              │              │    │         │         └── columns: c2:199
+ │         │              │              │    │         └── filters
+ │         │              │              │    │              └── c2:199 = b3:193 [outer=(193,199), constraints=(/193: (/NULL - ]; /199: (/NULL - ]), fd=(193)==(199), (199)==(193)]
+ │         │              │              │    └── project
+ │         │              │              │         ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null
+ │         │              │              │         ├── key: (209)
+ │         │              │              │         ├── fd: (209)-->(205-207)
+ │         │              │              │         └── project
+ │         │              │              │              ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null
+ │         │              │              │              ├── key: (209)
+ │         │              │              │              ├── fd: (209)-->(205-207)
+ │         │              │              │              └── inner-join (cross)
+ │         │              │              │                   ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null c2:213
+ │         │              │              │                   ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │              │              │                   ├── key: (209)
+ │         │              │              │                   ├── fd: ()-->(213), (209)-->(205-207)
+ │         │              │              │                   ├── scan b
+ │         │              │              │                   │    ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null
+ │         │              │              │                   │    ├── key: (209)
+ │         │              │              │                   │    └── fd: (209)-->(205-207)
+ │         │              │              │                   ├── limit
+ │         │              │              │                   │    ├── columns: c2:213
+ │         │              │              │                   │    ├── cardinality: [0 - 1]
+ │         │              │              │                   │    ├── key: ()
+ │         │              │              │                   │    ├── fd: ()-->(213)
+ │         │              │              │                   │    ├── select
+ │         │              │              │                   │    │    ├── columns: c2:213
+ │         │              │              │                   │    │    ├── fd: ()-->(213)
+ │         │              │              │                   │    │    ├── limit hint: 1.00
+ │         │              │              │                   │    │    ├── scan c
+ │         │              │              │                   │    │    │    ├── columns: c2:213
+ │         │              │              │                   │    │    │    └── limit hint: 100.00
+ │         │              │              │                   │    │    └── filters
+ │         │              │              │                   │    │         └── c2:213 IS NULL [outer=(213), constraints=(/213: [/NULL - /NULL]; tight), fd=()-->(213)]
+ │         │              │              │                   │    └── 1
+ │         │              │              │                   └── filters (true)
+ │         │              │              └── aggregations
+ │         │              │                   ├── const-agg [as=b1:37, outer=(37)]
+ │         │              │                   │    └── b1:37
+ │         │              │                   ├── const-agg [as=b2:38, outer=(38)]
+ │         │              │                   │    └── b2:38
+ │         │              │                   └── const-agg [as=b3:39, outer=(39)]
+ │         │              │                        └── b3:39
+ │         │              └── aggregations
+ │         │                   ├── const-agg [as=b1:7, outer=(7)]
+ │         │                   │    └── b1:7
+ │         │                   ├── const-agg [as=b2:8, outer=(8)]
+ │         │                   │    └── b2:8
+ │         │                   └── const-agg [as=b3:9, outer=(9)]
+ │         │                        └── b3:9
+ │         └── filters
+ │              └── a1:1 = b1:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ └── projections
+      └── (a1:1 + a3:3) - a2:2 [as="?column?":22, outer=(1-3), immutable]
+
+# IN subquery, 2 columns
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1+a3-a2 FROM a WHERE (a1,a2) IN (SELECT b1,b2 FROM b WHERE
+                                            EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
+----
+project
+ ├── columns: "?column?":23!null
+ ├── immutable
+ ├── semi-join (hash)
+ │    ├── columns: a1:1!null a2:2!null a3:3!null
+ │    ├── scan a
+ │    │    └── columns: a1:1!null a2:2!null a3:3!null
+ │    ├── project
+ │    │    ├── columns: b1:7 b2:8 b3:9
+ │    │    └── distinct-on
+ │    │         ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
+ │    │         ├── grouping columns: b.rowid:11!null
+ │    │         ├── key: (11)
+ │    │         ├── fd: (11)-->(7-9)
+ │    │         ├── union-all
+ │    │         │    ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
+ │    │         │    ├── left columns: b1:24 b2:25 b3:26 b.rowid:28
+ │    │         │    ├── right columns: b1:38 b2:39 b3:40 b.rowid:42
+ │    │         │    ├── project
+ │    │         │    │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
+ │    │         │    │    ├── key: (28)
+ │    │         │    │    ├── fd: (28)-->(24-26)
+ │    │         │    │    └── inner-join (hash)
+ │    │         │    │         ├── columns: b1:24 b2:25!null b3:26 b.rowid:28!null c2:32!null
+ │    │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         │    │         ├── key: (28)
+ │    │         │    │         ├── fd: (28)-->(24-26), (25)==(32), (32)==(25)
+ │    │         │    │         ├── scan b
+ │    │         │    │         │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
+ │    │         │    │         │    ├── key: (28)
+ │    │         │    │         │    └── fd: (28)-->(24-26)
+ │    │         │    │         ├── distinct-on
+ │    │         │    │         │    ├── columns: c2:32
+ │    │         │    │         │    ├── grouping columns: c2:32
+ │    │         │    │         │    ├── key: (32)
+ │    │         │    │         │    └── scan c
+ │    │         │    │         │         └── columns: c2:32
+ │    │         │    │         └── filters
+ │    │         │    │              └── c2:32 = b2:25 [outer=(25,32), constraints=(/25: (/NULL - ]; /32: (/NULL - ]), fd=(25)==(32), (32)==(25)]
+ │    │         │    └── project
+ │    │         │         ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
+ │    │         │         ├── key: (42)
+ │    │         │         ├── fd: (42)-->(38-40)
+ │    │         │         └── distinct-on
+ │    │         │              ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
+ │    │         │              ├── grouping columns: b.rowid:42!null
+ │    │         │              ├── key: (42)
+ │    │         │              ├── fd: (42)-->(38-40)
+ │    │         │              ├── union-all
+ │    │         │              │    ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
+ │    │         │              │    ├── left columns: b1:192 b2:193 b3:194 b.rowid:196
+ │    │         │              │    ├── right columns: b1:206 b2:207 b3:208 b.rowid:210
+ │    │         │              │    ├── project
+ │    │         │              │    │    ├── columns: b1:192 b2:193 b3:194 b.rowid:196!null
+ │    │         │              │    │    ├── key: (196)
+ │    │         │              │    │    ├── fd: (196)-->(192-194)
+ │    │         │              │    │    └── inner-join (hash)
+ │    │         │              │    │         ├── columns: b1:192 b2:193 b3:194!null b.rowid:196!null c2:200!null
+ │    │         │              │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         │              │    │         ├── key: (196)
+ │    │         │              │    │         ├── fd: (196)-->(192-194), (194)==(200), (200)==(194)
+ │    │         │              │    │         ├── scan b
+ │    │         │              │    │         │    ├── columns: b1:192 b2:193 b3:194 b.rowid:196!null
+ │    │         │              │    │         │    ├── key: (196)
+ │    │         │              │    │         │    └── fd: (196)-->(192-194)
+ │    │         │              │    │         ├── distinct-on
+ │    │         │              │    │         │    ├── columns: c2:200
+ │    │         │              │    │         │    ├── grouping columns: c2:200
+ │    │         │              │    │         │    ├── key: (200)
+ │    │         │              │    │         │    └── scan c
+ │    │         │              │    │         │         └── columns: c2:200
+ │    │         │              │    │         └── filters
+ │    │         │              │    │              └── c2:200 = b3:194 [outer=(194,200), constraints=(/194: (/NULL - ]; /200: (/NULL - ]), fd=(194)==(200), (200)==(194)]
+ │    │         │              │    └── project
+ │    │         │              │         ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null
+ │    │         │              │         ├── key: (210)
+ │    │         │              │         ├── fd: (210)-->(206-208)
+ │    │         │              │         └── project
+ │    │         │              │              ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null
+ │    │         │              │              ├── key: (210)
+ │    │         │              │              ├── fd: (210)-->(206-208)
+ │    │         │              │              └── inner-join (cross)
+ │    │         │              │                   ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null c2:214
+ │    │         │              │                   ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         │              │                   ├── key: (210)
+ │    │         │              │                   ├── fd: ()-->(214), (210)-->(206-208)
+ │    │         │              │                   ├── scan b
+ │    │         │              │                   │    ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null
+ │    │         │              │                   │    ├── key: (210)
+ │    │         │              │                   │    └── fd: (210)-->(206-208)
+ │    │         │              │                   ├── limit
+ │    │         │              │                   │    ├── columns: c2:214
+ │    │         │              │                   │    ├── cardinality: [0 - 1]
+ │    │         │              │                   │    ├── key: ()
+ │    │         │              │                   │    ├── fd: ()-->(214)
+ │    │         │              │                   │    ├── select
+ │    │         │              │                   │    │    ├── columns: c2:214
+ │    │         │              │                   │    │    ├── fd: ()-->(214)
+ │    │         │              │                   │    │    ├── limit hint: 1.00
+ │    │         │              │                   │    │    ├── scan c
+ │    │         │              │                   │    │    │    ├── columns: c2:214
+ │    │         │              │                   │    │    │    └── limit hint: 100.00
+ │    │         │              │                   │    │    └── filters
+ │    │         │              │                   │    │         └── c2:214 IS NULL [outer=(214), constraints=(/214: [/NULL - /NULL]; tight), fd=()-->(214)]
+ │    │         │              │                   │    └── 1
+ │    │         │              │                   └── filters (true)
+ │    │         │              └── aggregations
+ │    │         │                   ├── const-agg [as=b1:38, outer=(38)]
+ │    │         │                   │    └── b1:38
+ │    │         │                   ├── const-agg [as=b2:39, outer=(39)]
+ │    │         │                   │    └── b2:39
+ │    │         │                   └── const-agg [as=b3:40, outer=(40)]
+ │    │         │                        └── b3:40
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=b1:7, outer=(7)]
+ │    │              │    └── b1:7
+ │    │              ├── const-agg [as=b2:8, outer=(8)]
+ │    │              │    └── b2:8
+ │    │              └── const-agg [as=b3:9, outer=(9)]
+ │    │                   └── b3:9
+ │    └── filters
+ │         ├── b1:7 = a1:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ │         └── b2:8 = a2:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── projections
+      └── (a1:1 + a3:3) - a2:2 [as="?column?":23, outer=(1-3), immutable]
+
+# ANDed disjuncts
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = a2) AND (a1 = c1 OR c1 = c2))
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null c1:7!null c2:8!null c3:9 c4:10
+ ├── fd: (2)==(8), (8)==(2)
+ └── group-by (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
+      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
+      ├── key: (1,3,4,11)
+      ├── fd: (11)-->(7-10), (2)==(8), (8)==(2), (1,3,4,11)-->(2,7-10)
+      ├── inner-join (cross)
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14
+      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    ├── scan b
+      │    │    └── columns: b1:14
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
+      │    │    ├── key: (1,3,4,11)
+      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    │    └── key: (1-4)
+      │    │    ├── scan c
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
+      │    │    │    ├── key: (11)
+      │    │    │    └── fd: (11)-->(7-10)
+      │    │    └── filters
+      │    │         ├── (a1:1 = c1:7) OR (c1:7 = c2:8) [outer=(1,7,8), constraints=(/7: (/NULL - ])]
+      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    └── filters
+      │         └── (a1:1 = b1:14) OR (a1:1 = a2:2) [outer=(1,2,14), constraints=(/1: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=c1:7, outer=(7)]
+           │    └── c1:7
+           ├── const-agg [as=c2:8, outer=(8)]
+           │    └── c2:8
+           ├── const-agg [as=c3:9, outer=(9)]
+           │    └── c3:9
+           ├── const-agg [as=c4:10, outer=(10)]
+           │    └── c4:10
+           └── const-agg [as=a2:2, outer=(2)]
+                └── a2:2
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b2) AND (c1 = b1 OR c1 = b2))
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null c1:7!null c2:8!null c3:9 c4:10
+ ├── fd: (2)==(8), (8)==(2)
+ └── group-by (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
+      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
+      ├── key: (1,3,4,11)
+      ├── fd: (11)-->(7-10), (2)==(8), (8)==(2), (1,3,4,11)-->(2,7-10)
+      ├── inner-join (hash)
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
+      │    ├── key: (1,3,4,11,18)
+      │    ├── fd: (11,18)-->(7-10,14,15), (2)==(8), (8)==(2)
+      │    ├── scan a
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    └── key: (1-4)
+      │    ├── distinct-on
+      │    │    ├── columns: c1:7!null c2:8 c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
+      │    │    ├── grouping columns: c.rowid:11!null b.rowid:18!null
+      │    │    ├── key: (11,18)
+      │    │    ├── fd: (11,18)-->(7-10,14,15)
+      │    │    ├── union-all
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 c4:10 c.rowid:11!null b1:14 b2:15 b.rowid:18!null
+      │    │    │    ├── left columns: c1:24 c2:25 c3:26 c4:27 c.rowid:28 b1:31 b2:32 b.rowid:35
+      │    │    │    ├── right columns: c1:38 c2:39 c3:40 c4:41 c.rowid:42 b1:45 b2:46 b.rowid:49
+      │    │    │    ├── inner-join (hash)
+      │    │    │    │    ├── columns: c1:24!null c2:25 c3:26 c4:27 c.rowid:28!null b1:31!null b2:32 b.rowid:35!null
+      │    │    │    │    ├── key: (28,35)
+      │    │    │    │    ├── fd: (28)-->(24-27), (35)-->(31,32), (24)==(31), (31)==(24)
+      │    │    │    │    ├── scan c
+      │    │    │    │    │    ├── columns: c1:24 c2:25 c3:26 c4:27 c.rowid:28!null
+      │    │    │    │    │    ├── key: (28)
+      │    │    │    │    │    └── fd: (28)-->(24-27)
+      │    │    │    │    ├── scan b
+      │    │    │    │    │    ├── columns: b1:31 b2:32 b.rowid:35!null
+      │    │    │    │    │    ├── key: (35)
+      │    │    │    │    │    └── fd: (35)-->(31,32)
+      │    │    │    │    └── filters
+      │    │    │    │         └── c1:24 = b1:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+      │    │    │    └── inner-join (hash)
+      │    │    │         ├── columns: c1:38!null c2:39 c3:40 c4:41 c.rowid:42!null b1:45 b2:46!null b.rowid:49!null
+      │    │    │         ├── key: (42,49)
+      │    │    │         ├── fd: (42)-->(38-41), (49)-->(45,46), (38)==(46), (46)==(38)
+      │    │    │         ├── scan c
+      │    │    │         │    ├── columns: c1:38 c2:39 c3:40 c4:41 c.rowid:42!null
+      │    │    │         │    ├── key: (42)
+      │    │    │         │    └── fd: (42)-->(38-41)
+      │    │    │         ├── scan b
+      │    │    │         │    ├── columns: b1:45 b2:46 b.rowid:49!null
+      │    │    │         │    ├── key: (49)
+      │    │    │         │    └── fd: (49)-->(45,46)
+      │    │    │         └── filters
+      │    │    │              └── c1:38 = b2:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
+      │    │    └── aggregations
+      │    │         ├── const-agg [as=c1:7, outer=(7)]
+      │    │         │    └── c1:7
+      │    │         ├── const-agg [as=c2:8, outer=(8)]
+      │    │         │    └── c2:8
+      │    │         ├── const-agg [as=c3:9, outer=(9)]
+      │    │         │    └── c3:9
+      │    │         ├── const-agg [as=c4:10, outer=(10)]
+      │    │         │    └── c4:10
+      │    │         ├── const-agg [as=b1:14, outer=(14)]
+      │    │         │    └── b1:14
+      │    │         └── const-agg [as=b2:15, outer=(15)]
+      │    │              └── b2:15
+      │    └── filters
+      │         ├── (a1:1 = b1:14) OR (a1:1 = b2:15) [outer=(1,14,15), constraints=(/1: (/NULL - ])]
+      │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      └── aggregations
+           ├── const-agg [as=c1:7, outer=(7)]
+           │    └── c1:7
+           ├── const-agg [as=c2:8, outer=(8)]
+           │    └── c2:8
+           ├── const-agg [as=c3:9, outer=(9)]
+           │    └── c3:9
+           ├── const-agg [as=c4:10, outer=(10)]
+           │    └── c4:10
+           └── const-agg [as=a2:2, outer=(2)]
+                └── a2:2
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a1,a2,a3,c.* FROM a,c
+       WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b3) AND (a1 = c1 OR a1 = c3))
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null c1:7 c2:8!null c3:9 c4:10
+ ├── fd: (2)==(8), (8)==(2)
+ └── group-by (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
+      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
+      ├── key: (1,3,4,11)
+      ├── fd: (11)-->(7-10), (2)==(8), (8)==(2), (1,3,4,11)-->(2,7-10)
+      ├── inner-join (cross)
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b3:16
+      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    ├── scan b
+      │    │    └── columns: b1:14 b3:16
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
+      │    │    ├── key: (1,3,4,11)
+      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    │    └── key: (1-4)
+      │    │    ├── scan c
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
+      │    │    │    ├── key: (11)
+      │    │    │    └── fd: (11)-->(7-10)
+      │    │    └── filters
+      │    │         ├── (a1:1 = c1:7) OR (a1:1 = c3:9) [outer=(1,7,9), constraints=(/1: (/NULL - ])]
+      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    └── filters
+      │         └── (a1:1 = b1:14) OR (a1:1 = b3:16) [outer=(1,14,16), constraints=(/1: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=c1:7, outer=(7)]
+           │    └── c1:7
+           ├── const-agg [as=c2:8, outer=(8)]
+           │    └── c2:8
+           ├── const-agg [as=c3:9, outer=(9)]
+           │    └── c3:9
+           ├── const-agg [as=c4:10, outer=(10)]
+           │    └── c4:10
+           └── const-agg [as=a2:2, outer=(2)]
+                └── a2:2
+
+# Nested EXISTS
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE (a1=b1 OR a1=b2) AND EXISTS(SELECT 1 FROM c WHERE b1=c1))
+----
+project
+ ├── columns: a2:2!null a4:4!null
+ └── project
+      ├── columns: a1:1!null a2:2!null a4:4!null
+      └── distinct-on
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+           ├── key: (1-4)
+           └── inner-join (hash)
+                ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b.rowid:11!null c1:14!null
+                ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+                ├── key: (1-4,11)
+                ├── fd: (1-4,11)-->(7,8), (7)==(14), (14)==(7)
+                ├── distinct-on
+                │    ├── columns: c1:14
+                │    ├── grouping columns: c1:14
+                │    ├── key: (14)
+                │    └── scan c
+                │         └── columns: c1:14
+                ├── distinct-on
+                │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
+                │    ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
+                │    ├── key: (1-4,11)
+                │    ├── fd: (1-4,11)-->(7,8)
+                │    ├── union-all
+                │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
+                │    │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b.rowid:32
+                │    │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b.rowid:45
+                │    │    ├── inner-join (merge)
+                │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b.rowid:32!null
+                │    │    │    ├── left ordering: +22
+                │    │    │    ├── right ordering: +28
+                │    │    │    ├── key: (23-25,32)
+                │    │    │    ├── fd: (32)-->(28,29), (22)==(28), (28)==(22)
+                │    │    │    ├── scan a
+                │    │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+                │    │    │    │    ├── key: (22-25)
+                │    │    │    │    └── ordering: +22
+                │    │    │    ├── scan b@b_b1_b2_idx
+                │    │    │    │    ├── columns: b1:28 b2:29 b.rowid:32!null
+                │    │    │    │    ├── key: (32)
+                │    │    │    │    ├── fd: (32)-->(28,29)
+                │    │    │    │    └── ordering: +28
+                │    │    │    └── filters (true)
+                │    │    └── inner-join (merge)
+                │    │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41 b2:42!null b.rowid:45!null
+                │    │         ├── left ordering: +35
+                │    │         ├── right ordering: +42
+                │    │         ├── key: (36-38,45)
+                │    │         ├── fd: (45)-->(41,42), (35)==(42), (42)==(35)
+                │    │         ├── scan a
+                │    │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+                │    │         │    ├── key: (35-38)
+                │    │         │    └── ordering: +35
+                │    │         ├── scan b@b_b2_idx
+                │    │         │    ├── columns: b1:41 b2:42 b.rowid:45!null
+                │    │         │    ├── key: (45)
+                │    │         │    ├── fd: (45)-->(41,42)
+                │    │         │    └── ordering: +42
+                │    │         └── filters (true)
+                │    └── aggregations
+                │         ├── const-agg [as=b1:7, outer=(7)]
+                │         │    └── b1:7
+                │         └── const-agg [as=b2:8, outer=(8)]
+                │              └── b2:8
+                └── filters
+                     └── b1:7 = c1:14 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+
+# Two EXISTS at same nesting level; only one disjuction pair can be optimized
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2) AND
+                          EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2)
+----
+project
+ ├── columns: a2:2!null a4:4!null
+ └── semi-join (cross)
+      ├── columns: a1:1!null a2:2!null a4:4!null
+      ├── project
+      │    ├── columns: a1:1!null a2:2!null a4:4!null
+      │    └── distinct-on
+      │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │         ├── key: (1-4)
+      │         └── union-all
+      │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │              ├── left columns: a1:100 a2:101 a3:102 a4:103
+      │              ├── right columns: a1:113 a2:114 a3:115 a4:116
+      │              ├── project
+      │              │    ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null
+      │              │    ├── key: (100-103)
+      │              │    └── inner-join (merge)
+      │              │         ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null b1:106!null
+      │              │         ├── left ordering: +100
+      │              │         ├── right ordering: +106
+      │              │         ├── key: (101-103,106)
+      │              │         ├── fd: (100)==(106), (106)==(100)
+      │              │         ├── scan a
+      │              │         │    ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null
+      │              │         │    ├── key: (100-103)
+      │              │         │    └── ordering: +100
+      │              │         ├── distinct-on
+      │              │         │    ├── columns: b1:106
+      │              │         │    ├── grouping columns: b1:106
+      │              │         │    ├── key: (106)
+      │              │         │    ├── ordering: +106
+      │              │         │    └── scan b@b_b1_b2_idx
+      │              │         │         ├── columns: b1:106
+      │              │         │         └── ordering: +106
+      │              │         └── filters (true)
+      │              └── project
+      │                   ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null
+      │                   ├── key: (113-116)
+      │                   └── inner-join (merge)
+      │                        ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null b2:120!null
+      │                        ├── left ordering: +113
+      │                        ├── right ordering: +120
+      │                        ├── key: (114-116,120)
+      │                        ├── fd: (113)==(120), (120)==(113)
+      │                        ├── scan a
+      │                        │    ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null
+      │                        │    ├── key: (113-116)
+      │                        │    └── ordering: +113
+      │                        ├── distinct-on
+      │                        │    ├── columns: b2:120
+      │                        │    ├── grouping columns: b2:120
+      │                        │    ├── key: (120)
+      │                        │    ├── ordering: +120
+      │                        │    └── scan b@b_b2_idx
+      │                        │         ├── columns: b2:120
+      │                        │         └── ordering: +120
+      │                        └── filters (true)
+      ├── scan c
+      │    └── columns: c1:14 c2:15
+      └── filters
+           └── (a1:1 = c1:14) OR (a1:1 = c2:15) [outer=(1,14,15), constraints=(/1: (/NULL - ])]
+
+# Two EXISTS at same nesting level; only one disjuction chain can be optimized
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT a2,a4 FROM a WHERE EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2 OR a1=b3 OR a1=b4) AND
+                          EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2 OR a1=c3 OR a1=c4)
+----
+project
+ ├── columns: a2:2!null a4:4!null
+ └── semi-join (cross)
+      ├── columns: a1:1!null a2:2!null a4:4!null
+      ├── project
+      │    ├── columns: a1:1!null a2:2!null a4:4!null
+      │    └── distinct-on
+      │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │         ├── key: (1-4)
+      │         └── union-all
+      │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │              ├── left columns: a1:516 a2:517 a3:518 a4:519
+      │              ├── right columns: a1:529 a2:530 a3:531 a4:532
+      │              ├── project
+      │              │    ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null
+      │              │    ├── key: (516-519)
+      │              │    └── inner-join (merge)
+      │              │         ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null b1:522!null
+      │              │         ├── left ordering: +516
+      │              │         ├── right ordering: +522
+      │              │         ├── key: (517-519,522)
+      │              │         ├── fd: (516)==(522), (522)==(516)
+      │              │         ├── scan a
+      │              │         │    ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null
+      │              │         │    ├── key: (516-519)
+      │              │         │    └── ordering: +516
+      │              │         ├── distinct-on
+      │              │         │    ├── columns: b1:522
+      │              │         │    ├── grouping columns: b1:522
+      │              │         │    ├── key: (522)
+      │              │         │    ├── ordering: +522
+      │              │         │    └── scan b@b_b1_b2_idx
+      │              │         │         ├── columns: b1:522
+      │              │         │         └── ordering: +522
+      │              │         └── filters (true)
+      │              └── project
+      │                   ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
+      │                   ├── key: (529-532)
+      │                   └── distinct-on
+      │                        ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
+      │                        ├── grouping columns: a1:529!null a2:530!null a3:531!null a4:532!null
+      │                        ├── key: (529-532)
+      │                        └── union-all
+      │                             ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
+      │                             ├── left columns: a1:620 a2:621 a3:622 a4:623
+      │                             ├── right columns: a1:633 a2:634 a3:635 a4:636
+      │                             ├── project
+      │                             │    ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null
+      │                             │    ├── key: (620-623)
+      │                             │    └── inner-join (hash)
+      │                             │         ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null b4:629!null
+      │                             │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │                             │         ├── key: (621-623,629)
+      │                             │         ├── fd: (620)==(629), (629)==(620)
+      │                             │         ├── scan a
+      │                             │         │    ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null
+      │                             │         │    └── key: (620-623)
+      │                             │         ├── distinct-on
+      │                             │         │    ├── columns: b4:629
+      │                             │         │    ├── grouping columns: b4:629
+      │                             │         │    ├── key: (629)
+      │                             │         │    └── scan b
+      │                             │         │         └── columns: b4:629
+      │                             │         └── filters
+      │                             │              └── a1:620 = b4:629 [outer=(620,629), constraints=(/620: (/NULL - ]; /629: (/NULL - ]), fd=(620)==(629), (629)==(620)]
+      │                             └── project
+      │                                  ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
+      │                                  ├── key: (633-636)
+      │                                  └── distinct-on
+      │                                       ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
+      │                                       ├── grouping columns: a1:633!null a2:634!null a3:635!null a4:636!null
+      │                                       ├── key: (633-636)
+      │                                       └── union-all
+      │                                            ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
+      │                                            ├── left columns: a1:698 a2:699 a3:700 a4:701
+      │                                            ├── right columns: a1:711 a2:712 a3:713 a4:714
+      │                                            ├── project
+      │                                            │    ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null
+      │                                            │    ├── key: (698-701)
+      │                                            │    └── inner-join (merge)
+      │                                            │         ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null b2:705!null
+      │                                            │         ├── left ordering: +698
+      │                                            │         ├── right ordering: +705
+      │                                            │         ├── key: (699-701,705)
+      │                                            │         ├── fd: (698)==(705), (705)==(698)
+      │                                            │         ├── scan a
+      │                                            │         │    ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null
+      │                                            │         │    ├── key: (698-701)
+      │                                            │         │    └── ordering: +698
+      │                                            │         ├── distinct-on
+      │                                            │         │    ├── columns: b2:705
+      │                                            │         │    ├── grouping columns: b2:705
+      │                                            │         │    ├── key: (705)
+      │                                            │         │    ├── ordering: +705
+      │                                            │         │    └── scan b@b_b2_idx
+      │                                            │         │         ├── columns: b2:705
+      │                                            │         │         └── ordering: +705
+      │                                            │         └── filters (true)
+      │                                            └── project
+      │                                                 ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null
+      │                                                 ├── key: (711-714)
+      │                                                 └── inner-join (merge)
+      │                                                      ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null b3:719!null
+      │                                                      ├── left ordering: +711
+      │                                                      ├── right ordering: +719
+      │                                                      ├── key: (712-714,719)
+      │                                                      ├── fd: (711)==(719), (719)==(711)
+      │                                                      ├── scan a
+      │                                                      │    ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null
+      │                                                      │    ├── key: (711-714)
+      │                                                      │    └── ordering: +711
+      │                                                      ├── distinct-on
+      │                                                      │    ├── columns: b3:719
+      │                                                      │    ├── grouping columns: b3:719
+      │                                                      │    ├── key: (719)
+      │                                                      │    ├── ordering: +719
+      │                                                      │    └── scan b@b_b3_idx
+      │                                                      │         ├── columns: b3:719
+      │                                                      │         └── ordering: +719
+      │                                                      └── filters (true)
+      ├── scan c
+      │    └── columns: c1:14 c2:15 c3:16 c4:17
+      └── filters
+           └── (((a1:1 = c1:14) OR (a1:1 = c2:15)) OR (a1:1 = c3:16)) OR (a1:1 = c4:17) [outer=(1,14-17), constraints=(/1: (/NULL - ])]
+
+# Outer Select is Join
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c WHERE c1=b1))
+                       AS foo on a1=foo.b1 OR a2=foo.b2
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 c1:14!null
+      ├── fd: (7)==(14), (14)==(7)
+      └── inner-join (hash)
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null c1:14!null
+           ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           ├── key: (1-4,11)
+           ├── fd: (1-4,11)-->(7-10), (7)==(14), (14)==(7)
+           ├── distinct-on
+           │    ├── columns: c1:14!null
+           │    ├── grouping columns: c1:14!null
+           │    ├── key: (14)
+           │    └── select
+           │         ├── columns: c1:14!null
+           │         ├── scan c
+           │         │    └── columns: c1:14
+           │         └── filters
+           │              └── c1:14 > 0 [outer=(14), constraints=(/14: [/1 - ]; tight)]
+           ├── distinct-on
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+           │    ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null b.rowid:11!null
+           │    ├── key: (1-4,11)
+           │    ├── fd: (1-4,11)-->(7-10)
+           │    ├── union-all
+           │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+           │    │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b3:30 b4:31 b.rowid:32
+           │    │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b3:43 b4:44 b.rowid:45
+           │    │    ├── inner-join (merge)
+           │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
+           │    │    │    ├── left ordering: +22
+           │    │    │    ├── right ordering: +28
+           │    │    │    ├── key: (23-25,32)
+           │    │    │    ├── fd: (32)-->(28-31), (22)==(28), (28)==(22)
+           │    │    │    ├── scan a
+           │    │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+           │    │    │    │    ├── key: (22-25)
+           │    │    │    │    └── ordering: +22
+           │    │    │    ├── scan b@b_b1_b2_idx
+           │    │    │    │    ├── columns: b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
+           │    │    │    │    ├── constraint: /28/29/32: [/1 - ]
+           │    │    │    │    ├── key: (32)
+           │    │    │    │    ├── fd: (32)-->(28-31)
+           │    │    │    │    └── ordering: +28
+           │    │    │    └── filters (true)
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41!null b2:42!null b3:43 b4:44 b.rowid:45!null
+           │    │         ├── key: (35,37,38,45)
+           │    │         ├── fd: (45)-->(41-44), (36)==(42), (42)==(36)
+           │    │         ├── scan a
+           │    │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+           │    │         │    └── key: (35-38)
+           │    │         ├── scan b@b_b1_b2_idx
+           │    │         │    ├── columns: b1:41!null b2:42 b3:43 b4:44 b.rowid:45!null
+           │    │         │    ├── constraint: /41/42/45: [/1 - ]
+           │    │         │    ├── key: (45)
+           │    │         │    └── fd: (45)-->(41-44)
+           │    │         └── filters
+           │    │              └── a2:36 = b2:42 [outer=(36,42), constraints=(/36: (/NULL - ]; /42: (/NULL - ]), fd=(36)==(42), (42)==(36)]
+           │    └── aggregations
+           │         ├── const-agg [as=b1:7, outer=(7)]
+           │         │    └── b1:7
+           │         ├── const-agg [as=b2:8, outer=(8)]
+           │         │    └── b2:8
+           │         ├── const-agg [as=b3:9, outer=(9)]
+           │         │    └── b3:9
+           │         └── const-agg [as=b4:10, outer=(10)]
+           │              └── b4:10
+           └── filters
+                └── c1:14 = b1:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND EXISTS (SELECT 1 FROM c WHERE c1=b1 or c2=b2))
+                       AS foo on a1=foo.b1
+----
+inner-join (hash)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
+ ├── fd: (1)==(7), (7)==(1)
+ ├── scan a
+ │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │    └── key: (1-4)
+ ├── project
+ │    ├── columns: b1:7!null b2:8 b3:9 b4:10
+ │    └── distinct-on
+ │         ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+ │         ├── grouping columns: b.rowid:11!null
+ │         ├── key: (11)
+ │         ├── fd: (11)-->(7-10)
+ │         ├── union-all
+ │         │    ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+ │         │    ├── left columns: b1:22 b2:23 b3:24 b4:25 b.rowid:26
+ │         │    ├── right columns: b1:36 b2:37 b3:38 b4:39 b.rowid:40
+ │         │    ├── project
+ │         │    │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
+ │         │    │    ├── key: (26)
+ │         │    │    ├── fd: (26)-->(22-25)
+ │         │    │    └── inner-join (hash)
+ │         │    │         ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null c1:29!null
+ │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │    │         ├── key: (26)
+ │         │    │         ├── fd: (26)-->(22-25), (22)==(29), (29)==(22)
+ │         │    │         ├── scan b@b_b1_b2_idx
+ │         │    │         │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
+ │         │    │         │    ├── constraint: /22/23/26: [/1 - ]
+ │         │    │         │    ├── key: (26)
+ │         │    │         │    └── fd: (26)-->(22-25)
+ │         │    │         ├── distinct-on
+ │         │    │         │    ├── columns: c1:29
+ │         │    │         │    ├── grouping columns: c1:29
+ │         │    │         │    ├── key: (29)
+ │         │    │         │    └── scan c
+ │         │    │         │         └── columns: c1:29
+ │         │    │         └── filters
+ │         │    │              └── c1:29 = b1:22 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │         │    └── project
+ │         │         ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
+ │         │         ├── key: (40)
+ │         │         ├── fd: (40)-->(36-39)
+ │         │         └── inner-join (hash)
+ │         │              ├── columns: b1:36!null b2:37!null b3:38 b4:39 b.rowid:40!null c2:44!null
+ │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │              ├── key: (40)
+ │         │              ├── fd: (40)-->(36-39), (37)==(44), (44)==(37)
+ │         │              ├── scan b@b_b1_b2_idx
+ │         │              │    ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
+ │         │              │    ├── constraint: /36/37/40: [/1 - ]
+ │         │              │    ├── key: (40)
+ │         │              │    └── fd: (40)-->(36-39)
+ │         │              ├── distinct-on
+ │         │              │    ├── columns: c2:44
+ │         │              │    ├── grouping columns: c2:44
+ │         │              │    ├── key: (44)
+ │         │              │    └── scan c
+ │         │              │         └── columns: c2:44
+ │         │              └── filters
+ │         │                   └── c2:44 = b2:37 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
+ │         └── aggregations
+ │              ├── const-agg [as=b1:7, outer=(7)]
+ │              │    └── b1:7
+ │              ├── const-agg [as=b2:8, outer=(8)]
+ │              │    └── b2:8
+ │              ├── const-agg [as=b3:9, outer=(9)]
+ │              │    └── b3:9
+ │              └── const-agg [as=b4:10, outer=(10)]
+ │                   └── b4:10
+ └── filters
+      └── a1:1 = b1:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+#######################
+# Correlated antijoin #
+#######################
+
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT a1,a2,a3 FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a2 = b2 OR a3 = b3)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ └── intersect-all
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── left columns: a1:14 a2:15 a3:16 a4:17
+      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── key: (1-4)
+      ├── anti-join (hash)
+      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    ├── key: (14-17)
+      │    ├── scan a
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    └── key: (14-17)
+      │    ├── scan b
+      │    │    └── columns: b2:21
+      │    └── filters
+      │         └── a2:15 = b2:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
+      └── anti-join (hash)
+           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           ├── key: (27-30)
+           ├── scan a
+           │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           │    └── key: (27-30)
+           ├── scan b
+           │    └── columns: b3:35
+           └── filters
+                └── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT a1,a2,a3 FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null
+ └── intersect-all
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── left columns: a1:14 a2:15 a3:16 a4:17
+      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── key: (1-4)
+      ├── anti-join (merge)
+      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    ├── left ordering: +14
+      │    ├── right ordering: +20
+      │    ├── key: (14-17)
+      │    ├── scan a
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    ├── key: (14-17)
+      │    │    └── ordering: +14
+      │    ├── scan b@b_b1_b2_idx
+      │    │    ├── columns: b1:20
+      │    │    └── ordering: +20
+      │    └── filters (true)
+      └── anti-join (merge)
+           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           ├── left ordering: +27
+           ├── right ordering: +34
+           ├── key: (27-30)
+           ├── scan a
+           │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           │    ├── key: (27-30)
+           │    └── ordering: +27
+           ├── scan b@b_b2_idx
+           │    ├── columns: b2:34
+           │    └── ordering: +34
+           └── filters (true)
+
+# The left side of the join already produces key columns
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a1 = b1 OR a2 = b2 OR a3 = b3 OR a4 = b4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── intersect-all
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── left columns: a1:14 a2:15 a3:16 a4:17
+      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── key: (1-4)
+      ├── anti-join (merge)
+      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    ├── left ordering: +14
+      │    ├── right ordering: +20
+      │    ├── key: (14-17)
+      │    ├── scan a
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    ├── key: (14-17)
+      │    │    └── ordering: +14
+      │    ├── scan b@b_b1_b2_idx
+      │    │    ├── columns: b1:20
+      │    │    └── ordering: +20
+      │    └── filters (true)
+      └── project
+           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           ├── key: (27-30)
+           └── intersect-all
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── left columns: a1:40 a2:41 a3:42 a4:43
+                ├── right columns: a1:53 a2:54 a3:55 a4:56
+                ├── key: (27-30)
+                ├── anti-join (hash)
+                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    ├── key: (40-43)
+                │    ├── scan a
+                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    │    └── key: (40-43)
+                │    ├── scan b
+                │    │    └── columns: b4:49
+                │    └── filters
+                │         └── a4:43 = b4:49 [outer=(43,49), constraints=(/43: (/NULL - ]; /49: (/NULL - ]), fd=(43)==(49), (49)==(43)]
+                └── project
+                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                     ├── key: (53-56)
+                     └── intersect-all
+                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                          ├── left columns: a1:66 a2:67 a3:68 a4:69
+                          ├── right columns: a1:79 a2:80 a3:81 a4:82
+                          ├── key: (53-56)
+                          ├── anti-join (hash)
+                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    ├── key: (66-69)
+                          │    ├── scan a
+                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    │    └── key: (66-69)
+                          │    ├── scan b
+                          │    │    └── columns: b2:73
+                          │    └── filters
+                          │         └── a2:67 = b2:73 [outer=(67,73), constraints=(/67: (/NULL - ]; /73: (/NULL - ]), fd=(67)==(73), (73)==(67)]
+                          └── anti-join (hash)
+                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               ├── key: (79-82)
+                               ├── scan a
+                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               │    └── key: (79-82)
+                               ├── scan b
+                               │    └── columns: b3:87
+                               └── filters
+                                    └── a3:81 = b3:87 [outer=(81,87), constraints=(/81: (/NULL - ]; /87: (/NULL - ]), fd=(81)==(87), (87)==(81)]
+
+# More than one disjunction in the filter
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM c WHERE a1 = c1 OR a2 = c2 OR a3 = c3 OR a4 = c4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── intersect-all
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── left columns: a1:14 a2:15 a3:16 a4:17
+      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── key: (1-4)
+      ├── anti-join (hash)
+      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    ├── key: (14-17)
+      │    ├── scan a
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    └── key: (14-17)
+      │    ├── scan c
+      │    │    └── columns: c1:20
+      │    └── filters
+      │         └── a1:14 = c1:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+      └── project
+           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           ├── key: (27-30)
+           └── intersect-all
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── left columns: a1:40 a2:41 a3:42 a4:43
+                ├── right columns: a1:53 a2:54 a3:55 a4:56
+                ├── key: (27-30)
+                ├── anti-join (hash)
+                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    ├── key: (40-43)
+                │    ├── scan a
+                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    │    └── key: (40-43)
+                │    ├── scan c
+                │    │    └── columns: c4:49
+                │    └── filters
+                │         └── a4:43 = c4:49 [outer=(43,49), constraints=(/43: (/NULL - ]; /49: (/NULL - ]), fd=(43)==(49), (49)==(43)]
+                └── project
+                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                     ├── key: (53-56)
+                     └── intersect-all
+                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                          ├── left columns: a1:66 a2:67 a3:68 a4:69
+                          ├── right columns: a1:79 a2:80 a3:81 a4:82
+                          ├── key: (53-56)
+                          ├── anti-join (hash)
+                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    ├── key: (66-69)
+                          │    ├── scan a
+                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    │    └── key: (66-69)
+                          │    ├── scan c
+                          │    │    └── columns: c2:73
+                          │    └── filters
+                          │         └── a2:67 = c2:73 [outer=(67,73), constraints=(/67: (/NULL - ]; /73: (/NULL - ]), fd=(67)==(73), (73)==(67)]
+                          └── anti-join (hash)
+                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               ├── key: (79-82)
+                               ├── scan a
+                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               │    └── key: (79-82)
+                               ├── scan c
+                               │    └── columns: c3:87
+                               └── filters
+                                    └── a3:81 = c3:87 [outer=(81,87), constraints=(/81: (/NULL - ]; /87: (/NULL - ]), fd=(81)==(87), (87)==(81)]
+
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM c WHERE a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── intersect-all
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      ├── left columns: a1:14 a2:15 a3:16 a4:17
+      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── key: (1-4)
+      ├── anti-join (hash)
+      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    ├── key: (14-17)
+      │    ├── scan a
+      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
+      │    │    └── key: (14-17)
+      │    ├── scan c
+      │    │    └── columns: c2:21
+      │    └── filters
+      │         └── a1:14 = c2:21 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
+      └── project
+           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+           ├── key: (27-30)
+           └── intersect-all
+                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
+                ├── left columns: a1:40 a2:41 a3:42 a4:43
+                ├── right columns: a1:53 a2:54 a3:55 a4:56
+                ├── key: (27-30)
+                ├── anti-join (hash)
+                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    ├── key: (40-43)
+                │    ├── scan a
+                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
+                │    │    └── key: (40-43)
+                │    ├── scan c
+                │    │    └── columns: c4:49
+                │    └── filters
+                │         └── a3:42 = c4:49 [outer=(42,49), constraints=(/42: (/NULL - ]; /49: (/NULL - ]), fd=(42)==(49), (49)==(42)]
+                └── project
+                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                     ├── key: (53-56)
+                     └── intersect-all
+                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
+                          ├── left columns: a1:66 a2:67 a3:68 a4:69
+                          ├── right columns: a1:79 a2:80 a3:81 a4:82
+                          ├── key: (53-56)
+                          ├── anti-join (hash)
+                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    ├── key: (66-69)
+                          │    ├── scan a
+                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
+                          │    │    └── key: (66-69)
+                          │    ├── scan c
+                          │    │    └── columns: c1:72
+                          │    └── filters
+                          │         └── a2:67 = c1:72 [outer=(67,72), constraints=(/67: (/NULL - ]; /72: (/NULL - ]), fd=(67)==(72), (72)==(67)]
+                          └── anti-join (hash)
+                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               ├── key: (79-82)
+                               ├── scan a
+                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
+                               │    └── key: (79-82)
+                               ├── scan c
+                               │    └── columns: c4:88
+                               └── filters
+                                    └── a3:81 = c4:88 [outer=(81,88), constraints=(/81: (/NULL - ]; /88: (/NULL - ]), fd=(81)==(88), (88)==(81)]
+
+# Nested NOT EXISTS
+# Not currently supported. Maybe needs better subquery decorrelation?
+opt expect-not=SplitDisjunctionOfAntiJoinTerms
+SELECT a2,a4 FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE (a1=b1 OR a1=b2) AND NOT EXISTS(SELECT 1 FROM c WHERE b1=c1))
+----
+project
+ ├── columns: a2:2!null a4:4!null
+ └── anti-join (cross)
+      ├── columns: a1:1!null a2:2!null a4:4!null
+      ├── scan a
+      │    └── columns: a1:1!null a2:2!null a4:4!null
+      ├── anti-join (hash)
+      │    ├── columns: b1:7 b2:8
+      │    ├── scan b
+      │    │    └── columns: b1:7 b2:8
+      │    ├── scan c
+      │    │    └── columns: c1:14
+      │    └── filters
+      │         └── b1:7 = c1:14 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+      └── filters
+           └── (a1:1 = b1:7) OR (a1:1 = b2:8) [outer=(1,7,8), constraints=(/1: (/NULL - ])]
+
+# Two NOT EXISTS at same nesting level; only one disjuction pair can be optimized
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT a2,a4 FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE a1=b1 OR a1=b2) AND
+                          NOT EXISTS(SELECT * FROM c WHERE a1=c1 OR a1=c2)
+----
+project
+ ├── columns: a2:2!null a4:4!null
+ └── anti-join (cross)
+      ├── columns: a1:1!null a2:2!null a4:4!null
+      ├── project
+      │    ├── columns: a1:1!null a2:2!null a4:4!null
+      │    └── intersect-all
+      │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │         ├── left columns: a1:47 a2:48 a3:49 a4:50
+      │         ├── right columns: a1:60 a2:61 a3:62 a4:63
+      │         ├── key: (1-4)
+      │         ├── anti-join (merge)
+      │         │    ├── columns: a1:47!null a2:48!null a3:49!null a4:50!null
+      │         │    ├── left ordering: +47
+      │         │    ├── right ordering: +53
+      │         │    ├── key: (47-50)
+      │         │    ├── scan a
+      │         │    │    ├── columns: a1:47!null a2:48!null a3:49!null a4:50!null
+      │         │    │    ├── key: (47-50)
+      │         │    │    └── ordering: +47
+      │         │    ├── scan b@b_b1_b2_idx
+      │         │    │    ├── columns: b1:53
+      │         │    │    └── ordering: +53
+      │         │    └── filters (true)
+      │         └── anti-join (merge)
+      │              ├── columns: a1:60!null a2:61!null a3:62!null a4:63!null
+      │              ├── left ordering: +60
+      │              ├── right ordering: +67
+      │              ├── key: (60-63)
+      │              ├── scan a
+      │              │    ├── columns: a1:60!null a2:61!null a3:62!null a4:63!null
+      │              │    ├── key: (60-63)
+      │              │    └── ordering: +60
+      │              ├── scan b@b_b2_idx
+      │              │    ├── columns: b2:67
+      │              │    └── ordering: +67
+      │              └── filters (true)
+      ├── scan c
+      │    └── columns: c1:14 c2:15
+      └── filters
+           └── (a1:1 = c1:14) OR (a1:1 = c2:15) [outer=(1,14,15), constraints=(/1: (/NULL - ])]
+
+# Outer Select is Join
+build-cascades expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND NOT EXISTS (SELECT 1 FROM c WHERE c1=b1))
+                       AS foo on a1=foo.b1 OR a2=foo.b2
+----
+root
+ └── project
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
+      └── inner-join (cross)
+           ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6 b1:7!null b2:8 b3:9 b4:10
+           ├── fd: (1-4)-->(5,6)
+           ├── scan a
+           │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a.crdb_internal_mvcc_timestamp:5 a.tableoid:6
+           │    ├── key: (1-4)
+           │    └── fd: (1-4)-->(5,6)
+           ├── project
+           │    ├── columns: b1:7!null b2:8 b3:9 b4:10
+           │    └── select
+           │         ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null b.crdb_internal_mvcc_timestamp:12 b.tableoid:13
+           │         ├── key: (11)
+           │         ├── fd: (11)-->(7-10,12,13)
+           │         ├── scan b
+           │         │    ├── columns: b1:7 b2:8 b3:9 b4:10 b.rowid:11!null b.crdb_internal_mvcc_timestamp:12 b.tableoid:13
+           │         │    ├── key: (11)
+           │         │    └── fd: (11)-->(7-10,12,13)
+           │         └── filters
+           │              └── and [outer=(7), correlated-subquery, constraints=(/7: [/1 - ])]
+           │                   ├── b1:7 > 0
+           │                   └── not
+           │                        └── exists
+           │                             └── project
+           │                                  ├── columns: "?column?":21!null
+           │                                  ├── outer: (7)
+           │                                  ├── fd: ()-->(21)
+           │                                  ├── select
+           │                                  │    ├── columns: c1:14!null c2:15 c3:16 c4:17 c.rowid:18!null c.crdb_internal_mvcc_timestamp:19 c.tableoid:20
+           │                                  │    ├── outer: (7)
+           │                                  │    ├── key: (18)
+           │                                  │    ├── fd: ()-->(14), (18)-->(15-17,19,20)
+           │                                  │    ├── scan c
+           │                                  │    │    ├── columns: c1:14 c2:15 c3:16 c4:17 c.rowid:18!null c.crdb_internal_mvcc_timestamp:19 c.tableoid:20
+           │                                  │    │    ├── key: (18)
+           │                                  │    │    └── fd: (18)-->(14-17,19,20)
+           │                                  │    └── filters
+           │                                  │         └── c1:14 = b1:7 [outer=(7,14), constraints=(/7: (/NULL - ]; /14: (/NULL - ]), fd=(7)==(14), (14)==(7)]
+           │                                  └── projections
+           │                                       └── 1 [as="?column?":21]
+           └── filters
+                └── (a1:1 = b1:7) OR (a2:2 = b2:8) [outer=(1,2,7,8)]
+
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM a JOIN (SELECT * FROM b WHERE b1 > 0 AND NOT EXISTS (SELECT 1 FROM c WHERE c1=b1 or c2=b2))
+                       AS foo on a1=foo.b1
+----
+inner-join (lookup a)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10
+ ├── key columns: [7] = [1]
+ ├── fd: (1)==(7), (7)==(1)
+ ├── project
+ │    ├── columns: b1:7!null b2:8 b3:9 b4:10
+ │    └── intersect-all
+ │         ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
+ │         ├── left columns: b1:22 b2:23 b3:24 b4:25 b.rowid:26
+ │         ├── right columns: b1:36 b2:37 b3:38 b4:39 b.rowid:40
+ │         ├── key: (11)
+ │         ├── fd: (11)-->(7-10)
+ │         ├── anti-join (hash)
+ │         │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
+ │         │    ├── key: (26)
+ │         │    ├── fd: (26)-->(22-25)
+ │         │    ├── scan b@b_b1_b2_idx
+ │         │    │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
+ │         │    │    ├── constraint: /22/23/26: [/1 - ]
+ │         │    │    ├── key: (26)
+ │         │    │    └── fd: (26)-->(22-25)
+ │         │    ├── scan c
+ │         │    │    └── columns: c1:29
+ │         │    └── filters
+ │         │         └── c1:29 = b1:22 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │         └── anti-join (hash)
+ │              ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
+ │              ├── key: (40)
+ │              ├── fd: (40)-->(36-39)
+ │              ├── scan b@b_b1_b2_idx
+ │              │    ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
+ │              │    ├── constraint: /36/37/40: [/1 - ]
+ │              │    ├── key: (40)
+ │              │    └── fd: (40)-->(36-39)
+ │              ├── scan c
+ │              │    └── columns: c2:44
+ │              └── filters
+ │                   └── c2:44 = b2:37 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
+ └── filters (true)
+
+# NOT IN subquery
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT d3,d1,d2 FROM d WHERE d1 NOT IN (SELECT b1 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2=b2 OR c2=b3))
+----
+anti-join (cross)
+ ├── columns: d3:3 d1:1 d2:2
+ ├── scan d
+ │    └── columns: d1:1 d2:2 d3:3
+ ├── project
+ │    ├── columns: b1:8 b2:9 b3:10
+ │    └── distinct-on
+ │         ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
+ │         ├── grouping columns: b.rowid:12!null
+ │         ├── key: (12)
+ │         ├── fd: (12)-->(8-10)
+ │         ├── union-all
+ │         │    ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
+ │         │    ├── left columns: b1:23 b2:24 b3:25 b.rowid:27
+ │         │    ├── right columns: b1:37 b2:38 b3:39 b.rowid:41
+ │         │    ├── project
+ │         │    │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
+ │         │    │    ├── key: (27)
+ │         │    │    ├── fd: (27)-->(23-25)
+ │         │    │    └── inner-join (hash)
+ │         │    │         ├── columns: b1:23 b2:24!null b3:25 b.rowid:27!null c2:31!null
+ │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │    │         ├── key: (27)
+ │         │    │         ├── fd: (27)-->(23-25), (24)==(31), (31)==(24)
+ │         │    │         ├── scan b
+ │         │    │         │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
+ │         │    │         │    ├── key: (27)
+ │         │    │         │    └── fd: (27)-->(23-25)
+ │         │    │         ├── distinct-on
+ │         │    │         │    ├── columns: c2:31
+ │         │    │         │    ├── grouping columns: c2:31
+ │         │    │         │    ├── key: (31)
+ │         │    │         │    └── scan c
+ │         │    │         │         └── columns: c2:31
+ │         │    │         └── filters
+ │         │    │              └── c2:31 = b2:24 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │         │    └── project
+ │         │         ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
+ │         │         ├── key: (41)
+ │         │         ├── fd: (41)-->(37-39)
+ │         │         └── inner-join (hash)
+ │         │              ├── columns: b1:37 b2:38 b3:39!null b.rowid:41!null c2:45!null
+ │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │              ├── key: (41)
+ │         │              ├── fd: (41)-->(37-39), (39)==(45), (45)==(39)
+ │         │              ├── scan b
+ │         │              │    ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
+ │         │              │    ├── key: (41)
+ │         │              │    └── fd: (41)-->(37-39)
+ │         │              ├── distinct-on
+ │         │              │    ├── columns: c2:45
+ │         │              │    ├── grouping columns: c2:45
+ │         │              │    ├── key: (45)
+ │         │              │    └── scan c
+ │         │              │         └── columns: c2:45
+ │         │              └── filters
+ │         │                   └── c2:45 = b3:39 [outer=(39,45), constraints=(/39: (/NULL - ]; /45: (/NULL - ]), fd=(39)==(45), (45)==(39)]
+ │         └── aggregations
+ │              ├── const-agg [as=b1:8, outer=(8)]
+ │              │    └── b1:8
+ │              ├── const-agg [as=b2:9, outer=(9)]
+ │              │    └── b2:9
+ │              └── const-agg [as=b3:10, outer=(10)]
+ │                   └── b3:10
+ └── filters
+      └── (d1:1 = b1:8) IS NOT false [outer=(1,8)]
+
+# NOT IN subquery, 2 columns
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT d3,d1,d2 FROM d WHERE (d1,d3) NOT IN (SELECT b1,b2 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2=b2 OR c2=b3))
+----
+anti-join (cross)
+ ├── columns: d3:3 d1:1 d2:2
+ ├── immutable
+ ├── scan d
+ │    └── columns: d1:1 d2:2 d3:3
+ ├── project
+ │    ├── columns: column23:23
+ │    ├── project
+ │    │    ├── columns: b1:8 b2:9 b3:10
+ │    │    └── distinct-on
+ │    │         ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
+ │    │         ├── grouping columns: b.rowid:12!null
+ │    │         ├── key: (12)
+ │    │         ├── fd: (12)-->(8-10)
+ │    │         ├── union-all
+ │    │         │    ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
+ │    │         │    ├── left columns: b1:24 b2:25 b3:26 b.rowid:28
+ │    │         │    ├── right columns: b1:38 b2:39 b3:40 b.rowid:42
+ │    │         │    ├── project
+ │    │         │    │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
+ │    │         │    │    ├── key: (28)
+ │    │         │    │    ├── fd: (28)-->(24-26)
+ │    │         │    │    └── inner-join (hash)
+ │    │         │    │         ├── columns: b1:24 b2:25!null b3:26 b.rowid:28!null c2:32!null
+ │    │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         │    │         ├── key: (28)
+ │    │         │    │         ├── fd: (28)-->(24-26), (25)==(32), (32)==(25)
+ │    │         │    │         ├── scan b
+ │    │         │    │         │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
+ │    │         │    │         │    ├── key: (28)
+ │    │         │    │         │    └── fd: (28)-->(24-26)
+ │    │         │    │         ├── distinct-on
+ │    │         │    │         │    ├── columns: c2:32
+ │    │         │    │         │    ├── grouping columns: c2:32
+ │    │         │    │         │    ├── key: (32)
+ │    │         │    │         │    └── scan c
+ │    │         │    │         │         └── columns: c2:32
+ │    │         │    │         └── filters
+ │    │         │    │              └── c2:32 = b2:25 [outer=(25,32), constraints=(/25: (/NULL - ]; /32: (/NULL - ]), fd=(25)==(32), (32)==(25)]
+ │    │         │    └── project
+ │    │         │         ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
+ │    │         │         ├── key: (42)
+ │    │         │         ├── fd: (42)-->(38-40)
+ │    │         │         └── inner-join (hash)
+ │    │         │              ├── columns: b1:38 b2:39 b3:40!null b.rowid:42!null c2:46!null
+ │    │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │         │              ├── key: (42)
+ │    │         │              ├── fd: (42)-->(38-40), (40)==(46), (46)==(40)
+ │    │         │              ├── scan b
+ │    │         │              │    ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
+ │    │         │              │    ├── key: (42)
+ │    │         │              │    └── fd: (42)-->(38-40)
+ │    │         │              ├── distinct-on
+ │    │         │              │    ├── columns: c2:46
+ │    │         │              │    ├── grouping columns: c2:46
+ │    │         │              │    ├── key: (46)
+ │    │         │              │    └── scan c
+ │    │         │              │         └── columns: c2:46
+ │    │         │              └── filters
+ │    │         │                   └── c2:46 = b3:40 [outer=(40,46), constraints=(/40: (/NULL - ]; /46: (/NULL - ]), fd=(40)==(46), (46)==(40)]
+ │    │         └── aggregations
+ │    │              ├── const-agg [as=b1:8, outer=(8)]
+ │    │              │    └── b1:8
+ │    │              ├── const-agg [as=b2:9, outer=(9)]
+ │    │              │    └── b2:9
+ │    │              └── const-agg [as=b3:10, outer=(10)]
+ │    │                   └── b3:10
+ │    └── projections
+ │         └── (b1:8, b2:9) [as=column23:23, outer=(8,9)]
+ └── filters
+      └── (column23:23 = (d1:1, d3:3)) IS NOT false [outer=(1,3,23), immutable]
+
+# The conjuncts under the top-level disjunct contain no join terms directly,
+# but are nested in another OR. Join terms should still be detected.
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (((t1.a1 = t2.a1 OR t1.a1 = t2.a2) AND (t1.a2 = t2.a2 OR t1.a2 = t2.a2)) OR
+                                ((t1.a1+1 = t2.a1 OR t1.a1+4 = t2.a2) AND (t1.a2+8 = t2.a2 OR t1.a2+9 = t2.a2)))
+----
+inner-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── immutable
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── (((t1.a1:1 = t2.a1:7) OR (t1.a1:1 = t2.a2:8)) AND (t1.a2:2 = t2.a2:8)) OR (((t2.a1:7 = (t1.a1:1 + 1)) OR (t2.a2:8 = (t1.a1:1 + 4))) AND ((t2.a2:8 = (t1.a2:2 + 8)) OR (t2.a2:8 = (t1.a2:2 + 9)))) [outer=(1,2,7,8), immutable, constraints=(/8: (/NULL - ])]
+
+# Negative Tests
+# No equijoin terms. Must be at least one equality predicate referencing
+# columns from both tables.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (t1.a2 = 1 OR t2.a2 = 1)
+----
+inner-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── (t1.a2:2 = 1) OR (t2.a2:8 = 1) [outer=(2,8)]
+
+# No equijoin terms. Must be at least one equality predicate referencing
+# columns from both tables.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (t1.a2 > t2.a2 AND t1.a3 > t2.a3 OR t2.a2 = 1)
+----
+inner-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── ((t1.a2:2 > t2.a2:8) AND (t1.a3:3 > t2.a3:9)) OR (t2.a2:8 = 1) [outer=(2,3,8,9), constraints=(/8: (/NULL - ])]
+
+# Outer join not supported with this optimization
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1 LEFT OUTER JOIN a t2 ON (t1.a2 = t2.a2 OR t1.a3 = t2.a3)
+----
+left-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7 a2:8 a3:9 a4:10
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── (t1.a2:2 = t2.a2:8) OR (t1.a3:3 = t2.a3:9) [outer=(2,3,8,9)]
+
+# Outer join not supported with this optimization
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1 FULL OUTER JOIN a t2 ON (t1.a2 = t2.a2 OR t1.a3 = t2.a3)
+----
+full-join (cross)
+ ├── columns: a1:1 a2:2 a3:3 a4:4 a1:7 a2:8 a3:9 a4:10
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── (t1.a2:2 = t2.a2:8) OR (t1.a3:3 = t2.a3:9) [outer=(2,3,8,9)]
+
+# Complex join condition where we can't decorrelate, so the join terms aren't
+# between 2 scans.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1 WHERE a2 IN (SELECT a2 from a t2 WHERE t1.a3 = t2.a3 OR t1.a1 = t2.a1)
+                   OR    a2 IN (SELECT a2 from a t3 WHERE t3.a3 = t3.a3 OR t3.a1 = t3.a1)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── select
+      ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null case:21
+      ├── key: (1-4)
+      ├── fd: (1-4)-->(21)
+      ├── project
+      │    ├── columns: case:21 t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    ├── key: (1-4)
+      │    ├── fd: (1-4)-->(21)
+      │    ├── group-by (hash)
+      │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null bool_or:20
+      │    │    ├── grouping columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    │    ├── key: (1-4)
+      │    │    ├── fd: (1-4)-->(20)
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7 t2.a2:8 t2.a3:9 notnull:19
+      │    │    │    ├── fd: (8)-->(19)
+      │    │    │    ├── scan a [as=t1]
+      │    │    │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    │    │    │    └── key: (1-4)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: notnull:19!null t2.a1:7!null t2.a2:8!null t2.a3:9!null
+      │    │    │    │    ├── fd: (8)-->(19)
+      │    │    │    │    ├── scan a [as=t2]
+      │    │    │    │    │    └── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null
+      │    │    │    │    └── projections
+      │    │    │    │         └── t2.a2:8 IS NOT NULL [as=notnull:19, outer=(8)]
+      │    │    │    └── filters
+      │    │    │         ├── (t1.a3:3 = t2.a3:9) OR (t1.a1:1 = t2.a1:7) [outer=(1,3,7,9)]
+      │    │    │         └── t1.a2:2 = t2.a2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    └── aggregations
+      │    │         └── bool-or [as=bool_or:20, outer=(19)]
+      │    │              └── notnull:19
+      │    └── projections
+      │         └── CASE WHEN bool_or:20 AND (t1.a2:2 IS NOT NULL) THEN true WHEN bool_or:20 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:21, outer=(2,20)]
+      └── filters
+           └── or [outer=(2,21), correlated-subquery]
+                ├── case:21
+                └── any: eq
+                     ├── project
+                     │    ├── columns: t3.a2:14!null
+                     │    └── select
+                     │         ├── columns: t3.a1:13!null t3.a2:14!null t3.a3:15!null
+                     │         ├── scan a [as=t3]
+                     │         │    └── columns: t3.a1:13!null t3.a2:14!null t3.a3:15!null
+                     │         └── filters
+                     │              └── ((t3.a3:15 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) OR ((t3.a1:13 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) [outer=(13,15)]
+                     └── t1.a2:2
+
+# Complex join condition where we can't decorrelate, so the join terms aren't
+# between 2 scans.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1 WHERE a2 NOT IN (SELECT a2 from a t2 WHERE t1.a3 = t2.a3 OR t1.a1 = t2.a1)
+                   OR    a2 NOT IN (SELECT a2 from a t3 WHERE t3.a3 = t3.a3 OR t3.a1 = t3.a1)
+----
+project
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ ├── key: (1-4)
+ └── select
+      ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null case:21
+      ├── key: (1-4)
+      ├── fd: (1-4)-->(21)
+      ├── project
+      │    ├── columns: case:21 t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    ├── key: (1-4)
+      │    ├── fd: (1-4)-->(21)
+      │    ├── group-by (hash)
+      │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null bool_or:20
+      │    │    ├── grouping columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    │    ├── key: (1-4)
+      │    │    ├── fd: (1-4)-->(20)
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null t2.a1:7 t2.a2:8 t2.a3:9 notnull:19
+      │    │    │    ├── fd: (8)-->(19)
+      │    │    │    ├── scan a [as=t1]
+      │    │    │    │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+      │    │    │    │    └── key: (1-4)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: notnull:19!null t2.a1:7!null t2.a2:8!null t2.a3:9!null
+      │    │    │    │    ├── fd: (8)-->(19)
+      │    │    │    │    ├── scan a [as=t2]
+      │    │    │    │    │    └── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null
+      │    │    │    │    └── projections
+      │    │    │    │         └── t2.a2:8 IS NOT NULL [as=notnull:19, outer=(8)]
+      │    │    │    └── filters
+      │    │    │         ├── (t1.a3:3 = t2.a3:9) OR (t1.a1:1 = t2.a1:7) [outer=(1,3,7,9)]
+      │    │    │         └── t1.a2:2 = t2.a2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    └── aggregations
+      │    │         └── bool-or [as=bool_or:20, outer=(19)]
+      │    │              └── notnull:19
+      │    └── projections
+      │         └── CASE WHEN bool_or:20 AND (t1.a2:2 IS NOT NULL) THEN true WHEN bool_or:20 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:21, outer=(2,20)]
+      └── filters
+           └── or [outer=(2,21), correlated-subquery]
+                ├── NOT case:21
+                └── not
+                     └── any: eq
+                          ├── project
+                          │    ├── columns: t3.a2:14!null
+                          │    └── select
+                          │         ├── columns: t3.a1:13!null t3.a2:14!null t3.a3:15!null
+                          │         ├── scan a [as=t3]
+                          │         │    └── columns: t3.a1:13!null t3.a2:14!null t3.a3:15!null
+                          │         └── filters
+                          │              └── ((t3.a3:15 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) OR ((t3.a1:13 IS DISTINCT FROM CAST(NULL AS INT8)) OR CAST(NULL AS BOOL)) [outer=(13,15)]
+                          └── t1.a2:2
+
+# The conjuncts under the top-level disjunct contain no equijoin terms, and
+# neither do the nested simple predicates.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t1, a t2 WHERE (((t1.a1 > t1.a1 OR t1.a1 <= t1.a2) AND (t1.a2 > t2.a2+1 OR t1.a1 <= t1.a2-1)) OR
+                                ((t1.a1 > t1.a1+5 OR t1.a1 <= t1.a2+5) AND (t1.a2 > t2.a2+7 OR t1.a1 <= t1.a2-9)))
+----
+inner-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null
+ ├── immutable
+ ├── key: (1-4,7-10)
+ ├── scan a [as=t1]
+ │    ├── columns: t1.a1:1!null t1.a2:2!null t1.a3:3!null t1.a4:4!null
+ │    └── key: (1-4)
+ ├── scan a [as=t2]
+ │    ├── columns: t2.a1:7!null t2.a2:8!null t2.a3:9!null t2.a4:10!null
+ │    └── key: (7-10)
+ └── filters
+      └── ((((t1.a1:1 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL)) OR (t1.a1:1 <= t1.a2:2)) AND ((t1.a2:2 > (t2.a2:8 + 1)) OR (t1.a1:1 <= (t1.a2:2 - 1)))) OR (((t1.a1:1 > (t1.a1:1 + 5)) OR (t1.a1:1 <= (t1.a2:2 + 5))) AND ((t1.a2:2 > (t2.a2:8 + 7)) OR (t1.a1:1 <= (t1.a2:2 - 9)))) [outer=(1,2,8), immutable, constraints=(/1: (/NULL - ])]
+
+# Can't consume both OR terms with a join to a single Scan relation. Both sides
+# of each equijoin predicate must be applied on a simple Scan or Select.
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM a t2 INNER JOIN a t1 ON TRUE LEFT OUTER JOIN a t3 ON (t1.a1 = t3.a1 OR t2.a2 = t3.a2)
+----
+left-join (cross)
+ ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null a1:7!null a2:8!null a3:9!null a4:10!null a1:13 a2:14 a3:15 a4:16
+ ├── key: (1-4,7-10,13-16)
+ ├── inner-join (cross)
+ │    ├── columns: t2.a1:1!null t2.a2:2!null t2.a3:3!null t2.a4:4!null t1.a1:7!null t1.a2:8!null t1.a3:9!null t1.a4:10!null
+ │    ├── key: (1-4,7-10)
+ │    ├── scan a [as=t2]
+ │    │    ├── columns: t2.a1:1!null t2.a2:2!null t2.a3:3!null t2.a4:4!null
+ │    │    └── key: (1-4)
+ │    ├── scan a [as=t1]
+ │    │    ├── columns: t1.a1:7!null t1.a2:8!null t1.a3:9!null t1.a4:10!null
+ │    │    └── key: (7-10)
+ │    └── filters (true)
+ ├── scan a [as=t3]
+ │    ├── columns: t3.a1:13!null t3.a2:14!null t3.a3:15!null t3.a4:16!null
+ │    └── key: (13-16)
+ └── filters
+      └── (t1.a1:7 = t3.a1:13) OR (t2.a2:2 = t3.a2:14) [outer=(2,7,13,14)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1593,9 +1593,55 @@ semi-join (cross)
  └── filters
       └── a:1 < e:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
 
+# Test that we commute a SemiJoin after the On conditions have been
+# split into equality predicates by the SplitDisjunctionOfSemiJoinTerms rule.
+opt expect=CommuteSemiJoin
+SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR c=e)
+----
+project
+ ├── columns: a:1 b:2 c:3
+ └── distinct-on
+      ├── columns: a:1 b:2 c:3 rowid:4!null
+      ├── grouping columns: rowid:4!null
+      ├── key: (4)
+      ├── fd: (4)-->(1-3)
+      ├── union-all
+      │    ├── columns: a:1 b:2 c:3 rowid:4!null
+      │    ├── left columns: a:12 b:13 c:14 rowid:15
+      │    ├── right columns: a:23 b:24 c:25 rowid:26
+      │    ├── semi-join (lookup def)
+      │    │    ├── columns: a:12 b:13 c:14 rowid:15!null
+      │    │    ├── key columns: [12] = [18]
+      │    │    ├── key: (15)
+      │    │    ├── fd: (15)-->(12-14)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:12 b:13 c:14 rowid:15!null
+      │    │    │    ├── key: (15)
+      │    │    │    └── fd: (15)-->(12-14)
+      │    │    └── filters (true)
+      │    └── semi-join (hash)
+      │         ├── columns: a:23 b:24 c:25 rowid:26!null
+      │         ├── key: (26)
+      │         ├── fd: (26)-->(23-25)
+      │         ├── scan abc
+      │         │    ├── columns: a:23 b:24 c:25 rowid:26!null
+      │         │    ├── key: (26)
+      │         │    └── fd: (26)-->(23-25)
+      │         ├── scan def
+      │         │    └── columns: e:30!null
+      │         └── filters
+      │              └── c:25 = e:30 [outer=(25,30), constraints=(/25: (/NULL - ]; /30: (/NULL - ]), fd=(25)==(30), (30)==(25)]
+      └── aggregations
+           ├── const-agg [as=a:1, outer=(1)]
+           │    └── a:1
+           ├── const-agg [as=b:2, outer=(2)]
+           │    └── b:2
+           └── const-agg [as=c:3, outer=(3)]
+                └── c:3
+
 # Test that we don't commute a SemiJoin when the On conditions are not
 # equalities. For example, in this test we have an Or condition.
-opt expect-not=CommuteSemiJoin
+opt disable=SplitDisjunctionOfJoinTerms expect-not=CommuteSemiJoin
 SELECT * from abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR c=e)
 ----
 semi-join (cross)
@@ -9394,30 +9440,84 @@ project
  ├── columns: b:2 c:3
  ├── lax-key: (2,3)
  ├── fd: (3)~~>(2)
- └── project
-      ├── columns: a:1!null b:2!null c:3!null
+ └── distinct-on
+      ├── columns: a:1!null b:2 c:3
+      ├── grouping columns: a:1!null
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-      └── inner-join (lookup zz)
-           ├── columns: a:1!null b:2!null c:3!null p:6!null q:7!null r:8
-           ├── key columns: [1] = [1]
-           ├── lookup columns are key
-           ├── key: (1)
-           ├── fd: ()-->(2,6-8), (1)-->(3), (3)-->(1), (2)==(7), (7)==(2)
-           ├── inner-join (lookup zz@idx_b)
-           │    ├── columns: a:1!null b:2!null p:6!null q:7!null r:8
-           │    ├── key columns: [7] = [2]
-           │    ├── key: (1)
-           │    ├── fd: ()-->(2,6-8), (2)==(7), (7)==(2)
-           │    ├── scan pqr
-           │    │    ├── columns: p:6!null q:7 r:8
-           │    │    ├── constraint: /6: [/0 - /0]
-           │    │    ├── cardinality: [0 - 1]
-           │    │    ├── key: ()
-           │    │    └── fd: ()-->(6-8)
-           │    └── filters (true)
-           └── filters
-                └── (c:3 = 0) OR (r:8 = c:3) [outer=(3,8), constraints=(/3: (/NULL - ])]
+      ├── fd: (1)-->(2,3)
+      ├── union-all
+      │    ├── columns: a:1!null b:2 c:3
+      │    ├── left columns: a:13 b:14 c:15
+      │    ├── right columns: a:25 b:26 c:27
+      │    ├── cardinality: [0 - 2]
+      │    ├── ordering: +1
+      │    ├── project
+      │    │    ├── columns: a:13!null b:14 c:15
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: (13)
+      │    │    ├── fd: (13)-->(14,15), (15)~~>(13,14)
+      │    │    ├── ordering: +13 [actual: ]
+      │    │    └── project
+      │    │         ├── columns: a:13!null b:14!null c:15!null q:19!null r:20!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(13-15,19,20), (15)==(20), (20)==(15), (14)==(19), (19)==(14)
+      │    │         └── inner-join (lookup zz)
+      │    │              ├── columns: a:13!null b:14!null c:15!null p:18!null q:19!null r:20!null
+      │    │              ├── key columns: [13] = [13]
+      │    │              ├── lookup columns are key
+      │    │              ├── cardinality: [0 - 1]
+      │    │              ├── key: ()
+      │    │              ├── fd: ()-->(13-15,18-20), (19)==(14), (15)==(20), (20)==(15), (14)==(19)
+      │    │              ├── inner-join (lookup zz@idx_c)
+      │    │              │    ├── columns: a:13!null c:15!null p:18!null q:19 r:20!null
+      │    │              │    ├── key columns: [20] = [15]
+      │    │              │    ├── lookup columns are key
+      │    │              │    ├── cardinality: [0 - 1]
+      │    │              │    ├── key: ()
+      │    │              │    ├── fd: ()-->(13,15,18-20), (20)==(15), (15)==(20)
+      │    │              │    ├── scan pqr
+      │    │              │    │    ├── columns: p:18!null q:19 r:20
+      │    │              │    │    ├── constraint: /18: [/0 - /0]
+      │    │              │    │    ├── cardinality: [0 - 1]
+      │    │              │    │    ├── key: ()
+      │    │              │    │    └── fd: ()-->(18-20)
+      │    │              │    └── filters (true)
+      │    │              └── filters
+      │    │                   └── q:19 = b:14 [outer=(14,19), constraints=(/14: (/NULL - ]; /19: (/NULL - ]), fd=(14)==(19), (19)==(14)]
+      │    └── semi-join (lookup pqr@q)
+      │         ├── columns: a:25!null b:26 c:27!null
+      │         ├── key columns: [26 107] = [31 30]
+      │         ├── lookup columns are key
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(25-27)
+      │         ├── project
+      │         │    ├── columns: "lookup_join_const_col_@30":107!null a:25!null b:26 c:27!null
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(25-27,107)
+      │         │    ├── index-join zz
+      │         │    │    ├── columns: a:25!null b:26 c:27!null
+      │         │    │    ├── cardinality: [0 - 1]
+      │         │    │    ├── key: ()
+      │         │    │    ├── fd: ()-->(25-27)
+      │         │    │    └── scan zz@idx_c
+      │         │    │         ├── columns: a:25!null c:27!null
+      │         │    │         ├── constraint: /27: [/0 - /0]
+      │         │    │         ├── cardinality: [0 - 1]
+      │         │    │         ├── key: ()
+      │         │    │         └── fd: ()-->(25,27)
+      │         │    └── projections
+      │         │         └── 0 [as="lookup_join_const_col_@30":107]
+      │         └── filters (true)
+      └── aggregations
+           ├── const-agg [as=b:2, outer=(2)]
+           │    └── b:2
+           └── const-agg [as=c:3, outer=(3)]
+                └── c:3
 
 # --------------------------------------------------
 # PushJoinIntoIndexJoin
@@ -11357,3 +11457,579 @@ project
  │    └── filters (true)
  └── projections
       └── NULL [as="?column?":11]
+
+# --------------------------------------------------
+# SplitDisjunctionOfJoinTerms
+# --------------------------------------------------
+exec-ddl
+DROP TABLE abc
+----
+
+exec-ddl
+CREATE TABLE abc
+(
+    a INT,
+    b INT,
+    c INT,
+    PRIMARY KEY(a,b),
+    INDEX bc (b,c) STORING (a)
+)
+----
+
+exec-ddl
+ALTER TABLE abc INJECT STATISTICS '[
+  {
+    "columns": ["b"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE xyz INJECT STATISTICS '[
+  {
+    "columns": ["y"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  }
+]'
+----
+
+# Inner join with PK columns selected and without constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM abc INNER JOIN xyz on abc.a = xyz.x or abc.b = xyz.y
+----
+project
+ ├── columns: a:1!null b:2!null c:3 x:6 y:7 z:8
+ ├── fd: (1,2)-->(3)
+ └── distinct-on
+      ├── columns: a:1!null b:2!null c:3 x:6 y:7 z:8 rowid:9!null
+      ├── grouping columns: a:1!null b:2!null rowid:9!null
+      ├── key: (1,2,9)
+      ├── fd: (1,2,9)-->(3,6-8)
+      ├── union-all
+      │    ├── columns: a:1!null b:2!null c:3 x:6 y:7 z:8 rowid:9!null
+      │    ├── left columns: a:12 b:13 c:14 x:17 y:18 z:19 rowid:20
+      │    ├── right columns: a:23 b:24 c:25 x:28 y:29 z:30 rowid:31
+      │    ├── inner-join (merge)
+      │    │    ├── columns: a:12!null b:13!null c:14 x:17!null y:18 z:19 rowid:20!null
+      │    │    ├── left ordering: +12
+      │    │    ├── right ordering: +17
+      │    │    ├── key: (13,20)
+      │    │    ├── fd: (12,13)-->(14), (20)-->(17-19), (12)==(17), (17)==(12)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    │    ├── key: (12,13)
+      │    │    │    ├── fd: (12,13)-->(14)
+      │    │    │    └── ordering: +12
+      │    │    ├── scan xyz@xy
+      │    │    │    ├── columns: x:17 y:18 z:19 rowid:20!null
+      │    │    │    ├── key: (20)
+      │    │    │    ├── fd: (20)-->(17-19)
+      │    │    │    └── ordering: +17
+      │    │    └── filters (true)
+      │    └── inner-join (merge)
+      │         ├── columns: a:23!null b:24!null c:25 x:28 y:29!null z:30 rowid:31!null
+      │         ├── left ordering: +24
+      │         ├── right ordering: +29
+      │         ├── key: (23,31)
+      │         ├── fd: (23,24)-->(25), (31)-->(28-30), (24)==(29), (29)==(24)
+      │         ├── scan abc@bc
+      │         │    ├── columns: a:23!null b:24!null c:25
+      │         │    ├── key: (23,24)
+      │         │    ├── fd: (23,24)-->(25)
+      │         │    └── ordering: +24
+      │         ├── scan xyz@yz
+      │         │    ├── columns: x:28 y:29 z:30 rowid:31!null
+      │         │    ├── key: (31)
+      │         │    ├── fd: (31)-->(28-30)
+      │         │    └── ordering: +29
+      │         └── filters (true)
+      └── aggregations
+           ├── const-agg [as=c:3, outer=(3)]
+           │    └── c:3
+           ├── const-agg [as=x:6, outer=(6)]
+           │    └── x:6
+           ├── const-agg [as=y:7, outer=(7)]
+           │    └── y:7
+           └── const-agg [as=z:8, outer=(8)]
+                └── z:8
+
+# Inner join with PK columns selected and with constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM abc INNER JOIN xyz on abc.a = xyz.x or abc.b = xyz.y where abc.b < 1 and xyz.y > 1
+----
+project
+ ├── columns: a:1!null b:2!null c:3 x:6 y:7!null z:8
+ ├── fd: (1,2)-->(3)
+ └── distinct-on
+      ├── columns: a:1!null b:2!null c:3 x:6 y:7!null z:8 rowid:9!null
+      ├── grouping columns: a:1!null b:2!null rowid:9!null
+      ├── key: (1,2,9)
+      ├── fd: (1,2,9)-->(3,6-8)
+      ├── union-all
+      │    ├── columns: a:1!null b:2!null c:3 x:6 y:7!null z:8 rowid:9!null
+      │    ├── left columns: a:12 b:13 c:14 x:17 y:18 z:19 rowid:20
+      │    ├── right columns: a:23 b:24 c:25 x:28 y:29 z:30 rowid:31
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a:12!null b:13!null c:14 x:17!null y:18!null z:19 rowid:20!null
+      │    │    ├── key: (13,20)
+      │    │    ├── fd: (12,13)-->(14), (20)-->(17-19), (12)==(17), (17)==(12)
+      │    │    ├── scan abc@bc
+      │    │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    │    ├── constraint: /13/14/12: [ - /0]
+      │    │    │    ├── key: (12,13)
+      │    │    │    └── fd: (12,13)-->(14)
+      │    │    ├── scan xyz@yz
+      │    │    │    ├── columns: x:17 y:18!null z:19 rowid:20!null
+      │    │    │    ├── constraint: /18/19/20: [/2 - ]
+      │    │    │    ├── key: (20)
+      │    │    │    └── fd: (20)-->(17-19)
+      │    │    └── filters
+      │    │         └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+      │    └── inner-join (merge)
+      │         ├── columns: a:23!null b:24!null c:25 x:28 y:29!null z:30 rowid:31!null
+      │         ├── left ordering: +24
+      │         ├── right ordering: +29
+      │         ├── key: (23,31)
+      │         ├── fd: (23,24)-->(25), (31)-->(28-30), (24)==(29), (29)==(24)
+      │         ├── scan abc@bc
+      │         │    ├── columns: a:23!null b:24!null c:25
+      │         │    ├── constraint: /24/25/23: [ - /0]
+      │         │    ├── key: (23,24)
+      │         │    ├── fd: (23,24)-->(25)
+      │         │    └── ordering: +24
+      │         ├── scan xyz@yz
+      │         │    ├── columns: x:28 y:29!null z:30 rowid:31!null
+      │         │    ├── constraint: /29/30/31: [/2 - ]
+      │         │    ├── key: (31)
+      │         │    ├── fd: (31)-->(28-30)
+      │         │    └── ordering: +29
+      │         └── filters (true)
+      └── aggregations
+           ├── const-agg [as=c:3, outer=(3)]
+           │    └── c:3
+           ├── const-agg [as=x:6, outer=(6)]
+           │    └── x:6
+           ├── const-agg [as=y:7, outer=(7)]
+           │    └── y:7
+           └── const-agg [as=z:8, outer=(8)]
+                └── z:8
+
+# Inner join with not all PK columns selected and with constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT c, a FROM abc INNER JOIN xyz on abc.a = xyz.x or abc.b = xyz.y where abc.b < 1 and xyz.y > 1
+----
+project
+ ├── columns: c:3 a:1!null
+ └── project
+      ├── columns: a:1!null b:2!null c:3 x:6 y:7!null
+      ├── fd: (1,2)-->(3)
+      └── distinct-on
+           ├── columns: a:1!null b:2!null c:3 x:6 y:7!null rowid:9!null
+           ├── grouping columns: a:1!null b:2!null rowid:9!null
+           ├── key: (1,2,9)
+           ├── fd: (1,2,9)-->(3,6,7)
+           ├── union-all
+           │    ├── columns: a:1!null b:2!null c:3 x:6 y:7!null rowid:9!null
+           │    ├── left columns: a:12 b:13 c:14 x:17 y:18 rowid:20
+           │    ├── right columns: a:23 b:24 c:25 x:28 y:29 rowid:31
+           │    ├── inner-join (hash)
+           │    │    ├── columns: a:12!null b:13!null c:14 x:17!null y:18!null rowid:20!null
+           │    │    ├── key: (13,20)
+           │    │    ├── fd: (12,13)-->(14), (20)-->(17,18), (12)==(17), (17)==(12)
+           │    │    ├── scan abc@bc
+           │    │    │    ├── columns: a:12!null b:13!null c:14
+           │    │    │    ├── constraint: /13/14/12: [ - /0]
+           │    │    │    ├── key: (12,13)
+           │    │    │    └── fd: (12,13)-->(14)
+           │    │    ├── scan xyz@yz
+           │    │    │    ├── columns: x:17 y:18!null rowid:20!null
+           │    │    │    ├── constraint: /18/19/20: [/2 - ]
+           │    │    │    ├── key: (20)
+           │    │    │    └── fd: (20)-->(17,18)
+           │    │    └── filters
+           │    │         └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+           │    └── inner-join (merge)
+           │         ├── columns: a:23!null b:24!null c:25 x:28 y:29!null rowid:31!null
+           │         ├── left ordering: +24
+           │         ├── right ordering: +29
+           │         ├── key: (23,31)
+           │         ├── fd: (23,24)-->(25), (31)-->(28,29), (24)==(29), (29)==(24)
+           │         ├── scan abc@bc
+           │         │    ├── columns: a:23!null b:24!null c:25
+           │         │    ├── constraint: /24/25/23: [ - /0]
+           │         │    ├── key: (23,24)
+           │         │    ├── fd: (23,24)-->(25)
+           │         │    └── ordering: +24
+           │         ├── scan xyz@yz
+           │         │    ├── columns: x:28 y:29!null rowid:31!null
+           │         │    ├── constraint: /29/30/31: [/2 - ]
+           │         │    ├── key: (31)
+           │         │    ├── fd: (31)-->(28,29)
+           │         │    └── ordering: +29
+           │         └── filters (true)
+           └── aggregations
+                ├── const-agg [as=c:3, outer=(3)]
+                │    └── c:3
+                ├── const-agg [as=x:6, outer=(6)]
+                │    └── x:6
+                └── const-agg [as=y:7, outer=(7)]
+                     └── y:7
+
+# Inner join on compound PK columns
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT c, a FROM abc INNER JOIN xyz on (abc.a = xyz.x and abc.b = xyz.y) or (abc.b = xyz.x and abc.a = xyz.y)
+where abc.b < 1 and xyz.y > 1;
+----
+project
+ ├── columns: c:3 a:1!null
+ └── project
+      ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null
+      ├── fd: (1,2)-->(3)
+      └── distinct-on
+           ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null rowid:9!null
+           ├── grouping columns: a:1!null b:2!null rowid:9!null
+           ├── key: (1,2,9)
+           ├── fd: (1,2,9)-->(3,6,7)
+           ├── union-all
+           │    ├── columns: a:1!null b:2!null c:3 x:6!null y:7!null rowid:9!null
+           │    ├── left columns: a:12 b:13 c:14 x:17 y:18 rowid:20
+           │    ├── right columns: a:23 b:24 c:25 x:28 y:29 rowid:31
+           │    ├── inner-join (hash)
+           │    │    ├── columns: a:12!null b:13!null c:14 x:17!null y:18!null rowid:20!null
+           │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           │    │    ├── key: (20)
+           │    │    ├── fd: (12,13)-->(14), (20)-->(17,18), (12)==(17), (17)==(12), (13)==(18), (18)==(13)
+           │    │    ├── scan abc@bc
+           │    │    │    ├── columns: a:12!null b:13!null c:14
+           │    │    │    ├── constraint: /13/14/12: [ - /0]
+           │    │    │    ├── key: (12,13)
+           │    │    │    └── fd: (12,13)-->(14)
+           │    │    ├── scan xyz@yz
+           │    │    │    ├── columns: x:17 y:18!null rowid:20!null
+           │    │    │    ├── constraint: /18/19/20: [/2 - ]
+           │    │    │    ├── key: (20)
+           │    │    │    └── fd: (20)-->(17,18)
+           │    │    └── filters
+           │    │         ├── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+           │    │         └── b:13 = y:18 [outer=(13,18), constraints=(/13: (/NULL - ]; /18: (/NULL - ]), fd=(13)==(18), (18)==(13)]
+           │    └── inner-join (hash)
+           │         ├── columns: a:23!null b:24!null c:25 x:28!null y:29!null rowid:31!null
+           │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           │         ├── key: (31)
+           │         ├── fd: (23,24)-->(25), (31)-->(28,29), (24)==(28), (28)==(24), (23)==(29), (29)==(23)
+           │         ├── scan abc@bc
+           │         │    ├── columns: a:23!null b:24!null c:25
+           │         │    ├── constraint: /24/25/23: [ - /0]
+           │         │    ├── key: (23,24)
+           │         │    └── fd: (23,24)-->(25)
+           │         ├── scan xyz@yz
+           │         │    ├── columns: x:28 y:29!null rowid:31!null
+           │         │    ├── constraint: /29/30/31: [/2 - ]
+           │         │    ├── key: (31)
+           │         │    └── fd: (31)-->(28,29)
+           │         └── filters
+           │              ├── b:24 = x:28 [outer=(24,28), constraints=(/24: (/NULL - ]; /28: (/NULL - ]), fd=(24)==(28), (28)==(24)]
+           │              └── a:23 = y:29 [outer=(23,29), constraints=(/23: (/NULL - ]; /29: (/NULL - ]), fd=(23)==(29), (29)==(23)]
+           └── aggregations
+                ├── const-agg [as=c:3, outer=(3)]
+                │    └── c:3
+                ├── const-agg [as=x:6, outer=(6)]
+                │    └── x:6
+                └── const-agg [as=y:7, outer=(7)]
+                     └── y:7
+
+# Semijoin without constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.x or abc.b = xyz.y)
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
+ └── distinct-on
+      ├── columns: a:1!null b:2!null c:3
+      ├── grouping columns: a:1!null b:2!null
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      ├── union-all
+      │    ├── columns: a:1!null b:2!null c:3
+      │    ├── left columns: a:12 b:13 c:14
+      │    ├── right columns: a:23 b:24 c:25
+      │    ├── project
+      │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    ├── key: (12,13)
+      │    │    ├── fd: (12,13)-->(14)
+      │    │    └── inner-join (merge)
+      │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
+      │    │         ├── left ordering: +12
+      │    │         ├── right ordering: +17
+      │    │         ├── key: (13,17)
+      │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+      │    │         ├── scan abc
+      │    │         │    ├── columns: a:12!null b:13!null c:14
+      │    │         │    ├── key: (12,13)
+      │    │         │    ├── fd: (12,13)-->(14)
+      │    │         │    └── ordering: +12
+      │    │         ├── distinct-on
+      │    │         │    ├── columns: x:17
+      │    │         │    ├── grouping columns: x:17
+      │    │         │    ├── key: (17)
+      │    │         │    ├── ordering: +17
+      │    │         │    └── scan xyz@xy
+      │    │         │         ├── columns: x:17
+      │    │         │         └── ordering: +17
+      │    │         └── filters (true)
+      │    └── semi-join (merge)
+      │         ├── columns: a:23!null b:24!null c:25
+      │         ├── left ordering: +24
+      │         ├── right ordering: +29
+      │         ├── key: (23,24)
+      │         ├── fd: (23,24)-->(25)
+      │         ├── scan abc@bc
+      │         │    ├── columns: a:23!null b:24!null c:25
+      │         │    ├── key: (23,24)
+      │         │    ├── fd: (23,24)-->(25)
+      │         │    └── ordering: +24
+      │         ├── scan xyz@yz
+      │         │    ├── columns: y:29
+      │         │    └── ordering: +29
+      │         └── filters (true)
+      └── aggregations
+           └── const-agg [as=c:3, outer=(3)]
+                └── c:3
+
+# Semijoin with constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT * FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x or abc.b = xyz.y) and xyz.y > 1) and abc.b < 1
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
+ └── distinct-on
+      ├── columns: a:1!null b:2!null c:3
+      ├── grouping columns: a:1!null b:2!null
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      ├── union-all
+      │    ├── columns: a:1!null b:2!null c:3
+      │    ├── left columns: a:12 b:13 c:14
+      │    ├── right columns: a:23 b:24 c:25
+      │    ├── project
+      │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    ├── key: (12,13)
+      │    │    ├── fd: (12,13)-->(14)
+      │    │    └── inner-join (hash)
+      │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
+      │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │         ├── key: (13,17)
+      │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+      │    │         ├── scan abc@bc
+      │    │         │    ├── columns: a:12!null b:13!null c:14
+      │    │         │    ├── constraint: /13/14/12: [ - /0]
+      │    │         │    ├── key: (12,13)
+      │    │         │    └── fd: (12,13)-->(14)
+      │    │         ├── distinct-on
+      │    │         │    ├── columns: x:17
+      │    │         │    ├── grouping columns: x:17
+      │    │         │    ├── key: (17)
+      │    │         │    └── scan xyz@yz
+      │    │         │         ├── columns: x:17 y:18!null
+      │    │         │         └── constraint: /18/19/20: [/2 - ]
+      │    │         └── filters
+      │    │              └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+      │    └── semi-join (merge)
+      │         ├── columns: a:23!null b:24!null c:25
+      │         ├── left ordering: +24
+      │         ├── right ordering: +29
+      │         ├── key: (23,24)
+      │         ├── fd: (23,24)-->(25)
+      │         ├── scan abc@bc
+      │         │    ├── columns: a:23!null b:24!null c:25
+      │         │    ├── constraint: /24/25/23: [ - /0]
+      │         │    ├── key: (23,24)
+      │         │    ├── fd: (23,24)-->(25)
+      │         │    └── ordering: +24
+      │         ├── scan xyz@yz
+      │         │    ├── columns: y:29!null
+      │         │    ├── constraint: /29/30/31: [/2 - ]
+      │         │    └── ordering: +29
+      │         └── filters (true)
+      └── aggregations
+           └── const-agg [as=c:3, outer=(3)]
+                └── c:3
+
+# Semijoin with not all PK columns selected and with constraints
+opt expect=SplitDisjunctionOfJoinTerms
+SELECT c FROM abc WHERE EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x or abc.b = xyz.y) and xyz.y > 1) and abc.b < 1
+----
+project
+ ├── columns: c:3
+ └── project
+      ├── columns: a:1!null b:2!null c:3
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      └── distinct-on
+           ├── columns: a:1!null b:2!null c:3
+           ├── grouping columns: a:1!null b:2!null
+           ├── key: (1,2)
+           ├── fd: (1,2)-->(3)
+           ├── union-all
+           │    ├── columns: a:1!null b:2!null c:3
+           │    ├── left columns: a:12 b:13 c:14
+           │    ├── right columns: a:23 b:24 c:25
+           │    ├── project
+           │    │    ├── columns: a:12!null b:13!null c:14
+           │    │    ├── key: (12,13)
+           │    │    ├── fd: (12,13)-->(14)
+           │    │    └── inner-join (hash)
+           │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
+           │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │    │         ├── key: (13,17)
+           │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+           │    │         ├── scan abc@bc
+           │    │         │    ├── columns: a:12!null b:13!null c:14
+           │    │         │    ├── constraint: /13/14/12: [ - /0]
+           │    │         │    ├── key: (12,13)
+           │    │         │    └── fd: (12,13)-->(14)
+           │    │         ├── distinct-on
+           │    │         │    ├── columns: x:17
+           │    │         │    ├── grouping columns: x:17
+           │    │         │    ├── key: (17)
+           │    │         │    └── scan xyz@yz
+           │    │         │         ├── columns: x:17 y:18!null
+           │    │         │         └── constraint: /18/19/20: [/2 - ]
+           │    │         └── filters
+           │    │              └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+           │    └── semi-join (merge)
+           │         ├── columns: a:23!null b:24!null c:25
+           │         ├── left ordering: +24
+           │         ├── right ordering: +29
+           │         ├── key: (23,24)
+           │         ├── fd: (23,24)-->(25)
+           │         ├── scan abc@bc
+           │         │    ├── columns: a:23!null b:24!null c:25
+           │         │    ├── constraint: /24/25/23: [ - /0]
+           │         │    ├── key: (23,24)
+           │         │    ├── fd: (23,24)-->(25)
+           │         │    └── ordering: +24
+           │         ├── scan xyz@yz
+           │         │    ├── columns: y:29!null
+           │         │    ├── constraint: /29/30/31: [/2 - ]
+           │         │    └── ordering: +29
+           │         └── filters (true)
+           └── aggregations
+                └── const-agg [as=c:3, outer=(3)]
+                     └── c:3
+
+# Outer join must use cross join
+opt expect-not=SplitDisjunctionOfJoinTerms
+SELECT * FROM abc LEFT JOIN xyz on abc.a = xyz.x or abc.b = xyz.y
+----
+left-join (cross)
+ ├── columns: a:1!null b:2!null c:3 x:6 y:7 z:8
+ ├── fd: (1,2)-->(3)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2!null c:3
+ │    ├── key: (1,2)
+ │    └── fd: (1,2)-->(3)
+ ├── scan xyz
+ │    └── columns: x:6 y:7 z:8
+ └── filters
+      └── (a:1 = x:6) OR (b:2 = y:7) [outer=(1,2,6,7)]
+
+# Antijoin without constraints
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE abc.a = xyz.x or abc.b = xyz.y);
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
+ └── intersect-all
+      ├── columns: a:1!null b:2!null c:3
+      ├── left columns: a:12 b:13 c:14
+      ├── right columns: a:23 b:24 c:25
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      ├── anti-join (merge)
+      │    ├── columns: a:12!null b:13!null c:14
+      │    ├── left ordering: +12
+      │    ├── right ordering: +17
+      │    ├── key: (12,13)
+      │    ├── fd: (12,13)-->(14)
+      │    ├── scan abc
+      │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    ├── key: (12,13)
+      │    │    ├── fd: (12,13)-->(14)
+      │    │    └── ordering: +12
+      │    ├── scan xyz@xy
+      │    │    ├── columns: x:17
+      │    │    └── ordering: +17
+      │    └── filters (true)
+      └── anti-join (merge)
+           ├── columns: a:23!null b:24!null c:25
+           ├── left ordering: +24
+           ├── right ordering: +29
+           ├── key: (23,24)
+           ├── fd: (23,24)-->(25)
+           ├── scan abc@bc
+           │    ├── columns: a:23!null b:24!null c:25
+           │    ├── key: (23,24)
+           │    ├── fd: (23,24)-->(25)
+           │    └── ordering: +24
+           ├── scan xyz@yz
+           │    ├── columns: y:29
+           │    └── ordering: +29
+           └── filters (true)
+
+# Antijoin with constraints
+opt expect=SplitDisjunctionOfAntiJoinTerms
+SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x or abc.b = xyz.y) and xyz.y > 1) and abc.b < 1;
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(3)
+ └── intersect-all
+      ├── columns: a:1!null b:2!null c:3
+      ├── left columns: a:12 b:13 c:14
+      ├── right columns: a:23 b:24 c:25
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(3)
+      ├── anti-join (hash)
+      │    ├── columns: a:12!null b:13!null c:14
+      │    ├── key: (12,13)
+      │    ├── fd: (12,13)-->(14)
+      │    ├── scan abc@bc
+      │    │    ├── columns: a:12!null b:13!null c:14
+      │    │    ├── constraint: /13/14/12: [ - /0]
+      │    │    ├── key: (12,13)
+      │    │    └── fd: (12,13)-->(14)
+      │    ├── scan xyz@yz
+      │    │    ├── columns: x:17 y:18!null
+      │    │    └── constraint: /18/19/20: [/2 - ]
+      │    └── filters
+      │         └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+      └── anti-join (merge)
+           ├── columns: a:23!null b:24!null c:25
+           ├── left ordering: +24
+           ├── right ordering: +29
+           ├── key: (23,24)
+           ├── fd: (23,24)-->(25)
+           ├── scan abc@bc
+           │    ├── columns: a:23!null b:24!null c:25
+           │    ├── constraint: /24/25/23: [ - /0]
+           │    ├── key: (23,24)
+           │    ├── fd: (23,24)-->(25)
+           │    └── ordering: +24
+           ├── scan xyz@yz
+           │    ├── columns: y:29!null
+           │    ├── constraint: /29/30/31: [/2 - ]
+           │    └── ordering: +29
+           └── filters (true)


### PR DESCRIPTION
Previously, when the ON clause of an inner, semi or anti join contained
ORed equality predicates, the only available join method was cross join.

This was inadequate because cross join is often the worst performing
join method for joining large tables.

To address this, this patch adds a new cost-based transformation which
evaluates each disjunct in a separate join and unions or intersects the
results together.

Fixes #74302

Example query:

```
SELECT *
FROM   classRequest
       INNER JOIN classes
               ON classRequest.firstChoiceClassid = classes.classid
                  OR classRequest.secondChoiceClassid = classes.classid;
```
Transformation result written in pseudo-SQL:
```
SELECT DISTINCT ON (classes.<rowid_or_primary_key_columns>,
                    classRequest.<rowid_or_primary_key_columns>)
       dt.*
FROM   (
        SELECT     *
        FROM       classRequest
                   INNER JOIN classes
                   ON         classRequest.firstChoiceClassid =
		              classes.classid
                   UNION ALL
        SELECT     *
        FROM       classRequest
                   INNER JOIN classes
                   ON         classRequest.secondChoiceClassid =
		              classes.classid
       ) dt;
```

In addition, ORed ON clause selectivity estimation is enhanced to
estimate the selectivity of each '=' predicate separately and
combine the estimates in an iterative fashion like PostgreSQL does. This
enables the optimizer to cost the rewritten plan more accurately so it
will get picked.

Release justification: Performance improvement for queries with ORed
join predicates and improved selectivity estimation of ORed predicates

Release note (performance improvement): Performance of inner, semi or
anti join between two tables with ORed equijoin predicates is improved
by enabling the optimizer to select a join plan in which each equijoin
predicate is evaluated by a separate join, with the results of the joins
unioned or intersected together.