### PR TITLE
kvserver: fix nil pointer dereferencing in `replicaRankings.topQPS`

### DIFF
--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -57,7 +57,7 @@ func (rr *replicaRankings) topQPS() []replicaWithStats {
 	defer rr.mu.Unlock()
 	// If we have a new set of data, consume it. Otherwise, just return the most
 	// recently consumed data.
-	if rr.mu.qpsAccumulator.qps.Len() > 0 {
+	if rr.mu.qpsAccumulator != nil && rr.mu.qpsAccumulator.qps.Len() > 0 {
 		rr.mu.byQPS = consumeAccumulator(&rr.mu.qpsAccumulator.qps)
 	}
 	return rr.mu.byQPS


### PR DESCRIPTION
If `replicaRankings.topQPS()` was called before a QPS accumulator had
been set for the rankings, it would attempt to dereference a nil pointer
and panic. This could happen e.g. if the status server's
`/_status/hotranges` endpoint was accessed during node startup.

The initialization story here is a bit unclear -- it appears that the
accumulator is set up in `Store.Capacity()`, which is called by
`Store.Descriptor()`. So this will only be initialized once the store
descriptor is requested by someone, e.g. during `Store.GossipStore()` or
`MetricsRecorder.GenerateNodeStatus()`. I haven't made an attempt at
reviewing or revising this.

This patch explicitly checks if a QPS accumulator has been set before
attempting to access it, avoiding the nil pointer dereferencing.

Release note (bug fix): Fixed a panic when attempting to access the
hottest ranges (e.g. via the `/_status/hotranges` endpoint) before
initial statistics had been gathered.