### PR TITLE
opt: add Distribution physical property and Distribute enforcer

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -257,6 +257,7 @@ ALL_TESTS = [
     "//pkg/sql/opt/bench:bench_test",
     "//pkg/sql/opt/cat:cat_test",
     "//pkg/sql/opt/constraint:constraint_test",
+    "//pkg/sql/opt/distribution:distribution_test",
     "//pkg/sql/opt/exec/execbuilder:execbuilder_test",
     "//pkg/sql/opt/exec/explain:explain_test",
     "//pkg/sql/opt/idxconstraint:idxconstraint_test",

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -174,21 +174,36 @@ SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2
 query T
 EXPLAIN (OPT, MEMO) SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms') WHERE j = 2 AND i = 1
 ----
-memo (optimized, ~8KB, required=[presentation: info:6])
- ├── G1: (explain G2 [presentation: i:1,j:2,k:3])
- │    └── [presentation: info:6]
- │         ├── best: (explain G2="[presentation: i:1,j:2,k:3]" [presentation: i:1,j:2,k:3])
+memo (optimized, ~8KB, required=[presentation: info:6] [distribution: test])
+ ├── G1: (explain G2 [presentation: i:1,j:2,k:3] [distribution: test])
+ │    ├── [presentation: info:6] [distribution: test]
+ │    │    ├── best: (explain G2="[presentation: i:1,j:2,k:3] [distribution: test]" [presentation: i:1,j:2,k:3] [distribution: test])
+ │    │    └── cost: 5.18
+ │    └── []
+ │         ├── best: (explain G2="[presentation: i:1,j:2,k:3]" [presentation: i:1,j:2,k:3] [distribution: test])
  │         └── cost: 5.18
  ├── G2: (select G3 G4) (select G5 G6)
- │    └── [presentation: i:1,j:2,k:3]
+ │    ├── [presentation: i:1,j:2,k:3]
+ │    │    ├── best: (select G5 G6)
+ │    │    └── cost: 5.16
+ │    ├── [presentation: i:1,j:2,k:3] [distribution: test]
+ │    │    ├── best: (select G5="[distribution: test]" G6)
+ │    │    └── cost: 5.16
+ │    └── []
  │         ├── best: (select G5 G6)
  │         └── cost: 5.16
  ├── G3: (scan t,cols=(1-3)) (scan t@t_k_key,cols=(1-3))
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan t,cols=(1-3))
+ │    │    └── cost: 1145.22
  │    └── []
  │         ├── best: (scan t,cols=(1-3))
  │         └── cost: 1145.22
  ├── G4: (filters G7 G8)
  ├── G5: (scan t,cols=(1-3),constrained)
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan t,cols=(1-3),constrained)
+ │    │    └── cost: 5.13
  │    └── []
  │         ├── best: (scan t,cols=(1-3),constrained)
  │         └── cost: 5.13

--- a/pkg/sql/opt/distribution/BUILD.bazel
+++ b/pkg/sql/opt/distribution/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "distribution",
+    srcs = ["distribution.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/distribution",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/opt/memo",
+        "//pkg/sql/opt/props/physical",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/buildutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "distribution_test",
+    srcs = ["distribution_test.go"],
+    embed = [":distribution"],
+    deps = [
+        "//pkg/settings/cluster",
+        "//pkg/sql/opt/memo",
+        "//pkg/sql/opt/norm",
+        "//pkg/sql/opt/props",
+        "//pkg/sql/opt/props/physical",
+        "//pkg/sql/opt/testutils/testcat",
+        "//pkg/sql/opt/testutils/testexpr",
+        "//pkg/sql/sem/tree",
+    ],
+)

--- a/pkg/sql/opt/distribution/distribution.go
+++ b/pkg/sql/opt/distribution/distribution.go
@@ -1,0 +1,144 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package distribution
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/errors"
+)
+
+// CanProvide returns true if the given operator returns rows that can
+// satisfy the given required distribution.
+func CanProvide(
+	evalCtx *tree.EvalContext, expr memo.RelExpr, required *physical.Distribution,
+) bool {
+	if required.Any() {
+		return true
+	}
+	if buildutil.CrdbTestBuild {
+		checkRequired(required)
+	}
+
+	var provided physical.Distribution
+	switch t := expr.(type) {
+	case *memo.DistributeExpr:
+		return true
+
+	case *memo.LocalityOptimizedSearchExpr:
+		provided.FromLocality(evalCtx.Locality)
+
+	case *memo.ScanExpr:
+		md := expr.Memo().Metadata()
+		index := md.Table(t.Table).Index(t.Index)
+		provided.FromIndexScan(evalCtx, index, t.Constraint)
+
+	default:
+		// Other operators can pass through the distribution to their children.
+	}
+
+	return provided.Any() || provided.Equals(*required)
+}
+
+// BuildChildRequired returns the distribution that must be required of its
+// given child in order to satisfy a required distribution. Can only be called if
+// CanProvide is true for the required distribution.
+func BuildChildRequired(
+	parent memo.RelExpr, required *physical.Distribution, childIdx int,
+) physical.Distribution {
+	if required.Any() {
+		return physical.Distribution{}
+	}
+
+	switch parent.(type) {
+	case *memo.DistributeExpr:
+		return physical.Distribution{}
+
+	case *memo.LocalityOptimizedSearchExpr:
+		return physical.Distribution{}
+
+	case *memo.ScanExpr:
+		return physical.Distribution{}
+	}
+
+	if buildutil.CrdbTestBuild {
+		checkRequired(required)
+	}
+	return *required
+}
+
+// BuildProvided returns a specific distribution that the operator provides. The
+// returned distribution must match the required distribution.
+//
+// This function assumes that the provided distributions have already been set in
+// the children of the expression.
+func BuildProvided(
+	evalCtx *tree.EvalContext, expr memo.RelExpr, required *physical.Distribution,
+) physical.Distribution {
+	var provided physical.Distribution
+	switch t := expr.(type) {
+	case *memo.DistributeExpr:
+		return *required
+
+	case *memo.LocalityOptimizedSearchExpr:
+		provided.FromLocality(evalCtx.Locality)
+
+	case *memo.ScanExpr:
+		md := expr.Memo().Metadata()
+		index := md.Table(t.Table).Index(t.Index)
+		provided.FromIndexScan(evalCtx, index, t.Constraint)
+
+	default:
+		for i, n := 0, expr.ChildCount(); i < n; i++ {
+			if relExpr, ok := expr.Child(i).(memo.RelExpr); ok {
+				provided = provided.Union(relExpr.ProvidedPhysical().Distribution)
+			}
+		}
+	}
+
+	if buildutil.CrdbTestBuild {
+		checkProvided(&provided, required)
+	}
+
+	return provided
+}
+
+func checkRequired(required *physical.Distribution) {
+	// There should be exactly one region in the required distribution (for now,
+	// assuming this is coming from the gateway).
+	if len(required.Regions) != 1 {
+		panic(errors.AssertionFailedf(
+			"There should be at most one region in the required distribution: %s", required.String(),
+		))
+	}
+	check(required)
+}
+
+func checkProvided(provided, required *physical.Distribution) {
+	if !provided.Any() && !required.Any() && !provided.Equals(*required) {
+		panic(errors.AssertionFailedf("expression can't provide required distribution"))
+	}
+	check(provided)
+}
+
+func check(distribution *physical.Distribution) {
+	for i := range distribution.Regions {
+		if i > 0 {
+			if distribution.Regions[i] <= distribution.Regions[i-1] {
+				panic(errors.AssertionFailedf(
+					"Distribution regions are not sorted and deduplicated: %s", distribution.String(),
+				))
+			}
+		}
+	}
+}

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -1,0 +1,108 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package distribution
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestBuildProvided(t *testing.T) {
+	tc := testcat.New()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.NewTestingEvalContext(st)
+	var f norm.Factory
+	f.Init(evalCtx, tc)
+
+	testCases := []struct {
+		leftDist  []string
+		rightDist []string
+		expected  []string
+	}{
+		{
+			leftDist:  []string{},
+			rightDist: []string{},
+			expected:  []string{},
+		},
+		{
+			leftDist: []string{},
+			expected: []string{},
+		},
+		{
+			leftDist:  []string{},
+			rightDist: []string{"west"},
+			expected:  []string{"west"},
+		},
+		{
+			leftDist: []string{"east", "west"},
+			expected: []string{"east", "west"},
+		},
+		{
+			leftDist:  []string{"east"},
+			rightDist: []string{"east"},
+			expected:  []string{"east"},
+		},
+		{
+			leftDist:  []string{"west"},
+			rightDist: []string{"east"},
+			expected:  []string{"east", "west"},
+		},
+		{
+			leftDist:  []string{"central", "east", "west"},
+			rightDist: []string{"central", "west"},
+			expected:  []string{"central", "east", "west"},
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			expected := physical.Distribution{Regions: tc.expected}
+
+			leftInput := &testexpr.Instance{
+				Rel: &props.Relational{},
+				Provided: &physical.Provided{
+					Distribution: physical.Distribution{Regions: tc.leftDist},
+				},
+			}
+
+			// If there is only one input, build provided distribution for a Select.
+			// Otherwise, build the distribution for a join (we use anti join to avoid
+			// calling initJoinMultiplicity).
+			var expr memo.RelExpr
+			if tc.rightDist == nil {
+				expr = f.Memo().MemoizeSelect(leftInput, memo.FiltersExpr{})
+			} else {
+				rightInput := &testexpr.Instance{
+					Rel: &props.Relational{},
+					Provided: &physical.Provided{
+						Distribution: physical.Distribution{Regions: tc.rightDist},
+					},
+				}
+				expr = f.Memo().MemoizeAntiJoin(
+					leftInput, rightInput, memo.FiltersExpr{}, &memo.JoinPrivate{},
+				)
+			}
+
+			res := BuildProvided(evalCtx, expr, &physical.Distribution{})
+			if res.String() != expected.String() {
+				t.Errorf("expected '%s', got '%s'", expected, res)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -232,6 +232,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.SortExpr:
 		ep, err = b.buildSort(t)
 
+	case *memo.DistributeExpr:
+		ep, err = b.buildDistribute(t)
+
 	case *memo.IndexJoinExpr:
 		ep, err = b.buildIndexJoin(t)
 
@@ -1648,6 +1651,23 @@ func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 	return execPlan{root: node, outputCols: input.outputCols}, nil
+}
+
+func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (execPlan, error) {
+	input, err := b.buildRelational(distribute.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	distribution := distribute.ProvidedPhysical().Distribution
+	inputDistribution := distribute.Input.ProvidedPhysical().Distribution
+	if distribution.Equals(inputDistribution) {
+		return execPlan{}, errors.AssertionFailedf("distribution already provided by input")
+	}
+
+	// TODO(rytaft): This is currently a no-op. We should pass this distribution
+	// info to the DistSQL planner.
+	return input, err
 }
 
 func (b *Builder) buildOrdinality(ord *memo.OrdinalityExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -993,6 +993,7 @@ group-by (streaming)
  ├── cost: 25.1456179
  ├── key: (2)
  ├── fd: (2)-->(5)
+ ├── distribution: test
  ├── prune: (5)
  ├── scan data2
  │    ├── columns: a:1 b:2
@@ -1002,6 +1003,7 @@ group-by (streaming)
  │    ├── key: (2)
  │    ├── fd: ()-->(1)
  │    ├── ordering: +2 opt(1) [actual: +2]
+ │    ├── distribution: test
  │    ├── prune: (2)
  │    └── interesting orderings: (+2 opt(1))
  └── aggregations

--- a/pkg/sql/opt/exec/execbuilder/testdata/enums
+++ b/pkg/sql/opt/exec/execbuilder/testdata/enums
@@ -23,6 +23,7 @@ scan t
  ├── cost: 18.05
  ├── key: (1)
  ├── fd: (1)-->(2)
+ ├── distribution: test
  └── prune: (1,2)
 
 query T
@@ -123,11 +124,13 @@ distinct-on
  ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  ├── cost: 1114.88
  ├── key: (1)
+ ├── distribution: test
  └── scan checks@checks_x_y_idx
       ├── columns: x:1
       ├── stats: [rows=1000, distinct(1)=4, null(1)=0]
       ├── cost: 1104.82
       ├── ordering: +1
+      ├── distribution: test
       ├── prune: (1)
       └── interesting orderings: (+1)
 
@@ -172,24 +175,28 @@ union
  ├── stats: [rows=5, distinct(11)=5, null(11)=1]
  ├── cost: 2276.86667
  ├── key: (11)
+ ├── distribution: test
  ├── interesting orderings: (+11)
  ├── project
  │    ├── columns: nulls.x:1
  │    ├── stats: [rows=333.333333, distinct(1)=5, null(1)=3.33333333]
  │    ├── cost: 1138.40333
  │    ├── ordering: +1
+ │    ├── distribution: test
  │    ├── interesting orderings: (+1)
  │    └── select
  │         ├── columns: nulls.x:1 y:2
  │         ├── stats: [rows=333.333333, distinct(1)=5, null(1)=3.33333333, distinct(2)=33.3333333, null(2)=0]
  │         ├── cost: 1135.05
  │         ├── ordering: +1
+ │         ├── distribution: test
  │         ├── interesting orderings: (+1,+2)
  │         ├── scan nulls@nulls_x_y_idx
  │         │    ├── columns: nulls.x:1 y:2
  │         │    ├── stats: [rows=1000, distinct(1)=5, null(1)=10, distinct(2)=100, null(2)=10]
  │         │    ├── cost: 1125.02
  │         │    ├── ordering: +1
+ │         │    ├── distribution: test
  │         │    ├── prune: (1,2)
  │         │    └── interesting orderings: (+1,+2)
  │         └── filters
@@ -199,18 +206,21 @@ union
       ├── stats: [rows=333.333333, distinct(6)=5, null(6)=3.33333333]
       ├── cost: 1138.40333
       ├── ordering: +6
+      ├── distribution: test
       ├── interesting orderings: (+6)
       └── select
            ├── columns: nulls.x:6 y:7
            ├── stats: [rows=333.333333, distinct(6)=5, null(6)=3.33333333, distinct(7)=33.3333333, null(7)=0]
            ├── cost: 1135.05
            ├── ordering: +6
+           ├── distribution: test
            ├── interesting orderings: (+6,+7)
            ├── scan nulls@nulls_x_y_idx
            │    ├── columns: nulls.x:6 y:7
            │    ├── stats: [rows=1000, distinct(6)=5, null(6)=10, distinct(7)=100, null(7)=10]
            │    ├── cost: 1125.02
            │    ├── ordering: +6
+           │    ├── distribution: test
            │    ├── prune: (6,7)
            │    └── interesting orderings: (+6,+7)
            └── filters

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1277,6 +1277,7 @@ values
  ├── cost: 0.02
  ├── key: ()
  ├── fd: ()-->(1)
+ ├── distribution: test
  ├── prune: (1)
  └── (1,)
 
@@ -1290,6 +1291,7 @@ values
  ├── cost: 0.02
  ├── key: ()
  ├── fd: ()-->(1)
+ ├── distribution: test
  ├── prune: (1)
  └── tuple [type=tuple{int}]
       └── const: 1 [type=int]
@@ -1396,11 +1398,13 @@ inner-join (hash)
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(6)=99, null(6)=0]
  ├── cost: 2269.90625
  ├── fd: (6)-->(7), (1)==(6), (6)==(1)
+ ├── distribution: test
  ├── prune: (2,7)
  ├── scan tc
  │    ├── columns: a:1 b:2
  │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
  │    ├── cost: 1125.02
+ │    ├── distribution: test
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
  │    └── unfiltered-cols: (1-5)
@@ -1410,6 +1414,7 @@ inner-join (hash)
  │    ├── cost: 1104.82
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
+ │    ├── distribution: test
  │    ├── prune: (6,7)
  │    ├── interesting orderings: (+6)
  │    └── unfiltered-cols: (6-9)
@@ -1805,24 +1810,45 @@ regions: <hidden>
 query T
 EXPLAIN (OPT, MEMO) SELECT * FROM tc JOIN t ON k=a
 ----
-memo (optimized, ~11KB, required=[presentation: info:10])
- ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7])
- │    └── [presentation: info:10]
- │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7])
+memo (optimized, ~11KB, required=[presentation: info:10] [distribution: test])
+ ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7] [distribution: test])
+ │    ├── [presentation: info:10] [distribution: test]
+ │    │    ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7] [distribution: test]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])
+ │    │    └── cost: 2269.93
+ │    └── []
+ │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])
  │         └── cost: 2269.93
  ├── G2: (inner-join G3 G4 G5) (inner-join G4 G3 G5) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G4 G3 G6 inner-join,+6,+1) (lookup-join G7 G6 tc,keyCols=[3],outCols=(1,2,6,7))
