### PR TITLE
sql: support readonly default_with_oids var

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4636,6 +4636,7 @@ default_transaction_isolation                         serializable
 default_transaction_priority                          normal
 default_transaction_read_only                         off
 default_transaction_use_follower_reads                off
+default_with_oids                                     off
 disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4043,6 +4043,7 @@ default_transaction_isolation                         serializable        NULL  
 default_transaction_priority                          normal              NULL      NULL        NULL        string
 default_transaction_read_only                         off                 NULL      NULL        NULL        string
 default_transaction_use_follower_reads                off                 NULL      NULL        NULL        string
+default_with_oids                                     off                 NULL      NULL        NULL        string
 disable_partially_distributed_plans                   off                 NULL      NULL        NULL        string
 disable_plan_gists                                    off                 NULL      NULL        NULL        string
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
@@ -4151,6 +4152,7 @@ default_transaction_isolation                         serializable        NULL  
 default_transaction_priority                          normal              NULL  user     NULL      normal              normal
 default_transaction_read_only                         off                 NULL  user     NULL      off                 off
 default_transaction_use_follower_reads                off                 NULL  user     NULL      off                 off
+default_with_oids                                     off                 NULL  user     NULL      off                 off
 disable_partially_distributed_plans                   off                 NULL  user     NULL      off                 off
 disable_plan_gists                                    off                 NULL  user     NULL      off                 off
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
@@ -4254,6 +4256,7 @@ default_transaction_isolation                         NULL    NULL     NULL     
 default_transaction_priority                          NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only                         NULL    NULL     NULL     NULL        NULL
 default_transaction_use_follower_reads                NULL    NULL     NULL     NULL        NULL
+default_with_oids                                     NULL    NULL     NULL     NULL        NULL
 disable_partially_distributed_plans                   NULL    NULL     NULL     NULL        NULL
 disable_plan_gists                                    NULL    NULL     NULL     NULL        NULL
 disallow_full_table_scans                             NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -530,6 +530,24 @@ SET standard_conforming_strings='true'
 statement ok
 SET standard_conforming_strings='on'
 
+subtest default_with_oids_test
+
+query T
+SHOW default_with_oids
+----
+off
+
+statement ok
+SET default_with_oids = 'false'
+
+query T
+SHOW default_with_oids
+----
+off
+
+statement error invalid value for parameter "default_with_oids": "true"
+SET default_with_oids = 'true'
+
 subtest backslash_quote_test
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -41,6 +41,7 @@ default_transaction_isolation                         serializable
 default_transaction_priority                          normal
 default_transaction_read_only                         off
 default_transaction_use_follower_reads                off
+default_with_oids                                     off
 disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -86,7 +86,7 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	"default_transaction_deferrable",
 	// "default_transaction_isolation",
 	// "default_transaction_read_only",
-	"default_with_oids",
+	// "default_with_oids",
 	"dynamic_library_path",
 	"effective_cache_size",
 	"enable_bitmapscan",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1039,6 +1039,9 @@ var varGen = map[string]sessionVar{
 	// be changed to `on`.
 	`backslash_quote`: makeCompatStringVar(`backslash_quote`, `safe_encoding`),
 
+	// See https://www.postgresql.org/docs/9.5/runtime-config-compatible.html
+	`default_with_oids`: makeCompatBoolVar(`default_with_oids`, false, false),
+
 	// Supported for PG compatibility only.
 	// See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 	`max_identifier_length`: {


### PR DESCRIPTION
This is just one less error when importing PGDUMP.

Release note (sql change): We now support `default_with_oids` which
only accepts being false.