### PR TITLE
dev: quiet bazel when running `dev generate go`

### DIFF
--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -161,6 +161,7 @@ func (d *dev) generateGo(cmd *cobra.Command) error {
 	args = append(args, "build")
 	args = append(args, mustGetRemoteCacheArgs(remoteCacheAddr)...)
 	args = append(args, "//:go_path")
+	args = append(args, "--show_result=0")
 	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	if err != nil {
 		return err

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -21,7 +21,7 @@ echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/gene
 
 dev gen go
 ----
-bazel build //:go_path
+bazel build //:go_path --show_result=0
 bazel info workspace --color=no
 bazel info bazel-bin --color=no
 git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -102,7 +102,7 @@ MOCK_REDACT_SAFE_OUTPUT
 echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/generated/redact_safe.md
 ----
 
-bazel build //:go_path
+bazel build //:go_path --show_result=0
 ----
 
 bazel info workspace --color=no


### PR DESCRIPTION
Before this, the Bazel build would print out the names of every file in
the built `go_path`, which is thousands of files. That output isn't
useful when doing `dev generate` so we can just quiet it.

Release note: None