### PR TITLE
opt: fix SimplifyPartialIndexProjections

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1753,6 +1753,7 @@ ALTER TABLE t58390 ALTER PRIMARY KEY USING COLUMNS (b, a)
 # Regression tests for #61414. Upsert execution should not error if partial
 # index PUT and DEL columns are not the last columns in the input of the
 # mutation.
+subtest regression_61414
 
 statement ok
 create table t61414_a (
@@ -1800,6 +1801,7 @@ UPSERT INTO t61414_c (k, a, b, d) VALUES (1, 2, 3, 4)
 # expressions, there should not be ambiguous column errors if there exists
 # columns in an UPDATE FROM clause that match column names in the partial index
 # predicate.
+subtest regression_61284
 
 statement ok
 CREATE TABLE t61284 (
@@ -1809,3 +1811,24 @@ CREATE TABLE t61284 (
 
 statement ok
 UPDATE t61284 SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE t61284.a = v.a
+
+# Regression test for #74385. Correctly maintain multiple partial indexes with
+# the same predicate.
+subtest regression_74385
+
+statement ok
+CREATE TABLE t74385 (
+  k INT PRIMARY KEY,
+  a STRING,
+  b STRING,
+  c STRING,
+  INDEX b_idx (b) WHERE c IS NULL,
+  INDEX a_idx (a) WHERE c IS NULL
+);
+INSERT INTO t74385 (k, a, b, c) VALUES (10, 'a', 'b', NULL);
+UPDATE t74385 SET b = NULL
+
+query ITTT
+SELECT * FROM t74385@b_idx
+WHERE b = 'b' AND c IS NULL;
+----

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -256,3 +256,46 @@ update t
            ├── false [as=partial_index_put2:24]
            ├── false [as=partial_index_put3:25]
            └── d:16 > 1 [as=h_new:23, outer=(16)]
+
+# Regression for #74385. Do not simplify partial index put/del columns to false
+# for one index which includes mutating columns where there is another index
+# with the same predicate that does not include mutating columns.
+exec-ddl
+CREATE TABLE t74385 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  INDEX b_idx (b) WHERE c IS NULL,
+  INDEX a_idx (a) WHERE c IS NULL
+)
+----
+
+norm expect-not=SimplifyPartialIndexProjections
+UPDATE t74385 SET b = NULL
+----
+update t74385
+ ├── columns: <none>
+ ├── fetch columns: k:7 a:8 b:9 c:10
+ ├── update-mapping:
+ │    └── b_new:13 => b:3
+ ├── partial index put columns: partial_index_put1:14 partial_index_put1:14
+ ├── partial index del columns: partial_index_put1:14 partial_index_put1:14
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: partial_index_put1:14!null b_new:13 k:7!null a:8 b:9 c:10
+      ├── key: (7)
+      ├── fd: ()-->(13), (7)-->(8-10), (10)-->(14)
+      ├── scan t74385
+      │    ├── columns: k:7!null a:8 b:9 c:10
+      │    ├── partial index predicates
+      │    │    ├── b_idx: filters
+      │    │    │    └── c:10 IS NULL [outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
+      │    │    └── a_idx: filters
+      │    │         └── c:10 IS NULL [outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
+      │    ├── key: (7)
+      │    └── fd: (7)-->(8-10)
+      └── projections
+           ├── c:10 IS NULL [as=partial_index_put1:14, outer=(10)]
+           └── CAST(NULL AS INT8) [as=b_new:13]


### PR DESCRIPTION
Previously, the SimplifyPartialIndexProjections rule incorrectly
simplified partial index PUT and DEL columns that were reused for
multiple partial indexes. This caused index corruption which could
result in incorrect query results.

For example, consider:

    CREATE TABLE t (
      a INT,
      b INT,
      c INT,
      INDEX a_idx (a) WHERE c IS NULL,
      INDEX b_idx (b) WHERE c IS NULL
    )

    UPDATE t SET a = NULL

In the UPDATE, a single column will be synthesized for the PUT and DEL
columns of both partial indexes. The UPDATE does not mutate columns in
b_idx, so the synthesized column was simplified to false. However, this
caused index corruption of a_idx because a_idx contains mutating columns
and it may require writes.

The rule has been updated so that synthesized PUT and DEL columns are
only simplified to false if they are used for a single partial index.

Fixes #74385

Release note (bug fix): A bug has been fixed which caused corruption of
partial indexes, which could cause incorrect query results. The bug was
only present when two or more partial indexes in the same table had
identical `WHERE` clauses. This bug has been present since version
21.1.0.