### PR TITLE
pgwire: fix an assertion

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1042,8 +1042,12 @@ func (s *Server) maybeUpgradeToSecureConn(
 	}
 
 	if connType == hba.ConnLocal {
+		// No existing PostgreSQL driver ever tries to activate TLS over
+		// a unix socket. But in case someone, sometime, somewhere, makes
+		// that mistake, let them know that we don't want it.
 		clientErr = pgerror.New(pgcode.ProtocolViolation,
 			"cannot use SSL/TLS over local connections")
+		return
 	}
 
 	// Protocol sanity check.


### PR DESCRIPTION
When a client connects over a unix socket, we don't support TLS.
The assertion for this was wrong, it did not properly report
the invalid situation to the client.

We can't really test this - I was not able to find a single client
that gets this wrong.

Release note: None