### PR TITLE
sql: use _idx suffix for unique partial and expression indexes

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -490,7 +490,11 @@ func mysqlTableToCockroach(
 		}
 		idx := tree.IndexTableDef{Name: idxName, Columns: elems}
 		if raw.Info.Primary || raw.Info.Unique {
-			stmt.Defs = append(stmt.Defs, &tree.UniqueConstraintTableDef{IndexTableDef: idx, PrimaryKey: raw.Info.Primary})
+			stmt.Defs = append(stmt.Defs, &tree.UniqueConstraintTableDef{
+				IndexTableDef: idx,
+				PrimaryKey:    raw.Info.Primary,
+				ExplicitIndex: !raw.Info.Primary,
+			})
 		} else {
 			stmt.Defs = append(stmt.Defs, &idx)
 		}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -637,7 +637,10 @@ func readPostgresStmt(
 			StorageParams:    stmt.StorageParams,
 		}
 		if stmt.Unique {
-			idx = &tree.UniqueConstraintTableDef{IndexTableDef: *idx.(*tree.IndexTableDef)}
+			idx = &tree.UniqueConstraintTableDef{
+				IndexTableDef: *idx.(*tree.IndexTableDef),
+				ExplicitIndex: true,
+			}
 		}
 		create.Defs = append(create.Defs, idx)
 	case *tree.AlterSchema:

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -160,12 +160,11 @@ func (p *planner) AlterPrimaryKey(
 		return pgerror.Newf(pgcode.DuplicateRelation, "index with name %s already exists", alterPKNode.Name)
 	}
 	newPrimaryIndexDesc := &descpb.IndexDescriptor{
-		Name:              name,
-		Unique:            true,
-		CreatedExplicitly: true,
-		EncodingType:      descpb.PrimaryIndexEncoding,
-		Type:              descpb.IndexDescriptor_FORWARD,
-		Version:           descpb.LatestNonPrimaryIndexDescriptorVersion,
+		Name:         name,
+		Unique:       true,
+		EncodingType: descpb.PrimaryIndexEncoding,
+		Type:         descpb.IndexDescriptor_FORWARD,
+		Version:      descpb.LatestNonPrimaryIndexDescriptorVersion,
 	}
 
 	// If the new index is requested to be sharded, set up the index descriptor

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -1167,6 +1167,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{2, 3},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "jobs_created_by_type_created_by_id_idx",
@@ -1179,6 +1180,7 @@ var (
 				StoreColumnNames:    []string{"status"},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "jobs_run_stats_idx",
@@ -1192,6 +1194,7 @@ var (
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
 				Predicate:           JobsRunStatsIdxPredicate,
+				CreatedExplicitly:   true,
 			},
 		))
 
@@ -1238,6 +1241,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{5},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "web_sessions_createdAt_idx",
@@ -1248,6 +1252,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{4},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "web_sessions_revokedAt_idx",
@@ -1258,6 +1263,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{6},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "web_sessions_lastUsedAt_idx",
@@ -1268,6 +1274,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{7},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 		))
 
@@ -1393,6 +1400,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{1},
 				KeySuffixColumnIDs:  []descpb.ColumnID{2},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 			descpb.IndexDescriptor{
 				Name:                "role_members_member_idx",
@@ -1403,6 +1411,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{2},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 		))
 
@@ -1765,6 +1774,7 @@ var (
 				KeyColumnDirections: []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC},
 				StoreColumnIDs:      []descpb.ColumnID{3, 6, 7},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 		))
 
@@ -1841,6 +1851,7 @@ var (
 				KeyColumnIDs:        []descpb.ColumnID{5},
 				KeySuffixColumnIDs:  []descpb.ColumnID{1},
 				Version:             descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:   true,
 			},
 		))
 
