### PR TITLE
kvserver: determine if leaseholder is removed using proposed replica …

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -323,10 +323,11 @@ func (r *Replica) propose(
 		// the replica remains in the descriptor, but as VOTER_{OUTGOING,DEMOTING}.
 		// We want to block it from getting into that state in the first place,
 		// since there's no stopping the actual removal/demotion once it's there.
-		// The Removed() field has contains these replicas when this first
-		// transition is initiated, so its use here is copacetic.
+		// IsVoterNewConfig checks that the leaseholder is a voter in the
+		// proposed configuration.
 		replID := r.ReplicaID()
-		for _, rDesc := range crt.Removed() {
+		rDesc, ok := p.command.ReplicatedEvalResult.State.Desc.GetReplicaDescriptorByID(replID)
+		for !ok || !rDesc.IsVoterNewConfig() {
 			if rDesc.ReplicaID == replID {
 				err := errors.Mark(errors.Newf("received invalid ChangeReplicasTrigger %s to remove self (leaseholder)", crt),
 					errMarkInvalidReplicationChange)


### PR DESCRIPTION
…descriptor

Previosly, the determination of whether a leaseholder is being removed was made
by looking at the proposed changes. As a step towards https://github.com/cockroachdb/cockroach/pull/74077
we'd like to instead look at the replica descriptor that the reconfiguration change would result in.
This prepares the ground for making a distinction between incoming and outgoing replicas in the next PR.
This PR should not cause any change in behavior.

Release note: None