- │    └── [presentation: a:1,b:2,k:6,v:7]
+ │    ├── [presentation: a:1,b:2,k:6,v:7]
+ │    │    ├── best: (inner-join G3 G4 G5)
+ │    │    └── cost: 2269.91
+ │    ├── [presentation: a:1,b:2,k:6,v:7] [distribution: test]
+ │    │    ├── best: (inner-join G3="[distribution: test]" G4="[distribution: test]" G5)
+ │    │    └── cost: 2269.91
+ │    └── []
  │         ├── best: (inner-join G3 G4 G5)
  │         └── cost: 2269.91
  ├── G3: (scan tc,cols=(1,2))
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan tc,cols=(1,2))
+ │    │    └── cost: 1125.02
  │    ├── [ordering: +1]
  │    │    ├── best: (sort G3)
  │    │    └── cost: 1364.50
+ │    ├── [ordering: +1] [distribution: test]
+ │    │    ├── best: (distribute G3="[ordering: +1]")
+ │    │    └── cost: 1364.53
  │    └── []
  │         ├── best: (scan tc,cols=(1,2))
  │         └── cost: 1125.02
  ├── G4: (scan t,cols=(6,7))
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1104.82
  │    ├── [ordering: +6]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1104.82
+ │    ├── [ordering: +6] [distribution: test]
  │    │    ├── best: (scan t,cols=(6,7))
  │    │    └── cost: 1104.82
  │    └── []
@@ -1831,6 +1857,9 @@ memo (optimized, ~11KB, required=[presentation: info:10])
  ├── G5: (filters G8)
  ├── G6: (filters)
  ├── G7: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    ├── [distribution: test]
+ │    │    ├── best: (lookup-join G4="[distribution: test]" G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    │    └── cost: 23173.94
  │    └── []
  │         ├── best: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
  │         └── cost: 23173.94
@@ -1864,24 +1893,45 @@ TABLE t
  ├── tableoid oid [hidden] [system]
  └── PRIMARY INDEX t_pkey
       └── k int not null
-memo (optimized, ~11KB, required=[presentation: info:10])
- ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7])
- │    └── [presentation: info:10]
- │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7])
+memo (optimized, ~11KB, required=[presentation: info:10] [distribution: test])
+ ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7] [distribution: test])
+ │    ├── [presentation: info:10] [distribution: test]
+ │    │    ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7] [distribution: test]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])
+ │    │    └── cost: 2269.93
+ │    └── []
+ │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])
  │         └── cost: 2269.93
  ├── G2: (inner-join G3 G4 G5) (inner-join G4 G3 G5) (merge-join G3 G4 G6 inner-join,+1,+6) (lookup-join G3 G6 t,keyCols=[1],outCols=(1,2,6,7)) (merge-join G4 G3 G6 inner-join,+6,+1) (lookup-join G7 G6 tc,keyCols=[3],outCols=(1,2,6,7))
- │    └── [presentation: a:1,b:2,k:6,v:7]
+ │    ├── [presentation: a:1,b:2,k:6,v:7]
+ │    │    ├── best: (inner-join G3 G4 G5)
+ │    │    └── cost: 2269.91
+ │    ├── [presentation: a:1,b:2,k:6,v:7] [distribution: test]
+ │    │    ├── best: (inner-join G3="[distribution: test]" G4="[distribution: test]" G5)
+ │    │    └── cost: 2269.91
+ │    └── []
  │         ├── best: (inner-join G3 G4 G5)
  │         └── cost: 2269.91
  ├── G3: (scan tc,cols=(1,2))
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan tc,cols=(1,2))
+ │    │    └── cost: 1125.02
  │    ├── [ordering: +1]
  │    │    ├── best: (sort G3)
  │    │    └── cost: 1364.50
+ │    ├── [ordering: +1] [distribution: test]
+ │    │    ├── best: (distribute G3="[ordering: +1]")
+ │    │    └── cost: 1364.53
  │    └── []
  │         ├── best: (scan tc,cols=(1,2))
  │         └── cost: 1125.02
  ├── G4: (scan t,cols=(6,7))
+ │    ├── [distribution: test]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1104.82
  │    ├── [ordering: +6]
+ │    │    ├── best: (scan t,cols=(6,7))
+ │    │    └── cost: 1104.82
+ │    ├── [ordering: +6] [distribution: test]
  │    │    ├── best: (scan t,cols=(6,7))
  │    │    └── cost: 1104.82
  │    └── []
@@ -1890,6 +1940,9 @@ memo (optimized, ~11KB, required=[presentation: info:10])
  ├── G5: (filters G8)
  ├── G6: (filters)
  ├── G7: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    ├── [distribution: test]
+ │    │    ├── best: (lookup-join G4="[distribution: test]" G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
+ │    │    └── cost: 23173.94
  │    └── []
  │         ├── best: (lookup-join G4 G6 tc@c,keyCols=[6],outCols=(1,3,6,7))
  │         └── cost: 23173.94
@@ -1902,11 +1955,13 @@ inner-join (hash)
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(6)=99, null(6)=0]
  ├── cost: 2269.90625
  ├── fd: (6)-->(7), (1)==(6), (6)==(1)
+ ├── distribution: test
  ├── prune: (2,7)
  ├── scan tc
  │    ├── columns: a:1 b:2
  │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
  │    ├── cost: 1125.02
+ │    ├── distribution: test
  │    ├── prune: (1,2)
  │    ├── interesting orderings: (+1)
  │    └── unfiltered-cols: (1-5)
@@ -1916,6 +1971,7 @@ inner-join (hash)
  │    ├── cost: 1104.82
  │    ├── key: (6)
  │    ├── fd: (6)-->(7)
+ │    ├── distribution: test
  │    ├── prune: (6,7)
  │    ├── interesting orderings: (+6)
  │    └── unfiltered-cols: (6-9)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1471,6 +1471,7 @@ inner-join (lookup geo_table)
  ├── cost: 112704.87
  ├── key: (1,5)
  ├── fd: (1)-->(2), (5)-->(6)
+ ├── distribution: test
  ├── prune: (1,5)
  ├── inner-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11
@@ -1480,12 +1481,14 @@ inner-join (lookup geo_table)
  │    ├── cost: 41804.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2)
+ │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
  │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
  │    │    ├── cost: 1104.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
+ │    │    ├── distribution: test
  │    │    ├── prune: (1,2)
  │    │    └── unfiltered-cols: (1-4)
  │    └── filters (true)
@@ -1561,6 +1564,7 @@ left-join (lookup geo_table)
  ├── cost: 112904.87
  ├── key: (1,5)
  ├── fd: (1)-->(2), (5)-->(6)
+ ├── distribution: test
  ├── prune: (1,5)
  ├── left-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
@@ -1571,12 +1575,14 @@ left-join (lookup geo_table)
  │    ├── cost: 42004.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
+ │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
  │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    │    ├── cost: 1104.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
+ │    │    ├── distribution: test
  │    │    ├── prune: (1,2)
  │    │    └── unfiltered-cols: (1-4)
  │    └── filters (true)
@@ -1597,6 +1603,7 @@ semi-join (lookup geo_table)
  ├── cost: 112704.87
  ├── key: (1)
  ├── fd: (1)-->(2)
+ ├── distribution: test
  ├── prune: (1)
  ├── inner-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
@@ -1607,12 +1614,14 @@ semi-join (lookup geo_table)
  │    ├── cost: 42004.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
+ │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
  │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
  │    │    ├── cost: 1104.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
+ │    │    ├── distribution: test
  │    │    ├── prune: (1,2)
  │    │    ├── interesting orderings: (+1)
  │    │    └── unfiltered-cols: (1-4)
@@ -1634,6 +1643,7 @@ anti-join (lookup geo_table)
  ├── cost: 112704.87
  ├── key: (1)
  ├── fd: (1)-->(2)
+ ├── distribution: test
  ├── prune: (1)
  ├── left-join (inverted geo_table@geom_index)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
