### PR TITLE
[DNM] col/coldata: batch allocate big.Int coefficients for Decimals vectors

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -264,7 +264,7 @@ func mysqlValueToDatum(
 				return tree.NewDFloat(-*i), nil
 			case *tree.DDecimal:
 				dec := &i.Decimal
-				dd := &tree.DDecimal{}
+				dd := tree.NewDDecimal()
 				dd.Decimal.Neg(dec)
 				return dd, nil
 			default:

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -73,8 +72,9 @@ func makeDatumFromColOffset(
 			case types.IntFamily:
 				return alloc.NewDInt(tree.DInt(col.Int64()[rowIdx])), nil
 			case types.DecimalFamily:
-				d := *apd.New(col.Int64()[rowIdx], 0)
-				return alloc.NewDDecimal(tree.DDecimal{Decimal: d}), nil
+				d := alloc.NewDDecimal(tree.DDecimal{})
+				d.SetInt64(col.Int64()[rowIdx])
+				return d, nil
 			case types.DateFamily:
 				date, err := pgdate.MakeDateFromUnixEpoch(col.Int64()[rowIdx])
 				if err != nil {
@@ -93,11 +93,11 @@ func makeDatumFromColOffset(
 		case types.FloatFamily:
 			return alloc.NewDFloat(tree.DFloat(col.Float64()[rowIdx])), nil
 		case types.DecimalFamily:
-			var d apd.Decimal
+			d := alloc.NewDDecimal(tree.DDecimal{})
 			if _, err := d.SetFloat64(col.Float64()[rowIdx]); err != nil {
 				return nil, err
 			}
-			return alloc.NewDDecimal(tree.DDecimal{Decimal: d}), nil
+			return d, nil
 		}
 	case types.BytesFamily:
 		switch hint.Family() {

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -1401,8 +1401,15 @@ func tupleEquals(expected Tuple, actual Tuple, evalCtx *tree.EvalContext) bool {
 			}
 			// Special case for decimals.
 			if d1, ok := actual[i].(apd.Decimal); ok {
-				if f2, ok := expected[i].(float64); ok {
-					d2, _, err := apd.NewFromString(fmt.Sprintf("%f", f2))
+				switch t := expected[i].(type) {
+				case apd.Decimal:
+					if d1.Cmp(&t) == 0 {
+						continue
+					} else {
+						return false
+					}
+				case float64:
+					d2, _, err := apd.NewFromString(fmt.Sprintf("%f", t))
 					if err == nil && d1.Cmp(d2) == 0 {
 						continue
 					} else {

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -67,14 +67,10 @@ var vecToDatumConversionTmpls = map[types.Family]string{
 	types.BoolFamily: `%[1]s := tree.MakeDBool(tree.DBool(%[2]s))`,
 	// Note that currently, regardless of the integer's width, we always return
 	// INT8, so there is a single conversion template for IntFamily.
-	types.IntFamily:   `%[1]s := %[3]s.NewDInt(tree.DInt(%[2]s))`,
-	types.FloatFamily: `%[1]s := %[3]s.NewDFloat(tree.DFloat(%[2]s))`,
-	types.DecimalFamily: `  %[1]s := %[3]s.NewDDecimal(tree.DDecimal{Decimal: %[2]s})
-							// Clear the Coeff so that the Set below allocates a new slice for the
-							// Coeff.abs field.
-							%[1]s.Coeff = big.Int{}
-							%[1]s.Coeff.Set(&%[2]s.Coeff)`,
-	types.DateFamily: `%[1]s := %[3]s.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(%[2]s)})`,
+	types.IntFamily:     `%[1]s := %[3]s.NewDInt(tree.DInt(%[2]s))`,
+	types.FloatFamily:   `%[1]s := %[3]s.NewDFloat(tree.DFloat(%[2]s))`,
+	types.DecimalFamily: `%[1]s := %[3]s.NewDDecimal(tree.DDecimal{Decimal: %[2]s})`,
+	types.DateFamily:    `%[1]s := %[3]s.NewDDate(tree.DDate{Date: pgdate.MakeCompatibleDateFromDisk(%[2]s)})`,
 	types.BytesFamily: `// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
 						%[1]s := %[3]s.NewDBytes(tree.DBytes(%[2]s))`,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1554,7 +1554,7 @@ func golangFillQueryArguments(args ...interface{}) (tree.Datums, error) {
 		case bitarray.BitArray:
 			d = &tree.DBitArray{BitArray: t}
 		case *apd.Decimal:
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			dd.Set(t)
 			d = dd
 		case security.SQLUsername:

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -116,7 +116,7 @@ func RandDatumWithNullChance(rng *rand.Rand, typ *types.T, nullChance int) tree.
 		}
 		return tree.NewDGeometry(geogen.RandomGeometry(rng, gm.SRID))
 	case types.DecimalFamily:
-		d := &tree.DDecimal{}
+		d := tree.NewDDecimal()
 		// int64(rng.Uint64()) to get negative numbers, too
 		d.Decimal.SetFinite(int64(rng.Uint64()), int32(rng.Intn(40)-20))
 		return d

--- a/pkg/sql/rowenc/datum_alloc.go
+++ b/pkg/sql/rowenc/datum_alloc.go
@@ -34,7 +34,7 @@ type DatumAlloc struct {
 	dstringAlloc      []tree.DString
 	dbytesAlloc       []tree.DBytes
 	dbitArrayAlloc    []tree.DBitArray
-	ddecimalAlloc     []tree.DDecimal
+	ddecimalAlloc     []tree.DDecimalAlloc
 	ddateAlloc        []tree.DDate
 	denumAlloc        []tree.DEnum
 	dbox2dAlloc       []tree.DBox2D
@@ -170,10 +170,10 @@ func (a *DatumAlloc) NewDDecimal(v tree.DDecimal) *tree.DDecimal {
 	}
 	buf := &a.ddecimalAlloc
 	if len(*buf) == 0 {
-		*buf = make([]tree.DDecimal, a.AllocSize)
+		*buf = make([]tree.DDecimalAlloc, a.AllocSize)
 	}
-	r := &(*buf)[0]
-	*r = v
+	r := (*buf)[0].Get()
+	r.Set(&v.Decimal)
 	*buf = (*buf)[1:]
 	return r
 }

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -60,7 +60,7 @@ func toEncDatum(datumType *types.T, v interface{}) rowenc.EncDatum {
 		switch concreteType := v.(type) {
 		case int:
 			if datumType.Family() == types.DecimalFamily {
-				dd := &tree.DDecimal{}
+				dd := tree.NewDDecimal()
 				dd.SetInt64(int64(v.(int)))
 				return dd
 			}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -2577,7 +2577,7 @@ func (a *intSumAggregate) Result() (tree.Datum, error) {
 	if !a.seenNonNull {
 		return tree.DNull, nil
 	}
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	if a.large {
 		dd.Set(&a.decSum)
 	} else {
@@ -2644,7 +2644,7 @@ func (a *decimalSumAggregate) Result() (tree.Datum, error) {
 	if !a.sawNonNull {
 		return tree.DNull, nil
 	}
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	dd.Set(&a.sum)
 	return dd, nil
 }
@@ -2947,7 +2947,7 @@ func (a *decimalSqrDiffAggregate) Result() (tree.Datum, error) {
 	if a.count.Cmp(decimalOne) < 0 {
 		return tree.DNull, nil
 	}
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	dd.Set(&a.sqrDiff)
 	// Remove trailing zeros. Depending on the order in which the input
 	// is processed, some number of trailing zeros could be added to the
@@ -3267,7 +3267,7 @@ func (a *decimalVarianceAggregate) Result() (tree.Datum, error) {
 	if _, err = tree.IntermediateCtx.Sub(a.agg.Tmp(), a.agg.Count(), decimalOne); err != nil {
 		return nil, err
 	}
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	if _, err = tree.DecimalCtx.Quo(&dd.Decimal, &sqrDiff.(*tree.DDecimal).Decimal, a.agg.Tmp()); err != nil {
 		return nil, err
 	}
@@ -3382,7 +3382,7 @@ func (a *decimalVarPopAggregate) Result() (tree.Datum, error) {
 	if err != nil {
 		return nil, err
 	}
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	if _, err = tree.DecimalCtx.Quo(&dd.Decimal, &sqrDiff.(*tree.DDecimal).Decimal, a.agg.Count()); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -499,7 +499,7 @@ func makeDecimalTestDatum(count int) []tree.Datum {
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
-		dd := &tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		if _, err := dd.SetFloat64(rng.Float64()); err != nil {
 			panic(err)
 		}

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -53,7 +53,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Abs(x))), nil
 		}, "Calculates the absolute value of `val`.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			dd.Abs(x)
 			return dd, nil
 		}, "Calculates the absolute value of `val`.", tree.VolatilityImmutable),
@@ -197,7 +197,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			if y.Sign() == 0 {
 				return nil, tree.ErrDivByZero
 			}
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			_, err := tree.HighPrecisionCtx.QuoInteger(&dd.Decimal, x, y)
 			return dd, err
 		}, "Calculates the integer quotient of `x`/`y`.", tree.VolatilityImmutable),
@@ -222,7 +222,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Exp(x))), nil
 		}, "Calculates *e* ^ `val`.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			_, err := tree.DecimalCtx.Exp(&dd.Decimal, x)
 			return dd, err
 		}, "Calculates *e* ^ `val`.", tree.VolatilityImmutable),
@@ -233,7 +233,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Floor(x))), nil
 		}, "Calculates the largest integer not greater than `val`.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			_, err := tree.ExactCtx.Floor(&dd.Decimal, x)
 			return dd, err
 		}, "Calculates the largest integer not greater than `val`.", tree.VolatilityImmutable),
