### PR TITLE
spanconfig: support rangefeeds for dynamic system tables

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigcomparedccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigcomparedccl/testdata/basic
@@ -20,21 +20,25 @@ ALTER TABLE db.t1 CONFIGURE ZONE USING num_voters = 5;
 #   range's contents whenever anything in it changes.
 # - The span configs infrastructure doesn't, at least for now, for
 #   inter-operability with the gossip-backed system.
+# That said, the span configs infrastructure is used to drive whether
+# rangefeeds are enabled on the system database tables. It also controls
+# whether strict GC is enforced. For that reason we expect to find different
+# span configs from each ("range system" vs. "database system").
 
 configs version=legacy offset=4 limit=3
 ----
 ...
-/System/"tse"                              range system
-/Table/SystemConfigSpan/Start              range system
-/Table/11                                  range system
+/System/"tse"                              database system (host)
+/Table/SystemConfigSpan/Start              database system (host)
+/Table/11                                  database system (host)
 ...
 
 configs version=current offset=4 limit=3
 ----
 ...
 /System/"tse"                              range system
-/Table/SystemConfigSpan/Start              range system
-/Table/11                                  range system
+/Table/SystemConfigSpan/Start              database system (host)
+/Table/11                                  database system (host)
 ...
 
 # Both subsystems observe splits for the tables created above.
@@ -42,23 +46,69 @@ configs version=current offset=4 limit=3
 configs version=current offset=41
 ----
 ...
-/Table/46                                  range system
-/Table/47                                  range system
+/Table/46                                  database system (host)
+/Table/47                                  database system (host)
 /Table/56                                  num_replicas=7 num_voters=5
 /Table/57                                  num_replicas=7
 
 configs version=legacy offset=41
 ----
 ...
-/Table/46                                  range system
-/Table/47                                  range system
+/Table/46                                  database system (host)
+/Table/47                                  database system (host)
 /Table/56                                  num_replicas=7 num_voters=5
 /Table/57                                  num_replicas=7
 
-# Both subsystems are identical with respect to exposed configs (including for
-# pseudo table IDs).
+# Both subsystems differ slightly with respect to exposed configs ("range
+# system" vs. "database system" as described earlier). This only applies to
+# tables in the system database, excluding pseudo table IDs.
 
 diff
 ----
+--- gossiped system config span (legacy)
++++ span config infrastructure (current)
+@@ -1,7 +1,7 @@
+-/Min                                       ttl_seconds=3600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+-/System/NodeLiveness                       ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+-/System/NodeLivenessMax                    database system (host)
+-/System/tsd                                database system (tenant)
+-/System/"tse"                              database system (host)
++/Min                                       ttl_seconds=3600 num_replicas=5
++/System/NodeLiveness                       ttl_seconds=600 num_replicas=5
++/System/NodeLivenessMax                    range system
++/System/tsd                                range default
++/System/"tse"                              range system
+ /Table/SystemConfigSpan/Start              database system (host)
+ /Table/11                                  database system (host)
+@@ -10,11 +10,11 @@
+ /Table/14                                  database system (host)
+ /Table/15                                  database system (host)
+-/Table/16                                  database system (host)
+-/Table/17                                  database system (host)
+-/Table/18                                  database system (host)
++/Table/16                                  range system
++/Table/17                                  range system
++/Table/18                                  range system
+ /Table/19                                  database system (host)
+ /Table/20                                  database system (host)
+ /Table/21                                  database system (host)
+-/Table/22                                  database system (host)
++/Table/22                                  range system
+ /Table/23                                  database system (host)
+ /Table/24                                  database system (host)
+@@ -23,5 +23,5 @@
+ /Table/27                                  ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+ /Table/28                                  database system (host)
+-/Table/29                                  database system (host)
++/Table/29                                  range system
+ /NamespaceTable/30                         database system (host)
+ /NamespaceTable/Max                        database system (host)
+@@ -32,5 +32,5 @@
+ /Table/36                                  database system (host)
+ /Table/37                                  database system (host)
+-/Table/38                                  database system (host)
++/Table/38                                  range system
+ /Table/39                                  database system (host)
+ /Table/40                                  database system (host)
 
 # vim:ft=diff

--- a/pkg/ccl/spanconfigccl/spanconfigcomparedccl/testdata/multitenant
+++ b/pkg/ccl/spanconfigccl/spanconfigcomparedccl/testdata/multitenant
@@ -12,52 +12,58 @@ initialize tenant=11
 ----
 
 # Before kicking starting off tenant reconciliation, we should find seed
-# configs for the newly initialized tenants. As yet, there are no differences
-# between the subsystems.
+# configs for the newly initialized tenants. As yet, there are no (unexpected)
+# differences between the subsystems.
+
 configs version=current offset=43
 ----
 ...
 /Tenant/10                                 range default
 /Tenant/11                                 range default
 
-diff
+diff offset=50
 ----
+--- gossiped system config span (legacy)
++++ span config infrastructure (current)
+...
 
 reconcile tenant=11
 ----
 
 # As soon as tenant-11 starts reconciling, we should observe more fine-grained
 # span configs within its keyspan. This isn't true for the legacy system.
+
 configs version=current offset=43 limit=5
 ----
 ...
 /Tenant/10                                 range default
-/Tenant/11                                 range default
-/Tenant/11/Table/4                         range default
-/Tenant/11/Table/5                         range default
-/Tenant/11/Table/6                         range default
+/Tenant/11                                 database system (tenant)
+/Tenant/11/Table/4                         database system (tenant)
+/Tenant/11/Table/5                         database system (tenant)
+/Tenant/11/Table/6                         database system (tenant)
 ...
 
 configs version=legacy offset=43
 ----
 ...
-/Tenant/10                                 range default
-/Tenant/11                                 range default
+/Tenant/10                                 database system (tenant)
+/Tenant/11                                 database system (tenant)
 
-diff limit=10
+diff offset=48 limit=10
 ----
 --- gossiped system config span (legacy)
 +++ span config infrastructure (current)
-@@ -44,3 +44,36 @@
- /Tenant/10                                 range default
- /Tenant/11                                 range default
-+/Tenant/11/Table/4                         range default
-+/Tenant/11/Table/5                         range default
-+/Tenant/11/Table/6                         range default
-+/Tenant/11/Table/7                         range default
-+/Tenant/11/Table/11                        range default
-+/Tenant/11/Table/12                        range default
-+/Tenant/11/Table/13                        range default
+...
+ /Tenant/11                                 database system (tenant)
++/Tenant/11/Table/4                         database system (tenant)
++/Tenant/11/Table/5                         database system (tenant)
++/Tenant/11/Table/6                         database system (tenant)
++/Tenant/11/Table/7                         database system (tenant)
++/Tenant/11/Table/11                        database system (tenant)
++/Tenant/11/Table/12                        database system (tenant)
++/Tenant/11/Table/13                        database system (tenant)
++/Tenant/11/Table/14                        database system (tenant)
++/Tenant/11/Table/15                        database system (tenant)
  ...
 
 # Sanity check that new tenant tables show up correctly.
@@ -69,46 +75,45 @@ CREATE TABLE db.t2();
 ALTER TABLE db.t1 CONFIGURE ZONE using num_replicas = 42, gc.ttlseconds = 1000;
 ----
 
-diff
+diff offset=48
 ----
 --- gossiped system config span (legacy)
 +++ span config infrastructure (current)
-@@ -44,3 +44,38 @@
- /Tenant/10                                 range default
- /Tenant/11                                 range default
-+/Tenant/11/Table/4                         range default
-+/Tenant/11/Table/5                         range default
-+/Tenant/11/Table/6                         range default
-+/Tenant/11/Table/7                         range default
-+/Tenant/11/Table/11                        range default
-+/Tenant/11/Table/12                        range default
-+/Tenant/11/Table/13                        range default
-+/Tenant/11/Table/14                        range default
-+/Tenant/11/Table/15                        range default
-+/Tenant/11/Table/19                        range default
-+/Tenant/11/Table/20                        range default
-+/Tenant/11/Table/21                        range default
-+/Tenant/11/Table/23                        range default
-+/Tenant/11/Table/24                        range default
-+/Tenant/11/Table/25                        range default
-+/Tenant/11/Table/26                        range default
-+/Tenant/11/Table/27                        range default
-+/Tenant/11/Table/28                        range default
-+/Tenant/11/NamespaceTable/30               range default
-+/Tenant/11/NamespaceTable/Max              range default
-+/Tenant/11/Table/32                        range default
-+/Tenant/11/Table/33                        range default
-+/Tenant/11/Table/34                        range default
-+/Tenant/11/Table/35                        range default
-+/Tenant/11/Table/36                        range default
-+/Tenant/11/Table/37                        range default
-+/Tenant/11/Table/39                        range default
-+/Tenant/11/Table/40                        range default
-+/Tenant/11/Table/41                        range default
-+/Tenant/11/Table/42                        range default
-+/Tenant/11/Table/43                        range default
-+/Tenant/11/Table/44                        range default
-+/Tenant/11/Table/46                        range default
+...
+ /Tenant/11                                 database system (tenant)
++/Tenant/11/Table/4                         database system (tenant)
++/Tenant/11/Table/5                         database system (tenant)
++/Tenant/11/Table/6                         database system (tenant)
++/Tenant/11/Table/7                         database system (tenant)
++/Tenant/11/Table/11                        database system (tenant)
++/Tenant/11/Table/12                        database system (tenant)
++/Tenant/11/Table/13                        database system (tenant)
++/Tenant/11/Table/14                        database system (tenant)
++/Tenant/11/Table/15                        database system (tenant)
++/Tenant/11/Table/19                        database system (tenant)
++/Tenant/11/Table/20                        database system (tenant)
++/Tenant/11/Table/21                        database system (tenant)
++/Tenant/11/Table/23                        database system (tenant)
++/Tenant/11/Table/24                        database system (tenant)
++/Tenant/11/Table/25                        database system (tenant)
++/Tenant/11/Table/26                        database system (tenant)
++/Tenant/11/Table/27                        database system (tenant)
++/Tenant/11/Table/28                        database system (tenant)
++/Tenant/11/NamespaceTable/30               database system (tenant)
++/Tenant/11/NamespaceTable/Max              database system (tenant)
++/Tenant/11/Table/32                        database system (tenant)
++/Tenant/11/Table/33                        database system (tenant)
++/Tenant/11/Table/34                        database system (tenant)
++/Tenant/11/Table/35                        database system (tenant)
++/Tenant/11/Table/36                        database system (tenant)
++/Tenant/11/Table/37                        database system (tenant)
++/Tenant/11/Table/39                        database system (tenant)
++/Tenant/11/Table/40                        database system (tenant)
++/Tenant/11/Table/41                        database system (tenant)
++/Tenant/11/Table/42                        database system (tenant)
++/Tenant/11/Table/43                        database system (tenant)
++/Tenant/11/Table/44                        database system (tenant)
++/Tenant/11/Table/46                        database system (tenant)
 +/Tenant/11/Table/56                        ttl_seconds=1000 num_replicas=42
 +/Tenant/11/Table/57                        range default
 

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
@@ -12,48 +12,48 @@ upsert /System/NodeLiveness{-Max}          ttl_seconds=600 num_replicas=5
 upsert /System/{NodeLivenessMax-tsd}       range system
 upsert /System{/tsd-tse}                   range default
 upsert /System{tse-/Max}                   range system