@@ -1644,12 +1654,14 @@ anti-join (lookup geo_table)
  │    ├── cost: 42004.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
+ │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
  │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    │    ├── cost: 1104.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
+ │    │    ├── distribution: test
  │    │    ├── prune: (1,2)
  │    │    └── unfiltered-cols: (1-4)
  │    └── filters (true)

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -221,11 +221,13 @@ distinct-on
  ├── stats: [rows=20.0617284, distinct(1,2)=20.0617284, null(1,2)=0]
  ├── cost: 51.917284
  ├── key: (1,2)
+ ├── distribution: test
  └── scan uv@uv_u_idx
       ├── columns: u:1 v:2
       ├── constraint: /1/3: (/NULL - /29]
       ├── stats: [rows=33.3333333, distinct(1)=6.66666667, null(1)=0, distinct(1,2)=20.0617284, null(1,2)=0]
       ├── cost: 50.6866667
+      ├── distribution: test
       ├── prune: (2)
       └── interesting orderings: (+1) (+2)
 
@@ -241,11 +243,13 @@ distinct-on
  ├── stats: [rows=33.3333333, distinct(1,2)=33.3333333, null(1,2)=0]
  ├── cost: 52.05
  ├── key: (1,2)
+ ├── distribution: test
  └── scan uv@uv_u_idx
       ├── columns: u:1 v:2
       ├── constraint: /1/3: (/NULL - /29]
       ├── stats: [rows=33.3333333, distinct(1)=6.66666667, null(1)=0, distinct(1,2)=33.3333333, null(1,2)=0]
       ├── cost: 50.6866667
+      ├── distribution: test
       ├── prune: (2)
       └── interesting orderings: (+1) (+2)
 
@@ -261,6 +265,7 @@ distinct-on
  ├── stats: [rows=100, distinct(1,2)=100, null(1,2)=0]
  ├── cost: 128.050563
  ├── key: (1,2)
+ ├── distribution: test
  └── scan uv@uv_u_idx
       ├── columns: u:1 v:2
       ├── constraint: /1/3: (/NULL - /29]
@@ -268,6 +273,7 @@ distinct-on
       │   histogram(1)=  0 50  0 20  8  5   12  5
       │                <--- 1 --- 2 --- 10 ---- 20
       ├── cost: 124.02
+      ├── distribution: test
       ├── prune: (2)
       └── interesting orderings: (+1) (+2)
 
@@ -283,6 +289,7 @@ distinct-on
  ├── stats: [rows=25, distinct(1,2)=25, null(1,2)=0]
  ├── cost: 127.3
  ├── key: (1,2)
+ ├── distribution: test
  └── scan uv@uv_u_idx
       ├── columns: u:1 v:2
       ├── constraint: /1/3: (/NULL - /29]
@@ -290,6 +297,7 @@ distinct-on
       │   histogram(1)=  0 50  0 20  8  5   12  5
       │                <--- 1 --- 2 --- 10 ---- 20
       ├── cost: 124.02
+      ├── distribution: test
       ├── prune: (2)
       └── interesting orderings: (+1) (+2)
 
@@ -312,6 +320,7 @@ limit
  ├── cost: 121.069999
  ├── key: ()
  ├── fd: ()-->(1)
+ ├── distribution: test
  ├── select
  │    ├── columns: j:1
  │    ├── immutable
@@ -319,11 +328,13 @@ limit
  │    ├── cost: 121.049999
  │    ├── fd: ()-->(1)
  │    ├── limit hint: 1.00
+ │    ├── distribution: test
  │    ├── scan tj
  │    │    ├── columns: j:1
  │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
  │    │    ├── cost: 120.019999
  │    │    ├── limit hint: 100.00
+ │    │    ├── distribution: test
  │    │    └── prune: (1)
  │    └── filters
  │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
@@ -343,6 +354,7 @@ limit
  ├── cost: 19.42
  ├── key: ()
  ├── fd: ()-->(1)
+ ├── distribution: test
  ├── select
  │    ├── columns: j:1
  │    ├── immutable
@@ -350,11 +362,13 @@ limit
  │    ├── cost: 19.4
  │    ├── fd: ()-->(1)
  │    ├── limit hint: 1.00
+ │    ├── distribution: test
  │    ├── scan tj
  │    │    ├── columns: j:1
  │    │    ├── stats: [rows=5, distinct(1)=4, null(1)=1]
  │    │    ├── cost: 19.32
  │    │    ├── limit hint: 5.00
+ │    │    ├── distribution: test
  │    │    └── prune: (1)
  │    └── filters
  │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -817,6 +817,15 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if required.LimitHint != 0 {
 			tp.Childf("limit hint: %.2f", required.LimitHint)
 		}
+
+		// Show the required distribution, if any, and also show the provided input
+		// distribution if this is a Distribute expression.
+		if !required.Distribution.Any() {
+			tp.Childf("distribution: %s", required.Distribution.String())
+		}
+		if distribute, ok := e.(*DistributeExpr); ok {
+			tp.Childf("input distribution: %s", distribute.Input.ProvidedPhysical().Distribution.String())
+		}
 	}
 
 	if !f.HasFlags(ExprFmtHideRuleProps) {

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -52,11 +52,7 @@ type bestProps struct {
 	required *physical.Required
 
 	// Provided properties, which must be compatible with the required properties.
-	//
-	// We store these properties in-place because the structure is very small; if
-	// that changes we will want to intern them, similar to the required
-	// properties.
-	provided physical.Provided
+	provided *physical.Provided
 
 	// Cost of the best expression.
 	cost Cost

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -630,6 +630,9 @@ func (h *hasher) HashPhysProps(val *physical.Required) {
 	}
 	h.HashOrderingChoice(val.Ordering)
 	h.HashFloat64(val.LimitHint)
+	for _, region := range val.Distribution.Regions {
+		h.HashString(region)
+	}
 }
 
 func (h *hasher) HashLockingItem(val *tree.LockingItem) {

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -588,6 +588,23 @@ func TestInternerPhysProps(t *testing.T) {
 		Presentation: physical.Presentation{{Alias: "d", ID: 2}, {Alias: "e", ID: 3}},
 		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5,6)"),
 	}
+	physProps7 := physical.Required{
+		Presentation: physical.Presentation{{Alias: "c", ID: 1}},
+		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+		LimitHint:    1,
+	}
+	physProps8 := physical.Required{
+		Presentation: physical.Presentation{{Alias: "c", ID: 1}},
+		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+		LimitHint:    1,
+		Distribution: physical.Distribution{Regions: []string{"us-east", "us-west"}},
+	}
+	physProps9 := physical.Required{
+		Presentation: physical.Presentation{{Alias: "c", ID: 1}},
+		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+		LimitHint:    1,
+		Distribution: physical.Distribution{Regions: []string{"us-east", "us-west"}},
+	}
 
 	testCases := []struct {
 		phys    *physical.Required
@@ -600,6 +617,9 @@ func TestInternerPhysProps(t *testing.T) {
 		{phys: &physProps4, inCache: false},
 		{phys: &physProps5, inCache: false},
 		{phys: &physProps6, inCache: false},
+		{phys: &physProps7, inCache: false},
+		{phys: &physProps8, inCache: false},
+		{phys: &physProps9, inCache: true},
 	}
 
 	inCache := make(map[*physical.Required]bool)

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -364,7 +364,7 @@ func (m *Memo) SetBestProps(
 	}
 	bp := e.bestProps()
 	bp.required = required
-	bp.provided = *provided
+	bp.provided = provided
 	bp.cost = cost
 }
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -357,7 +357,7 @@ memo (optimized, ~4KB, required=[presentation: array_agg:5])
 memo
 SELECT DISTINCT info FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized, ~9KB, required=[presentation: info:3])
+memo (optimized, ~8KB, required=[presentation: info:3])
  ├── G1: (distinct-on G2 G3 cols=(3))
  │    └── [presentation: info:3]
  │         ├── best: (distinct-on G2 G3 cols=(3))

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -1075,6 +1075,7 @@ values
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
+ ├── distribution: east
  └── ('east1-b',)
 
 norm expect=FoldFunction

--- a/pkg/sql/opt/ops/enforcer.opt
+++ b/pkg/sql/opt/ops/enforcer.opt
@@ -25,3 +25,15 @@ define Sort {
     # specified prefix of columns.
     InputOrdering OrderingChoice
 }
+
+# Distribute enforces the physical distribution of rows returned by its input
+# expression. Currently, it is only used to re-distribute data across different
+# sets of regions in a multi-region cluster. For example, if rows are spread
+# across multiple regions, a Distribute enforcer can be used to route the rows
+# to the gateway region. See the Distribution field in the PhysicalProps struct.
+# TODO(rytaft): We should probably include the input distribution here so we can
+# accurately cost the Distribute operator. This will likely require calculating
+# "interesting distributions", similar to "interesting orderings".
+[Enforcer, Telemetry]
+define Distribute {
+}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -344,12 +344,15 @@ func (s *scope) makeOrderingChoice() props.OrderingChoice {
 }
 
 // makePhysicalProps constructs physical properties using the columns in the
