### PR TITLE
kv: return RangeIterator by value from constructor

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -250,7 +250,7 @@ func allRangeSpans(
 
 	ranges := make([]roachpb.Span, 0, len(spans))
 
-	it := kvcoord.NewRangeIterator(ds)
+	it := kvcoord.MakeRangeIterator(ds)
 
 	for i := range spans {
 		rSpan, err := keys.SpanAddr(spans[i])

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -555,7 +555,7 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 // CountRanges returns the number of ranges that encompass the given key span.
 func (ds *DistSender) CountRanges(ctx context.Context, rs roachpb.RSpan) (int64, error) {
 	var count int64
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	for ri.Seek(ctx, rs.Key, Ascending); ri.Valid(); ri.Next(ctx) {
 		count++
 		if !ri.NeedAnother(rs) {
@@ -1165,7 +1165,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		scanDir = Descending
 		seekKey = rs.EndKey
 	}
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	ri.Seek(ctx, seekKey, scanDir)
 	if !ri.Valid() {
 		return nil, roachpb.NewError(ri.Error())

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -208,7 +208,7 @@ func (ds *DistSender) divideAndSendRangeFeedToRanges(
 	// boundaries. So, as we go, keep track of the remaining uncovered part of
 	// `rs` in `nextRS`.
 	nextRS := rs
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	for ri.Seek(ctx, nextRS.Key, Ascending); ri.Valid(); ri.Next(ctx) {
 		desc := ri.Desc()
 		partialRS, err := nextRS.Intersect(desc)

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -35,9 +35,9 @@ type RangeIterator struct {
 	err   error
 }
 
-// NewRangeIterator creates a new RangeIterator.
-func NewRangeIterator(ds *DistSender) *RangeIterator {
-	return &RangeIterator{
+// MakeRangeIterator creates a new RangeIterator.
+func MakeRangeIterator(ds *DistSender) RangeIterator {
+	return RangeIterator{
 		ds: ds,
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -69,7 +69,7 @@ func TestRangeIterForward(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	})
 
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	i := 0
 	span := roachpb.RSpan{
 		Key:    testMetaEndKey,
@@ -105,7 +105,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	})
 
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	i := 0
 	for ri.Seek(ctx, testMetaEndKey, Ascending); ri.Valid(); {
 		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {
@@ -144,7 +144,7 @@ func TestRangeIterReverse(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	})
 
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	i := len(alphaRangeDescriptors) - 1
 	span := roachpb.RSpan{
 		Key:    testMetaEndKey,
@@ -180,7 +180,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 		Settings:          cluster.MakeTestingClusterSettings(),
 	})
 
-	ri := NewRangeIterator(ds)
+	ri := MakeRangeIterator(ds)
 	i := len(alphaRangeDescriptors) - 1
 	for ri.Seek(ctx, roachpb.RKey([]byte{'z'}), Descending); ri.Valid(); {
 		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -250,7 +250,8 @@ func (f rangeIteratorFactory) newRangeIterator() condensableSpanSetRangeIterator
 		return f.factory()
 	}
 	if f.ds != nil {
-		return NewRangeIterator(f.ds)
+		ri := MakeRangeIterator(f.ds)
+		return &ri
 	}
 	panic("no iterator factory configured")
 }

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -232,7 +232,7 @@ func (dbc *dbAdapter) divideAndSendScanRequests(
 
 	currentScanLimit := parallelismFn()
 	exportLim := limit.MakeConcurrentRequestLimiter("rangefeedScanLimiter", parallelismFn())
-	ri := kvcoord.NewRangeIterator(dbc.distSender)
+	ri := kvcoord.MakeRangeIterator(dbc.distSender)
 
 	for _, sp := range sg.Slice() {
 		nextRS, err := keys.SpanAddr(sp)

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -134,7 +134,7 @@ func clearSpanData(
 
 	var n int
 	lastKey := span.Key
-	ri := kvcoord.NewRangeIterator(distSender)
+	ri := kvcoord.MakeRangeIterator(distSender)
 	timer := timeutil.NewTimer()
 	defer timer.Stop()
 

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -150,7 +150,7 @@ type spanResolverIterator struct {
 	// txn is the transaction using the iterator.
 	txn *kv.Txn
 	// it is a wrapped RangeIterator.
-	it *kvcoord.RangeIterator
+	it kvcoord.RangeIterator
 	// oracle is used to choose a lease holders for ranges when one isn't present
 	// in the cache.
 	oracle replicaoracle.Oracle
@@ -170,7 +170,7 @@ var _ SpanResolverIterator = &spanResolverIterator{}
 func (sr *spanResolver) NewSpanResolverIterator(txn *kv.Txn) SpanResolverIterator {
 	return &spanResolverIterator{
 		txn:        txn,
-		it:         kvcoord.NewRangeIterator(sr.distSender),
+		it:         kvcoord.MakeRangeIterator(sr.distSender),
 		oracle:     sr.oracle,
 		queryState: replicaoracle.MakeQueryState(),
 	}


### PR DESCRIPTION
This commit changes `RangeIterator`'s constructor to return the struct
by value. The methods on `RangeIterator` continue to use a pointer
receiver, but this allows the struct to remain on the stack in some
cases and to be embedded in larger structs (e.g. `spanResolverIterator`)
in others. As a result, it avoids some heap allocations.

```
name                   old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10    92.5µs ± 4%    94.4µs ± 5%    ~     (p=0.211 n=9+10)

name                   old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10    20.1kB ± 0%    20.1kB ± 0%    ~     (p=0.782 n=10+10)

name                   old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10       245 ± 0%       244 ± 0%  -0.41%  (p=0.000 n=10+8)
```
----

This is part of a collection of assorted micro-optimizations:
- #74336
- #74337
- #74338
- #74339
- #74340
- #74341
- #74342
- #74343
- #74344
- #74345
- #74346
- #74347
- #74348

Combined, these changes have the following effect on end-to-end SQL query performance:
```
name                      old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10       94.4µs ±10%    92.3µs ±11%   -2.20%  (p=0.000 n=93+93)
KV/Scan/SQL/rows=10-10       102µs ±10%      99µs ±10%   -2.16%  (p=0.000 n=94+94)
KV/Update/SQL/rows=10-10     378µs ±15%     370µs ±11%   -2.04%  (p=0.003 n=95+91)
KV/Insert/SQL/rows=1-10      133µs ±14%     132µs ±12%     ~     (p=0.738 n=95+93)
KV/Insert/SQL/rows=10-10     197µs ±14%     196µs ±13%     ~     (p=0.902 n=95+94)
KV/Update/SQL/rows=1-10      186µs ±14%     185µs ±14%     ~     (p=0.351 n=94+93)
KV/Delete/SQL/rows=1-10      132µs ±13%     132µs ±14%     ~     (p=0.473 n=94+94)
KV/Delete/SQL/rows=10-10     254µs ±16%     250µs ±16%     ~     (p=0.086 n=100+99)

name                      old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10       20.1kB ± 0%    19.1kB ± 1%   -4.91%  (p=0.000 n=96+96)
KV/Scan/SQL/rows=10-10      21.7kB ± 0%    20.7kB ± 1%   -4.61%  (p=0.000 n=96+97)
KV/Delete/SQL/rows=10-10    64.0kB ± 3%    63.7kB ± 3%   -0.55%  (p=0.000 n=100+100)
KV/Update/SQL/rows=1-10     45.8kB ± 1%    45.5kB ± 1%   -0.55%  (p=0.000 n=97+98)
KV/Update/SQL/rows=10-10     105kB ± 1%     105kB ± 1%   -0.10%  (p=0.008 n=97+98)
KV/Delete/SQL/rows=1-10     40.8kB ± 0%    40.7kB ± 0%   -0.08%  (p=0.001 n=95+96)
KV/Insert/SQL/rows=1-10     37.4kB ± 1%    37.4kB ± 0%     ~     (p=0.698 n=97+96)
KV/Insert/SQL/rows=10-10    76.4kB ± 1%    76.4kB ± 0%     ~     (p=0.822 n=99+98)

name                      old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10          245 ± 0%       217 ± 0%  -11.43%  (p=0.000 n=95+92)
KV/Scan/SQL/rows=10-10         280 ± 0%       252 ± 0%  -10.11%  (p=0.000 n=75+97)
KV/Delete/SQL/rows=10-10       478 ± 0%       459 ± 0%   -4.04%  (p=0.000 n=94+97)
KV/Delete/SQL/rows=1-10        297 ± 1%       287 ± 1%   -3.34%  (p=0.000 n=97+97)
KV/Update/SQL/rows=1-10        459 ± 0%       444 ± 0%   -3.27%  (p=0.000 n=97+97)
KV/Insert/SQL/rows=1-10        291 ± 0%       286 ± 0%   -1.72%  (p=0.000 n=82+86)
KV/Update/SQL/rows=10-10       763 ± 1%       750 ± 1%   -1.68%  (p=0.000 n=96+98)
KV/Insert/SQL/rows=10-10       489 ± 0%       484 ± 0%   -1.03%  (p=0.000 n=98+98)
```