-upsert /Table/{SystemConfigSpan/Start-4}   range system
-upsert /Table/{4-5}                        range system
-upsert /Table/{5-6}                        range system
-upsert /Table/{6-7}                        range system
-upsert /Table/{8-9}                        range system
-upsert /Table/1{1-2}                       range system
-upsert /Table/1{2-3}                       range system
-upsert /Table/1{3-4}                       range system
-upsert /Table/1{4-5}                       range system
-upsert /Table/1{5-6}                       range system
+upsert /Table/{SystemConfigSpan/Start-4}   database system (host)
+upsert /Table/{4-5}                        database system (host)
+upsert /Table/{5-6}                        database system (host)
+upsert /Table/{6-7}                        database system (host)
+upsert /Table/{8-9}                        database system (host)
+upsert /Table/1{1-2}                       database system (host)
+upsert /Table/1{2-3}                       database system (host)
+upsert /Table/1{3-4}                       database system (host)
+upsert /Table/1{4-5}                       database system (host)
+upsert /Table/1{5-6}                       database system (host)
 upsert /Table/1{6-7}                       range system
 upsert /Table/1{7-8}                       range system
 upsert /Table/1{8-9}                       range system
-upsert /Table/{19-20}                      range system
-upsert /Table/2{0-1}                       range system
-upsert /Table/2{1-2}                       range system
+upsert /Table/{19-20}                      database system (host)
+upsert /Table/2{0-1}                       database system (host)
+upsert /Table/2{1-2}                       database system (host)
 upsert /Table/2{2-3}                       range system
-upsert /Table/2{3-4}                       range system
-upsert /Table/2{4-5}                       range system
-upsert /Table/2{5-6}                       ttl_seconds=600 num_replicas=5
-upsert /Table/2{6-7}                       range system
-upsert /Table/2{7-8}                       ttl_seconds=600 num_replicas=5
-upsert /Table/2{8-9}                       range system
+upsert /Table/2{3-4}                       database system (host)
+upsert /Table/2{4-5}                       database system (host)
+upsert /Table/2{5-6}                       ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+upsert /Table/2{6-7}                       database system (host)
+upsert /Table/2{7-8}                       ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+upsert /Table/2{8-9}                       database system (host)
 upsert /{Table/29-NamespaceTable/30}       range system
-upsert /NamespaceTable/{30-Max}            range system
-upsert /{NamespaceTable/Max-Table/32}      range system
-upsert /Table/3{2-3}                       range system
-upsert /Table/3{3-4}                       range system
-upsert /Table/3{4-5}                       range system
-upsert /Table/3{5-6}                       range system
-upsert /Table/3{6-7}                       range system
-upsert /Table/3{7-8}                       range system
+upsert /NamespaceTable/{30-Max}            database system (host)
+upsert /{NamespaceTable/Max-Table/32}      database system (host)
+upsert /Table/3{2-3}                       database system (host)
+upsert /Table/3{3-4}                       database system (host)
+upsert /Table/3{4-5}                       database system (host)
+upsert /Table/3{5-6}                       database system (host)
+upsert /Table/3{6-7}                       database system (host)
+upsert /Table/3{7-8}                       database system (host)
 upsert /Table/3{8-9}                       range system
-upsert /Table/{39-40}                      range system
-upsert /Table/4{0-1}                       range system
-upsert /Table/4{1-2}                       range system
-upsert /Table/4{2-3}                       range system
-upsert /Table/4{3-4}                       range system
-upsert /Table/4{4-5}                       range system
-upsert /Table/4{5-6}                       ttl_seconds=7200 num_replicas=5
-upsert /Table/4{6-7}                       range system
-upsert /Table/4{7-8}                       range system
+upsert /Table/{39-40}                      database system (host)
+upsert /Table/4{0-1}                       database system (host)
+upsert /Table/4{1-2}                       database system (host)
+upsert /Table/4{2-3}                       database system (host)
+upsert /Table/4{3-4}                       database system (host)
+upsert /Table/4{4-5}                       database system (host)
+upsert /Table/4{5-6}                       ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+upsert /Table/4{6-7}                       database system (host)
+upsert /Table/4{7-8}                       database system (host)
 
 exec-sql
 CREATE DATABASE db;
@@ -93,25 +93,25 @@ ALTER DATABASE system CONFIGURE ZONE USING gc.ttlseconds = 100;
 mutations
 ----
 delete /Table/{SystemConfigSpan/Start-4}
-upsert /Table/{SystemConfigSpan/Start-4}   ttl_seconds=100 num_replicas=5
+upsert /Table/{SystemConfigSpan/Start-4}   ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/{4-5}
-upsert /Table/{4-5}                        ttl_seconds=100 num_replicas=5
+upsert /Table/{4-5}                        ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/{5-6}
-upsert /Table/{5-6}                        ttl_seconds=100 num_replicas=5
+upsert /Table/{5-6}                        ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/{6-7}
-upsert /Table/{6-7}                        ttl_seconds=100 num_replicas=5
+upsert /Table/{6-7}                        ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/{8-9}
-upsert /Table/{8-9}                        ttl_seconds=100 num_replicas=5
+upsert /Table/{8-9}                        ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{1-2}
-upsert /Table/1{1-2}                       ttl_seconds=100 num_replicas=5
+upsert /Table/1{1-2}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{2-3}
-upsert /Table/1{2-3}                       ttl_seconds=100 num_replicas=5
+upsert /Table/1{2-3}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{3-4}
-upsert /Table/1{3-4}                       ttl_seconds=100 num_replicas=5
+upsert /Table/1{3-4}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{4-5}
-upsert /Table/1{4-5}                       ttl_seconds=100 num_replicas=5
+upsert /Table/1{4-5}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{5-6}
-upsert /Table/1{5-6}                       ttl_seconds=100 num_replicas=5
+upsert /Table/1{5-6}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/1{6-7}
 upsert /Table/1{6-7}                       ttl_seconds=100 num_replicas=5
 delete /Table/1{7-8}
@@ -119,101 +119,101 @@ upsert /Table/1{7-8}                       ttl_seconds=100 num_replicas=5
 delete /Table/1{8-9}
 upsert /Table/1{8-9}                       ttl_seconds=100 num_replicas=5
 delete /Table/{19-20}
-upsert /Table/{19-20}                      ttl_seconds=100 num_replicas=5
+upsert /Table/{19-20}                      ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{0-1}
-upsert /Table/2{0-1}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{0-1}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{1-2}
-upsert /Table/2{1-2}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{1-2}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{2-3}
 upsert /Table/2{2-3}                       ttl_seconds=100 num_replicas=5
 delete /Table/2{3-4}
-upsert /Table/2{3-4}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{3-4}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{4-5}
-upsert /Table/2{4-5}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{4-5}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{6-7}
-upsert /Table/2{6-7}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{6-7}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/2{8-9}
-upsert /Table/2{8-9}                       ttl_seconds=100 num_replicas=5
+upsert /Table/2{8-9}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /{Table/29-NamespaceTable/30}
 upsert /{Table/29-NamespaceTable/30}       ttl_seconds=100 num_replicas=5
 delete /NamespaceTable/{30-Max}
-upsert /NamespaceTable/{30-Max}            ttl_seconds=100 num_replicas=5
+upsert /NamespaceTable/{30-Max}            ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /{NamespaceTable/Max-Table/32}
-upsert /{NamespaceTable/Max-Table/32}      ttl_seconds=100 num_replicas=5
+upsert /{NamespaceTable/Max-Table/32}      ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{2-3}
-upsert /Table/3{2-3}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{2-3}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{3-4}
-upsert /Table/3{3-4}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{3-4}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{4-5}
-upsert /Table/3{4-5}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{4-5}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{5-6}
-upsert /Table/3{5-6}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{5-6}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{6-7}
-upsert /Table/3{6-7}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{6-7}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{7-8}
-upsert /Table/3{7-8}                       ttl_seconds=100 num_replicas=5
+upsert /Table/3{7-8}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/3{8-9}
 upsert /Table/3{8-9}                       ttl_seconds=100 num_replicas=5
 delete /Table/{39-40}
