### PR TITLE
kv: Cancel range cache lookup when shutting down.

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -658,7 +658,9 @@ func (rc *RangeCache) tryLookup(
 			// Clear the context's cancelation. This request services potentially many
 			// callers waiting for its result, and using the flight's leader's
 			// cancelation doesn't make sense.
-			ctx = logtags.WithTags(context.Background(), logtags.FromContext(ctx))
+			ctx, cancel := rc.stopper.WithCancelOnQuiesce(
+				logtags.WithTags(context.Background(), logtags.FromContext(ctx)))
+			defer cancel()
 			ctx = tracing.ContextWithSpan(ctx, reqSpan)
 
 			// Since we don't inherit any other cancelation, let's put in a generous


### PR DESCRIPTION
Use stopper `WithCancelOnQuiesce` as a context when performing
rangecache lookup.

The primary motivation for this change is to speed up tests
which maybe stuck for 10 seconds waiting for timeout instead of
terminating upon server shutdown.

Release Notes: None