@@ -2030,6 +2041,7 @@ var (
 				KeyColumnIDs:       []descpb.ColumnID{2, 3},
 				KeySuffixColumnIDs: []descpb.ColumnID{11, 1, 4, 5, 6},
 				Version:            descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:  true,
 			},
 		),
 		func(tbl *descpb.TableDescriptor) {
@@ -2126,6 +2138,7 @@ var (
 				KeyColumnIDs:       []descpb.ColumnID{2},
 				KeySuffixColumnIDs: []descpb.ColumnID{8, 1, 3, 4},
 				Version:            descpb.LatestNonPrimaryIndexDescriptorVersion,
+				CreatedExplicitly:  true,
 			},
 		),
 		func(tbl *descpb.TableDescriptor) {

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -205,8 +205,9 @@ func BuildIndexName(tableDesc *Mutable, idx *descpb.IndexDescriptor) (string, er
 		segments = append(segments, segmentName)
 	}
 
-	// Add the final segment.
-	if idx.Unique {
+	// Add the final segment. Unique partial and unique expression indexes
+	// should always have the "idx" suffix.
+	if idx.Unique && !idx.CreatedExplicitly {
 		segments = append(segments, "key")
 	} else {
 		segments = append(segments, "idx")

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1677,9 +1677,10 @@ func NewTableDesc(
 				return nil, err
 			}
 			idx := descpb.IndexDescriptor{
-				Name:             string(d.Name),
-				StoreColumnNames: d.Storing.ToStrings(),
-				Version:          indexEncodingVersion,
+				Name:              string(d.Name),
+				StoreColumnNames:  d.Storing.ToStrings(),
+				Version:           indexEncodingVersion,
+				CreatedExplicitly: true,
 			}
 			if d.Inverted {
 				idx.Type = descpb.IndexDescriptor_INVERTED
@@ -1797,10 +1798,11 @@ func NewTableDesc(
 				return nil, err
 			}
 			idx := descpb.IndexDescriptor{
-				Name:             string(d.Name),
-				Unique:           true,
-				StoreColumnNames: d.Storing.ToStrings(),
-				Version:          indexEncodingVersion,
+				Name:              string(d.Name),
+				Unique:            true,
+				StoreColumnNames:  d.Storing.ToStrings(),
+				Version:           indexEncodingVersion,
+				CreatedExplicitly: d.ExplicitIndex,
 			}
 			columns := d.Columns
 			if d.Sharded != nil {
@@ -2446,6 +2448,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					def = &tree.UniqueConstraintTableDef{
 						IndexTableDef: indexDef,
 						PrimaryKey:    idx.Primary(),
+						ExplicitIndex: idx.IsCreatedExplicitly(),
 					}
 				}
 				if idx.IsPartial() {

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -423,7 +423,7 @@ CREATE TABLE public.copy_indexes (
    CONSTRAINT src_pkey PRIMARY KEY (k ASC),
    INDEX src_expr_idx ((a + b) ASC),
    INDEX named_idx ((a + 1:::INT8) ASC),
-   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+   UNIQUE INDEX src_expr_idx1 ((a + 10:::INT8) ASC),
    INVERTED INDEX src_expr_expr1_idx ((a + b), (j->'a':::STRING)),
    FAMILY "primary" (k, a, b, j, comp)
 )
@@ -451,7 +451,7 @@ CREATE TABLE public.copy_all (
    CONSTRAINT src_pkey PRIMARY KEY (k ASC),
    INDEX src_expr_idx ((a + b) ASC),
    INDEX named_idx ((a + 1:::INT8) ASC),
-   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+   UNIQUE INDEX src_expr_idx1 ((a + 10:::INT8) ASC),
    INVERTED INDEX src_expr_expr1_idx ((a + b), (j->'a':::STRING)),
    FAMILY "primary" (k, a, b, j)
 )
@@ -494,7 +494,7 @@ CREATE TABLE public.anon (
    CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
    INDEX anon_expr_idx ((a + b) ASC),
    INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
-   UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+   UNIQUE INDEX anon_expr_b_idx1 (lower(c) ASC, b ASC),
    INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
    INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
    FAMILY fam_0_k_a_b_c (k, a, b, c)
@@ -526,7 +526,7 @@ CREATE TABLE public.anon (
    CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
    INDEX anon_expr_idx ((a + b) ASC),
    INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
-   UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+   UNIQUE INDEX anon_expr_b_idx1 (lower(c) ASC, b ASC),
    INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
    INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
    FAMILY fam_0_k_a_b_c (k, a, b, c)
@@ -888,7 +888,7 @@ INSERT INTO uniq VALUES (1, 10, 100), (2, 20, 200)
 statement error duplicate key value violates unique constraint \"uniq_idx\"
 CREATE UNIQUE INDEX uniq_idx ON uniq ((a > 0))
 
-statement error duplicate key value violates unique constraint \"uniq_expr_key\"\nDETAIL: Key \(a \+ b\)=\(110\) already exists
+statement error duplicate key value violates unique constraint \"uniq_expr_idx\"\nDETAIL: Key \(a \+ b\)=\(110\) already exists
 INSERT INTO uniq VALUES (3, 1, 109)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -120,9 +120,9 @@ t6  CREATE TABLE public.t6 (
     INDEX t6_a_idx (a ASC) WHERE a > 0:::INT8,
     INDEX t6_a_idx1 (a ASC) WHERE a > 1:::INT8,
     INDEX t6_a_idx2 (a DESC) WHERE a > 2:::INT8,
-    UNIQUE INDEX t6_a_key (a ASC) WHERE a > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (a ASC) WHERE a > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (a DESC) WHERE a > 5:::INT8,
+    UNIQUE INDEX t6_a_idx3 (a ASC) WHERE a > 3:::INT8,
+    UNIQUE INDEX t6_a_idx4 (a ASC) WHERE a > 4:::INT8,
+    UNIQUE INDEX t6_a_idx5 (a DESC) WHERE a > 5:::INT8,
     INDEX t6i1 (a ASC) WHERE a > 6:::INT8,
     INDEX t6i2 (a ASC) WHERE a > 7:::INT8,
     INDEX t6i3 (a DESC) WHERE a > 8:::INT8,
@@ -144,9 +144,9 @@ t6  CREATE TABLE public.t6 (
     INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
     INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
     INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+    UNIQUE INDEX t6_a_idx3 (b ASC) WHERE b > 3:::INT8,
+    UNIQUE INDEX t6_a_idx4 (b ASC) WHERE b > 4:::INT8,
+    UNIQUE INDEX t6_a_idx5 (b DESC) WHERE b > 5:::INT8,
     INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
     INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
     INDEX t6i3 (b DESC) WHERE b > 8:::INT8,
@@ -168,9 +168,9 @@ t7  CREATE TABLE public.t7 (
     INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
     INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
     INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+    UNIQUE INDEX t6_a_idx3 (b ASC) WHERE b > 3:::INT8,
+    UNIQUE INDEX t6_a_idx4 (b ASC) WHERE b > 4:::INT8,
+    UNIQUE INDEX t6_a_idx5 (b DESC) WHERE b > 5:::INT8,
     INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
     INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
     INDEX t6i3 (b DESC) WHERE b > 8:::INT8,
@@ -237,7 +237,7 @@ query TTTTB colnames
 SHOW CONSTRAINTS FROM t11
 ----
 table_name  constraint_name  constraint_type  details                       validated
-t11         t11_a_key        UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
+t11         t11_a_idx        UNIQUE           UNIQUE (a ASC) WHERE (b > 0)  true
 t11         t11_b_key        UNIQUE           UNIQUE (b ASC) WHERE (a > 0)  true
 
 # Update a non-indexed column referenced by the predicate.
@@ -617,7 +617,7 @@ CREATE TABLE k (a INT, b INT)
 statement ok
 INSERT INTO k VALUES (1, 1), (1, 2)
 
-statement error pgcode 23505 violates unique constraint \"k_a_key\"
+statement error pgcode 23505 violates unique constraint \"k_a_idx\"
 CREATE UNIQUE INDEX ON k (a) WHERE b > 0
 
 statement ok
@@ -627,7 +627,7 @@ statement ok
 CREATE UNIQUE INDEX ON k (a) WHERE b > 0
 
 query II rowsort
-SELECT * FROM k@k_a_key WHERE b > 0
+SELECT * FROM k@k_a_idx WHERE b > 0
 ----
 1  1
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -559,8 +559,8 @@ oid         relname            relnamespace  reltype  reloftype  relowner    rel
 1656389978  t6_pkey            541687103     0        0          1546506610  2631952481  0            0
 1656389977  t6_expr_idx        541687103     0        0          1546506610  2631952481  0            0
 1656389976  t6_expr_expr1_idx  541687103     0        0          1546506610  2631952481  0            0
-1656389983  t6_expr_key        541687103     0        0          1546506610  2631952481  0            0
-1656389982  t6_expr_idx1       541687103     0        0          1546506610  2631952481  0            0
+1656389983  t6_expr_idx1       541687103     0        0          1546506610  2631952481  0            0
+1656389982  t6_expr_idx2       541687103     0        0          1546506610  2631952481  0            0
 71          mv1                541687103     100071   0          1546506610  0           0            0
 311312971   mv1_pkey           541687103     0        0          1546506610  2631952481  0            0
 
@@ -592,8 +592,8 @@ t6                 NULL      NULL       0              0              true      
 t6_pkey            NULL      NULL       0              0              false        false        p
 t6_expr_idx        NULL      NULL       0              0              false        false        p
 t6_expr_expr1_idx  NULL      NULL       0              0              false        false        p
-t6_expr_key        NULL      NULL       0              0              false        false        p
 t6_expr_idx1       NULL      NULL       0              0              false        false        p
+t6_expr_idx2       NULL      NULL       0              0              false        false        p
 mv1                NULL      NULL       0              0              true         false        p
 mv1_pkey           NULL      NULL       0              0              false        false        p
 
@@ -625,8 +625,8 @@ t6                 false      r        5         0          false       true
 t6_pkey            false      i        1         0          false       false
 t6_expr_idx        false      i        1         0          false       false
 t6_expr_expr1_idx  false      i        2         0          false       false
-t6_expr_key        false      i        1         0          false       false
 t6_expr_idx1       false      i        1         0          false       false
+t6_expr_idx2       false      i        1         0          false       false
 mv1                false      m        2         0          false       true
 mv1_pkey           false      i        1         0          false       false
 
@@ -658,8 +658,8 @@ t6                 false        false           false           0             NU
 t6_pkey            false        false           false           0             NULL    NULL
 t6_expr_idx        false        false           false           0             NULL    NULL
 t6_expr_expr1_idx  false        false           false           0             NULL    NULL
-t6_expr_key        false        false           false           0             NULL    NULL
 t6_expr_idx1       false        false           false           0             NULL    NULL
+t6_expr_idx2       false        false           false           0             NULL    NULL
 mv1                false        false           false           0             NULL    NULL
 mv1_pkey           false        false           false           0             NULL    NULL
 
@@ -728,8 +728,8 @@ attrelid    relname            attname                   atttypid  attstattarget
 1656389977  t6_expr_idx        crdb_internal_idx_expr    20        0              8       5       0         -1
 1656389976  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      7       0         -1
 1656389976  t6_expr_expr1_idx  crdb_internal_idx_expr_2  20        0              8       8       0         -1
-1656389983  t6_expr_key        crdb_internal_idx_expr_3  25        0              -1      9       0         -1
-1656389982  t6_expr_idx1       crdb_internal_idx_expr_4  16        0              1       10      0         -1
+1656389983  t6_expr_idx1       crdb_internal_idx_expr_3  25        0              -1      9       0         -1
+1656389982  t6_expr_idx2       crdb_internal_idx_expr_4  16        0              1       10      0         -1
 71          mv1                ?column?                  20        0              8       1       0         -1
 71          mv1                rowid                     20        0              8       2       0         -1
 311312971   mv1_pkey           rowid                     20        0              8       2       0         -1
@@ -797,8 +797,8 @@ t6_pkey            rowid                     -1         NULL      NULL        NU
 t6_expr_idx        crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       false      ·            v
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       false      ·            v
 t6_expr_expr1_idx  crdb_internal_idx_expr_2  -1         NULL      NULL        NULL      false       false      ·            v
-t6_expr_key        crdb_internal_idx_expr_3  -1         NULL      NULL        NULL      false       false      ·            v
-t6_expr_idx1       crdb_internal_idx_expr_4  -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_idx1       crdb_internal_idx_expr_3  -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_idx2       crdb_internal_idx_expr_4  -1         NULL      NULL        NULL      false       false      ·            v
 mv1                ?column?                  -1         NULL      NULL        NULL      false       false      ·            ·
 mv1                rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 mv1_pkey           rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
@@ -866,8 +866,8 @@ t6_pkey            rowid                     false         true        0        
 t6_expr_idx        crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
 t6_expr_expr1_idx  crdb_internal_idx_expr_2  false         true        0            NULL    NULL        NULL
-t6_expr_key        crdb_internal_idx_expr_3  false         true        0            NULL    NULL        NULL
-t6_expr_idx1       crdb_internal_idx_expr_4  false         true        0            NULL    NULL        NULL
+t6_expr_idx1       crdb_internal_idx_expr_3  false         true        0            NULL    NULL        NULL
+t6_expr_idx2       crdb_internal_idx_expr_4  false         true        0            NULL    NULL        NULL
 mv1                ?column?                  false         true        0            NULL    NULL        NULL
 mv1                rowid                     false         true        0            NULL    NULL        NULL
 mv1_pkey           rowid                     false         true        0            NULL    NULL        NULL
@@ -927,7 +927,7 @@ WHERE n.nspname = 'public'
 ----
 relname            attname                   typname   attcollation  collname
 t1                 d                         varchar   3403232968    default
-t6_expr_key        crdb_internal_idx_expr_3  text      3403232968    default
+t6_expr_idx1       crdb_internal_idx_expr_3  text      3403232968    default
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  text      3403232968    default
 t6                 c                         text      3403232968    default
 t5                 c                         text      3403232968    default
@@ -992,8 +992,8 @@ crdb_oid    schemaname  tablename  indexname          tablespace
 1656389978  public      t6         t6_pkey            NULL
 1656389977  public      t6         t6_expr_idx        NULL
 1656389976  public      t6         t6_expr_expr1_idx  NULL
-1656389983  public      t6         t6_expr_key        NULL
-1656389982  public      t6         t6_expr_idx1       NULL
+1656389983  public      t6         t6_expr_idx1       NULL
+1656389982  public      t6         t6_expr_idx2       NULL
 311312971   public      mv1        mv1_pkey           NULL
 
 query OTTT colnames
@@ -1016,8 +1016,8 @@ crdb_oid    tablename  indexname          indexdef
 1656389978  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
 1656389977  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
 1656389976  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
-1656389983  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
-1656389982  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::public.mytype) ASC) WHERE (m = 'foo'::public.mytype)
+1656389983  t6         t6_expr_idx1       CREATE UNIQUE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree (lower(c) ASC)
+1656389982  t6         t6_expr_idx2       CREATE INDEX t6_expr_idx2 ON constraint_db.public.t6 USING btree ((m = 'foo'::public.mytype) ASC) WHERE (m = 'foo'::public.mytype)
 311312971   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
 
 ## pg_catalog.pg_index
@@ -1066,8 +1066,8 @@ relname            indkey  indexprs                    indpred
 t6_pkey            6       NULL                        NULL
 t6_expr_idx        0       (a + b)                     NULL
 t6_expr_expr1_idx  0 0     (lower(c)) (a + b)          NULL
-t6_expr_key        0       (lower(c))                  NULL
-t6_expr_idx1       0       (m = 'foo'::public.mytype)  m = 'foo'::public.mytype
+t6_expr_idx1       0       (lower(c))                  NULL
+t6_expr_idx2       0       (m = 'foo'::public.mytype)  m = 'foo'::public.mytype
 
 statement ok
 SET DATABASE = system
@@ -1276,7 +1276,7 @@ oid         conname        connamespace  contype  condef
 3419369536  primary        541687103     p        PRIMARY KEY (value ASC)
 3540172298  index_key      541687103     u        UNIQUE (b ASC, c ASC)
 3540172299  t1_a_key       541687103     u        UNIQUE (a ASC)
-3734875191  t6_expr_key    541687103     u        UNIQUE (lower(c) ASC)
+3734875191  t6_expr_idx1   541687103     u        UNIQUE (lower(c) ASC)
 3823689858  fk             541687103     f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
 4221688865  fk             541687103     f        FOREIGN KEY (t1_id) REFERENCES t1(a)
 
@@ -1300,7 +1300,7 @@ fk_b_c         f        false          false        true          67        0   
 primary        p        false          false        true          61        0         4179599057
 index_key      u        false          false        true          60        0         1229708770
 t1_a_key       u        false          false        true          60        0         1229708771
-t6_expr_key    u        false          false        true          70        0         1656389983
+t6_expr_idx1   u        false          false        true          70        0         1656389983
 fk             f        false          false        true          64        0         1229708770
 fk             f        false          false        true          63        0         1229708771
 
@@ -1330,7 +1330,7 @@ t1_pkey        0          NULL         NULL         NULL
 primary        0          NULL         NULL         NULL
 index_key      0          NULL         NULL         NULL
 t1_a_key       0          NULL         NULL         NULL
-t6_expr_key    0          NULL         NULL         NULL
+t6_expr_idx1   0          NULL         NULL         NULL
 
 query TOTTT colnames
 SELECT conname, confrelid, confupdtype, confdeltype, confmatchtype
@@ -1365,7 +1365,7 @@ fk_b_c         true        0            true          {2,3}
 primary        true        0            true          {1}
 index_key      true        0            true          {3,4}
 t1_a_key       true        0            true          {2}
-t6_expr_key    true        0            true          {9}
+t6_expr_idx1   true        0            true          {9}
 fk             true        0            true          {1,2}
 fk             true        0            true          {1}
 
@@ -1387,7 +1387,7 @@ t1_pkey        NULL     NULL       NULL       NULL       NULL       NULL        
 primary        NULL     NULL       NULL       NULL       NULL       NULL               NULL               PRIMARY KEY (value ASC)
 index_key      NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (b ASC, c ASC)
 t1_a_key       NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (a ASC)
-t6_expr_key    NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (lower(c) ASC)
+t6_expr_idx1   NULL     NULL       NULL       NULL       NULL       NULL               NULL               UNIQUE (lower(c) ASC)
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc
@@ -4856,8 +4856,8 @@ WHERE tablename = 'partial_index_table'
 ----
 indexname                   indexdef
 partial_index_table_pkey    CREATE UNIQUE INDEX partial_index_table_pkey ON test.public.partial_index_table USING btree (rowid ASC)
-partial_index_table_a_key   CREATE UNIQUE INDEX partial_index_table_a_key ON test.public.partial_index_table USING btree (a ASC) WHERE (a > 0)
-partial_index_table_a_key1  CREATE UNIQUE INDEX partial_index_table_a_key1 ON test.public.partial_index_table USING btree (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
+partial_index_table_a_idx   CREATE UNIQUE INDEX partial_index_table_a_idx ON test.public.partial_index_table USING btree (a ASC) WHERE (a > 0)
+partial_index_table_a_idx1  CREATE UNIQUE INDEX partial_index_table_a_idx1 ON test.public.partial_index_table USING btree (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 query TT colnames
 SELECT conname, condef
@@ -4867,8 +4867,8 @@ WHERE t.relname = 'partial_index_table'
 ORDER BY conname
 ----
 conname                     condef
-partial_index_table_a_key   UNIQUE (a ASC) WHERE (a > 0)
-partial_index_table_a_key1  UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
+partial_index_table_a_idx   UNIQUE (a ASC) WHERE (a > 0)
+partial_index_table_a_idx1  UNIQUE (a ASC) WHERE (b IN ('foo'::public.testenum, 'bar'::public.testenum))
 
 subtest regression_46799
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1617,10 +1617,10 @@ vectorized: true
 • insert
 │ into: u(k, v)
 │ auto commit
-│ arbiter indexes: u_pkey, u_v_key
+│ arbiter indexes: u_pkey, u_v_idx
 │
 └── • lookup join (anti)
-    │ table: u@u_v_key
+    │ table: u@u_v_idx
     │ equality: (column2) = (v)
     │ equality cols are key
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1025,7 +1025,7 @@ vectorized: true
 • scan
   columns: (f float)
   estimated row count: 1 (missing stats)
-  table: flt@flt_f_key
+  table: flt@flt_f_idx
   spans: /NaN/0
 
 query T
@@ -1037,7 +1037,7 @@ vectorized: true
 • scan
   columns: (f float)
   estimated row count: 1 (missing stats)
-  table: flt@flt_f_key
+  table: flt@flt_f_idx
   spans: /NaN/0
 
 query T
@@ -1687,7 +1687,7 @@ vectorized: true
 ·
 • scan
   missing stats
-  table: b@b_c_key
+  table: b@b_c_idx
   spans: [/10 - /10] [/20 - /20]
 
 query T
@@ -1698,7 +1698,7 @@ vectorized: true
 ·
 • scan
   missing stats
-  table: b@b_c_key
+  table: b@b_c_idx
   spans: (/NULL - /1] [/10 - /10]
 
 statement ok
@@ -1714,7 +1714,7 @@ vectorized: true
 ·
 • scan
   missing stats
-  table: b@b_d_key
+  table: b@b_d_idx
   spans: [/10 - /10] [/1 - /NULL)
 
 statement ok
@@ -1730,7 +1730,7 @@ vectorized: true
 ·
 • scan
   missing stats
-  table: b@b_c_d_key
+  table: b@b_c_d_idx
   spans: [/NULL/1 - /NULL/1] [/10/10 - /10/10]
 
 statement ok
@@ -1748,7 +1748,7 @@ vectorized: true
 ·
 • scan
   missing stats
-  table: b@b_b_key
+  table: b@b_b_idx
   spans: [/10 - /10] [/20 - /20]
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -792,7 +792,7 @@ vectorized: true
                 │
                 └── • lookup join (semi)
                     │ columns: ("lookup_join_const_col_@22", column1, column2, column3, column4)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
+                    │ table: uniq_enum@uniq_enum_r_s_j_idx
                     │ equality: (lookup_join_const_col_@22, column2, column4) = (r,s,j)
                     │ equality cols are key
                     │ pred: (column1 != r) OR (column3 != i)
@@ -914,7 +914,7 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: uniq_enum(r, s, i, j)
 │ auto commit
-│ arbiter indexes: uniq_enum_pkey, uniq_enum_r_s_j_key
+│ arbiter indexes: uniq_enum_pkey, uniq_enum_r_s_j_idx
 │ arbiter constraints: unique_i, unique_s_j
 │
 └── • render
@@ -929,7 +929,7 @@ vectorized: true
     └── • lookup join (anti)
         │ columns: (column1, column2, column3, column4)
         │ estimated row count: 0 (missing stats)
-        │ table: uniq_enum@uniq_enum_r_s_j_key
+        │ table: uniq_enum@uniq_enum_r_s_j_idx
         │ equality cols are key
         │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
         │
@@ -950,7 +950,7 @@ vectorized: true
                 └── • lookup join (anti)
                     │ columns: (column1, column2, column3, column4)
                     │ estimated row count: 0 (missing stats)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
+                    │ table: uniq_enum@uniq_enum_r_s_j_idx
                     │ equality: (column1, column2, column4) = (r,s,j)
                     │ equality cols are key
                     │
@@ -2245,7 +2245,7 @@ vectorized: true
                 │
                 └── • lookup join (semi)
                     │ columns: (r_new, s_new, i_new, j, "lookup_join_const_col_@27")
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
+                    │ table: uniq_enum@uniq_enum_r_s_j_idx
                     │ equality: (lookup_join_const_col_@27, s_new, j) = (r,s,j)
                     │ equality cols are key
                     │ pred: (r_new != r) OR (i_new != i)
@@ -3463,7 +3463,7 @@ vectorized: true
                 │
                 └── • lookup join (semi)
                     │ columns: ("lookup_join_const_col_@30", upsert_r, column2, upsert_i, column4)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
+                    │ table: uniq_enum@uniq_enum_r_s_j_idx
                     │ equality: (lookup_join_const_col_@30, column2, column4) = (r,s,j)
                     │ equality cols are key
                     │ pred: (upsert_r != r) OR (upsert_i != i)
@@ -3543,7 +3543,7 @@ vectorized: true
 │                   └── • lookup join (left outer)
 │                       │ columns: (column1, column2, column3, column4, r, s, i, j)
 │                       │ estimated row count: 2 (missing stats)
-│                       │ table: uniq_enum@uniq_enum_r_s_j_key
+│                       │ table: uniq_enum@uniq_enum_r_s_j_idx
 │                       │ equality cols are key
 │                       │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
 │                       │ locking strength: for update

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -348,11 +348,11 @@ project
  └── scan c
       ├── columns: k:1(int!null) x:2(int!null) y:3(int) s:4(string) crdb_internal_mvcc_timestamp:5(decimal) tableoid:6(oid)
       ├── partial index predicates
-      │    ├── c_x_key: filters
+      │    ├── c_x_idx: filters
       │    │    └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
       │    │         ├── variable: s:4 [type=string]
       │    │         └── const: 'foo' [type=string]
-      │    └── c_y_key: filters
+      │    └── c_y_idx: filters
       │         └── eq [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight), fd=()-->(4)]
       │              ├── variable: s:4 [type=string]
       │              └── const: 'bar' [type=string]
@@ -372,7 +372,7 @@ index-join c
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── prune: (1-3)
  ├── interesting orderings: (+1 opt(4)) (+2 opt(4)) (+3,+1 opt(4))
- └── scan c@c_x_key,partial
+ └── scan c@c_x_idx,partial
       ├── columns: k:1(int!null) x:2(int!null)
       ├── key: (1)
       ├── fd: (1)-->(2), (2)-->(1)
@@ -390,7 +390,7 @@ index-join c
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── prune: (1-3)
  ├── interesting orderings: (+1 opt(4)) (+2 opt(4)) (+3,+1 opt(4))
- └── scan c@c_y_key,partial
+ └── scan c@c_y_idx,partial
       ├── columns: k:1(int!null) y:3(int)
       ├── key: (1)
       ├── fd: (1)-->(3), (3)~~>(1)

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -239,11 +239,11 @@ delete ambig
       │    ├── scan ambig
       │    │    ├── columns: partial_index_put1:7 ambig.partial_index_del1:8 check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    └── partial index predicates
-      │    │         ├── ambig_partial_index_put1_key: filters
+      │    │         ├── ambig_partial_index_put1_idx: filters
       │    │         │    └── partial_index_put1:7 > 0
-      │    │         ├── ambig_partial_index_del1_key: filters
+      │    │         ├── ambig_partial_index_del1_idx: filters
       │    │         │    └── ambig.partial_index_del1:8 > 0
-      │    │         └── ambig_partial_index_put1_idx: filters
+      │    │         └── ambig_partial_index_put1_idx1: filters
       │    │              └── check1:9 > 0
       │    └── filters
       │         └── ambig.partial_index_del1:8 = 5
@@ -431,11 +431,11 @@ update ambig
       │    │    │    ├── scan ambig
       │    │    │    │    ├── columns: ambig.partial_index_put1:7 ambig.partial_index_del1:8 ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── ambig_partial_index_put1_key: filters
+      │    │    │    │         ├── ambig_partial_index_put1_idx: filters
       │    │    │    │         │    └── ambig.partial_index_put1:7 > 0
-      │    │    │    │         ├── ambig_partial_index_del1_key: filters
+      │    │    │    │         ├── ambig_partial_index_del1_idx: filters
       │    │    │    │         │    └── ambig.partial_index_del1:8 > 0
-      │    │    │    │         └── ambig_partial_index_put1_idx: filters
+      │    │    │    │         └── ambig_partial_index_put1_idx1: filters
       │    │    │    │              └── ambig.check1:9 > 0
       │    │    │    └── filters
       │    │    │         └── (ambig.partial_index_put1:7 = 10) AND (ambig.partial_index_del1:8 = 20)
@@ -1011,7 +1011,7 @@ INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert uniq
  ├── columns: <none>
- ├── arbiter indexes: uniq_pkey uniq_b_key
+ ├── arbiter indexes: uniq_pkey uniq_b_idx
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1022,10 +1022,10 @@ insert uniq
       ├── project
       │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    └── upsert-distinct-on
-      │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_key_distinct:19
-      │         ├── grouping columns: column2:7!null arbiter_uniq_b_key_distinct:19
+      │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_idx_distinct:19
+      │         ├── grouping columns: column2:7!null arbiter_uniq_b_idx_distinct:19
       │         ├── project
-      │         │    ├── columns: arbiter_uniq_b_key_distinct:19 column1:6!null column2:7!null column3:8!null
+      │         │    ├── columns: arbiter_uniq_b_idx_distinct:19 column1:6!null column2:7!null column3:8!null
       │         │    ├── upsert-distinct-on
       │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │    ├── grouping columns: column1:6!null
@@ -1039,7 +1039,7 @@ insert uniq
       │         │    │    │    │    ├── scan uniq
       │         │    │    │    │    │    ├── columns: a:9!null b:10 c:11
       │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │         └── uniq_b_key: filters
+      │         │    │    │    │    │         └── uniq_b_idx: filters
       │         │    │    │    │    │              └── c:11 = 'foo'
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── column1:6 = a:9
@@ -1048,7 +1048,7 @@ insert uniq
       │         │    │    │    │    ├── scan uniq
       │         │    │    │    │    │    ├── columns: a:14!null b:15 c:16
       │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │         └── uniq_b_key: filters
+      │         │    │    │    │    │         └── uniq_b_idx: filters
       │         │    │    │    │    │              └── c:16 = 'foo'
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── c:16 = 'foo'
@@ -1061,7 +1061,7 @@ insert uniq
       │         │    │         └── first-agg [as=column3:8]
       │         │    │              └── column3:8
       │         │    └── projections
-      │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_key_distinct:19]
+      │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_idx_distinct:19]
       │         └── aggregations
       │              ├── first-agg [as=column1:6]
       │              │    └── column1:6
@@ -1080,7 +1080,7 @@ INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'b
 ----
 insert uniq
  ├── columns: <none>
- ├── arbiter indexes: uniq_b_key u2
+ ├── arbiter indexes: uniq_b_idx u2
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1098,10 +1098,10 @@ insert uniq
       │         │    ├── project
       │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │    └── upsert-distinct-on
-      │         │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_key_distinct:19
-      │         │    │         ├── grouping columns: column2:7!null arbiter_uniq_b_key_distinct:19
+      │         │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_idx_distinct:19
+      │         │    │         ├── grouping columns: column2:7!null arbiter_uniq_b_idx_distinct:19
       │         │    │         ├── project
-      │         │    │         │    ├── columns: arbiter_uniq_b_key_distinct:19 column1:6!null column2:7!null column3:8!null
+      │         │    │         │    ├── columns: arbiter_uniq_b_idx_distinct:19 column1:6!null column2:7!null column3:8!null
       │         │    │         │    ├── anti-join (hash)
       │         │    │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │         │    │    ├── anti-join (hash)
@@ -1114,7 +1114,7 @@ insert uniq
       │         │    │         │    │    │    │    ├── scan uniq
       │         │    │         │    │    │    │    │    ├── columns: a:9!null b:10 c:11
       │         │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │         ├── uniq_b_key: filters
+      │         │    │         │    │    │    │    │         ├── uniq_b_idx: filters
       │         │    │         │    │    │    │    │         │    └── c:11 = 'foo'
       │         │    │         │    │    │    │    │         └── u2: filters
       │         │    │         │    │    │    │    │              └── c:11 = 'bar'
@@ -1128,7 +1128,7 @@ insert uniq
       │         │    │         │    │    │    ├── scan uniq
       │         │    │         │    │    │    │    ├── columns: a:14!null b:15 c:16
       │         │    │         │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │         ├── uniq_b_key: filters
+      │         │    │         │    │    │    │         ├── uniq_b_idx: filters
       │         │    │         │    │    │    │         │    └── c:16 = 'foo'
       │         │    │         │    │    │    │         └── u2: filters
       │         │    │         │    │    │    │              └── c:16 = 'bar'
@@ -1138,7 +1138,7 @@ insert uniq
       │         │    │         │    │         ├── column2:7 = b:15
       │         │    │         │    │         └── column3:8 = 'bar'
       │         │    │         │    └── projections
-      │         │    │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_key_distinct:19]
+      │         │    │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_idx_distinct:19]
       │         │    │         └── aggregations
       │         │    │              ├── first-agg [as=column1:6]
       │         │    │              │    └── column1:6
@@ -1194,7 +1194,7 @@ insert uniq
       │    │    ├── scan uniq
       │    │    │    ├── columns: a:9!null b:10 c:11
       │    │    │    └── partial index predicates
-      │    │    │         ├── uniq_b_key: filters
+      │    │    │         ├── uniq_b_idx: filters
       │    │    │         │    └── c:11 = 'foo'
       │    │    │         └── u2: filters
       │    │    │              └── c:11 = 'bar'
@@ -1271,7 +1271,7 @@ INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' DO UPDATE 
 ----
 upsert uniq
  ├── columns: <none>
- ├── arbiter indexes: uniq_b_key
+ ├── arbiter indexes: uniq_b_idx
  ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12
  ├── insert-mapping:
@@ -1293,15 +1293,15 @@ upsert uniq
       │    │    │    ├── project
       │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_key_distinct:9
-      │    │    │    │         ├── grouping columns: column2:7!null arbiter_uniq_b_key_distinct:9
+      │    │    │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_b_idx_distinct:9
+      │    │    │    │         ├── grouping columns: column2:7!null arbiter_uniq_b_idx_distinct:9
       │    │    │    │         ├── project
-      │    │    │    │         │    ├── columns: arbiter_uniq_b_key_distinct:9 column1:6!null column2:7!null column3:8!null
+      │    │    │    │         │    ├── columns: arbiter_uniq_b_idx_distinct:9 column1:6!null column2:7!null column3:8!null
       │    │    │    │         │    ├── values
       │    │    │    │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    │         │    │    └── (1, 1, 'bar')
       │    │    │    │         │    └── projections
-      │    │    │    │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_key_distinct:9]
+      │    │    │    │         │         └── (column3:8 = 'foo') OR NULL::BOOL [as=arbiter_uniq_b_idx_distinct:9]
       │    │    │    │         └── aggregations
       │    │    │    │              ├── first-agg [as=column1:6]
       │    │    │    │              │    └── column1:6
@@ -1312,7 +1312,7 @@ upsert uniq
       │    │    │    │    ├── scan uniq
       │    │    │    │    │    ├── columns: a:10!null b:11 c:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │         ├── uniq_b_key: filters
+      │    │    │    │    │         ├── uniq_b_idx: filters
       │    │    │    │    │         │    └── c:12 = 'foo'
       │    │    │    │    │         └── u2: filters
       │    │    │    │    │              └── c:12 = 'bar'
@@ -1342,7 +1342,7 @@ DO UPDATE SET partial_index_put1 = 10, partial_index_del1 = 20
 ----
 upsert ambig
  ├── columns: <none>
- ├── arbiter indexes: ambig_partial_index_put1_key
+ ├── arbiter indexes: ambig_partial_index_put1_idx
  ├── canary column: rowid:15
  ├── fetch columns: ambig.partial_index_put1:12 ambig.partial_index_del1:13 ambig.check1:14 rowid:15
  ├── insert-mapping:
@@ -1369,10 +1369,10 @@ upsert ambig
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column1:7!null column2:8!null check1_default:9 rowid_default:10
       │    │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │    │         ├── columns: column1:7!null column2:8!null check1_default:9 rowid_default:10 arbiter_ambig_partial_index_put1_key_distinct:11
-      │    │    │    │    │         ├── grouping columns: column1:7!null arbiter_ambig_partial_index_put1_key_distinct:11
+      │    │    │    │    │         ├── columns: column1:7!null column2:8!null check1_default:9 rowid_default:10 arbiter_ambig_partial_index_put1_idx_distinct:11
+      │    │    │    │    │         ├── grouping columns: column1:7!null arbiter_ambig_partial_index_put1_idx_distinct:11
       │    │    │    │    │         ├── project
-      │    │    │    │    │         │    ├── columns: arbiter_ambig_partial_index_put1_key_distinct:11 column1:7!null column2:8!null check1_default:9 rowid_default:10
+      │    │    │    │    │         │    ├── columns: arbiter_ambig_partial_index_put1_idx_distinct:11 column1:7!null column2:8!null check1_default:9 rowid_default:10
       │    │    │    │    │         │    ├── project
       │    │    │    │    │         │    │    ├── columns: check1_default:9 rowid_default:10 column1:7!null column2:8!null
       │    │    │    │    │         │    │    ├── values
@@ -1382,7 +1382,7 @@ upsert ambig
       │    │    │    │    │         │    │         ├── NULL::INT8 [as=check1_default:9]
       │    │    │    │    │         │    │         └── unique_rowid() [as=rowid_default:10]
       │    │    │    │    │         │    └── projections
-      │    │    │    │    │         │         └── (column1:7 > 0) OR NULL::BOOL [as=arbiter_ambig_partial_index_put1_key_distinct:11]
+      │    │    │    │    │         │         └── (column1:7 > 0) OR NULL::BOOL [as=arbiter_ambig_partial_index_put1_idx_distinct:11]
       │    │    │    │    │         └── aggregations
       │    │    │    │    │              ├── first-agg [as=column2:8]
       │    │    │    │    │              │    └── column2:8
@@ -1395,11 +1395,11 @@ upsert ambig
       │    │    │    │    │    ├── scan ambig
       │    │    │    │    │    │    ├── columns: ambig.partial_index_put1:12 ambig.partial_index_del1:13 ambig.check1:14 rowid:15!null crdb_internal_mvcc_timestamp:16 tableoid:17
       │    │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │    │         ├── ambig_partial_index_put1_key: filters
+      │    │    │    │    │    │         ├── ambig_partial_index_put1_idx: filters
       │    │    │    │    │    │         │    └── ambig.partial_index_put1:12 > 0
-      │    │    │    │    │    │         ├── ambig_partial_index_del1_key: filters
+      │    │    │    │    │    │         ├── ambig_partial_index_del1_idx: filters
       │    │    │    │    │    │         │    └── ambig.partial_index_del1:13 > 0
-      │    │    │    │    │    │         └── ambig_partial_index_put1_idx: filters
+      │    │    │    │    │    │         └── ambig_partial_index_put1_idx1: filters
       │    │    │    │    │    │              └── ambig.check1:14 > 0
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── ambig.partial_index_put1:12 > 0

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -1311,7 +1311,7 @@ ON CONFLICT (a) WHERE b > 10 DO NOTHING
 ----
 insert uniq_partial_constraint_and_index
  ├── columns: <none>
- ├── arbiter indexes: uniq_partial_constraint_and_index_a_key
+ ├── arbiter indexes: uniq_partial_constraint_and_index_a_idx
  ├── insert-mapping:
  │    ├── column1:6 => uniq_partial_constraint_and_index.k:1
  │    ├── column2:7 => uniq_partial_constraint_and_index.a:2
@@ -1330,7 +1330,7 @@ insert uniq_partial_constraint_and_index
  │    │    │    ├── scan uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.a:10
  │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │         └── uniq_partial_constraint_and_index_a_idx: filters (true)
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:10 = 1
  │    │    └── filters (true)
@@ -1357,7 +1357,7 @@ insert uniq_partial_constraint_and_index
                      │    ├── scan uniq_partial_constraint_and_index
                      │    │    ├── columns: uniq_partial_constraint_and_index.k:16!null uniq_partial_constraint_and_index.a:17 uniq_partial_constraint_and_index.b:18
                      │    │    └── partial index predicates
-                     │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+                     │    │         └── uniq_partial_constraint_and_index_a_idx: filters (true)
                      │    └── filters
                      │         └── uniq_partial_constraint_and_index.b:18 > 10
                      └── filters
@@ -1401,7 +1401,7 @@ insert uniq_constraint_and_partial_index
       │    │    ├── scan uniq_constraint_and_partial_index
       │    │    │    ├── columns: a:10
       │    │    │    └── partial index predicates
-      │    │    │         └── uniq_constraint_and_partial_index_a_key: filters
+      │    │    │         └── uniq_constraint_and_partial_index_a_idx: filters
       │    │    │              └── b:11 > 0
       │    │    └── filters
       │    │         └── a:10 = 1
@@ -1427,7 +1427,7 @@ ON CONFLICT (a) WHERE b > 10 DO NOTHING
 ----
 insert uniq_partial_constraint_and_partial_index
  ├── columns: <none>
- ├── arbiter indexes: uniq_partial_constraint_and_partial_index_a_key
+ ├── arbiter indexes: uniq_partial_constraint_and_partial_index_a_idx
  ├── arbiter constraints: unique_a
  ├── insert-mapping:
  │    ├── column1:6 => k:1
@@ -1446,10 +1446,10 @@ insert uniq_partial_constraint_and_partial_index
       │         │    ├── project
       │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │    └── upsert-distinct-on
-      │         │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_partial_constraint_and_partial_index_a_key_distinct:19
-      │         │    │         ├── grouping columns: column2:7!null arbiter_uniq_partial_constraint_and_partial_index_a_key_distinct:19
+      │         │    │         ├── columns: column1:6!null column2:7!null column3:8!null arbiter_uniq_partial_constraint_and_partial_index_a_idx_distinct:19
+      │         │    │         ├── grouping columns: column2:7!null arbiter_uniq_partial_constraint_and_partial_index_a_idx_distinct:19
       │         │    │         ├── project
-      │         │    │         │    ├── columns: arbiter_uniq_partial_constraint_and_partial_index_a_key_distinct:19 column1:6!null column2:7!null column3:8!null
+      │         │    │         │    ├── columns: arbiter_uniq_partial_constraint_and_partial_index_a_idx_distinct:19 column1:6!null column2:7!null column3:8!null
       │         │    │         │    ├── anti-join (hash)
       │         │    │         │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │         │    │         │    │    ├── anti-join (hash)
@@ -1462,7 +1462,7 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    │    ├── columns: k:9!null a:10 b:11
       │         │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_key: filters
+      │         │    │         │    │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_idx: filters
       │         │    │         │    │    │    │    │              └── b:11 > 0
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         └── b:11 > 0
@@ -1474,7 +1474,7 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    ├── scan uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    ├── columns: k:14!null a:15 b:16
       │         │    │         │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_key: filters
+      │         │    │         │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_idx: filters
       │         │    │         │    │    │    │              └── b:16 > 0
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         └── b:16 > 10
@@ -1482,7 +1482,7 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │         ├── column2:7 = a:15
       │         │    │         │    │         └── column3:8 > 10
       │         │    │         │    └── projections
-      │         │    │         │         └── (column3:8 > 0) OR NULL::BOOL [as=arbiter_uniq_partial_constraint_and_partial_index_a_key_distinct:19]
+      │         │    │         │         └── (column3:8 > 0) OR NULL::BOOL [as=arbiter_uniq_partial_constraint_and_partial_index_a_idx_distinct:19]
       │         │    │         └── aggregations
       │         │    │              ├── first-agg [as=column1:6]
       │         │    │              │    └── column1:6

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -1801,7 +1801,7 @@ ON CONFLICT (a) WHERE b > 10 DO UPDATE SET a = 10
 ----
 upsert uniq_partial_constraint_and_index
  ├── columns: <none>
- ├── arbiter indexes: uniq_partial_constraint_and_index_a_key
+ ├── arbiter indexes: uniq_partial_constraint_and_index_a_idx
  ├── canary column: uniq_partial_constraint_and_index.k:10
  ├── fetch columns: uniq_partial_constraint_and_index.k:10 uniq_partial_constraint_and_index.a:11 uniq_partial_constraint_and_index.b:12
  ├── insert-mapping:
@@ -1825,7 +1825,7 @@ upsert uniq_partial_constraint_and_index
  │    │    │    ├── scan uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.k:10!null uniq_partial_constraint_and_index.a:11 uniq_partial_constraint_and_index.b:12
  │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │         └── uniq_partial_constraint_and_index_a_idx: filters (true)
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:11 = 1
  │    │    └── filters (true)
@@ -1855,7 +1855,7 @@ upsert uniq_partial_constraint_and_index
                      │    ├── scan uniq_partial_constraint_and_index
                      │    │    ├── columns: uniq_partial_constraint_and_index.k:20!null uniq_partial_constraint_and_index.a:21 uniq_partial_constraint_and_index.b:22
                      │    │    └── partial index predicates
-                     │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+                     │    │         └── uniq_partial_constraint_and_index_a_idx: filters (true)
                      │    └── filters
                      │         └── uniq_partial_constraint_and_index.b:22 > 10
                      └── filters
@@ -1905,7 +1905,7 @@ upsert uniq_constraint_and_partial_index
  │    │    │    ├── scan uniq_constraint_and_partial_index
  │    │    │    │    ├── columns: uniq_constraint_and_partial_index.k:10!null uniq_constraint_and_partial_index.a:11 uniq_constraint_and_partial_index.b:12
  │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_constraint_and_partial_index_a_key: filters
+ │    │    │    │         └── uniq_constraint_and_partial_index_a_idx: filters
  │    │    │    │              └── uniq_constraint_and_partial_index.b:12 > 0
  │    │    │    └── filters
  │    │    │         └── uniq_constraint_and_partial_index.a:11 = 1
@@ -1929,7 +1929,7 @@ upsert uniq_constraint_and_partial_index
                      ├── scan uniq_constraint_and_partial_index
                      │    ├── columns: uniq_constraint_and_partial_index.k:21!null uniq_constraint_and_partial_index.a:22
                      │    └── partial index predicates
-                     │         └── uniq_constraint_and_partial_index_a_key: filters
+                     │         └── uniq_constraint_and_partial_index_a_idx: filters
                      │              └── uniq_constraint_and_partial_index.b:23 > 0
                      └── filters
                           ├── a:27 = uniq_constraint_and_partial_index.a:22

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -48,6 +48,10 @@ CREATE INDEX idx ON kv (v) STORING (k) WHERE v > 1
 ----
 
 exec-ddl
+CREATE UNIQUE INDEX ON kv (v) WHERE v > 10
+----
+
+exec-ddl
 SHOW CREATE kv
 ----
 TABLE kv
@@ -57,10 +61,14 @@ TABLE kv
  ├── tableoid oid [hidden] [system]
  ├── PRIMARY INDEX kv_pkey
  │    └── k int not null
- └── INDEX idx
+ ├── INDEX idx
+ │    ├── v int
+ │    ├── k int not null
+ │    └── WHERE v > 1
+ └── UNIQUE INDEX kv_v_idx
       ├── v int
-      ├── k int not null
-      └── WHERE v > 1
+      ├── k int not null (storing)
+      └── WHERE v > 10
 
 exec-ddl
 CREATE TABLE g (
@@ -107,6 +115,7 @@ CREATE TABLE xyz (
     INDEX idx1 (lower(z)),
     INDEX idx2 (lower(z), y),
     INDEX idx3 ((y+1), lower(z)),
+    UNIQUE INDEX ((y+10)),
     INVERTED INDEX idx4 ((j->'a')),
     INVERTED INDEX idx5 (y, z, (j->'a'))
 )
@@ -134,14 +143,15 @@ TABLE xyz
  ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [inaccessible]
  ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [inaccessible]
  ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [inaccessible]
- ├── crdb_internal_idx_expr_4 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_4 int as (y + 10) virtual [inaccessible]
  ├── crdb_internal_idx_expr_5 jsonb as (j->'a') virtual [inaccessible]
  ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
- ├── crdb_internal_idx_expr_6 int as (x + y) virtual [inaccessible]
+ ├── crdb_internal_idx_expr_6 jsonb as (j->'a') virtual [inaccessible]
+ ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [inverted]
  ├── crdb_internal_idx_expr_7 int as (x + y) virtual [inaccessible]
- ├── crdb_internal_idx_expr_8 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_8 int as (x + y) virtual [inaccessible]
+ ├── crdb_internal_idx_expr_9 jsonb as (j->'a') virtual [inaccessible]
+ ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [inverted]
  ├── PRIMARY INDEX xyz_pkey
  │    └── x int not null
  ├── INDEX idx1
@@ -155,22 +165,25 @@ TABLE xyz
  │    ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [inaccessible]
  │    ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [inaccessible]
  │    └── x int not null
+ ├── UNIQUE INDEX xyz_expr_idx
+ │    ├── crdb_internal_idx_expr_4 int as (y + 10) virtual [inaccessible]
+ │    └── x int not null (storing)
  ├── INVERTED INDEX idx4
- │    ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INVERTED INDEX idx5
  │    ├── y int
  │    ├── z string
- │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_6_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INDEX idx6
- │    ├── crdb_internal_idx_expr_6 int as (x + y) virtual [inaccessible]
+ │    ├── crdb_internal_idx_expr_7 int as (x + y) virtual [inaccessible]
  │    ├── y int
  │    ├── x int not null
  │    ├── z string (storing)
  │    └── WHERE v > 1
  └── INVERTED INDEX idx7
-      ├── crdb_internal_idx_expr_7 int as (x + y) virtual [inaccessible]
-      ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
+      ├── crdb_internal_idx_expr_8 int as (x + y) virtual [inaccessible]
+      ├── crdb_internal_idx_expr_9_inverted_key jsonb not null [inverted]
       ├── x int not null
       └── WHERE v > 1

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7056,6 +7056,7 @@ index_def:
         StorageParams:    $10.storageParams(),
         Predicate:        $11.expr(),
       },
+      ExplicitIndex: true,
     }
   }
 | INVERTED INDEX opt_name '(' index_params ')' opt_partition_by_index opt_with_storage_parameter_list opt_where_clause
@@ -7433,7 +7434,7 @@ sequence_option_list:
 | sequence_option_list sequence_option_elem  { $$.val = append($1.seqOpts(), $2.seqOpt()) }
 
 sequence_option_elem:
-  AS typename                  { 
+  AS typename                  {
                                   // Valid option values must be integer types (ex. int2, bigint)
                                   parsedType := $2.colType()
                                   if parsedType.Family() != types.IntFamily {

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -165,6 +165,7 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 		if unique {
 			defs = append(defs, &tree.UniqueConstraintTableDef{
 				IndexTableDef: indexDef,
+				ExplicitIndex: rng.Intn(2) == 0,
 			})
 		} else {
 			defs = append(defs, &indexDef)

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -993,6 +993,12 @@ type UniqueConstraintTableDef struct {
 	PrimaryKey   bool
 	WithoutIndex bool
 	IfNotExists  bool
+
+	// ExplicitIndex is true when the unique index was created explicitly using
+	// a UNIQUE INDEX clause in either CREATE TABLE or CREATE INDEX. It is false
+	// when the unique index was implicitly created from a CONSTRAINT ... UNIQUE
+	// clause in CREATE TABLE or ALTER TABLE.
+	ExplicitIndex bool
 }
 
 // SetName implements the TableDef interface.

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -128,7 +128,7 @@ func TestShowCreateTable(t *testing.T) {
 	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
 	CONSTRAINT %[1]s_pkey PRIMARY KEY (rowid ASC),
 	INDEX idx_if (f ASC, i ASC) STORING (s, d),
-	UNIQUE INDEX %[1]s_d_key (d ASC),
+	UNIQUE INDEX %[1]s_d_idx (d ASC),
 	FAMILY "primary" (i, f, d, rowid),
 	FAMILY fam_1_s (s)
 )`,


### PR DESCRIPTION
Only anonymous unique constraints should have the `_key` suffix.
Anonymous unique indexes should have the `_idx` suffix. CRDB currently
parsers unqiue constraints and unique str's internal

TODO

Release note (<category, see below>): <what> <show> <why>