-upsert /Table/{39-40}                      ttl_seconds=100 num_replicas=5
+upsert /Table/{39-40}                      ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{0-1}
-upsert /Table/4{0-1}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{0-1}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{1-2}
-upsert /Table/4{1-2}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{1-2}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{2-3}
-upsert /Table/4{2-3}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{2-3}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{3-4}
-upsert /Table/4{3-4}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{3-4}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{4-5}
-upsert /Table/4{4-5}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{4-5}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{6-7}
-upsert /Table/4{6-7}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{6-7}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 delete /Table/4{7-8}
-upsert /Table/4{7-8}                       ttl_seconds=100 num_replicas=5
+upsert /Table/4{7-8}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 
 state offset=5 limit=42
 ----
 ...
-/Table/{SystemConfigSpan/Start-4}          ttl_seconds=100 num_replicas=5
-/Table/{4-5}                               ttl_seconds=100 num_replicas=5
-/Table/{5-6}                               ttl_seconds=100 num_replicas=5
-/Table/{6-7}                               ttl_seconds=100 num_replicas=5
-/Table/{8-9}                               ttl_seconds=100 num_replicas=5
-/Table/1{1-2}                              ttl_seconds=100 num_replicas=5
-/Table/1{2-3}                              ttl_seconds=100 num_replicas=5
-/Table/1{3-4}                              ttl_seconds=100 num_replicas=5
-/Table/1{4-5}                              ttl_seconds=100 num_replicas=5
-/Table/1{5-6}                              ttl_seconds=100 num_replicas=5
+/Table/{SystemConfigSpan/Start-4}          ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/{4-5}                               ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/{5-6}                               ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/{6-7}                               ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/{8-9}                               ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/1{1-2}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/1{2-3}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/1{3-4}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/1{4-5}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/1{5-6}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 /Table/1{6-7}                              ttl_seconds=100 num_replicas=5
 /Table/1{7-8}                              ttl_seconds=100 num_replicas=5
 /Table/1{8-9}                              ttl_seconds=100 num_replicas=5
-/Table/{19-20}                             ttl_seconds=100 num_replicas=5
-/Table/2{0-1}                              ttl_seconds=100 num_replicas=5
-/Table/2{1-2}                              ttl_seconds=100 num_replicas=5
+/Table/{19-20}                             ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{0-1}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{1-2}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 /Table/2{2-3}                              ttl_seconds=100 num_replicas=5
-/Table/2{3-4}                              ttl_seconds=100 num_replicas=5
-/Table/2{4-5}                              ttl_seconds=100 num_replicas=5
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=5
-/Table/2{6-7}                              ttl_seconds=100 num_replicas=5
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=5
-/Table/2{8-9}                              ttl_seconds=100 num_replicas=5
+/Table/2{3-4}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{4-5}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{6-7}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{8-9}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 /{Table/29-NamespaceTable/30}              ttl_seconds=100 num_replicas=5
-/NamespaceTable/{30-Max}                   ttl_seconds=100 num_replicas=5
-/{NamespaceTable/Max-Table/32}             ttl_seconds=100 num_replicas=5
-/Table/3{2-3}                              ttl_seconds=100 num_replicas=5
-/Table/3{3-4}                              ttl_seconds=100 num_replicas=5
-/Table/3{4-5}                              ttl_seconds=100 num_replicas=5
-/Table/3{5-6}                              ttl_seconds=100 num_replicas=5
-/Table/3{6-7}                              ttl_seconds=100 num_replicas=5
-/Table/3{7-8}                              ttl_seconds=100 num_replicas=5
+/NamespaceTable/{30-Max}                   ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/{NamespaceTable/Max-Table/32}             ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{2-3}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{3-4}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{4-5}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{5-6}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{6-7}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/3{7-8}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 /Table/3{8-9}                              ttl_seconds=100 num_replicas=5
-/Table/{39-40}                             ttl_seconds=100 num_replicas=5
-/Table/4{0-1}                              ttl_seconds=100 num_replicas=5
-/Table/4{1-2}                              ttl_seconds=100 num_replicas=5
-/Table/4{2-3}                              ttl_seconds=100 num_replicas=5
-/Table/4{3-4}                              ttl_seconds=100 num_replicas=5
-/Table/4{4-5}                              ttl_seconds=100 num_replicas=5
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=5
-/Table/4{6-7}                              ttl_seconds=100 num_replicas=5
-/Table/4{7-8}                              ttl_seconds=100 num_replicas=5
+/Table/{39-40}                             ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{0-1}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{1-2}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{2-3}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{3-4}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{4-5}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{6-7}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{7-8}                              ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 ...

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/indexes
@@ -104,4 +104,4 @@ delete /Table/5{6/3-7}
 state offset=46
 ----
 ...
-/Table/4{7-8}                              range system
+/Table/4{7-8}                              database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
@@ -32,78 +32,78 @@ reconcile tenant=10
 mutations tenant=10
 ----
 delete /Tenant/10{-"\x00"}
-upsert /Tenant/10{-/Table/4}               range default
-upsert /Tenant/10/Table/{4-5}              range default
-upsert /Tenant/10/Table/{5-6}              range default
-upsert /Tenant/10/Table/{6-7}              range default
-upsert /Tenant/10/Table/{7-8}              range default
-upsert /Tenant/10/Table/1{1-2}             range default
-upsert /Tenant/10/Table/1{2-3}             range default
-upsert /Tenant/10/Table/1{3-4}             range default
-upsert /Tenant/10/Table/1{4-5}             range default
-upsert /Tenant/10/Table/1{5-6}             range default
-upsert /Tenant/10/Table/{19-20}            range default
-upsert /Tenant/10/Table/2{0-1}             range default
-upsert /Tenant/10/Table/2{1-2}             range default
-upsert /Tenant/10/Table/2{3-4}             range default
-upsert /Tenant/10/Table/2{4-5}             range default
-upsert /Tenant/10/Table/2{5-6}             range default
-upsert /Tenant/10/Table/2{6-7}             range default
-upsert /Tenant/10/Table/2{7-8}             range default
-upsert /Tenant/10/Table/2{8-9}             range default
-upsert /Tenant/10/NamespaceTable/{30-Max}  range default
-upsert /Tenant/10/{NamespaceTable/Max-Table/32} range default
-upsert /Tenant/10/Table/3{2-3}             range default
-upsert /Tenant/10/Table/3{3-4}             range default
-upsert /Tenant/10/Table/3{4-5}             range default
-upsert /Tenant/10/Table/3{5-6}             range default
-upsert /Tenant/10/Table/3{6-7}             range default
-upsert /Tenant/10/Table/3{7-8}             range default
-upsert /Tenant/10/Table/{39-40}            range default
-upsert /Tenant/10/Table/4{0-1}             range default
-upsert /Tenant/10/Table/4{1-2}             range default
-upsert /Tenant/10/Table/4{2-3}             range default
-upsert /Tenant/10/Table/4{3-4}             range default
-upsert /Tenant/10/Table/4{4-5}             range default
-upsert /Tenant/10/Table/4{6-7}             range default
+upsert /Tenant/10{-/Table/4}               database system (tenant)
+upsert /Tenant/10/Table/{4-5}              database system (tenant)
+upsert /Tenant/10/Table/{5-6}              database system (tenant)
+upsert /Tenant/10/Table/{6-7}              database system (tenant)
+upsert /Tenant/10/Table/{7-8}              database system (tenant)
+upsert /Tenant/10/Table/1{1-2}             database system (tenant)
+upsert /Tenant/10/Table/1{2-3}             database system (tenant)
+upsert /Tenant/10/Table/1{3-4}             database system (tenant)
+upsert /Tenant/10/Table/1{4-5}             database system (tenant)
+upsert /Tenant/10/Table/1{5-6}             database system (tenant)
+upsert /Tenant/10/Table/{19-20}            database system (tenant)
+upsert /Tenant/10/Table/2{0-1}             database system (tenant)
+upsert /Tenant/10/Table/2{1-2}             database system (tenant)
+upsert /Tenant/10/Table/2{3-4}             database system (tenant)
+upsert /Tenant/10/Table/2{4-5}             database system (tenant)
+upsert /Tenant/10/Table/2{5-6}             database system (tenant)
+upsert /Tenant/10/Table/2{6-7}             database system (tenant)
+upsert /Tenant/10/Table/2{7-8}             database system (tenant)
+upsert /Tenant/10/Table/2{8-9}             database system (tenant)
+upsert /Tenant/10/NamespaceTable/{30-Max}  database system (tenant)
+upsert /Tenant/10/{NamespaceTable/Max-Table/32} database system (tenant)
+upsert /Tenant/10/Table/3{2-3}             database system (tenant)
+upsert /Tenant/10/Table/3{3-4}             database system (tenant)
+upsert /Tenant/10/Table/3{4-5}             database system (tenant)
+upsert /Tenant/10/Table/3{5-6}             database system (tenant)
+upsert /Tenant/10/Table/3{6-7}             database system (tenant)
+upsert /Tenant/10/Table/3{7-8}             database system (tenant)
+upsert /Tenant/10/Table/{39-40}            database system (tenant)
+upsert /Tenant/10/Table/4{0-1}             database system (tenant)
+upsert /Tenant/10/Table/4{1-2}             database system (tenant)
+upsert /Tenant/10/Table/4{2-3}             database system (tenant)
+upsert /Tenant/10/Table/4{3-4}             database system (tenant)
+upsert /Tenant/10/Table/4{4-5}             database system (tenant)
+upsert /Tenant/10/Table/4{6-7}             database system (tenant)
 
 state offset=47
 ----
 ...