-// scope for presentation and s.ordering for required ordering.
+// scope for presentation and s.ordering for required ordering. The distribution
+// is determined based on the locality of the gateway node, since data must
+// always be returned to the gateway.
 func (s *scope) makePhysicalProps() *physical.Required {
 	p := &physical.Required{
 		Presentation: s.makePresentation(),
 	}
 	p.Ordering.FromOrdering(s.ordering)
+	p.Distribution.FromLocality(s.builder.evalCtx.Locality)
 	return p
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -371,7 +371,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 
 		// Generate the ProvidedPhysical method.
 		fmt.Fprintf(g.w, "func (e *%s) ProvidedPhysical() *physical.Provided {\n", opTyp.name)
-		fmt.Fprintf(g.w, "  return &e.grp.bestProps().provided\n")
+		fmt.Fprintf(g.w, "  return e.grp.bestProps().provided\n")
 		fmt.Fprintf(g.w, "}\n\n")
 
 		// Generate the Cost method.
@@ -479,7 +479,7 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 
 	// Generate the ProvidedPhysical method.
 	fmt.Fprintf(g.w, "func (e *%s) ProvidedPhysical() *physical.Provided {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  return &e.best.provided\n")
+	fmt.Fprintf(g.w, "  return e.best.provided\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the Cost method.

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -138,7 +138,7 @@ func (e *ProjectExpr) RequiredPhysical() *physical.Required {
 }
 
 func (e *ProjectExpr) ProvidedPhysical() *physical.Provided {
-	return &e.grp.bestProps().provided
+	return e.grp.bestProps().provided
 }
 
 func (e *ProjectExpr) Cost() Cost {
@@ -352,7 +352,7 @@ func (e *SortExpr) RequiredPhysical() *physical.Required {
 }
 
 func (e *SortExpr) ProvidedPhysical() *physical.Provided {
-	return &e.best.provided
+	return e.best.provided
 }
 
 func (e *SortExpr) Cost() Cost {

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -356,7 +356,7 @@ func convertSlice(
 func (eg *exprGen) populateBestProps(expr opt.Expr, required *physical.Required) memo.Cost {
 	rel, _ := expr.(memo.RelExpr)
 	if rel != nil {
-		if !xform.CanProvidePhysicalProps(rel, required) {
+		if !xform.CanProvidePhysicalProps(eg.f.EvalContext(), rel, required) {
 			panic(errorf("operator %s cannot provide required props %s", rel.Op(), required))
 		}
 	}

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ordering",
     srcs = [
+        "distribute.go",
         "doc.go",
         "group_by.go",
         "interesting_orderings.go",

--- a/pkg/sql/opt/ordering/distribute.go
+++ b/pkg/sql/opt/ordering/distribute.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+)
+
+func distributeCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+	// Distribute operator can always pass through ordering to its input.
+	return true
+}
+
+func distributeBuildChildReqOrdering(
+	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+) props.OrderingChoice {
+	// We can pass through any required ordering to the input.
+	return *required
+}
+
+func distributeBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+	d := expr.(*memo.DistributeExpr)
+	return d.Input.ProvidedPhysical().Ordering
+}

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -216,6 +216,11 @@ func init() {
 		buildChildReqOrdering: sortBuildChildReqOrdering,
 		buildProvidedOrdering: sortBuildProvided,
 	}
+	funcMap[opt.DistributeOp] = funcs{
+		canProvideOrdering:    distributeCanProvideOrdering,
+		buildChildReqOrdering: distributeBuildChildReqOrdering,
+		buildProvidedOrdering: distributeBuildProvided,
+	}
 	funcMap[opt.InsertOp] = funcs{
 		canProvideOrdering:    mutationCanProvideOrdering,
 		buildChildReqOrdering: mutationBuildChildReqOrdering,

--- a/pkg/sql/opt/props/physical/BUILD.bazel
+++ b/pkg/sql/opt/props/physical/BUILD.bazel
@@ -3,24 +3,37 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "physical",
     srcs = [
+        "distribution.go",
         "provided.go",
         "required.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb:with-mocks",
         "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
+        "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/props",
+        "//pkg/sql/sem/tree",
     ],
 )
 
 go_test(
     name = "physical_test",
     size = "small",
-    srcs = ["required_test.go"],
+    srcs = [
+        "distribution_test.go",
+        "required_test.go",
+    ],
+    embed = [":physical"],
     deps = [
-        ":physical",
+        "//pkg/config/zonepb",
+        "//pkg/roachpb:with-mocks",
         "//pkg/sql/opt",
         "//pkg/sql/opt/props",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/sql/opt/props/physical/distribution.go
+++ b/pkg/sql/opt/props/physical/distribution.go
@@ -1,0 +1,240 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package physical
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// Distribution represents the physical distribution of data for a relational
+// operator. It is used to describe where the data will be physically located
+// during execution, to enable more accurate costing of each operator by taking
+// latency and network bandwidth into account.
+type Distribution struct {
+	// Regions is the set of regions that make up this Distribution. They should
+	// be sorted in lexicographical order.
+	// TODO(rytaft): Consider abstracting this to a list of "neighborhoods" to
+	// support more different types of localities.
+	// TODO(rytaft): Consider mapping the region strings to integers and storing
+	// this as a FastIntSet.
+	Regions []string
+}
+
+// Any is true if this Distribution allows any set of regions.
+func (d Distribution) Any() bool {
+	return len(d.Regions) == 0
+}
+
+func (d Distribution) String() string {
+	var buf bytes.Buffer
+	d.format(&buf)
+	return buf.String()
+}
+
+func (d Distribution) format(buf *bytes.Buffer) {
+	for i, r := range d.Regions {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+		buf.WriteString(r)
+	}
+}
+
+// Equals returns true if the two Distributions are identical.
+func (d Distribution) Equals(rhs Distribution) bool {
+	if len(d.Regions) != len(rhs.Regions) {
+		return false
+	}
+
+	for i := range d.Regions {
+		if d.Regions[i] != rhs.Regions[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Union unions the other distribution with the given distribution,
+// removing duplicates. It assumes both distributions are sorted.
+func (d Distribution) Union(rhs Distribution) Distribution {
+	regions := make([]string, 0, len(d.Regions)+len(rhs.Regions))
+	l, r := 0, 0
+	for l < len(d.Regions) && r < len(rhs.Regions) {
+		if d.Regions[l] == rhs.Regions[r] {
+			regions = append(regions, d.Regions[l])
+			l++
+			r++
+		} else if d.Regions[l] < rhs.Regions[r] {
+			regions = append(regions, d.Regions[l])
+			l++
+		} else {
+			regions = append(regions, rhs.Regions[r])
+			r++
+		}
+	}
+	if l < len(d.Regions) {
+		regions = append(regions, d.Regions[l:]...)
+	} else if r < len(rhs.Regions) {
+		regions = append(regions, rhs.Regions[r:]...)
+	}
+	return Distribution{Regions: regions}
+}
+
+const regionKey = "region"
+
+// FromLocality sets the Distribution with the region from the given locality
+// (if any).
+func (d *Distribution) FromLocality(locality roachpb.Locality) {
+	if region, ok := locality.Find(regionKey); ok {
+		d.Regions = []string{region}
+	}
+}
+
+// FromIndexScan sets the Distribution that results from scanning the given
+// index with the given constraint c (c can be nil).
+func (d *Distribution) FromIndexScan(
+	evalCtx *tree.EvalContext, index cat.Index, c *constraint.Constraint,
+) {
+	if index.Table().IsVirtualTable() {
+		// Virtual tables do not have zone configurations.
+		return
+	}
+
+	var regions map[string]struct{}
+	for i, n := 0, index.PartitionCount(); i < n; i++ {
+		part := index.Partition(i)
+
+		// If the index scan is constrained, see if we can prune this partition.
+		if c != nil {
+			prefixes := part.PartitionByListPrefixes()
+			var found bool
+			for _, datums := range prefixes {
+				if len(datums) == 0 {
+					// This indicates a DEFAULT value, so we can't easily prune this partition.
+					found = true
+					break
+				}
+				key := constraint.MakeCompositeKey(datums...)
+				var span constraint.Span
+				span.Init(key, constraint.IncludeBoundary, key, constraint.IncludeBoundary)
+				if c.IntersectsSpan(evalCtx, &span) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				// This partition does not intersect the constraint, so skip it.
+				continue
+			}
+		}
+
+		// Add the regions from this partition to the distribution.
+		zoneRegions := getRegionsFromZone(part.Zone())
+		if len(regions) == 0 {
+			regions = zoneRegions
+		} else {
+			for r := range zoneRegions {
+				regions[r] = struct{}{}
+			}
+		}
+	}
+
+	if len(regions) == 0 {
+		regions = getRegionsFromZone(index.Zone())
+	}
+
+	// Convert to a slice and sort regions.
+	d.Regions = make([]string, 0, len(regions))
+	for r := range regions {
+		d.Regions = append(d.Regions, r)
+	}
+	sort.Strings(d.Regions)
+}
+
+// getRegionsFromZone returns the regions of the given zone config, if any. It
+// attempts to find the smallest set of regions likely to hold the leaseholder.
+func getRegionsFromZone(zone cat.Zone) map[string]struct{} {
+	// First find any regional replica constraints. If there is exactly one, we
+	// can return early.
+	var regions map[string]struct{}
+	for i, n := 0, zone.ReplicaConstraintsCount(); i < n; i++ {
+		replicaConstraint := zone.ReplicaConstraints(i)
+		for j, m := 0, replicaConstraint.ConstraintCount(); j < m; j++ {
+			constraint := replicaConstraint.Constraint(j)
+			if region, ok := getRegionFromConstraint(constraint); ok {
+				if regions == nil {
+					regions = make(map[string]struct{})
+				}
+				regions[region] = struct{}{}
+			}
+		}
+	}
+	if len(regions) == 1 {
+		return regions
+	}
+
+	// Next check the voter replica constraints. Once again, if there is exactly
+	// one regional constraint, we can return early.
+	var voterRegions map[string]struct{}
+	for i, n := 0, zone.VoterConstraintsCount(); i < n; i++ {
+		replicaConstraint := zone.VoterConstraint(i)
+		for j, m := 0, replicaConstraint.ConstraintCount(); j < m; j++ {
+			constraint := replicaConstraint.Constraint(j)
+			if region, ok := getRegionFromConstraint(constraint); ok {
+				if voterRegions == nil {
+					voterRegions = make(map[string]struct{})
+				}
+				voterRegions[region] = struct{}{}
+			}
+		}
+	}
+	if len(voterRegions) == 1 {
+		return voterRegions
+	}
+
+	// Use the lease preferences as a tie breaker. We only really care about the
+	// first one, since subsequent lease preferences only apply in edge cases.
+	if zone.LeasePreferenceCount() > 0 {
+		leasePref := zone.LeasePreference(0)
+		for i, n := 0, leasePref.ConstraintCount(); i < n; i++ {
+			constraint := leasePref.Constraint(i)
+			if region, ok := getRegionFromConstraint(constraint); ok {
+				return map[string]struct{}{region: {}}
+			}
+		}
+	}
+
+	if len(voterRegions) > 0 {
+		return voterRegions
+	}
+	return regions
+}
+
+// getRegionFromConstraint returns the region and ok=true if the given
+// constraint is a required region constraint. Otherwise, returns ok=false.
+func getRegionFromConstraint(constraint cat.Constraint) (region string, ok bool) {
+	if constraint.GetKey() != regionKey {
+		// We only care about constraints on the region.
+		return "", false /* ok */
+	}
+	if constraint.IsRequired() {
+		// The region is required.
+		return constraint.GetValue(), true /* ok */
+	}
+	// The region is prohibited.
+	return "", false /* ok */
+}

--- a/pkg/sql/opt/props/physical/distribution_test.go
+++ b/pkg/sql/opt/props/physical/distribution_test.go
@@ -1,0 +1,201 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package physical
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnion(t *testing.T) {
+	testCases := []struct {
+		leftDist  []string
+		rightDist []string
+		expected  []string
+	}{
+		{
+			leftDist:  []string{},
+			rightDist: []string{},
+			expected:  []string{},
+		},
+		{
+			leftDist:  []string{},
+			rightDist: []string{"west"},
+			expected:  []string{"west"},
+		},
+		{
+			leftDist:  []string{"east"},
+			rightDist: []string{"east"},
+			expected:  []string{"east"},
+		},
+		{
+			leftDist:  []string{"west"},
+			rightDist: []string{"east"},
+			expected:  []string{"east", "west"},
+		},
+		{
+			leftDist:  []string{"central", "east", "west"},
+			rightDist: []string{"central", "west"},
+			expected:  []string{"central", "east", "west"},
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			leftDist := Distribution{Regions: tc.leftDist}
+			rightDist := Distribution{Regions: tc.rightDist}
+			expected := Distribution{Regions: tc.expected}
+
+			res := leftDist.Union(rightDist)
+			if !res.Equals(expected) {
+				t.Errorf("expected '%s', got '%s'", expected, res)
+			}
+		})
+	}
+}
+
+func TestFromLocality(t *testing.T) {
+	testCases := []struct {
+		locality roachpb.Locality
+		expected []string
+	}{
+		{
+			locality: roachpb.Locality{},
+			expected: []string{},
+		},
+		{
+			locality: roachpb.Locality{Tiers: []roachpb.Tier{
+				{Key: "region", Value: "west"},
+				{Key: "zone", Value: "b"},
+			}},
+			expected: []string{"west"},
+		},
+		{
+			locality: roachpb.Locality{Tiers: []roachpb.Tier{
+				{Key: "zone", Value: "b"},
+			}},
+			expected: []string{},
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			expected := Distribution{Regions: tc.expected}
+
+			var res Distribution
+			res.FromLocality(tc.locality)
+			if !res.Equals(expected) {
+				t.Errorf("expected '%s', got '%s'", expected, res)
+			}
+		})
+	}
+}
+
+func TestGetRegionsFromZone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		constraints      string
+		voterConstraints string
+		leasePrefs       string
+		expected         []string
+	}{
+		{constraints: "[]", expected: []string{}},
+		{constraints: "[+region=eu,+dc=uk]", expected: []string{"eu"}},
+		{constraints: "[-region=us,+dc=east]", expected: []string{}},
+		{constraints: "[-region=eu]", expected: []string{}},
+		{constraints: "[+region=us]", expected: []string{"us"}},
+		{constraints: "[+region=us,-region=eu]", expected: []string{"us"}},
+
+		{voterConstraints: "[+region=us,-dc=east]", expected: []string{"us"}},
+		{voterConstraints: "[+region=us,+dc=west]", expected: []string{"us"}},
+		{voterConstraints: "[+dc=east]", expected: []string{}},
+		{voterConstraints: "[+dc=west,+ssd]", expected: []string{}},
+		{voterConstraints: "[-region=eu,+dc=east]", expected: []string{}},
+		{voterConstraints: "[+region=us,+dc=east,+rack=1,-ssd]", expected: []string{"us"}},
+
+		{constraints: `{"+region=us,+dc=east":3,"-dc=east":2}`, expected: []string{"us"}},
+		{constraints: `{"+region=us,+dc=east":3,"+region=us,+dc=west":2}`, expected: []string{"us"}},
+		{constraints: `{"+region=us,+dc=east":3,"+region=eu":2}`, expected: []string{"eu", "us"}},
+
+		{leasePrefs: "[[]]", expected: []string{}},
+		{leasePrefs: "[[+dc=west]]", expected: []string{}},
+		{leasePrefs: "[[+region=us]]", expected: []string{"us"}},
+		{leasePrefs: "[[+region=us,+dc=east]]", expected: []string{"us"}},
+
+		{constraints: "[+region=eu]", voterConstraints: "[+region=eu]",
+			leasePrefs: "[[+dc=west]]", expected: []string{"eu"}},
+		{constraints: "[+region=eu]", voterConstraints: "[+region=eu]",
+			leasePrefs: "[[+region=us]]", expected: []string{"eu"}},
+		{constraints: "[+region=us]", voterConstraints: "[+region=us]",
+			leasePrefs: "[[+dc=west]]", expected: []string{"us"}},
+		{constraints: "[+region=us]", voterConstraints: "[+region=us]",
+			leasePrefs: "[[+region=us]]", expected: []string{"us"}},
+		{constraints: "[+dc=east]", voterConstraints: "[+region=us]",
+			leasePrefs: "[[+region=us]]", expected: []string{"us"}},
+		{constraints: "[+dc=east]", voterConstraints: "[+dc=east]",
+			leasePrefs: "[[+region=us]]", expected: []string{"us"}},
+		{constraints: "[+dc=east]", voterConstraints: "[+dc=east]",
+			leasePrefs: "[[+dc=east]]", expected: []string{}},
+		{constraints: "[+region=us,+dc=east]", voterConstraints: "[-region=eu]",
+			leasePrefs: "[[+region=us,+dc=east]]", expected: []string{"us"}},
+		{constraints: `{"+region=us":3,"+region=eu":2}`,
+			voterConstraints: `[+region=us]`, expected: []string{"us"}},
+		{constraints: `{"+region=us":3,"+region=eu":2}`,
+			voterConstraints: `{"+region=us":1,"+region=eu":1}`, expected: []string{"eu", "us"}},
+		{constraints: `{"+region=us":3,"+region=eu":2}`,
+			voterConstraints: `{"+region=us":1,"+region=eu":1}`, leasePrefs: "[[+region=us]]", expected: []string{"us"}},
+	}
+
+	for _, tc := range testCases {
+		zone := &zonepb.ZoneConfig{}
+
+		if tc.constraints != "" {
+			constraintsList := &zonepb.ConstraintsList{}
+			if err := yaml.UnmarshalStrict([]byte(tc.constraints), constraintsList); err != nil {
+				t.Fatal(err)
+			}
+			zone.Constraints = constraintsList.Constraints
+		}
+
+		if tc.voterConstraints != "" {
+			constraintsList := &zonepb.ConstraintsList{}
+			if err := yaml.UnmarshalStrict([]byte(tc.voterConstraints), constraintsList); err != nil {
+				t.Fatal(err)
+			}
+			zone.VoterConstraints = constraintsList.Constraints
+		}
+
+		if tc.leasePrefs != "" {
+			if err := yaml.UnmarshalStrict([]byte(tc.leasePrefs), &zone.LeasePreferences); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		regions := getRegionsFromZone(zone)
+		actual := make([]string, 0, len(regions))
+		for r := range regions {
+			actual = append(actual, r)
+		}
+		sort.Strings(actual)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("constraints=%v, voterConstraints=%v, leasePrefs=%v: expected %v, got %v",
+				tc.constraints, tc.voterConstraints, tc.leasePrefs, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/sql/opt/props/physical/provided.go
+++ b/pkg/sql/opt/props/physical/provided.go
@@ -36,14 +36,22 @@ type Provided struct {
 	// See the documentation for the opt/ordering package for some examples.
 	Ordering opt.Ordering
 
-	// Note: we store a Provided structure in-place within each group because the
-	// struct is very small (see memo.bestProps). If we add more fields here, that
-	// decision needs to be revisited.
+	// Distribution is a distribution that needs to be maintained on the rows
+	// produced by this operator in order to satisfy its required distribution. If
+	// there is a required distribution, the provided distribution must match it
+	// exactly.
+	//
+	// The provided distribution is not yet used when building the DistSQL plan,
+	// but eventually it should inform the decision about whether to plan
+	// processors locally or remotely. Currently, it is used to determine whether
+	// a Distribute operator is needed between this operator and its parent, which
+	// can affect the cost of a plan.
+	Distribution Distribution
 }
 
 // Equals returns true if the two sets of provided properties are identical.
 func (p *Provided) Equals(other *Provided) bool {
-	return p.Ordering.Equals(other.Ordering)
+	return p.Ordering.Equals(other.Ordering) && p.Distribution.Equals(other.Distribution)
 }
 
 func (p *Provided) String() string {
@@ -52,6 +60,19 @@ func (p *Provided) String() string {
 	if len(p.Ordering) > 0 {
 		buf.WriteString("[ordering: ")
 		p.Ordering.Format(&buf)
+		if p.Distribution.Any() {
+			buf.WriteByte(']')
+		} else {
+			buf.WriteString(", ")
+		}
+	}
+
+	if !p.Distribution.Any() {
+		if len(p.Ordering) == 0 {
+			buf.WriteByte('[')
+		}
+		buf.WriteString("distribution: ")
+		p.Distribution.format(&buf)
 		buf.WriteByte(']')
 	}
 

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -53,6 +53,14 @@ type Required struct {
 	// float64 representation, and can be converted to an integer number of rows
 	// using math.Ceil.
 	LimitHint float64
+
+	// Distribution specifies the physical distribution of result rows. This is
+	// defined as the set of regions that may contain result rows. If
+	// Distribution is not defined, then no particular distribution is required.
+	// Currently, the only operator in a plan tree that has a required
+	// distribution is the root, since data must always be returned to the gateway
+	// region.
+	Distribution Distribution
 }
 
 // MinRequired are the default physical properties that require nothing and
@@ -62,7 +70,7 @@ var MinRequired = &Required{}
 // Defined is true if any physical property is defined. If none is defined, then
 // this is an instance of MinRequired.
 func (p *Required) Defined() bool {
-	return !p.Presentation.Any() || !p.Ordering.Any() || p.LimitHint != 0
+	return !p.Presentation.Any() || !p.Ordering.Any() || p.LimitHint != 0 || !p.Distribution.Any()
 }
 
 // ColSet returns the set of columns used by any of the physical properties.
@@ -96,6 +104,9 @@ func (p *Required) String() string {
 	if p.LimitHint != 0 {
 		output("limit hint", func(buf *bytes.Buffer) { fmt.Fprintf(buf, "%.2f", p.LimitHint) })
 	}
+	if !p.Distribution.Any() {
+		output("distribution", p.Distribution.format)
+	}
 
 	// Handle empty properties case.
 	if buf.Len() == 0 {
@@ -106,7 +117,8 @@ func (p *Required) String() string {
 
 // Equals returns true if the two physical properties are identical.
 func (p *Required) Equals(rhs *Required) bool {
-	return p.Presentation.Equals(rhs.Presentation) && p.Ordering.Equals(&rhs.Ordering) && p.LimitHint == rhs.LimitHint
+	return p.Presentation.Equals(rhs.Presentation) && p.Ordering.Equals(&rhs.Ordering) &&
+		p.LimitHint == rhs.LimitHint && p.Distribution.Equals(rhs.Distribution)
 }
 
 // Presentation specifies the naming, membership (including duplicates), and

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",
+        "//pkg/sql/opt/distribution",
         "//pkg/sql/opt/idxconstraint",
         "//pkg/sql/opt/invertedexpr",
         "//pkg/sql/opt/invertedidx",

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -466,6 +466,9 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.SortOp:
 		cost = c.computeSortCost(candidate.(*memo.SortExpr), required)
 
+	case opt.DistributeOp:
+		cost = c.computeDistributeCost(candidate.(*memo.DistributeExpr), required)
+
 	case opt.ScanOp:
 		cost = c.computeScanCost(candidate.(*memo.ScanExpr), required)
 
@@ -640,6 +643,14 @@ func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Require
 	// TODO(harding): Add the CPU cost of emitting the output rows. This should be
 	// done in conjunction with computeTopKCost.
 	return cost
+}
+
+func (c *coster) computeDistributeCost(
+	distribute *memo.DistributeExpr, required *physical.Required,
+) memo.Cost {
+	// TODO(rytaft): Compute a real cost here. Currently we just add a tiny cost
+	// as a placeholder.
+	return cpuCostFactor
 }
 
 func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Required) memo.Cost {

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -43,6 +43,7 @@ scan t.public.abc
  ├── cost: 1084.62
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: central
  ├── prune: (1-3)
  └── interesting orderings: (+1) (+2,+3,+1)
 
@@ -50,15 +51,25 @@ scan t.public.abc
 opt format=show-all locality=(region=central)
 SELECT * FROM abc WHERE b=10
 ----
-scan t.public.abc@bc1
+distribute
  ├── columns: a:1(int!null) b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 25.22
+ ├── cost: 25.25
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
+ ├── distribution: central
+ ├── input distribution: east
  ├── prune: (1,3)
- └── interesting orderings: (+1 opt(2)) (+3,+1 opt(2))
+ ├── interesting orderings: (+1 opt(2)) (+3,+1 opt(2))
+ └── scan t.public.abc@bc1
+      ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 25.22
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
+      ├── prune: (1,3)
+      └── interesting orderings: (+1 opt(2)) (+3,+1 opt(2))
 
 # With locality in east, use bc1 index.
 opt format=show-all locality=(region=east)
@@ -71,6 +82,7 @@ scan t.public.abc@bc1
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: east
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -85,6 +97,7 @@ scan t.public.abc@bc2
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: west
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -106,15 +119,25 @@ scan t.public.abc@bc1
 opt format=show-all locality=(region=central)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc1
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 25.02
+ ├── cost: 25.05
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: central
+ ├── input distribution: east
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc1
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 25.02
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 # --------------------------------------------------
 # Multiple constraints.
@@ -143,6 +166,7 @@ scan t.public.abc
  ├── cost: 1084.62
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: us
  ├── prune: (1-3)
  └── interesting orderings: (+1) (+2,+3,+1)
 
@@ -157,6 +181,7 @@ scan t.public.abc@bc1
  ├── cost: 24.77
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -171,6 +196,7 @@ scan t.public.abc@bc1
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -186,6 +212,7 @@ scan t.public.abc@bc2
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -213,6 +240,7 @@ scan t.public.abc@bc1
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -228,6 +256,7 @@ scan t.public.abc@bc2
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -247,59 +276,99 @@ ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=eu,+region=us,+dc
 opt format=show-all locality=(region=us)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc1
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 24.52
+ ├── cost: 24.55
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
+ ├── input distribution: ap,us
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc1
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 24.52
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 # With locality in eu, use bc2, since it's prohibited with bc1.
 opt format=show-all locality=(region=eu)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc2
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 24.52
+ ├── cost: 24.55
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: eu
+ ├── input distribution: eu,us
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc2
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 24.52
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 # With locality in us + east, use bc2, since it matches both tiers, even though
 # "us" match is after "eu" in list.
 opt format=show-all locality=(region=us,dc=east)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc2
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 24.52
+ ├── cost: 24.55
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
+ ├── input distribution: eu,us
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc2
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 24.52
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 # With locality in ap + east, use bc1, since ap is not in list of regions for
 # bc2, even though dc=east matches.
 opt format=show-all locality=(region=ap,dc=east)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc1
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 24.77
+ ├── cost: 24.8
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: ap
+ ├── input distribution: ap,us
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc1
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 24.77
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[-region=eu,+dc=east]'
@@ -320,6 +389,7 @@ scan t.public.abc@bc1
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -334,6 +404,7 @@ scan t.public.abc@bc2
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: eu
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -370,6 +441,7 @@ inner-join (lookup t.public.xy@y2)
  ├── cost: 427.6
  ├── key: (1,6)
  ├── fd: ()-->(2,7), (1)-->(3), (2,3)~~>(1), (2)==(7), (7)==(2)
+ ├── distribution: us
  ├── prune: (1,3,6)
  ├── interesting orderings: (+1 opt(2)) (+3,+1 opt(2)) (+6 opt(7))
  ├── scan t.public.abc@bc2
@@ -379,6 +451,7 @@ inner-join (lookup t.public.xy@y2)
  │    ├── cost: 24.62
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
+ │    ├── distribution: us
  │    ├── prune: (1,3)
  │    └── interesting orderings: (+1 opt(2)) (+3,+1 opt(2))
  └── filters
@@ -408,6 +481,7 @@ inner-join (lookup t.public.xy@y1)
  ├── cost: 427.6
  ├── key: (1,6)
  ├── fd: ()-->(2,7), (1)-->(3), (2,3)~~>(1), (2)==(7), (7)==(2)
+ ├── distribution: us
  ├── prune: (1,3,6)
  ├── interesting orderings: (+1 opt(2)) (+3,+1 opt(2)) (+6 opt(7))
  ├── scan t.public.abc@bc2
@@ -417,6 +491,7 @@ inner-join (lookup t.public.xy@y1)
  │    ├── cost: 24.62
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
+ │    ├── distribution: us
  │    ├── prune: (1,3)
  │    └── interesting orderings: (+1 opt(2)) (+3,+1 opt(2))
  └── filters
@@ -450,6 +525,7 @@ scan t.public.abc
  ├── cost: 1125.02
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: central
  ├── prune: (1-3)
  └── interesting orderings: (+1) (+2,+3,+1)
 
@@ -457,15 +533,25 @@ scan t.public.abc
 opt format=show-all locality=(region=central)
 SELECT b, c FROM abc WHERE b=10
 ----
-scan t.public.abc@bc1
+distribute
  ├── columns: b:2(int!null) c:3(string)
- ├── constraint: /2/3: [/10 - /10]
  ├── stats: [rows=10, distinct(2)=1, null(2)=0]
- ├── cost: 25.02
+ ├── cost: 25.05
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: central
+ ├── input distribution: east
  ├── prune: (3)
- └── interesting orderings: (+3 opt(2))
+ ├── interesting orderings: (+3 opt(2))
+ └── scan t.public.abc@bc1
+      ├── columns: t.public.abc.b:2(int!null) t.public.abc.c:3(string)
+      ├── constraint: /2/3: [/10 - /10]
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      ├── cost: 25.02
+      ├── lax-key: (3)
+      ├── fd: ()-->(2)
+      ├── prune: (3)
+      └── interesting orderings: (+3 opt(2))
 
 # With locality in east, use bc1 index.
 opt format=show-all locality=(region=east)
@@ -478,6 +564,7 @@ scan t.public.abc@bc1
  ├── cost: 24.8533333
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: east
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -492,6 +579,7 @@ scan t.public.abc@bc2
  ├── cost: 24.8533333
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: west
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -521,6 +609,7 @@ scan t.public.abc
  ├── cost: 1125.02
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: us
  ├── prune: (1-3)
  └── interesting orderings: (+1) (+2,+3,+1)
 
@@ -535,6 +624,7 @@ scan t.public.abc@bc1
  ├── cost: 24.9366667
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -549,6 +639,7 @@ scan t.public.abc@bc1
  ├── cost: 24.8533333
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -563,6 +654,7 @@ scan t.public.abc@bc2
  ├── cost: 24.8533333
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -595,6 +687,7 @@ scan t.public.abc
  ├── cost: 1104.82
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: us
  ├── prune: (1-3)
  └── interesting orderings: (+1) (+2,+3,+1)
 
@@ -609,6 +702,7 @@ scan t.public.abc@bc1
  ├── cost: 24.77
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -623,6 +717,7 @@ scan t.public.abc@bc1
  ├── cost: 24.6866667
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -637,6 +732,7 @@ scan t.public.abc@bc2
  ├── cost: 24.6866667
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -666,6 +762,7 @@ scan t.public.abc@bc2
  ├── cost: 24.52
  ├── lax-key: (3)
  ├── fd: ()-->(2)
+ ├── distribution: us
  ├── prune: (3)
  └── interesting orderings: (+3 opt(2))
 
@@ -718,6 +815,7 @@ locality-optimized-search
  ├── cost: 3.468444
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── prune: (1,2)
  ├── scan t.public.abc_part@bc_idx
  │    ├── columns: t.public.abc_part.r:7(string!null) t.public.abc_part.a:8(int!null) t.public.abc_part.b:9(int!null) t.public.abc_part.c:10(string!null)
@@ -755,6 +853,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  ├── cost: 18.1443257
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part@bc_idx [as=a2])
  │    ├── columns: a1.r:1!null a1.a:2!null a1.b:3!null a1.c:4!null
  │    ├── lookup expression
@@ -766,6 +865,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    ├── cost: 10.8432087
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: a1.r:1!null a1.a:2!null a1.b:3!null a1.c:4!null
  │    │    ├── left columns: a1.r:13 a1.a:14 a1.b:15 a1.c:16
@@ -775,6 +875,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │    ├── cost: 3.468444
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan abc_part@bc_idx [as=a1]
  │    │    │    ├── columns: a1.r:13!null a1.a:14!null a1.b:15!null a1.c:16!null
  │    │    │    ├── constraint: /13/15/16: [/'east'/1/'foo' - /'east'/1/'foo']

--- a/pkg/sql/opt/xform/testdata/physprops/distribution
+++ b/pkg/sql/opt/xform/testdata/physprops/distribution
@@ -1,0 +1,271 @@
+# Tests for distribution property with a non-partitioned table.
+
+exec-ddl
+CREATE TABLE abc (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    UNIQUE INDEX bc (b, c)
+)
+----
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us,+dc=central,+rack=1]'
+----
+
+exec-ddl
+ALTER INDEX abc@bc CONFIGURE ZONE USING constraints='[+region=us,-region=eu,+region=ap]'
+----
+
+opt locality=(region=us)
+SELECT a FROM abc
+----
+scan abc
+ ├── columns: a:1!null
+ ├── key: (1)
+ └── distribution: us
+
+opt locality=(region=eu)
+SELECT a FROM abc
+----
+distribute
+ ├── columns: a:1!null
+ ├── key: (1)
+ ├── distribution: eu
+ ├── input distribution: us
+ └── scan abc
+      ├── columns: a:1!null
+      └── key: (1)
+
+opt locality=(region=us)
+SELECT a FROM abc WHERE b = 1
+----
+distribute
+ ├── columns: a:1!null
+ ├── key: (1)
+ ├── distribution: us
+ ├── input distribution: ap,us
+ └── project
+      ├── columns: a:1!null
+      ├── key: (1)
+      └── scan abc@bc
+           ├── columns: a:1!null b:2!null
+           ├── constraint: /2/3: [/1 - /1]
+           ├── key: (1)
+           └── fd: ()-->(2)
+
+opt locality=(region=us)
+SELECT * FROM abc WHERE a > 10
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── constraint: /1: [/11 - ]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ └── distribution: us
+
+opt locality=(region=ap)
+SELECT * FROM abc WHERE a > 10
+----
+distribute
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── distribution: ap
+ ├── input distribution: us
+ └── scan abc
+      ├── columns: a:1!null b:2 c:3
+      ├── constraint: /1: [/11 - ]
+      ├── key: (1)
+      └── fd: (1)-->(2,3), (2,3)~~>(1)
+
+# Combined with sorting.
+opt locality=(region=ap)
+SELECT * FROM abc WHERE a > 10 ORDER BY c
+----
+distribute
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── ordering: +3
+ ├── distribution: ap
+ ├── input distribution: us
+ └── sort
+      ├── columns: a:1!null b:2 c:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (2,3)~~>(1)
+      ├── ordering: +3
+      └── scan abc
+           ├── columns: a:1!null b:2 c:3
+           ├── constraint: /1: [/11 - ]
+           ├── key: (1)
+           └── fd: (1)-->(2,3), (2,3)~~>(1)
+
+
+# Tests for distribution property with a partitioned table.
+
+exec-ddl
+CREATE TABLE abc_part (
+    r STRING NOT NULL CHECK (r IN ('east', 'west', 'central')),
+    t INT NOT NULL CHECK (t IN (1, 2, 3)),
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    d INT,
+    UNIQUE WITHOUT INDEX (c),
+    UNIQUE INDEX c_idx (r, t, c) PARTITION BY LIST (r, t) (
+      PARTITION east VALUES IN (('east', 1), ('east', 2)),
+      PARTITION west VALUES IN (('west', DEFAULT)),
+      PARTITION default VALUES IN (DEFAULT)
+    ),
+    INDEX d_idx (r, d) PARTITION BY LIST (r) (
+      PARTITION east VALUES IN (('east')),
+      PARTITION west VALUES IN (('west')),
+      PARTITION central VALUES IN (('central'))
+    )
+)
+----
+
+exec-ddl
+ALTER PARTITION "east" OF INDEX abc_part@c_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=east: 2}',
+  lease_preferences = '[[+region=east]]'
+----
+
+exec-ddl
+ALTER PARTITION "west" OF INDEX abc_part@c_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=west: 2}',
+  lease_preferences = '[[+region=west]]'
+----
+
+exec-ddl
+ALTER PARTITION "default" OF INDEX abc_part@c_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  lease_preferences = '[[+region=central]]';
+----
+
+exec-ddl
+ALTER PARTITION "east" OF INDEX abc_part@d_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=east: 2}',
+  lease_preferences = '[[+region=east]]'
+----
+
+exec-ddl
+ALTER PARTITION "west" OF INDEX abc_part@d_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=west: 2}',
+  lease_preferences = '[[+region=west]]';
+----
+
+exec-ddl
+ALTER PARTITION "central" OF INDEX abc_part@d_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=central: 2}',
+  lease_preferences = '[[+region=central]]';
+----
+
+opt locality=(region=east)
+SELECT a FROM abc_part WHERE r = 'east' AND t = 1
+----
+project
+ ├── columns: a:3!null
+ ├── key: (3)
+ ├── distribution: east
+ └── scan abc_part@c_idx
+      ├── columns: r:1!null t:2!null a:3!null
+      ├── constraint: /1/2/5: [/'east'/1 - /'east'/1]
+      ├── key: (3)
+      ├── fd: ()-->(1,2)
+      └── distribution: east
+
+opt locality=(region=west)
+SELECT a FROM abc_part WHERE r = 'east' AND t = 1
+----
+distribute
+ ├── columns: a:3!null
+ ├── key: (3)
+ ├── distribution: west
+ ├── input distribution: east
+ └── project
+      ├── columns: a:3!null
+      ├── key: (3)
+      └── scan abc_part@c_idx
+           ├── columns: r:1!null t:2!null a:3!null
+           ├── constraint: /1/2/5: [/'east'/1 - /'east'/1]
+           ├── key: (3)
+           └── fd: ()-->(1,2)
+
+opt locality=(region=west)
+SELECT a FROM abc_part WHERE r IN ('east', 'west') AND d = 10
+----
+distribute
+ ├── columns: a:3!null
+ ├── key: (3)
+ ├── distribution: west
+ ├── input distribution: east,west
+ └── project
+      ├── columns: a:3!null
+      ├── key: (3)
+      └── scan abc_part@d_idx
+           ├── columns: r:1!null a:3!null d:6!null
+           ├── constraint: /1/6/3
+           │    ├── [/'east'/10 - /'east'/10]
+           │    └── [/'west'/10 - /'west'/10]
+           ├── key: (3)
+           └── fd: ()-->(6), (3)-->(1)
+
+opt locality=(region=east)
+SELECT a FROM abc_part WHERE d = 10
+----
+distribute
+ ├── columns: a:3!null
+ ├── key: (3)
+ ├── distribution: east
+ ├── input distribution: central,east,west
+ └── project
+      ├── columns: a:3!null
+      ├── key: (3)
+      └── scan abc_part@d_idx
+           ├── columns: a:3!null d:6!null
+           ├── constraint: /1/6/3
+           │    ├── [/'central'/10 - /'central'/10]
+           │    ├── [/'east'/10 - /'east'/10]
+           │    └── [/'west'/10 - /'west'/10]
+           ├── key: (3)
+           └── fd: ()-->(6)
+
+# Combined with sorting.
+opt locality=(region=east)
+SELECT a FROM abc_part WHERE d = 10 ORDER BY c
+----
+distribute
+ ├── columns: a:3!null  [hidden: c:5]
+ ├── key: (3)
+ ├── fd: (3)-->(5), (5)~~>(3)
+ ├── ordering: +5
+ ├── distribution: east
+ ├── input distribution: central,east,west
+ └── sort
+      ├── columns: a:3!null c:5
+      ├── key: (3)
+      ├── fd: (3)-->(5), (5)~~>(3)
+      ├── ordering: +5
+      └── project
+           ├── columns: a:3!null c:5
+           ├── key: (3)
+           ├── fd: (3)-->(5), (5)~~>(3)
+           └── index-join abc_part
+                ├── columns: a:3!null c:5 d:6!null
+                ├── key: (3)
+                ├── fd: ()-->(6), (3)-->(5), (5)~~>(3)
+                └── scan abc_part@d_idx
+                     ├── columns: a:3!null d:6!null
+                     ├── constraint: /1/6/3
+                     │    ├── [/'central'/10 - /'central'/10]
+                     │    ├── [/'east'/10 - /'east'/10]
+                     │    └── [/'west'/10 - /'west'/10]
+                     ├── key: (3)
+                     └── fd: ()-->(6)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2172,7 +2172,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~32KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~31KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2246,7 +2246,7 @@ memo (optimized, ~32KB, required=[presentation: w:12] [ordering: +13,+1])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
-memo (optimized, ~25KB, required=[])
+memo (optimized, ~24KB, required=[])
  ├── G1: (insert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 xyz)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -182,7 +182,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~42KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~41KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -244,7 +244,7 @@ memo (optimized, ~42KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:1
 memo
 SELECT * FROM abc, stu, xyz, pqr WHERE a = 1
 ----
-memo (optimized, ~28KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~27KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (inner-join G3 G2 G4)
@@ -1823,7 +1823,7 @@ inner-join (lookup xyz@xy)
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~18KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
+memo (optimized, ~17KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+6,+7,+8) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+8,+7,+6) (lookup-join G2 G5 stu [as=r],keyCols=[1 2 3],outCols=(1-3,6-8)) (lookup-join G2 G5 stu@uts [as=r],keyCols=[3 2 1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+7,+8,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+8,+7,+6,+3,+2,+1) (lookup-join G3 G5 stu [as=l],keyCols=[6 7 8],outCols=(1-3,6-8)) (lookup-join G3 G5 stu@uts [as=l],keyCols=[8 7 6],outCols=(1-3,6-8))
  │    └── [presentation: s:1,t:2,u:3,s:6,t:7,u:8]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +6,+7,+8]" G5 inner-join,+1,+2,+3,+6,+7,+8)
@@ -2030,7 +2030,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -5346,7 +5346,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~33KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~32KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)
@@ -8205,7 +8205,7 @@ SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
 UNION ALL
 SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
 ----
-memo (optimized, ~21KB, required=[presentation: ?column?:7])
+memo (optimized, ~20KB, required=[presentation: ?column?:7])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: ?column?:7]
  │         ├── best: (union-all G2 G3)
@@ -8851,6 +8851,7 @@ anti-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -8861,6 +8862,7 @@ anti-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -8868,6 +8870,7 @@ anti-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/1 - /'east'/1]
@@ -8899,6 +8902,7 @@ anti-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: west
  ├── anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -8909,6 +8913,7 @@ anti-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: west
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -8916,6 +8921,7 @@ anti-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: west
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'west'/1 - /'west'/1]
@@ -8947,6 +8953,7 @@ anti-join (lookup abc_part@b_idx)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part@b_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -8957,6 +8964,7 @@ anti-join (lookup abc_part@b_idx)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -8964,6 +8972,7 @@ anti-join (lookup abc_part@b_idx)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -8995,6 +9004,7 @@ anti-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -9005,6 +9015,7 @@ anti-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9012,6 +9023,7 @@ anti-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/1 - /'east'/1]
@@ -9035,38 +9047,44 @@ anti-join (lookup abc_part)
 opt locality=(region=east) expect=GenerateLocalityOptimizedAntiJoin
 SELECT * FROM def_part WHERE NOT EXISTS (SELECT * FROM abc_part WHERE e = a) AND f = 10
 ----
-anti-join (lookup abc_part)
+distribute
  ├── columns: r:1!null d:2!null e:3 f:4!null
- ├── lookup expression
- │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
- ├── lookup columns are key
  ├── key: (2)
  ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
- ├── anti-join (lookup abc_part)
- │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
- │    ├── lookup expression
- │    │    └── filters
- │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
- │    ├── lookup columns are key
- │    ├── key: (2)
- │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
- │    ├── index-join def_part
- │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
- │    │    ├── key: (2)
- │    │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
- │    │    └── scan def_part@f_idx
- │    │         ├── columns: def_part.r:1!null d:2!null f:4!null
- │    │         ├── constraint: /1/4/2
- │    │         │    ├── [/'central'/10 - /'central'/10]
- │    │         │    ├── [/'east'/10 - /'east'/10]
- │    │         │    └── [/'west'/10 - /'west'/10]
- │    │         ├── key: (2)
- │    │         └── fd: ()-->(4), (2)-->(1)
- │    └── filters (true)
- └── filters (true)
+ ├── distribution: east
+ ├── input distribution: central,east,west
+ └── anti-join (lookup abc_part)
+      ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
+      ├── lookup expression
+      │    └── filters
+      │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
+      │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      ├── lookup columns are key
+      ├── key: (2)
+      ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
+      ├── anti-join (lookup abc_part)
+      │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
+      │    ├── lookup expression
+      │    │    └── filters
+      │    │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
+      │    │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      │    ├── lookup columns are key
+      │    ├── key: (2)
+      │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
+      │    ├── index-join def_part
+      │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
+      │    │    ├── key: (2)
+      │    │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
+      │    │    └── scan def_part@f_idx
+      │    │         ├── columns: def_part.r:1!null d:2!null f:4!null
+      │    │         ├── constraint: /1/4/2
+      │    │         │    ├── [/'central'/10 - /'central'/10]
+      │    │         │    ├── [/'east'/10 - /'east'/10]
+      │    │         │    └── [/'west'/10 - /'west'/10]
+      │    │         ├── key: (2)
+      │    │         └── fd: ()-->(4), (2)-->(1)
+      │    └── filters (true)
+      └── filters (true)
 
 # Optimization applies even though the lookup join may have more than one
 # matching row.
@@ -9082,6 +9100,7 @@ anti-join (lookup abc_part@c_idx)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part@c_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -9091,6 +9110,7 @@ anti-join (lookup abc_part@c_idx)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9098,6 +9118,7 @@ anti-join (lookup abc_part@c_idx)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9130,6 +9151,7 @@ anti-join (lookup abc_part@c_idx)
  ├── immutable
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part@c_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -9140,6 +9162,7 @@ anti-join (lookup abc_part@c_idx)
  │    ├── immutable
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9147,6 +9170,7 @@ anti-join (lookup abc_part@c_idx)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9184,6 +9208,7 @@ semi-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: central
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9191,6 +9216,7 @@ semi-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: central
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'central'/1 - /'central'/1]
@@ -9229,6 +9255,7 @@ inner-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4,7-10), (8)==(3), (3)==(8)
+ ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9236,6 +9263,7 @@ inner-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'east'/1 - /'east'/1]
@@ -9270,6 +9298,7 @@ left-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4,7-10)
+ ├── distribution: west
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9277,6 +9306,7 @@ left-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: west
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'west'/1 - /'west'/1]
@@ -9311,6 +9341,7 @@ semi-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: central
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9318,6 +9349,7 @@ semi-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: central
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'central'/1 - /'central'/1]
@@ -9352,6 +9384,7 @@ semi-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: west
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9359,6 +9392,7 @@ semi-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: west
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'west'/1 - /'west'/1]
@@ -9387,6 +9421,7 @@ inner-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4,7-10), (9)==(4), (4)==(9)
+ ├── distribution: east
  ├── inner-join (lookup abc_part@b_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null abc_part.r:7!null a:8!null b:9!null
  │    ├── lookup expression
@@ -9401,6 +9436,7 @@ inner-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4,7-9), (9)==(4), (4)==(9)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9408,6 +9444,7 @@ inner-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9443,6 +9480,7 @@ inner-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4,7-10), (8)==(3), (3)==(8)
+ ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9450,6 +9488,7 @@ inner-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'east'/1 - /'east'/1]
@@ -9471,32 +9510,38 @@ inner-join (lookup abc_part)
 opt locality=(region=east) expect=GenerateLocalityOptimizedLookupJoin
 SELECT * FROM def_part INNER JOIN abc_part ON e = a WHERE f = 10
 ----
