### PR TITLE
roachprod: Increase file num limit to fix various roachprod issue

### DIFF
--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -93,5 +93,5 @@ sudo systemd-run --unit cockroach \
   --service-type=notify -p NotifyAccess=all \
   -p "MemoryMax=${MEMORY_MAX}" \
   -p LimitCORE=infinity \
-  -p LimitNOFILE=65536 \
+  -p LimitNOFILE=655360 \
   bash "${0}" run


### PR DESCRIPTION
When running this year's cloud report, we began to hit two major issues:
In tpcc test we frequently hit various kv errors, some of them will result in test emit COMMAND_ERROR, and end the test well before a machine type could reach its peak performance;
This limit also caused a random issue in `roachprod get`, which various microbench tests use to copy result files from host to client. When parallel microbench tests are running and result files were successfully generated on the host, the copy op will randomly fail, result in all empty files (length=0) under the target directory.
Both of the above issues happened in random but pretty frequently.
Increase the file number limit seemed to fix the above issues: For hundred runs after applying this fix, not a single copy issue has happened so far, and runs near the real limit is much stable.

Release note: none