### PR TITLE
sql: wrong column is used for foreign keys when adding multiple columns

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1273,8 +1273,9 @@ func (desc *Mutable) RenameColumnDescriptor(column catalog.Column, newColName st
 func (desc *Mutable) FindActiveOrNewColumnByName(name tree.Name) (catalog.Column, error) {
 	currentMutationID := desc.ClusterVersion.NextMutationID
 	for _, col := range desc.DeletableColumns() {
-		if (col.Public() && col.ColName() == name) ||
-			(col.Adding() && col.MutationID() == currentMutationID) {
+		if col.ColName() == name &&
+			((col.Public()) ||
+				(col.Adding() && col.MutationID() == currentMutationID)) {
 			return col, nil
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2080,3 +2080,29 @@ CREATE TABLE public.t (
 
 statement error multiple primary keys for table "t" are not allowed
 ALTER TABLE t ADD CONSTRAINT t_pkey PRIMARY KEY (id)
+
+# Fixes issues 74360, 73798 which occur because we were not looking up
+# the column names for non-public column mutations and only using the
+# mutation ID when creating the foreign key. As a result the wrong column
+# could be referenced for a foreign key (or an error could occur if the types
+# of the selected column doesn't match) referenced column did not match.
+subtest add_column_with_constraint
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE colref (id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY);
+CREATE TABLE colsource (id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY);
+
+statement ok
+ALTER TABLE colsource ADD COLUMN description STRING NULL, ADD COLUMN customer_id UUID REFERENCES colref(id);
+
+statement ok
+ALTER TABLE colsource DROP COLUMN description, DROP COLUMN customer_id
+
+statement ok
+ALTER TABLE colsource ADD COLUMN customer_id UUID  REFERENCES colref(id), ADD COLUMN description STRING NULL;
+
+statement ok
+COMMIT


### PR DESCRIPTION
Fixes: #74360, #73798

Previously, when we added columns and foreign keys in
the same transaction, we incorrectly looked up the added
columns only based on the mutation ID (ignoring the name).
This was inadequate, because the mutation ID would tell us
only *if* a column was added at the same time as the foreign
key reference. However, multiple columns can be added in the
same statement, so the first matching column may not necessarily
be the correct one. To address this, this patch modifies the
logic to find the matching column for the foreign key references
compare both mutation ID and column name.

Release note (bug fix): when foreign keys were included inside
an add column statement and multiple columns were added in
a single statement then the wrong column could have the foreign
key applied (or an error generated based on the wrong column).