### PR TITLE
backupccl: add dry_run option to RESTORE

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -972,6 +972,7 @@ unreserved_keyword ::=
 	| 'DOMAIN'
 	| 'DOUBLE'
 	| 'DROP'
+	| 'DRY_RUN'
 	| 'ENCODING'
 	| 'ENCRYPTED'
 	| 'ENCRYPTION_PASSPHRASE'
@@ -2239,6 +2240,7 @@ restore_options ::=
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
+	| 'DRY_RUN' '=' string_or_placeholder
 	| 'NEW_DB_NAME' '=' string_or_placeholder
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'TENANT' '=' string_or_placeholder

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6163,6 +6163,7 @@ func TestBackupRestoreEmptyDB(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE empty`)
 	sqlDB.Exec(t, `BACKUP DATABASE empty TO $1`, localFoo)
 	sqlDB.Exec(t, `DROP DATABASE empty`)
+	sqlDB.Exec(t, `RESTORE DATABASE empty FROM $1 WITH dry_run`, localFoo)
 	sqlDB.Exec(t, `RESTORE DATABASE empty FROM $1`, localFoo)
 	sqlDB.CheckQueryResults(t, `USE empty; SHOW TABLES;`, [][]string{})
 }
@@ -9562,6 +9563,55 @@ func TestBackupRestoreSeparateIncrementalPrefix(t *testing.T) {
 		sqlDB.Exec(t, "DROP DATABASE fkdb")
 		sqlDB.Exec(t, "DROP DATABASE trad_fkdb;")
 		sqlDB.Exec(t, "DROP DATABASE inc_fkdb;")
+	}
+}
+
+// TestDryRestore tests that table, database and cluster level dry run restores
+// do not alter the descriptors in the target cluster. This ensures that the dry run
+// did not write any new data to disk.
+func TestDryRunRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts,
+		InitManualReplication)
+	defer cleanupFn()
+	dest := "nodelocal://0/a"
+	sqlDB.Exec(t, `
+		CREATE DATABASE fkdb; 
+		CREATE TABLE fkdb.fk (ind INT)`)
+
+	for i := 0; i < 10; i++ {
+		sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, i)
+	}
+
+	sqlDB.Exec(t, `BACKUP INTO $1`, dest)
+	sqlDB.Exec(t, `ALTER TABLE fkdb.fk RENAME TO fkdb.fk_original`)
+
+	descriptorsQuery := `SELECT * FROM system.descriptor`
+	//descriptors := sqlDB.QueryStr(t, descriptorsQuery)
+
+	{
+		sqlDB.Exec(t, `RESTORE DATABASE fkdb FROM LATEST IN $1 WITH dry_run='short',new_db_name = fkdb2`,
+			dest)
+		descriptorsClusterPost := sqlDB.QueryStr(t, descriptorsQuery)
+		fmt.Println(descriptorsClusterPost)
+		//sqlDB.CheckQueryResults(t, descriptorsQuery, descriptors)
+
+		sqlDB.Exec(t, `RESTORE TABLE fkdb.fk FROM LATEST IN $1 WITH dry_run='short'`, dest)
+		//sqlDB.CheckQueryResults(t, descriptorsQuery, descriptors)
+	}
+
+	{
+		_, sqlDBRestore, cleanupRestore := backupRestoreTestSetupEmpty(t, multiNode, dir,
+			InitManualReplication, base.TestClusterArgs{})
+		defer cleanupRestore()
+		//descriptorsCluster := sqlDBRestore.QueryStr(t, descriptorsQuery)
+		sqlDBRestore.Exec(t, `RESTORE FROM LATEST IN $1 WITH dry_run='short'`, dest)
+		descriptorsClusterPost := sqlDBRestore.QueryStr(t, descriptorsQuery)
+		fmt.Println(descriptorsClusterPost)
+		//sqlDBRestore.CheckQueryResults(t, descriptorsQuery, descriptorsCluster)
 	}
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -328,7 +329,8 @@ func (rd *restoreDataProcessor) openSSTs(
 		return nil
 	}
 
-	log.VEventf(ctx, 1 /* level */, "ingesting span [%s-%s)", entry.Span.Key, entry.Span.EndKey)
+	log.VEventf(ctx, 1 /* level */, "ingesting span [%s-%s) (dry-run %v)", entry.Span.Key,
+		entry.Span.EndKey, rd.spec.DryRun)
 
 	for _, file := range entry.Files {
 		log.VEventf(ctx, 2, "import file %s which starts at %s", file.Path, entry.Span.Key)
@@ -390,6 +392,49 @@ func (rd *restoreDataProcessor) runRestoreWorkers(ctx context.Context, ssts chan
 	})
 }
 
+type noopSender struct {
+	clock *hlc.Clock
+}
+
+func (ns noopSender) AddSSTable(
+	ctx context.Context,
+	begin, end interface{},
+	data []byte,
+	disallowConflicts bool,
+	disallowShadowing bool,
+	disallowShadowingBelow hlc.Timestamp,
+	stats *enginepb.MVCCStats,
+	ingestAsWrites bool,
+	batchTs hlc.Timestamp,
+) error {
+	return nil
+}
+
+func (ns noopSender) AddSSTableAtBatchTimestamp(
+	ctx context.Context,
+	begin, end interface{},
+	data []byte,
+	disallowConflicts bool,
+	disallowShadowing bool,
+	disallowShadowingBelow hlc.Timestamp,
+	stats *enginepb.MVCCStats,
+	ingestAsWrites bool,
+	batchTs hlc.Timestamp,
+) (hlc.Timestamp, error) {
+	return hlc.Timestamp{}, nil
+}
+
+func (ns noopSender) SplitAndScatter(
+	ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp, predicateKeys ...roachpb.Key,
+) error {
+	return nil
+}
+func (ns noopSender) Clock() *hlc.Clock {
+	return ns.clock
+}
+
+var _ bulk.SSTSender = &noopSender{}
+
 func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	ctx context.Context, kr *KeyRewriter, sst mergedSST,
 ) (roachpb.BulkOpSummary, error) {
@@ -426,8 +471,14 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	// this comes at the cost of said overlap check, but in the common case of
 	// non-overlapping ingestion into empty spans, that is just one seek.
 	disallowShadowingBelow := hlc.Timestamp{Logical: 1}
+
+	var sender bulk.SSTSender = db
+	if rd.spec.DryRun != "" {
+		sender = noopSender{db.Clock()}
+	}
+
 	batcher, err := bulk.MakeSSTBatcher(ctx,
-		db,
+		sender,
 		evalCtx.Settings,
 		func() int64 { return rd.flushBytes },
 		disallowShadowingBelow,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -257,7 +257,11 @@ func restore(
 		// There are no files to restore.
 		return emptyRowCount, nil
 	}
-
+	if details.DryRun == "short" {
+		return emptyRowCount, shortDryRunValidation(restoreCtx,
+			execCtx.ExecCfg().DistSQLSrv.ExternalStorage,
+			importSpans)
+	}
 	for i := range importSpans {
 		importSpans[i].ProgressIdx = int64(i)
 	}
@@ -364,6 +368,7 @@ func restore(
 			dataToRestore.getTenantRekeys(),
 			endTime,
 			progCh,
+			details.DryRun,
 		)
 	}
 	tasks = append(tasks, runRestore)
@@ -428,6 +433,56 @@ func loadBackupSQLDescs(
 	}
 
 	return backupManifests, latestBackupManifest, sqlDescs, sz, nil
+}
+
+// shortDryRunValidation checks that every SST file is in its expected
+// directory.
+func shortDryRunValidation(
+	ctx context.Context,
+	makeCloudStorage cloud.ExternalStorageFactory,
+	spans []execinfrapb.RestoreSpanEntry,
+) error {
+	checkedFiles := make(map[string]bool)
+	stores := make(map[roachpb.ExternalStorage]cloud.ExternalStorage)
+
+	defer func() {
+		for _, store := range stores {
+			if err := store.Close(); err != nil {
+				log.Warningf(ctx, "close export storage failed %v", err)
+			}
+		}
+	}()
+
+	for _, span := range spans {
+		for _, file := range span.Files {
+			if _, skip := checkedFiles[file.Path]; !skip {
+				var (
+					store cloud.ExternalStorage
+					ok    bool
+					err   error
+				)
+				if store, ok = stores[file.Dir]; !ok {
+					store, err = makeCloudStorage(ctx, file.Dir)
+					if err != nil {
+						return err
+					}
+					stores[file.Dir] = store
+				}
+				f, err := store.ReadFile(ctx, file.Path)
+
+				if closeErr := f.Close(ctx); closeErr != nil {
+					log.Warningf(ctx, "close file failed %v", closeErr)
+				}
+				if err != nil {
+					return err
+				}
+				checkedFiles[file.Path] = true
+			}
+		}
+		return nil
+	}
+
+	return nil
 }
 
 // restoreResumer should only store a reference to the job it's running. State
@@ -830,6 +885,8 @@ func createImportingDescriptors(
 	}
 
 	if !details.PrepareCompleted {
+
+		// Create new descriptors for the data we're restoring.
 		err := sql.DescsTxn(ctx, p.ExecCfg(), func(
 			ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 		) error {
@@ -1192,8 +1249,8 @@ func remapPublicSchemas(
 
 // Resume is part of the jobs.Resumer interface.
 func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error {
+	details := r.job.Details().(jobspb.RestoreDetails)
 	if err := r.doResume(ctx, execCtx); err != nil {
-		details := r.job.Details().(jobspb.RestoreDetails)
 		if details.DebugPauseOn == "error" {
 			const errorFmt = "job failed with error (%v) but is being paused due to the %s=%s setting"
 			log.Warningf(ctx, errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn)
@@ -1203,6 +1260,14 @@ func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error 
 				restoreOptDebugPauseOn, details.DebugPauseOn))
 		}
 		return err
+	}
+	if details.DryRun != "" {
+		// Revert test cluster to state before dry run.
+		err := r.OnFailOrCancel(ctx, execCtx)
+		if err != nil {
+			return err
+		}
+		emitRestoreJobEvent(ctx, execCtx.(sql.JobExecContext), jobs.StatusSucceeded, r.job)
 	}
 
 	return nil
@@ -1320,7 +1385,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		log.Warningf(ctx, "failed to resolve table statistics from backup during restore: %+v",
 			err.Error())
 	}
-
 	if len(details.TableDescs) == 0 && len(details.Tenants) == 0 && len(details.TypeDescs) == 0 {
 		// We have no tables to restore (we are restoring an empty DB).
 		// Since we have already created any new databases that we needed,
@@ -1330,6 +1394,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		// public.
 		// TODO (lucy): Ideally we'd just create the database in the public state in
 		// the first place, as a special case.
+
 		publishDescriptors := func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) (err error) {
 			return r.publishDescriptors(ctx, txn, p.ExecCfg(), p.User(), descsCol, details, nil)
 		}
@@ -1384,7 +1449,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 
 		resTotal.Add(res)
 
-		if details.DescriptorCoverage == tree.AllDescriptors {
+		if details.DescriptorCoverage == tree.AllDescriptors && details.DryRun == "" {
 			if err := r.restoreSystemTables(ctx, p.ExecCfg().DB, preData.systemTables); err != nil {
 				return err
 			}
@@ -1449,7 +1514,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	details = r.job.Details().(jobspb.RestoreDetails)
 	p.ExecCfg().JobRegistry.NotifyToAdoptJobs()
 
-	if details.DescriptorCoverage == tree.AllDescriptors {
+	if details.DescriptorCoverage == tree.AllDescriptors && details.DryRun == "" {
 		// We restore the system tables from the main data bundle so late because it
 		// includes the jobs that are being restored. As soon as we restore these
 		// jobs, they become accessible to the user, and may start executing. We
@@ -1920,17 +1985,26 @@ func emitRestoreJobEvent(
 // has been committed from a restore that has failed or been canceled. It does
 // this by adding the table descriptors in DROP state, which causes the schema
 // change stuff to delete the keys in the background.
+//
+// During a Dry Run Restore, OnFailOrCancel ensures that no changes to on disk
+// data persists.
 func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}) error {
 	p := execCtx.(sql.JobExecContext)
-	// Emit to the event log that the job has started reverting.
-	emitRestoreJobEvent(ctx, p, jobs.StatusReverting, r.job)
 
-	telemetry.Count("restore.total.failed")
-	telemetry.CountBucketed("restore.duration-sec.failed",
-		int64(timeutil.Since(timeutil.FromUnixMicros(r.job.Payload().StartedMicros)).Seconds()))
+	// NB: a dry run restore job will never emit job.StatusReverting or
+	// jobs.StatusFailed job events, even if the dry run failed during execution.
+	trueFailOrCancel := r.job.Details().(jobspb.RestoreDetails).DryRun != ""
+
+	if trueFailOrCancel {
+		// Emit to the event log that the job has started reverting.
+		emitRestoreJobEvent(ctx, p, jobs.StatusReverting, r.job)
+
+		telemetry.Count("restore.total.failed")
+		telemetry.CountBucketed("restore.duration-sec.failed",
+			int64(timeutil.Since(timeutil.FromUnixMicros(r.job.Payload().StartedMicros)).Seconds()))
+	}
 
 	details := r.job.Details().(jobspb.RestoreDetails)
-
 	execCfg := execCtx.(sql.JobExecContext).ExecCfg()
 	if err := sql.DescsTxn(ctx, execCfg, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
@@ -1975,8 +2049,10 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}
 		}
 	}
 
-	// Emit to the event log that the job has completed reverting.
-	emitRestoreJobEvent(ctx, p, jobs.StatusFailed, r.job)
+	if trueFailOrCancel {
+		// Emit to the event log that the job has completed reverting.
+		emitRestoreJobEvent(ctx, p, jobs.StatusFailed, r.job)
+	}
 	return nil
 }
 

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -48,6 +48,7 @@ func distRestore(
 	tenantRekeys []execinfrapb.TenantRekey,
 	restoreTime hlc.Timestamp,
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+	dryRun string,
 ) error {
 	ctx = logtags.AddTag(ctx, "restore-distsql", nil)
 	defer close(progCh)
@@ -83,7 +84,8 @@ func distRestore(
 		return err
 	}
 
-	splitAndScatterSpecs, err := makeSplitAndScatterSpecs(sqlInstanceIDs, chunks, tableRekeys, tenantRekeys)
+	splitAndScatterSpecs, err := makeSplitAndScatterSpecs(sqlInstanceIDs, chunks, tableRekeys,
+		tenantRekeys, dryRun)
 	if err != nil {
 		return err
 	}
@@ -94,6 +96,7 @@ func distRestore(
 		TableRekeys:  tableRekeys,
 		TenantRekeys: tenantRekeys,
 		PKIDs:        pkIDs,
+		DryRun:       dryRun,
 	}
 
 	if len(splitAndScatterSpecs) == 0 {
@@ -243,6 +246,7 @@ func makeSplitAndScatterSpecs(
 	chunks [][]execinfrapb.RestoreSpanEntry,
 	tableRekeys []execinfrapb.TableRekey,
 	tenantRekeys []execinfrapb.TenantRekey,
+	dryRun string,
 ) (map[base.SQLInstanceID]*execinfrapb.SplitAndScatterSpec, error) {
 	specsBySQLInstanceID := make(map[base.SQLInstanceID]*execinfrapb.SplitAndScatterSpec)
 	for i, chunk := range chunks {
@@ -258,6 +262,7 @@ func makeSplitAndScatterSpecs(
 				}},
 				TableRekeys:  tableRekeys,
 				TenantRekeys: tenantRekeys,
+				DryRun:       dryRun,
 			}
 		}
 	}

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -40,12 +40,33 @@ type splitAndScatterer interface {
 	scatter(ctx context.Context, codec keys.SQLCodec, scatterKey roachpb.Key) (roachpb.NodeID, error)
 }
 
-type noopSplitAndScatterer struct{}
+type noopSplitAndScatterer struct {
+	scatterNode roachpb.NodeID
+	kr          *KeyRewriter
+}
 
 var _ splitAndScatterer = noopSplitAndScatterer{}
 
 // split implements splitAndScatterer.
-func (n noopSplitAndScatterer) split(_ context.Context, _ keys.SQLCodec, _ roachpb.Key) error {
+func (n noopSplitAndScatterer) split(
+	ctx context.Context, codec keys.SQLCodec, splitKey roachpb.Key,
+) error {
+	if n.kr == nil {
+		return errors.AssertionFailedf("KeyRewriter was not set when expected to be")
+	}
+	/*if s.db == nil {
+		return errors.AssertionFailedf("split and scatterer's database was not set when expected")
+	}*/
+
+	newSplitKey, err := rewriteBackupSpanKey(codec, n.kr, splitKey)
+	if err != nil {
+		return err
+	}
+	if splitAt, err := keys.EnsureSafeSplitKey(newSplitKey); err != nil {
+		// Ignore the error, not all keys are table keys.
+	} else if len(splitAt) != 0 {
+		newSplitKey = splitAt
+	}
 	return nil
 }
 
@@ -53,7 +74,7 @@ func (n noopSplitAndScatterer) split(_ context.Context, _ keys.SQLCodec, _ roach
 func (n noopSplitAndScatterer) scatter(
 	_ context.Context, _ keys.SQLCodec, _ roachpb.Key,
 ) (roachpb.NodeID, error) {
-	return 0, nil
+	return n.scatterNode, nil
 }
 
 // dbSplitAndScatter is the production implementation of this processor's
@@ -220,6 +241,10 @@ func newSplitAndScatterProcessor(
 	}
 
 	scatterer := makeSplitAndScatterer(db, kr)
+	/*if spec.DryRun {
+		nodeID, _ := flowCtx.NodeID.OptionalNodeID()
+		scatterer = noopSplitAndScatterer{nodeID, kr}
+	}*/
 	ssp := &splitAndScatterProcessor{
 		flowCtx:   flowCtx,
 		spec:      spec,

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -219,7 +219,7 @@ message BackupProgress {
 }
 
 // DescriptorRewrite specifies a remapping from one descriptor ID to another for
-// use in rewritting descriptors themselves or things that reference them such 
+// use in rewritting descriptors themselves or things that reference them such
 // as is done during RESTORE or IMPORT.
 message DescriptorRewrite {
   uint32 id = 1 [
@@ -276,6 +276,9 @@ message RestoreDetails {
 
   // The restore job has several atomic stages. For now, we keep track of which
   // stages have completed via these flags.
+
+  // PrepareCompleted: indicates that the updated descriptors have been written to disk in
+  // offline state
   bool prepare_completed = 8;
   bool stats_inserted = 9;
   // SystemTablesMigrated keeps track of which system tables data have been
@@ -325,9 +328,12 @@ message RestoreDetails {
 
   // PreRewrittenTenantID is the ID of tenants[0] in the backup, aka its old ID;
   // it is only valid to set this if len(tenants) == 1.
-  roachpb.TenantID pre_rewrite_tenant_id = 23; 
+  roachpb.TenantID pre_rewrite_tenant_id = 23;
 
-  // NEXT ID: 24.
+  // DryRun indicates the restore job will not actually write data to disk
+  string dry_run = 24;
+
+  // NEXT ID: 25
 }
 
 message RestoreProgress {

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -64,17 +64,20 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 64
+const Version execinfrapb.DistSQLVersion = 65
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 63
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 65
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+ - Version: 65 (MinAcceptedVersion: 65)
+   - A new field, DryRun, was added to the RestoreDataSpec and the SplitAndScatterSpec
 
 - Version: 64 (MinAcceptedVersion: 63)
   - final_covar_samp, final_corr, and final_sqrdiff aggregate functions were

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -270,7 +270,9 @@ message RestoreDataSpec {
   // PKIDs is used to convert result from an ExportRequest into row count
   // information passed back to track progress in the backup job.
   map<uint64, bool> pk_ids = 4 [(gogoproto.customname) = "PKIDs"];
-  // NEXT ID: 6.
+  optional string dry_run = 6 [(gogoproto.nullable) = false];
+
+  // NEXT ID: 7.
 }
 
 message SplitAndScatterSpec {
@@ -281,6 +283,7 @@ message SplitAndScatterSpec {
   repeated RestoreEntryChunk chunks = 1 [(gogoproto.nullable) = false];
   repeated TableRekey table_rekeys = 2 [(gogoproto.nullable) = false];
   repeated TenantRekey tenant_rekeys = 3 [(gogoproto.nullable) = false];
+  optional string dry_run = 4 [(gogoproto.nullable) = false];
 }
 
 // ExporterSpec is the specification for a processor that consumes rows and

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -809,7 +809,7 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 
 %token <str> DATA DATABASE DATABASES DATE DAY DEBUG_PAUSE_ON DEC DECIMAL DEFAULT DEFAULTS
 %token <str> DEALLOCATE DECLARE DEFERRABLE DEFERRED DELETE DELIMITER DESC DESTINATION DETACHED
-%token <str> DISCARD DISTINCT DO DOMAIN DOUBLE DROP
+%token <str> DISCARD DISTINCT DO DOMAIN DOUBLE DROP DRY_RUN
 
 %token <str> ELSE ENCODING ENCRYPTED ENCRYPTION_PASSPHRASE END ENUM ENUMS ESCAPE EXCEPT EXCLUDE EXCLUDING
 %token <str> EXISTS EXECUTE EXECUTION EXPERIMENTAL
@@ -2868,7 +2868,6 @@ backup_options:
   $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
   }
 
-
 // %Help: CREATE SCHEDULE FOR BACKUP - backup data periodically
 // %Category: CCL
 // %Text:
@@ -3055,6 +3054,7 @@ opt_with_schedule_options:
 //    detached: execute restore job asynchronously, without waiting for its completion
 //    skip_localities_check: ignore difference of zone configuration between restore cluster and backup cluster
 //    debug_pause_on: describes the events that the job should pause itself on for debugging purposes.
+//    dry_run: go through the motions of restoring to verify the backup's contents could be used to restore but do not restore the actual data.
 //    new_db_name: renames the restored database. only applies to database restores
 // %SeeAlso: BACKUP, WEBDOCS/restore.html
 restore_stmt:
@@ -3215,6 +3215,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{DebugPauseOn: $3.expr()}
   }
+ | DRY_RUN '=' string_or_placeholder
+ 	{
+ 		$$.val = &tree.RestoreOptions{DryRun: $3.expr()}
+ 	}
 | NEW_DB_NAME '=' string_or_placeholder
   {
     $$.val = &tree.RestoreOptions{NewDBName: $3.expr()}
@@ -13848,6 +13852,7 @@ unreserved_keyword:
 | DOMAIN
 | DOUBLE
 | DROP
+| DRY_RUN
 | ENCODING
 | ENCRYPTED
 | ENCRYPTION_PASSPHRASE

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -487,6 +487,14 @@ RESTORE DATABASE foo FROM '_' WITH new_db_name = '_' -- literals removed
 RESTORE DATABASE _ FROM 'bar' WITH new_db_name = 'baz' -- identifiers removed
 
 parse
+RESTORE DATABASE foo FROM 'bar' WITH dry_run
+----
+RESTORE DATABASE foo FROM 'bar' WITH dry_run
+RESTORE DATABASE foo FROM ('bar') WITH dry_run -- fully parenthesized
+RESTORE DATABASE foo FROM '_' WITH dry_run -- literals removed
+RESTORE DATABASE _ FROM 'bar' WITH dry_run -- identifiers removed
+
+parse
 RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_location = 'baz'
 ----
 RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH incremental_location = 'baz' -- normalized!

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -133,6 +133,7 @@ type RestoreOptions struct {
 	NewDBName                 Expr
 	IncrementalStorage        StringOrPlaceholderOptList
 	AsTenant                  Expr
+	DryRun                    Expr
 }
 
 var _ NodeFormatter = &RestoreOptions{}
@@ -404,6 +405,12 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("tenant = ")
 		ctx.FormatNode(o.AsTenant)
 	}
+
+	if o.DryRun != nil {
+		maybeAddSep()
+		ctx.WriteString("dry_run = ")
+		ctx.FormatNode(o.DryRun)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -499,6 +506,12 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		return errors.New("tenant option specified multiple times")
 	}
 
+	if o.DryRun == nil {
+		o.DryRun = other.DryRun
+	} else if other.DryRun != nil {
+		return errors.New("dry run option specified multiple times")
+	}
+
 	return nil
 }
 
@@ -517,5 +530,6 @@ func (o RestoreOptions) IsDefault() bool {
 		o.DebugPauseOn == options.DebugPauseOn &&
 		o.NewDBName == options.NewDBName &&
 		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage) &&
-		o.AsTenant == options.AsTenant
+		o.AsTenant == options.AsTenant &&
+		o.DryRun == options.DryRun
 }


### PR DESCRIPTION
backupccl: add dry_run option to RESTORE
    
Previously, users could not test whether their RESTORE would run correctly
without actually running a RESTORE. The dry_run option allows users to test
whether their table, database, or cluster level RESTORE will work on a test
cluster. A 'long' dry run RESTORE will perform all aspects of the restore,
short of writing actual data to disk. A 'short' dry run RESTORE will plan the
restore and check that all needed SSTs exist. At the end of the dry run
restore, all state in from the test cluster will be recovered.

Fixes: #67935

Release note (sql change): user can now test whether a RESTORE will run
successfully by using the dry_run option, in a test cluster. dry_run='short'
plans the restore and checks that all needed backup files exist and
dry_run='long' conducts the whole restore, short of writing data to disk.

Release justification: low risk, high benefit changes to existing functionality