### PR TITLE
clusterversion,batcheval: revert "remove TargetBytesAvoidExcess"

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -164,6 +164,11 @@ const (
 	// Start22_1 demarcates work towards CockroachDB v22.1.
 	Start22_1
 
+	// TargetBytesAvoidExcess prevents exceeding BatchRequest.Header.TargetBytes
+	// except when there is a single value in the response. 21.2 DistSender logic
+	// requires the limit to always be overshot in order to properly enforce
+	// limits when splitting requests.
+	TargetBytesAvoidExcess
 	// AvoidDrainingNames avoids using the draining_names field when renaming or
 	// dropping descriptors.
 	AvoidDrainingNames
@@ -259,6 +264,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     Start22_1,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 2},
+	},
+	{
+		Key:     TargetBytesAvoidExcess,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 4},
 	},
 	{
 		Key:     AvoidDrainingNames,

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -10,26 +10,27 @@ func _() {
 	var x [1]struct{}
 	_ = x[V21_2-0]
 	_ = x[Start22_1-1]
-	_ = x[AvoidDrainingNames-2]
-	_ = x[DrainingNamesMigration-3]
-	_ = x[TraceIDDoesntImplyStructuredRecording-4]
-	_ = x[AlterSystemTableStatisticsAddAvgSizeCol-5]
-	_ = x[AlterSystemStmtDiagReqs-6]
-	_ = x[MVCCAddSSTable-7]
-	_ = x[InsertPublicSchemaNamespaceEntryOnRestore-8]
-	_ = x[UnsplitRangesInAsyncGCJobs-9]
-	_ = x[ValidateGrantOption-10]
-	_ = x[PebbleFormatBlockPropertyCollector-11]
-	_ = x[ProbeRequest-12]
-	_ = x[SelectRPCsTakeTracingInfoInband-13]
-	_ = x[PreSeedTenantSpanConfigs-14]
-	_ = x[SeedTenantSpanConfigs-15]
-	_ = x[PublicSchemasWithDescriptors-16]
+	_ = x[TargetBytesAvoidExcess-2]
+	_ = x[AvoidDrainingNames-3]
+	_ = x[DrainingNamesMigration-4]
+	_ = x[TraceIDDoesntImplyStructuredRecording-5]
+	_ = x[AlterSystemTableStatisticsAddAvgSizeCol-6]
+	_ = x[AlterSystemStmtDiagReqs-7]
+	_ = x[MVCCAddSSTable-8]
+	_ = x[InsertPublicSchemaNamespaceEntryOnRestore-9]
+	_ = x[UnsplitRangesInAsyncGCJobs-10]
+	_ = x[ValidateGrantOption-11]
+	_ = x[PebbleFormatBlockPropertyCollector-12]
+	_ = x[ProbeRequest-13]
+	_ = x[SelectRPCsTakeTracingInfoInband-14]
+	_ = x[PreSeedTenantSpanConfigs-15]
+	_ = x[SeedTenantSpanConfigs-16]
+	_ = x[PublicSchemasWithDescriptors-17]
 }
 
-const _Key_name = "V21_2Start22_1AvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptors"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptors"
 
-var _Key_index = [...]uint16{0, 5, 14, 32, 54, 91, 130, 153, 167, 208, 234, 253, 287, 299, 330, 354, 375, 403}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/kvserver/batcheval/cmd_get_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get_test.go
@@ -52,6 +52,7 @@ func TestGetResumeSpan(t *testing.T) {
 		maxKeys         int64
 		targetBytes     int64
 		allowEmpty      bool
+		avoidExcess     bool
 		expectResume    bool
 		expectReason    roachpb.ResumeReason
 		expectNextBytes int64
@@ -66,18 +67,26 @@ func TestGetResumeSpan(t *testing.T) {
 		{targetBytes: 1, expectResume: false},
 		{targetBytes: 11, expectResume: false},
 		{targetBytes: 12, expectResume: false},
-		{targetBytes: 1, allowEmpty: true, expectResume: true, expectReason: roachpb.RESUME_BYTE_LIMIT, expectNextBytes: 11},
+		// allowEmpty takes precedence over avoidExcess at the RPC level, since
+		// callers have no control over avoidExcess.
+		{targetBytes: 1, allowEmpty: true, avoidExcess: false, expectResume: true, expectReason: roachpb.RESUME_BYTE_LIMIT, expectNextBytes: 11},
 		{targetBytes: 11, allowEmpty: true, expectResume: false},
 		{targetBytes: 12, allowEmpty: true, expectResume: false},
+		{targetBytes: 1, allowEmpty: true, avoidExcess: true, expectResume: true, expectReason: roachpb.RESUME_BYTE_LIMIT, expectNextBytes: 11},
+		{targetBytes: 11, allowEmpty: true, avoidExcess: true, expectResume: false},
+		{targetBytes: 12, allowEmpty: true, avoidExcess: true, expectResume: false},
 
 		{maxKeys: -1, targetBytes: -1, expectResume: true, expectReason: roachpb.RESUME_KEY_LIMIT, expectNextBytes: 0},
 		{maxKeys: 10, targetBytes: 100, expectResume: false},
 	}
 	for _, tc := range testCases {
-		name := fmt.Sprintf("maxKeys=%d targetBytes=%d allowEmpty=%t",
-			tc.maxKeys, tc.targetBytes, tc.allowEmpty)
+		name := fmt.Sprintf("maxKeys=%d targetBytes=%d allowEmpty=%t avoidExcess=%t",
+			tc.maxKeys, tc.targetBytes, tc.allowEmpty, tc.avoidExcess)
 		t.Run(name, func(t *testing.T) {
 			version := clusterversion.TestingBinaryVersion
+			if !tc.avoidExcess {
+				version = clusterversion.ByKey(clusterversion.TargetBytesAvoidExcess - 1)
+			}
 			settings := cluster.MakeTestingClusterSettingsWithVersions(version, clusterversion.TestingBinaryMinSupportedVersion, true)
 
 			resp := roachpb.GetResponse{}

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -39,13 +40,15 @@ func ReverseScan(
 	var scanRes storage.MVCCScanResult
 	var err error
 
+	avoidExcess := cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx,
+		clusterversion.TargetBytesAvoidExcess)
 	opts := storage.MVCCScanOptions{
 		Inconsistent:           h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:                    h.Txn,
 		MaxKeys:                h.MaxSpanRequestKeys,
 		MaxIntents:             storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:            h.TargetBytes,
-		TargetBytesAvoidExcess: true,
+		TargetBytesAvoidExcess: h.TargetBytesAllowEmpty || avoidExcess, // AllowEmpty takes precedence
 		TargetBytesAllowEmpty:  h.TargetBytesAllowEmpty,
 		FailOnMoreRecent:       args.KeyLocking != lock.None,
 		Reverse:                true,

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -39,6 +40,8 @@ func Scan(
 	var scanRes storage.MVCCScanResult
 	var err error
 
+	avoidExcess := cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx,
+		clusterversion.TargetBytesAvoidExcess)
 	opts := storage.MVCCScanOptions{
 		Inconsistent:           h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:                    h.Txn,
@@ -46,7 +49,7 @@ func Scan(
 		MaxKeys:                h.MaxSpanRequestKeys,
 		MaxIntents:             storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:            h.TargetBytes,
-		TargetBytesAvoidExcess: true,
+		TargetBytesAvoidExcess: h.TargetBytesAllowEmpty || avoidExcess, // AllowEmpty takes precedence
 		TargetBytesAllowEmpty:  h.TargetBytesAllowEmpty,
 		FailOnMoreRecent:       args.KeyLocking != lock.None,
 		Reverse:                false,


### PR DESCRIPTION
This reverts commit 99c6e5728162a52fb33d0619f031c5d0d5d8b364, which erroneously removed the cluster version `TargetBytesAvoidExcess`. This version gate is required to maintain compatibility with 21.2 DistSender logic for enforcing limits.

Release note: None