-/Tenant/10{-/Table/4}                      range default
-/Tenant/10/Table/{4-5}                     range default
-/Tenant/10/Table/{5-6}                     range default
-/Tenant/10/Table/{6-7}                     range default
-/Tenant/10/Table/{7-8}                     range default
-/Tenant/10/Table/1{1-2}                    range default
-/Tenant/10/Table/1{2-3}                    range default
-/Tenant/10/Table/1{3-4}                    range default
-/Tenant/10/Table/1{4-5}                    range default
-/Tenant/10/Table/1{5-6}                    range default
-/Tenant/10/Table/{19-20}                   range default
-/Tenant/10/Table/2{0-1}                    range default
-/Tenant/10/Table/2{1-2}                    range default
-/Tenant/10/Table/2{3-4}                    range default
-/Tenant/10/Table/2{4-5}                    range default
-/Tenant/10/Table/2{5-6}                    range default
-/Tenant/10/Table/2{6-7}                    range default
-/Tenant/10/Table/2{7-8}                    range default
-/Tenant/10/Table/2{8-9}                    range default
-/Tenant/10/NamespaceTable/{30-Max}         range default
-/Tenant/10/{NamespaceTable/Max-Table/32}   range default
-/Tenant/10/Table/3{2-3}                    range default
-/Tenant/10/Table/3{3-4}                    range default
-/Tenant/10/Table/3{4-5}                    range default
-/Tenant/10/Table/3{5-6}                    range default
-/Tenant/10/Table/3{6-7}                    range default
-/Tenant/10/Table/3{7-8}                    range default
-/Tenant/10/Table/{39-40}                   range default
-/Tenant/10/Table/4{0-1}                    range default
-/Tenant/10/Table/4{1-2}                    range default
-/Tenant/10/Table/4{2-3}                    range default
-/Tenant/10/Table/4{3-4}                    range default
-/Tenant/10/Table/4{4-5}                    range default
-/Tenant/10/Table/4{6-7}                    range default
+/Tenant/10{-/Table/4}                      database system (tenant)
+/Tenant/10/Table/{4-5}                     database system (tenant)
+/Tenant/10/Table/{5-6}                     database system (tenant)
+/Tenant/10/Table/{6-7}                     database system (tenant)
+/Tenant/10/Table/{7-8}                     database system (tenant)
+/Tenant/10/Table/1{1-2}                    database system (tenant)
+/Tenant/10/Table/1{2-3}                    database system (tenant)
+/Tenant/10/Table/1{3-4}                    database system (tenant)
+/Tenant/10/Table/1{4-5}                    database system (tenant)
+/Tenant/10/Table/1{5-6}                    database system (tenant)
+/Tenant/10/Table/{19-20}                   database system (tenant)
+/Tenant/10/Table/2{0-1}                    database system (tenant)
+/Tenant/10/Table/2{1-2}                    database system (tenant)
+/Tenant/10/Table/2{3-4}                    database system (tenant)
+/Tenant/10/Table/2{4-5}                    database system (tenant)
+/Tenant/10/Table/2{5-6}                    database system (tenant)
+/Tenant/10/Table/2{6-7}                    database system (tenant)
+/Tenant/10/Table/2{7-8}                    database system (tenant)
+/Tenant/10/Table/2{8-9}                    database system (tenant)
+/Tenant/10/NamespaceTable/{30-Max}         database system (tenant)
+/Tenant/10/{NamespaceTable/Max-Table/32}   database system (tenant)
+/Tenant/10/Table/3{2-3}                    database system (tenant)
+/Tenant/10/Table/3{3-4}                    database system (tenant)
+/Tenant/10/Table/3{4-5}                    database system (tenant)
+/Tenant/10/Table/3{5-6}                    database system (tenant)
+/Tenant/10/Table/3{6-7}                    database system (tenant)
+/Tenant/10/Table/3{7-8}                    database system (tenant)
+/Tenant/10/Table/{39-40}                   database system (tenant)
+/Tenant/10/Table/4{0-1}                    database system (tenant)
+/Tenant/10/Table/4{1-2}                    database system (tenant)
+/Tenant/10/Table/4{2-3}                    database system (tenant)
+/Tenant/10/Table/4{3-4}                    database system (tenant)
+/Tenant/10/Table/4{4-5}                    database system (tenant)
+/Tenant/10/Table/4{6-7}                    database system (tenant)
 /Tenant/11{-"\x00"}                        range default
 
 exec-sql tenant=10

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
@@ -123,7 +123,7 @@ state limit=5
 state offset=46
 ----
 ...
-/Table/4{7-8}                              range system
+/Table/4{7-8}                              database system (host)
 /Table/5{6-7}                              ttl_seconds=50
 
 # Make sure future descendants observe the same.
@@ -138,7 +138,7 @@ upsert /Table/5{7-8}                       ttl_seconds=50
 state offset=46
 ----
 ...
-/Table/4{7-8}                              range system
+/Table/4{7-8}                              database system (host)
 /Table/5{6-7}                              ttl_seconds=50
 /Table/5{7-8}                              ttl_seconds=50
 

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
@@ -25,46 +25,46 @@ full-translate
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
 /System{tse-/Max}                          range system
-/Table/{SystemConfigSpan/Start-4}          range system
-/Table/{4-5}                               range system
-/Table/{5-6}                               range system
-/Table/{6-7}                               range system
-/Table/{8-9}                               range system
-/Table/1{1-2}                              range system
-/Table/1{2-3}                              range system
-/Table/1{3-4}                              range system
-/Table/1{4-5}                              range system
-/Table/1{5-6}                              range system
+/Table/{SystemConfigSpan/Start-4}          database system (host)
+/Table/{4-5}                               database system (host)
+/Table/{5-6}                               database system (host)
+/Table/{6-7}                               database system (host)
+/Table/{8-9}                               database system (host)
+/Table/1{1-2}                              database system (host)
+/Table/1{2-3}                              database system (host)
+/Table/1{3-4}                              database system (host)
+/Table/1{4-5}                              database system (host)
+/Table/1{5-6}                              database system (host)
 /Table/1{6-7}                              range system
 /Table/1{7-8}                              range system
 /Table/1{8-9}                              range system
-/Table/{19-20}                             range system
-/Table/2{0-1}                              range system
-/Table/2{1-2}                              range system
+/Table/{19-20}                             database system (host)
+/Table/2{0-1}                              database system (host)
+/Table/2{1-2}                              database system (host)
 /Table/2{2-3}                              range system
-/Table/2{3-4}                              range system
-/Table/2{4-5}                              range system
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=5
-/Table/2{6-7}                              range system
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=5
-/Table/2{8-9}                              range system
+/Table/2{3-4}                              database system (host)
+/Table/2{4-5}                              database system (host)
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{6-7}                              database system (host)
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{8-9}                              database system (host)
 /{Table/29-NamespaceTable/30}              range system
-/NamespaceTable/{30-Max}                   range system
-/{NamespaceTable/Max-Table/32}             range system
-/Table/3{2-3}                              range system
-/Table/3{3-4}                              range system
-/Table/3{4-5}                              range system
-/Table/3{5-6}                              range system
-/Table/3{6-7}                              range system
-/Table/3{7-8}                              range system
+/NamespaceTable/{30-Max}                   database system (host)
+/{NamespaceTable/Max-Table/32}             database system (host)
+/Table/3{2-3}                              database system (host)
+/Table/3{3-4}                              database system (host)
+/Table/3{4-5}                              database system (host)
+/Table/3{5-6}                              database system (host)
+/Table/3{6-7}                              database system (host)
+/Table/3{7-8}                              database system (host)
 /Table/3{8-9}                              range system
-/Table/{39-40}                             range system
-/Table/4{0-1}                              range system
-/Table/4{1-2}                              range system
-/Table/4{2-3}                              range system
-/Table/4{3-4}                              range system
-/Table/4{4-5}                              range system
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=5
-/Table/4{6-7}                              range system
-/Table/4{7-8}                              range system
+/Table/{39-40}                             database system (host)
+/Table/4{0-1}                              database system (host)
+/Table/4{1-2}                              database system (host)
+/Table/4{2-3}                              database system (host)
+/Table/4{3-4}                              database system (host)
+/Table/4{4-5}                              database system (host)
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{6-7}                              database system (host)
+/Table/4{7-8}                              database system (host)
 /Table/{59-60}                             range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
@@ -41,45 +41,45 @@ full-translate
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
 /System{tse-/Max}                          range default
-/Table/{SystemConfigSpan/Start-4}          range system
-/Table/{4-5}                               range system
-/Table/{5-6}                               range system
-/Table/{6-7}                               range system
-/Table/{8-9}                               range system
-/Table/1{1-2}                              range system
-/Table/1{2-3}                              range system
-/Table/1{3-4}                              range system
-/Table/1{4-5}                              range system
-/Table/1{5-6}                              range system
+/Table/{SystemConfigSpan/Start-4}          database system (host)
+/Table/{4-5}                               database system (host)
+/Table/{5-6}                               database system (host)
+/Table/{6-7}                               database system (host)
+/Table/{8-9}                               database system (host)
+/Table/1{1-2}                              database system (host)
+/Table/1{2-3}                              database system (host)
+/Table/1{3-4}                              database system (host)
+/Table/1{4-5}                              database system (host)
+/Table/1{5-6}                              database system (host)
 /Table/1{6-7}                              range system
 /Table/1{7-8}                              range system
 /Table/1{8-9}                              range system
-/Table/{19-20}                             range system
-/Table/2{0-1}                              range system
-/Table/2{1-2}                              range system
+/Table/{19-20}                             database system (host)
+/Table/2{0-1}                              database system (host)
+/Table/2{1-2}                              database system (host)
 /Table/2{2-3}                              range system
-/Table/2{3-4}                              range system
-/Table/2{4-5}                              range system
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=5
-/Table/2{6-7}                              range system
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=5
-/Table/2{8-9}                              range system
+/Table/2{3-4}                              database system (host)
+/Table/2{4-5}                              database system (host)
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{6-7}                              database system (host)
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{8-9}                              database system (host)
 /{Table/29-NamespaceTable/30}              range system
