### PR TITLE
release-21.1: sql: fix enum hydration in nested tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -1,0 +1,33 @@
+# LogicTest: 5node-default-configs
+
+# Regression test for nested tuple enum hydration (#74189)
+statement ok
+CREATE TYPE greeting AS ENUM ('hello')
+
+statement ok
+CREATE TABLE IF NOT EXISTS seed AS
+	SELECT
+		enum_range('hello'::greeting)[g] as _enum
+	FROM
+		generate_series(1, 1) AS g
+
+query TT nodeidx=3
+WITH w (col)
+				AS (
+					SELECT
+						*
+					FROM
+						(
+							VALUES
+								(
+									((('hello':::greeting, 0), 0))
+								)
+						)
+				)
+		SELECT
+			seed._enum, w.col
+		FROM
+			w, seed
+----
+hello     ("(hello,0)",0)
+


### PR DESCRIPTION
If an enum type was in a doubly nested tuple it would not get hydrated.
Fix by hydrating entire type tree with recursion.

Fixes: #73422

Release note (bug fix): A doubly nested enum in a distsql query would
not get hydrated on remote nodes resulting in panic.

Release justification: Fix node crashing panic.
