### PR TITLE
server: ensure drain of client connections at the end of decommission

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -177,7 +177,8 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 	adminClient := serverpb.NewAdminClient(grpcConn)
 
 	require.NoError(t, runDecommissionNodeImpl(
-		ctx, adminClient, nodeDecommissionWaitNone, []roachpb.NodeID{roachpb.NodeID(2), roachpb.NodeID(3)}),
+		ctx, adminClient, nodeDecommissionWaitNone,
+		[]roachpb.NodeID{roachpb.NodeID(2), roachpb.NodeID(3)}, tcAfter.Server(0).NodeID()),
 		"Failed to decommission removed nodes")
 
 	for i := 0; i < len(tcAfter.Servers); i++ {

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -343,7 +343,7 @@ func TestRemoveDeadReplicas(t *testing.T) {
 				}
 
 				if err := runDecommissionNodeImpl(
-					ctx, adminClient, nodeDecommissionWaitNone, deadNodes,
+					ctx, adminClient, nodeDecommissionWaitNone, deadNodes, tc.Server(0).NodeID(),
 				); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -316,8 +316,12 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if nodeCtx.nodeDecommissionSelf {
+		log.Warningf(ctx, "--%s for decommission is deprecated.", cliflags.NodeDecommissionSelf.Name)
+	}
+
 	if !nodeCtx.nodeDecommissionSelf && len(args) == 0 {
-		return errors.New("no node ID specified; use --self to target the node specified with --host")
+		return errors.New("no node ID specified")
 	}
 
 	nodeIDs, err := parseNodeIDs(args)

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -333,7 +333,12 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 
 	s := serverpb.NewStatusClient(conn)
 
-	nodeIDs, err = handleNodeDecommissionSelf(ctx, s, nodeIDs, "decommissioning")
+	localNodeID, err := getLocalNodeID(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	nodeIDs, err = handleNodeDecommissionSelf(ctx, nodeIDs, localNodeID, "decommissioning")
 	if err != nil {
 		return err
 	}
@@ -343,7 +348,7 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	}
 
 	c := serverpb.NewAdminClient(conn)
-	if err := runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait, nodeIDs); err != nil {
+	if err := runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait, nodeIDs, localNodeID); err != nil {
 		cause := errors.UnwrapAll(err)
 		if s, ok := status.FromError(cause); ok && s.Code() == codes.NotFound {
 			// Are we trying to decommission a node that does not
@@ -356,8 +361,18 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func getLocalNodeID(ctx context.Context, s serverpb.StatusClient) (roachpb.NodeID, error) {
+	var nodeID roachpb.NodeID
+	resp, err := s.Node(ctx, &serverpb.NodeRequest{NodeId: "local"})
+	if err != nil {
+		return nodeID, err
+	}
+	nodeID = resp.Desc.NodeID
+	return nodeID, nil
+}
+
 func handleNodeDecommissionSelf(
-	ctx context.Context, s serverpb.StatusClient, nodeIDs []roachpb.NodeID, command string,
+	ctx context.Context, nodeIDs []roachpb.NodeID, localNodeID roachpb.NodeID, command string,
 ) ([]roachpb.NodeID, error) {
 	if !nodeCtx.nodeDecommissionSelf {
 		// --self not passed; nothing to do.
@@ -369,13 +384,8 @@ func handleNodeDecommissionSelf(
 			cliflags.NodeDecommissionSelf.Name)
 	}
 
-	// What's this node's ID?
-	resp, err := s.Node(ctx, &serverpb.NodeRequest{NodeId: "local"})
-	if err != nil {
-		return nil, err
-	}
-	log.Infof(ctx, "%s node %d", log.Safe(command), resp.Desc.NodeID)
-	return []roachpb.NodeID{resp.Desc.NodeID}, nil
+	log.Infof(ctx, "%s node %d", log.Safe(command), localNodeID)
+	return []roachpb.NodeID{localNodeID}, nil
 }
 
 func expectNodesDecommissioned(
@@ -423,6 +433,7 @@ func runDecommissionNodeImpl(
 	c serverpb.AdminClient,
 	wait nodeDecommissionWaitType,
 	nodeIDs []roachpb.NodeID,
+	localNodeID roachpb.NodeID,
 ) error {
 	minReplicaCount := int64(math.MaxInt64)
 	opts := retry.Options{
@@ -431,12 +442,16 @@ func runDecommissionNodeImpl(
 		MaxBackoff:     20 * time.Second,
 	}
 
-	// Marking a node as fully decommissioned is driven by a two-step process.
-	// We start off by marking each node as 'decommissioning'. In doing so,
-	// replicas are slowly moved off of these nodes. It's only after when we're
-	// made aware that the replica counts have all hit zero, and that all nodes
-	// have been successfully marked as 'decommissioning', that we then go and
-	// mark each node as 'decommissioned'.
+	// Decommissioning a node is driven by a three-step process.
+	// 1) Mark each node as 'decommissioning'. In doing so, all replicas are
+	// slowly moved off of these nodes.
+	// 2) Drain each node.
+	// 3) Mark each node as 'decommissioned'.
+	// Note: if the node serving the decommission request is a target node,
+	// the draining step for that node will be skipped. This is because
+	// after a drain, issuing a decommission RPC against this node will fail.
+	// TODO(cameron): update the note once decommission requests are
+	// routed to another selected "control" node in the cluster.
 	prevResponse := serverpb.DecommissionStatusResponse{}
 	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
 		req := &serverpb.DecommissionRequest{
@@ -467,12 +482,35 @@ func runDecommissionNodeImpl(
 		}
 
 		if !anyActive && replicaCount == 0 {
-			// We now mark the nodes as fully decommissioned.
-			req := &serverpb.DecommissionRequest{
+			// We now drain the nodes in order to close all SQL connections.
+			// Note: iteration is not necessary here since there are no remaining leases
+			// on the decommissioning node after replica transferral.
+			for _, targetNode := range nodeIDs {
+				if targetNode == localNodeID {
+					// Skip the draining step for the node serving the request, if it is a target node.
+					log.Warningf(ctx,
+						"skipping drain step for node n%d; it is decommissioning and serving the request",
+						localNodeID,
+					)
+					continue
+				}
+				drainReq := &serverpb.DrainRequest{
+					Shutdown: false,
+					DoDrain:  true,
+					NodeId:   targetNode.String(),
+				}
+				if _, err = c.Drain(ctx, drainReq); err != nil {
+					fmt.Fprintln(stderr)
+					return errors.Wrapf(err, "while trying to drain n%d", targetNode)
+				}
+			}
+
+			// Finally, mark the nodes as fully decommissioned.
+			decommissionReq := &serverpb.DecommissionRequest{
 				NodeIDs:          nodeIDs,
 				TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONED,
 			}
-			_, err = c.Decommission(ctx, req)
+			_, err = c.Decommission(ctx, decommissionReq)
 			if err != nil {
 				fmt.Fprintln(stderr)
 				return errors.Wrap(err, "while trying to mark as decommissioned")
@@ -559,7 +597,12 @@ func runRecommissionNode(cmd *cobra.Command, args []string) error {
 
 	s := serverpb.NewStatusClient(conn)
 
-	nodeIDs, err = handleNodeDecommissionSelf(ctx, s, nodeIDs, "recommissioning")
+	localNodeID, err := getLocalNodeID(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	nodeIDs, err = handleNodeDecommissionSelf(ctx, nodeIDs, localNodeID, "recommissioning")
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/quit.go
+++ b/pkg/cli/quit.go
@@ -180,7 +180,7 @@ func doDrainNoTimeout(
 			if err != nil {
 				// Unexpected error.
 				fmt.Fprintf(stderr, "\n") // finish the line started above.
-				log.Infof(ctx, "graceful shutdown failed: %v", err)
+				log.Infof(ctx, "graceful drain failed: %v", err)
 				return false, remaining > 0, err
 			}
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -59,6 +61,17 @@ func registerDecommission(r registry.Registry) {
 			Cluster: r.MakeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDrainAndDecommission(ctx, t, c, numNodes, duration)
+			},
+		})
+	}
+	{
+		numNodes := 4
+		r.Add(registry.TestSpec{
+			Name:    "decommission/drains",
+			Owner:   registry.OwnerServer,
+			Cluster: r.MakeClusterSpec(numNodes),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runDecommissionDrains(ctx, t, c)
 			},
 		})
 	}
@@ -991,6 +1004,99 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// runDecommissionDrains tests that a decommission implies a drain.
+// This means that SQL connections of a decommissioning node will be closed near
+// the end of decommissioning. The test cluster contains 4 nodes and the fourth
+// node is decommissioned. While the decommissioning node has open SQL
+// connections, queries should never fail.
+func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) {
+	var (
+		numNodes     = 4
+		pinnedNodeID = 1
+		decommNodeID = numNodes
+		decommNode   = c.Node(decommNodeID)
+	)
+
+	err := c.PutE(ctx, t.L(), t.Cockroach(), "./cockroach", c.All())
+	require.NoError(t, err)
+
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+
+	h := newDecommTestHelper(t, c)
+
+	run := func(db *gosql.DB, query string) error {
+		_, err = db.ExecContext(ctx, query)
+		t.L().Printf("run: %s\n", query)
+		return err
+	}
+
+	{
+		db := c.Conn(ctx, t.L(), pinnedNodeID)
+		defer db.Close()
+
+		// Increase the speed of decommissioning.
+		err = run(db, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)
+		require.NoError(t, err)
+		err = run(db, `SET CLUSTER SETTING kv.snapshot_recovery.max_rate='2GiB'`)
+		require.NoError(t, err)
+
+		// Wait for initial up-replication.
+		WaitFor3XReplication(t, db)
+	}
+
+	// Connect to node 4 (the target node of the decommission).
+	decommNodeDB := c.Conn(ctx, t.L(), decommNodeID)
+	defer decommNodeDB.Close()
+
+	// Decommission node 4 and poll its status during the decommission.
+	var (
+		maxAttempts = 50
+		retryOpts   = retry.Options{
+			InitialBackoff: time.Second,
+			MaxBackoff:     5 * time.Second,
+			Multiplier:     2,
+		}
+		// The expected output of decommission while the node is about to be drained/is draining.
+		expReplicasTransferred = [][]string{
+			decommissionHeader,
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioning", "false"},
+			decommissionFooter,
+		}
+		// The expected output of decommission once the node is finally marked as "decommissioned."
+		expDecommissioned = [][]string{
+			decommissionHeader,
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioned", "false"},
+			decommissionFooter,
+		}
+	)
+	t.Status(fmt.Sprintf("decommissioning node %d", decommNodeID))
+	e := retry.WithMaxAttempts(ctx, retryOpts, maxAttempts, func() error {
+		o, err := h.decommission(ctx, decommNode, pinnedNodeID, "--wait=none", "--format=csv")
+		require.NoError(t, errors.Wrapf(err, "decommission failed"))
+
+		// Check if all the replicas have been transferred.
+		if err = cli.MatchCSV(o, expReplicasTransferred); err != nil {
+			return err
+		}
+
+		// Check to see if the node has been drained.
+		// If not, send a query and verify that the query does not fail.
+		if decommNodeDB.Ping() != nil { // not drained
+			err = run(decommNodeDB, `SHOW DATABASES`)
+			require.NoError(t, err)
+			return errors.New("not drained")
+		}
+
+		return nil
+	})
+	require.NoError(t, e)
+
+	// Check that the node is fully decommissioned.
+	o, err := h.decommission(ctx, decommNode, pinnedNodeID, "--format=csv")
+	require.NoError(t, err)
+	require.NoError(t, cli.MatchCSV(o, expDecommissioned))
 }
 
 // Header from the output of `cockroach node decommission`.


### PR DESCRIPTION
Fixes #72754.

Previously, operators did not have the option to drain late into the decommissioning process, which caused queries to hang. This was a result of SQL client connections at the end of the process becoming suddenly unusable. This patch ensures that these client connections on the decommissioning node are closed before the node is marked as decommissioned. 

There is one caveat which is that the draining step of the decommissioning process will be skipped if the node serving the decommission request is a target. A follow-up PR will fix this by enforcing that nodes serving requests are not target nodes. Decommission requests will be routed to other nodes in the cluster that are not targets. 

### What's the difference between drain and decommission?

A drain prepares a node for process termination. This process moves all range leases away from the node but keeps the replicas. While a node is in the draining state, ranges cannot be rebalanced onto the node. 

Here are the steps in the drain sequence (**documentation needed**):

1. Initial wait
    - Continues normal node operation
    - Health check `/health?ready=1` starts returning false
    - LBs & connection management tools begin routing traffic to other nodes
    - Minimum duration: `server.shutdown.drain_wait` (default 0s)
            - This should be configured in coordination with the LB’s settings
2. ([DEV IN PROGRESS](https://github.com/cockroachdb/cockroach/pull/72991)) Wait for clients to close SQL connections
    - Maximum duration: `server.shutdown.connection_wait` (default 0s)
3. SQL connection closure
    - Completes processing of transactions started on the node
    - Refuses new connections and transactions
    - Finally, closes all SQL connections
    - Maximum duration: `server.shutdown.query_wait` (default 10s)
4. Lease and leadership transferral
    - Transfers all range leases and raft leaderships to other nodes
    - Maximum duration between iterations in the infinite loop: `server.shutdown.lease_transfer_wait` (default 5s)

A decommission prepares a node for permanent removal and **(NEW) process termination**. This process moves all range replicas away from the node.

Here are the steps in the decommission sequence (**documentation needed**):
1. Replica transferral
    - Transfers all range replicas to other nodes
2. **(NEW) Drain**
3. Final state transition
    - Marks the node as fully decommissioned


### How does shutdown work in relation to drain and decommission?

Shutdown consists of two phases: (1) shutdown preparation (with either a drain or decommission) and (2) process termination. 

If the goal is to have the node restart and continue to be active (e.g. software upgrade), the first phase should be a drain. On the other hand, if the node should be permanently removed from the cluster, the first phase should be a decommission; it is optional, but recommended, to precede the decommission with a drain to avoid possible disturbances in query performance. 

Once the first phase is complete, the process will still be running. It is only stopped after process termination. 


### Release notes


Release note (bug fix): `cockroach node decommission` no longer causes query failure due to the decommissioning node not closing open SQL connections and still being marked as ready. The decommissioning process now includes a draining step that fixes this. In other words, a decommission now automatically drains a node. This also means that running a drain after a decommission is no longer necessary. It is optional, but recommended, that `cockroach node drain` is used before `cockroach node decommission` to avoid the possibility of a disturbance in query performance. 

Release note (cli change): the flag `--self` of the `cockroach node decommission` command is deprecated. Instead, operators should specify the node ID of the target node as an explicit argument. The node that the command is connected to should not be a target node.