### PR TITLE
build: add <release branch> to nightly and latest tag values

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -11,8 +11,11 @@ build/builder.sh make .buildinfo/tag
 build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
+release_branch="$(echo "$TC_BUILD_BRANCH" || echo "")"
 is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
+
+# Prepend release branch onto build_name
+build_name="${release_branch}-${build_name}"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET-cockroach-builds}"

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -4,13 +4,13 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 # mark_build marks a build with a given label specified as a parameter on
 # docker. For example, calling this function on the label "qualified", on a
-# v19.2.4 build would tag it as `latest-v19.2-qualified-build`.
+# v19.2.4 build would tag it as `latest-release-19.2-qualified-build`.
 mark_build() {
   tc_start_block "Variable Setup"
   build_label=$1
 
   # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
+  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9]+\.[0-9]+)|(master)" || echo"")"
 
   if [[ -z "${DRY_RUN}" ]] ; then
     google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS


### PR DESCRIPTION
Previously, it was unclear if a nightly build was generated
from a release branch or a custom branch.

This commit clarifies that by incorporating `<release branch>`
into both the nightly tag and latest tag values. For
example:

||Old value|New value|
|--|--|--|
|Nightly tag|`v21.1.12-110-g697d71136a`|`release-21.1-v21.1.12-110-g697d71136a`|
|Latest tag|`latest-v21.1-build`|`latest-release-21.1-build`|
|Latest qualified tag|`latest-v21.1-qualified-build`|`latest-release-21.1-qualified-build`|

Release note: None