### PR TITLE
sql: set volatility to stable for enum casts

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -777,3 +777,15 @@ query T
 EXECUTE s73450_c('foo')
 ----
 f
+
+# Regression test for #74470. Casts to and from ENUMs should have stable
+# volatility so that they are not allowed in check constraints, computed column
+# expressions, and partial index predicates.
+statement ok
+CREATE TYPE typ74470 AS ENUM ('foo', 'bar');
+
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE tab74470 (a typ74470, b TEXT AS (a::TEXT) STORED);
+
+statement error context-dependent operators are not allowed in computed column
+CREATE TABLE tab74470 (a TEXT, b typ74470 AS (a::typ74470) STORED);

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -124,8 +124,8 @@ CREATE TYPE t4 AS ENUM ('cheers')
 statement ok
 CREATE TABLE expr (
   x BOOL DEFAULT ('hello'::t1 = 'hello'::t1),
-  y STRING AS ('howdy'::t2::STRING) STORED,
-  CHECK ('hi'::t3::string = 'hi'),
+  y t2 AS ('howdy'::t2) STORED,
+  CHECK ('hi'::t3 = 'hi'::t3),
   INDEX i(y) WHERE ('cheers'::t4 = 'cheers'::t4)
 )
 
@@ -184,7 +184,7 @@ ROLLBACK
 
 statement ok
 BEGIN;
-ALTER TABLE expr ADD COLUMN y STRING AS ('howdy'::t2::STRING) STORED
+ALTER TABLE expr ADD COLUMN y t2 AS ('howdy'::t2) STORED
 
 statement error pq: cannot drop type "t2" because other objects \(\[test.public.expr\]\) still depend on it
 DROP TYPE t2
@@ -215,8 +215,8 @@ ROLLBACK
 # Now add all of the schema elements.
 statement ok
 ALTER TABLE expr ADD COLUMN x BOOL DEFAULT ('hello'::t1 = 'hello'::t1);
-ALTER TABLE expr ADD COLUMN y STRING AS ('howdy'::t2::STRING) STORED;
-ALTER TABLE expr ADD CONSTRAINT "check" CHECK ('hi'::t3::string = 'hi');
+ALTER TABLE expr ADD COLUMN y t2 AS ('howdy'::t2) STORED;
+ALTER TABLE expr ADD CONSTRAINT "check" CHECK ('hi'::t3 = 'hi'::t3);
 CREATE INDEX i ON expr (y) WHERE ('cheers'::t4 = 'cheers'::t4)
 
 statement error pq: cannot drop type "t1" because other objects \(\[test.public.expr\]\) still depend on it

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1422,7 +1422,7 @@ statement error pq: could not remove enum value "a" as it is being used in a com
 ALTER TYPE computed_abc DROP VALUE 'a'
 
 statement ok
-CREATE TABLE t6 (k INT PRIMARY KEY, y string AS ('b'::computed_abc::string) STORED)
+CREATE TABLE t6 (k INT PRIMARY KEY, y computed_abc AS ('b'::computed_abc) STORED)
 
 statement error pq: could not remove enum value "b" as it is being used in a computed column of "t6"
 ALTER TYPE computed_abc DROP VALUE 'b'

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -652,23 +652,21 @@ DROP TABLE bf
 # Backfill a expression index with a user defined type.
 
 statement ok
-CREATE TYPE enum AS ENUM ('Foo', 'BAR', 'baz')
+CREATE TYPE enum AS ENUM ('foo', 'bar', 'baz')
 
 statement ok
 CREATE TABLE bf (a enum)
 
 statement ok
-INSERT INTO bf VALUES ('Foo'), ('BAR'), ('baz')
+INSERT INTO bf VALUES ('foo'), ('bar'), ('baz')
 
 statement ok
-CREATE INDEX lower_a ON bf (lower(a::STRING))
+CREATE INDEX a_eq_foo ON bf ((a = 'foo'::enum))
 
 query T rowsort
-SELECT a FROM bf@lower_a WHERE lower(a::STRING) IN ('foo', 'bar', 'baz')
+SELECT a FROM bf@a_eq_foo WHERE a = 'foo'::enum
 ----
-Foo
-BAR
-baz
+foo
 
 statement ok
 DROP TABLE bf
@@ -683,20 +681,18 @@ statement ok
 CREATE TABLE bf (a enum)
 
 statement ok