-inner-join (lookup abc_part)
+distribute
  ├── columns: r:1!null d:2!null e:3!null f:4!null r:7!null a:8!null b:9 c:10
- ├── lookup expression
- │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
- ├── remote lookup expression
- │    └── filters
- │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
- │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
- ├── lookup columns are key
  ├── key: (2)
  ├── fd: ()-->(4), (2)-->(1,3), (3)-->(1,2), (8)-->(7,9,10), (9)~~>(7,8,10), (3)==(8), (8)==(3)
- ├── index-join def_part
- │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
- │    ├── key: (2)
- │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
- │    └── scan def_part@f_idx
- │         ├── columns: def_part.r:1!null d:2!null f:4!null
- │         ├── constraint: /1/4/2
- │         │    ├── [/'central'/10 - /'central'/10]
- │         │    ├── [/'east'/10 - /'east'/10]
- │         │    └── [/'west'/10 - /'west'/10]
- │         ├── key: (2)
- │         └── fd: ()-->(4), (2)-->(1)
- └── filters (true)
+ ├── distribution: east
+ ├── input distribution: central,east,west
+ └── inner-join (lookup abc_part)
+      ├── columns: def_part.r:1!null d:2!null e:3!null f:4!null abc_part.r:7!null a:8!null b:9 c:10
+      ├── lookup expression
+      │    └── filters
+      │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
+      │         └── abc_part.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
+      ├── remote lookup expression
+      │    └── filters
+      │         ├── e:3 = a:8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
+      │         └── abc_part.r:7 IN ('central', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'west' - /'west']; tight)]
+      ├── lookup columns are key
+      ├── key: (2)
+      ├── fd: ()-->(4), (2)-->(1,3), (3)-->(1,2), (8)-->(7,9,10), (9)~~>(7,8,10), (3)==(8), (8)==(3)
+      ├── index-join def_part
+      │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null
+      │    ├── key: (2)
+      │    ├── fd: ()-->(4), (2)-->(1,3), (3)~~>(1,2)
+      │    └── scan def_part@f_idx
+      │         ├── columns: def_part.r:1!null d:2!null f:4!null
+      │         ├── constraint: /1/4/2
+      │         │    ├── [/'central'/10 - /'central'/10]
+      │         │    ├── [/'east'/10 - /'east'/10]
+      │         │    └── [/'west'/10 - /'west'/10]
+      │         ├── key: (2)
+      │         └── fd: ()-->(4), (2)-->(1)
+      └── filters (true)
 
 # Optimization applies for a semi join even though the lookup join may have more
 # than one matching row.
