### PR TITLE
sql: fix bugs in unsafe_upsert_descriptor

### DIFF
--- a/pkg/cli/testdata/doctor/test_examine_zipdir
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir
@@ -3,12 +3,12 @@ debug doctor examine zipdir testdata/doctor/debugzip
 debug doctor examine zipdir testdata/doctor/debugzip
 WARNING: errors occurred during the production of system.jobs.txt, contents may be missing or incomplete.
 Examining 37 descriptors and 42 namespace entries...
-  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
   ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found
 Examining 2 jobs...
 job 587337426984566785: running schema change GC refers to missing table descriptor(s) [59]; existing descriptors that still need to be dropped []; job safe to delete: true.

--- a/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
@@ -37,17 +37,17 @@ Examining 37 descriptors and 42 namespace entries...
   ParentID   1, ParentSchemaID 29: relation "sqlliveness" (39): processed
   ParentID   0, ParentSchemaID  0: database "defaultdb" (50): processed
   ParentID   0, ParentSchemaID  0: database "postgres" (51): processed
-  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "users" (53): processed
-  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "vehicles" (54): processed
-  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "rides" (55): processed
-  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): processed
-  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): processed
-  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): processed
   ParentID   0, ParentSchemaID  0: namespace entry "defaultdb" (50): processed
   ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -164,7 +164,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			},
 		},
 		{ // 3
-			err: `schema mapping entry "schema1" (500): referenced schema ID 500: descriptor not found`,
+			err: `schema mapping entry "schema1" (500): referenced schema ID 500: referenced descriptor not found`,
 			desc: descpb.DatabaseDescriptor{
 				ID:   51,
 				Name: "db1",
@@ -208,7 +208,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			},
 		},
 		{ // 6
-			err: `multi-region enum: referenced type ID 500: descriptor not found`,
+			err: `multi-region enum: referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.DatabaseDescriptor{
 				ID:   51,
 				Name: "db1",

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -83,6 +83,10 @@ func HasInactiveDescriptorError(err error) bool {
 // found with the given id.
 var ErrDescriptorNotFound = errors.New("descriptor not found")
 
+// ErrReferencedDescriptorNotFound is like ErrDescriptorNotFound but for
+// descriptors referenced within another descriptor.
+var ErrReferencedDescriptorNotFound = errors.New("referenced descriptor not found")
+
 // ErrDescriptorWrongType is returned to signal that a descriptor was found but
 // that it wasn't of the expected type.
 var ErrDescriptorWrongType = errors.New("unexpected descriptor type")

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -86,7 +86,7 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 			},
 		},
 		{ // 1
-			err: `referenced database ID 500: descriptor not found`,
+			err: `referenced database ID 500: referenced descriptor not found`,
 			desc: descpb.SchemaDescriptor{
 				ID:       52,
 				ParentID: 500,

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -315,20 +315,32 @@ func maybeUpgradeForeignKeyRepOnIndex(
 	idx *descpb.IndexDescriptor,
 	skipFKsWithNoMatchingTable bool,
 ) (bool, error) {
+	updateUnupgradedTablesMap := func(id descpb.ID) (err error) {
+		defer func() {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
+				err = nil
+			}
+		}()
+		if _, found := otherUnupgradedTables[id]; found {
+			return nil
+		}
+		d, err := dg.GetDesc(ctx, id)
+		if err != nil {
+			return err
+		}
+		tbl, ok := d.(catalog.TableDescriptor)
+		if !ok {
+			return catalog.WrapTableDescRefErr(id, catalog.ErrDescriptorNotFound)
+		}
+		otherUnupgradedTables[id] = tbl
+		return nil
+	}
+
 	var changed bool
 	if idx.ForeignKey.IsSet() {
 		ref := &idx.ForeignKey
-		if _, ok := otherUnupgradedTables[ref.Table]; !ok {
-			tbl, err := catalog.GetTableDescFromID(ctx, dg, ref.Table)
-			if err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
-					// Ignore this FK and keep going.
-				} else {
-					return false, err
-				}
-			} else {
-				otherUnupgradedTables[ref.Table] = tbl
-			}
+		if err := updateUnupgradedTablesMap(ref.Table); err != nil {
+			return false, err
 		}
 		if tbl, ok := otherUnupgradedTables[ref.Table]; ok {
 			referencedIndex, err := tbl.FindIndexWithID(ref.Index)
@@ -355,19 +367,9 @@ func maybeUpgradeForeignKeyRepOnIndex(
 
 	for refIdx := range idx.ReferencedBy {
 		ref := &(idx.ReferencedBy[refIdx])
-		if _, ok := otherUnupgradedTables[ref.Table]; !ok {
-			tbl, err := catalog.GetTableDescFromID(ctx, dg, ref.Table)
-			if err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
-					// Ignore this FK and keep going.
-				} else {
-					return false, err
-				}
-			} else {
-				otherUnupgradedTables[ref.Table] = tbl
-			}
+		if err := updateUnupgradedTablesMap(ref.Table); err != nil {
+			return false, err
 		}
-
 		if otherTable, ok := otherUnupgradedTables[ref.Table]; ok {
 			originIndexI, err := otherTable.FindIndexWithID(ref.Index)
 			if err != nil {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1620,7 +1620,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 	}{
 		// Foreign keys
 		{ // 0
-			err: `invalid foreign key: missing table=52: referenced table ID 52: descriptor not found`,
+			err: `invalid foreign key: missing table=52: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1666,7 +1666,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{ // 2
-			err: `invalid foreign key backreference: missing table=52: referenced table ID 52: descriptor not found`,
+			err: `invalid foreign key backreference: missing table=52: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1715,7 +1715,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{ // 4
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1738,7 +1738,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 		},
 		// Add some expressions with invalid type references.
 		{ // 5
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1761,7 +1761,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		{ // 6
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1784,7 +1784,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		{ // 7
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1798,7 +1798,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		{ // 8
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -591,7 +591,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`referenced database ID 500: descriptor not found`,
+			`referenced database ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -603,7 +603,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`referenced schema ID 500: descriptor not found`,
+			`referenced schema ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -615,7 +615,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`arrayTypeID 500 does not exist for "ENUM": referenced type ID 500: descriptor not found`,
+			`arrayTypeID 500 does not exist for "ENUM": referenced type ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -627,7 +627,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`arrayTypeID 500 does not exist for "MULTIREGION_ENUM": referenced type ID 500: descriptor not found`,
+			`arrayTypeID 500 does not exist for "MULTIREGION_ENUM": referenced type ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -648,7 +648,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			"referenced table ID 500: descriptor not found",
+			"referenced table ID 500: referenced descriptor not found",
 			descpb.TypeDescriptor{
 				Name:                     "t",
 				ID:                       typeDescID,
@@ -661,7 +661,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			"referenced table ID 500: descriptor not found",
+			"referenced table ID 500: referenced descriptor not found",
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -366,7 +366,7 @@ func (vdg *validationDescGetterImpl) GetDatabaseDescriptor(
 ) (DatabaseDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapDatabaseDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapDatabaseDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsDatabaseDescriptor(desc)
 }
@@ -375,7 +375,7 @@ func (vdg *validationDescGetterImpl) GetDatabaseDescriptor(
 func (vdg *validationDescGetterImpl) GetSchemaDescriptor(id descpb.ID) (SchemaDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapSchemaDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapSchemaDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsSchemaDescriptor(desc)
 }
@@ -384,7 +384,7 @@ func (vdg *validationDescGetterImpl) GetSchemaDescriptor(id descpb.ID) (SchemaDe
 func (vdg *validationDescGetterImpl) GetTableDescriptor(id descpb.ID) (TableDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapTableDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapTableDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsTableDescriptor(desc)
 }
@@ -393,7 +393,7 @@ func (vdg *validationDescGetterImpl) GetTableDescriptor(id descpb.ID) (TableDesc
 func (vdg *validationDescGetterImpl) GetTypeDescriptor(id descpb.ID) (TypeDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapTypeDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapTypeDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	descriptor, err := AsTypeDescriptor(desc)
 	if err != nil {

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -460,7 +460,8 @@ SELECT
 				),
 				true
 			)
-		)
+		),
+		true
 	)
 FROM
 	system.descriptor
@@ -484,7 +485,7 @@ UPDATE system.namespace SET id = 12345 WHERE id = %d;
 	require.Equal(t, tableTID, id)
 	require.Equal(t, "", dbName)
 	require.Equal(t, "", schemaName)
-	require.Equal(t, fmt.Sprintf(`relation "test" (%d): referenced database ID %d: descriptor not found`, tableTID, databaseID), errStr)
+	require.Equal(t, fmt.Sprintf(`relation "test" (%d): referenced database ID %d: referenced descriptor not found`, tableTID, databaseID), errStr)
 
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(&id, &dbName, &schemaName, &objName, &errStr))
@@ -499,7 +500,7 @@ UPDATE system.namespace SET id = 12345 WHERE id = %d;
 	require.Equal(t, "defaultdb", dbName)
 	require.Equal(t, "public", schemaName)
 	require.Equal(t, fmt.Sprintf(
-		`relation "tbl" (%d): invalid foreign key: missing table=%d: referenced table ID %d: descriptor not found`,
+		`relation "tbl" (%d): invalid foreign key: missing table=%d: referenced table ID %d: referenced descriptor not found`,
 		tableTblID, tableFkTblID, tableFkTblID), errStr)
 
 	require.True(t, rows.Next())

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -244,7 +244,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{ParentID: 2, Name: "schema"}, ID: 51},
 			},
 			expected: `Examining 1 descriptors and 1 namespace entries...
-  ParentID   2, ParentSchemaID  0: schema "schema" (51): referenced database ID 2: descriptor not found
+  ParentID   2, ParentSchemaID  0: schema "schema" (51): referenced database ID 2: referenced descriptor not found
 `,
 		},
 		{ // 9
@@ -284,8 +284,8 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 3},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID   3, ParentSchemaID  2: type "type" (51): referenced schema ID 2: descriptor not found
-  ParentID   3, ParentSchemaID  2: type "type" (51): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: descriptor not found
+  ParentID   3, ParentSchemaID  2: type "type" (51): referenced schema ID 2: referenced descriptor not found
+  ParentID   3, ParentSchemaID  2: type "type" (51): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: referenced descriptor not found
 `,
 		},
 		{ // 11
@@ -313,7 +313,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{ParentID: 51, ParentSchemaID: keys.PublicSchemaID, Name: "type"}, ID: 52},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID  51, ParentSchemaID 29: type "type" (52): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: descriptor not found
+  ParentID  51, ParentSchemaID 29: type "type" (52): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: referenced descriptor not found
 `,
 		},
 		{ // 12

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -68,6 +69,7 @@ func (p *planner) UnsafeUpsertDescriptor(
 	ctx context.Context, descID int64, encodedDesc []byte, force bool,
 ) error {
 	const method = "crdb_internal.unsafe_upsert_descriptor()"
+	ev := eventpb.UnsafeUpsertDescriptor{Force: force}
 	if err := checkPlannerStateForRepairFunctions(ctx, p, method); err != nil {
 		return err
 	}
@@ -82,31 +84,26 @@ func (p *planner) UnsafeUpsertDescriptor(
 		return pgerror.Wrapf(err, pgcode.InvalidObjectDefinition, "invalid descriptor")
 	}
 	if newID != id {
-		return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid descriptor ID %d, expected %d", newID, id)
-	}
-	if newVersion > 1 && newModTime.IsEmpty() {
-		return pgerror.Newf(pgcode.InvalidObjectDefinition, "missing descriptor modification time for version %d",
-			newVersion)
+		if !force {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid descriptor ID %d, expected %d", newID, id)
+		}
+		newID = id
 	}
 
-	// Fetch the existing descriptor.
-	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
-	var forceNoticeString string // for the event
-	if !errors.Is(err, catalog.ErrDescriptorNotFound) && err != nil {
-		if force {
-			notice := pgnotice.NewWithSeverityf("WARNING",
-				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
-			p.BufferClientNotice(ctx, notice)
-			forceNoticeString = notice.Error()
-		} else {
-			return err
-		}
+	// Fetch the existing descriptor, if it exists.
+	mut, notice, err := unsafeReadDescriptor(ctx, p, id, force)
+	if err != nil {
+		return err
+	}
+	if notice != nil {
+		ev.ForceNotice = notice.Error()
 	}
 
 	// Validate that existing is sane and store its hex serialization into
 	// existingStr to be written to the event log.
-	var existingStr string
+	var existingProto *descpb.Descriptor
 	var existingVersion descpb.DescriptorVersion
+	var existingModTime hlc.Timestamp
 	var previousOwner string
 	var previousUserPrivileges []descpb.UserPrivileges
 	if mut != nil {
@@ -114,51 +111,113 @@ func (p *planner) UnsafeUpsertDescriptor(
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"cannot modify a modified descriptor (%d) with UnsafeUpsertDescriptor", id)
 		}
+		existingProto = protoutil.Clone(mut.DescriptorProto()).(*descpb.Descriptor)
 		existingVersion = mut.GetVersion()
-		marshaled, err := protoutil.Marshal(mut.DescriptorProto())
-		if err != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(err, "failed to marshal existing descriptor %v", mut)
-		}
-		existingStr = hex.EncodeToString(marshaled)
+		existingModTime = mut.GetModificationTime()
 		previousOwner = mut.GetPrivileges().Owner().Normalized()
 		previousUserPrivileges = mut.GetPrivileges().Users
 	}
 
-	if newVersion != existingVersion && newVersion != existingVersion+1 {
-		return pgerror.Newf(pgcode.InvalidObjectDefinition, "mismatched descriptor version %d, expected %v or %v",
-			newVersion, existingVersion, existingVersion+1)
+	// Check version validity.
+	if newVersion != existingVersion+1 {
+		if !force {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid new descriptor version %d, expected %v",
+				newVersion, existingVersion+1)
+		}
+		newVersion = existingVersion + 1
+	}
+	if newModTime.IsEmpty() {
+		if newVersion > 1 && existingModTime.IsEmpty() {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "missing modification time in updated descriptor with version %d",
+				newVersion)
+		}
+		// Override the modification time in all cases to prevent panics.
+		// It will be reset to the empty value by the descs.Collection's
+		// WriteDescToBatch method.
+		newModTime = existingModTime
 	}
 
-	tbl, db, typ, schema := descpb.FromDescriptor(&desc)
+	// Overwrite corrected version and ID values and fetch new descriptor type.
+	objectType := privilege.Any
+	{
+		//nolint:descriptormarshal
+		if tbl := desc.GetTable(); tbl != nil {
+			tbl.ID = newID
+			tbl.Version = newVersion
+			objectType = privilege.Table
+		}
+		//nolint:descriptormarshal
+		if db := desc.GetDatabase(); db != nil {
+			db.ID = newID
+			db.Version = newVersion
+			objectType = privilege.Database
+		}
+		//nolint:descriptormarshal
+		if typ := desc.GetType(); typ != nil {
+			typ.ID = newID
+			typ.Version = newVersion
+			objectType = privilege.Type
+		}
+		//nolint:descriptormarshal
+		if sc := desc.GetSchema(); sc != nil {
+			sc.ID = newID
+			sc.Version = newVersion
+			objectType = privilege.Schema
+		}
+	}
+	if objectType == privilege.Any {
+		return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid new descriptor %+v", desc)
+	}
+
+	// Update the mutable descriptor with the new proto.
+	tbl, db, typ, schema := descpb.FromDescriptorWithMVCCTimestamp(&desc, newModTime)
 	switch md := mut.(type) {
 	case *tabledesc.Mutable:
+		if objectType != privilege.Table {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "cannot replace table descriptor with %s", objectType)
+		}
 		md.TableDescriptor = *tbl
 	case *schemadesc.Mutable:
+		if objectType != privilege.Schema {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "cannot replace schema descriptor with %s", objectType)
+		}
 		md.SchemaDescriptor = *schema
 	case *dbdesc.Mutable:
+		if objectType != privilege.Database {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "cannot replace database descriptor with %s", objectType)
+		}
 		md.DatabaseDescriptor = *db
 	case *typedesc.Mutable:
+		if objectType != privilege.Type {
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "cannot replace type descriptor with %s", objectType)
+		}
 		md.TypeDescriptor = *typ
 	case nil:
-		b := catalogkv.NewBuilder(&desc)
+		b := catalogkv.NewBuilderWithMVCCTimestamp(&desc, newModTime)
 		if b == nil {
-			return pgerror.New(pgcode.InvalidTableDefinition, "invalid ")
+			return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid new descriptor %+v", desc)
 		}
 		mut = b.BuildCreatedMutable()
 	default:
 		return errors.AssertionFailedf("unknown descriptor type %T for id %d", mut, id)
 	}
 
-	objectType := privilege.Any
-	switch mut.DescriptorType() {
-	case catalog.Database:
-		objectType = privilege.Database
-	case catalog.Table:
-		objectType = privilege.Table
-	case catalog.Type:
-		objectType = privilege.Type
-	case catalog.Schema:
-		objectType = privilege.Schema
+	// Marshal the hex encoding of the existing protobuf for the event log.
+	if existingProto != nil {
+		marshaled, err := protoutil.Marshal(existingProto)
+		if err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "failed to marshal existing descriptor %+v", existingProto)
+		}
+		ev.PreviousDescriptor = hex.EncodeToString(marshaled)
+	}
+
+	// Marshal the hex encoding of the new protobuf for the event log.
+	{
+		marshaled, err := protoutil.Marshal(mut.DescriptorProto())
+		if err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "failed to marshal new descriptor %+v", mut.DescriptorProto())
+		}
+		ev.NewDescriptor = hex.EncodeToString(marshaled)
 	}
 
 	// Check that the descriptor ID is less than the counter used for creating new
@@ -214,12 +273,7 @@ func (p *planner) UnsafeUpsertDescriptor(
 		return err
 	}
 
-	return p.logEvent(ctx, id, &eventpb.UnsafeUpsertDescriptor{
-		PreviousDescriptor: existingStr,
-		NewDescriptor:      hex.EncodeToString(encodedDesc),
-		Force:              force,
-		ForceNotice:        forceNoticeString,
-	})
+	return p.logEvent(ctx, id, &ev)
 }
 
 // comparePrivileges iterates through all users and for each user, compares
@@ -557,36 +611,28 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 				parentID, parentSchemaID, name, existingID, descID)
 		}
 	}
-	flags := p.CommonLookupFlags(true /* required */)
-	flags.IncludeDropped = true
-	flags.IncludeOffline = true
-	desc, err := p.Descriptors().GetImmutableDescriptorByID(ctx, p.txn, descID, flags)
-	var forceNoticeString string // for the event
-	if err != nil && !errors.Is(err, catalog.ErrDescriptorNotFound) {
-		if force {
-			notice := pgnotice.NewWithSeverityf("WARNING",
-				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
-			p.BufferClientNotice(ctx, notice)
-			forceNoticeString = notice.Error()
-		} else {
-			return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
-		}
+	desc, notice, err := unsafeReadDescriptor(ctx, p, descID, force)
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve descriptor %d", descID)
 	}
-	if err == nil && !desc.Dropped() {
+	if desc != nil && !desc.Dropped() && !force {
 		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"refusing to delete namespace entry for non-dropped descriptor")
 	}
 	if err := p.txn.Del(ctx, key); err != nil {
 		return errors.Wrap(err, "failed to delete entry")
 	}
-	return p.logEvent(ctx, descID,
-		&eventpb.UnsafeDeleteNamespaceEntry{
-			ParentID:       uint32(parentID),
-			ParentSchemaID: uint32(parentSchemaID),
-			Name:           name,
-			Force:          force,
-			ForceNotice:    forceNoticeString,
-		})
+
+	ev := eventpb.UnsafeDeleteNamespaceEntry{
+		ParentID:       uint32(parentID),
+		ParentSchemaID: uint32(parentSchemaID),
+		Name:           name,
+		Force:          force,
+	}
+	if notice != nil {
+		ev.ForceNotice = notice.Error()
+	}
+	return p.logEvent(ctx, descID, &ev)
 }
 
 // UnsafeDeleteDescriptor powers the repair builtin of the same name. The
@@ -604,17 +650,9 @@ func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64, forc
 		return err
 	}
 	id := descpb.ID(descID)
-	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
-	var forceNoticeString string // for the event
+	mut, notice, err := unsafeReadDescriptor(ctx, p, id, force)
 	if err != nil {
-		if force {
-			notice := pgnotice.NewWithSeverityf("WARNING",
-				"failed to retrieve existing descriptor, continuing with force flag: %v", err)
-			p.BufferClientNotice(ctx, notice)
-			forceNoticeString = notice.Error()
-		} else {
-			return err
-		}
+		return err
 	}
 
 	// Set the descriptor to dropped so that subsequent attempts to use it in
@@ -633,16 +671,56 @@ func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64, forc
 	if err := p.txn.Del(ctx, descKey); err != nil {
 		return err
 	}
-	ev := &eventpb.UnsafeDeleteDescriptor{
-		Force:       force,
-		ForceNotice: forceNoticeString,
+
+	ev := eventpb.UnsafeDeleteDescriptor{
+		Force: force,
 	}
 	if mut != nil {
 		ev.ParentID = uint32(mut.GetParentID())
 		ev.ParentSchemaID = uint32(mut.GetParentSchemaID())
 		ev.Name = mut.GetName()
 	}
-	return p.logEvent(ctx, id, ev)
+	if notice != nil {
+		ev.ForceNotice = notice.Error()
+	}
+	return p.logEvent(ctx, id, &ev)
+}
+
+// unsafeReadDescriptor reads a descriptor by id. It first tries to go through
+// the descs.Collection, but this can fail if the descriptor exists but has been
+// corrupted and fails validation. In this case, if the force flag is set, we
+// bypass the collection and the validation checks and read the descriptor proto
+// straight from KV and issue a notice. Otherwise, we return an error.
+func unsafeReadDescriptor(
+	ctx context.Context, p *planner, id descpb.ID, force bool,
+) (mut catalog.MutableDescriptor, notice error, err error) {
+	mut, err = p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	if mut != nil {
+		return mut, nil, nil
+	}
+	if errors.Is(err, catalog.ErrDescriptorNotFound) {
+		return nil, nil, nil
+	}
+	if !force {
+		return nil, nil, err
+	}
+	notice = pgnotice.NewWithSeverityf("WARNING",
+		"failed to retrieve existing descriptor, continuing with force flag: %v", err)
+	p.BufferClientNotice(ctx, notice)
+	// Fall back to low-level descriptor read which bypasses validation.
+	descKey := catalogkeys.MakeDescMetadataKey(p.execCfg.Codec, id)
+	descRow, err := p.txn.Get(ctx, descKey)
+	if err != nil {
+		return nil, notice, err
+	}
+	var descProto descpb.Descriptor
+	if err := descRow.ValueProto(&descProto); err != nil {
+		return nil, notice, err
+	}
+	if b := catalogkv.NewBuilderWithMVCCTimestamp(&descProto, descRow.Value.Timestamp); b != nil {
+		mut = b.BuildExistingMutable()
+	}
+	return mut, notice, nil
 }
 
 func checkPlannerStateForRepairFunctions(ctx context.Context, p *planner, method string) error {

--- a/pkg/sql/tests/repair_test.go
+++ b/pkg/sql/tests/repair_test.go
@@ -114,7 +114,7 @@ func TestDescriptorRepairOrphanedDescriptors(t *testing.T) {
 		_, err := db.Exec(
 			"SELECT count(*) FROM \"\".crdb_internal.tables WHERE table_id = $1",
 			descID)
-		require.Regexp(t, fmt.Sprintf(`pq: relation "foo" \(%d\): referenced database ID %d: descriptor not found`, descID, parentID), err)
+		require.Regexp(t, fmt.Sprintf(`pq: relation "foo" \(%d\): referenced database ID %d: referenced descriptor not found`, descID, parentID), err)
 
 		// In this case, we're treating the injected descriptor as having no data
 		// so we can clean it up by just deleting the erroneous descriptor and
@@ -174,7 +174,7 @@ func TestDescriptorRepairOrphanedDescriptors(t *testing.T) {
 		_, err := db.Exec(
 			"SELECT count(*) FROM \"\".crdb_internal.tables WHERE table_id = $1",
 			descID)
-		require.Regexp(t, fmt.Sprintf(`pq: relation "foo" \(%d\): referenced database ID %d: descriptor not found`, descID, parentID), err)
+		require.Regexp(t, fmt.Sprintf(`pq: relation "foo" \(%d\): referenced database ID %d: referenced descriptor not found`, descID, parentID), err)
 
 		// In this case, we're going to inject a parent database
 		require.NoError(t, crdb.ExecuteTx(ctx, db, nil, func(tx *gosql.Tx) error {
@@ -686,7 +686,7 @@ var repairedDescriptor = fmt.Sprintf(`'{
     },
     "state": "PUBLIC",
     "unexposedParentSchemaId": %d,
