### PR TITLE
Make infinite sleep actually infinite

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/client.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/client.yaml
@@ -24,7 +24,7 @@ spec:
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:
     - sleep
-    - "2147483648" # 2^31
+    - inf
     volumeMounts:
     - name: client-certs
       mountPath: /cockroach-certs

--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -40,7 +40,7 @@ spec:
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:
     - sleep
-    - "2147483648" # 2^31
+    - inf
   # This pod isn't doing anything important, so don't bother waiting to terminate it.
   terminationGracePeriodSeconds: 0
   volumes:

--- a/cloud/kubernetes/multiregion/client-secure.yaml
+++ b/cloud/kubernetes/multiregion/client-secure.yaml
@@ -17,7 +17,7 @@ spec:
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:
     - sleep
-    - "2147483648" # 2^31
+    - inf
   # This pod isn't doing anything important, so don't bother waiting to terminate it.
   terminationGracePeriodSeconds: 0
   volumes:

--- a/cloud/kubernetes/v1.6/client-secure.yaml
+++ b/cloud/kubernetes/v1.6/client-secure.yaml
@@ -40,7 +40,7 @@ spec:
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:
     - sleep
-    - "2147483648" # 2^31
+    - inf
   # This pod isn't doing anything important, so don't bother waiting to terminate it.
   terminationGracePeriodSeconds: 0
   volumes:

--- a/cloud/kubernetes/v1.7/client-secure.yaml
+++ b/cloud/kubernetes/v1.7/client-secure.yaml
@@ -40,7 +40,7 @@ spec:
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:
     - sleep
-    - "2147483648" # 2^31
+    - inf
   # This pod isn't doing anything important, so don't bother waiting to terminate it.
   terminationGracePeriodSeconds: 0
   volumes:


### PR DESCRIPTION
GNU sleep supports "inf" as an argument, which internally works basically as "while true; sleep maxint" (not really, but effectively that).  This is better than an integer argument not so much because of a  billion seconds possibly not being long enough, but mostly because it's way more self-documenting as to the intent.

https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html#sleep-invocation for reference, because "inf" as an arg to sleep isn't nearly as well-known as I think it should be. :)