### PR TITLE
bench/tpcc: add a go benchmark for tpcc queries

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -4,6 +4,7 @@
 ALL_TESTS = [
     "//pkg/base:base_test",
     "//pkg/bench/rttanalysis:rttanalysis_test",
+    "//pkg/bench/tpcc:tpcc_test",
     "//pkg/bench:bench_test",
     "//pkg/blobs:blobs_test",
     "//pkg/build/util:util_test",

--- a/pkg/bench/tpcc/BUILD.bazel
+++ b/pkg/bench/tpcc/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tpcc",
+    srcs = ["tpcc_bench.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/bench/tpcc",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "tpcc_test",
+    srcs = [
+        "main_test.go",
+        "subprocess_commands_test.go",
+        "subprocess_utils_test.go",
+        "tpcc_bench_generate_data_test.go",
+        "tpcc_bench_options_test.go",
+        "tpcc_bench_test.go",
+    ],
+    embed = [":tpcc"],
+    deps = [
+        "//pkg/base",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/envutil",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "//pkg/workload/tpcc",
+        "//pkg/workload/workloadsql",
+        "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/bench/tpcc/main_test.go
+++ b/pkg/bench/tpcc/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/bench/tpcc/subprocess_commands_test.go
+++ b/pkg/bench/tpcc/subprocess_commands_test.go
@@ -1,0 +1,155 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// databaseName is the name of the database used by this test.
+const databaseName = "tpcc"
+
+// Environment variables used to communicate configuration from the benchmark
+// to the client subprocess.
+const (
+	internalTestEnvVar = "COCKROACH_INTERNAL_TEST"
+	pgurlEnvVar        = "COCKROACH_PGURL"
+	nEnvVar            = "COCKROACH_N"
+	eventEnvVar        = "COCKROACH_STATUS_SERVER_ADDR"
+	storeDirEnvVar     = "COCKROACH_STORE_DIR"
+	srcEngineEnvVar    = "COCKROACH_SRC_ENGINE"
+	dstEngineEnvVar    = "COCKROACH_DST_ENGINE"
+)
+
+var (
+	benchmarkN = envutil.EnvOrDefaultInt(nEnvVar, -1)
+)
+
+func TestInternalCloneEngine(t *testing.T)      { internalCommand(t) }
+func TestInternalRunClient(t *testing.T)        { internalCommand(t) }
+func TestInternalGenerateStoreDir(t *testing.T) { internalCommand(t) }
+
+var (
+	commands         = map[string]*cmd{}
+	generateStoreDir = registerCmd("GenerateStoreDir", func(t *testing.T) {
+		ctx := context.Background()
+		storeDir, ok := envutil.EnvString(storeDirEnvVar, 0)
+		require.True(t, ok)
+
+		defer log.Scope(t).Close(t)
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				StoreSpecs: []base.StoreSpec{{Path: storeDir}},
+			},
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		db := tc.ServerConn(0)
+		tdb := sqlutils.MakeSQLRunner(db)
+		tdb.Exec(t, "CREATE DATABASE "+databaseName)
+		tdb.Exec(t, "SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true")
+		tdb.Exec(t, "USE "+databaseName)
+		tpcc, err := workload.Get("tpcc")
+		require.NoError(t, err)
+		gen := tpcc.New().(interface {
+			workload.Flagser
+			workload.Hookser
+			workload.Generator
+		})
+		require.NoError(t, gen.Flags().Parse([]string{
+			"--db=" + databaseName,
+		}))
+		require.NoError(t, gen.Hooks().Validate())
+		{
+			var l workloadsql.InsertsDataLoader
+			_, err := workloadsql.Setup(ctx, db, gen, l)
+			require.NoError(t, err)
+		}
+	})
+	cloneEngine = registerCmd("CloneEngine", func(t *testing.T) {
+		src, ok := envutil.EnvString(srcEngineEnvVar, 0)
+		require.True(t, ok)
+		dst, ok := envutil.EnvString(dstEngineEnvVar, 0)
+		require.True(t, ok)
+		_, err := vfs.Clone(vfs.Default, vfs.Default, src, dst)
+		require.NoError(t, err)
+	})
+	runClient = registerCmd("RunClient", func(t *testing.T) {
+		require.Positive(t, benchmarkN)
+
+		pgURL, ok := envutil.EnvString(pgurlEnvVar, 0)
+		require.True(t, ok)
+		ql := makeQueryLoad(t, pgURL)
+		defer ql.Close(context.Background())
+		eventAddr, ok := envutil.EnvString(eventEnvVar, 0)
+		require.True(t, ok)
+		sendEvent(t, eventAddr, runStartEvent)
+		for i := 0; i < benchmarkN; i++ {
+			require.NoError(t, ql.WorkerFns[0](context.Background()))
+		}
+		sendEvent(t, eventAddr, runDoneEvent)
+	})
+)
+
+func makeQueryLoad(t *testing.T, pgURL string) workload.QueryLoad {
+	tpcc, err := workload.Get("tpcc")
+	require.NoError(t, err)
+	gen := tpcc.New()
+	wl := gen.(interface {
+		workload.Flagser
+		workload.Hookser
+		workload.Opser
+	})
+	ctx := context.Background()
+
+	flags := append([]string{
+		"--wait=0",
+		"--workers=1",
+		"--db=" + databaseName,
+	}, flag.CommandLine.Args()...)
+	require.NoError(t, wl.Flags().Parse(flags))
+
+	require.NoError(t, wl.Hooks().Validate())
+
+	reg := histogram.NewRegistry(time.Minute, "tpcc")
+	ql, err := wl.Ops(ctx, []string{pgURL}, reg)
+	require.NoError(t, err)
+	return ql
+}
+
+// These event strings are used to synchronize the client process with the
+// benchmark process.
+const (
+	runStartEvent = "run start"
+	runDoneEvent  = "run done"
+)
+
+func sendEvent(t *testing.T, statusAddr, evName string) {
+	resp, err := http.Post(statusAddr, "", strings.NewReader(evName))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, evName)
+}

--- a/pkg/bench/tpcc/subprocess_utils_test.go
+++ b/pkg/bench/tpcc/subprocess_utils_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/stretchr/testify/require"
+)
+
+type cmd struct {
+	name string
+	impl func(t *testing.T)
+}
+
+func (c *cmd) exec(env cmdEnv, args ...string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0],
+		"--test.run=^TestInternal"+c.name+"$",
+		"--test.v")
+	if len(args) > 0 {
+		cmd.Args = append(cmd.Args, "--")
+		cmd.Args = append(cmd.Args, args...)
+	}
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=t", internalTestEnvVar))
+	cmd.Env = append(cmd.Env, env.toStrings()...)
+	return cmd
+}
+
+var isInternalTest = envutil.EnvOrDefaultBool(internalTestEnvVar, false)
+
+func internalCommand(t *testing.T) {
+	if !isInternalTest {
+		skip.IgnoreLint(t)
+	}
+	f, ok := commands[strings.TrimPrefix(t.Name(), "TestInternal")]
+	require.True(t, ok)
+	f.impl(t)
+}
+
+func registerCmd(name string, impl func(t *testing.T)) *cmd {
+	c := &cmd{
+		name: name,
+		impl: impl,
+	}
+	commands[name] = c
+	return c
+}
+
+type envVar struct {
+	k string
+	v interface{}
+}
+
+type cmdEnv []envVar
+
+func (ce cmdEnv) toStrings() (ret []string) {
+	for _, v := range ce {
+		ret = append(ret, fmt.Sprintf("%s=%v", v.k, v.v))
+	}
+	return ret
+}

