### PR TITLE
colexecagg: reduce the size of hash aggregates

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -101,7 +101,7 @@ var aggTypesWithPartial = []aggType{
 	},
 }
 
-var aggTypes = aggTypesWithPartial[:1]
+var aggTypes = aggTypesWithPartial[:2]
 
 func (tc *aggregatorTestCase) init() error {
 	if tc.convToDecimal {

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -105,7 +105,7 @@ type avg_TYPE_AGGKINDAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []_RET_GOTYPE
+	col _RET_GOTYPESLICE
 	// {{if .NeedsHelper}}
 	// {{/*
 	// overloadHelper is used only when we perform the summation of integers

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -59,10 +59,10 @@ func newBool_OP_TYPE_AGGKINDAggAlloc(
 type bool_OP_TYPE_AGGKINDAgg struct {
 	// {{if eq "_AGGKIND" "Ordered"}}
 	orderedAggregateFuncBase
+	col coldata.Bools
 	// {{else}}
 	unorderedAggregateFuncBase
 	// {{end}}
-	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -71,14 +71,13 @@ type bool_OP_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &bool_OP_TYPE_AGGKINDAgg{}
 
+// {{if eq "_AGGKIND" "Ordered"}}
 func (a *bool_OP_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
-	// {{if eq "_AGGKIND" "Ordered"}}
 	a.orderedAggregateFuncBase.SetOutput(vec)
-	// {{else}}
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	// {{end}}
 	a.col = vec.Bool()
 }
+
+// {{end}}
 
 func (a *bool_OP_TYPE_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -153,11 +152,14 @@ func (a *bool_OP_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
+	// {{else}}
+	col := a.vec.Bool()
 	// {{end}}
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/bool_and_or_agg_tmpl.go
@@ -62,7 +62,7 @@ type bool_OP_TYPE_AGGKINDAgg struct {
 	// {{else}}
 	unorderedAggregateFuncBase
 	// {{end}}
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -43,23 +43,22 @@ func newCount_COUNTKIND_AGGKINDAggAlloc(
 type count_COUNTKIND_AGGKINDAgg struct {
 	// {{if eq "_AGGKIND" "Ordered"}}
 	orderedAggregateFuncBase
+	col coldata.Int64s
 	// {{else}}
 	unorderedAggregateFuncBase
 	// {{end}}
-	col    coldata.Int64s
 	curAgg int64
 }
 
 var _ AggregateFunc = &count_COUNTKIND_AGGKINDAgg{}
 
+// {{if eq "_AGGKIND" "Ordered"}}
 func (a *count_COUNTKIND_AGGKINDAgg) SetOutput(vec coldata.Vec) {
-	// {{if eq "_AGGKIND" "Ordered"}}
 	a.orderedAggregateFuncBase.SetOutput(vec)
-	// {{else}}
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	// {{end}}
 	a.col = vec.Int64()
 }
+
+// {{end}}
 
 func (a *count_COUNTKIND_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -146,8 +145,11 @@ func (a *count_COUNTKIND_AGGKINDAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
+	// {{else}}
+	col := a.vec.Int64()
 	// {{end}}
-	a.col[outputIdx] = a.curAgg
+	col[outputIdx] = a.curAgg
 }
 
 // {{if eq "_AGGKIND" "Ordered"}}

--- a/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/count_agg_tmpl.go
@@ -46,7 +46,7 @@ type count_COUNTKIND_AGGKINDAgg struct {
 	// {{else}}
 	unorderedAggregateFuncBase
 	// {{end}}
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -56,14 +56,6 @@ type default_AGGKINDAgg struct {
 
 var _ AggregateFunc = &default_AGGKINDAgg{}
 
-func (a *default_AGGKINDAgg) SetOutput(vec coldata.Vec) {
-	// {{if eq "_AGGKIND" "Ordered"}}
-	a.orderedAggregateFuncBase.SetOutput(vec)
-	// {{else}}
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	// {{end}}
-}
-
 func (a *default_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -106,17 +106,11 @@ func newAnyNotNullHashAggAlloc(
 // first non-null value in the input column.
 type anyNotNullBoolHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Bools
 	curAgg                      bool
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullBoolHashAgg{}
-
-func (a *anyNotNullBoolHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *anyNotNullBoolHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -183,10 +177,11 @@ func (a *anyNotNullBoolHashAgg) Compute(
 func (a *anyNotNullBoolHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Bool()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -219,17 +214,11 @@ func (a *anyNotNullBoolHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullBytesHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         *coldata.Bytes
 	curAgg                      []byte
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullBytesHashAgg{}
-
-func (a *anyNotNullBytesHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
-}
 
 func (a *anyNotNullBytesHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -296,10 +285,11 @@ func (a *anyNotNullBytesHashAgg) Compute(
 func (a *anyNotNullBytesHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Bytes()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	oldCurAggSize := len(a.curAgg)
@@ -336,17 +326,11 @@ func (a *anyNotNullBytesHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullDecimalHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Decimals
 	curAgg                      apd.Decimal
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullDecimalHashAgg{}
-
-func (a *anyNotNullDecimalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *anyNotNullDecimalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -413,10 +397,11 @@ func (a *anyNotNullDecimalHashAgg) Compute(
 func (a *anyNotNullDecimalHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Decimal()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -449,17 +434,11 @@ func (a *anyNotNullDecimalHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullInt16HashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Int16s
 	curAgg                      int16
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullInt16HashAgg{}
-
-func (a *anyNotNullInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int16()
-}
 
 func (a *anyNotNullInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -526,10 +505,11 @@ func (a *anyNotNullInt16HashAgg) Compute(
 func (a *anyNotNullInt16HashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Int16()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -562,17 +542,11 @@ func (a *anyNotNullInt16HashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullInt32HashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Int32s
 	curAgg                      int32
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullInt32HashAgg{}
-
-func (a *anyNotNullInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int32()
-}
 
 func (a *anyNotNullInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -639,10 +613,11 @@ func (a *anyNotNullInt32HashAgg) Compute(
 func (a *anyNotNullInt32HashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Int32()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -675,17 +650,11 @@ func (a *anyNotNullInt32HashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullInt64HashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Int64s
 	curAgg                      int64
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullInt64HashAgg{}
-
-func (a *anyNotNullInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *anyNotNullInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -752,10 +721,11 @@ func (a *anyNotNullInt64HashAgg) Compute(
 func (a *anyNotNullInt64HashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Int64()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -788,17 +758,11 @@ func (a *anyNotNullInt64HashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullFloat64HashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Float64s
 	curAgg                      float64
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullFloat64HashAgg{}
-
-func (a *anyNotNullFloat64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *anyNotNullFloat64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -865,10 +829,11 @@ func (a *anyNotNullFloat64HashAgg) Compute(
 func (a *anyNotNullFloat64HashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Float64()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -901,17 +866,11 @@ func (a *anyNotNullFloat64HashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullTimestampHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Times
 	curAgg                      time.Time
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullTimestampHashAgg{}
-
-func (a *anyNotNullTimestampHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Timestamp()
-}
 
 func (a *anyNotNullTimestampHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -978,10 +937,11 @@ func (a *anyNotNullTimestampHashAgg) Compute(
 func (a *anyNotNullTimestampHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Timestamp()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1014,17 +974,11 @@ func (a *anyNotNullTimestampHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullIntervalHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.Durations
 	curAgg                      duration.Duration
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullIntervalHashAgg{}
-
-func (a *anyNotNullIntervalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *anyNotNullIntervalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1091,10 +1045,11 @@ func (a *anyNotNullIntervalHashAgg) Compute(
 func (a *anyNotNullIntervalHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Interval()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1127,17 +1082,11 @@ func (a *anyNotNullIntervalHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullJSONHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         *coldata.JSONs
 	curAgg                      json.JSON
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullJSONHashAgg{}
-
-func (a *anyNotNullJSONHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.JSON()
-}
 
 func (a *anyNotNullJSONHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1232,10 +1181,11 @@ func (a *anyNotNullJSONHashAgg) Compute(
 func (a *anyNotNullJSONHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.JSON()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	var oldCurAggSize uintptr
@@ -1275,17 +1225,11 @@ func (a *anyNotNullJSONHashAggAlloc) newAggFunc() AggregateFunc {
 // first non-null value in the input column.
 type anyNotNullDatumHashAgg struct {
 	unorderedAggregateFuncBase
-	col                         coldata.DatumVec
 	curAgg                      interface{}
 	foundNonNullForCurrentGroup bool
 }
 
 var _ AggregateFunc = &anyNotNullDatumHashAgg{}
-
-func (a *anyNotNullDatumHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Datum()
-}
 
 func (a *anyNotNullDatumHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1359,10 +1303,11 @@ func (a *anyNotNullDatumHashAgg) Compute(
 func (a *anyNotNullDatumHashAgg) Flush(outputIdx int) {
 	// If we haven't found any non-nulls for this group so far, the output for
 	// this group should be null.
+	col := a.vec.Datum()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -76,18 +76,11 @@ type avgInt16HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt16HashAgg{}
-
-func (a *avgInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -155,12 +148,13 @@ func (a *avgInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -200,18 +194,11 @@ type avgInt32HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt32HashAgg{}
-
-func (a *avgInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -279,12 +266,13 @@ func (a *avgInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -324,18 +312,11 @@ type avgInt64HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt64HashAgg{}
-
-func (a *avgInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -403,12 +384,13 @@ func (a *avgInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -449,16 +431,9 @@ type avgDecimalHashAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalHashAgg{}
-
-func (a *avgDecimalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgDecimalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -521,12 +496,13 @@ func (a *avgDecimalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -567,16 +543,9 @@ type avgFloat64HashAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64HashAgg{}
-
-func (a *avgFloat64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *avgFloat64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -633,10 +602,11 @@ func (a *avgFloat64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Float64()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum / float64(a.curCount)
+		col[outputIdx] = a.curSum / float64(a.curCount)
 	}
 }
 
@@ -675,16 +645,9 @@ type avgIntervalHashAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalHashAgg{}
-
-func (a *avgIntervalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *avgIntervalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -731,10 +694,11 @@ func (a *avgIntervalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Interval()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
+		col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -78,7 +78,7 @@ type avgInt16HashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -202,7 +202,7 @@ type avgInt32HashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -326,7 +326,7 @@ type avgInt64HashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -450,7 +450,7 @@ type avgDecimalHashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []apd.Decimal
+	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalHashAgg{}
@@ -568,7 +568,7 @@ type avgFloat64HashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []float64
+	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64HashAgg{}
@@ -676,7 +676,7 @@ type avgIntervalHashAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []duration.Duration
+	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalHashAgg{}

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -31,7 +31,6 @@ func newBoolAndHashAggAlloc(
 
 type boolAndHashAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -39,11 +38,6 @@ type boolAndHashAgg struct {
 }
 
 var _ AggregateFunc = &boolAndHashAgg{}
-
-func (a *boolAndHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *boolAndHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -87,10 +81,11 @@ func (a *boolAndHashAgg) Compute(
 }
 
 func (a *boolAndHashAgg) Flush(outputIdx int) {
+	col := a.vec.Bool()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 
@@ -132,7 +127,6 @@ func newBoolOrHashAggAlloc(
 
 type boolOrHashAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -140,11 +134,6 @@ type boolOrHashAgg struct {
 }
 
 var _ AggregateFunc = &boolOrHashAgg{}
-
-func (a *boolOrHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *boolOrHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -188,10 +177,11 @@ func (a *boolOrHashAgg) Compute(
 }
 
 func (a *boolOrHashAgg) Flush(outputIdx int) {
+	col := a.vec.Bool()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_bool_and_or_agg.eg.go
@@ -31,7 +31,7 @@ func newBoolAndHashAggAlloc(
 
 type boolAndHashAgg struct {
 	unorderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -132,7 +132,7 @@ func newBoolOrHashAggAlloc(
 
 type boolOrHashAgg struct {
 	unorderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.

--- a/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_concat_agg.eg.go
@@ -27,16 +27,9 @@ type concatHashAgg struct {
 	unorderedAggregateFuncBase
 	// curAgg holds the running total.
 	curAgg []byte
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
 	foundNonNullForCurrentGroup bool
-}
-
-func (a *concatHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
 }
 
 func (a *concatHashAgg) Compute(
@@ -79,10 +72,11 @@ func (a *concatHashAgg) Compute(
 }
 
 func (a *concatHashAgg) Flush(outputIdx int) {
+	col := a.vec.Bytes()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(len(a.curAgg)))

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -28,16 +28,10 @@ func newCountRowsHashAggAlloc(
 // countRowsHashAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countRowsHashAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Int64s
 	curAgg int64
 }
 
 var _ AggregateFunc = &countRowsHashAgg{}
-
-func (a *countRowsHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *countRowsHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -57,7 +51,8 @@ func (a *countRowsHashAgg) Compute(
 }
 
 func (a *countRowsHashAgg) Flush(outputIdx int) {
-	a.col[outputIdx] = a.curAgg
+	col := a.vec.Int64()
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countRowsHashAgg) Reset() {
@@ -97,16 +92,10 @@ func newCountHashAggAlloc(
 // countHashAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countHashAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Int64s
 	curAgg int64
 }
 
 var _ AggregateFunc = &countHashAgg{}
-
-func (a *countHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *countHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -140,7 +129,8 @@ func (a *countHashAgg) Compute(
 }
 
 func (a *countHashAgg) Flush(outputIdx int) {
-	a.col[outputIdx] = a.curAgg
+	col := a.vec.Int64()
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countHashAgg) Reset() {

--- a/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_count_agg.eg.go
@@ -28,7 +28,7 @@ func newCountRowsHashAggAlloc(
 // countRowsHashAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countRowsHashAgg struct {
 	unorderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 
@@ -97,7 +97,7 @@ func newCountHashAggAlloc(
 // countHashAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countHashAgg struct {
 	unorderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -40,10 +40,6 @@ type defaultHashAgg struct {
 
 var _ AggregateFunc = &defaultHashAgg{}
 
-func (a *defaultHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-}
-
 func (a *defaultHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {

--- a/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_min_max_agg.eg.go
@@ -112,8 +112,6 @@ func newMinHashAggAlloc(
 
 type minBoolHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Bools
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -124,11 +122,6 @@ type minBoolHashAgg struct {
 }
 
 var _ AggregateFunc = &minBoolHashAgg{}
-
-func (a *minBoolHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *minBoolHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -221,10 +214,11 @@ func (a *minBoolHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bool()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -255,8 +249,6 @@ func (a *minBoolHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minBytesHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -267,11 +259,6 @@ type minBytesHashAgg struct {
 }
 
 var _ AggregateFunc = &minBytesHashAgg{}
-
-func (a *minBytesHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
-}
 
 func (a *minBytesHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -348,10 +335,11 @@ func (a *minBytesHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bytes()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	oldCurAggSize := len(a.curAgg)
 	// Release the reference to curAgg eagerly. We can't do this for the window
@@ -391,8 +379,6 @@ func (a *minBytesHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minDecimalHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -403,11 +389,6 @@ type minDecimalHashAgg struct {
 }
 
 var _ AggregateFunc = &minDecimalHashAgg{}
-
-func (a *minDecimalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *minDecimalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -484,10 +465,11 @@ func (a *minDecimalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -518,8 +500,6 @@ func (a *minDecimalHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minInt16HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int16s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -530,11 +510,6 @@ type minInt16HashAgg struct {
 }
 
 var _ AggregateFunc = &minInt16HashAgg{}
-
-func (a *minInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int16()
-}
 
 func (a *minInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -633,10 +608,11 @@ func (a *minInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int16()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -667,8 +643,6 @@ func (a *minInt16HashAggAlloc) newAggFunc() AggregateFunc {
 
 type minInt32HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int32s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -679,11 +653,6 @@ type minInt32HashAgg struct {
 }
 
 var _ AggregateFunc = &minInt32HashAgg{}
-
-func (a *minInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int32()
-}
 
 func (a *minInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -782,10 +751,11 @@ func (a *minInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int32()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -816,8 +786,6 @@ func (a *minInt32HashAggAlloc) newAggFunc() AggregateFunc {
 
 type minInt64HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -828,11 +796,6 @@ type minInt64HashAgg struct {
 }
 
 var _ AggregateFunc = &minInt64HashAgg{}
-
-func (a *minInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *minInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -931,10 +894,11 @@ func (a *minInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -965,8 +929,6 @@ func (a *minInt64HashAggAlloc) newAggFunc() AggregateFunc {
 
 type minFloat64HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -977,11 +939,6 @@ type minFloat64HashAgg struct {
 }
 
 var _ AggregateFunc = &minFloat64HashAgg{}
-
-func (a *minFloat64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *minFloat64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1096,10 +1053,11 @@ func (a *minFloat64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1130,8 +1088,6 @@ func (a *minFloat64HashAggAlloc) newAggFunc() AggregateFunc {
 
 type minTimestampHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Times
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1142,11 +1098,6 @@ type minTimestampHashAgg struct {
 }
 
 var _ AggregateFunc = &minTimestampHashAgg{}
-
-func (a *minTimestampHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Timestamp()
-}
 
 func (a *minTimestampHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1237,10 +1188,11 @@ func (a *minTimestampHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Timestamp()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1271,8 +1223,6 @@ func (a *minTimestampHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minIntervalHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1283,11 +1233,6 @@ type minIntervalHashAgg struct {
 }
 
 var _ AggregateFunc = &minIntervalHashAgg{}
-
-func (a *minIntervalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *minIntervalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1364,10 +1309,11 @@ func (a *minIntervalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1398,8 +1344,6 @@ func (a *minIntervalHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minJSONHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.JSONs
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1410,11 +1354,6 @@ type minJSONHashAgg struct {
 }
 
 var _ AggregateFunc = &minJSONHashAgg{}
-
-func (a *minJSONHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.JSON()
-}
 
 func (a *minJSONHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1553,10 +1492,11 @@ func (a *minJSONHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.JSON()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -1602,8 +1542,6 @@ func (a *minJSONHashAggAlloc) newAggFunc() AggregateFunc {
 
 type minDatumHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.DatumVec
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1614,11 +1552,6 @@ type minDatumHashAgg struct {
 }
 
 var _ AggregateFunc = &minDatumHashAgg{}
-
-func (a *minDatumHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Datum()
-}
 
 func (a *minDatumHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1707,10 +1640,11 @@ func (a *minDatumHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Datum()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 
 	var oldCurAggSize uintptr
@@ -1827,8 +1761,6 @@ func newMaxHashAggAlloc(
 
 type maxBoolHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Bools
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1839,11 +1771,6 @@ type maxBoolHashAgg struct {
 }
 
 var _ AggregateFunc = &maxBoolHashAgg{}
-
-func (a *maxBoolHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *maxBoolHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1936,10 +1863,11 @@ func (a *maxBoolHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bool()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1970,8 +1898,6 @@ func (a *maxBoolHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxBytesHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1982,11 +1908,6 @@ type maxBytesHashAgg struct {
 }
 
 var _ AggregateFunc = &maxBytesHashAgg{}
-
-func (a *maxBytesHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
-}
 
 func (a *maxBytesHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2063,10 +1984,11 @@ func (a *maxBytesHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bytes()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	oldCurAggSize := len(a.curAgg)
 	// Release the reference to curAgg eagerly. We can't do this for the window
@@ -2106,8 +2028,6 @@ func (a *maxBytesHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxDecimalHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2118,11 +2038,6 @@ type maxDecimalHashAgg struct {
 }
 
 var _ AggregateFunc = &maxDecimalHashAgg{}
-
-func (a *maxDecimalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *maxDecimalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2199,10 +2114,11 @@ func (a *maxDecimalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2233,8 +2149,6 @@ func (a *maxDecimalHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxInt16HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int16s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2245,11 +2159,6 @@ type maxInt16HashAgg struct {
 }
 
 var _ AggregateFunc = &maxInt16HashAgg{}
-
-func (a *maxInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int16()
-}
 
 func (a *maxInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2348,10 +2257,11 @@ func (a *maxInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int16()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2382,8 +2292,6 @@ func (a *maxInt16HashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxInt32HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int32s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2394,11 +2302,6 @@ type maxInt32HashAgg struct {
 }
 
 var _ AggregateFunc = &maxInt32HashAgg{}
-
-func (a *maxInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int32()
-}
 
 func (a *maxInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2497,10 +2400,11 @@ func (a *maxInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int32()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2531,8 +2435,6 @@ func (a *maxInt32HashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxInt64HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2543,11 +2445,6 @@ type maxInt64HashAgg struct {
 }
 
 var _ AggregateFunc = &maxInt64HashAgg{}
-
-func (a *maxInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *maxInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2646,10 +2543,11 @@ func (a *maxInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2680,8 +2578,6 @@ func (a *maxInt64HashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxFloat64HashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2692,11 +2588,6 @@ type maxFloat64HashAgg struct {
 }
 
 var _ AggregateFunc = &maxFloat64HashAgg{}
-
-func (a *maxFloat64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *maxFloat64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2811,10 +2702,11 @@ func (a *maxFloat64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2845,8 +2737,6 @@ func (a *maxFloat64HashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxTimestampHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Times
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2857,11 +2747,6 @@ type maxTimestampHashAgg struct {
 }
 
 var _ AggregateFunc = &maxTimestampHashAgg{}
-
-func (a *maxTimestampHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Timestamp()
-}
 
 func (a *maxTimestampHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2952,10 +2837,11 @@ func (a *maxTimestampHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Timestamp()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2986,8 +2872,6 @@ func (a *maxTimestampHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxIntervalHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2998,11 +2882,6 @@ type maxIntervalHashAgg struct {
 }
 
 var _ AggregateFunc = &maxIntervalHashAgg{}
-
-func (a *maxIntervalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *maxIntervalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3079,10 +2958,11 @@ func (a *maxIntervalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3113,8 +2993,6 @@ func (a *maxIntervalHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxJSONHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.JSONs
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -3125,11 +3003,6 @@ type maxJSONHashAgg struct {
 }
 
 var _ AggregateFunc = &maxJSONHashAgg{}
-
-func (a *maxJSONHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.JSON()
-}
 
 func (a *maxJSONHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3268,10 +3141,11 @@ func (a *maxJSONHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.JSON()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -3317,8 +3191,6 @@ func (a *maxJSONHashAggAlloc) newAggFunc() AggregateFunc {
 
 type maxDatumHashAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.DatumVec
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -3329,11 +3201,6 @@ type maxDatumHashAgg struct {
 }
 
 var _ AggregateFunc = &maxDatumHashAgg{}
-
-func (a *maxDatumHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Datum()
-}
 
 func (a *maxDatumHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3422,10 +3289,11 @@ func (a *maxDatumHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Datum()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 
 	var oldCurAggSize uintptr

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -74,7 +74,7 @@ type sumInt16HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -193,7 +193,7 @@ type sumInt32HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -312,7 +312,7 @@ type sumInt64HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -431,7 +431,7 @@ type sumDecimalHashAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -544,7 +544,7 @@ type sumFloat64HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -651,7 +651,7 @@ type sumIntervalHashAgg struct {
 	// group, instead of on each iteration.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -73,8 +73,6 @@ type sumInt16HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -82,11 +80,6 @@ type sumInt16HashAgg struct {
 }
 
 var _ AggregateFunc = &sumInt16HashAgg{}
-
-func (a *sumInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -154,10 +147,11 @@ func (a *sumInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -192,8 +186,6 @@ type sumInt32HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -201,11 +193,6 @@ type sumInt32HashAgg struct {
 }
 
 var _ AggregateFunc = &sumInt32HashAgg{}
-
-func (a *sumInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -273,10 +260,11 @@ func (a *sumInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -311,8 +299,6 @@ type sumInt64HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -320,11 +306,6 @@ type sumInt64HashAgg struct {
 }
 
 var _ AggregateFunc = &sumInt64HashAgg{}
-
-func (a *sumInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -392,10 +373,11 @@ func (a *sumInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -430,19 +412,12 @@ type sumDecimalHashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumDecimalHashAgg{}
-
-func (a *sumDecimalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumDecimalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -505,10 +480,11 @@ func (a *sumDecimalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -543,19 +519,12 @@ type sumFloat64HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg float64
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumFloat64HashAgg{}
-
-func (a *sumFloat64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *sumFloat64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -612,10 +581,11 @@ func (a *sumFloat64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -650,19 +620,12 @@ type sumIntervalHashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg duration.Duration
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntervalHashAgg{}
-
-func (a *sumIntervalHashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *sumIntervalHashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -709,10 +672,11 @@ func (a *sumIntervalHashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -157,7 +157,7 @@ func (a *sumInt16HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -276,7 +276,7 @@ func (a *sumInt32HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -395,7 +395,7 @@ func (a *sumInt64HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -508,7 +508,7 @@ func (a *sumDecimalHashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -615,7 +615,7 @@ func (a *sumFloat64HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -712,7 +712,7 @@ func (a *sumIntervalHashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -55,7 +55,7 @@ type sumIntInt16HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -168,7 +168,7 @@ type sumIntInt32HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -281,7 +281,7 @@ type sumIntInt64HashAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -132,7 +132,7 @@ func (a *sumIntInt16HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -245,7 +245,7 @@ func (a *sumIntInt32HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -358,7 +358,7 @@ func (a *sumIntInt64HashAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -54,19 +54,12 @@ type sumIntInt16HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt16HashAgg{}
-
-func (a *sumIntInt16HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -129,10 +122,11 @@ func (a *sumIntInt16HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -167,19 +161,12 @@ type sumIntInt32HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt32HashAgg{}
-
-func (a *sumIntInt32HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -242,10 +229,11 @@ func (a *sumIntInt32HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -280,19 +268,12 @@ type sumIntInt64HashAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt64HashAgg{}
-
-func (a *sumIntInt64HashAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -355,10 +336,11 @@ func (a *sumIntInt64HashAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -197,11 +197,6 @@ func (a *_AGG_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// {{if eq "_AGGKIND" "Window"}}
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		execgen.COPYVAL(a.curAgg, a.curAgg)
-		// {{end}}
 		a.col.Set(outputIdx, a.curAgg)
 	}
 	// {{if and (not (eq "_AGGKIND" "Window")) (or (.IsBytesLike) (eq .VecMethod "Datum"))}}

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -267,10 +267,11 @@ func (a *anyNotNullBoolOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -465,10 +466,11 @@ func (a *anyNotNullBytesOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	oldCurAggSize := len(a.curAgg)
@@ -667,10 +669,11 @@ func (a *anyNotNullDecimalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -865,10 +868,11 @@ func (a *anyNotNullInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1063,10 +1067,11 @@ func (a *anyNotNullInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1261,10 +1266,11 @@ func (a *anyNotNullInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1459,10 +1465,11 @@ func (a *anyNotNullFloat64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1657,10 +1664,11 @@ func (a *anyNotNullTimestampOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1855,10 +1863,11 @@ func (a *anyNotNullIntervalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2103,10 +2112,11 @@ func (a *anyNotNullJSONOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	var oldCurAggSize uintptr
@@ -2315,10 +2325,11 @@ func (a *anyNotNullDatumOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -70,15 +70,15 @@ func newAvgOrderedAggAlloc(
 
 type avgInt16OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Decimals
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -291,12 +291,13 @@ func (a *avgInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -331,15 +332,15 @@ func (a *avgInt16OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type avgInt32OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Decimals
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -552,12 +553,13 @@ func (a *avgInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -592,15 +594,15 @@ func (a *avgInt32OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type avgInt64OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Decimals
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -813,12 +815,13 @@ func (a *avgInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -853,6 +856,8 @@ func (a *avgInt64OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type avgDecimalOrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Decimals
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
@@ -860,8 +865,6 @@ type avgDecimalOrderedAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalOrderedAgg{}
@@ -1066,12 +1069,13 @@ func (a *avgDecimalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -1106,6 +1110,8 @@ func (a *avgDecimalOrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type avgFloat64OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Float64s
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
@@ -1113,8 +1119,6 @@ type avgFloat64OrderedAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64OrderedAgg{}
@@ -1291,10 +1295,11 @@ func (a *avgFloat64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum / float64(a.curCount)
+		col[outputIdx] = a.curSum / float64(a.curCount)
 	}
 }
 
@@ -1327,6 +1332,8 @@ func (a *avgFloat64OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type avgIntervalOrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the statically-typed output vector.
+	col coldata.Durations
 	// curSum keeps track of the sum of elements belonging to the current group,
 	// so we can index into the slice once per group, instead of on each
 	// iteration.
@@ -1334,8 +1341,6 @@ type avgIntervalOrderedAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalOrderedAgg{}
@@ -1492,10 +1497,11 @@ func (a *avgIntervalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
+		col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -78,7 +78,7 @@ type avgInt16OrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -339,7 +339,7 @@ type avgInt32OrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -600,7 +600,7 @@ type avgInt64OrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -861,7 +861,7 @@ type avgDecimalOrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []apd.Decimal
+	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalOrderedAgg{}
@@ -1114,7 +1114,7 @@ type avgFloat64OrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []float64
+	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64OrderedAgg{}
@@ -1335,7 +1335,7 @@ type avgIntervalOrderedAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []duration.Duration
+	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalOrderedAgg{}

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -177,10 +177,11 @@ func (a *boolAndOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 
@@ -369,10 +370,11 @@ func (a *boolOrOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_bool_and_or_agg.eg.go
@@ -31,7 +31,7 @@ func newBoolAndOrderedAggAlloc(
 
 type boolAndOrderedAgg struct {
 	orderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -223,7 +223,7 @@ func newBoolOrOrderedAggAlloc(
 
 type boolOrOrderedAgg struct {
 	orderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.

--- a/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_concat_agg.eg.go
@@ -25,10 +25,10 @@ func newConcatOrderedAggAlloc(allocator *colmem.Allocator, allocSize int64) aggr
 
 type concatOrderedAgg struct {
 	orderedAggregateFuncBase
-	// curAgg holds the running total.
-	curAgg []byte
 	// col points to the output vector we are updating.
 	col *coldata.Bytes
+	// curAgg holds the running total.
+	curAgg []byte
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
 	foundNonNullForCurrentGroup bool
@@ -177,10 +177,11 @@ func (a *concatOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(len(a.curAgg)))

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -92,7 +92,8 @@ func (a *countRowsOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
-	a.col[outputIdx] = a.curAgg
+	col := a.col
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countRowsOrderedAgg) HandleEmptyInputScalar() {
@@ -244,7 +245,8 @@ func (a *countOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
-	a.col[outputIdx] = a.curAgg
+	col := a.col
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countOrderedAgg) HandleEmptyInputScalar() {

--- a/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_count_agg.eg.go
@@ -28,7 +28,7 @@ func newCountRowsOrderedAggAlloc(
 // countRowsOrderedAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countRowsOrderedAgg struct {
 	orderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 
@@ -139,7 +139,7 @@ func newCountOrderedAggAlloc(
 // countOrderedAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countOrderedAgg struct {
 	orderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -40,10 +40,6 @@ type defaultOrderedAgg struct {
 
 var _ AggregateFunc = &defaultOrderedAgg{}
 
-func (a *defaultOrderedAgg) SetOutput(vec coldata.Vec) {
-	a.orderedAggregateFuncBase.SetOutput(vec)
-}
-
 func (a *defaultOrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {

--- a/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_min_max_agg.eg.go
@@ -363,10 +363,11 @@ func (a *minBoolOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -617,10 +618,11 @@ func (a *minBytesOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	oldCurAggSize := len(a.curAgg)
 	// Release the reference to curAgg eagerly. We can't do this for the window
@@ -880,10 +882,11 @@ func (a *minDecimalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1178,10 +1181,11 @@ func (a *minInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1476,10 +1480,11 @@ func (a *minInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1774,10 +1779,11 @@ func (a *minInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2104,10 +2110,11 @@ func (a *minFloat64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2386,10 +2393,11 @@ func (a *minTimestampOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2640,10 +2648,11 @@ func (a *minIntervalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3012,10 +3021,11 @@ func (a *minJSONOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -3297,10 +3307,11 @@ func (a *minDatumOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 
 	var oldCurAggSize uintptr
@@ -3669,10 +3680,11 @@ func (a *maxBoolOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3923,10 +3935,11 @@ func (a *maxBytesOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	oldCurAggSize := len(a.curAgg)
 	// Release the reference to curAgg eagerly. We can't do this for the window
@@ -4186,10 +4199,11 @@ func (a *maxDecimalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -4484,10 +4498,11 @@ func (a *maxInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -4782,10 +4797,11 @@ func (a *maxInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5080,10 +5096,11 @@ func (a *maxInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5410,10 +5427,11 @@ func (a *maxFloat64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5692,10 +5710,11 @@ func (a *maxTimestampOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -5946,10 +5965,11 @@ func (a *maxIntervalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -6318,10 +6338,11 @@ func (a *maxJSONOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	var oldCurAggSize uintptr
 	if a.curAgg != nil {
@@ -6603,10 +6624,11 @@ func (a *maxDatumOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 
 	var oldCurAggSize uintptr

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -74,7 +74,7 @@ type sumInt16OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -316,7 +316,7 @@ type sumInt32OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -558,7 +558,7 @@ type sumInt64OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -800,7 +800,7 @@ type sumDecimalOrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -1034,7 +1034,7 @@ type sumFloat64OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -1256,7 +1256,7 @@ type sumIntervalOrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -70,11 +70,11 @@ func newSumOrderedAggAlloc(
 
 type sumInt16OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Decimals
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -276,10 +276,11 @@ func (a *sumInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -312,11 +313,11 @@ func (a *sumInt16OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumInt32OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Decimals
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -518,10 +519,11 @@ func (a *sumInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -554,11 +556,11 @@ func (a *sumInt32OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumInt64OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Decimals
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -760,10 +762,11 @@ func (a *sumInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -796,11 +799,11 @@ func (a *sumInt64OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumDecimalOrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Decimals
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -994,10 +997,11 @@ func (a *sumDecimalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1030,11 +1034,11 @@ func (a *sumDecimalOrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumFloat64OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Float64s
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg float64
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -1216,10 +1220,11 @@ func (a *sumFloat64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1252,11 +1257,11 @@ func (a *sumFloat64OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumIntervalOrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Durations
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg duration.Duration
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -1418,10 +1423,11 @@ func (a *sumIntervalOrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -279,7 +279,7 @@ func (a *sumInt16OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -521,7 +521,7 @@ func (a *sumInt32OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -763,7 +763,7 @@ func (a *sumInt64OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -997,7 +997,7 @@ func (a *sumDecimalOrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1219,7 +1219,7 @@ func (a *sumFloat64OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1421,7 +1421,7 @@ func (a *sumIntervalOrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -51,11 +51,11 @@ func newSumIntOrderedAggAlloc(
 
 type sumIntInt16OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Int64s
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -249,10 +249,11 @@ func (a *sumIntInt16OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -285,11 +286,11 @@ func (a *sumIntInt16OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumIntInt32OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Int64s
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -483,10 +484,11 @@ func (a *sumIntInt32OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -519,11 +521,11 @@ func (a *sumIntInt32OrderedAggAlloc) newAggFunc() AggregateFunc {
 
 type sumIntInt64OrderedAgg struct {
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col coldata.Int64s
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -717,10 +719,11 @@ func (a *sumIntInt64OrderedAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -252,7 +252,7 @@ func (a *sumIntInt16OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -486,7 +486,7 @@ func (a *sumIntInt32OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -720,7 +720,7 @@ func (a *sumIntInt64OrderedAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -55,7 +55,7 @@ type sumIntInt16OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -289,7 +289,7 @@ type sumIntInt32OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -523,7 +523,7 @@ type sumIntInt64OrderedAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -94,7 +94,7 @@ type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 	// group, instead of on each iteration.
 	curAgg _RET_GOTYPE
 	// col points to the output vector we are updating.
-	col []_RET_GOTYPE
+	col _RET_GOTYPESLICE
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -211,13 +211,7 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// {{if eq "_AGGKIND" "Window"}}
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		execgen.COPYVAL(a.col[outputIdx], a.curAgg)
-		// {{else}}
-		a.col[outputIdx] = a.curAgg
-		// {{end}}
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -87,14 +87,14 @@ func newSum_SUMKIND_AGGKINDAggAlloc(
 type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 	// {{if eq "_AGGKIND" "Ordered"}}
 	orderedAggregateFuncBase
+	// col points to the output vector we are updating.
+	col _RET_GOTYPESLICE
 	// {{else}}
 	unorderedAggregateFuncBase
 	// {{end}}
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg _RET_GOTYPE
-	// col points to the output vector we are updating.
-	col _RET_GOTYPESLICE
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -111,14 +111,13 @@ type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 
 var _ AggregateFunc = &sum_SUMKIND_TYPE_AGGKINDAgg{}
 
+// {{if eq "_AGGKIND" "Ordered"}}
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
-	// {{if eq "_AGGKIND" "Ordered"}}
 	a.orderedAggregateFuncBase.SetOutput(vec)
-	// {{else}}
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	// {{end}}
 	a.col = vec._RET_TYPE()
 }
+
+// {{end}}
 
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -207,11 +206,14 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Flush(outputIdx int) {
 	_ = outputIdx
 	outputIdx = a.curIdx
 	a.curIdx++
+	col := a.col
+	// {{else}}
+	col := a.vec._RET_TYPE()
 	// {{end}}
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -76,18 +76,11 @@ type avgInt16WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt16WindowAgg{}
-
-func (a *avgInt16WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -155,12 +148,13 @@ func (a *avgInt16WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -259,18 +253,11 @@ type avgInt32WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt32WindowAgg{}
-
-func (a *avgInt32WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -338,12 +325,13 @@ func (a *avgInt32WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -442,18 +430,11 @@ type avgInt64WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount int64
-	// col points to the statically-typed output vector.
-	col            coldata.Decimals
+	curCount       int64
 	overloadHelper execgen.OverloadHelper
 }
 
 var _ AggregateFunc = &avgInt64WindowAgg{}
-
-func (a *avgInt64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -521,12 +502,13 @@ func (a *avgInt64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -626,16 +608,9 @@ type avgDecimalWindowAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalWindowAgg{}
-
-func (a *avgDecimalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *avgDecimalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -698,12 +673,13 @@ func (a *avgDecimalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Decimal()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
 
-		a.col[outputIdx].SetInt64(a.curCount)
-		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
+		col[outputIdx].SetInt64(a.curCount)
+		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
 			colexecerror.InternalError(err)
 		}
 	}
@@ -798,16 +774,9 @@ type avgFloat64WindowAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64WindowAgg{}
-
-func (a *avgFloat64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *avgFloat64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -864,10 +833,11 @@ func (a *avgFloat64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Float64()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum / float64(a.curCount)
+		col[outputIdx] = a.curSum / float64(a.curCount)
 	}
 }
 
@@ -954,16 +924,9 @@ type avgIntervalWindowAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// col points to the statically-typed output vector.
-	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalWindowAgg{}
-
-func (a *avgIntervalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *avgIntervalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1010,10 +973,11 @@ func (a *avgIntervalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// NULL.
+	col := a.vec.Interval()
 	if a.curCount == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curSum.Div(int64(a.curCount))
+		col[outputIdx] = a.curSum.Div(int64(a.curCount))
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -78,7 +78,7 @@ type avgInt16WindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -261,7 +261,7 @@ type avgInt32WindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -444,7 +444,7 @@ type avgInt64WindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col            []apd.Decimal
+	col            coldata.Decimals
 	overloadHelper execgen.OverloadHelper
 }
 
@@ -627,7 +627,7 @@ type avgDecimalWindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []apd.Decimal
+	col coldata.Decimals
 }
 
 var _ AggregateFunc = &avgDecimalWindowAgg{}
@@ -799,7 +799,7 @@ type avgFloat64WindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []float64
+	col coldata.Float64s
 }
 
 var _ AggregateFunc = &avgFloat64WindowAgg{}
@@ -955,7 +955,7 @@ type avgIntervalWindowAgg struct {
 	// belonging to the current group.
 	curCount int64
 	// col points to the statically-typed output vector.
-	col []duration.Duration
+	col coldata.Durations
 }
 
 var _ AggregateFunc = &avgIntervalWindowAgg{}

--- a/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
@@ -31,7 +31,7 @@ func newBoolAndWindowAggAlloc(
 
 type boolAndWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -132,7 +132,7 @@ func newBoolOrWindowAggAlloc(
 
 type boolOrWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    []bool
+	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.

--- a/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_bool_and_or_agg.eg.go
@@ -31,7 +31,6 @@ func newBoolAndWindowAggAlloc(
 
 type boolAndWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -39,11 +38,6 @@ type boolAndWindowAgg struct {
 }
 
 var _ AggregateFunc = &boolAndWindowAgg{}
-
-func (a *boolAndWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *boolAndWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -87,10 +81,11 @@ func (a *boolAndWindowAgg) Compute(
 }
 
 func (a *boolAndWindowAgg) Flush(outputIdx int) {
+	col := a.vec.Bool()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 
@@ -132,7 +127,6 @@ func newBoolOrWindowAggAlloc(
 
 type boolOrWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Bools
 	curAgg bool
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
@@ -140,11 +134,6 @@ type boolOrWindowAgg struct {
 }
 
 var _ AggregateFunc = &boolOrWindowAgg{}
-
-func (a *boolOrWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *boolOrWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -188,10 +177,11 @@ func (a *boolOrWindowAgg) Compute(
 }
 
 func (a *boolOrWindowAgg) Flush(outputIdx int) {
+	col := a.vec.Bool()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col[outputIdx] = a.curAgg
+		col[outputIdx] = a.curAgg
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_concat_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_concat_agg.eg.go
@@ -27,16 +27,9 @@ type concatWindowAgg struct {
 	unorderedAggregateFuncBase
 	// curAgg holds the running total.
 	curAgg []byte
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// foundNonNullForCurrentGroup tracks if we have seen any non-null values
 	// for the group that is currently being aggregated.
 	foundNonNullForCurrentGroup bool
-}
-
-func (a *concatWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
 }
 
 func (a *concatWindowAgg) Compute(
@@ -76,10 +69,11 @@ func (a *concatWindowAgg) Compute(
 }
 
 func (a *concatWindowAgg) Flush(outputIdx int) {
+	col := a.vec.Bytes()
 	if !a.foundNonNullForCurrentGroup {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 	// Release the reference to curAgg eagerly.
 	a.allocator.AdjustMemoryUsage(-int64(len(a.curAgg)))

--- a/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
@@ -28,7 +28,7 @@ func newCountRowsWindowAggAlloc(
 // countRowsWindowAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countRowsWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 
@@ -96,7 +96,7 @@ func newCountWindowAggAlloc(
 // countWindowAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    []int64
+	col    coldata.Int64s
 	curAgg int64
 }
 

--- a/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_count_agg.eg.go
@@ -28,16 +28,10 @@ func newCountRowsWindowAggAlloc(
 // countRowsWindowAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countRowsWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Int64s
 	curAgg int64
 }
 
 var _ AggregateFunc = &countRowsWindowAgg{}
-
-func (a *countRowsWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *countRowsWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -56,7 +50,8 @@ func (a *countRowsWindowAgg) Compute(
 }
 
 func (a *countRowsWindowAgg) Flush(outputIdx int) {
-	a.col[outputIdx] = a.curAgg
+	col := a.vec.Int64()
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countRowsWindowAgg) Reset() {
@@ -96,16 +91,10 @@ func newCountWindowAggAlloc(
 // countWindowAgg supports either COUNT(*) or COUNT(col) aggregate.
 type countWindowAgg struct {
 	unorderedAggregateFuncBase
-	col    coldata.Int64s
 	curAgg int64
 }
 
 var _ AggregateFunc = &countWindowAgg{}
-
-func (a *countWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *countWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -138,7 +127,8 @@ func (a *countWindowAgg) Compute(
 }
 
 func (a *countWindowAgg) Flush(outputIdx int) {
-	a.col[outputIdx] = a.curAgg
+	col := a.vec.Int64()
+	col[outputIdx] = a.curAgg
 }
 
 func (a *countWindowAgg) Reset() {

--- a/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
@@ -222,9 +222,6 @@ func (a *minBoolWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -358,9 +355,6 @@ func (a *minBytesWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = append(a.curAgg[:0], a.curAgg...)
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -498,9 +492,6 @@ func (a *minDecimalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg.Set(&a.curAgg)
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -656,9 +647,6 @@ func (a *minInt16WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -814,9 +802,6 @@ func (a *minInt32WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -972,9 +957,6 @@ func (a *minInt64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -1146,9 +1128,6 @@ func (a *minFloat64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -1296,9 +1275,6 @@ func (a *minTimestampWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -1432,9 +1408,6 @@ func (a *minIntervalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -1630,20 +1603,6 @@ func (a *minJSONWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-
-		var _err error
-		var _bytes []byte
-		_bytes, _err = json.EncodeJSON(nil, a.curAgg)
-		if _err != nil {
-			colexecerror.ExpectedError(_err)
-		}
-		a.curAgg, _err = json.FromEncoding(_bytes)
-		if _err != nil {
-			colexecerror.ExpectedError(_err)
-		}
-
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -1796,9 +1755,6 @@ func (a *minDatumWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2025,9 +1981,6 @@ func (a *maxBoolWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2161,9 +2114,6 @@ func (a *maxBytesWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = append(a.curAgg[:0], a.curAgg...)
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2301,9 +2251,6 @@ func (a *maxDecimalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg.Set(&a.curAgg)
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2459,9 +2406,6 @@ func (a *maxInt16WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2617,9 +2561,6 @@ func (a *maxInt32WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2775,9 +2716,6 @@ func (a *maxInt64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -2949,9 +2887,6 @@ func (a *maxFloat64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -3099,9 +3034,6 @@ func (a *maxTimestampWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -3235,9 +3167,6 @@ func (a *maxIntervalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -3433,20 +3362,6 @@ func (a *maxJSONWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-
-		var _err error
-		var _bytes []byte
-		_bytes, _err = json.EncodeJSON(nil, a.curAgg)
-		if _err != nil {
-			colexecerror.ExpectedError(_err)
-		}
-		a.curAgg, _err = json.FromEncoding(_bytes)
-		if _err != nil {
-			colexecerror.ExpectedError(_err)
-		}
-
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }
@@ -3599,9 +3514,6 @@ func (a *maxDatumWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.curAgg = a.curAgg
 		a.col.Set(outputIdx, a.curAgg)
 	}
 }

--- a/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_min_max_agg.eg.go
@@ -112,8 +112,6 @@ func newMinWindowAggAlloc(
 
 type minBoolWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Bools
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -124,11 +122,6 @@ type minBoolWindowAgg struct {
 }
 
 var _ AggregateFunc = &minBoolWindowAgg{}
-
-func (a *minBoolWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *minBoolWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -219,10 +212,11 @@ func (a *minBoolWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bool()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -261,8 +255,6 @@ func (*minBoolWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx
 
 type minBytesWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -273,11 +265,6 @@ type minBytesWindowAgg struct {
 }
 
 var _ AggregateFunc = &minBytesWindowAgg{}
-
-func (a *minBytesWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
-}
 
 func (a *minBytesWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -352,10 +339,11 @@ func (a *minBytesWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bytes()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -398,8 +386,6 @@ func (*minBytesWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type minDecimalWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -410,11 +396,6 @@ type minDecimalWindowAgg struct {
 }
 
 var _ AggregateFunc = &minDecimalWindowAgg{}
-
-func (a *minDecimalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *minDecimalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -489,10 +470,11 @@ func (a *minDecimalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -531,8 +513,6 @@ func (*minDecimalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 type minInt16WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int16s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -543,11 +523,6 @@ type minInt16WindowAgg struct {
 }
 
 var _ AggregateFunc = &minInt16WindowAgg{}
-
-func (a *minInt16WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int16()
-}
 
 func (a *minInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -644,10 +619,11 @@ func (a *minInt16WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int16()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -686,8 +662,6 @@ func (*minInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type minInt32WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int32s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -698,11 +672,6 @@ type minInt32WindowAgg struct {
 }
 
 var _ AggregateFunc = &minInt32WindowAgg{}
-
-func (a *minInt32WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int32()
-}
 
 func (a *minInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -799,10 +768,11 @@ func (a *minInt32WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int32()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -841,8 +811,6 @@ func (*minInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type minInt64WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -853,11 +821,6 @@ type minInt64WindowAgg struct {
 }
 
 var _ AggregateFunc = &minInt64WindowAgg{}
-
-func (a *minInt64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *minInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -954,10 +917,11 @@ func (a *minInt64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -996,8 +960,6 @@ func (*minInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type minFloat64WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1008,11 +970,6 @@ type minFloat64WindowAgg struct {
 }
 
 var _ AggregateFunc = &minFloat64WindowAgg{}
-
-func (a *minFloat64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *minFloat64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1125,10 +1082,11 @@ func (a *minFloat64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1167,8 +1125,6 @@ func (*minFloat64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 type minTimestampWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Times
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1179,11 +1135,6 @@ type minTimestampWindowAgg struct {
 }
 
 var _ AggregateFunc = &minTimestampWindowAgg{}
-
-func (a *minTimestampWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Timestamp()
-}
 
 func (a *minTimestampWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1272,10 +1223,11 @@ func (a *minTimestampWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Timestamp()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1314,8 +1266,6 @@ func (*minTimestampWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, sta
 
 type minIntervalWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1326,11 +1276,6 @@ type minIntervalWindowAgg struct {
 }
 
 var _ AggregateFunc = &minIntervalWindowAgg{}
-
-func (a *minIntervalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *minIntervalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1405,10 +1350,11 @@ func (a *minIntervalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1447,8 +1393,6 @@ func (*minIntervalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, star
 
 type minJSONWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.JSONs
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1459,11 +1403,6 @@ type minJSONWindowAgg struct {
 }
 
 var _ AggregateFunc = &minJSONWindowAgg{}
-
-func (a *minJSONWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.JSON()
-}
 
 func (a *minJSONWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1600,10 +1539,11 @@ func (a *minJSONWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.JSON()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1649,8 +1589,6 @@ func (*minJSONWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx
 
 type minDatumWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.DatumVec
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1661,11 +1599,6 @@ type minDatumWindowAgg struct {
 }
 
 var _ AggregateFunc = &minDatumWindowAgg{}
-
-func (a *minDatumWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Datum()
-}
 
 func (a *minDatumWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1752,10 +1685,11 @@ func (a *minDatumWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Datum()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1871,8 +1805,6 @@ func newMaxWindowAggAlloc(
 
 type maxBoolWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Bools
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -1883,11 +1815,6 @@ type maxBoolWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxBoolWindowAgg{}
-
-func (a *maxBoolWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bool()
-}
 
 func (a *maxBoolWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -1978,10 +1905,11 @@ func (a *maxBoolWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bool()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2020,8 +1948,6 @@ func (*maxBoolWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx
 
 type maxBytesWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.Bytes
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2032,11 +1958,6 @@ type maxBytesWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxBytesWindowAgg{}
-
-func (a *maxBytesWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Bytes()
-}
 
 func (a *maxBytesWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2111,10 +2032,11 @@ func (a *maxBytesWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Bytes()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2157,8 +2079,6 @@ func (*maxBytesWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type maxDecimalWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2169,11 +2089,6 @@ type maxDecimalWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxDecimalWindowAgg{}
-
-func (a *maxDecimalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *maxDecimalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2248,10 +2163,11 @@ func (a *maxDecimalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2290,8 +2206,6 @@ func (*maxDecimalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 type maxInt16WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int16s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2302,11 +2216,6 @@ type maxInt16WindowAgg struct {
 }
 
 var _ AggregateFunc = &maxInt16WindowAgg{}
-
-func (a *maxInt16WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int16()
-}
 
 func (a *maxInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2403,10 +2312,11 @@ func (a *maxInt16WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int16()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2445,8 +2355,6 @@ func (*maxInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type maxInt32WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int32s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2457,11 +2365,6 @@ type maxInt32WindowAgg struct {
 }
 
 var _ AggregateFunc = &maxInt32WindowAgg{}
-
-func (a *maxInt32WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int32()
-}
 
 func (a *maxInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2558,10 +2461,11 @@ func (a *maxInt32WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int32()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2600,8 +2504,6 @@ func (*maxInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type maxInt64WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2612,11 +2514,6 @@ type maxInt64WindowAgg struct {
 }
 
 var _ AggregateFunc = &maxInt64WindowAgg{}
-
-func (a *maxInt64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *maxInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2713,10 +2610,11 @@ func (a *maxInt64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2755,8 +2653,6 @@ func (*maxInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startId
 
 type maxFloat64WindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2767,11 +2663,6 @@ type maxFloat64WindowAgg struct {
 }
 
 var _ AggregateFunc = &maxFloat64WindowAgg{}
-
-func (a *maxFloat64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *maxFloat64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -2884,10 +2775,11 @@ func (a *maxFloat64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -2926,8 +2818,6 @@ func (*maxFloat64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 type maxTimestampWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Times
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -2938,11 +2828,6 @@ type maxTimestampWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxTimestampWindowAgg{}
-
-func (a *maxTimestampWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Timestamp()
-}
 
 func (a *maxTimestampWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3031,10 +2916,11 @@ func (a *maxTimestampWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Timestamp()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3073,8 +2959,6 @@ func (*maxTimestampWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, sta
 
 type maxIntervalWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -3085,11 +2969,6 @@ type maxIntervalWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxIntervalWindowAgg{}
-
-func (a *maxIntervalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *maxIntervalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3164,10 +3043,11 @@ func (a *maxIntervalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3206,8 +3086,6 @@ func (*maxIntervalWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, star
 
 type maxJSONWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col *coldata.JSONs
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -3218,11 +3096,6 @@ type maxJSONWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxJSONWindowAgg{}
-
-func (a *maxJSONWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.JSON()
-}
 
 func (a *maxJSONWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3359,10 +3232,11 @@ func (a *maxJSONWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.JSON()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -3408,8 +3282,6 @@ func (*maxJSONWindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx
 
 type maxDatumWindowAgg struct {
 	unorderedAggregateFuncBase
-	// col points to the output vector we are updating.
-	col coldata.DatumVec
 	// curAgg holds the running min/max, so we can index into the slice once per
 	// group, instead of on each iteration.
 	// NOTE: if numNonNull is zero, curAgg is undefined.
@@ -3420,11 +3292,6 @@ type maxDatumWindowAgg struct {
 }
 
 var _ AggregateFunc = &maxDatumWindowAgg{}
-
-func (a *maxDatumWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Datum()
-}
 
 func (a *maxDatumWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -3511,10 +3378,11 @@ func (a *maxDatumWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should
 	// be null.
+	col := a.vec.Datum()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -73,8 +73,6 @@ type sumInt16WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -82,11 +80,6 @@ type sumInt16WindowAgg struct {
 }
 
 var _ AggregateFunc = &sumInt16WindowAgg{}
-
-func (a *sumInt16WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -154,10 +147,11 @@ func (a *sumInt16WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -253,8 +247,6 @@ type sumInt32WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -262,11 +254,6 @@ type sumInt32WindowAgg struct {
 }
 
 var _ AggregateFunc = &sumInt32WindowAgg{}
-
-func (a *sumInt32WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -334,10 +321,11 @@ func (a *sumInt32WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -433,8 +421,6 @@ type sumInt64WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -442,11 +428,6 @@ type sumInt64WindowAgg struct {
 }
 
 var _ AggregateFunc = &sumInt64WindowAgg{}
-
-func (a *sumInt64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -514,10 +495,11 @@ func (a *sumInt64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -613,19 +595,12 @@ type sumDecimalWindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
-	// col points to the output vector we are updating.
-	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumDecimalWindowAgg{}
-
-func (a *sumDecimalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Decimal()
-}
 
 func (a *sumDecimalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -688,10 +663,11 @@ func (a *sumDecimalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Decimal()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -782,19 +758,12 @@ type sumFloat64WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg float64
-	// col points to the output vector we are updating.
-	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumFloat64WindowAgg{}
-
-func (a *sumFloat64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Float64()
-}
 
 func (a *sumFloat64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -851,10 +820,11 @@ func (a *sumFloat64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Float64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -939,19 +909,12 @@ type sumIntervalWindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg duration.Duration
-	// col points to the output vector we are updating.
-	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntervalWindowAgg{}
-
-func (a *sumIntervalWindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Interval()
-}
 
 func (a *sumIntervalWindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -998,10 +961,11 @@ func (a *sumIntervalWindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Interval()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -74,7 +74,7 @@ type sumInt16WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -256,7 +256,7 @@ type sumInt32WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -438,7 +438,7 @@ type sumInt64WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull     uint64
@@ -620,7 +620,7 @@ type sumDecimalWindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg apd.Decimal
 	// col points to the output vector we are updating.
-	col []apd.Decimal
+	col coldata.Decimals
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -791,7 +791,7 @@ type sumFloat64WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg float64
 	// col points to the output vector we are updating.
-	col []float64
+	col coldata.Float64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -950,7 +950,7 @@ type sumIntervalWindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg duration.Duration
 	// col points to the output vector we are updating.
-	col []duration.Duration
+	col coldata.Durations
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -157,9 +157,7 @@ func (a *sumInt16WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -339,9 +337,7 @@ func (a *sumInt32WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -521,9 +517,7 @@ func (a *sumInt64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -697,9 +691,7 @@ func (a *sumDecimalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx].Set(&a.curAgg)
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -862,9 +854,7 @@ func (a *sumFloat64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -1011,9 +1001,7 @@ func (a *sumIntervalWindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -55,7 +55,7 @@ type sumIntInt16WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -226,7 +226,7 @@ type sumIntInt32WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
@@ -397,7 +397,7 @@ type sumIntInt64WindowAgg struct {
 	// group, instead of on each iteration.
 	curAgg int64
 	// col points to the output vector we are updating.
-	col []int64
+	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -132,9 +132,7 @@ func (a *sumIntInt16WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -303,9 +301,7 @@ func (a *sumIntInt32WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -474,9 +470,7 @@ func (a *sumIntInt64WindowAgg) Flush(outputIdx int) {
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		// We need to copy the value because window functions reuse the aggregation
-		// between rows.
-		a.col[outputIdx] = a.curAgg
+		a.col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -54,19 +54,12 @@ type sumIntInt16WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt16WindowAgg{}
-
-func (a *sumIntInt16WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -129,10 +122,11 @@ func (a *sumIntInt16WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -223,19 +217,12 @@ type sumIntInt32WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt32WindowAgg{}
-
-func (a *sumIntInt32WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -298,10 +285,11 @@ func (a *sumIntInt32WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 
@@ -392,19 +380,12 @@ type sumIntInt64WindowAgg struct {
 	// curAgg holds the running total, so we can index into the slice once per
 	// group, instead of on each iteration.
 	curAgg int64
-	// col points to the output vector we are updating.
-	col coldata.Int64s
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumIntInt64WindowAgg{}
-
-func (a *sumIntInt64WindowAgg) SetOutput(vec coldata.Vec) {
-	a.unorderedAggregateFuncBase.SetOutput(vec)
-	a.col = vec.Int64()
-}
 
 func (a *sumIntInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
@@ -467,10 +448,11 @@ func (a *sumIntInt64WindowAgg) Flush(outputIdx int) {
 	// The aggregation is finished. Flush the last value. If we haven't found
 	// any non-nulls for this group so far, the output for this group should be
 	// null.
+	col := a.vec.Int64()
 	if a.numNonNull == 0 {
 		a.nulls.SetNull(outputIdx)
 	} else {
-		a.col.Set(outputIdx, a.curAgg)
+		col.Set(outputIdx, a.curAgg)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -239,9 +239,6 @@ func (a *minBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -406,9 +403,6 @@ func (a *minBytesAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = append(a.curAgg[:0], a.curAgg...)
-
 				outCol.Set(i, a.curAgg)
 			}
 		}
@@ -557,9 +551,6 @@ func (a *minDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg.Set(&a.curAgg)
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -709,9 +700,6 @@ func (a *minInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -883,9 +871,6 @@ func (a *minInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -1057,9 +1042,6 @@ func (a *minInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -1231,9 +1213,6 @@ func (a *minFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -1421,9 +1400,6 @@ func (a *minTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -1587,9 +1563,6 @@ func (a *minIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -1749,19 +1722,6 @@ func (a *minJSONAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-
-				var _err error
-				var _bytes []byte
-				_bytes, _err = json.EncodeJSON(nil, a.curAgg)
-				if _err != nil {
-					colexecerror.ExpectedError(_err)
-				}
-				a.curAgg, _err = json.FromEncoding(_bytes)
-				if _err != nil {
-					colexecerror.ExpectedError(_err)
-				}
-
 				outCol.Set(i, a.curAgg)
 			}
 		}
@@ -1933,9 +1893,6 @@ func (a *minDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -2172,9 +2129,6 @@ func (a *maxBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -2339,9 +2293,6 @@ func (a *maxBytesAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = append(a.curAgg[:0], a.curAgg...)
-
 				outCol.Set(i, a.curAgg)
 			}
 		}
@@ -2490,9 +2441,6 @@ func (a *maxDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg.Set(&a.curAgg)
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -2642,9 +2590,6 @@ func (a *maxInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -2816,9 +2761,6 @@ func (a *maxInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -2990,9 +2932,6 @@ func (a *maxInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -3164,9 +3103,6 @@ func (a *maxFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -3354,9 +3290,6 @@ func (a *maxTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -3520,9 +3453,6 @@ func (a *maxIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}
@@ -3682,19 +3612,6 @@ func (a *maxJSONAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-
-				var _err error
-				var _bytes []byte
-				_bytes, _err = json.EncodeJSON(nil, a.curAgg)
-				if _err != nil {
-					colexecerror.ExpectedError(_err)
-				}
-				a.curAgg, _err = json.FromEncoding(_bytes)
-				if _err != nil {
-					colexecerror.ExpectedError(_err)
-				}
-
 				outCol.Set(i, a.curAgg)
 			}
 		}
@@ -3866,9 +3783,6 @@ func (a *maxDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				a.curAgg = a.curAgg
-
 				// gcassert:bce
 				outCol.Set(i, a.curAgg)
 			}

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -220,9 +220,6 @@ func (a *_AGG_TYPEAggregator) processBatch(batch coldata.Batch, startIdx, endIdx
 			if a.queue.isEmpty() {
 				outNulls.SetNull(i)
 			} else {
-				// The aggregate may be reused between rows, so we need to copy it.
-				execgen.COPYVAL(a.curAgg, a.curAgg)
-
 				// {{if not .IsBytesLike}}
 				// gcassert:bce
 				// {{end}}

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -28,6 +28,7 @@ type avgTmplInfo struct {
 	NeedsHelper    bool
 	InputVecMethod string
 	RetGoType      string
+	RetGoTypeSlice string
 	RetVecMethod   string
 
 	avgOverload assignFunc
@@ -109,6 +110,7 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
 		"_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
+		"_RET_GOTYPESLICE", `{{.RetGoTypeSlice}}`,
 		"_RET_GOTYPE", `{{.RetGoType}}`,
 		"_RET_TYPE", "{{.RetVecMethod}}",
 		"_TYPE", "{{.InputVecMethod}}",
@@ -165,6 +167,7 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 					NeedsHelper:    needsHelper,
 					InputVecMethod: toVecMethod(inputTypeFamily, inputTypeWidth),
 					RetGoType:      toPhysicalRepresentation(retTypeFamily, retTypeWidth),
+					RetGoTypeSlice: goTypeSliceName(retTypeFamily, retTypeWidth),
 					RetVecMethod:   toVecMethod(retTypeFamily, retTypeWidth),
 					avgOverload:    getSumAddOverload(inputTypeFamily),
 				}})

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -28,6 +28,7 @@ type sumAggTmplInfo struct {
 	NeedsHelper    bool
 	InputVecMethod string
 	RetGoType      string
+	RetGoTypeSlice string
 	RetVecMethod   string
 
 	sumOverload assignFunc
@@ -115,6 +116,7 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 		"_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_SUMKIND", "{{.SumKind}}",
+		"_RET_GOTYPESLICE", `{{.RetGoTypeSlice}}`,
 		"_RET_GOTYPE", `{{.RetGoType}}`,
 		"_RET_TYPE", "{{.RetVecMethod}}",
 		"_TYPE", "{{.InputVecMethod}}",
@@ -188,6 +190,7 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 					NeedsHelper:    needsHelper,
 					InputVecMethod: toVecMethod(inputTypeFamily, inputTypeWidth),
 					RetGoType:      toPhysicalRepresentation(retTypeFamily, retTypeWidth),
+					RetGoTypeSlice: goTypeSliceName(retTypeFamily, retTypeWidth),
 					RetVecMethod:   toVecMethod(retTypeFamily, retTypeWidth),
 					sumOverload:    getAddOverload(inputTypeFamily),
 				}})


### PR DESCRIPTION
**colexec: fix a recent bug with aggTypes**

When we introduced the hash aggregation with partial order support, we
mistakenly removed the ordered aggregation from `aggTypes` slice that is
used in some tests as well as in the benchmarks. This is now fixed.

Release note: None

**colexecagg: replace concrete slices with native type aliases**

This commit replaces concrete slices (like `[]int64`) with the
corresponding native type aliases (like `coldata.Int64s`). This allows
us to use inlined `Set` methods.

Release note: None

**colexecagg: remove some redundant COPYVAL calls**

This commit removes several `execgen.COPYVAL` calls that were redundant
because the first and the second argument are the same. These calls are
redundant because we already performed the same call right after
calling `Get` from the original vector and we will perform a deep copy
when calling `Set` next.

Release note: None

**colexecagg: reduce the size of hash aggregates**

This commit reduces the size of the hash aggregates by removing the
reference to the well-typed column (i.e. a concrete unwrapped
`coldata.Vec`, something like `[]int64`). This is possible because the
hash aggregates only access the concrete column once, in `Flush`, so
there is no point in storing the concrete column as we do for the
ordered aggregates. We still perform the interface dispatch call only
once - previously it was in `SetOutput`, now it is in `Flush`. This
should be a non-trivial improvement since the hash aggregation uses
a separate aggregation function object for each bucket.

This change also allows us to remove the overriding of `SetOutput`
method implementation provided by the base struct from the hash and
window aggregates.

Release note: None