-INSERT INTO bf VALUES ('Foo'), ('BAR'), ('baz')
+INSERT INTO bf VALUES ('foo'), ('bar'), ('baz')
 
 statement ok
-CREATE INDEX lower_a ON bf (lower(a::STRING))
+CREATE INDEX a_eq_foo ON bf ((a = 'foo'::enum))
 
 statement ok
 COMMIT
 
 query T rowsort
-SELECT a FROM bf@lower_a WHERE lower(a::STRING) IN ('foo', 'bar', 'baz')
+SELECT a FROM bf@a_eq_foo WHERE a = 'foo'::enum
 ----
-Foo
-BAR
-baz
+foo
 
 statement ok
 DROP TABLE bf

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -246,7 +246,7 @@ statement ok
 DROP VIEW v
 
 statement ok
-CREATE TABLE t (i INT, k STRING AS ('a'::typ::string) STORED)
+CREATE TABLE t (i INT, k typ AS ('a'::typ) STORED)
 
 statement ok
 CREATE VIEW v AS (SELECT i FROM t)
@@ -1215,8 +1215,8 @@ CREATE TABLE ttc1 (x d_tc);
 CREATE TABLE ttc2 (y d_tc[]);
 CREATE TABLE ttc3 (
   x BOOL DEFAULT ('hello'::d_tc = 'hello'::d_tc),
-  y STRING AS ('howdy'::d2_tc::STRING) STORED,
-  CHECK ('hello'::d_tc::string = 'hello'),
+  y d2_tc AS ('howdy'::d2_tc) STORED,
+  CHECK ('hello'::d_tc = 'hello'::d_tc),
   INDEX i(y) WHERE ('hello'::d_tc = 'hello'::d_tc)
 );
 

--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -120,28 +120,28 @@ statement error cannot modify table record type
 ALTER TABLE b ADD COLUMN b INT DEFAULT (((1,'a')::b).a)
 
 statement error cannot modify table record type
-CREATE TABLE fail (b INT AS (((1,'a')::b).a) VIRTUAL)
+CREATE TABLE fail (b INT AS (((1,'a'::e)::b).a) VIRTUAL)
 
 statement error cannot modify table record type
-ALTER TABLE b ADD COLUMN b INT AS (((1,'a')::b).a) VIRTUAL
+ALTER TABLE b ADD COLUMN b INT AS (((1,'a'::e)::b).a) VIRTUAL
 
 statement error cannot modify table record type
-CREATE TABLE fail (b INT AS (((1,'a')::b).a) STORED)
+CREATE TABLE fail (b INT AS (((1,'a'::e)::b).a) STORED)
 
 statement error cannot modify table record type
-ALTER TABLE b ADD COLUMN b INT AS (((1,'a')::b).a) STORED
+ALTER TABLE b ADD COLUMN b INT AS (((1,'a'::e)::b).a) STORED
 
 statement error cannot modify table record type
-CREATE TABLE fail (b INT, INDEX(b) WHERE b > (((1,'a')::b).a))
+CREATE TABLE fail (b INT, INDEX(b) WHERE b > (((1,'a'::e)::b).a))
 
 statement error cannot modify table record type
-CREATE INDEX ON a(a) WHERE a > (((1,'a')::b).a)
+CREATE INDEX ON a(a) WHERE a > (((1,'a'::e)::b).a)
 
 statement error cannot modify table record type
-CREATE TABLE fail (b INT, INDEX((b + (((1,'a')::b).a))))
+CREATE TABLE fail (b INT, INDEX((b + (((1,'a'::e)::b).a))))
 
 statement error cannot modify table record type
-CREATE INDEX ON a((a + (((1,'a')::b).a)))
+CREATE INDEX ON a((a + (((1,'a'::e)::b).a)))
 
 statement error value type tuple{int AS a, e AS e} cannot be used for table columns
 CREATE VIEW v AS SELECT (1,'a')::b

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -936,7 +936,7 @@ statement ok
 DROP VIEW v
 
 statement ok