@@ -322,7 +322,7 @@ var mathBuiltins = map[string]builtinDefinition{
 				return nil, err
 			}
 
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			_, err := tree.DecimalCtx.Quo(&dd.Decimal, top, bot)
 			return dd, err
 		}, "Calculates the base `b` log of `val`.", tree.VolatilityImmutable),
@@ -336,7 +336,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			if y.Sign() == 0 {
 				return nil, tree.ErrDivByZero
 			}
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			_, err := tree.HighPrecisionCtx.Rem(&dd.Decimal, x, y)
 			return dd, err
 		}, "Calculates `x`%`y`.", tree.VolatilityImmutable),
@@ -462,7 +462,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		}, "Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for "+
 			"negative.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-			d := &tree.DDecimal{}
+			d := tree.NewDDecimal()
 			d.Decimal.SetInt64(int64(x.Sign()))
 			return d, nil
 		}, "Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for "+
@@ -518,7 +518,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			return tree.NewDFloat(tree.DFloat(math.Trunc(x))), nil
 		}, "Truncates the decimal values of `val`.", tree.VolatilityImmutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-			dd := &tree.DDecimal{}
+			dd := tree.NewDDecimal()
 			x.Modf(&dd.Decimal, nil)
 			return dd, nil
 		}, "Truncates the decimal values of `val`.", tree.VolatilityImmutable),