-/NamespaceTable/{30-Max}                   range system
-/{NamespaceTable/Max-Table/32}             range system
-/Table/3{2-3}                              range system
-/Table/3{3-4}                              range system
-/Table/3{4-5}                              range system
-/Table/3{5-6}                              range system
-/Table/3{6-7}                              range system
-/Table/3{7-8}                              range system
+/NamespaceTable/{30-Max}                   database system (host)
+/{NamespaceTable/Max-Table/32}             database system (host)
+/Table/3{2-3}                              database system (host)
+/Table/3{3-4}                              database system (host)
+/Table/3{4-5}                              database system (host)
+/Table/3{5-6}                              database system (host)
+/Table/3{6-7}                              database system (host)
+/Table/3{7-8}                              database system (host)
 /Table/3{8-9}                              range system
-/Table/{39-40}                             range system
-/Table/4{0-1}                              range system
-/Table/4{1-2}                              range system
-/Table/4{2-3}                              range system
-/Table/4{3-4}                              range system
-/Table/4{4-5}                              range system
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=5
-/Table/4{6-7}                              range system
-/Table/4{7-8}                              range system
+/Table/{39-40}                             database system (host)
+/Table/4{0-1}                              database system (host)
+/Table/4{1-2}                              database system (host)
+/Table/4{2-3}                              database system (host)
+/Table/4{3-4}                              database system (host)
+/Table/4{4-5}                              database system (host)
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{6-7}                              database system (host)
+/Table/4{7-8}                              database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
@@ -1,50 +1,51 @@
 # Translating the system database itself should surface entries for all system
-# tables (including pseudo table IDs).
+# tables (including pseudo table IDs). Pseudo table ID keyspans show up as
+# "range system" since rangefeeds/ignore_strict_gc are unset.
 
 translate database=system
 ----
-/Table/{SystemConfigSpan/Start-4}          range system
-/Table/{4-5}                               range system
-/Table/{5-6}                               range system
-/Table/{6-7}                               range system
-/Table/{8-9}                               range system
-/Table/1{1-2}                              range system
-/Table/1{2-3}                              range system
-/Table/1{3-4}                              range system
-/Table/1{4-5}                              range system
-/Table/1{5-6}                              range system
+/Table/{SystemConfigSpan/Start-4}          database system (host)
+/Table/{4-5}                               database system (host)
+/Table/{5-6}                               database system (host)
+/Table/{6-7}                               database system (host)
+/Table/{8-9}                               database system (host)
+/Table/1{1-2}                              database system (host)
+/Table/1{2-3}                              database system (host)
+/Table/1{3-4}                              database system (host)
+/Table/1{4-5}                              database system (host)
+/Table/1{5-6}                              database system (host)
 /Table/1{6-7}                              range system
 /Table/1{7-8}                              range system
 /Table/1{8-9}                              range system
-/Table/{19-20}                             range system
-/Table/2{0-1}                              range system
-/Table/2{1-2}                              range system
+/Table/{19-20}                             database system (host)
+/Table/2{0-1}                              database system (host)
+/Table/2{1-2}                              database system (host)
 /Table/2{2-3}                              range system
-/Table/2{3-4}                              range system
-/Table/2{4-5}                              range system
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=5
-/Table/2{6-7}                              range system
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=5
-/Table/2{8-9}                              range system
+/Table/2{3-4}                              database system (host)
+/Table/2{4-5}                              database system (host)
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{6-7}                              database system (host)
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/2{8-9}                              database system (host)
 /{Table/29-NamespaceTable/30}              range system
-/NamespaceTable/{30-Max}                   range system
-/{NamespaceTable/Max-Table/32}             range system
-/Table/3{2-3}                              range system
-/Table/3{3-4}                              range system
-/Table/3{4-5}                              range system
-/Table/3{5-6}                              range system
-/Table/3{6-7}                              range system
-/Table/3{7-8}                              range system
+/NamespaceTable/{30-Max}                   database system (host)
+/{NamespaceTable/Max-Table/32}             database system (host)
+/Table/3{2-3}                              database system (host)
+/Table/3{3-4}                              database system (host)
+/Table/3{4-5}                              database system (host)
+/Table/3{5-6}                              database system (host)
+/Table/3{6-7}                              database system (host)
+/Table/3{7-8}                              database system (host)
 /Table/3{8-9}                              range system
-/Table/{39-40}                             range system
-/Table/4{0-1}                              range system
-/Table/4{1-2}                              range system
-/Table/4{2-3}                              range system
-/Table/4{3-4}                              range system
-/Table/4{4-5}                              range system
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=5
-/Table/4{6-7}                              range system
-/Table/4{7-8}                              range system
+/Table/{39-40}                             database system (host)
+/Table/4{0-1}                              database system (host)
+/Table/4{1-2}                              database system (host)
+/Table/4{2-3}                              database system (host)
+/Table/4{3-4}                              database system (host)
+/Table/4{4-5}                              database system (host)
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Table/4{6-7}                              database system (host)
+/Table/4{7-8}                              database system (host)
 
 # Alter zone config fields on the database to ensure the effects cascade.
 exec-sql
@@ -53,48 +54,48 @@ ALTER DATABASE system CONFIGURE ZONE USING num_replicas = 7
 
 translate database=system
 ----
-/Table/{SystemConfigSpan/Start-4}          num_replicas=7
-/Table/{4-5}                               num_replicas=7
-/Table/{5-6}                               num_replicas=7
-/Table/{6-7}                               num_replicas=7
-/Table/{8-9}                               num_replicas=7
-/Table/1{1-2}                              num_replicas=7
-/Table/1{2-3}                              num_replicas=7
-/Table/1{3-4}                              num_replicas=7
-/Table/1{4-5}                              num_replicas=7
-/Table/1{5-6}                              num_replicas=7
+/Table/{SystemConfigSpan/Start-4}          ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{4-5}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{5-6}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{6-7}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{8-9}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{5-6}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/1{6-7}                              num_replicas=7
 /Table/1{7-8}                              num_replicas=7
 /Table/1{8-9}                              num_replicas=7
