### PR TITLE
kv: Allow nil when checking for empty lease.

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1887,7 +1887,7 @@ func (l *Lease) SafeFormat(w redact.SafePrinter, _ rune) {
 
 // Empty returns true for the Lease zero-value.
 func (l *Lease) Empty() bool {
-	return *l == (Lease{})
+	return l == nil || *l == (Lease{})
 }
 
 // OwnedBy returns whether the given store is the lease owner.

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -154,7 +154,7 @@ func TestLeaseString(t *testing.T) {
 		},
 		{
 			lease:    nil,
-			expected: "<nil>",
+			expected: "<empty>",
 		},
 		{
 			lease: &roachpb.Lease{


### PR DESCRIPTION
Treat nil lease as empty when checking for empty lease.
Recent changes in https://github.com/cockroachdb/cockroach/pull/66374
as well as in https://github.com/cockroachdb/cockroach/pull/74315 changed
how lease is stored as well as modified receiver type.  As a result,
attempts to print empty `EvictionToken{}` will result in a nil panic.

Release Notes: None