### PR TITLE
vendor: bump Pebble to a71dc5a033cf

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1218,10 +1218,10 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sha256 = "6812b1e9a3cc7e810415d30ed87419ede2bfe2bc90cf9f8b3a252c3c3ccff923",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20211019184201-7fec828fc1af",
+        sha256 = "01bbbd8a079753674a8a5698054506ea2db167e94be52a094c2ee0779a88d9c6",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220104184117-a71dc5a033cf",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20211019184201-7fec828fc1af.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220104184117-a71dc5a033cf.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20211019184201-7fec828fc1af
+	github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20211019184201-7fec828fc1af h1:NY+UDVTyU+Y2wKr0ocnBSbXGYTHEGwnQ9ukP+qg7xfY=
-github.com/cockroachdb/pebble v0.0.0-20211019184201-7fec828fc1af/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf h1:jjRy2qNBIrU2zyo4MQy4ywP9PkRhHTowAYoxP7RCMGM=
+github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
a71dc5a0 internal/keyspan: emit fragmented spans ordered by (seqnum, kind)
b82ab130 vfs: allow MemFS to be Open()'d at the root directory
06e42cfa internal/rangekey: add IsRangeKey helper
4143e5c1 sstable: use exclusive upper bounds in valueCharBlockIntervalCollector
3fb2ba80 internal/rangekey: configure Coalescer to drop spans not visible
95196c54 sstable: add data-driven test for block property collectors
31e9d6b7 tool: add brief description of LSM tool to usage output
e3d940c5 sstable: clarify comment on block restart interval placement
e4892ffd internal/metamorphic: generate keys with suffixes
e2a8aef2 internal/rangekey: add InterleavingIter
bcd4c82e sstable: add range keys to sstable.Layout
cccd12fe sstable: fix properties block location in docs
989fa6f0 sstable: add meta block for range keys; support writing range keys
cf6c4746 db: introduce TotalDuration to FlushInfo and CompactionInfo events
6c6ca21e internal/testkeys: change suffix delimiter to just '@'
a9a2b6e3 sstable: fix comments about the sstable format
b10ca3a5 internal/keyspan: adjust Span.Empty for range keys
68bac99f internal/base: adjust InternalCompare comment on key kinds
afc7368a sstable: rename {Smallest,Largest}Range to {Smallest,Largest}RangeDel
f5b94e81 db: add test that shows effects of InternalKeyKind ordering for ingested sstables
218cfbf8 internal/rangekeys: add Iter
6b0d835f internal/rangekey: add Coalescer, CoalescedSpan
4b595de9 compaction: use sstable writer for detecting user key changes
afaa43db mkbench: emit and parse write amplification in write benchmarks
f6167e30 rangekey: fix formatting
7fb375f7 *: format files according to gofmt
fc3ffab0 ci: add gofmt linter
08c5d46c internal/base: document new Split requirements
5d99779c batch: add RangeKey{Set,Unset,Delete} methods
e6abf342 sstable: gofmt -s
83099538 sstable: add RewriteKeySuffixes function
9791c0f4 Revert "sstable: reduce allocations during index flushing"
0dc90bc4 docs: add write-throughput visualization
613e08ee internal/keyspan: add Value to Span
b2722167 sstable: pass prevKey at callsite to writer.addIndexEntry
09a38edc sstable: refactor tests slightly
bd9b59c8 sstable: reduce allocations during index flushing
9cece175 ci: add go mod tidy lint check
3036ce0f sstable: use package-level error in place of runtime allocation
e614af10 *: add .editorconfig
e57e5fdb sstable: extend BenchmarkWriter
4bd8dd15 cmd: remove references to badger
a6f09273 mkbench: use benchmark data to infer names
1adc45db internal/testkeys: new package
6c34da06 cmd: match admission control values in write-throughput benchmark
b4d64c64 db: add deletable value merger
447349ef docs: add annotations for recent changes to benchmarks
cb8172c0 db: add a benchmark for block property filtering
8a465836 internal/mkbench: follow symbolic links
c0661aef mkbench: add write-throughput benchmark data parser
32634c4b mkbench: minor improvements / refactoring / cleanup
1c17b69e internal/mkbench: add tests
aaa0b524 cmd/pebble: avoid bursts in `pebble bench write`
c06c65fd Add .gitignore; ignore profiling artifacts
45b96c44 *: move test-only code into test files
7369c457 db: genericize rangeDel{Cache,Frags} into keySpan{Cache,Frags}
27954e17 db: add randomized block property filtering test
efc52615 cmd/pebble: add `--max-rate-dip-fraction` flag to `pebble bench write`
28b26b65 ci: bump specialized CI runs to use Go 1.17
bd32bf58 internal/keyspan: rename from rangedel
1682bf97 ci: pin macOS builds to macos-11
8704826b cmd/pebble: add sustainable write throughput benchmark
e9e20826 db: add in-progress compaction count metric
9106d5d2 docs: add closing body tag in index.html

Release note: