### PR TITLE
sql,gcjob: add mechanism to destroy tenant synchronously

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -525,6 +525,7 @@ go_test(
         "telemetry_logging_test.go",
         "telemetry_test.go",
         "temporary_schema_test.go",
+        "tenant_test.go",
         "trace_test.go",
         "txn_restart_test.go",
         "txn_state_test.go",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2727,7 +2727,8 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
 			ex.server.cfg.InternalExecutor,
-			ex.extraTxnState.jobs); err != nil {
+			ex.extraTxnState.jobs,
+		); err != nil {
 			handleErr(err)
 		}
 		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionEndPostCommitJob, timeutil.Now())
@@ -2956,7 +2957,7 @@ func (ex *connExecutor) runPreCommitStages(ctx context.Context) error {
 	scs.state = after
 	scs.jobID = jobID
 	if jobID != jobspb.InvalidJobID {
-		ex.extraTxnState.jobs = append(ex.extraTxnState.jobs, jobID)
+		ex.extraTxnState.jobs.add(jobID)
 		log.Infof(ctx, "queued new schema change job %d using the new schema changer", jobID)
 	}
 	return nil

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -923,7 +923,7 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	*ex.planner.extendedEvalCtx.Jobs = append(*ex.planner.extendedEvalCtx.Jobs, jobIDs...)
+	ex.planner.extendedEvalCtx.Jobs.add(jobIDs...)
 	return nil
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1906,6 +1906,10 @@ const MaxSQLBytes = 1000
 
 type jobsCollection []jobspb.JobID
 
+func (jc *jobsCollection) add(ids ...jobspb.JobID) {
+	*jc = append(*jc, ids...)
+}
+
 // truncateStatementStringForTelemetry truncates the string
 // representation of a statement to a maximum length, so as to not
 // create unduly large logging and error payloads.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -441,7 +441,9 @@ func (c *DummyTenantOperator) CreateTenant(_ context.Context, _ uint64) error {
 }
 
 // DestroyTenant is part of the tree.TenantOperator interface.
-func (c *DummyTenantOperator) DestroyTenant(_ context.Context, _ uint64) error {
+func (c *DummyTenantOperator) DestroyTenant(
+	ctx context.Context, tenantID uint64, synchronous bool,
+) error {
 	return errors.WithStack(errEvalTenant)
 }
 

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -96,7 +96,7 @@ func initializeProgress(
 	progress *jobspb.SchemaChangeGCProgress,
 ) error {
 	var update bool
-	if details.Tenant != nil {
+	if details.Tenant != nil && progress.Tenant == nil {
 		progress.Tenant = &jobspb.SchemaChangeGCProgress_TenantProgress{
 			Status: jobspb.SchemaChangeGCProgress_WAITING_FOR_GC,
 		}

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -284,6 +284,9 @@ func refreshTenant(
 	details *jobspb.SchemaChangeGCDetails,
 	progress *jobspb.SchemaChangeGCProgress,
 ) (expired bool, deadline time.Time) {
+	if progress.Tenant.Status != jobspb.SchemaChangeGCProgress_WAITING_FOR_GC {
+		return true, time.Time{}
+	}
 	tenantTTLSeconds := execCfg.DefaultZoneConfig.GC.TTLSeconds
 	tenID := details.Tenant.ID
 	cfg := execCfg.SystemConfig.GetSystemConfig()

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -146,7 +146,7 @@ func (evalCtx *extendedEvalContext) QueueJob(
 	if err != nil {
 		return nil, err
 	}
-	*evalCtx.Jobs = append(*evalCtx.Jobs, jobID)
+	evalCtx.Jobs.add(jobID)
 	return job, nil
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4596,12 +4596,37 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := ctx.Tenant.DestroyTenant(ctx.Context, uint64(sTenID)); err != nil {
+				if err := ctx.Tenant.DestroyTenant(
+					ctx.Context, uint64(sTenID), false, /* synchronous */
+				); err != nil {
 					return nil, err
 				}
 				return args[0], nil
 			},
 			Info:       "Destroys a tenant with the provided ID. Must be run by the System tenant.",
+			Volatility: tree.VolatilityVolatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"id", types.Int},
+				{"synchronous", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				sTenID, err := mustBeDIntInTenantRange(args[0])
+				if err != nil {
+					return nil, err
+				}
+				synchronous := tree.MustBeDBool(args[1])
+				if err := ctx.Tenant.DestroyTenant(
+					ctx.Context, uint64(sTenID), bool(synchronous),
+				); err != nil {
+					return nil, err
+				}
+				return args[0], nil
+			},
+			Info: "Destroys a tenant with the provided ID. Must be run by the System tenant. " +
+				"Optionally, synchronously destroy the data",
 			Volatility: tree.VolatilityVolatile,
 		},
 	),

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3415,8 +3415,9 @@ type TenantOperator interface {
 	CreateTenant(ctx context.Context, tenantID uint64) error
 
 	// DestroyTenant attempts to uninstall an existing tenant from the system.
-	// It returns an error if the tenant does not exist.
-	DestroyTenant(ctx context.Context, tenantID uint64) error
+	// It returns an error if the tenant does not exist. If synchronous is true
+	// the gc job will not wait for a GC ttl.
+	DestroyTenant(ctx context.Context, tenantID uint64, synchronous bool) error
 
 	// GCTenant attempts to garbage collect a DROP tenant from the system. Upon
 	// success it also removes the tenant record.

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDestroyTenantSynchronous tests that destroying a tenant synchronously
+// with crdb_internal.destroy_tenant(<ten_id>, true) works.
+func TestDestroyTenantSynchronous(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	tenantID := roachpb.MakeTenantID(10)
+	codec := keys.MakeSQLCodec(tenantID)
+	const tenantStateQuery = `
+SELECT id, active FROM system.tenants WHERE id = 10
+`
+	checkKVsExistForTenant := func(t *testing.T, shouldExist bool) {
+		rows, err := kvDB.Scan(
+			ctx, codec.TenantPrefix(), codec.TenantPrefix().PrefixEnd(),
+			1, /* maxRows */
+		)
+		require.NoError(t, err)
+		require.Equal(t, shouldExist, len(rows) > 0)
+	}
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create the tenant, make sure it has data and state.
+	tdb.Exec(t, "SELECT crdb_internal.create_tenant(10)")
+	tdb.CheckQueryResults(t, tenantStateQuery, [][]string{{"10", "true"}})
+	checkKVsExistForTenant(t, true /* shouldExist */)
+
+	// Destroy the tenant, make sure it does not have data and state.
+	tdb.Exec(t, "SELECT crdb_internal.destroy_tenant(10, true)")
+	tdb.CheckQueryResults(t, tenantStateQuery, [][]string{})
+	checkKVsExistForTenant(t, false /* shouldExist */)
+}


### PR DESCRIPTION
Apparently this is important. The approach is to create the gc job in a state
where it believes the ttl has already expired and then to make sure that the
connExecutor waits for the GC job.

Fixes #73919.

Release note: None