### PR TITLE
sql/schemachanger: change BUILD.bazel test size to medium

### DIFF
--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "schemachanger_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "end_to_end_test.go",
         "main_test.go",


### PR DESCRIPTION
The test was marked `small`. Such tests get a `1m` timeout. This tests was
timing out sometimes in teamcity (see [internal slack convo](
https://cockroachlabs.slack.com/archives/C019A8NANH0/p1640873408239100)).

The test started [here](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests_BazelUnitTests/4031081?buildTab=log&focusLine=75078&linesState=4608.4613.77679.77680)
```
I220103 07:35:43.002985 1 (gostd) rand.go:147  [-] 1  random seed: -458878662082605538
```
And timed out [here](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests_BazelUnitTests/4031081?buildTab=log&focusLine=77673&linesState=4608.4613.77679.77680)
```
-- Test timed out at 2022-01-03 07:36:41 UTC --
```

Release note: None