@@ -593,7 +593,7 @@ var ceilImpl = makeBuiltin(defProps(),
 		return tree.NewDFloat(tree.DFloat(math.Ceil(x))), nil
 	}, "Calculates the smallest integer not smaller than `val`.", tree.VolatilityImmutable),
 	decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
-		dd := &tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		_, err := tree.ExactCtx.Ceil(&dd.Decimal, x)
 		if dd.IsZero() {
 			dd.Negative = false
@@ -616,7 +616,7 @@ var powImpls = makeBuiltin(defProps(),
 		return tree.NewDFloat(tree.DFloat(math.Pow(x, y))), nil
 	}, "Calculates `x`^`y`.", tree.VolatilityImmutable),
 	decimalOverload2("x", "y", func(x, y *apd.Decimal) (tree.Datum, error) {
-		dd := &tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		_, err := tree.DecimalCtx.Pow(&dd.Decimal, x, y)
 		return dd, err
 	}, "Calculates `x`^`y`.", tree.VolatilityImmutable),
@@ -646,7 +646,7 @@ func decimalLogFn(
 		case 0:
 			return nil, errLogOfZero
 		}
-		dd := &tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		_, err := logFn(&dd.Decimal, x)
 		return dd, err
 	}, info, tree.VolatilityImmutable)