-CREATE TABLE t (i INT, k STRING AS ('a'::typ::string) STORED)
+CREATE TABLE t (i INT, k typ AS ('a'::typ) STORED)
 
 statement ok
 CREATE VIEW v AS (SELECT i FROM t)

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1269,21 +1269,21 @@ func lookupCast(src, tgt *types.T, intervalStyleEnabled, dateStyleEnabled bool) 
 	// Enums have dynamic OIDs, so they can't be populated in castMap. Instead,
 	// we dynamically create cast structs for valid enum casts.
 	if srcFamily == types.EnumFamily && tgtFamily == types.StringFamily {
-		// Casts from enum types to strings are immutable and allowed in
+		// Casts from enum types to strings are stable and allowed in
 		// assignment contexts.
 		return cast{
 			maxContext: CastContextAssignment,
-			volatility: VolatilityImmutable,
+			volatility: VolatilityStable,
 		}, true
 	}
 	if tgtFamily == types.EnumFamily {
 		switch srcFamily {
 		case types.StringFamily:
-			// Casts from string types to enums are immutable and allowed in
+			// Casts from string types to enums are stable and allowed in
 			// explicit contexts.
 			return cast{
 				maxContext: CastContextExplicit,
-				volatility: VolatilityImmutable,
+				volatility: VolatilityStable,
 			}, true
 		case types.UnknownFamily:
 			// Casts from unknown to enums are immutable and allowed in implicit
@@ -1293,14 +1293,14 @@ func lookupCast(src, tgt *types.T, intervalStyleEnabled, dateStyleEnabled bool) 
 				volatility: VolatilityImmutable,
 			}, true
 		case types.BytesFamily:
-			// Casts from byte types to enums are immutable and allowed in
+			// Casts from byte types to enums are stable and allowed in
 			// explicit contexts.
 			// TODO(mgartner): We may not want to support the cast from BYTES to
 			// ENUM because Postgres does not support it, and it's been the
 			// source of at least one minor bug (see #74316).
 			return cast{
 				maxContext: CastContextExplicit,
-				volatility: VolatilityImmutable,
+				volatility: VolatilityStable,
 			}, true
 		}
 	}
@@ -1514,7 +1514,7 @@ var validCasts = []castInfo{
 	{from: types.OidFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 	{from: types.INetFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 	{from: types.JsonFamily, to: types.StringFamily, volatility: VolatilityImmutable},
-	{from: types.EnumFamily, to: types.StringFamily, volatility: VolatilityImmutable},
+	{from: types.EnumFamily, to: types.StringFamily, volatility: VolatilityStable},
 	{from: types.VoidFamily, to: types.StringFamily, volatility: VolatilityImmutable},
 
 	// Casts to CollatedStringFamily.
@@ -1542,7 +1542,7 @@ var validCasts = []castInfo{
 	{from: types.OidFamily, to: types.CollatedStringFamily, volatility: VolatilityImmutable},
 	{from: types.INetFamily, to: types.CollatedStringFamily, volatility: VolatilityImmutable},
 	{from: types.JsonFamily, to: types.CollatedStringFamily, volatility: VolatilityImmutable},
-	{from: types.EnumFamily, to: types.CollatedStringFamily, volatility: VolatilityImmutable},
+	{from: types.EnumFamily, to: types.CollatedStringFamily, volatility: VolatilityStable},
 
 	// Casts to BytesFamily.
 	{from: types.UnknownFamily, to: types.BytesFamily, volatility: VolatilityImmutable},
@@ -1671,9 +1671,9 @@ var validCasts = []castInfo{
 
 	// Casts to EnumFamily.
 	{from: types.UnknownFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
-	{from: types.StringFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
+	{from: types.StringFamily, to: types.EnumFamily, volatility: VolatilityStable},
 	{from: types.EnumFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
-	{from: types.BytesFamily, to: types.EnumFamily, volatility: VolatilityImmutable},
+	{from: types.BytesFamily, to: types.EnumFamily, volatility: VolatilityStable},
 
 	// Casts to TupleFamily.
 	{from: types.UnknownFamily, to: types.TupleFamily, volatility: VolatilityImmutable},


### PR DESCRIPTION
Casts from ENUM to STRING, STRING to ENUM, and BYTES to ENUM now have a
volatility of stable. This is correct because the outcome of these casts
is dependent on the state of the ENUM in the cast.

Fixes #74470

Release note (bug fix): Casts involving ENUM types were previously
considered context-independent, when they are actually context-
dependent. This allowed them to be included in check constraint
expressions, computed column expressions, partial index WHERE clauses,
and expression indexes. This could result in incorrectly enforced check
constraints, incorrect computed column values, and corrupt indexes. This
bug has been present since ENUM types were released in version 20.2.
