### PR TITLE
opt: fix PushAssignmnetCastsIntoValues

### DIFF
--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -177,6 +177,11 @@ $input
 # This allows other rules to fire, with the ultimate goal of eliminating the
 # project so that the insert fast-path optimization is used in more cases and
 # uniqueness checks for gen_random_uuid() values are eliminated in more cases.
+#
+# Assignment casts in projections cannot be pushed into values expressions if
+# the casted column is referenced in another projection expression
+# (AssignmentCastCols ensures this) or if the casted column also a passthrough
+# column (notice the DifferenceCols function).
 [PushAssignmentCastsIntoValues, Normalize]
 (Project
     $input:(Values)
@@ -184,7 +189,10 @@ $input
     $passthrough:* &
         ^(ColsAreEmpty
             $castCols:(IntersectionCols
-                (AssignmentCastCols $projections)
+                (DifferenceCols
+                    (AssignmentCastCols $projections)
+                    $passthrough
+                )
                 (OutputCols $input)
             )
         )

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -1188,6 +1188,49 @@ project
  └── projections
       └── column1:1 + 10 [as="?column?":2, outer=(1), immutable]
 
+# Regression test for #74241. Do not push assignment casts into values when the
+# casted column is also a passthrough column.
+exec-ddl
+CREATE TABLE t74241 (
+  a INT2,
+  b INT,
+  c INT2,
+  d INT
+)
+----
+
+norm
+INSERT INTO t74241 (a, b, c)
+SELECT tmp.b, tmp.b, tmp.d FROM t74241 AS tmp
+WHERE false
+----
+insert t74241
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a_cast:15 => t74241.a:1
+ │    ├── tmp.b:9 => t74241.b:2
+ │    ├── c_cast:16 => t74241.c:3
+ │    ├── d_default:17 => t74241.d:4
+ │    └── rowid_default:18 => t74241.rowid:5
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: d_default:17 rowid_default:18 a_cast:15!null tmp.b:9!null c_cast:16!null
+      ├── cardinality: [0 - 0]
+      ├── volatile
+      ├── key: ()
+      ├── fd: ()-->(9,15-18)
+      ├── values
+      │    ├── columns: tmp.b:9!null c_cast:16!null
+      │    ├── cardinality: [0 - 0]
+      │    ├── key: ()
+      │    └── fd: ()-->(9,16)
+      └── projections
+           ├── CAST(NULL AS INT8) [as=d_default:17]
+           ├── unique_rowid() [as=rowid_default:18, volatile]
+           └── assignment-cast: INT2 [as=a_cast:15, outer=(9), immutable]
+                └── tmp.b:9
+
 # --------------------------------------------------
 # FoldJSONAccessIntoValues
 # --------------------------------------------------


### PR DESCRIPTION
Previously, PushAssignmentCastsIntoValues could push an assignment cast
projection into a values expression when the casted column was also a
passthrough column. This could create invalid project expressions that
had a passthrough column that did not exist in the input expression.
This commit fixes PushAssignmentCastsIntoValues so that it will not push
assignment casts into values expressions if the casted column is also a
passthrough column.

Fixes #74241

There is no release note because this bug does not exist in any
releases.

Release note: None