@@ -730,7 +730,7 @@ func roundDDecimal(d *tree.DDecimal, scale int32) (tree.Datum, error) {
 }
 
 func roundDecimal(x *apd.Decimal, scale int32) (tree.Datum, error) {
-	dd := &tree.DDecimal{}
+	dd := tree.NewDDecimal()
 	_, err := tree.HighPrecisionCtx.Quantize(&dd.Decimal, x, -scale)
 	return dd, err
 }

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -246,9 +246,9 @@ func (w *slidingWindowSumFunc) removeAllBefore(
 		case *tree.DInt:
 			err = w.agg.Add(ctx, tree.NewDInt(-*v))
 		case *tree.DDecimal:
-			d := tree.DDecimal{}
+			d := tree.NewDDecimal()
 			d.Neg(&v.Decimal)
-			err = w.agg.Add(ctx, &d)
+			err = w.agg.Add(ctx, d)
 		case *tree.DFloat:
 			err = w.agg.Add(ctx, tree.NewDFloat(-*v))
 		case *tree.DInterval:
@@ -405,7 +405,7 @@ func (w *avgWindowFunc) Compute(
 		_, err := tree.DecimalCtx.Quo(&avg.Decimal, &t.Decimal, count)
 		return &avg, err
 	case *tree.DInt:
-		dd := tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		dd.SetInt64(int64(*t))
 		var avg tree.DDecimal
 		count := apd.New(int64(frameSize), 0)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -192,7 +192,7 @@ var UnaryOps = unaryOpFixups(map[UnaryOperatorSymbol]unaryOpOverload{
 			ReturnType: types.Decimal,
 			Fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				dec := &d.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.Decimal.Neg(dec)
 				return dd, nil
 			},
@@ -696,7 +696,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := ExactCtx.Add(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -709,7 +709,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Add(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -723,7 +723,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Add(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -991,7 +991,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := ExactCtx.Sub(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1004,7 +1004,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Sub(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1018,7 +1018,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Sub(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -1313,7 +1313,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := ExactCtx.Mul(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1329,7 +1329,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := ExactCtx.Mul(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1343,7 +1343,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := ExactCtx.Mul(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -1429,7 +1429,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 					return nil, ErrDivByZero
 				}
 				div := ctx.getTmpDec().SetInt64(int64(rInt))
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(MustBeDInt(left)))
 				_, err := DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, div)
 				return dd, err
@@ -1459,7 +1459,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := DecimalCtx.Quo(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1475,7 +1475,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r == 0 {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := DecimalCtx.Quo(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1492,7 +1492,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -1565,7 +1565,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := HighPrecisionCtx.QuoInteger(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1581,7 +1581,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r == 0 {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := HighPrecisionCtx.QuoInteger(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1598,7 +1598,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := HighPrecisionCtx.QuoInteger(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -1645,7 +1645,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := HighPrecisionCtx.Rem(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1661,7 +1661,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r == 0 {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := HighPrecisionCtx.Rem(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1678,7 +1678,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 				if r.IsZero() {
 					return nil, ErrDivByZero
 				}
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := HighPrecisionCtx.Rem(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -1844,7 +1844,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				_, err := DecimalCtx.Pow(&dd.Decimal, l, r)
 				return dd, err
 			},
@@ -1857,7 +1857,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Decimal
 				r := MustBeDInt(right)
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(r))
 				_, err := DecimalCtx.Pow(&dd.Decimal, l, &dd.Decimal)
 				return dd, err
@@ -1871,7 +1871,7 @@ var BinOps = map[BinaryOperatorSymbol]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := MustBeDInt(left)
 				r := &right.(*DDecimal).Decimal
-				dd := &DDecimal{}
+				dd := NewDDecimal()
 				dd.SetInt64(int64(l))
 				_, err := DecimalCtx.Pow(&dd.Decimal, &dd.Decimal, r)
 				return dd, err
@@ -5713,7 +5713,7 @@ func DecimalSqrt(x *apd.Decimal) (*DDecimal, error) {
 	if x.Sign() < 0 {
 		return nil, errSqrtOfNegNumber
 	}
-	dd := &DDecimal{}
+	dd := NewDDecimal()
 	_, err := DecimalCtx.Sqrt(&dd.Decimal, x)
 	return dd, err
 }
@@ -5725,7 +5725,7 @@ func Cbrt(x float64) (*DFloat, error) {
 
 // DecimalCbrt returns the cube root of x.
 func DecimalCbrt(x *apd.Decimal) (*DDecimal, error) {
-	dd := &DDecimal{}
+	dd := NewDDecimal()
 	_, err := DecimalCtx.Cbrt(&dd.Decimal, x)
 	return dd, err
 }

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -49,7 +49,7 @@ func SampleDatum(t *types.T) Datum {
 		f := DFloat(123.456)
 		return &f
 	case types.DecimalFamily:
-		d := &DDecimal{}
+		d := NewDDecimal()
 		// int64(rng.Uint64()) to get negative numbers, too
 		d.Decimal.SetFinite(3, 6)
 		return d

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -127,7 +127,7 @@ func dint(i tree.DInt) copyableExpr {
 }
 func ddecimal(f float64) copyableExpr {
 	return func() tree.Expr {
-		dd := &tree.DDecimal{}
+		dd := tree.NewDDecimal()
 		if _, err := dd.SetFloat64(f); err != nil {
 			panic(err)
 		}

--- a/pkg/sql/sem/tree/window_funcs_test.go
+++ b/pkg/sql/sem/tree/window_funcs_test.go
@@ -73,9 +73,9 @@ func testStartPreceding(
 		case types.FloatFamily:
 			typedOffset = NewDFloat(DFloat(offset))
 		case types.DecimalFamily:
-			decimal := apd.Decimal{}
+			decimal := NewDDecimal()
 			decimal.SetInt64(int64(offset))
-			typedOffset = &DDecimal{Decimal: decimal}
+			typedOffset = decimal
 		default:
 			t.Fatal("unsupported offset type")
 		}
@@ -123,9 +123,9 @@ func testStartFollowing(
 		case types.FloatFamily:
 			typedOffset = NewDFloat(DFloat(offset))
 		case types.DecimalFamily:
-			decimal := apd.Decimal{}
+			decimal := NewDDecimal()
 			decimal.SetInt64(int64(offset))
-			typedOffset = &DDecimal{Decimal: decimal}
+			typedOffset = decimal
 		default:
 			t.Fatal("unsupported offset type")
 		}
@@ -182,9 +182,9 @@ func testEndPreceding(
 		case types.FloatFamily:
 			typedOffset = NewDFloat(DFloat(offset))
 		case types.DecimalFamily:
-			decimal := apd.Decimal{}
+			decimal := NewDDecimal()
 			decimal.SetInt64(int64(offset))
-			typedOffset = &DDecimal{Decimal: decimal}
+			typedOffset = decimal
 		default:
 			t.Fatal("unsupported offset type")
 		}
@@ -232,9 +232,9 @@ func testEndFollowing(
 		case types.FloatFamily:
 			typedOffset = NewDFloat(DFloat(offset))
 		case types.DecimalFamily:
-			decimal := apd.Decimal{}
+			decimal := NewDDecimal()
 			decimal.SetInt64(int64(offset))
-			typedOffset = &DDecimal{Decimal: decimal}
+			typedOffset = decimal
 		default:
 			t.Fatal("unsupported offset type")
 		}
@@ -296,7 +296,7 @@ func makeFloatSortedPartition(count int) indexedRows {
 func makeDecimalSortedPartition(t *testing.T, count int) indexedRows {
 	partition := indexedRows{rows: make([]indexedRow, count)}
 	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	number := &DDecimal{}
+	number := NewDDecimal()
 	for idx := 0; idx < count; idx++ {
 		tmp := apd.Decimal{}
 		if r.Float64() < probabilityOfNewNumber {
@@ -309,7 +309,7 @@ func makeDecimalSortedPartition(t *testing.T, count int) indexedRows {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		}
-		value := &DDecimal{}
+		value := NewDDecimal()
 		_, err := tmp.SetFloat64(0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Related to #57593. Not a full replacement, but maybe a medium-term mitigation.

This commit updates `defaultColumnFactory.MakeColumn` to batch allocate the coefficients of each decimal in a `Decimals` vector.

Each `Decimal` maintains (through an embedded `big.Int`) an internal reference to a variable-length coefficient which is represented by a `[]big.Word`. This commit attempts to minimize heap allocations by pre-allocating a single large `[]big.Word` and distributing chunks of this slice to each `Decimal` in a `Decimals` vector. `big.Int` will avoid re-allocating unless its coefficient unless it is provided with a coefficient that exceeds the initial capacity. We set this capacity to accommodate any coefficient that would fit in a 64-bit integer (i.e. up to 2^64).

On the read-only portion of the TPC-E (77% of the full workload, in terms of txn mix), this change has a significant impact on total heap allocations. Before the change, `math/big.nat.make` was responsible for **51.07%** of total heap allocations:

<img width="1587" alt="Screen Shot 2021-12-31 at 8 01 00 PM" src="https://user-images.githubusercontent.com/5438456/147842722-965d649d-b29a-4f66-aa07-1b05e52e97af.png">

After the change, `math/big.nat.make` is responsible for only **1.1%** of total heap allocations:

<img width="1580" alt="Screen Shot 2021-12-31 at 9 04 24 PM" src="https://user-images.githubusercontent.com/5438456/147842727-a881a5a3-d038-48bb-bd44-4ade665afe73.png">

That equates to roughly a **50%** reduction in heap allocations.

----

The PR also contains a second commit that does something similar for non-vectorized execution. That commit needs more work and can be split from the first commit if we'd like.