-/Table/{19-20}                             num_replicas=7
-/Table/2{0-1}                              num_replicas=7
-/Table/2{1-2}                              num_replicas=7
+/Table/{19-20}                             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{0-1}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/2{2-3}                              num_replicas=7
-/Table/2{3-4}                              num_replicas=7
-/Table/2{4-5}                              num_replicas=7
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=7
-/Table/2{6-7}                              num_replicas=7
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=7
-/Table/2{8-9}                              num_replicas=7
+/Table/2{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{8-9}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /{Table/29-NamespaceTable/30}              num_replicas=7
-/NamespaceTable/{30-Max}                   num_replicas=7
-/{NamespaceTable/Max-Table/32}             num_replicas=7
-/Table/3{2-3}                              num_replicas=7
-/Table/3{3-4}                              num_replicas=7
-/Table/3{4-5}                              num_replicas=7
-/Table/3{5-6}                              num_replicas=7
-/Table/3{6-7}                              num_replicas=7
-/Table/3{7-8}                              num_replicas=7
+/NamespaceTable/{30-Max}                   ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/{NamespaceTable/Max-Table/32}             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{5-6}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{7-8}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/3{8-9}                              num_replicas=7
-/Table/{39-40}                             num_replicas=7
-/Table/4{0-1}                              num_replicas=7
-/Table/4{1-2}                              num_replicas=7
-/Table/4{2-3}                              num_replicas=7
-/Table/4{3-4}                              num_replicas=7
-/Table/4{4-5}                              num_replicas=7
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=7
-/Table/4{6-7}                              num_replicas=7
-/Table/4{7-8}                              num_replicas=7
+/Table/{39-40}                             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{0-1}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{7-8}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 
 # Alter a named range that maps to a pseudo table ID, ensuring that its effects
 # are independent.
@@ -109,45 +110,45 @@ full-translate
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
 /System{tse-/Max}                          range system
-/Table/{SystemConfigSpan/Start-4}          num_replicas=7
-/Table/{4-5}                               num_replicas=7
-/Table/{5-6}                               num_replicas=7
-/Table/{6-7}                               num_replicas=7
-/Table/{8-9}                               num_replicas=7
-/Table/1{1-2}                              num_replicas=7
-/Table/1{2-3}                              num_replicas=7
-/Table/1{3-4}                              num_replicas=7
-/Table/1{4-5}                              num_replicas=7
-/Table/1{5-6}                              num_replicas=7
+/Table/{SystemConfigSpan/Start-4}          ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{4-5}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{5-6}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{6-7}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/{8-9}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/1{5-6}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/1{6-7}                              num_replicas=7
 /Table/1{7-8}                              num_replicas=7
 /Table/1{8-9}                              num_replicas=7
-/Table/{19-20}                             num_replicas=7
-/Table/2{0-1}                              num_replicas=7
-/Table/2{1-2}                              num_replicas=7
+/Table/{19-20}                             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{0-1}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/2{2-3}                              num_replicas=7
-/Table/2{3-4}                              num_replicas=7
-/Table/2{4-5}                              num_replicas=7
-/Table/2{5-6}                              ttl_seconds=600 num_replicas=7
-/Table/2{6-7}                              num_replicas=7
-/Table/2{7-8}                              ttl_seconds=600 num_replicas=7
-/Table/2{8-9}                              num_replicas=7
+/Table/2{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{5-6}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{7-8}                              ttl_seconds=600 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/2{8-9}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /{Table/29-NamespaceTable/30}              num_replicas=7
-/NamespaceTable/{30-Max}                   num_replicas=7
-/{NamespaceTable/Max-Table/32}             num_replicas=7
-/Table/3{2-3}                              num_replicas=7
-/Table/3{3-4}                              num_replicas=7
-/Table/3{4-5}                              num_replicas=7
-/Table/3{5-6}                              num_replicas=7
-/Table/3{6-7}                              num_replicas=7
-/Table/3{7-8}                              num_replicas=7
+/NamespaceTable/{30-Max}                   ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/{NamespaceTable/Max-Table/32}             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{5-6}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/3{7-8}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/3{8-9}                              num_replicas=7
-/Table/{39-40}                             num_replicas=7
-/Table/4{0-1}                              num_replicas=7
-/Table/4{1-2}                              num_replicas=7
-/Table/4{2-3}                              num_replicas=7
-/Table/4{3-4}                              num_replicas=7
-/Table/4{4-5}                              num_replicas=7
-/Table/4{5-6}                              ttl_seconds=7200 num_replicas=7
-/Table/4{6-7}                              num_replicas=7
-/Table/4{7-8}                              num_replicas=7
+/Table/{39-40}                             ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{0-1}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{1-2}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{2-3}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{3-4}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{4-5}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{6-7}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
+/Table/4{7-8}                              ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
@@ -14,77 +14,77 @@ CREATE TABLE db.t();
 # - The user created table
 full-translate
 ----
-/Tenant/10{-/Table/4}                      range default
-/Tenant/10/Table/{4-5}                     range default
-/Tenant/10/Table/{5-6}                     range default
-/Tenant/10/Table/{6-7}                     range default
-/Tenant/10/Table/{7-8}                     range default
-/Tenant/10/Table/1{1-2}                    range default
-/Tenant/10/Table/1{2-3}                    range default
-/Tenant/10/Table/1{3-4}                    range default
-/Tenant/10/Table/1{4-5}                    range default
-/Tenant/10/Table/1{5-6}                    range default
-/Tenant/10/Table/{19-20}                   range default
-/Tenant/10/Table/2{0-1}                    range default
-/Tenant/10/Table/2{1-2}                    range default
-/Tenant/10/Table/2{3-4}                    range default
-/Tenant/10/Table/2{4-5}                    range default
-/Tenant/10/Table/2{5-6}                    range default
-/Tenant/10/Table/2{6-7}                    range default
-/Tenant/10/Table/2{7-8}                    range default
-/Tenant/10/Table/2{8-9}                    range default
-/Tenant/10/NamespaceTable/{30-Max}         range default
-/Tenant/10/{NamespaceTable/Max-Table/32}   range default
-/Tenant/10/Table/3{2-3}                    range default
-/Tenant/10/Table/3{3-4}                    range default
-/Tenant/10/Table/3{4-5}                    range default
-/Tenant/10/Table/3{5-6}                    range default
-/Tenant/10/Table/3{6-7}                    range default
-/Tenant/10/Table/3{7-8}                    range default
-/Tenant/10/Table/{39-40}                   range default
-/Tenant/10/Table/4{0-1}                    range default
-/Tenant/10/Table/4{1-2}                    range default
-/Tenant/10/Table/4{2-3}                    range default
-/Tenant/10/Table/4{3-4}                    range default
-/Tenant/10/Table/4{4-5}                    range default
-/Tenant/10/Table/4{6-7}                    range default
+/Tenant/10{-/Table/4}                      database system (tenant)
+/Tenant/10/Table/{4-5}                     database system (tenant)
+/Tenant/10/Table/{5-6}                     database system (tenant)
+/Tenant/10/Table/{6-7}                     database system (tenant)
+/Tenant/10/Table/{7-8}                     database system (tenant)
+/Tenant/10/Table/1{1-2}                    database system (tenant)
+/Tenant/10/Table/1{2-3}                    database system (tenant)
+/Tenant/10/Table/1{3-4}                    database system (tenant)
+/Tenant/10/Table/1{4-5}                    database system (tenant)
+/Tenant/10/Table/1{5-6}                    database system (tenant)
+/Tenant/10/Table/{19-20}                   database system (tenant)
+/Tenant/10/Table/2{0-1}                    database system (tenant)
+/Tenant/10/Table/2{1-2}                    database system (tenant)
+/Tenant/10/Table/2{3-4}                    database system (tenant)
+/Tenant/10/Table/2{4-5}                    database system (tenant)
+/Tenant/10/Table/2{5-6}                    database system (tenant)
+/Tenant/10/Table/2{6-7}                    database system (tenant)
+/Tenant/10/Table/2{7-8}                    database system (tenant)
+/Tenant/10/Table/2{8-9}                    database system (tenant)
+/Tenant/10/NamespaceTable/{30-Max}         database system (tenant)
+/Tenant/10/{NamespaceTable/Max-Table/32}   database system (tenant)
+/Tenant/10/Table/3{2-3}                    database system (tenant)
+/Tenant/10/Table/3{3-4}                    database system (tenant)
+/Tenant/10/Table/3{4-5}                    database system (tenant)
+/Tenant/10/Table/3{5-6}                    database system (tenant)
+/Tenant/10/Table/3{6-7}                    database system (tenant)
+/Tenant/10/Table/3{7-8}                    database system (tenant)
+/Tenant/10/Table/{39-40}                   database system (tenant)
+/Tenant/10/Table/4{0-1}                    database system (tenant)
+/Tenant/10/Table/4{1-2}                    database system (tenant)
+/Tenant/10/Table/4{2-3}                    database system (tenant)
+/Tenant/10/Table/4{3-4}                    database system (tenant)
+/Tenant/10/Table/4{4-5}                    database system (tenant)
+/Tenant/10/Table/4{6-7}                    database system (tenant)
 /Tenant/10/Table/{59-60}                   range default
 
 # We should expect the same for RANGE DEFAULT.
 translate named-zone=default
 ----
-/Tenant/10{-/Table/4}                      range default
-/Tenant/10/Table/{4-5}                     range default
-/Tenant/10/Table/{5-6}                     range default
-/Tenant/10/Table/{6-7}                     range default
-/Tenant/10/Table/{7-8}                     range default
-/Tenant/10/Table/1{1-2}                    range default
-/Tenant/10/Table/1{2-3}                    range default
-/Tenant/10/Table/1{3-4}                    range default
-/Tenant/10/Table/1{4-5}                    range default
-/Tenant/10/Table/1{5-6}                    range default
-/Tenant/10/Table/{19-20}                   range default
-/Tenant/10/Table/2{0-1}                    range default
-/Tenant/10/Table/2{1-2}                    range default
-/Tenant/10/Table/2{3-4}                    range default
-/Tenant/10/Table/2{4-5}                    range default
-/Tenant/10/Table/2{5-6}                    range default
-/Tenant/10/Table/2{6-7}                    range default
-/Tenant/10/Table/2{7-8}                    range default
-/Tenant/10/Table/2{8-9}                    range default
-/Tenant/10/NamespaceTable/{30-Max}         range default
-/Tenant/10/{NamespaceTable/Max-Table/32}   range default
-/Tenant/10/Table/3{2-3}                    range default
-/Tenant/10/Table/3{3-4}                    range default
-/Tenant/10/Table/3{4-5}                    range default
-/Tenant/10/Table/3{5-6}                    range default
-/Tenant/10/Table/3{6-7}                    range default
-/Tenant/10/Table/3{7-8}                    range default
-/Tenant/10/Table/{39-40}                   range default
-/Tenant/10/Table/4{0-1}                    range default
-/Tenant/10/Table/4{1-2}                    range default
-/Tenant/10/Table/4{2-3}                    range default
-/Tenant/10/Table/4{3-4}                    range default
-/Tenant/10/Table/4{4-5}                    range default
-/Tenant/10/Table/4{6-7}                    range default
+/Tenant/10{-/Table/4}                      database system (tenant)
+/Tenant/10/Table/{4-5}                     database system (tenant)
+/Tenant/10/Table/{5-6}                     database system (tenant)
+/Tenant/10/Table/{6-7}                     database system (tenant)
+/Tenant/10/Table/{7-8}                     database system (tenant)
+/Tenant/10/Table/1{1-2}                    database system (tenant)
+/Tenant/10/Table/1{2-3}                    database system (tenant)
+/Tenant/10/Table/1{3-4}                    database system (tenant)
+/Tenant/10/Table/1{4-5}                    database system (tenant)
+/Tenant/10/Table/1{5-6}                    database system (tenant)
+/Tenant/10/Table/{19-20}                   database system (tenant)
+/Tenant/10/Table/2{0-1}                    database system (tenant)
+/Tenant/10/Table/2{1-2}                    database system (tenant)
+/Tenant/10/Table/2{3-4}                    database system (tenant)
+/Tenant/10/Table/2{4-5}                    database system (tenant)
+/Tenant/10/Table/2{5-6}                    database system (tenant)
+/Tenant/10/Table/2{6-7}                    database system (tenant)
+/Tenant/10/Table/2{7-8}                    database system (tenant)
+/Tenant/10/Table/2{8-9}                    database system (tenant)
+/Tenant/10/NamespaceTable/{30-Max}         database system (tenant)
+/Tenant/10/{NamespaceTable/Max-Table/32}   database system (tenant)
+/Tenant/10/Table/3{2-3}                    database system (tenant)
+/Tenant/10/Table/3{3-4}                    database system (tenant)
+/Tenant/10/Table/3{4-5}                    database system (tenant)
+/Tenant/10/Table/3{5-6}                    database system (tenant)
+/Tenant/10/Table/3{6-7}                    database system (tenant)
+/Tenant/10/Table/3{7-8}                    database system (tenant)
+/Tenant/10/Table/{39-40}                   database system (tenant)
+/Tenant/10/Table/4{0-1}                    database system (tenant)
+/Tenant/10/Table/4{1-2}                    database system (tenant)
+/Tenant/10/Table/4{2-3}                    database system (tenant)
+/Tenant/10/Table/4{3-4}                    database system (tenant)
+/Tenant/10/Table/4{4-5}                    database system (tenant)
+/Tenant/10/Table/4{6-7}                    database system (tenant)
 /Tenant/10/Table/{59-60}                   range default

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/spanconfig",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -150,7 +150,7 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			repl := &Replica{}
+			repl := &Replica{store: testCtx.store}
 			repl.mu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -767,6 +767,9 @@ func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig) {
 		}
 	}
 
