### PR TITLE
sql: deflake TestScheduledSQLStatsCompaction

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -155,11 +155,11 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 	schedule = getSQLStatsCompactionSchedule(t, helper)
 	require.Equal(t, string(jobs.StatusSucceeded), schedule.ScheduleStatus())
 
-	stmtStatsCnt, txnStatsCnt = getPersistedStatsEntry(t, helper.sqlDB)
-	require.Equal(t, 1 /* expected */, stmtStatsCnt,
-		"expecting exactly 1 persisted stmt fingerprints, but found: %d", stmtStatsCnt)
-	require.Equal(t, 1 /* expected */, txnStatsCnt,
-		"expecting exactly 1 persisted txn fingerprints, but found: %d", txnStatsCnt)
+	stmtStatsCntPostCompact, txnStatsCntPostCompact := getPersistedStatsEntry(t, helper.sqlDB)
+	require.Less(t, stmtStatsCntPostCompact, stmtStatsCnt,
+		"expecting persisted stmt fingerprints count to be less than %d, but found: %d", stmtStatsCnt, stmtStatsCntPostCompact)
+	require.Less(t, txnStatsCntPostCompact, txnStatsCnt,
+		"expecting persisted txn fingerprints count to be less than %d, but found: %d", txnStatsCnt, txnStatsCntPostCompact)
 }
 
 func TestSQLStatsScheduleOperations(t *testing.T) {


### PR DESCRIPTION
Previously, TestScheduledSQLStatsCompaction tried to assert the
exact number of rows present in the system table after the compaction
job finishes executing. However, due to the limit-per-shard
implementation used by the compaction job, this can cause flakes when
there the last shard of the system table is empty.

This commit addresses this problem by asserting that the number of rows
present in the system table is strictly less than the row count prior to
compaction job's execution.

Addresses #74428

Release note: None