### PR TITLE
sql: don't formatStatementHideConstants when profiling prepared stmt

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -116,11 +116,17 @@ func (ex *connExecutor) execStmt(
 			if rAddr := ex.sessionData().RemoteAddr; rAddr != nil {
 				remoteAddr = rAddr.String()
 			}
+			var stmtNoConstants string
+			if prepared != nil {
+				stmtNoConstants = prepared.StatementNoConstants
+			} else {
+				stmtNoConstants = formatStatementHideConstants(ast)
+			}
 			labels := pprof.Labels(
 				"appname", ex.sessionData().ApplicationName,
 				"addr", remoteAddr,
 				"stmt.tag", ast.StatementTag(),
-				"stmt.no.constants", formatStatementHideConstants(ast),
+				"stmt.no.constants", stmtNoConstants,
 			)
 			pprof.Do(ctx, labels, func(ctx context.Context) {
 				ev, payload, err = ex.execStmtInOpenState(ctx, parserStmt, prepared, pinfo, res)


### PR DESCRIPTION
This commit removes the call to `formatStatementHideConstants` when
executing a prepared statement while CPU profiling is enabled. The
formatted statement is already available, so there's no need to
re-format.

Formatting isn't excessively expensive and we do expect CPU profiling to
be disruptive, so the cost wasn't a big deal on its own. However, the
more important part of the change is that it helps clean up the CPU
profiles and make them more representative.