### PR TITLE
sql : alter sequence's increment and the results of 'select nextval()' were not as expected

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -141,6 +141,18 @@ func (e sqlEncoder) SequenceKey(tableID uint32) roachpb.Key {
 	return k
 }
 
+// CurrentSequenceKey returns the key used to store the current value of
+// a sequence, after the use of nextval() and alter_sequence_stmt.
+func (e sqlEncoder) CurrentSequenceKey(tableID uint32) roachpb.Key {
+	k := e.IndexPrefix(tableID, SequenceIndexID)
+	k = encoding.EncodeUvarintAscending(k, 0)    // Primary key value
+	k = MakeFamilyKey(k, SequenceColumnFamilyID) // Column family
+
+	// Column family added to distinguish from SequenceKey()
+	k = MakeFamilyKey(k, SequenceColumnFamilyID)
+	return k
+}
+
 // DescIDSequenceKey returns the key used for the descriptor ID sequence.
 func (e sqlEncoder) DescIDSequenceKey() roachpb.Key {
 	if e.ForSystemTenant() {

--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -231,3 +231,119 @@ query T
 SELECT create_statement FROM [SHOW CREATE SEQUENCE reverse_direction_seqas]
 ----
 CREATE SEQUENCE public.reverse_direction_seqas AS INT8 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+
+
+# The flowing four cases are for sequence which is altered before it has ever been used
+# case 1 : Modify successfully, without START
+statement ok
+CREATE SEQUENCE seq_testx_1 INCREMENT BY 3 MINVALUE 1 MAXVALUE 12
+
+statement ok
+ALTER SEQUENCE seq_testx_1 INCREMENT BY 8 MINVALUE 1 MAXVALUE 12
+
+query I
+SELECT nextval('seq_testx_1')
+----
+1
+
+query  I
+SELECT nextval('seq_testx_1')
+----
+9
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "seq_testx_1" \(12\)
+SELECT nextval('seq_testx_1')
+
+# case 2 : Fail to modify, and set START when create sequence
+statement ok
+CREATE SEQUENCE seq_testx_2 INCREMENT BY 3 MINVALUE 1 MAXVALUE 12 START 2
+
+statement error pq: START value \(2\) cannot be less than MINVALUE \(4\)
+ALTER SEQUENCE seq_testx_2 INCREMENT BY 1 MINVALUE 4 MAXVALUE 12
+
+query  I
+SELECT nextval('seq_testx_2')
+----
+2
+
+# case 3 : Modify successfully, and set START when create sequence
+statement ok
+CREATE SEQUENCE seq_testx_3 INCREMENT BY 3 MINVALUE 1 MAXVALUE 12 start 5
+
+statement ok
+ALTER SEQUENCE seq_testx_3 INCREMENT BY 8 MINVALUE 1 MAXVALUE 12
+
+query I
+select nextval('seq_testx_3')
+----
+5
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "seq_testx_3" \(12\)
+select nextval('seq_testx_3')
+
+# case 4 : Modify successfully, and the START set when create sequence not in [newMinValue, newMaxValue]
+statement ok
+CREATE SEQUENCE seq_testx_4 INCREMENT BY 3 MINVALUE 1 MAXVALUE 12 start 5
+
+statement error pq: START value \(5\) cannot be greater than MAXVALUE \(4\)
+ALTER SEQUENCE seq_testx_4 INCREMENT BY 1 MINVALUE 1 MAXVALUE 4
+
+# customer_seq_alter_1 is for the sequence which is altered after it has ever been used
+statement ok
+CREATE SEQUENCE customer_seq_alter_1 MINVALUE -2 MAXVALUE 2 START WITH 1 CACHE 5 INCREMENT BY -2
+
+statement error pq: START value \(1\) cannot be less than MINVALUE \(6\)
+ALTER SEQUENCE customer_seq_alter_1 INCREMENT  BY -1   MINVALUE 6 MAXVALUE 10
+
+query I
+SELECT nextval('customer_seq_alter_1')
+----
+1
+
+query I
+select currval('customer_seq_alter_1')
+----
+1
+
+statement ok
+ALTER SEQUENCE customer_seq_alter_1 INCREMENT  BY 1 MINVALUE -5 MAXVALUE 10
+
+query I
+select currval('customer_seq_alter_1')
+----
+1
+
+query I
+select nextval('customer_seq_alter_1')
+----
+2
+
+# sequenceVal in [Minimum, Maximum], increment = -1, Minimum < oldMinimum, Maximum > oldMaximum
+statement ok
+ALTER SEQUENCE customer_seq_alter_1 INCREMENT  BY -1   MINVALUE -5 MAXVALUE 15
+
+query I
+select currval('customer_seq_alter_1')
+----
+2
+
+query I
+select nextval('customer_seq_alter_1')
+----
+1
+
+statement error pq: START value \(15\) cannot be greater than MAXVALUE \(0\)
+ALTER SEQUENCE customer_seq_alter_1 INCREMENT  BY 1 MINVALUE -5 MAXVALUE 0
+
+query I
+select currval('customer_seq_alter_1')
+----
+1
+
+query I
+select nextval('customer_seq_alter_1')
+----
+0
+
+statement error pq: START value \(15\) cannot be greater than MAXVALUE \(10\)
+ALTER SEQUENCE customer_seq_alter_1 INCREMENT  BY 3  MINVALUE 0 MAXVALUE 10

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2214,3 +2214,37 @@ SELECT lastval()
 
 statement ok
 END
+
+# The value value(12) is out-of-bounds
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_1 INCREMENT  BY 3  MINVALUE 6 MAXVALUE 10
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+6
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+----
+9
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "customer_seq_check_cache_and_bounds_1" \(10\)
+SELECT nextval('customer_seq_check_cache_and_bounds_1')
+
+# Set the cache to 5
+statement ok
+CREATE SEQUENCE customer_seq_check_cache_and_bounds_2 MINVALUE -2 MAXVALUE 2 START WITH 1 CACHE 5 INCREMENT BY -2
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+1
+
+query I
+SELECT nextval('customer_seq_check_cache_and_bounds_2')
+----
+-1
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "customer_seq_check_cache_and_bounds_2" \(-2\)
+SELECT nextval('customer_seq_check_cache_and_bounds_2')

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -133,7 +133,7 @@ func incrementSequenceHelper(
 func (p *planner) incrementSequenceUsingCache(
 	ctx context.Context, descriptor catalog.TableDescriptor,
 ) (int64, error) {
-	seqOpts := descriptor.GetSequenceOpts()
+	opts := descriptor.GetSequenceOpts()
 
 	sequenceID := descriptor.GetID()
 	createdInCurrentTxn := p.createdSequences.isCreatedSequence(sequenceID)
@@ -141,10 +141,10 @@ func (p *planner) incrementSequenceUsingCache(
 	if createdInCurrentTxn {
 		cacheSize = 1
 	} else {
-		cacheSize = seqOpts.EffectiveCacheSize()
+		cacheSize = opts.EffectiveCacheSize()
 	}
 
-	fetchNextValues := func() (currentValue, incrementAmount, sizeOfCache int64, err error) {
+	fetchNextValues := func() (nextVal, incrementAmount, sizeOfCache int64, err error) {
 		seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(sequenceID))
 
 		// The planner txn is only used if the sequence is accessed in the same
@@ -152,14 +152,14 @@ func (p *planner) incrementSequenceUsingCache(
 		// txn here, since nextval does not respect transaction boundaries.
 		// This matches the specification at
 		// https://www.postgresql.org/docs/14/functions-sequence.html.
-		var endValue int64
+		var postIncrement int64
 		if createdInCurrentTxn {
 			var res kv.KeyValue
-			res, err = p.txn.Inc(ctx, seqValueKey, seqOpts.Increment*cacheSize)
-			endValue = res.ValueInt()
+			res, err = p.txn.Inc(ctx, seqValueKey, opts.Increment*cacheSize)
+			postIncrement = res.ValueInt()
 		} else {
-			endValue, err = kv.IncrementValRetryable(
-				ctx, p.ExecCfg().DB, seqValueKey, seqOpts.Increment*cacheSize)
+			postIncrement, err = kv.IncrementValRetryable(
+				ctx, p.ExecCfg().DB, seqValueKey, opts.Increment*cacheSize)
 		}
 
 		if err != nil {
@@ -169,31 +169,39 @@ func (p *planner) incrementSequenceUsingCache(
 			return 0, 0, 0, err
 		}
 
-		// This sequence has exceeded its bounds after performing this increment.
-		if endValue > seqOpts.MaxValue || endValue < seqOpts.MinValue {
-			// If the sequence exceeded its bounds prior to the increment, then return an error.
-			if (seqOpts.Increment > 0 && endValue-seqOpts.Increment*cacheSize >= seqOpts.MaxValue) ||
-				(seqOpts.Increment < 0 && endValue-seqOpts.Increment*cacheSize <= seqOpts.MinValue) {
-				return 0, 0, 0, boundsExceededError(descriptor)
+		preIncrement := postIncrement - opts.Increment*cacheSize
+		nextVal = preIncrement + opts.Increment
+
+		// The postIncrement value is in-bounds, this implies that nextVal and
+		// all interceding values are too.
+		if postIncrement <= opts.MaxValue && postIncrement >= opts.MinValue {
+			return nextVal, opts.Increment, cacheSize, nil
+		}
+		// The postIncrement value is out-of-bounds, find the portion of
+		// the cached sequence which is valid, if any.
+		positiveIncrement := opts.Increment > 0
+		if (positiveIncrement && nextVal > opts.MaxValue) ||
+			(!positiveIncrement && nextVal < opts.MinValue) {
+			return 0, 0, 0, boundsExceededError(descriptor)
+		}
+		// Otherwise, some values between the limit and the value prior to
+		// incrementing can be cached. Figure out how many.
+		var limit int64
+		switch positiveIncrement {
+		case true:
+			limit = opts.MaxValue
+		case false:
+			limit = opts.MinValue
+		}
+		abs := func(i int64) int64 {
+			if i < 0 {
+				return -i
 			}
-			// Otherwise, values between the limit and the value prior to incrementing can be cached.
-			limit := seqOpts.MaxValue
-			if seqOpts.Increment < 0 {
-				limit = seqOpts.MinValue
-			}
-			abs := func(i int64) int64 {
-				if i < 0 {
-					return -i
-				}
-				return i
-			}
-			currentValue = endValue - seqOpts.Increment*(cacheSize-1)
-			incrementAmount = seqOpts.Increment
-			sizeOfCache = abs(limit-(endValue-seqOpts.Increment*cacheSize)) / abs(seqOpts.Increment)
-			return currentValue, incrementAmount, sizeOfCache, nil
+			return i
 		}
 
-		return endValue - seqOpts.Increment*(cacheSize-1), seqOpts.Increment, cacheSize, nil
+		sizeOfCache = abs(limit-preIncrement) / abs(opts.Increment)
+		return nextVal, opts.Increment, sizeOfCache, nil
 	}
 
 	var val int64
@@ -208,6 +216,10 @@ func (p *planner) incrementSequenceUsingCache(
 		if err != nil {
 			return 0, err
 		}
+	}
+	currentSeqKey := p.ExecCfg().Codec.CurrentSequenceKey(uint32(descriptor.GetID()))
+	if err := p.txn.Put(ctx, currentSeqKey, val); err != nil {
+		return 0, err
 	}
 	return val, nil
 }


### PR DESCRIPTION
sql : alter sequence's increment and the results of 'select nextval()' were not as expected

If the sequenceVal exceeded the old MinValue or MaxValue, we must set sequenceVal to the last valid one.

1. Values is just init, when the sequence is altered before it has ever been used.
In this case, last valid sequenceVal is oldStart.
Set the initial value to the oldStartValue(just like pg), when last valid sequenceVal in [newMinValue, newMaxValue].

2. When the sequenceVal out of range result from increment, report an error.

Fixes #52552

sql : sequence value out of bounds

    Previously, an additional out-of-range sequence value may have been
    generated.
    The original criterion was whether the previous endSequence value exceeded the limit.
    However, when the current endSequence is 1, the increment is 2 and the MaxValue is 2,
    the previous endSequence value is 1 and the program does not report an error.
    However, when the current endSequenceValue 3 exceeds the limit, an error should be reported

    In incrementSequenceUsingCache, the criterion for determining whether a cache's data is eligible is modified to whether the first data that may be stored in the cache exceeds the limit.

Fixes #74127.