--- a/pkg/bench/tpcc/tpcc_bench.go
+++ b/pkg/bench/tpcc/tpcc_bench.go
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc

--- a/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	storeDirFlag = flag.String(
+		"store-dir", "", "name of the directory on disk to use for the loaded TPCC state",
+	)
+	generateStoreDirFlag = flag.Bool("generate-store-dir", false,
+		"if store-dir is set, remove any exist data and regenerate the data")
+)
+
+func maybeGenerateStoreDir(b testing.TB) (_ vfs.FS, storeDir string, cleanup func()) {
+	storeDir = *storeDirFlag
+	cleanup = func() {}
+
+	if storeDir != "" {
+		if !*generateStoreDirFlag {
+			fi, err := os.Stat(storeDir)
+			require.NoError(b, err, "consider --generate-store-dir")
+			require.True(b, fi.IsDir(), "consider --generate-store-dir")
+			return vfs.Default, *storeDirFlag, cleanup
+		}
+		require.NoError(b, os.RemoveAll(storeDir))
+		require.NoError(b, os.MkdirAll(storeDir, 0777))
+	} else {
+		storeDir, cleanup = testutils.TempDir(b)
+		defer func() {
+			if b.Failed() {
+				cleanup()
+			}
+		}()
+	}
+
+	require.NoError(b, generateStoreDir.exec(cmdEnv{
+		{storeDirEnvVar, storeDir},
+	}).Run())
+	return vfs.Default, storeDir, cleanup
+}

