### PR TITLE
kvserver/loqrecovery: write replica recovery events to rangelog

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -174,4 +174,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-46	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-48	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -181,6 +181,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-46</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-48</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -444,7 +444,8 @@ func runDebugExecuteRecoverPlan(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, r := range prepReport.SkippedReplicas {
-		_, _ = fmt.Fprintf(stderr, "Replica %s for range r%d is already updated.\n", r.Replica, r.RangeID)
+		_, _ = fmt.Fprintf(stderr, "Replica %s for range r%d is already updated.\n",
+			r.Replica, r.RangeID())
 	}
 
 	if len(prepReport.UpdatedReplicas) == 0 {
@@ -459,7 +460,7 @@ func runDebugExecuteRecoverPlan(cmd *cobra.Command, args []string) error {
 	for _, r := range prepReport.UpdatedReplicas {
 		message := fmt.Sprintf(
 			"Replica %s for range %d:%s will be updated to %s with peer replica(s) removed: %s",
-			r.OldReplica, r.RangeID, r.StartKey, r.Replica, r.RemovedReplicas)
+			r.OldReplica, r.RangeID(), r.StartKey(), r.Replica, r.RemovedReplicas)
 		if r.AbortedTransaction {
 			message += fmt.Sprintf(", and range update transaction %s aborted.",
 				r.AbortedTransactionID.Short())

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -244,6 +244,10 @@ const (
 	ScanWholeRows
 	// SCRAM authentication is available.
 	SCRAMAuthentication
+	// UnsafeLossOfQuorumRecoveryRangeLog adds a new value to RangeLogEventReason
+	// that correspond to range descriptor changes resulting from recovery
+	// procedures.
+	UnsafeLossOfQuorumRecoveryRangeLog
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -371,6 +375,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     SCRAMAuthentication,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 46},
+	},
+	{
+		Key:     UnsafeLossOfQuorumRecoveryRangeLog,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 48},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -32,11 +32,12 @@ func _() {
 	_ = x[EnableSpanConfigStore-21]
 	_ = x[ScanWholeRows-22]
 	_ = x[SCRAMAuthentication-23]
+	_ = x[UnsafeLossOfQuorumRecoveryRangeLog-24]
 }
 
-const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsAlterSystemProtectedTimestampAddColumnEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthentication"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsAlterSystemProtectedTimestampAddColumnEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLog"
 
-var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 463, 493, 521, 542, 555, 574}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 463, 493, 521, 542, 555, 574, 608}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/kvserver/kvserverpb/log.go
+++ b/pkg/kv/kvserver/kvserverpb/log.go
@@ -23,4 +23,5 @@ const (
 	ReasonRebalance            RangeLogEventReason = "rebalance"
 	ReasonAdminRequest         RangeLogEventReason = "admin request"
 	ReasonAbandonedLearner     RangeLogEventReason = "abandoned learner replica"
+	ReasonUnsafeRecovery       RangeLogEventReason = "unsafe loss of quorum recovery"
 )

--- a/pkg/kv/kvserver/kvserverpb/log.proto
+++ b/pkg/kv/kvserver/kvserverpb/log.proto
@@ -31,6 +31,10 @@ enum RangeLogEventType {
   add_non_voter = 4;
   // RemoveNonVoter is the event type recorded when a range removes an existing non-voting replica.
   remove_non_voter = 5;
+  // UnsafeQuorumRecovery is the event type recorded when all replicas are
+  // replaced by a new one that acts as the source of truth possibly losing
+  // latest updates.
+  unsafe_quorum_recovery = 6;
 }
 
 message RangeLogEvent {

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/stateloader",
         "//pkg/roachpb:with-mocks",
@@ -21,6 +22,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],
@@ -29,6 +31,7 @@ go_library(
 go_test(
     name = "loqrecovery_test",
     srcs = [
+        "record_test.go",
         "recovery_env_test.go",
         "recovery_test.go",
     ],

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -89,4 +89,6 @@ message ReplicaRecoveryRecord {
     (gogoproto.moretags) = 'yaml:"OldReplicaID"'];
   roachpb.ReplicaDescriptor new_replica = 6 [(gogoproto.nullable) = false,
     (gogoproto.moretags) = 'yaml:"NewReplica"'];
+  roachpb.RangeDescriptor range_descriptor = 7 [(gogoproto.nullable) = false,
+    (gogoproto.moretags) = 'yaml:"RangeDescriptor"'];
 }

--- a/pkg/kv/kvserver/loqrecovery/record_test.go
+++ b/pkg/kv/kvserver/loqrecovery/record_test.go
@@ -1,0 +1,101 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package loqrecovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPublishRangeLogEvents verifies that inserting recovery events into
+// RangeLog handles sql execution errors and unexpected results by propagating
+// errors up. This is important as caller relies on errors to preserve events if
+// they were not reflected in RangeLog.
+// It also performs basic sanity check that inserted records have correct range
+// id and reason for update and a timestamp.
+func TestPublishRangeLogEvents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	for _, td := range []struct {
+		name string
+
+		// Recovery event and function under test arguments.
+		rangeID roachpb.RangeID
+		time    int64
+
+		// Callback results returned to function under test.
+		returnedRowCount int
+		queryExecError   error
+
+		// Expectations in callback and call results.
+		expectSuccess bool
+	}{
+		{
+			name:             "success",
+			rangeID:          7,
+			time:             1021,
+			returnedRowCount: 1,
+			expectSuccess:    true,
+		},
+		{
+			name:             "sql error",
+			rangeID:          7,
+			time:             1021,
+			returnedRowCount: 1,
+			queryExecError:   errors.New("stray sql error occurred"),
+		},
+		{
+			name:             "wrong row count",
+			rangeID:          7,
+			time:             1021,
+			returnedRowCount: 0,
+			expectSuccess:    false,
+		},
+	} {
+		t.Run(td.name, func(t *testing.T) {
+			var actualArgs []interface{}
+			execFn := func(ctx context.Context, stmt string, args ...interface{}) (int, error) {
+				actualArgs = args
+				return td.returnedRowCount, td.queryExecError
+			}
+
+			event := loqrecoverypb.ReplicaRecoveryRecord{
+				Timestamp: td.time,
+				RangeID:   td.rangeID,
+				StartKey:  loqrecoverypb.RecoveryKey(roachpb.RKeyMin),
+				EndKey:    loqrecoverypb.RecoveryKey(roachpb.RKeyMax),
+			}
+
+			err := UpdateRangeLogWithRecovery(ctx, execFn, event)
+			if td.expectSuccess {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			require.Equal(t, 6, len(actualArgs), "not enough query args were provided")
+			require.Contains(t, actualArgs[5], "Performed unsafe range loss of quorum recovery")
+			require.Equal(t, td.rangeID, actualArgs[1], "RangeID query arg doesn't match event")
+			require.Equal(t, timeutil.Unix(0, td.time), actualArgs[0],
+				"timestamp query arg doesn't match event")
+			require.Equal(t, kvserverpb.RangeLogEventType_unsafe_quorum_recovery.String(), actualArgs[3],
+				"incorrect RangeLog event type")
+		})
+	}
+}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
@@ -41,6 +41,9 @@ function printLogEventType(
       return "Split";
     case protos.cockroach.kv.kvserver.storagepb.RangeLogEventType.merge:
       return "Merge";
+    case protos.cockroach.kv.kvserver.storagepb.RangeLogEventType
+      .unsafe_quorum_recovery:
+      return "Unsafe Quorum Recovery";
     default:
       return "Unknown";
   }


### PR DESCRIPTION
Previously a fact of loss of quorum replica recovery was only written
as a structured log entry. This information is local to the node and
does not survive if node is decommissioned. It would be beneficial
to preserve this information longer. Range log while being limited
to 30 days still provide a good reference data for investigations if
recovery wasn't performed too long ago.
This patch adds entries to rangelog for every updated range first time
node that holds survivor replica is started after recovery.

Release note: None

Addresses #73679