### PR TITLE
server: new discrete security overrides to replace `--insecure`

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -271,6 +271,7 @@ func (c *Cluster) makeNode(ctx context.Context, nodeIdx int, cfg NodeConfig) (*N
 		User:     security.NodeUserName(),
 		Insecure: true,
 	}
+	_ = baseCtx.SecurityOverrides.Set("disable-all")
 	rpcCtx := rpc.NewContext(ctx, rpc.ContextOptions{
 		TenantID: roachpb.SystemTenantID,
 		Config:   baseCtx,

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "constants.go",
         "license.go",
         "node_id.go",
+        "security_flags.go",
         "store_spec.go",
         "test_server_args.go",
         "testing_knobs.go",
@@ -53,10 +54,11 @@ go_test(
         "cluster_id_test.go",
         "main_test.go",
         "node_id_test.go",
+        "security_flags_test.go",
         "store_spec_test.go",
     ],
+    embed = [":base"],
     deps = [
-        ":base",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",
@@ -65,6 +67,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -151,15 +151,21 @@ var (
 type Config struct {
 	// Insecure specifies whether to disable security checks throughout
 	// the code base.
-	// This is really not recommended.
 	// See: https://github.com/cockroachdb/cockroach/issues/53404
+	//
+	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
 	Insecure bool
+
+	// SecurityOverrides indicates which security mechanisms to disable.
+	SecurityOverrides SecurityOverrides
 
 	// AcceptSQLWithoutTLS, when set, makes it possible for SQL
 	// clients to authenticate without TLS on a secure cluster.
 	//
 	// Authentication is, as usual, subject to the HBA configuration: in
 	// the default case, password authentication is still mandatory.
+	//
+	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
 	AcceptSQLWithoutTLS bool
 
 	// SSLCAKey is used to sign new certs.
@@ -190,6 +196,8 @@ type Config struct {
 	// verification to only verify that a non-empty cluster name on
 	// both sides match. This is meant for use while rolling an
 	// existing cluster into using a new cluster name.
+	//
+	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
 	DisableClusterNameVerification bool
 
 	// SplitListenSQL indicates whether to listen for SQL
@@ -208,6 +216,8 @@ type Config struct {
 	HTTPAddr string
 
 	// DisableTLSForHTTP, if set, disables TLS for the HTTP listener.
+	//
+	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
 	DisableTLSForHTTP bool
 
 	// HTTPAdvertiseAddr is the advertised HTTP address.
@@ -255,6 +265,7 @@ func (*Config) HistogramWindowInterval() time.Duration {
 // This is also used in tests to reset global objects.
 func (cfg *Config) InitDefaults() {
 	cfg.Insecure = defaultInsecure
+	cfg.SecurityOverrides = 0
 	cfg.User = security.MakeSQLUsernameFromPreNormalizedString(defaultUser)
 	cfg.Addr = defaultAddr
 	cfg.AdvertiseAddr = cfg.Addr

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -159,15 +159,6 @@ type Config struct {
 	// SecurityOverrides indicates which security mechanisms to disable.
 	SecurityOverrides SecurityOverrides
 
-	// AcceptSQLWithoutTLS, when set, makes it possible for SQL
-	// clients to authenticate without TLS on a secure cluster.
-	//
-	// Authentication is, as usual, subject to the HBA configuration: in
-	// the default case, password authentication is still mandatory.
-	//
-	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
-	AcceptSQLWithoutTLS bool
-
 	// SSLCAKey is used to sign new certs.
 	SSLCAKey string
 	// SSLCertsDir is the path to the certificate/key directory.
@@ -271,7 +262,6 @@ func (cfg *Config) InitDefaults() {
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""
 	cfg.ClockDevicePath = ""
-	cfg.AcceptSQLWithoutTLS = false
 }
 
 // HTTPRequestScheme returns "http" or "https" based on the value of

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -192,14 +192,6 @@ type Config struct {
 	// negotiated on both sides, the cluster name is not used any more.
 	ClusterName string
 
-	// DisableClusterNameVerification, when set, alters the cluster name
-	// verification to only verify that a non-empty cluster name on
-	// both sides match. This is meant for use while rolling an
-	// existing cluster into using a new cluster name.
-	//
-	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
-	DisableClusterNameVerification bool
-
 	// SplitListenSQL indicates whether to listen for SQL
 	// clients on a separate address from RPC requests.
 	SplitListenSQL bool
@@ -278,7 +270,6 @@ func (cfg *Config) InitDefaults() {
 	cfg.SSLCertsDir = DefaultCertsDirectory
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""
-	cfg.DisableClusterNameVerification = false
 	cfg.ClockDevicePath = ""
 	cfg.AcceptSQLWithoutTLS = false
 }

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -198,11 +198,6 @@ type Config struct {
 	// HTTPAddr is the configured HTTP listen address.
 	HTTPAddr string
 
-	// DisableTLSForHTTP, if set, disables TLS for the HTTP listener.
-	//
-	// TODO(knz): Remove this once the SecurityOverrides are used throughout.
-	DisableTLSForHTTP bool
-
 	// HTTPAdvertiseAddr is the advertised HTTP address.
 	// This is computed from HTTPAddr if specified otherwise Addr.
 	HTTPAdvertiseAddr string
@@ -253,7 +248,6 @@ func (cfg *Config) InitDefaults() {
 	cfg.Addr = defaultAddr
 	cfg.AdvertiseAddr = cfg.Addr
 	cfg.HTTPAddr = defaultHTTPAddr
-	cfg.DisableTLSForHTTP = false
 	cfg.HTTPAdvertiseAddr = ""
 	cfg.SplitListenSQL = false
 	cfg.SQLAddr = defaultSQLAddr
@@ -267,7 +261,7 @@ func (cfg *Config) InitDefaults() {
 // HTTPRequestScheme returns "http" or "https" based on the value of
 // Insecure and DisableTLSForHTTP.
 func (cfg *Config) HTTPRequestScheme() string {
-	if cfg.Insecure || cfg.DisableTLSForHTTP {
+	if cfg.SecurityOverrides.IsSet(DisableHTTPTLS) {
 		return httpScheme
 	}
 	return httpsScheme

--- a/pkg/base/security_flags.go
+++ b/pkg/base/security_flags.go
@@ -13,6 +13,7 @@ package base
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -167,7 +168,14 @@ func (o *SecurityOverrides) Validate() {
 	if o.IsSet(DisableSQLTLS) {
 		o.addInternal(DisableSQLRequireTLS)
 	}
+	if disableWebLogin {
+		o.addInternal(DisableHTTPAuthn)
+	}
 	if o.IsSet(DisableRPCTLS) || o.IsSet(DisableRPCAuthn) || o.IsSet(DisableHTTPTLS) || o.IsSet(DisableHTTPAuthn) {
 		o.addInternal(DisableRemoteCertsRetrieval)
 	}
 }
+
+// disableWebLogin is an env var override for DisableHTTPAuthn, provided
+// for backward compatibility with previous versions of CockroachDB.
+var disableWebLogin = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)

--- a/pkg/base/security_flags.go
+++ b/pkg/base/security_flags.go
@@ -130,6 +130,16 @@ func (o *SecurityOverrides) Set(v string) error {
 	return nil
 }
 
+// SetFlag sets a flag using a boolean.
+func (o *SecurityOverrides) SetFlag(flag SecurityOverrides, value bool) {
+	if value {
+		*o = *o | flag
+	} else {
+		*o = *o & ^flag
+	}
+	o.Validate()
+}
+
 // IsSet checks whether the given flags are all set.
 func (o SecurityOverrides) IsSet(flag SecurityOverrides) bool {
 	return o&flag == flag

--- a/pkg/base/security_flags.go
+++ b/pkg/base/security_flags.go
@@ -1,0 +1,163 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package base
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// SecurityOverrides stores the boolean flags that override security protections
+// inside CockroachDB.
+type SecurityOverrides int
+
+const (
+	// DisableTLS disables all the TLS configuration.
+	DisableTLS SecurityOverrides = 1 << iota
+	// DisableRPCTLS disables usage of TLS for RPC connections. This impacts
+	// all types of RPC connections: node-node, tenant-node and client-node.
+	DisableRPCTLS
+	// DisableRPCAuthn disables RPC authentication.
+	// Currently implied by DisableRPCTLS, because the only authentication
+	// mechanism supported for RPC conns is TLS. We may be able to separate
+	// them in the future by implementing a non-TLS RPC authn mechanism.
+	// See also: https://github.com/cockroachdb/cockroach/issues/54007
+	DisableRPCAuthn
+	// DisableSQLAuthn disables authentication of SQL clients, i.e.
+	// accept all connections as if processed via the 'trust' authentication
+	// method.
+	DisableSQLAuthn
+	// DisableSQLTLS disables the availability of TLS connections for SQL clients.
+	// Implied by DisableTLS.
+	// When this option is not specified, SQL clients may, but do not have to,
+	// use a TLS connection (ie. non-TLS connections are still allowed).
+	DisableSQLTLS
+	// DisableSQLRequireTLS disables the requirement that SQL clients use a TLS
+	// connection.
+	// When this option is not specified, SQL clients must use a TLS connection.
+	DisableSQLRequireTLS
+	// DisableSQLSetCredentials prevents SQL clients from setting new
+	// password credentials on roles/users via the CREATE/ALTER USER/ROLE WITH PASSWORD
+	// statement.
+	// (They can still remove credentials though, or set password
+	// credentials if they have write access to system.users)
+	DisableSQLSetCredentials
+	// DisableHTTPTLS disables TLS for HTTP connections.
+	// Implied by DisableTLS.
+	DisableHTTPTLS
+	// DisableHTTPAuthn disables user authentication for HTTP requests.
+	DisableHTTPAuthn
+	// DisableRemoteCertsRetrieval disables the retrieval of TLS certificates
+	// using the 'Certificates' RPC / API.
+	// Implied by DisableRPCTLS, DisableRPCAuthn, DisableHTTPTLS or DisableHTTPAuthn.
+	DisableRemoteCertsRetrieval
+	// DisableClusterNameVerification alters the cluster name
+	// verification to only verify that a non-empty cluster name on
+	// both sides match. This is meant for use while rolling an
+	// existing cluster into using a new cluster name.
+	DisableClusterNameVerification
+
+	// lastSecurityOverride must be last in the list above.
+	lastSecurityOverride
+	// DisableAll includes all the flags above.
+	DisableAll SecurityOverrides = lastSecurityOverride - 1
+)
+
+var flagNames = map[SecurityOverrides]string{
+	DisableTLS:                     "disable-tls",
+	DisableRPCTLS:                  "disable-rpc-tls",
+	DisableRPCAuthn:                "disable-rpc-authn",
+	DisableSQLAuthn:                "disable-sql-authn",
+	DisableSQLTLS:                  "disable-sql-tls",
+	DisableSQLRequireTLS:           "disable-sql-require-tls",
+	DisableSQLSetCredentials:       "disable-sql-set-credentials",
+	DisableHTTPTLS:                 "disable-http-tls",
+	DisableHTTPAuthn:               "disable-http-authn",
+	DisableRemoteCertsRetrieval:    "disable-remote-certs-retrieval",
+	DisableClusterNameVerification: "disable-cluster-name-verification",
+}
+
+var flagFromName = func() map[string]SecurityOverrides {
+	m := make(map[string]SecurityOverrides)
+	for k, v := range flagNames {
+		k.Validate()
+		m[v] = k
+	}
+	// DisableAll is special: it can be set from string, but
+	// it does not have a distinct name.
+	m["disable-all"] = DisableAll
+	return m
+}()
+
+// String implements the fmt.Stringer interface.
+func (o SecurityOverrides) String() string {
+	var buf strings.Builder
+	for i := SecurityOverrides(1); i < DisableAll; i = i * 2 {
+		if o&i != 0 {
+			if buf.Len() > 0 {
+				buf.WriteByte(',')
+			}
+			buf.WriteString(flagNames[i])
+		}
+	}
+	return buf.String()
+}
+
+// Type implements the pflag.Value interface.
+func (o SecurityOverrides) Type() string { return "<override flags>" }
+
+// Set implements the pflag.Value interface.
+func (o *SecurityOverrides) Set(v string) error {
+	parts := strings.Split(v, ",")
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		flag, ok := flagFromName[part]
+		if !ok {
+			return errors.Newf("unknown security override: %q", part)
+		}
+		o.addInternal(flag)
+	}
+	o.Validate()
+	return nil
+}
+
+// IsSet checks whether the given flags are all set.
+func (o SecurityOverrides) IsSet(flag SecurityOverrides) bool {
+	return o&flag == flag
+}
+
+// AddOverride adds an override.
+func (o *SecurityOverrides) AddOverride(flag SecurityOverrides) {
+	o.addInternal(flag)
+	o.Validate()
+}
+
+func (o *SecurityOverrides) addInternal(flag SecurityOverrides) {
+	*o = *o | flag
+}
+
+// Validate checks the combination of flags and propagates
+// flag implications.
+func (o *SecurityOverrides) Validate() {
+	if o.IsSet(DisableTLS) {
+		o.addInternal(DisableRPCTLS | DisableSQLTLS | DisableHTTPTLS)
+	}
+	if o.IsSet(DisableRPCTLS) {
+		o.addInternal(DisableRPCAuthn)
+	}
+	if o.IsSet(DisableSQLTLS) {
+		o.addInternal(DisableSQLRequireTLS)
+	}
+	if o.IsSet(DisableRPCTLS) || o.IsSet(DisableRPCAuthn) || o.IsSet(DisableHTTPTLS) || o.IsSet(DisableHTTPAuthn) {
+		o.addInternal(DisableRemoteCertsRetrieval)
+	}
+}

--- a/pkg/base/security_flags_test.go
+++ b/pkg/base/security_flags_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package base
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllSecurityOverridesHaveName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for i := SecurityOverrides(1); i < DisableAll; i = i * 2 {
+		// Check that all settings have a name.
+		name := i.String()
+		require.NotEmpty(t, name)
+
+		// Check that setting a new override set from that name
+		// yields the same set of flags.
+		copy := i
+		copy.Validate()
+		var j SecurityOverrides
+		require.NoError(t, j.Set(name))
+		assert.Equal(t, j, copy)
+	}
+}
+
+func TestSecurityOverridesValidate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		in, out string
+	}{
+		{"disable-all", "disable-tls,disable-rpc-tls,disable-rpc-authn,disable-sql-authn,disable-sql-tls,disable-sql-require-tls,disable-sql-set-credentials,disable-http-tls,disable-http-authn,disable-remote-certs-retrieval,disable-cluster-name-verification"},
+		{"disable-tls", "disable-tls,disable-rpc-tls,disable-rpc-authn,disable-sql-tls,disable-sql-require-tls,disable-http-tls,disable-remote-certs-retrieval"},
+		{"disable-rpc-tls", "disable-rpc-tls,disable-rpc-authn,disable-remote-certs-retrieval"},
+		{"disable-rpc-authn", "disable-rpc-authn,disable-remote-certs-retrieval"},
+		{"disable-sql-tls", "disable-sql-tls,disable-sql-require-tls"},
+	}
+
+	for _, tc := range testCases {
+		var fl SecurityOverrides
+		require.NoError(t, fl.Set(tc.in))
+		assert.Equal(t, fl.String(), tc.out)
+	}
+}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -353,23 +353,15 @@ or both, have not yet been initialized and do not yet know their cluster ID.
 
 </PRE>
 To introduce a cluster name into an already-initialized cluster, pair this flag
-with --disable-cluster-name-verification.
+with --security-overrides=disable-cluster-name-verification.
 `,
 	}
 
 	DisableClusterNameVerification = FlagInfo{
 		Name: "disable-cluster-name-verification",
 		Description: `
-Tell the server to ignore cluster name mismatches. This is meant for use when
-opting an existing cluster into starting to use cluster name verification, or
-when changing the cluster name.
-<PRE>
-
-</PRE>
-The cluster should be restarted once with --cluster-name and
---disable-cluster-name-verification combined, and once all nodes have
-been updated to know the new cluster name, the cluster can be
-restarted again with this flag removed.`,
+Alias for --security-overrides=disable-cluster-name-verification.
+`,
 	}
 
 	Join = FlagInfo{

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -563,10 +563,7 @@ local testing without requiring certificate setups in web browsers.`,
 	AcceptSQLWithoutTLS = FlagInfo{
 		Name: "accept-sql-without-tls",
 		Description: `
-When specified, this node will accept SQL client connections that do not wish
-to negotiate a TLS handshake. Authentication is still otherwise required
-as per the HBA configuration and all other security mechanisms continue to
-apply. This flag is experimental.
+Alias for --security-overrides=disable-sql-require-tls.
 `,
 	}
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -651,7 +651,8 @@ This makes the client-server connection vulnerable to MITM attacks. Use with car
 	ServerInsecure = FlagInfo{
 		Name: "insecure",
 		Description: `
-Start a node with all security controls disabled.
+Alias for --security-overrides=disable-all.
+
 There is no encryption, no authentication and internal security
 checks are also disabled. This makes any client able to take
 over the entire cluster.
@@ -668,8 +669,34 @@ is likely to cause the entire host server to become compromised.
 
 </PRE>
 To simply accept non-TLS connections for SQL clients while keeping
-the cluster secure, consider using --accept-sql-without-tls instead.
+the cluster secure, consider using
+--security-overrides=disable-sql-require-tls instead.
 Also see: ` + build.MakeIssueURL(53404) + `
+`,
+	}
+
+	ServerSecurityOverrides = FlagInfo{
+		Name: "security-overrides",
+		Description: `
+Disable some security protections:
+<PRE>
+- disable-tls
+- disable-rpc-tls (implied by disable-tls; implies disable-rpc-authn)
+- disable-rpc-authn (implied by disable-rpc-tls; implies disable-rpc-tls)
+- disable-sql-authn
+- disable-sql-tls (implied by disable-tls)
+- disable-sql-require-tls (implied by disable-sql-tls)
+- disable-sql-set-credentials
+- disable-http-tls (implied by disable-tls)
+- disable-http-authn
+- disable-remote-cert-retrieval (implied by any of disable-{rpc,http}-{tls,authn})
+- disable-cluster-name-verification
+- disable-all (implies all of the above)
+</PRE>
+
+See the documentation for details about these options.
+Note that each of these options, in isolation, can be sufficient
+to fully compromise an entire cluster's security. Proceed with care.
 `,
 	}
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -430,10 +430,11 @@ func setDebugContextDefaults() {
 // See below for defaults.
 var startCtx struct {
 	// server-specific values of some flags.
-	serverInsecure         bool
-	serverSSLCertsDir      string
-	serverCertPrincipalMap []string
-	serverListenAddr       string
+	serverInsecure          bool
+	serverSecurityOverrides base.SecurityOverrides
+	serverSSLCertsDir       string
+	serverCertPrincipalMap  []string
+	serverListenAddr        string
 
 	// The TLS auto-handshake parameters.
 	initToken             string
@@ -472,6 +473,7 @@ var startCtx struct {
 // test that exercises command-line parsing.
 func setStartContextDefaults() {
 	startCtx.serverInsecure = baseCfg.Insecure
+	startCtx.serverSecurityOverrides = baseCfg.SecurityOverrides
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
 	startCtx.serverCertPrincipalMap = nil
 	startCtx.serverListenAddr = ""

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -98,7 +98,7 @@ func Example_demo() {
 	// demo --multitenant=false -e CREATE USER test WITH PASSWORD 'testpass'
 	// CREATE ROLE
 	// demo --multitenant=false --insecure -e CREATE USER test WITH PASSWORD 'testpass'
-	// ERROR: setting or updating a password is not supported in insecure mode
+	// ERROR: setting or updating passwords was disabled by configuration
 	// SQLSTATE: 28P01
 	// demo --multitenant=false --geo-partitioned-replicas --disable-demo-license
 	// ERROR: enterprise features are needed for this demo (--geo-partitioned-replicas)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1226,7 +1226,7 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		serverHTTPAddr = "localhost"
 		// We then also tell the server to disable TLS for the HTTP
 		// listener.
-		serverCfg.DisableTLSForHTTP = true
+		serverCfg.SecurityOverrides.SetFlag(base.DisableHTTPTLS, true)
 	}
 	serverCfg.HTTPAddr = net.JoinHostPort(serverHTTPAddr, serverHTTPPort)
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -498,6 +498,7 @@ func init() {
 		//
 		// NB: Insecure is deprecated. See #53404.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
+		varFlag(f, &startCtx.serverSecurityOverrides, cliflags.ServerSecurityOverrides)
 
 		// Enable/disable various external storage endpoints.
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
@@ -964,6 +965,7 @@ func init() {
 		_ = extraServerFlagInit // guru assignment
 		// NB: Insecure is deprecated. See #53404.
 		boolFlag(f, &startCtx.serverInsecure, cliflags.ServerInsecure)
+		varFlag(f, &startCtx.serverSecurityOverrides, cliflags.ServerSecurityOverrides)
 
 		stringFlag(f, &startCtx.serverSSLCertsDir, cliflags.ServerCertsDir)
 		// NB: this also gets PreRun treatment via extraServerFlagInit to populate BaseCfg.SQLAddr.
@@ -1113,6 +1115,10 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	}
 	serverCfg.User = security.NodeUserName()
 	serverCfg.Insecure = startCtx.serverInsecure
+	serverCfg.SecurityOverrides = startCtx.serverSecurityOverrides
+	if serverCfg.Insecure {
+		_ = serverCfg.SecurityOverrides.Set("disable-all")
+	}
 	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
 
 	// Construct the main RPC listen address.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -473,7 +473,10 @@ func init() {
 		boolFlag(f, &startCtx.unencryptedLocalhostHTTP, cliflags.UnencryptedLocalhostHTTP)
 
 		// The following flag is planned to become non-experimental in 21.1.
-		boolFlag(f, &serverCfg.AcceptSQLWithoutTLS, cliflags.AcceptSQLWithoutTLS)
+		varFlag(f, secOverrideSetter{
+			dst:  &baseCfg.SecurityOverrides,
+			flag: base.DisableSQLRequireTLS}, cliflags.AcceptSQLWithoutTLS)
+		f.Lookup(cliflags.AcceptSQLWithoutTLS.Name).NoOptDefVal = "false"
 		_ = f.MarkHidden(cliflags.AcceptSQLWithoutTLS.Name)
 
 		// More server flags.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -511,7 +511,12 @@ func init() {
 
 		// Cluster name verification.
 		varFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
-		boolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
+		varFlag(f, secOverrideSetter{
+			dst:  &baseCfg.SecurityOverrides,
+			flag: base.DisableClusterNameVerification}, cliflags.DisableClusterNameVerification)
+		f.Lookup(cliflags.DisableClusterNameVerification.Name).NoOptDefVal = "false"
+		_ = f.MarkHidden(cliflags.DisableClusterNameVerification.Name)
+
 		if cmd == startSingleNodeCmd {
 			// Even though all server flags are supported for
 			// 'start-single-node', we intend that command to be used by
@@ -797,7 +802,13 @@ func init() {
 		varFlag(f, urlParser{cmd, &cliCtx, true /* strictSSL */}, cliflags.URL)
 
 		varFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
-		boolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
+		varFlag(f, secOverrideSetter{
+			dst:  &baseCfg.SecurityOverrides,
+			flag: base.DisableClusterNameVerification}, cliflags.DisableClusterNameVerification)
+		f.Lookup(cliflags.DisableClusterNameVerification.Name).NoOptDefVal = "false"
+		// TODO(knz): hide the client-side flag, once we have set up a way to set the
+		// overrides for client commands.
+		// _ = f.MarkHidden(cliflags.DisableClusterNameVerification)
 	}
 
 	// Commands that print tables.

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -406,4 +407,24 @@ func (b *bytesOrPercentageValue) String() string {
 // IsSet returns true iff Set has successfully been called.
 func (b *bytesOrPercentageValue) IsSet() bool {
 	return b.bval.IsSet()
+}
+
+type secOverrideSetter struct {
+	dst  *base.SecurityOverrides
+	flag base.SecurityOverrides
+}
+
+func (s secOverrideSetter) String() string {
+	return strconv.FormatBool(s.dst.IsSet(s.flag))
+}
+
+func (s secOverrideSetter) Type() string { return "bool" }
+
+func (s secOverrideSetter) Set(v string) error {
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return err
+	}
+	s.dst.SetFlag(s.flag, b)
+	return nil
 }

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -70,10 +70,12 @@ func NewNetwork(
 		Nodes:   []*Node{},
 		Stopper: stopper,
 	}
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	n.RPCContext = rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
-			Config:   &base.Config{Insecure: true},
+			Config:   cfg,
 			Clock:    hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 			Stopper:  n.Stopper,
 			Settings: cluster.MakeTestingClusterSettings(),

--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -7390,9 +7390,11 @@ func TestAllocatorFullDisks(t *testing.T) {
 
 	// Model a set of stores in a cluster doing rebalancing, with ranges being
 	// randomly added occasionally.
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	rpcContext := rpc.NewContext(ctx, rpc.ContextOptions{
 		TenantID: roachpb.SystemTenantID,
-		Config:   &base.Config{Insecure: true},
+		Config:   cfg,
 		Clock:    clock,
 		Stopper:  stopper,
 		Settings: st,
@@ -7838,9 +7840,11 @@ func exampleRebalancing(
 
 	// Model a set of stores in a cluster,
 	// adding / rebalancing ranges of random sizes.
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	rpcContext := rpc.NewContext(ctx, rpc.ContextOptions{
 		TenantID: roachpb.SystemTenantID,
-		Config:   &base.Config{Insecure: true},
+		Config:   cfg,
 		Clock:    clock,
 		Stopper:  stopper,
 		Settings: st,

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -42,10 +42,12 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	rpcC := rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
-			Config:   &base.Config{Insecure: true},
+			Config:   cfg,
 			Clock:    hlc.NewClock(hlc.UnixNano, 500*time.Millisecond),
 			Stopper:  stopper,
 			Settings: st,

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -103,10 +103,12 @@ func createTestStorePool(
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	st := cluster.MakeTestingClusterSettings()
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	rpcContext := rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
-			Config:   &base.Config{Insecure: true},
+			Config:   cfg,
 			Clock:    clock,
 			Stopper:  stopper,
 			Settings: st,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -156,10 +156,13 @@ func createTestStoreWithoutStart(
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 
+	baseCfg := &base.Config{Insecure: true}
+	_ = baseCfg.SecurityOverrides.Set("disable-all")
+
 	rpcContext := rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
-			Config:   &base.Config{Insecure: true},
+			Config:   baseCfg,
 			Clock:    cfg.Clock,
 			Stopper:  stopper,
 			Settings: cfg.Settings,

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1441,7 +1441,7 @@ func (rpcCtx *Context) runHeartbeat(
 				// new node in a cluster and mistakenly joins the wrong
 				// cluster gets a chance to see the error message on their
 				// management console.
-				if !rpcCtx.Config.DisableClusterNameVerification && !response.DisableClusterNameVerification {
+				if !rpcCtx.Config.SecurityOverrides.IsSet(base.DisableClusterNameVerification) && !response.DisableClusterNameVerification {
 					err = errors.Wrap(
 						checkClusterName(rpcCtx.Config.ClusterName, response.ClusterName),
 						"cluster name check failed on ping response")
@@ -1513,7 +1513,7 @@ func (rpcCtx *Context) NewHeartbeatService() *HeartbeatService {
 		clock:                                 rpcCtx.Clock,
 		remoteClockMonitor:                    rpcCtx.RemoteClocks,
 		clusterName:                           rpcCtx.ClusterName(),
-		disableClusterNameVerification:        rpcCtx.Config.DisableClusterNameVerification,
+		disableClusterNameVerification:        rpcCtx.Config.SecurityOverrides.IsSet(base.DisableClusterNameVerification),
 		clusterID:                             rpcCtx.ClusterID,
 		nodeID:                                rpcCtx.NodeID,
 		settings:                              rpcCtx.Settings,

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1498,7 +1499,7 @@ func TestClusterNameMismatch(t *testing.T) {
 
 			serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 			serverCtx.Config.ClusterName = c.serverName
-			serverCtx.Config.DisableClusterNameVerification = c.serverDisablePeerCheck
+			serverCtx.Config.SecurityOverrides.SetFlag(base.DisableClusterNameVerification, c.serverDisablePeerCheck)
 
 			s := newTestServer(t, serverCtx)
 			RegisterHeartbeatServer(s, &HeartbeatService{
@@ -1508,7 +1509,7 @@ func TestClusterNameMismatch(t *testing.T) {
 				nodeID:                         serverCtx.NodeID,
 				settings:                       serverCtx.Settings,
 				clusterName:                    serverCtx.Config.ClusterName,
-				disableClusterNameVerification: serverCtx.Config.DisableClusterNameVerification,
+				disableClusterNameVerification: serverCtx.Config.SecurityOverrides.IsSet(base.DisableClusterNameVerification),
 			})
 
 			ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
@@ -1519,7 +1520,7 @@ func TestClusterNameMismatch(t *testing.T) {
 
 			clientCtx := newTestContext(serverCtx.ClusterID.Get(), clock, stopper)
 			clientCtx.Config.ClusterName = c.clientName
-			clientCtx.Config.DisableClusterNameVerification = c.clientDisablePeerCheck
+			clientCtx.Config.SecurityOverrides.SetFlag(base.DisableClusterNameVerification, c.clientDisablePeerCheck)
 
 			var wg sync.WaitGroup
 			for i := 0; i < 10; i++ {

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -74,10 +74,12 @@ func NewInsecureTestingContextWithClusterID(
 func NewInsecureTestingContextWithKnobs(
 	ctx context.Context, clock *hlc.Clock, stopper *stop.Stopper, knobs ContextTestingKnobs,
 ) *Context {
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	return NewContext(ctx,
 		ContextOptions{
 			TenantID: roachpb.SystemTenantID,
-			Config:   &base.Config{Insecure: true},
+			Config:   cfg,
 			Clock:    clock,
 			Stopper:  stopper,
 			Settings: cluster.MakeTestingClusterSettings(),

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -443,6 +443,7 @@ func newTestServer(
 func newTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
 	cfg := testutils.NewNodeTestBaseContext()
 	cfg.Insecure = true
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	cfg.RPCHeartbeatInterval = 100 * time.Millisecond
 	ctx := context.Background()
 	rctx := rpc.NewContext(ctx, rpc.ContextOptions{

--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -210,7 +210,7 @@ func (ctx *SecurityContext) getUIClientTLSConfig() (*tls.Config, error) {
 // `Server.Start`. Move it.
 func (ctx *SecurityContext) GetUIServerTLSConfig() (*tls.Config, error) {
 	// Early out.
-	if ctx.config.Insecure || ctx.config.DisableTLSForHTTP {
+	if ctx.config.SecurityOverrides.IsSet(base.DisableHTTPTLS) {
 		return nil, nil
 	}
 

--- a/pkg/rpc/tls_test.go
+++ b/pkg/rpc/tls_test.go
@@ -54,6 +54,11 @@ func TestClientSSLSettings(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			cfg := &base.Config{Insecure: tc.insecure, User: tc.user}
+			// TODO(knz): check the consequences of disable-http-tls and
+			// disable-rpc-tls separately in the test below.
+			if tc.insecure {
+				_ = cfg.SecurityOverrides.Set("disable-all")
+			}
 			if tc.hasCerts {
 				testutils.FillCerts(cfg)
 			} else {
@@ -116,6 +121,11 @@ func TestServerSSLSettings(t *testing.T) {
 	for tcNum, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			cfg := &base.Config{Insecure: tc.insecure, User: security.NodeUserName()}
+			// TODO(knz): check the consequences of disable-http-tls and
+			// disable-rpc-tls separately in the test below.
+			if tc.insecure {
+				_ = cfg.SecurityOverrides.Set("disable-all")
+			}
 			if tc.hasCerts {
 				testutils.FillCerts(cfg)
 			}

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -294,7 +294,7 @@ func (s *authenticationServer) createSessionFor(
 		ID:     id,
 		Secret: secret,
 	}
-	return EncodeSessionCookie(cookieValue, !s.cfg.DisableTLSForHTTP)
+	return EncodeSessionCookie(cookieValue, !s.cfg.SecurityOverrides.IsSet(base.DisableHTTPTLS))
 }
 
 // UserLogout allows a user to terminate their currently active session.

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -111,7 +111,7 @@ func TestSSLEnforcement(t *testing.T) {
 	noCertsContext := insecureCtx{}
 	// Plain http.
 	plainHTTPCfg := testutils.NewTestBaseContext(security.TestUserName())
-	plainHTTPCfg.Insecure = true
+	plainHTTPCfg.SecurityOverrides.SetFlag(base.DisableHTTPTLS, true)
 	insecureContext := newRPCContext(plainHTTPCfg)
 
 	kvGet := &roachpb.GetRequest{}

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -82,7 +82,7 @@ func (s *httpServer) setupRoutes(
 
 	// Define the http.Handler for UI assets.
 	assetHandler := ui.Handler(ui.Config{
-		ExperimentalUseLogin: s.cfg.EnableWebSessionAuthentication,
+		ExperimentalUseLogin: s.cfg.RequireWebSession(),
 		LoginEnabled:         s.cfg.RequireWebSession(),
 		NodeID:               s.cfg.IDContainer,
 		OIDC:                 oidc,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -779,8 +779,10 @@ func (s *statusServer) Certificates(
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
-	if s.cfg.Insecure {
-		return nil, status.Errorf(codes.Unavailable, "server is in insecure mode, cannot examine certificates")
+	if s.cfg.SecurityOverrides.IsSet(base.DisableRemoteCertsRetrieval) {
+		// If some other part of TLS security was disabled, this flag will
+		// be set automatically.
+		return nil, status.Errorf(codes.Unavailable, "certificate retrieval disabled by configuration")
 	}
 
 	if !local {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -222,7 +222,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.HTTPAddr != "" {
 		cfg.HTTPAddr = params.HTTPAddr
 	}
-	cfg.DisableTLSForHTTP = params.DisableTLSForHTTP
+	cfg.SecurityOverrides.SetFlag(base.DisableHTTPTLS, params.DisableTLSForHTTP)
 	if params.DisableWebSessionAuthentication {
 		cfg.EnableWebSessionAuthentication = false
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -102,8 +102,6 @@ func makeTestBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 	baseCfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	baseCfg.User = security.NodeUserName()
-	// Enable web session authentication.
-	baseCfg.EnableWebSessionAuthentication = true
 	return baseCfg
 }
 
@@ -224,7 +222,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.SecurityOverrides.SetFlag(base.DisableHTTPTLS, params.DisableTLSForHTTP)
 	if params.DisableWebSessionAuthentication {
-		cfg.EnableWebSessionAuthentication = false
+		cfg.SecurityOverrides.SetFlag(base.DisableHTTPAuthn, true)
 	}
 	if params.EnableDemoLoginEndpoint {
 		cfg.EnableDemoLoginEndpoint = true

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -278,6 +278,12 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{}
 	}
 
+	if cfg.Insecure {
+		// We do this override at the end, after the other override
+		// flags above have been applied.
+		_ = cfg.SecurityOverrides.Set("disable-all")
+	}
+
 	return cfg
 }
 
@@ -683,6 +689,9 @@ func (ts *TestServer) StartTenant(
 	baseCfg := makeTestBaseConfig(st, stopper.Tracer())
 	baseCfg.TestingKnobs = params.TestingKnobs
 	baseCfg.Insecure = params.ForceInsecure
+	if baseCfg.Insecure {
+		_ = baseCfg.SecurityOverrides.Set("disable-all")
+	}
 	baseCfg.Locality = params.Locality
 	if params.SSLCertsDir != "" {
 		baseCfg.SSLCertsDir = params.SSLCertsDir

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -233,7 +234,7 @@ func retrievePasswordFromRoleOptions(
 	if err != nil {
 		return true, nil, err
 	}
-	if !isNull && params.extendedEvalCtx.ExecCfg.RPCContext.Config.Insecure {
+	if !isNull && params.extendedEvalCtx.ExecCfg.RPCContext.Config.SecurityOverrides.IsSet(base.DisableSQLSetCredentials) {
 		// We disallow setting a non-empty password in insecure mode
 		// because insecure means an observer may have MITM'ed the change
 		// and learned the password.
@@ -242,7 +243,7 @@ func retrievePasswordFromRoleOptions(
 		// since that forces cert auth when moving back to secure mode,
 		// and certs can't be MITM'ed over the insecure SQL connection.
 		return true, nil, pgerror.New(pgcode.InvalidPassword,
-			"setting or updating a password is not supported in insecure mode")
+			"setting or updating passwords was disabled by configuration")
 	}
 
 	if !isNull {

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/jackc/pgx/v4"
+	pgx "github.com/jackc/pgx/v4"
 )
 
 // createTestTable tries to create a new table named based on the passed in id.
@@ -359,7 +359,7 @@ func TestSetUserPasswordInsecure(t *testing.T) {
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer s.Stopper().Stop(context.Background())
 
-	errFail := "setting or updating a password is not supported in insecure mode"
+	errFail := "setting or updating passwords was disabled by configuration"
 
 	testCases := []struct {
 		sql       string

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -32,11 +32,13 @@ import (
 func newInsecureRPCContext(ctx context.Context, stopper *stop.Stopper) *rpc.Context {
 	nc := &base.NodeIDContainer{}
 	ctx = logtags.AddTag(ctx, "n", nc)
+	cfg := &base.Config{Insecure: true}
+	_ = cfg.SecurityOverrides.Set("disable-all")
 	return rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,
 			NodeID:   nc,
-			Config:   &base.Config{Insecure: true},
+			Config:   cfg,
 			Clock:    hlc.NewClock(hlc.UnixNano, time.Nanosecond),
 			Stopper:  stopper,
 			Settings: cluster.MakeTestingClusterSettings(),

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -46,10 +46,10 @@ const (
 )
 
 type authOptions struct {
-	// insecure indicates that all connections for existing users must
-	// be allowed to go through. A password, if presented, must be
-	// accepted.
-	insecure bool
+	// disableAuthn indicates that all connections for existing users must
+	// be allowed to go through. No password is requested; the connection
+	// proceeds always as if the 'trust' auth method was used.
+	disableAuthn bool
 	// connType is the actual type of client connection (e.g. local,
 	// hostssl, hostnossl).
 	connType hba.ConnType
@@ -69,12 +69,6 @@ type authOptions struct {
 
 	// The following fields are only used by tests.
 
-	// testingSkipAuth requires to skip authentication, not even
-	// allowing a password exchange.
-	// Note that this different from insecure auth: with no auth, no
-	// password is accepted (a protocol error is given if one is
-	// presented); with insecure auth; _any_ is accepted.
-	testingSkipAuth bool
 	// testingAuthHook, if provided, replaces the logic in
 	// handleAuthentication().
 	testingAuthHook func(ctx context.Context) error
@@ -89,9 +83,6 @@ type authOptions struct {
 func (c *conn) handleAuthentication(
 	ctx context.Context, ac AuthConn, authOpt authOptions, execCfg *sql.ExecutorConfig,
 ) (connClose func(), _ error) {
-	if authOpt.testingSkipAuth {
-		return nil, nil
-	}
 	if authOpt.testingAuthHook != nil {
 		return nil, authOpt.testingAuthHook(ctx)
 	}
@@ -240,9 +231,10 @@ func (c *conn) chooseDbRole(
 func (c *conn) findAuthenticationMethod(
 	authOpt authOptions,
 ) (tlsState tls.ConnectionState, hbaEntry *hba.Entry, methodFn AuthMethod, err error) {
-	if authOpt.insecure {
-		// Insecure connections always use "trust" no matter what, and the
-		// remaining of the configuration is ignored.
+	if authOpt.disableAuthn {
+		// When the security overrides contain "disable-sql-authn", we
+		// always use "trust" no matter what, and the remaining of the
+		// configuration is ignored.
 		methodFn = authTrust
 		hbaEntry = &insecureEntry
 		return

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -247,7 +247,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					}
 
 				case "accept_sql_without_tls":
-					testServer.Cfg.AcceptSQLWithoutTLS = true
+					testServer.Cfg.SecurityOverrides.SetFlag(base.DisableSQLRequireTLS, true)
 
 				case "set_hba":
 					_, err := conn.ExecContext(context.Background(),

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -126,8 +126,8 @@ func TestAuthenticationAndHBARules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderRace(t, "takes >1min under race")
 
-	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
-		hbaRunTest(t, insecure)
+	testutils.RunTrueAndFalse(t, "disable-sql-authn", func(t *testing.T, disableSQLAuthn bool) {
+		hbaRunTest(t, disableSQLAuthn)
 	})
 }
 
@@ -159,11 +159,8 @@ func makeSocketFile(t *testing.T) (socketDir, socketFile string, cleanupFn func(
 		func() { _ = os.RemoveAll(tempDir) }
 }
 
-func hbaRunTest(t *testing.T, insecure bool) {
-	httpScheme := "http://"
-	if !insecure {
-		httpScheme = "https://"
-	}
+func hbaRunTest(t *testing.T, disableSQLAuthn bool) {
+	const httpScheme = "https://"
 
 	datadriven.Walk(t, testutils.TestDataPath(t, "auth"), func(t *testing.T, path string) {
 		defer leaktest.AfterTest(t)()
@@ -198,9 +195,22 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		}
 		defer cleanup()
 
-		s, conn, _ := serverutils.StartServer(t,
-			base.TestServerArgs{Insecure: insecure, SocketFile: maybeSocketFile})
+		tcfg := base.TestServerArgs{SocketFile: maybeSocketFile}
+		s, conn, _ := serverutils.StartServer(t, tcfg)
 		defer s.Stopper().Stop(context.Background())
+
+		ts := s.(*server.TestServer)
+		if disableSQLAuthn {
+			// TODO(knz): We probably don't need the disableSQLAuthn bool
+			// any more, which is only necessary for the 'insecure' test
+			// file.
+			// Instead, we can create a new test DSL statement to
+			// change the override flags, and then change the checks
+			// in the 'insecure' test input to assert the effects of
+			// each override separately.
+			ts.Cfg.SecurityOverrides.SetFlag(base.DisableSQLAuthn, true)
+			ts.Cfg.SecurityOverrides.SetFlag(base.DisableSQLRequireTLS, true)
+		}
 
 		// Enable conn/auth logging.
 		// We can't use the cluster settings to do this, because
@@ -235,9 +245,9 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					for _, a := range td.CmdArgs {
 						switch a.Key {
 						case "secure":
-							allowed = allowed || !insecure
+							allowed = allowed || !disableSQLAuthn
 						case "insecure":
-							allowed = allowed || insecure
+							allowed = allowed || disableSQLAuthn
 						default:
 							t.Fatalf("unknown configuration: %s", a.Key)
 						}

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -115,7 +115,7 @@ func TestConn(t *testing.T) {
 			// sqlServer - nil means don't create a command processor and a write side of the conn
 			nil,
 			mon.BoundAccount{}, /* reserved */
-			authOptions{testingSkipAuth: true, connType: hba.ConnHostAny},
+			authOptions{disableAuthn: true, connType: hba.ConnHostAny},
 		)
 		return nil
 	})
@@ -1080,7 +1080,7 @@ func TestMaliciousInputs(t *testing.T) {
 				func() bool { return false }, /* draining */
 				nil,                          /* sqlServer */
 				mon.BoundAccount{},           /* reserved */
-				authOptions{testingSkipAuth: true, connType: hba.ConnHostAny},
+				authOptions{disableAuthn: true, connType: hba.ConnHostAny},
 			)
 			if err := <-errChan; err != nil {
 				t.Fatal(err)
@@ -1286,7 +1286,6 @@ func TestConnServerAbortsOnRepeatedErrors(t *testing.T) {
 	testingKnobError := fmt.Errorf("a random error")
 	s, db, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
-			Insecure: true,
 			Knobs: base.TestingKnobs{
 				PGWireTestingKnobs: &sql.PGWireTestingKnobs{
 					AfterReadMsgTestingKnob: func(ctx context.Context) error {

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -231,7 +231,7 @@ var insecureEntry = hba.Entry{
 	ConnType: hba.ConnHostAny,
 	User:     []hba.String{{Value: "all", Quoted: false}},
 	Address:  hba.AnyAddr{},
-	Method:   hba.String{Value: "--insecure"},
+	Method:   hba.String{Value: "--security-overrides=disable-sql-authn"},
 }
 
 var sessionRevivalEntry = hba.Entry{

--- a/pkg/sql/pgwire/pgtest_test.go
+++ b/pkg/sql/pgwire/pgtest_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package pgwire
+package pgwire_test
 
 import (
 	"context"
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgtest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -37,12 +38,12 @@ func TestPGTest(t *testing.T) {
 	if *flagAddr == "" {
 		newServer := func() (addr, user string, cleanup func()) {
 			ctx := context.Background()
-			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-				Insecure: true,
-			})
+			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 			cleanup = func() {
 				s.Stopper().Stop(ctx)
 			}
+			ts := s.(*server.TestServer)
+			ts.Cfg.SecurityOverrides.SetFlag(base.DisableSQLRequireTLS|base.DisableSQLAuthn, true)
 			addr = s.ServingSQLAddr()
 			user = security.RootUser
 			// None of the tests read that much data, so we hardcode the max message

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -83,7 +83,6 @@ func TestPGWireDrainClient(t *testing.T) {
 	// server fails to agree to set up TLS when receiving a new
 	// connection, no matter whether TLS is enabled.
 	ts := s.(*server.TestServer)
-	ts.Cfg.Insecure = true
 	ts.Cfg.SecurityOverrides.SetFlag(base.DisableSQLTLS|base.DisableSQLAuthn, true)
 	pgBaseURL := url.URL{
 		Scheme:   "postgres",

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1041,18 +1041,18 @@ func (s *Server) maybeUpgradeToSecureConn(
 	if version != versionSSL {
 		// The client did not require a SSL connection.
 
-		// Insecure mode: nothing to say, nothing to do.
-		// TODO(knz): Remove this condition - see
-		// https://github.com/cockroachdb/cockroach/issues/53404
-		if s.cfg.Insecure {
-			return
-		}
-
-		// Secure mode: disallow if TCP and the user did not opt into
-		// non-TLS SQL conns.
-		if !s.cfg.SecurityOverrides.IsSet(base.DisableSQLRequireTLS) && connType != hba.ConnLocal {
+		// By default we require TLS. This can be disabled via a security override.
+		// If TLS is required, and the client is using a TCP conn, then reject
+		// a non-TLS connection attempt.
+		requireTLS := !s.cfg.SecurityOverrides.IsSet(base.DisableSQLRequireTLS)
+		if requireTLS && connType != hba.ConnLocal {
 			clientErr = pgerror.New(pgcode.ProtocolViolation, ErrSSLRequired)
 		}
+		return
+	}
+
+	if s.cfg.SecurityOverrides.IsSet(base.DisableSQLTLS) {
+		clientErr = pgerror.New(pgcode.ProtocolViolation, "SSL/TLS disabled on server by configuration")
 		return
 	}
 

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1050,7 +1050,7 @@ func (s *Server) maybeUpgradeToSecureConn(
 
 		// Secure mode: disallow if TCP and the user did not opt into
 		// non-TLS SQL conns.
-		if !s.cfg.AcceptSQLWithoutTLS && connType != hba.ConnLocal {
+		if !s.cfg.SecurityOverrides.IsSet(base.DisableSQLRequireTLS) && connType != hba.ConnLocal {
 			clientErr = pgerror.New(pgcode.ProtocolViolation, ErrSSLRequired)
 		}
 		return

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -718,7 +718,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 		authOptions{
 			connType:        connType,
 			connDetails:     connDetails,
-			insecure:        s.cfg.Insecure,
+			disableAuthn:    s.cfg.SecurityOverrides.IsSet(base.DisableSQLAuthn),
 			ie:              s.execCfg.InternalExecutor,
 			auth:            hbaConf,
 			identMap:        identMap,

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -1,15 +1,6 @@
 config insecure
 ----
 
-subtest check_ssl_disabled_error
-
-# Check that an attempt to use SSL fails with "SSL not enabled".
-connect user=root sslmode=require
-----
-ERROR: pq: SSL is not enabled on the server
-
-subtest end
-
 subtest root_always_enabled
 
 # Regardless of the contents of hba.conf,


### PR DESCRIPTION
Fixes #74329.

tldr: This change breaks down the behavior of `--insecure` into a set of discrete security feature flags that can be applied separately. This makes it possible for a user to opt out from a certain protection without opting out from every protection.

An example of this is the new ability to disable the TLS protection on the HTTP interface while retaining authentication.

The new feature flags can be controlled via the command line flag `--security-overrides`, which takes a set of overrides delimited by commas.

This change also folds existing command-line flag under the new mechanism. For example:
- `--allow-sql-without-tls` (an experimental, previously hidden flag) is now `--security-overrides=disable-sql-require-tls`
- `--unencrypted-localhost-http` is now `--http-addr=localhost --security-overrides=disable-http-tls`

Here is a summary of the newly introduced feature flags:

| Flag                                | Description                                                                                                                         |
|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| `disable-tls`                       | Disable TLS on all interfaces.                                                                                                      |
| `disable-rpc-tls`                   | Disable TLS for RPC connections. Implies `disable-remote-certs-retrieval`. Currently implies `disable-rpc-authn`.                   |
| `disable-rpc-authn`                 | Disable authentication and authorization for RPC connections. Implies `disable-remote-certs-retrieval`.                             |
| `disable-sql-authn`                 | Disable authentication for SQL client connections. (As if the method `trust` was applied to all connections.)                       |
| `disable-sql-tls`                   | Disable TLS for SQL connections. Implies `disable-sql-require-tls`.                                                                 |
| `disable-sql-require-tls`           | Disable the requirement to use TLS for SQL clients. TLS is still allowed but becomes optional.  Replaces `--allow-sql-without-tls`. |
| `disable-sql-set-credentials`       | Disable the ability to set user passwords in SQL.                                                                                   |
| `disable-http-tls`                  | Disable TLS for HTTP clients. Implies `disable-remote-certs-retrieval`.    Replaces `--unencrypted-localhost-http`.                 |
| `disable-http-authn`                | Disable HTTP authentication. Users do not need to log in to perform HTTP queries.  Implies `disable-remote-certs-retrieval`.        |
| `disable-remote-certs-retrieval`    | Disable the retrieval of TLS certificates using HTTP and RPC requests.                                                              |
| `disable-cluster-name-verification` | Disable the RPC-level cluster name verification protocol.  Replaces `--disable-cluster-name-verification`.                          |
| `disable-all`                       | Implies all of the above.                                                                                                           |




See the individual commits for further details.