--- a/pkg/bench/tpcc/tpcc_bench_options_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_options_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+)
+
+type option interface {
+	fmt.Stringer
+	apply(*benchmarkConfig)
+}
+
+type options []option
+
+func (o options) String() string {
+	var buf strings.Builder
+	for i, opt := range o {
+		if i > 0 {
+			buf.WriteString(";")
+		}
+		buf.WriteString(opt.String())
+	}
+	return buf.String()
+}
+
+func (o options) apply(cfg *benchmarkConfig) {
+	for _, opt := range o {
+		opt.apply(cfg)
+	}
+}
+
+type benchmarkConfig struct {
+	workloadFlags []string
+	argsGenerator serverArgs
+	setupStmts    []string
+}
+
+type workloadFlagOption struct{ name, value string }
+
+func (w workloadFlagOption) apply(cfg *benchmarkConfig) {
+	cfg.workloadFlags = append(cfg.workloadFlags, "--"+w.name, w.value)
+}
+
+func (w workloadFlagOption) String() string {
+	return fmt.Sprintf("%s=%s", w.name, w.value)
+}
+
+func workloadFlag(name, value string) option {
+	return workloadFlagOption{name: name, value: value}
+}
+
+type serverArgs func(b testing.TB) (_ base.TestServerArgs, cleanup func())
+
+func (s serverArgs) apply(cfg *benchmarkConfig) {
+	cfg.argsGenerator = s
+}
+
+func (s serverArgs) String() string { return "generator" }
+
+type setupStmtOption string
+
+func (s setupStmtOption) apply(cfg *benchmarkConfig) {
+	cfg.setupStmts = append(cfg.setupStmts, string(s))
+}
+
+func setupStmt(stmt string) option {
+	return setupStmtOption(stmt)
+}
+
+func (s setupStmtOption) String() string { return string(s) }