@@ -9516,6 +9561,7 @@ semi-join (lookup abc_part@c_idx)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9523,6 +9569,7 @@ semi-join (lookup abc_part@c_idx)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9554,6 +9601,7 @@ semi-join (lookup abc_part@c_idx)
  ├── immutable
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9561,6 +9609,7 @@ semi-join (lookup abc_part@c_idx)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── scan def_part
  │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9589,6 +9638,7 @@ inner-join (lookup abc_part)
  ├── lookup columns are key
  ├── key: (8)
  ├── fd: ()-->(1-4,10), (8)-->(7,9), (9)~~>(7,8), (4)==(10), (10)==(4)
+ ├── distribution: east
  ├── inner-join (lookup abc_part@c_idx)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4!null abc_part.r:7!null a:8!null c:10!null
  │    ├── lookup expression
@@ -9597,6 +9647,7 @@ inner-join (lookup abc_part)
  │    │         └── abc_part.r:7 IN ('central', 'east', 'west') [outer=(7), constraints=(/7: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
  │    ├── key: (8)
  │    ├── fd: ()-->(1-4,10), (8)-->(7), (4)==(10), (10)==(4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9604,6 +9655,7 @@ inner-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/10 - /'east'/10]
@@ -9635,6 +9687,7 @@ anti-join (lookup abc_part)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-4)
+ ├── distribution: east
  ├── anti-join (lookup abc_part)
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    ├── lookup expression
@@ -9645,6 +9698,7 @@ anti-join (lookup abc_part)
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
+ │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
  │    │    ├── left columns: def_part.r:13 d:14 e:15 f:16
@@ -9652,6 +9706,7 @@ anti-join (lookup abc_part)
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
+ │    │    ├── distribution: east
  │    │    ├── scan def_part
  │    │    │    ├── columns: def_part.r:13!null d:14!null e:15 f:16
  │    │    │    ├── constraint: /13/14: [/'east'/1 - /'east'/1]

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -312,7 +312,7 @@ New expression 3 of 3:
 memo join-limit=0 expect-not=ReorderJoins
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~28KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~27KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+1,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (merge-join G2="[ordering: +1]" G3 G5 inner-join,+1,+10)
@@ -365,7 +365,7 @@ memo (optimized, ~28KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
 memo join-limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~45KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~44KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -47,7 +47,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized, ~5KB, required=[presentation: k:1,f:3] [ordering: -1])
+memo (optimized, ~4KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev)) (top-k G2 &{10 -1 })
  │    ├── [presentation: k:1,f:3] [ordering: -1]
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))
@@ -526,6 +526,7 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3)
+ ├── distribution: east
  └── locality-optimized-search
       ├── columns: a:3!null b:4!null
       ├── left columns: a:11 b:12
