### PR TITLE
sql: discard txn stats if stmt exec was aborted early

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1977,6 +1977,14 @@ func (ex *connExecutor) recordTransaction(
 	implicit bool,
 	txnStart time.Time,
 ) error {
+	if len(ex.extraTxnState.transactionStatementFingerprintIDs) == 0 {
+		// If the slice of transaction statement fingerprint IDs is empty, this
+		// means there is no statements that's being executed within this
+		// transaction. Hence, recording stats for this transaction is not
+		// meaningful.
+		return nil
+	}
+
 	txnEnd := timeutil.Now()
 	txnTime := txnEnd.Sub(txnStart)
 	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)


### PR DESCRIPTION
Previsouly, if the stmt execution was aborted before its stats can be
recorded, it would result in SQL Stats recording its corresponding
transaction stats with an empty list of statement fingerprint IDs.

This commit changes transaction stats recording to discard the
transaction stats if the list of statement fingerprint IDs is empty.

Addresses #71876

Release note: None