--- a/pkg/bench/tpcc/tpcc_bench_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_test.go
@@ -1,0 +1,211 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package tpcc is a benchmark suite to exercise the transactions of tpcc
+// in a benchmarking setting.
+//
+// We love to optimize our benchmarks, but some of them are too simplistic.
+// Hopefully optimizing these queries with a tight iteration cycle will better
+// reflect real world workloads.
+package tpcc
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkTPCC runs a benchmark of different mixes of TPCC queries against
+// a single warehouse. It runs the client side of the workload in a subprocess
+// to filter out the client overhead.
+//
+// Without any special flags, the benchmark will load the data for the single
+// warehouse once in a temp dir and will then copy the store directory for
+// that warehouse to an in-memory store for each sub-benchmark. The --store-dir
+// flag can be used to specify the path to such a store dir to enable faster
+// iteration re-running the test. The --generate-store-dir flag, when combined
+// with --store-dir will generate a new store directory at the specified path.
+// The combination of the two flags is how you bootstrap such a path initially.
+//
+// TODO(ajwerner): Consider moving this all to CCL to leverage the import data
+// loader.
+func BenchmarkTPCC(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+
+	_, engPath, cleanup := maybeGenerateStoreDir(b)
+	defer cleanup()
+	baseOptions := options{
+		serverArgs(func(
+			b testing.TB,
+		) (_ base.TestServerArgs, cleanup func()) {
+			td, cleanup := testutils.TempDir(b)
+			require.NoError(b, cloneEngine.exec(cmdEnv{
+				{srcEngineEnvVar, engPath},
+				{dstEngineEnvVar, td},
+			}).Run())
+			return base.TestServerArgs{
+				StoreSpecs: []base.StoreSpec{{Path: td}},
+			}, cleanup
+		}),
+		setupStmt(`
+SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true`),
+	}
+
+	for _, opts := range []options{
+		{workloadFlag("mix", "newOrder=1")},
+		{workloadFlag("mix", "payment=1")},
+		{workloadFlag("mix", "orderStatus=1")},
+		{workloadFlag("mix", "delivery=1")},
+		{workloadFlag("mix", "stockLevel=1")},
+		{workloadFlag("mix", "newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1")},
+	} {
+		b.Run(opts.String(), func(b *testing.B) {
+			defer log.Scope(b).Close(b)
+			newBenchmark(append(opts, baseOptions...)).run(b)
+		})
+	}
+}
+
+type benchmark struct {
+	benchmarkConfig
+
+	pgURL    string
+	eventURL string
+
+	closers []func()
+	closed  chan struct{}
+	eventCh chan event
+}
+
+func newBenchmark(opts ...options) *benchmark {
+	bm := benchmark{
+		eventCh: make(chan event),
+		closed:  make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt.apply(&bm.benchmarkConfig)
+	}
+	bm.closers = append(bm.closers, func() { close(bm.closed) })
+	return &bm
+}
+
+func (bm *benchmark) run(b *testing.B) {
+	defer bm.close()
+	bm.startCockroach(b)
+	bm.startEventServer(b)
+	wait := bm.startClient(b)
+	{
+		ev := bm.getEvent(b, runStartEvent)
+		b.Log("running benchmark")
+		b.ResetTimer()
+		close(ev)
+	}
+	{
+		doneEv := bm.getEvent(b, runDoneEvent)
+		b.StopTimer()
+		close(doneEv)
+	}
+	require.NoError(b, wait())
+}
+
+func (bm *benchmark) close() {
+	for i := len(bm.closers) - 1; i >= 0; i-- {
+		bm.closers[i]()
+	}
+}
+
+func (bm *benchmark) startCockroach(b testing.TB) {
+	args, cleanup := bm.argsGenerator(b)
+	bm.closers = append(bm.closers, cleanup)
+
+	s, db, _ := serverutils.StartServer(b, args)
+	bm.closers = append(bm.closers, func() {
+		s.Stopper().Stop(context.Background())
+	})
+
+	for _, stmt := range bm.setupStmts {
+		sqlutils.MakeSQLRunner(db).Exec(b, stmt)
+	}
+
+	pgURL, cleanup, err := sqlutils.PGUrlE(
+		s.ServingSQLAddr(), b.TempDir(), url.User("root"),
+	)
+	require.NoError(b, err)
+	pgURL.Path = databaseName
+	bm.pgURL = pgURL.String()
+	bm.closers = append(bm.closers, cleanup)
+}
+
+func (bm *benchmark) startEventServer(b testing.TB) {
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(b, err)
+	bm.closers = append(bm.closers, func() { _ = l.Close() })
+	bm.eventURL = "http://" + l.Addr().String()
+	go func() { _ = http.Serve(l, bm) }()
+}
+
+func (bm *benchmark) startClient(b *testing.B) (wait func() error) {
+	cmd := runClient.exec(cmdEnv{
+		{nEnvVar, b.N},
+		{pgurlEnvVar, bm.pgURL},
+		{eventEnvVar, bm.eventURL},
+	}, bm.workloadFlags...)
+	require.NoError(b, cmd.Start())
+	bm.closers = append(bm.closers,
+		func() { _ = cmd.Process.Kill(); _ = cmd.Wait() },
+	)
+	return cmd.Wait
+}
+
+// event is passed to the benchmark's eventCh when an HTTP request
+// comes in on the event server. The request blocks until the channel
+// is closed.
+type event struct {
+	name string
+	done chan struct{}
+}
+
+func (bm *benchmark) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		bm.addEvent(err.Error())
+		w.WriteHeader(500)
+		return
+	}
+	<-bm.addEvent(string(data))
+}
+
+func (bm *benchmark) addEvent(name string) <-chan struct{} {
+	ev := event{name: name, done: make(chan struct{})}
+	select {
+	case bm.eventCh <- ev:
+	case <-bm.closed:
+		close(ev.done)
+	}
+	return ev.done
+}
+
+func (bm *benchmark) getEvent(b *testing.B, evName string) chan<- struct{} {
+	ev := <-bm.eventCh
+	require.Equal(b, evName, ev.name)
+	return ev.done
+}