@@ -533,6 +534,7 @@ project
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(3,4)
+      ├── distribution: east
       ├── scan abc_part@b_idx
       │    ├── columns: a:11!null b:12!null
       │    ├── constraint: /9/12: [/'east'/1 - /'east'/1]
@@ -556,6 +558,7 @@ index-join abc_part
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
+ ├── distribution: west
  └── locality-optimized-search
       ├── columns: r:1!null a:3!null b:4!null
       ├── left columns: r:9 a:11 b:12
@@ -563,6 +566,7 @@ index-join abc_part
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1,3,4)
+      ├── distribution: west
       ├── scan abc_part@b_idx
       │    ├── columns: r:9!null a:11!null b:12!null
       │    ├── constraint: /9/12: [/'west'/1 - /'west'/1]
@@ -586,6 +590,7 @@ index-join abc_part
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
+ ├── distribution: central
  └── locality-optimized-search
       ├── columns: r:1!null a:3!null b:4!null
       ├── left columns: r:9 a:11 b:12
@@ -593,6 +598,7 @@ index-join abc_part
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1,3,4)
+      ├── distribution: central
       ├── scan abc_part@b_idx
       │    ├── columns: r:9!null a:11!null b:12!null
       │    ├── constraint: /9/12: [/'central'/1 - /'central'/1]