+	if knobs := r.store.TestingKnobs(); knobs != nil && knobs.SetSpanConfigInterceptor != nil {
+		conf = knobs.SetSpanConfigInterceptor(r.descRLocked(), conf)
+	}
 	r.mu.conf, r.mu.spanConfigExplicitlySet = conf, true
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -466,8 +466,14 @@ type Replica struct {
 		// lease extension that were in flight at the time of the transfer cannot be
 		// used, if they eventually apply.
 		minLeaseProposedTS hlc.ClockTimestamp
+
 		// The span config for this replica.
 		conf roachpb.SpanConfig
+		// spanConfigExplicitlySet tracks whether a span config was explicitly set
+		// on this replica (as opposed to it having initialized with the default
+		// span config).
+		spanConfigExplicitlySet bool
+
 		// proposalBuf buffers Raft commands as they are passed to the Raft
 		// replication subsystem. The buffer is populated by requests after
 		// evaluation and is consumed by the Raft processing thread. Once
@@ -603,11 +609,6 @@ type Replica struct {
 		// size drops below its current conf.MaxRangeBytes or if the
 		// conf.MaxRangeBytes increases to surpass the current value.
 		largestPreviousMaxRangeSizeBytes int64
-		// spanConfigExplicitlySet tracks whether a span config was explicitly set
-		// on this replica (as opposed to it having initialized with the default
-		// span config). It's used to reason about
-		// largestPreviousMaxRangeSizeBytes.
-		spanConfigExplicitlySet bool
 
 		// failureToGossipSystemConfig is set to true when the leaseholder of the
 		// range containing the system config span fails to gossip due to an
@@ -969,13 +970,14 @@ func (r *Replica) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
 // should be used to determine the validity of commands. The returned timestamp
 // may be newer than the replica's true GC threshold if strict enforcement
 // is enabled and the TTL has passed. If this is an admin command or this range
-// contains data outside of the user keyspace, we return the true GC threshold.
+// opts out of strict GC enforcement (typically data outside the user keyspace),
+// we return the true GC threshold.
 func (r *Replica) getImpliedGCThresholdRLocked(
 	st kvserverpb.LeaseStatus, isAdmin bool,
 ) hlc.Timestamp {
 	// The GC threshold is the oldest value we can return here.
 	if isAdmin || !StrictGCEnforcement.Get(&r.store.ClusterSettings().SV) ||
-		r.isSystemRangeRLocked() {
+		r.shouldIgnoreStrictGCEnforcementRLocked() {
 		return *r.mu.state.GCThreshold
 	}
 
@@ -1003,17 +1005,26 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	return threshold
 }
 
-// isSystemRange returns true if r's key range precedes the start of user
-// structured data (SQL keys) for the range's tenant keyspace.
-func (r *Replica) isSystemRange() bool {
+func (r *Replica) isRangefeedEnabled() (ret bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.isSystemRangeRLocked()
+
+	if !r.mu.spanConfigExplicitlySet {
+		return true
+	}
+	return r.mu.conf.RangefeedEnabled
 }
 
-func (r *Replica) isSystemRangeRLocked() bool {
-	rem, _, err := keys.DecodeTenantPrefix(r.mu.state.Desc.StartKey.AsRawKey())
-	return err == nil && roachpb.Key(rem).Compare(r.store.systemRangeStartUpperBound) < 0
+func (r *Replica) shouldIgnoreStrictGCEnforcementRLocked() (ret bool) {
+	if !r.mu.spanConfigExplicitlySet {
+		return true
+	}
+
+	if knobs := r.store.TestingKnobs(); knobs != nil && knobs.IgnoreStrictGCEnforcement {
+		return true
+	}
+
+	return r.mu.conf.GCPolicy.IgnoreStrictEnforcement
 }
 
 // maxReplicaIDOfAny returns the maximum ReplicaID of any replica, including

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -39,6 +39,9 @@ import (
 )
 
 // RangefeedEnabled is a cluster setting that enables rangefeed requests.
+// Certain ranges have span configs that specifically enable rangefeeds (system
+// ranges and ranges covering tables in the system database); this setting
+// covers everything else.
 var RangefeedEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.rangefeed.enabled",
@@ -150,7 +153,7 @@ func (r *Replica) rangeFeedWithRangeID(
 	args *roachpb.RangeFeedRequest,
 	stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
-	if !r.isSystemRange() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
+	if !r.isRangefeedEnabled() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return roachpb.NewErrorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -187,6 +187,11 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	require.Nil(t, tc.store)
 	require.Nil(t, tc.repl)
 
+	// testContext doesn't make use of the span configs infra (uses gossip
+	// in fact); it's not able to craft ranges that know that they're part
+	// of system tables and therefore can opt out of strict GC enforcement.
+	cfg.TestingKnobs.IgnoreStrictGCEnforcement = true
+
 	// NB: this also sets up fake zone config handlers via TestingSetupZoneConfigHook.
 	//
 	// TODO(tbg): the above is not good, figure out which tests need this and make them

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -648,7 +648,7 @@ func (r *Replica) newBatchedEngine(
 		panic("expected consistent iterators")
 	}
 	var opLogger *storage.OpLoggerBatch
-	if r.isSystemRange() || RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
+	if r.isRangefeedEnabled() || RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		// TODO(nvanbenschoten): once we get rid of the RangefeedEnabled
 		// cluster setting we'll need a way to turn this on when any
 		// replica (not just the leaseholder) wants it and off when no

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -343,6 +343,9 @@ type StoreTestingKnobs struct {
 	// SpanConfigUpdateInterceptor is called after the store hears about a span
 	// config update.
 	SpanConfigUpdateInterceptor func(spanconfig.Update)
+	// SetSpanConfigInterceptor is called before updating a replica's embedded
+	// SpanConfig. The returned SpanConfig is used instead.
+	SetSpanConfigInterceptor func(*roachpb.RangeDescriptor, roachpb.SpanConfig) roachpb.SpanConfig
 	// If set, use the given version as the initial replica version when
 	// bootstrapping ranges. This is used for testing the migration
 	// infrastructure.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -378,6 +378,9 @@ type StoreTestingKnobs struct {
 	// TODO(irfansharif): Get rid of this knob, maybe by first moving
 	// DisableSpanConfigs into a testing knob instead of a server arg.
 	UseSystemConfigSpanForQueues bool
+	// IgnoreStrictGCEnforcement is used by tests to op out of strict GC
+	// enforcement.
+	IgnoreStrictGCEnforcement bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -17,7 +17,6 @@ import "gogoproto/gogo.proto";
 import "util/hlc/timestamp.proto";
 
 // GCPolicy dictates the garbage collection policy to apply over a given span.
-// It parallels the definition found in zonepb/zone.proto.
 message GCPolicy {
   option (gogoproto.equal) = true;
   option (gogoproto.populate) = true;
@@ -33,6 +32,11 @@ message GCPolicy {
   // GC TTL. The data it applies over is guaranteed to not be GC-ed provided it
   // wasn't GC-ed before the config applied.
   repeated ProtectionPolicy protection_policies = 2 [(gogoproto.nullable) = false];
+
+  // IgnoreStrictEnforcement is used to selectively opt out of strict GC TTL
+  // enforcement (where requests served at timestamps below the TTL are made to
+  // fail, even if the data exists).
+  bool ignore_strict_enforcement = 3;
 }
 
 // ProtectionPolicy dictates a protection policy against garbage collection that
@@ -156,6 +160,10 @@ message SpanConfig {
   // preferred option to least. The first preference that an existing replica of
   // a range matches will take priority for the lease.
   repeated LeasePreference lease_preferences = 9 [(gogoproto.nullable) = false];
+
+  // RangefeedEnabled determines whether rangefeeds are enabled over the
+  // specific range.
+  bool rangefeed_enabled = 10;
 }
 
 // SpanConfigEntry ties a span to its corresponding config.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -655,6 +655,27 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		if spanConfigKnobs != nil && spanConfigKnobs.StoreKVSubscriberOverride != nil {
 			storeCfg.SpanConfigSubscriber = spanConfigKnobs.StoreKVSubscriberOverride
 		} else {
+			// We use the span configs infra to control whether rangefeeds are
+			// enabled on a given range. At the moment this only applies to
+			// system tables (on both host and secondary tenants). We need to
+			// consider two things:
+			// - The sql-side reconciliation process runs asynchronously. When
+			//   the config for a given range is requested, we might not yet have
+			//   it, thus falling back to the static config below.
+			// - Various internal subsystems rely on rangefeeds to function.
+			//
+			// Consequently, we configure our static fallback config to actually
+			// allow rangefeeds. As the sql-side reconciliation process kicks
+			// off, it'll install the actual configs that we'll later consult.
+			// For system table ranges we install configs that allow for
+			// rangefeeds. Until then, we simply allow rangefeeds when a more
+			// targeted config is not found.
+			fallbackConf := storeCfg.DefaultSpanConfig
+			fallbackConf.RangefeedEnabled = true
+			// We do the same for opting out of strict GC enforcement; it
+			// really only applies to user table ranges
+			fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
+
 			spanConfig.subscriber = spanconfigkvsubscriber.New(
 				stopper,
 				db,
@@ -662,7 +683,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 				rangeFeedFactory,
 				keys.SpanConfigurationsTableID,
 				1<<20, /* 1 MB */
-				storeCfg.DefaultSpanConfig,
+				fallbackConf,
 				spanConfigKnobs,
 			)
 			storeCfg.SpanConfigSubscriber = spanConfig.subscriber

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -201,14 +201,22 @@ func PrintSpanConfigEntry(entry roachpb.SpanConfigEntry) string {
 }
 
 // PrintSpanConfigDiffedAgainstDefaults is a helper function that diffs the given
-// config against RANGE {DEFAULT, SYSTEM} and returns a string for the
-// mismatched fields. If there are none, "range {default,system}" is returned.
+// config against RANGE {DEFAULT, SYSTEM} and the config for the system database
+// (as expected on both kinds of tenants), and returns a string for the
+// mismatched fields. If it matches one of the standard templates, "range
+// {default,system}" or "database system ({host,tenant})" is returned.
 func PrintSpanConfigDiffedAgainstDefaults(conf roachpb.SpanConfig) string {
 	if conf.Equal(roachpb.TestingDefaultSpanConfig()) {
 		return "range default"
 	}
 	if conf.Equal(roachpb.TestingSystemSpanConfig()) {
 		return "range system"
+	}
+	if conf.Equal(roachpb.TestingDatabaseSystemSpanConfig(true /* host */)) {
+		return "database system (host)"
+	}
+	if conf.Equal(roachpb.TestingDatabaseSystemSpanConfig(false /* host */)) {
+		return "database system (tenant)"
 	}
 
 	defaultConf := roachpb.TestingDefaultSpanConfig()
@@ -222,6 +230,9 @@ func PrintSpanConfigDiffedAgainstDefaults(conf roachpb.SpanConfig) string {
 	if conf.GCPolicy.TTLSeconds != defaultConf.GCPolicy.TTLSeconds {
 		diffs = append(diffs, fmt.Sprintf("ttl_seconds=%d", conf.GCPolicy.TTLSeconds))
 	}
+	if conf.GCPolicy.IgnoreStrictEnforcement != defaultConf.GCPolicy.IgnoreStrictEnforcement {
+		diffs = append(diffs, fmt.Sprintf("ignore_strict_gc=%t", conf.GCPolicy.IgnoreStrictEnforcement))
+	}
 	if conf.GlobalReads != defaultConf.GlobalReads {
 		diffs = append(diffs, fmt.Sprintf("global_reads=%v", conf.GlobalReads))
 	}
@@ -230,6 +241,9 @@ func PrintSpanConfigDiffedAgainstDefaults(conf roachpb.SpanConfig) string {
 	}
 	if conf.NumVoters != defaultConf.NumVoters {
 		diffs = append(diffs, fmt.Sprintf("num_voters=%d", conf.NumVoters))
+	}
+	if conf.RangefeedEnabled != defaultConf.RangefeedEnabled {
+		diffs = append(diffs, fmt.Sprintf("rangefeed_enabled=%t", conf.RangefeedEnabled))
 	}
 	if !reflect.DeepEqual(conf.Constraints, defaultConf.Constraints) {
 		diffs = append(diffs, fmt.Sprintf("constraints=%v", conf.Constraints))

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -122,6 +122,11 @@ func TestAsOfTime(t *testing.T) {
 		}
 	})
 
+	// We'll be querying against non-existent timestamps.
+	if _, err := db.Exec(" SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	// Future queries shouldn't work if not marked as synthetic.
 	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '2200-01-01'").Scan(&i); !testutils.IsError(err, "pq: AS OF SYSTEM TIME: cannot specify timestamp in the future") {
 		t.Fatal(err)

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -638,7 +638,7 @@ type Manager struct {
 	storage          storage
 	mu               struct {
 		syncutil.Mutex
-		//TODO(james): Track size of leased descriptors in memory.
+		// TODO(james): Track size of leased descriptors in memory.
 		descriptors map[descpb.ID]*descriptorState
 
 		// updatesResolvedTimestamp keeps track of a timestamp before which all

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1928,6 +1928,21 @@ func (c clusterOptTracingOff) apply(args *base.TestServerArgs) {
 	args.TracingDefault = tracing.TracingModeOnDemand
 }
 
+// clusterOptIgnoreStrictGCForTenants corresponds to the
+// ignore-tenant-strict-gc-enforcement directive.
+type clusterOptIgnoreStrictGCForTenants struct{}
+
+var _ clusterOpt = clusterOptIgnoreStrictGCForTenants{}
+
+// apply implements the clusterOpt interface.
+func (c clusterOptIgnoreStrictGCForTenants) apply(args *base.TestServerArgs) {
+	_, ok := args.Knobs.Store.(*kvserver.StoreTestingKnobs)
+	if !ok {
+		args.Knobs.Store = &kvserver.StoreTestingKnobs{}
+	}
+	args.Knobs.Store.(*kvserver.StoreTestingKnobs).IgnoreStrictGCEnforcement = true
+}
+
 // readClusterOptions looks around the beginning of the file for a line looking like:
 // # cluster-opt: opt1 opt2 ...
 // and parses that line into a set of clusterOpts that need to be applied to the
@@ -1968,6 +1983,8 @@ func readClusterOptions(t *testing.T, path string) []clusterOpt {
 					res = append(res, clusterOptDisableSpanConfigs{})
 				case "tracing-off":
 					res = append(res, clusterOptTracingOff{})
+				case "ignore-tenant-strict-gc-enforcement":
+					res = append(res, clusterOptIgnoreStrictGCForTenants{})
 				default:
 					t.Fatalf("unrecognized cluster option: %s", opt)
 				}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -202,6 +202,11 @@ s1               {a}           256        4               0
 
 # Test AS OF SYSTEM TIME
 
+# We're reading from timestamps that precede the GC thresholds, disable strict
+# enforcement.
+statement ok
+SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false
+
 statement error pgcode 3D000 database "test" does not exist
 CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '2017'
 

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -1,3 +1,7 @@
+# This test makes use of 'kv.gc_ttl.strict_enforcement.enabled = false', which
+# is not available to tenants. We use a cluster option instead.
+# cluster-opt: ignore-tenant-strict-gc-enforcement
+
 statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t
 -----
@@ -109,6 +113,11 @@ EXPERIMENTAL SCRUB TABLE test.fk_parent WITH OPTIONS CONSTRAINT (fkey)
 -----
 
 # Test AS OF SYSTEM TIME
+
+# We're reading from timestamps that precede the GC thresholds, disable strict
+# enforcement.
+statement ok
+SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false
 
 statement error pgcode 3D000 database "test" does not exist
 EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS PHYSICAL

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -1,11 +1,20 @@
+# This test makes use of 'kv.gc_ttl.strict_enforcement.enabled = false', which
+# is not available to tenants. We use a cluster option instead.
+# cluster-opt: ignore-tenant-strict-gc-enforcement
+
 statement ok
 CREATE TABLE t (i INT)
 
 statement ok
 INSERT INTO t VALUES (2)
 
-# Verify that transacations can be used for historical reads using BEGIN
+# Verify that transactions can be used for historical reads using BEGIN
 # or SET TRANSACTION
+
+# We're reading from timestamps that precede the GC thresholds, disable strict
+# enforcement.
+statement ok
+SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = false
 
 statement error pgcode 3D000 pq: database "test" does not exist
 BEGIN AS OF SYSTEM TIME '-1h'; SELECT * FROM t

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -123,7 +123,7 @@ func TestGetZoneConfig(t *testing.T) {
 			// Verify SystemConfig.GetZoneConfigForKey.
 			{
 				key := append(roachpb.RKey(keys.SystemSQLCodec.TablePrefix(tc.objectID)), tc.keySuffix...)
-				zoneCfg, err := cfg.GetZoneConfigForKey(key) // Complete ZoneConfig
+				_, zoneCfg, err := cfg.GetZoneConfigForKey(key) // Complete ZoneConfig
 				if err != nil {
 					t.Fatalf("#%d: err=%s", tcNum, err)
 				}
@@ -355,7 +355,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 			// Verify SystemConfig.GetZoneConfigForKey.
 			{
 				key := append(roachpb.RKey(keys.SystemSQLCodec.TablePrefix(tc.objectID)), tc.keySuffix...)
-				zoneCfg, err := cfg.GetZoneConfigForKey(key) // Complete ZoneConfig
+				_, zoneCfg, err := cfg.GetZoneConfigForKey(key) // Complete ZoneConfig
 				if err != nil {
 					t.Fatalf("#%d: err=%s", tcNum, err)
 				}
@@ -650,7 +650,7 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)))
-		_, err := cfg.GetZoneConfigForKey(key)
+		_, _, err := cfg.GetZoneConfigForKey(key)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Fixes #73045.

We're running out of system table IDs (see #57531), and as a result
we're now introducing the notion of dynamic system IDs throughout the
system. Previously KV baked-in the assumption of static system IDs at
two points:
- When deciding to allow rangefeeds on a given range;
- When enforcing strict GC TTL;

It did so by decoding the range's key span and comparing against the
hard-coded maximum system ID, all to determine whether the range in
question contained system tables. If so, we allowed rangefeeds to be
declared over it, and also did not enforce strict GC TTL (only really
applies to user tables). This way of doing things does not compose with
dynamically allocated system table IDs. With arbitrary, possibly
non-contiguous IDs, we don't have the convenient key-comparison
properties to rely on.

To that end, we use the span configs infrastructure to to delegate
control of whether rangefeeds are enabled over a given range and whether
strict GC is enforced. This scheme allows SQL code to declare "system
table configs" over arbitrary schemas, and have KV still respect it.
This PR does not expose these span config settings as part of zone
configs -- there's no need to (though we could in the future). To
account for the asynchronous nature of the span configs infra, we need
to ensure that ranges without an available config default to enabling
rangefeeds.

Release note: None