### PR TITLE
ptpb: remove unused proto import

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptpb/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptpb/BUILD.bazel
@@ -9,7 +9,6 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb:roachpb_proto",
-        "//pkg/sql/catalog/descpb:descpb_proto",
         "//pkg/util/hlc:hlc_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@go_googleapis//google/api:annotations_proto",
@@ -24,7 +23,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb:with-mocks",
-        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descpb",  # keep
         "//pkg/util/hlc",
         "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",

--- a/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
+++ b/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
@@ -17,7 +17,6 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "roachpb/data.proto";
 import "util/hlc/timestamp.proto";
-import "sql/catalog/descpb/structured.proto";
 
 
 // TODO(ajwerner): Consider splitting up Record into two pieces. It would


### PR DESCRIPTION
Shows up as warnings when using bazel/dev.

Release note: None