@@ -616,6 +622,7 @@ index-join abc_part
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
+ ├── distribution: east
  └── locality-optimized-search
       ├── columns: r:1!null t:2!null a:3!null c:5!null
       ├── left columns: r:9 t:10 a:11 c:13
@@ -623,6 +630,7 @@ index-join abc_part
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3,5)
+      ├── distribution: east
       ├── scan abc_part@c_idx
       │    ├── columns: r:9!null t:10!null a:11!null c:13!null
       │    ├── constraint: /9/10/13
@@ -653,6 +661,7 @@ index-join abc_part
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
+ ├── distribution: west
  └── locality-optimized-search
       ├── columns: r:1!null t:2!null a:3!null c:5!null
       ├── left columns: r:9 t:10 a:11 c:13
@@ -660,6 +669,7 @@ index-join abc_part
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3,5)
+      ├── distribution: west
       ├── scan abc_part@c_idx
       │    ├── columns: r:9!null t:10!null a:11!null c:13!null
       │    ├── constraint: /9/10/13
@@ -690,6 +700,7 @@ index-join abc_part
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1-6)
+ ├── distribution: central
  └── locality-optimized-search
       ├── columns: r:1!null t:2!null a:3!null c:5!null
       ├── left columns: r:9 t:10 a:11 c:13
@@ -697,6 +708,7 @@ index-join abc_part
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3,5)
+      ├── distribution: central
       ├── scan abc_part@c_idx
       │    ├── columns: r:9!null t:10!null a:11!null c:13!null
       │    ├── constraint: /9/10/13
@@ -727,6 +739,7 @@ project
  ├── columns: a:3!null
  ├── cardinality: [0 - 2]
  ├── key: (3)
+ ├── distribution: east
  └── locality-optimized-search
       ├── columns: a:3!null b:4!null
       ├── left columns: a:11 b:12
@@ -734,6 +747,7 @@ project
       ├── cardinality: [0 - 2]
       ├── key: (3)
       ├── fd: (3)-->(4), (4)-->(3)
+      ├── distribution: east
       ├── scan abc_part@b_idx
       │    ├── columns: a:11!null b:12!null
       │    ├── constraint: /9/12: [/'east'/1 - /'east'/2]
@@ -753,65 +767,85 @@ project
 opt locality=(region=east) expect-not=GenerateLocalityOptimizedScan
 SELECT a FROM abc_part WHERE b >= 0 AND b < 100001
 ----
-project
+distribute
  ├── columns: a:3!null
  ├── cardinality: [0 - 100001]
  ├── key: (3)
- └── select
-      ├── columns: a:3!null b:4!null
+ ├── distribution: east
+ ├── input distribution: east,west
+ └── project
+      ├── columns: a:3!null
       ├── cardinality: [0 - 100001]
       ├── key: (3)
-      ├── fd: (3)-->(4), (4)-->(3)
-      ├── index-join abc_part
-      │    ├── columns: a:3!null b:4
-      │    ├── key: (3)
-      │    ├── fd: (3)-->(4), (4)~~>(3)
-      │    └── scan abc_part@c_idx
-      │         ├── columns: a:3!null
-      │         ├── constraint: /1/2/5
-      │         │    ├── [/'central'/1 - /'central'/3]
-      │         │    ├── [/'east'/1 - /'east'/3]
-      │         │    └── [/'west'/1 - /'west'/3]
-      │         └── key: (3)
-      └── filters
-           └── (b:4 >= 0) AND (b:4 < 100001) [outer=(4), constraints=(/4: [/0 - /100000]; tight)]
+      └── select
+           ├── columns: a:3!null b:4!null
+           ├── cardinality: [0 - 100001]
+           ├── key: (3)
+           ├── fd: (3)-->(4), (4)-->(3)
+           ├── index-join abc_part
+           │    ├── columns: a:3!null b:4
+           │    ├── key: (3)
+           │    ├── fd: (3)-->(4), (4)~~>(3)
+           │    └── scan abc_part@c_idx
+           │         ├── columns: a:3!null
+           │         ├── constraint: /1/2/5
+           │         │    ├── [/'central'/1 - /'central'/3]
+           │         │    ├── [/'east'/1 - /'east'/3]
+           │         │    └── [/'west'/1 - /'west'/3]
+           │         └── key: (3)
+           └── filters
+                └── (b:4 >= 0) AND (b:4 < 100001) [outer=(4), constraints=(/4: [/0 - /100000]; tight)]
 
 # The spans target all remote partitions.
 opt locality=(region=east) expect-not=GenerateLocalityOptimizedScan
 SELECT a FROM abc_part WHERE b = 1 AND r IN ('west', 'central')
 ----
-project
+distribute
  ├── columns: a:3!null
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3)
- └── scan abc_part@b_idx
-      ├── columns: r:1!null a:3!null b:4!null
-      ├── constraint: /1/4
-      │    ├── [/'central'/1 - /'central'/1]
-      │    └── [/'west'/1 - /'west'/1]
+ ├── distribution: east
+ ├── input distribution: central,west
+ └── project
+      ├── columns: a:3!null
       ├── cardinality: [0 - 1]
       ├── key: ()
-      └── fd: ()-->(1,3,4)
+      ├── fd: ()-->(3)
+      └── scan abc_part@b_idx
+           ├── columns: r:1!null a:3!null b:4!null
+           ├── constraint: /1/4
+           │    ├── [/'central'/1 - /'central'/1]
+           │    └── [/'west'/1 - /'west'/1]
+           ├── cardinality: [0 - 1]
+           ├── key: ()
+           └── fd: ()-->(1,3,4)
 
 # The scan is limited.
 opt locality=(region=east) expect-not=GenerateLocalityOptimizedScan
 SELECT a FROM abc_part WHERE d = 1 LIMIT 1
 ----
-project
+distribute
  ├── columns: a:3!null
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3)
- └── scan abc_part@d_idx
-      ├── columns: a:3!null d:6!null
-      ├── constraint: /1/6/3
-      │    ├── [/'central'/1 - /'central'/1]
-      │    ├── [/'east'/1 - /'east'/1]
-      │    └── [/'west'/1 - /'west'/1]
-      ├── limit: 1
+ ├── distribution: east
+ ├── input distribution: central,east,west
+ └── project
+      ├── columns: a:3!null
+      ├── cardinality: [0 - 1]
       ├── key: ()
-      └── fd: ()-->(3,6)
+      ├── fd: ()-->(3)
+      └── scan abc_part@d_idx
+           ├── columns: a:3!null d:6!null
+           ├── constraint: /1/6/3
+           │    ├── [/'central'/1 - /'central'/1]
+           │    ├── [/'east'/1 - /'east'/1]
+           │    └── [/'west'/1 - /'west'/1]
+           ├── limit: 1
+           ├── key: ()
+           └── fd: ()-->(3,6)
 
 # The scan is limited, but b is known to be a key, so the limit is discarded.
 opt locality=(region=east) expect=GenerateLocalityOptimizedScan
@@ -822,6 +856,7 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(3)
+ ├── distribution: east
  └── locality-optimized-search
       ├── columns: a:3!null b:4!null
       ├── left columns: a:11 b:12
@@ -829,6 +864,7 @@ project
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(3,4)
+      ├── distribution: east
       ├── scan abc_part@b_idx
       │    ├── columns: a:11!null b:12!null
       │    ├── constraint: /9/12: [/'east'/1 - /'east'/1]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -263,7 +263,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~17KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
+memo (optimized, ~16KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
  │         ├── best: (index-join G4 p,cols=(1-5))
@@ -787,7 +787,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
-memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~6KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (index-join G4 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G4 b,cols=(1-4))
@@ -1710,7 +1710,7 @@ CREATE INDEX idx2 ON p (i) WHERE s = 'foo'
 memo
 SELECT i FROM p WHERE i = 3 AND s = 'foo'
 ----
-memo (optimized, ~21KB, required=[presentation: i:2])
+memo (optimized, ~20KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -4476,7 +4476,7 @@ CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
 memo expect-not=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'baz'
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~7KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3)
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (select G2 G3)
@@ -5912,7 +5912,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~36KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~35KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -7806,7 +7806,7 @@ CREATE TABLE t58390 (
 memo
 SELECT * FROM t58390 WHERE a > 1 OR b > 1
 ----
-memo (optimized, ~22KB, required=[presentation: k:1,a:2,b:3,c:4])
+memo (optimized, ~21KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G1: (select G2 G3) (index-join G4 t58390,cols=(1-4)) (distinct-on G5 G6 cols=(1)) (distinct-on G5 G6 cols=(1),ordering=+1)
  │    └── [presentation: k:1,a:2,b:3,c:4]
  │         ├── best: (select G2 G3)
@@ -7921,7 +7921,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~32KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~11KB, required=[presentation: u:13,v:14,w:15])
+memo (optimized, ~10KB, required=[presentation: u:13,v:14,w:15])
  ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
  │    └── [presentation: u:13,v:14,w:15]
  │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)


### PR DESCRIPTION
This commit adds a new physical property called `Distribution` to
expressions in the optimizer. Currently, `Distribution` is just the
list of regions that are touched by the expression.

This commit also adds a new enforcer called `Distribute`, which enforces
a particular `Distribution` on its input. This is similar to the way
`Sort` enforces a particular `Ordering`. Currently, `Distribute` is only
used to enforce that the results of a query end up in the same region
as the gateway node.

The `Distribution` property and `Distribute` enforcer will enable us to
perform better costing of query plans in future commits. This commit
adds a tiny cost for the `Distribute` enforcer, but otherwise does not
yet take advantage of distribution for costing. In the future, we can use
`Distribution` to better cost distributed joins and aggregations, and
accurately cost the `Distribute` enforcer so as to avoid scanning data
in remote regions if possible.

This commit represents a departure from the approach taken in the earlier
prototype in #43831. Instead of using a "neighborhood" abstraction to
represent arbitrary collections of nodes, this commit sticks to the
existing abstractions of region and locality. If we need a new abstration
in the future, we should be able to simply modify the representation of
`Distribution`.

Additionally, this commit does not make an attempt to represent exactly
how data is partitioned across regions (e.g., which column is the
partitioning key, whether the data is hash or range partitioned, etc.);
it only tracks *which* regions contain data. This greatly simplifies the
implementation, and I don't think it will significantly reduce the
accuracy of costing.

Informs #47226

Release note: None