### PR DESCRIPTION
This commit introduces a package for running go benchmarks for tpcc queries
against tpcc data. I envisioned some more advanced combinations but for now
this still seems pretty handy. @nvanbenschoten has been fighting the good fight
of micro-optimizations against comparatively simple benchmarks, I presume,
because the iteration cycle is tight and the tooling is good.

This benchmark suite seeks to also provide a tight iteration cycle. It does, by
default, load TPCC data into cockroach once per `go test` invocation, but it
also has flags to allow re-use of a previously generated store directory.
The benchmark also runs the client portion of the workload out-of-process
in order to prevent it from mucking with the `--benchmem` numbers and profiles.

In order to run it to generate a new store directory in a stable location, you
use the following incantation:

```bash
go test -v ./pkg/bench/tpcc --benchmem --bench . --store-dir=/tmp/benchtpcc --generate-store-dir
```

Subsequent runs can then be run with:

```bash
go test -v ./pkg/bench/tpcc --benchmem --bench . --store-dir=/tmp/benchtpcc
```

A `--count=10` run provided stable results, which is encouraging that this will
be a useful optimization target. Did I mention we allocate a lot?

```
name                                                                      time/op
TPCC/mix=newOrder=1-16                                                    7.75ms ± 2%
TPCC/mix=payment=1-16                                                     4.29ms ± 6%
TPCC/mix=orderStatus=1-16                                                 3.36ms ± 3%
TPCC/mix=delivery=1-16                                                    39.7ms ± 3%
TPCC/mix=stockLevel=1-16                                                  2.84ms ± 7%
TPCC/mix=newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1-16  7.66ms ± 5%

name                                                                      alloc/op
TPCC/mix=newOrder=1-16                                                    2.23MB ± 3%
TPCC/mix=payment=1-16                                                      746kB ± 1%
TPCC/mix=orderStatus=1-16                                                 1.83MB ± 5%
TPCC/mix=delivery=1-16                                                    8.85MB ± 1%
TPCC/mix=stockLevel=1-16                                                   602kB ± 0%
TPCC/mix=newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1-16  1.82MB ± 2%

name                                                                      allocs/op
TPCC/mix=newOrder=1-16                                                     15.8k ± 3%
TPCC/mix=payment=1-16                                                      5.07k ± 0%
TPCC/mix=orderStatus=1-16                                                  3.61k ± 4%
TPCC/mix=delivery=1-16                                                     84.0k ± 0%
TPCC/mix=stockLevel=1-16                                                   3.69k ± 1%
TPCC/mix=newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1-16   13.2k ± 1%
```

One somewhat painful thing is that the cloning the store ends up being most of
the allocations. I know there's some tricks to have a base for the heap profile
but I haven't started to make that pleasant.

Release note: None