### PR TITLE
ci: additionally build go-test-teamcity in ci

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -10,17 +10,18 @@ fi
 
 CONFIG="$1"
 
-# Only build generated files on Linux x86_64.
-GENFILES_TARGETS=
+# Extra targets to build on Linux x86_64 only.
+EXTRA_TARGETS=
 if [ "$CONFIG" == "crosslinux" ]
 then
     DOC_TARGETS=$(grep '^//' docs/generated/bazel_targets.txt)
     GO_TARGETS=$(grep -v '^#' build/bazelutil/checked_in_genfiles.txt | cut -d'|' -f1)
-    GENFILES_TARGETS="$DOC_TARGETS $GO_TARGETS"
+    BINARY_TARGETS=@com_github_cockroachdb_go_test_teamcity//:go-test-teamcity
+    EXTRA_TARGETS="$DOC_TARGETS $GO_TARGETS $BINARY_TARGETS"
 fi
 
 bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
 		       --config "$CONFIG" --config ci --config with_ui \
 		       build //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
-		       //pkg/cmd/cockroach-oss //c-deps:libgeos $GENFILES_TARGETS
+		       //pkg/cmd/cockroach-oss //c-deps:libgeos $EXTRA_TARGETS

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -21,9 +21,9 @@ import (
 
 // OutputOfBinaryRule returns the path of the binary produced by the
 // given build target, relative to bazel-bin. That is,
-//    filepath.Join(bazelBin, OutputOfBinaryRule(target)) is the absolute
+//    filepath.Join(bazelBin, OutputOfBinaryRule(target, isWindows)) is the absolute
 // path to the build binary for the target.
-func OutputOfBinaryRule(target string) string {
+func OutputOfBinaryRule(target string, isWindows bool) string {
 	colon := strings.Index(target, ":")
 	var bin string
 	if colon >= 0 {
@@ -41,6 +41,9 @@ func OutputOfBinaryRule(target string) string {
 		head = strings.TrimPrefix(target[:colon], "//")
 	} else {
 		head = strings.TrimPrefix(target, "//")
+	}
+	if isWindows {
+		return filepath.Join(head, bin+"_", bin+".exe")
 	}
 	return filepath.Join(head, bin+"_", bin)
 }

--- a/pkg/build/util/util_test.go
+++ b/pkg/build/util/util_test.go
@@ -17,17 +17,26 @@ import (
 )
 
 func TestOutputOfBinaryRule(t *testing.T) {
-	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short"),
+	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short", false),
 		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short")
-	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short:cockroach-short"),
+	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short", true),
+		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short.exe")
+	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short:cockroach-short", false),
 		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short")
-	require.Equal(t, OutputOfBinaryRule("pkg/cmd/cockroach-short"),
+	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short:cockroach-short", true),
+		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short.exe")
+	require.Equal(t, OutputOfBinaryRule("pkg/cmd/cockroach-short", false),
 		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short")
-
-	require.Equal(t, OutputOfBinaryRule("@com_github_cockroachdb_stress//:stress"),
+	require.Equal(t, OutputOfBinaryRule("pkg/cmd/cockroach-short", true),
+		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short.exe")
+	require.Equal(t, OutputOfBinaryRule("@com_github_cockroachdb_stress//:stress", false),
 		"external/com_github_cockroachdb_stress/stress_/stress")
-	require.Equal(t, OutputOfBinaryRule("@com_github_bazelbuild_buildtools//buildifier:buildifier"),
+	require.Equal(t, OutputOfBinaryRule("@com_github_cockroachdb_stress//:stress", true),
+		"external/com_github_cockroachdb_stress/stress_/stress.exe")
+	require.Equal(t, OutputOfBinaryRule("@com_github_bazelbuild_buildtools//buildifier:buildifier", false),
 		"external/com_github_bazelbuild_buildtools/buildifier/buildifier_/buildifier")
+	require.Equal(t, OutputOfBinaryRule("@com_github_bazelbuild_buildtools//buildifier:buildifier", true),
+		"external/com_github_bazelbuild_buildtools/buildifier/buildifier_/buildifier.exe")
 }
 
 func TestOutputsOfGenrule(t *testing.T) {

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -195,15 +195,7 @@ type xmlMessage struct {
 // results.)
 func (w watcher) stageBinaryArtifacts() error {
 	for _, bin := range w.info.goBinaries {
-		// Convert a target like `//pkg/cmd/cockroach-short` to the
-		// relative path atop bazel-bin where that file can be found --
-		// in this example, `pkg/cmd/cockroach-short/cockroach-short_/cockroach-short.
-		head := strings.ReplaceAll(strings.TrimPrefix(bin, "//"), ":", "/")
-		components := strings.Split(bin, ":")
-		relBinPath := path.Join(head+"_", components[len(components)-1])
-		if usingCrossWindowsConfig() {
-			relBinPath = relBinPath + ".exe"
-		}
+		relBinPath := bazelutil.OutputOfBinaryRule(bin, usingCrossWindowsConfig())
 		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0755, finalizePhase,
 			copyContentTo)
 		if err != nil {


### PR DESCRIPTION
It's used in examples-orms.

Release note: None