### PR TITLE
release-21.2: git: delete gitignore'd files automatically on checkout

### DIFF
--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -2,5 +2,6 @@
 set -e
 
 if [ "$1" != "$2" ]; then # previous ref != new ref.
+  git clean -fd "pkg/**.pb.go" "pkg/**.pb.gw.go" "pkg/**.eg.go" "pkg/**.og.go" "pkg/**generated.go"
   exec git submodule update --init --recursive
 fi


### PR DESCRIPTION
Backport change from #74255.

Release note: None
Release justification: Non-production code change