### PR TITLE
vendor: update petermattis/goid to support fast access on arm64

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6100,10 +6100,10 @@ def go_deps():
         name = "com_github_petermattis_goid",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/petermattis/goid",
-        sha256 = "5134a176e306f9b973ff670a33c7536b59bf4114d83fd94f74c736ff0cc10ef0",
-        strip_prefix = "github.com/petermattis/goid@v0.0.0-20180202154549-b0b1615b78e5",
+        sha256 = "9f536c5d39d6a3c851670ec585e1c876fe31f3402556d215ebbaffcecbacb30a",
+        strip_prefix = "github.com/petermattis/goid@v0.0.0-20211229010228-4d14c490ee36",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/petermattis/goid/com_github_petermattis_goid-v0.0.0-20180202154549-b0b1615b78e5.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/petermattis/goid/com_github_petermattis_goid-v0.0.0-20211229010228-4d14c490ee36.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opennota/wd v0.0.0-20180911144301-b446539ab1e7 // indirect
 	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea // indirect
-	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
+	github.com/petermattis/goid v0.0.0-20211229010228-4d14c490ee36
 	github.com/pierrre/geohash v1.0.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1662,8 +1662,9 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea h1:sKwxy1H95npauwu8vtF95vG/syrL0p8fSZo/XlDg5gk=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
-github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
+github.com/petermattis/goid v0.0.0-20211229010228-4d14c490ee36 h1:64bxqeTEN0/xoEqhKGowgihNuzISS9rEG6YUMU4bzJo=
+github.com/petermattis/goid v0.0.0-20211229010228-4d14c490ee36/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=


### PR DESCRIPTION
This commit updates the `github.com/petermattis/goid` dependency to pick
up https://github.com/petermattis/goid/pull/11. This speeds up access to
a goroutine's ID on arm64 systems.

I originally noticed the need for this when running microbenchmarks in
`pkg/util/tracing`. Here is the effect of this change on those
benchmarks when run on an M1 Mac (goos: darwin, goarch: arm64):

```
name                                           old time/op    new time/op    delta
SpanCreation/detached-child=false-10             73.6µs ± 3%     2.1µs ± 4%  -97.10%  (p=0.000 n=10+10)
SpanCreation/detached-child=true-10              73.3µs ± 3%     2.5µs ± 4%  -96.62%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real-10                 6.51µs ± 3%    0.35µs ± 4%  -94.69%  (p=0.000 n=10+9)
Tracer_StartSpanCtx/opts=none-10                 6.53µs ± 3%    0.35µs ± 3%  -94.68%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real,logtag-10          6.54µs ± 5%    0.37µs ± 5%  -94.34%  (p=0.000 n=10+10)
RecordingWithStructuredEvent-10                  13.8µs ± 1%     0.9µs ± 4%  -93.46%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,autoparent-10      6.62µs ± 3%    0.46µs ± 9%  -93.12%  (p=0.000 n=10+9)
Tracer_StartSpanCtx/opts=real,manualparent-10    6.64µs ± 3%    0.48µs ± 5%  -92.73%  (p=0.000 n=10+9)
Span_GetRecording/root-only-10                   16.8ns ± 2%    16.8ns ± 4%     ~     (p=0.810 n=10+10)
Span_GetRecording/child-only-10                  16.7ns ± 2%    16.8ns ± 2%     ~     (p=0.342 n=10+10)
Span_GetRecording/root-child-10                  26.6ns ± 4%    26.3ns ± 1%     ~     (p=0.529 n=10+8)

name                                           old alloc/op   new alloc/op   delta
RecordingWithStructuredEvent-10                  1.68kB ± 0%    1.54kB ± 0%   -8.17%  (p=0.000 n=10+10)
SpanCreation/detached-child=false-10             5.01kB ± 0%    4.61kB ± 0%   -8.02%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=none-10                   834B ± 0%      768B ± 0%   -7.91%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real-10                   834B ± 0%      768B ± 0%   -7.91%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,logtag-10            834B ± 0%      768B ± 0%   -7.91%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,autoparent-10        834B ± 0%      768B ± 0%   -7.91%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real,manualparent-10      834B ± 0%      768B ± 0%   -7.91%  (p=0.000 n=10+10)
SpanCreation/detached-child=true-10              5.49kB ± 0%    5.09kB ± 0%   -7.36%  (p=0.002 n=8+10)
Span_GetRecording/root-only-10                    0.00B          0.00B          ~     (all equal)
Span_GetRecording/child-only-10                   0.00B          0.00B          ~     (all equal)
Span_GetRecording/root-child-10                   0.00B          0.00B          ~     (all equal)

name                                           old allocs/op  new allocs/op  delta
Tracer_StartSpanCtx/opts=none-10                   3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real-10                   3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,logtag-10            3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,autoparent-10        3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real,manualparent-10      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
RecordingWithStructuredEvent-10                    6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
SpanCreation/detached-child=false-10               18.0 ± 0%       6.0 ± 0%  -66.67%  (p=0.000 n=10+10)
SpanCreation/detached-child=true-10                28.0 ± 0%      16.0 ± 0%  -42.86%  (p=0.000 n=10+10)
Span_GetRecording/root-only-10                     0.00           0.00          ~     (all equal)
Span_GetRecording/child-only-10                    0.00           0.00          ~     (all equal)
Span_GetRecording/root-child-10                    0.00           0.00          ~     (all equal)
```