### PR TITLE
sql: don't construct empty SessionData.CustomOptions

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -696,11 +696,13 @@ func (s *Server) newSessionData(args SessionArgs) *sessiondata.SessionData {
 		LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
 			ResultsBufferSize: args.ConnResultsBufferSize,
 			IsSuperuser:       args.IsSuperuser,
-			CustomOptions:     make(map[string]string),
 		},
 	}
-	for k, v := range args.CustomOptionSessionDefaults {
-		sd.CustomOptions[k] = v
+	if len(args.CustomOptionSessionDefaults) > 0 {
+		sd.CustomOptions = make(map[string]string)
+		for k, v := range args.CustomOptionSessionDefaults {
+			sd.CustomOptions[k] = v
+		}
 	}
 	s.populateMinimalSessionData(sd)
 	return sd

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -281,7 +282,7 @@ func (a ArgTypes) Types() []*types.T {
 }
 
 func (a ArgTypes) String() string {
-	var s bytes.Buffer
+	var s strings.Builder
 	for i, arg := range a {
 		if i > 0 {
 			s.WriteString(", ")

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -53,7 +53,7 @@ type SessionData struct {
 // Clone returns a clone of SessionData.
 func (s *SessionData) Clone() *SessionData {
 	var newCustomOptions map[string]string
-	if s.CustomOptions != nil {
+	if len(s.CustomOptions) > 0 {
 		newCustomOptions = make(map[string]string, len(s.CustomOptions))
 		for k, v := range s.CustomOptions {
 			newCustomOptions[k] = v


### PR DESCRIPTION
This commit updates `newSessionData` to only construct a `CustomOptions`
map if the `CustomOptionSessionDefaults` are not empty. The map is meant
to be lazily allocated (see `sessionDataMutator.SetCustomOption`), so
this ensures that it doesn't get created when it doesn't need to be.

This change has two effects:
1. it avoids constructing a map in `newSessionData`
2. as a result, it also avoids the construction of an unnecessary map on
   each call to `SessionData.Clone`. The commit also adds additional
   protection in that method to avoid unnecessary map construction, but
   this is no longer strictly necessary with the change to `newSessionData`.

```
name                   old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10    95.3µs ± 6%    94.5µs ± 7%    ~     (p=0.579 n=10+10)

name                   old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10    20.1kB ± 0%    20.0kB ± 0%  -0.34%  (p=0.001 n=10+10)

name                   old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10       245 ± 0%       244 ± 0%  -0.41%  (p=0.000 n=9+9)
```
----

This is part of a collection of assorted micro-optimizations:
- #74336
- #74337
- #74338
- #74339
- #74340
- #74341
- #74342
- #74343
- #74344
- #74345
- #74346
- #74347
- #74348

Combined, these changes have the following effect on end-to-end SQL query performance:
```
name                      old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10       94.4µs ±10%    92.3µs ±11%   -2.20%  (p=0.000 n=93+93)
KV/Scan/SQL/rows=10-10       102µs ±10%      99µs ±10%   -2.16%  (p=0.000 n=94+94)
KV/Update/SQL/rows=10-10     378µs ±15%     370µs ±11%   -2.04%  (p=0.003 n=95+91)
KV/Insert/SQL/rows=1-10      133µs ±14%     132µs ±12%     ~     (p=0.738 n=95+93)
KV/Insert/SQL/rows=10-10     197µs ±14%     196µs ±13%     ~     (p=0.902 n=95+94)
KV/Update/SQL/rows=1-10      186µs ±14%     185µs ±14%     ~     (p=0.351 n=94+93)
KV/Delete/SQL/rows=1-10      132µs ±13%     132µs ±14%     ~     (p=0.473 n=94+94)
KV/Delete/SQL/rows=10-10     254µs ±16%     250µs ±16%     ~     (p=0.086 n=100+99)

name                      old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10       20.1kB ± 0%    19.1kB ± 1%   -4.91%  (p=0.000 n=96+96)
KV/Scan/SQL/rows=10-10      21.7kB ± 0%    20.7kB ± 1%   -4.61%  (p=0.000 n=96+97)
KV/Delete/SQL/rows=10-10    64.0kB ± 3%    63.7kB ± 3%   -0.55%  (p=0.000 n=100+100)
KV/Update/SQL/rows=1-10     45.8kB ± 1%    45.5kB ± 1%   -0.55%  (p=0.000 n=97+98)
KV/Update/SQL/rows=10-10     105kB ± 1%     105kB ± 1%   -0.10%  (p=0.008 n=97+98)
KV/Delete/SQL/rows=1-10     40.8kB ± 0%    40.7kB ± 0%   -0.08%  (p=0.001 n=95+96)
KV/Insert/SQL/rows=1-10     37.4kB ± 1%    37.4kB ± 0%     ~     (p=0.698 n=97+96)
KV/Insert/SQL/rows=10-10    76.4kB ± 1%    76.4kB ± 0%     ~     (p=0.822 n=99+98)

name                      old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10          245 ± 0%       217 ± 0%  -11.43%  (p=0.000 n=95+92)
KV/Scan/SQL/rows=10-10         280 ± 0%       252 ± 0%  -10.11%  (p=0.000 n=75+97)
KV/Delete/SQL/rows=10-10       478 ± 0%       459 ± 0%   -4.04%  (p=0.000 n=94+97)
KV/Delete/SQL/rows=1-10        297 ± 1%       287 ± 1%   -3.34%  (p=0.000 n=97+97)
KV/Update/SQL/rows=1-10        459 ± 0%       444 ± 0%   -3.27%  (p=0.000 n=97+97)
KV/Insert/SQL/rows=1-10        291 ± 0%       286 ± 0%   -1.72%  (p=0.000 n=82+86)
KV/Update/SQL/rows=10-10       763 ± 1%       750 ± 1%   -1.68%  (p=0.000 n=96+98)
KV/Insert/SQL/rows=10-10       489 ± 0%       484 ± 0%   -1.03%  (p=0.000 n=98+98)
```
