### PR TITLE
bazel: increase stdouterr bytes limit for tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 try-import %workspace%/.bazelrc.user
 
 build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,gss --experimental_proto_descriptor_sets_include_source_info --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
-test --config=test
+test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build:with_ui --define cockroach_with_ui=y
 build:test --define crdb_test=y
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled


### PR DESCRIPTION
Bazel defaults to 1MiB of test output, easily exceeded when showing
logs/stack traces/etc. When exceeded, the test output is routed to a
file with an error saying as much: github.com/bazelbuild/bazel/issues/12602.
Use 10x the amount by default.

Release note: None