### PR TITLE
sql: handle panic in InternalExecutor.exec()

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -662,15 +662,15 @@ func (ie *InternalExecutor) execInternal(
 		//
 		// TODO(knz): track the callers and check whether opName could be turned
 		// into a type safe for reporting.
-		if retErr != nil {
-			if !errIsRetriable(retErr) {
+		if retErr != nil || r == nil {
+			// Both retErr and r can be nil in case of panic.
+			if retErr != nil && !errIsRetriable(retErr) {
 				retErr = errors.Wrapf(retErr, "%s", opName)
 			}
 			stmtBuf.Close()
 			wg.Wait()
 			sp.Finish()
 		} else {
-			// r must be non-nil here.
 			r.errCallback = func(err error) error {
 				if err != nil && !errIsRetriable(err) {
 					err = errors.Wrapf(err, "%s", opName)


### PR DESCRIPTION
Previously defered error augmentation in internal executor expectec
either resultset or error being populated and didn't handle panic
down the stack correctly.
This was giving slightly misleading error messages.
This change adds a case where panic is propagated correctly if both
error and resultset are nil.

Release note: None

Fixes: #74449