-    "version": 1
+    "version": 2
   }
 }'`, firstTableID, firstDatabaseID, firstPublicSchemaID)
 
@@ -804,7 +804,7 @@ SELECT crdb_internal.unsafe_upsert_descriptor(%d, crdb_internal.json_to_pb('cock
     },
     "state": "PUBLIC",
     "unexposedParentSchemaId": %d,
-    "version": 1
+    "version": 2
   }
 }
 '))
@@ -861,4 +861,88 @@ func TestDescriptorRepairIdGeneration(t *testing.T) {
 	// There should be 3 descriptors with an id >= 123, including the database
 	// descriptor and the public schema descriptor.
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.descriptor WHERE id >= 123", [][]string{{"3"}})
+}
+
+// TestCorruptDescriptorRepair tests that a corrupt table descriptor can be
+// repaired to a point where it can subsequently be dropped.
+func TestCorruptDescriptorRepair(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(db)
+
+	// Set up the test database with a parent table with a dangling foreign key
+	// back-reference.
+	tdb.Exec(t, `CREATE DATABASE testdb`)
+	tdb.Exec(t, `CREATE TABLE testdb.parent (k INT PRIMARY KEY, v STRING)`)
+	tdb.Exec(t, `CREATE TABLE testdb.child (k INT NOT NULL, FOREIGN KEY (k) REFERENCES testdb.parent (k))`)
+	tdb.Exec(t, `SELECT crdb_internal.unsafe_delete_descriptor(id) FROM system.namespace WHERE name = 'child'`)
+	tdb.Exec(t, `SELECT crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id) FROM system.namespace WHERE name = 'child'`)
+
+	// Dropping the table should fail, because the table descriptor will fail
+	// the validation checks when being read from storage.
+	tdb.ExpectErr(t, "invalid foreign key backreference", `DROP TABLE testdb.parent`)
+
+	const parentVersion = `SELECT
+				crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', sd.descriptor, false)->'table'->>'version'
+			FROM
+				system.descriptor AS sd INNER JOIN system.namespace AS sn ON sd.id = sn.id
+			WHERE
+				sn.name = 'parent'`
+	tdb.CheckQueryResults(t, parentVersion, [][]string{{"2"}})
+
+	// Repair query, with the following args:
+	// - $1: new version counter value
+	// - $2: force flag for unsafe_upsert_descriptor
+	const repair = `
+WITH
+	to_json
+		AS (
+			SELECT
+				sd.id,
+				crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', sd.descriptor, false) AS d
+			FROM
+				system.descriptor AS sd INNER JOIN system.namespace AS sn ON sd.id = sn.id
+			WHERE
+				sn.name = 'parent'
+		),
+	modified
+		AS (
+			SELECT
+				id,
+				json_set(
+					json_set(
+						json_set(d, ARRAY['table', 'inboundFks'], '[]'::JSONB),
+						ARRAY['table', 'version'],
+						$1
+					),
+					ARRAY['table', 'modificationTime'],
+					json_build_object(
+						'wallTime',
+						((extract('epoch', now()) * 1000000)::INT8 * 1000)::STRING
+					)
+				)
+					AS d
+			FROM
+				to_json
+		)
+SELECT
+	crdb_internal.unsafe_upsert_descriptor(
+		id,
+		crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor', d),
+		$2
+	)
+FROM
+	modified;
+`
+	// Repairing without the force flag should fail.
+	tdb.ExpectErr(t, "invalid foreign key backreference", repair, 3, false)
+
+	// Repairing with the force flag should succeed regardless of the supplied
+	// version.
+	tdb.Exec(t, repair, 12345, true)
+	tdb.Exec(t, `DROP TABLE testdb.parent`)
 }


### PR DESCRIPTION
    sql: fix bugs in unsafe_upsert_descriptor
    
    This commit fixes some bugs in the implementation of the
    unsafe_upsert_descriptor repair function:
    - The descriptor read via the descriptor collection falls back to
      a Get operation followed by descriptor proto unmarshalling in cases
      where the existing descriptor is invalid and the force flag is set.
    - The existing descriptor hex encoding in the event log is less
      incorrect.
    - The version check has been tightened to only allow the existing
      descriptor version plus one.
    
    This commit also comes with some quality-of-life improvements in that
    the unsafe_upsert_descriptor function will override incorrect version
    and ID fields when the force flag is set.
    
    Furthermore this commit fixes a bug where ErrDescriptorNotFound was
    mistakenly returned when a descriptor references another descriptor that
    doesn't exist. This commit introduces a new error for missing referenced
    descriptors so that this class of errors gets treated differently when
    handling errors returned by the descs.Collection API.
    
    Fixes #74465.
    
    Release note: None