### PR TITLE
server: hot ranges api

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3130,6 +3130,8 @@ of ranges currently considered “hot” by the node(s).
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is possible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
+| page_size | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  |  | [reserved](#support-status) |
+| page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -3236,6 +3238,8 @@ of ranges currently considered “hot” by the node(s).
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is possible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
+| page_size | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  |  | [reserved](#support-status) |
+| page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -3253,7 +3257,9 @@ HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| ranges | [HotRangesResponseV2.HotRange](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange) | repeated | ranges contain list of hot ranges info that has highest number of QPS. | [reserved](#support-status) |
+| ranges | [HotRangesResponseV2.HotRange](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange) | repeated | Ranges contain list of hot ranges info that has highest number of QPS. | [reserved](#support-status) |
+| errors_by_node_id | [HotRangesResponseV2.ErrorsByNodeIdEntry](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.ErrorsByNodeIdEntry) | repeated | errors contains any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
+| next_page_token | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | NextPageToken represents next pagination token to request next slice of data. | [reserved](#support-status) |
 
 
 
@@ -3276,6 +3282,20 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.ErrorsByNodeIdEntry"></a>
+#### HotRangesResponseV2.ErrorsByNodeIdEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  |  |  |
+| value | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  |  |  |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3209,7 +3209,7 @@ target node(s) selected in a HotRangesRequest.
 | ----- | ---- | ----- | ----------- | -------------- |
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
-| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder | [reserved](#support-status) |
+| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 
 
 
@@ -3218,7 +3218,7 @@ target node(s) selected in a HotRangesRequest.
 
 ## HotRangesV2
 
-`GET /_status/v2/hotranges`
+`POST /_status/v2/hotranges`
 
 
 
@@ -3253,7 +3253,7 @@ HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| ranges | [HotRangesResponseV2.HotRange](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange) | repeated | ranges contain list of hot ranges info that has highest number of QPS | [reserved](#support-status) |
+| ranges | [HotRangesResponseV2.HotRange](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange) | repeated | ranges contain list of hot ranges info that has highest number of QPS. | [reserved](#support-status) |
 
 
 
@@ -3267,15 +3267,15 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| range_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | range_id indicates Range ID that's identified as hot range | [reserved](#support-status) |
-| node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | node_id indicates on node that contains current hot range | [reserved](#support-status) |
-| qps | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | qps (queries per second) shows the amount of queries that interact with current range | [reserved](#support-status) |
-| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name indicates table which data is stored in this hot range | [reserved](#support-status) |
-| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name indicates on database that has current hot range | [reserved](#support-status) |
-| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name indicates the index name for current range | [reserved](#support-status) |
-| replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range | [reserved](#support-status) |
-| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates on Node ID that contains replica that is a leaseholder | [reserved](#support-status) |
-| schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range | [reserved](#support-status) |
+| range_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | range_id indicates Range ID that's identified as hot range. | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | node_id indicates the node that contains the current hot range. | [reserved](#support-status) |
+| qps | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | qps (queries per second) shows the amount of queries that interact with current range. | [reserved](#support-status) |
+| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name indicates the SQL table that the range belongs to. | [reserved](#support-status) |
+| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name indicates on database that has current hot range. | [reserved](#support-status) |
+| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name indicates the index name for current range. | [reserved](#support-status) |
+| replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
+| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
+| schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3209,6 +3209,72 @@ target node(s) selected in a HotRangesRequest.
 | ----- | ---- | ----- | ----------- | -------------- |
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
+| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder | [reserved](#support-status) |
+
+
+
+
+
+
+## HotRangesV2
+
+`GET /_status/v2/hotranges`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+HotRangesRequest queries one or more cluster nodes for a list
+of ranges currently considered “hot” by the node(s).
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  | NodeID indicates which node to query for a hot range report. It is possible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| ranges | [HotRangesResponseV2.HotRange](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange) | repeated | ranges contain list of hot ranges info that has highest number of QPS | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange"></a>
+#### HotRangesResponseV2.HotRange
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| range_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | range_id indicates Range ID that's identified as hot range | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | node_id indicates on node that contains current hot range | [reserved](#support-status) |
+| qps | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | qps (queries per second) shows the amount of queries that interact with current range | [reserved](#support-status) |
+| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name indicates table which data is stored in this hot range | [reserved](#support-status) |
+| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name indicates on database that has current hot range | [reserved](#support-status) |
+| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name indicates the index name for current range | [reserved](#support-status) |
+| replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range | [reserved](#support-status) |
+| leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates on Node ID that contains replica that is a leaseholder | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3248,7 +3248,7 @@ of ranges currently considered “hot” by the node(s).
 
 
 
-
+HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.
 
 
 | Field | Type | Label | Description | Support status |
@@ -3263,7 +3263,7 @@ of ranges currently considered “hot” by the node(s).
 <a name="cockroach.server.serverpb.HotRangesResponseV2-cockroach.server.serverpb.HotRangesResponseV2.HotRange"></a>
 #### HotRangesResponseV2.HotRange
 
-
+HotRange message describes a single hot range, ie its QPS, node ID it belongs to, etc.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
@@ -3275,6 +3275,7 @@ of ranges currently considered “hot” by the node(s).
 | index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name indicates the index name for current range | [reserved](#support-status) |
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates on Node ID that contains replica that is a leaseholder | [reserved](#support-status) |
+| schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -62,5 +62,6 @@ Support status: [alpha](#support-status)
 | ----- | ---- | ----- | ----------- | -------------- |
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
+| leaseholder_node_id | [int32](#int32) |  | LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder | [reserved](#support-status) |
 
 

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -62,6 +62,6 @@ Support status: [alpha](#support-status)
 | ----- | ---- | ----- | ----------- | -------------- |
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
-| leaseholder_node_id | [int32](#int32) |  | LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder | [reserved](#support-status) |
+| leaseholder_node_id | [int32](#int32) |  | LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 
 

--- a/docs/generated/http/hotranges-request.md
+++ b/docs/generated/http/hotranges-request.md
@@ -12,5 +12,7 @@ Support status: [alpha](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#string) |  | NodeID indicates which node to query for a hot range report. It is possible to populate any node ID; if the node receiving the request is not the target node, it will forward the request to the target node.<br><br>If left empty, the request is forwarded to every node in the cluster. | [alpha](#support-status) |
+| page_size | [int32](#int32) |  |  | [reserved](#support-status) |
+| page_token | [string](#string) |  |  | [reserved](#support-status) |
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1023,6 +1023,12 @@
       },
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/util/metric"
     },
+    "RangeID": {
+      "type": "integer",
+      "format": "int64",
+      "title": "A RangeID is a unique ID associated to a Raft consensus group.",
+      "x-go-package": "github.com/cockroachdb/cockroach/pkg/roachpb"
+    },
     "RangeProblems": {
       "type": "object",
       "title": "RangeProblems describes issues reported by a range. For internal use only.",
@@ -1788,6 +1794,51 @@
       },
       "x-go-package": "github.com/cockroachdb/cockroach/pkg/server"
     },
+    "hotRangeInfo": {
+      "description": "(ie its range ID, QPS, table name, etc.).",
+      "type": "object",
+      "title": "Hot range details struct describes common information about hot range,",
+      "properties": {
+        "database_name": {
+          "type": "string",
+          "x-go-name": "DatabaseName"
+        },
+        "index_name": {
+          "type": "string",
+          "x-go-name": "IndexName"
+        },
+        "leaseholder_node_id": {
+          "$ref": "#/definitions/NodeID"
+        },
+        "node_id": {
+          "$ref": "#/definitions/NodeID"
+        },
+        "qps": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "QPS"
+        },
+        "range_id": {
+          "$ref": "#/definitions/RangeID"
+        },
+        "replica_node_ids": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NodeID"
+          },
+          "x-go-name": "ReplicaNodeIDs"
+        },
+        "schema_name": {
+          "type": "string",
+          "x-go-name": "SchemaName"
+        },
+        "table_name": {
+          "type": "string",
+          "x-go-name": "TableName"
+        }
+      },
+      "x-go-package": "github.com/cockroachdb/cockroach/pkg/server"
+    },
     "hotRangesResponse": {
       "type": "object",
       "title": "Response struct for listHotRanges.",
@@ -1797,15 +1848,12 @@
           "type": "string",
           "x-go-name": "Next"
         },
-        "ranges_by_node_id": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/rangeDescriptorInfo"
-            }
+        "ranges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/hotRangeInfo"
           },
-          "x-go-name": "RangesByNodeID"
+          "x-go-name": "Ranges"
         },
         "response_error": {
           "type": "array",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -142,6 +142,7 @@ go_library(
         "//pkg/spanconfig/spanconfigsqltranslator",
         "//pkg/spanconfig/spanconfigsqlwatcher",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catconstants",

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -415,11 +414,27 @@ type responseError struct {
 //
 // swagger:model hotRangesResponse
 type hotRangesResponse struct {
-	RangesByNodeID map[string][]rangeDescriptorInfo `json:"ranges_by_node_id"`
-	Errors         []responseError                  `json:"response_error,omitempty"`
+	Ranges []hotRangeInfo  `json:"ranges"`
+	Errors []responseError `json:"response_error,omitempty"`
 	// Continuation token for the next paginated call. Use as the `start`
 	// parameter.
 	Next string `json:"next,omitempty"`
+}
+
+// Hot range details struct describes common information about hot range,
+// (ie its range ID, QPS, table name, etc.).
+//
+// swagger:model hotRangeInfo
+type hotRangeInfo struct {
+	RangeID           roachpb.RangeID  `json:"range_id"`
+	NodeID            roachpb.NodeID   `json:"node_id"`
+	QPS               float64          `json:"qps"`
+	LeaseholderNodeID roachpb.NodeID   `json:"leaseholder_node_id"`
+	TableName         string           `json:"table_name"`
+	DatabaseName      string           `json:"database_name"`
+	IndexName         string           `json:"index_name"`
+	SchemaName        string           `json:"schema_name"`
+	ReplicaNodeIDs    []roachpb.NodeID `json:"replica_node_ids"`
 }
 
 // swagger:operation GET /ranges/hot/ listHotRanges
@@ -464,9 +479,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 	nodeIDStr := r.URL.Query().Get("node_id")
 	limit, start := getRPCPaginationValues(r)
 
-	response := &hotRangesResponse{
-		RangesByNodeID: make(map[string][]rangeDescriptorInfo),
-	}
+	response := &hotRangesResponse{}
 	var requestedNodes []roachpb.NodeID
 	if len(nodeIDStr) > 0 {
 		requestedNodeID, _, err := a.status.parseNodeID(nodeIDStr)
@@ -484,32 +497,29 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
 	nodeFn := func(ctx context.Context, client interface{}, nodeID roachpb.NodeID) (interface{}, error) {
 		status := client.(serverpb.StatusClient)
-		resp, err := status.HotRanges(ctx, &remoteRequest)
+		resp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil || resp == nil {
 			return nil, err
 		}
-		rangeDescriptorInfos := make([]rangeDescriptorInfo, 0)
-		for _, store := range resp.HotRangesByNodeID[nodeID].Stores {
-			for _, hotRange := range store.HotRanges {
-				var r rangeDescriptorInfo
-				r.init(&hotRange.Desc)
-				r.StoreID = int32(store.StoreID)
-				r.QueriesPerSecond = hotRange.QueriesPerSecond
-				rangeDescriptorInfos = append(rangeDescriptorInfos, r)
+
+		var hotRangeInfos = make([]hotRangeInfo, len(resp.Ranges))
+		for i, r := range resp.Ranges {
+			hotRangeInfos[i] = hotRangeInfo{
+				RangeID:           r.RangeID,
+				NodeID:            r.NodeID,
+				QPS:               r.QPS,
+				LeaseholderNodeID: r.LeaseholderNodeID,
+				TableName:         r.TableName,
+				DatabaseName:      r.DatabaseName,
+				IndexName:         r.IndexName,
+				ReplicaNodeIDs:    r.ReplicaNodeIds,
+				SchemaName:        r.SchemaName,
 			}
 		}
-		sort.Slice(rangeDescriptorInfos, func(i, j int) bool {
-			if rangeDescriptorInfos[i].StoreID == rangeDescriptorInfos[j].StoreID {
-				return rangeDescriptorInfos[i].RangeID < rangeDescriptorInfos[j].RangeID
-			}
-			return rangeDescriptorInfos[i].StoreID < rangeDescriptorInfos[j].StoreID
-		})
-		return rangeDescriptorInfos, nil
+		return hotRangeInfos, nil
 	}
 	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		if hotRangesResp, ok := resp.([]rangeDescriptorInfo); ok {
-			response.RangesByNodeID[nodeID.String()] = hotRangesResp
-		}
+		response.Ranges = append(response.Ranges, resp.([]hotRangeInfo)...)
 	}
 	errorFn := func(nodeID roachpb.NodeID, err error) {
 		response.Errors = append(response.Errors, responseError{

--- a/pkg/server/api_v2_ranges_test.go
+++ b/pkg/server/api_v2_ranges_test.go
@@ -46,25 +46,16 @@ func TestHotRangesV2(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&hotRangesResp))
 	require.NoError(t, resp.Body.Close())
 
-	if len(hotRangesResp.RangesByNodeID) == 0 {
+	if len(hotRangesResp.Ranges) == 0 {
 		t.Fatalf("didn't get hot range responses from any nodes")
 	}
 	if len(hotRangesResp.Errors) > 0 {
 		t.Errorf("got an error in hot range response from n%d: %v",
 			hotRangesResp.Errors[0].NodeID, hotRangesResp.Errors[0].ErrorMessage)
 	}
-
-	for nodeID, nodeResp := range hotRangesResp.RangesByNodeID {
-		if len(nodeResp) == 0 {
-			t.Fatalf("didn't get hot range response from node n%s", nodeID)
-		}
-		// We don't check for ranges being sorted by QPS, as this hot ranges
-		// report does not use that as its sort key (for stability across multiple
-		// pagination calls).
-		for _, r := range nodeResp {
-			if r.RangeID == 0 || (len(r.StartKey) == 0 && len(r.EndKey) == 0) {
-				t.Errorf("unexpected empty/unpopulated range descriptor: %+v", r)
-			}
+	for _, r := range hotRangesResp.Ranges {
+		if r.RangeID == 0 || r.NodeID == 0 {
+			t.Errorf("unexpected empty/unpopulated range descriptor: %+v", r)
 		}
 	}
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1140,6 +1140,12 @@ message HotRangesResponse {
     // on this range.
     // API: PUBLIC ALPHA
     double queries_per_second = 2;
+    // LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder
+    int32 leaseholder_node_id = 3 [
+      (gogoproto.customname) = "LeaseholderNodeID",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+    ];
   }
 
   // StoreResponse contains the part of a hot ranges report that
@@ -1186,6 +1192,45 @@ message HotRangesResponse {
     (gogoproto.customname) = "HotRangesByNodeID",
     (gogoproto.nullable) = false
   ];
+}
+
+message HotRangesResponseV2 {
+  message HotRange {
+    // range_id indicates Range ID that's identified as hot range
+    int32 range_id = 1 [
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID",
+      (gogoproto.customname) = "RangeID"
+    ];
+    // node_id indicates on node that contains current hot range
+    int32 node_id = 2 [
+      (gogoproto.customname) = "NodeID",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+    ];
+    // qps (queries per second) shows the amount of queries that interact with current range
+    double qps = 3 [
+      (gogoproto.customname) = "QPS"
+    ];
+    // table_name indicates table which data is stored in this hot range
+    string table_name = 4;
+    // database_name indicates on database that has current hot range
+    string database_name = 5;
+    // index_name indicates the index name for current range
+    string index_name = 6;
+    // replica_node_ids specifies the list of node ids that contain replicas with current hot range
+    repeated int32 replica_node_ids = 7 [
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+    ];
+    // leaseholder_node_id indicates on Node ID that contains replica that is a leaseholder
+    int32 leaseholder_node_id = 8 [
+      (gogoproto.customname) = "LeaseholderNodeID",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+    ];
+  }
+  // ranges contain list of hot ranges info that has highest number of QPS
+  repeated HotRange ranges = 1;
 }
 
 message RangeRequest {
@@ -1874,6 +1919,13 @@ service Status {
       get : "/_status/hotranges"
     };
   }
+
+  rpc HotRangesV2(HotRangesRequest) returns (HotRangesResponseV2) {
+    option (google.api.http) = {
+      get : "/_status/v2/hotranges"
+    };
+  }
+
   rpc Range(RangeRequest) returns (RangeResponse) {
     option (google.api.http) = {
       get : "/_status/range/{range_id}"

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1110,6 +1110,8 @@ message HotRangesRequest {
   // in the cluster.
   // API: PUBLIC ALPHA
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
+  int32 page_size = 2 [(gogoproto.nullable) = true];
+  string page_token = 3 [(gogoproto.nullable) = true];
 }
 
 // HotRangesResponse is the payload produced in response
@@ -1233,8 +1235,16 @@ message HotRangesResponseV2 {
     // schema_name provides the name of schema (if exists) for table in current range.
     string schema_name = 9;
   }
-  // ranges contain list of hot ranges info that has highest number of QPS.
+  // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;
+  // errors contains any errors that occurred during fan-out calls to other nodes.
+  map<int32, string> errors_by_node_id = 2 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+    (gogoproto.customname) = "ErrorsByNodeID",
+    (gogoproto.nullable) = false
+  ];
+  // NextPageToken represents next pagination token to request next slice of data.
+  string next_page_token = 3 [(gogoproto.nullable) = true];
 }
 
 message RangeRequest {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1140,7 +1140,7 @@ message HotRangesResponse {
     // on this range.
     // API: PUBLIC ALPHA
     double queries_per_second = 2;
-    // LeaseholderNodeID indicates on Node ID that contains replica that is leaseholder
+    // LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range.
     int32 leaseholder_node_id = 3 [
       (gogoproto.customname) = "LeaseholderNodeID",
       (gogoproto.casttype) =
@@ -1198,42 +1198,42 @@ message HotRangesResponse {
 message HotRangesResponseV2 {
   // HotRange message describes a single hot range, ie its QPS, node ID it belongs to, etc.
   message HotRange {
-    // range_id indicates Range ID that's identified as hot range
+    // range_id indicates Range ID that's identified as hot range.
     int32 range_id = 1 [
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID",
       (gogoproto.customname) = "RangeID"
     ];
-    // node_id indicates on node that contains current hot range
+    // node_id indicates the node that contains the current hot range.
     int32 node_id = 2 [
       (gogoproto.customname) = "NodeID",
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
     ];
-    // qps (queries per second) shows the amount of queries that interact with current range
+    // qps (queries per second) shows the amount of queries that interact with current range.
     double qps = 3 [
       (gogoproto.customname) = "QPS"
     ];
-    // table_name indicates table which data is stored in this hot range
+    // table_name indicates the SQL table that the range belongs to.
     string table_name = 4;
-    // database_name indicates on database that has current hot range
+    // database_name indicates on database that has current hot range.
     string database_name = 5;
-    // index_name indicates the index name for current range
+    // index_name indicates the index name for current range.
     string index_name = 6;
-    // replica_node_ids specifies the list of node ids that contain replicas with current hot range
+    // replica_node_ids specifies the list of node ids that contain replicas with current hot range.
     repeated int32 replica_node_ids = 7 [
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
     ];
-    // leaseholder_node_id indicates on Node ID that contains replica that is a leaseholder
+    // leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range.
     int32 leaseholder_node_id = 8 [
       (gogoproto.customname) = "LeaseholderNodeID",
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
     ];
-    // schema_name provides the name of schema (if exists) for table in current range
+    // schema_name provides the name of schema (if exists) for table in current range.
     string schema_name = 9;
   }
-  // ranges contain list of hot ranges info that has highest number of QPS
+  // ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;
 }
 
@@ -1926,7 +1926,8 @@ service Status {
 
   rpc HotRangesV2(HotRangesRequest) returns (HotRangesResponseV2) {
     option (google.api.http) = {
-      get : "/_status/v2/hotranges"
+      post : "/_status/v2/hotranges"
+      body : "*"
     };
   }
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1194,7 +1194,9 @@ message HotRangesResponse {
   ];
 }
 
+// HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.
 message HotRangesResponseV2 {
+  // HotRange message describes a single hot range, ie its QPS, node ID it belongs to, etc.
   message HotRange {
     // range_id indicates Range ID that's identified as hot range
     int32 range_id = 1 [
@@ -1228,6 +1230,8 @@ message HotRangesResponseV2 {
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
     ];
+    // schema_name provides the name of schema (if exists) for table in current range
+    string schema_name = 9;
   }
   // ranges contain list of hot ranges info that has highest number of QPS
   repeated HotRange ranges = 1;

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2107,6 +2107,17 @@ func (s *statusServer) HotRanges(
 	return response, nil
 }
 
+type hotRangeReportMeta struct {
+	dbName         string
+	tableName      string
+	schemaName     string
+	indexNames     map[uint32]string
+	parentID       uint32
+	schemaParentID uint32
+}
+
+// HotRangesV2 returns hot ranges from all stores on requested node or all nodes in case
+// request message doesn't include specific node ID.
 func (s *statusServer) HotRangesV2(
 	ctx context.Context, req *serverpb.HotRangesRequest,
 ) (*serverpb.HotRangesResponseV2, error) {
@@ -2115,11 +2126,7 @@ func (s *statusServer) HotRangesV2(
 		return nil, err
 	}
 
-	dbNames := make(map[uint32]string)
-	tableNames := make(map[uint32]string)
-	indexNames := make(map[uint32]map[uint32]string)
-	parents := make(map[uint32]uint32)
-
+	rangeReportMetas := make(map[uint32]hotRangeReportMeta)
 	var descrs []catalog.Descriptor
 	if err = s.sqlServer.distSQLServer.CollectionFactory.Txn(
 		ctx, s.sqlServer.internalExecutor, s.db,
@@ -2136,42 +2143,49 @@ func (s *statusServer) HotRangesV2(
 
 	for _, desc := range descrs {
 		id := uint32(desc.GetID())
+		meta := hotRangeReportMeta{
+			indexNames: map[uint32]string{},
+		}
 		switch desc := desc.(type) {
 		case catalog.TableDescriptor:
-			parents[id] = uint32(desc.GetParentID())
-			tableNames[id] = desc.GetName()
-			indexNames[id] = make(map[uint32]string)
+			meta.tableName = desc.GetName()
+			meta.parentID = uint32(desc.GetParentID())
+			meta.schemaParentID = uint32(desc.GetParentSchemaID())
 			for _, idx := range desc.AllIndexes() {
-				indexNames[id][uint32(idx.GetID())] = idx.GetName()
+				meta.indexNames[uint32(idx.GetID())] = idx.GetName()
 			}
+		case catalog.SchemaDescriptor:
+			meta.schemaName = desc.GetName()
 		case catalog.DatabaseDescriptor:
-			dbNames[id] = desc.GetName()
+			meta.dbName = desc.GetName()
 		}
+		rangeReportMetas[id] = meta
 	}
 
 	var ranges []*serverpb.HotRangesResponseV2_HotRange
-	// TODO (koorosh): how to flatten triple nested loop?
 	for nodeID, hr := range resp.HotRangesByNodeID {
 		for _, store := range hr.Stores {
 			for _, r := range store.HotRanges {
 				var (
-					dbName, tableName, indexName string
-					replicaNodeIDs               []roachpb.NodeID
+					dbName, tableName, indexName, schemaName string
+					replicaNodeIDs                           []roachpb.NodeID
 				)
 				_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
 				if err != nil {
 					continue
 				}
-				parent := parents[tableID]
+				parent := rangeReportMetas[tableID].parentID
 				if parent != 0 {
-					tableName = tableNames[tableID]
-					dbName = dbNames[parent]
+					tableName = rangeReportMetas[tableID].tableName
+					dbName = rangeReportMetas[parent].dbName
 				} else {
-					dbName = dbNames[tableID]
+					dbName = rangeReportMetas[tableID].dbName
 				}
+				schemaParent := rangeReportMetas[tableID].schemaParentID
+				schemaName = rangeReportMetas[schemaParent].schemaName
 				_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
 				if err == nil {
-					indexName = indexNames[tableID][idxID]
+					indexName = rangeReportMetas[tableID].indexNames[idxID]
 				}
 				for _, repl := range r.Desc.Replicas().Descriptors() {
 					replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
@@ -2181,6 +2195,7 @@ func (s *statusServer) HotRangesV2(
 					NodeID:            nodeID,
 					QPS:               r.QueriesPerSecond,
 					TableName:         tableName,
+					SchemaName:        schemaName,
 					DatabaseName:      dbName,
 					IndexName:         indexName,
 					ReplicaNodeIds:    replicaNodeIDs,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2172,6 +2172,7 @@ func (s *statusServer) HotRangesV2(
 				)
 				_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
 				if err != nil {
+					log.Warningf(ctx, "cannot decode tableID for range descriptor: %s. %s", r.Desc.String(), err.Error())
 					continue
 				}
 				parent := rangeReportMetas[tableID].parentID

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -49,7 +49,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -2105,6 +2107,92 @@ func (s *statusServer) HotRanges(
 	return response, nil
 }
 
+func (s *statusServer) HotRangesV2(
+	ctx context.Context, req *serverpb.HotRangesRequest,
+) (*serverpb.HotRangesResponseV2, error) {
+	resp, err := s.HotRanges(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	dbNames := make(map[uint32]string)
+	tableNames := make(map[uint32]string)
+	indexNames := make(map[uint32]map[uint32]string)
+	parents := make(map[uint32]uint32)
+
+	var descrs []catalog.Descriptor
+	if err = s.sqlServer.distSQLServer.CollectionFactory.Txn(
+		ctx, s.sqlServer.internalExecutor, s.db,
+		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			all, err := descriptors.GetAllDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+			descrs = all.OrderedDescriptors()
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+
+	for _, desc := range descrs {
+		id := uint32(desc.GetID())
+		switch desc := desc.(type) {
+		case catalog.TableDescriptor:
+			parents[id] = uint32(desc.GetParentID())
+			tableNames[id] = desc.GetName()
+			indexNames[id] = make(map[uint32]string)
+			for _, idx := range desc.AllIndexes() {
+				indexNames[id][uint32(idx.GetID())] = idx.GetName()
+			}
+		case catalog.DatabaseDescriptor:
+			dbNames[id] = desc.GetName()
+		}
+	}
+
+	var ranges []*serverpb.HotRangesResponseV2_HotRange
+	// TODO (koorosh): how to flatten triple nested loop?
+	for nodeID, hr := range resp.HotRangesByNodeID {
+		for _, store := range hr.Stores {
+			for _, r := range store.HotRanges {
+				var (
+					dbName, tableName, indexName string
+					replicaNodeIDs               []roachpb.NodeID
+				)
+				_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
+				if err != nil {
+					continue
+				}
+				parent := parents[tableID]
+				if parent != 0 {
+					tableName = tableNames[tableID]
+					dbName = dbNames[parent]
+				} else {
+					dbName = dbNames[tableID]
+				}
+				_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
+				if err == nil {
+					indexName = indexNames[tableID][idxID]
+				}
+				for _, repl := range r.Desc.Replicas().Descriptors() {
+					replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
+				}
+				ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
+					RangeID:           r.Desc.RangeID,
+					NodeID:            nodeID,
+					QPS:               r.QueriesPerSecond,
+					TableName:         tableName,
+					DatabaseName:      dbName,
+					IndexName:         indexName,
+					ReplicaNodeIds:    replicaNodeIDs,
+					LeaseholderNodeID: r.LeaseholderNodeID,
+				})
+			}
+		}
+	}
+
+	return &serverpb.HotRangesResponseV2{Ranges: ranges}, nil
+}
+
 func (s *statusServer) localHotRanges(ctx context.Context) serverpb.HotRangesResponse_NodeResponse {
 	var resp serverpb.HotRangesResponse_NodeResponse
 	err := s.stores.VisitStores(func(store *kvserver.Store) error {
@@ -2114,6 +2202,10 @@ func (s *statusServer) localHotRanges(ctx context.Context) serverpb.HotRangesRes
 			HotRanges: make([]serverpb.HotRangesResponse_HotRange, len(ranges)),
 		}
 		for i, r := range ranges {
+			replica, err := store.GetReplica(r.Desc.GetRangeID())
+			if err == nil {
+				storeResp.HotRanges[i].LeaseholderNodeID = replica.State(ctx).Lease.Replica.NodeID
+			}
 			storeResp.HotRanges[i].Desc = *r.Desc
 			storeResp.HotRanges[i].QueriesPerSecond = r.QPS
 		}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2121,14 +2121,23 @@ type hotRangeReportMeta struct {
 func (s *statusServer) HotRangesV2(
 	ctx context.Context, req *serverpb.HotRangesRequest,
 ) (*serverpb.HotRangesResponseV2, error) {
-	resp, err := s.HotRanges(ctx, req)
-	if err != nil {
+	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
 		return nil, err
+	}
+
+	size := int(req.PageSize)
+	start := paginationState{}
+
+	if len(req.PageToken) > 0 {
+		if err := start.UnmarshalText([]byte(req.PageToken)); err != nil {
+			return nil, err
+		}
 	}
 
 	rangeReportMetas := make(map[uint32]hotRangeReportMeta)
 	var descrs []catalog.Descriptor
-	if err = s.sqlServer.distSQLServer.CollectionFactory.Txn(
+	var err error
+	if err := s.sqlServer.distSQLServer.CollectionFactory.Txn(
 		ctx, s.sqlServer.internalExecutor, s.db,
 		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
 			all, err := descriptors.GetAllDescriptors(ctx, txn)
@@ -2162,51 +2171,99 @@ func (s *statusServer) HotRangesV2(
 		rangeReportMetas[id] = meta
 	}
 
-	var ranges []*serverpb.HotRangesResponseV2_HotRange
-	for nodeID, hr := range resp.HotRangesByNodeID {
-		for _, store := range hr.Stores {
-			for _, r := range store.HotRanges {
-				var (
-					dbName, tableName, indexName, schemaName string
-					replicaNodeIDs                           []roachpb.NodeID
-				)
-				_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
-				if err != nil {
-					log.Warningf(ctx, "cannot decode tableID for range descriptor: %s. %s", r.Desc.String(), err.Error())
-					continue
-				}
-				parent := rangeReportMetas[tableID].parentID
-				if parent != 0 {
-					tableName = rangeReportMetas[tableID].tableName
-					dbName = rangeReportMetas[parent].dbName
-				} else {
-					dbName = rangeReportMetas[tableID].dbName
-				}
-				schemaParent := rangeReportMetas[tableID].schemaParentID
-				schemaName = rangeReportMetas[schemaParent].schemaName
-				_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
-				if err == nil {
-					indexName = rangeReportMetas[tableID].indexNames[idxID]
-				}
-				for _, repl := range r.Desc.Replicas().Descriptors() {
-					replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
-				}
-				ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
-					RangeID:           r.Desc.RangeID,
-					NodeID:            nodeID,
-					QPS:               r.QueriesPerSecond,
-					TableName:         tableName,
-					SchemaName:        schemaName,
-					DatabaseName:      dbName,
-					IndexName:         indexName,
-					ReplicaNodeIds:    replicaNodeIDs,
-					LeaseholderNodeID: r.LeaseholderNodeID,
-				})
-			}
-		}
+	response := &serverpb.HotRangesResponseV2{
+		ErrorsByNodeID: make(map[roachpb.NodeID]string),
 	}
 
-	return &serverpb.HotRangesResponseV2{Ranges: ranges}, nil
+	var requestedNodes []roachpb.NodeID
+	if len(req.NodeID) > 0 {
+		requestedNodeID, _, err := s.parseNodeID(req.NodeID)
+		if err != nil {
+			return nil, err
+		}
+		requestedNodes = []roachpb.NodeID{requestedNodeID}
+	}
+
+	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
+		client, err := s.dialNode(ctx, nodeID)
+		return client, err
+	}
+	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
+	nodeFn := func(ctx context.Context, client interface{}, nodeID roachpb.NodeID) (interface{}, error) {
+		status := client.(serverpb.StatusClient)
+		resp, err := status.HotRanges(ctx, &remoteRequest)
+		if err != nil || resp == nil {
+			return nil, err
+		}
+		var ranges []*serverpb.HotRangesResponseV2_HotRange
+		for nodeID, hr := range resp.HotRangesByNodeID {
+			for _, store := range hr.Stores {
+				for _, r := range store.HotRanges {
+					var (
+						dbName, tableName, indexName, schemaName string
+						replicaNodeIDs                           []roachpb.NodeID
+					)
+					_, tableID, err := s.sqlServer.execCfg.Codec.DecodeTablePrefix(r.Desc.StartKey.AsRawKey())
+					if err != nil {
+						log.Warningf(ctx, "cannot decode tableID for range descriptor: %s. %s", r.Desc.String(), err.Error())
+						continue
+					}
+					parent := rangeReportMetas[tableID].parentID
+					if parent != 0 {
+						tableName = rangeReportMetas[tableID].tableName
+						dbName = rangeReportMetas[parent].dbName
+					} else {
+						dbName = rangeReportMetas[tableID].dbName
+					}
+					schemaParent := rangeReportMetas[tableID].schemaParentID
+					schemaName = rangeReportMetas[schemaParent].schemaName
+					_, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey())
+					if err == nil {
+						indexName = rangeReportMetas[tableID].indexNames[idxID]
+					}
+					for _, repl := range r.Desc.Replicas().Descriptors() {
+						replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
+					}
+					ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
+						RangeID:           r.Desc.RangeID,
+						NodeID:            nodeID,
+						QPS:               r.QueriesPerSecond,
+						TableName:         tableName,
+						SchemaName:        schemaName,
+						DatabaseName:      dbName,
+						IndexName:         indexName,
+						ReplicaNodeIds:    replicaNodeIDs,
+						LeaseholderNodeID: r.LeaseholderNodeID,
+					})
+				}
+			}
+		}
+		return ranges, nil
+	}
+	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
+		if resp == nil {
+			return
+		}
+		hotRanges := resp.([]*serverpb.HotRangesResponseV2_HotRange)
+		response.Ranges = append(response.Ranges, hotRanges...)
+	}
+	errorFn := func(nodeID roachpb.NodeID, err error) {
+		response.ErrorsByNodeID[nodeID] = err.Error()
+	}
+
+	next, err := s.paginatedIterateNodes(
+		ctx, "hotRanges", size, start, requestedNodes, dialFn,
+		nodeFn, responseFn, errorFn)
+
+	if err != nil {
+		return nil, err
+	}
+	var nextBytes []byte
+	if nextBytes, err = next.MarshalText(); err != nil {
+		return nil, err
+	}
+	response.NextPageToken = string(nextBytes)
+	return response, nil
 }
 
 func (s *statusServer) localHotRanges(ctx context.Context) serverpb.HotRangesResponse_NodeResponse {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1102,6 +1102,31 @@ func TestHotRangesResponse(t *testing.T) {
 	}
 }
 
+func TestHotRanges2Response(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ts := startServer(t)
+	defer ts.Stopper().Stop(context.Background())
+
+	var hotRangesResp serverpb.HotRangesResponseV2
+	if err := getStatusJSONProto(ts, "v2/hotranges", &hotRangesResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(hotRangesResp.Ranges) == 0 {
+		t.Fatalf("didn't get hot range responses from any nodes")
+	}
+	lastQPS := math.MaxFloat64
+	for _, r := range hotRangesResp.Ranges {
+		if r.RangeID == 0 {
+			t.Errorf("unexpected empty range id: %d", r.RangeID)
+		}
+		if r.QPS > lastQPS {
+			t.Errorf("unexpected increase in qps between ranges; prev=%.2f, current=%.2f", lastQPS, r.QPS)
+		}
+		lastQPS = r.QPS
+	}
+}
+
 func TestRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1109,7 +1109,7 @@ func TestHotRanges2Response(t *testing.T) {
 	defer ts.Stopper().Stop(context.Background())
 
 	var hotRangesResp serverpb.HotRangesResponseV2
-	if err := getStatusJSONProto(ts, "v2/hotranges", &hotRangesResp); err != nil {
+	if err := postStatusJSONProto(ts, "v2/hotranges", &serverpb.HotRangesRequest{}, &hotRangesResp); err != nil {
 		t.Fatal(err)
 	}
 	if len(hotRangesResp.Ranges) == 0 {

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -62,6 +62,7 @@ import Nodes from "src/views/reports/containers/nodes";
 import ProblemRanges from "src/views/reports/containers/problemRanges";
 import Range from "src/views/reports/containers/range";
 import ReduxDebug from "src/views/reports/containers/redux";
+import HotRanges from "src/views/reports/containers/hotranges";
 import Settings from "src/views/reports/containers/settings";
 import Stores from "src/views/reports/containers/stores";
 import SQLActivityPage from "src/views/sqlActivity/sqlActivityPage";
@@ -273,6 +274,12 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   exact
                   path="/debug/enqueue_range"
                   component={EnqueueRange}
+                />
+                <Route exact path="/debug/hotranges" component={HotRanges} />
+                <Route
+                  exact
+                  path="/debug/hotranges/:node_id"
+                  component={HotRanges}
                 />
 
                 <Route path="/raft">

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -148,6 +148,9 @@ export type ResetIndexUsageStatsResponseMessage = protos.cockroach.server.server
 export type UserSQLRolesRequestMessage = protos.cockroach.server.serverpb.UserSQLRolesRequest;
 export type UserSQLRolesResponseMessage = protos.cockroach.server.serverpb.UserSQLRolesResponse;
 
+export type HotRangesRequestMessage = protos.cockroach.server.serverpb.HotRangesRequest;
+export type HotRangesV2ResponseMessage = protos.cockroach.server.serverpb.HotRangesResponseV2;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -817,6 +820,18 @@ export function getUserSQLRoles(
   return timeoutFetch(
     serverpb.UserSQLRolesResponse,
     `${STATUS_PREFIX}/sqlroles`,
+    req as any,
+    timeout,
+  );
+}
+
+export function getHotRanges(
+  req: HotRangesRequestMessage,
+  timeout?: moment.Duration,
+): Promise<HotRangesV2ResponseMessage> {
+  return timeoutFetch(
+    serverpb.HotRangesResponseV2,
+    `${STATUS_PREFIX}/v2/hotranges`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -505,13 +505,25 @@ export default function Debug() {
         <DebugTableRow title="Hot Ranges">
           <DebugTableLink
             name="All Nodes"
-            url="_status/v2/hotranges"
-            note="_status/v2/hotranges"
+            url="#/debug/hotranges"
+            note="#/debug/hotranges"
           />
           <DebugTableLink
             name="Single node's ranges"
-            url="_status/v2/hotranges?node_id=local"
-            note="_status/v2/hotranges?node_id=[node_id]"
+            url="#/debug/hotranges/local"
+            note="#/debug/hotranges/[node_id]"
+          />
+        </DebugTableRow>
+        <DebugTableRow title="Hot Ranges (legacy)">
+          <DebugTableLink
+            name="All Nodes"
+            url="_status/hotranges"
+            note="_status/hotranges"
+          />
+          <DebugTableLink
+            name="Single node's ranges"
+            url="_status/hotranges?node_id=local"
+            note="_status/hotranges?node_id=[node_id]"
           />
         </DebugTableRow>
         <DebugTableRow title="Single Node Specific">

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -505,13 +505,13 @@ export default function Debug() {
         <DebugTableRow title="Hot Ranges">
           <DebugTableLink
             name="All Nodes"
-            url="_status/hotranges"
-            note="_status/hotranges"
+            url="_status/v2/hotranges"
+            note="_status/v2/hotranges"
           />
           <DebugTableLink
             name="Single node's ranges"
-            url="_status/hotranges?node_id=local"
-            note="_status/hotranges?node_id=[node_id]"
+            url="_status/v2/hotranges?node_id=local"
+            note="_status/v2/hotranges?node_id=[node_id]"
           />
         </DebugTableRow>
         <DebugTableRow title="Single Node Specific">

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -1,0 +1,57 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useCallback, useEffect, useState } from "react";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import moment from "moment";
+import { Button } from "@cockroachlabs/ui-components";
+import { cockroach } from "src/js/protos";
+import { getHotRanges } from "src/util/api";
+
+type HotRangesProps = RouteComponentProps<{ node_id: string }>;
+
+const HotRanges = (props: HotRangesProps) => {
+  const nodeIdParam = props.match.params["node_id"];
+  const [nodeId, setNodeId] = useState(nodeIdParam);
+  const [time, setTime] = useState<moment.Moment>(moment());
+  const [hotRanges, setHotRanges] = useState<
+    cockroach.server.serverpb.HotRangesResponseV2["ranges"]
+  >([]);
+  const requestHotRanges = useCallback(() => {
+    const request = cockroach.server.serverpb.HotRangesRequest.create({
+      node_id: nodeId,
+    });
+    getHotRanges(request).then(response => {
+      setHotRanges(response.ranges);
+      setTime(moment());
+    });
+  }, [nodeId]);
+  useEffect(requestHotRanges, [requestHotRanges, nodeId]);
+  useEffect(() => {
+    setNodeId(nodeIdParam);
+  }, [nodeIdParam]);
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <span>{`Node ID: ${nodeId ?? "All nodes"}`}</span>
+      <span>{`Time: ${time.toISOString()}`}</span>
+      <Button onClick={requestHotRanges} intent={"secondary"}>
+        Refresh
+      </Button>
+      <pre className="state-json-box">{JSON.stringify(hotRanges, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default withRouter(HotRanges);


### PR DESCRIPTION
This change implements second version of hot ranges api that's required
for UI to represent enhanced Hot Ranges view.

It reuses former implementation but doesn't expose sensitive internal data.
Instead, it provides flat structure of fields required for ui.

New `HotRangeV2` endpoint is established to:
- maintain backward compatibility
- do not expose internal data as it's done in `HotRange` endpoint

Release note: None

Release justification: bug fixes and low-risk updates to new functionality