### PR TITLE
ci: bring bazel ci up to parity with checks performed in old ci

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# This script performs assorted checks to make sure there is nothing obviously
+# wrong with the Bazel build.
+
 EXISTING_GO_GENERATE_COMMENTS="
 pkg/roachprod/vm/aws/config.go://go:generate go-bindata -mode 0600 -modtime 1400000000 -pkg aws -o embedded.go config.json old.json
 pkg/roachprod/vm/aws/config.go://go:generate gofmt -s -w embedded.go

--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -5,22 +5,14 @@ set -euo pipefail
 source "$(dirname "${0}")/teamcity-support.sh"
 source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For run_bazel
 
-function check_clean() {
-  # The workspace is clean iff `git status --porcelain` produces no output. Any
-  # output is either an error message or a listing of an untracked/dirty file.
-  if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
-    git status >&2 || true
-    git diff -a >&2 || true
-    echo "====================================================" >&2
-    echo "Some automatically generated code is not up to date." >&2
-    echo $1 >&2
-    exit 1
-  fi
-}
-
 tc_prepare
 
 tc_start_block "Ensure generated code is up-to-date"
+
+# NOTE(ricky): Please make sure any changes to the Bazel-related checks here are
+# propagated to build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+# as well.
+
 # Buffer noisy output and only print it on failure.
 if ! (run run_bazel build/bazelutil/check.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)); then
     # The command will output instructions on how to fix the error.
@@ -37,23 +29,23 @@ if grep TODO DEPS.bzl; then
     echo "Missing TODO comment in DEPS.bzl. Did you run \`./dev generate bazel --mirror\`?"
     exit 1
 fi
-check_clean "Run \`./dev generate bazel\` to automatically regenerate these."
+check_workspace_clean "Run \`./dev generate bazel\` to automatically regenerate these."
 run build/builder.sh make generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
 rm artifacts/generate.log
-check_clean "Run \`make generate\` to automatically regenerate these."
+check_workspace_clean "Run \`make generate\` to automatically regenerate these."
 run build/builder.sh make buildshort &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
 rm artifacts/buildshort.log
-check_clean "Run \`make buildshort\` to automatically regenerate these."
+check_workspace_clean "Run \`make buildshort\` to automatically regenerate these."
 tc_end_block "Ensure generated code is up-to-date"
 
 # generated code can generate new dependencies; check dependencies after generated code.
 tc_start_block "Ensure dependencies are up-to-date"
 # Run go mod tidy and `make -k vendor_rebuild` and ensure nothing changes.
 run build/builder.sh go mod tidy
-check_clean "Run \`go mod tidy\` and \`make -k vendor_rebuild\` to automatically regenerate these."
+check_workspace_clean "Run \`go mod tidy\` and \`make -k vendor_rebuild\` to automatically regenerate these."
 run build/builder.sh make -k vendor_rebuild
 cd vendor
-check_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these."
+check_workspace_clean "Run \`make -k vendor_rebuild\` to automatically regenerate these."
 cd ..
 tc_end_block "Ensure dependencies are up-to-date"
 

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,26 +1,12 @@
 #!/usr/bin/env bash
 
-# Set this to 1 to require a "release justification" note in the commit message
-# or the PR description.
-require_justification=0
-
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
-if [ "$require_justification" = 1 ]; then
-  tc_start_block "Ensure commit message contains a release justification"
-  # Ensure master branch commits have a release justification.
-  if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
-    echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
-    echo "Commits must have a Release justification of the form:" >&2
-    echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
-    exit 1
-  fi
-  tc_end_block "Ensure commit message contains a release justification"
-fi
+maybe_require_release_justification
 
 tc_start_block "Lint"
 # Disable ccache so that Go doesn't try to install dependencies into GOROOT,

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -306,3 +306,35 @@ generate_ssh_key() {
     ssh-keygen -q -N "" -f ~/.ssh/id_rsa
   fi
 }
+
+maybe_require_release_justification() {
+    # Set this to 1 to require a "release justification" note in the commit message
+    # or the PR description.
+    require_justification=0
+    if [ "$require_justification" = 1 ]; then
+        tc_start_block "Ensure commit message contains a release justification"
+        # Ensure master branch commits have a release justification.
+        if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
+            echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
+            echo "Commits must have a Release justification of the form:" >&2
+            echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
+            exit 1
+        fi
+        tc_end_block "Ensure commit message contains a release justification"
+    fi
+}
+
+# Call this function with one argument, the error message to print if the
+# workspace is dirty.
+check_workspace_clean() {
+  # The workspace is clean iff `git status --porcelain` produces no output. Any
+  # output is either an error message or a listing of an untracked/dirty file.
+  if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+    git status >&2 || true
+    git diff -a >&2 || true
+    echo "====================================================" >&2
+    echo "Some automatically generated code is not up to date." >&2
+    echo $1 >&2
+    exit 1
+  fi
+}

--- a/build/teamcity/cockroach/ci/tests/check_generated_code.sh
+++ b/build/teamcity/cockroach/ci/tests/check_generated_code.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-maybe_require_release_justification
-
-tc_start_block "Run lints"
-run_bazel build/teamcity/cockroach/ci/tests/lint_impl.sh
-tc_end_block "Run lints"
+tc_start_block "Ensure generated code is up to date"
+run_bazel build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+tc_end_block "Ensure generated code is up to date"

--- a/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root, check_workspace_clean
+
+mkdir -p artifacts
+
+# Buffer noisy output and only print it on failure.
+if ! (./build/bazelutil/check.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)); then
+    # The command will output instructions on how to fix the error.
+    exit 1
+fi
+rm artifacts/buildshort.log
+
+build/bazelutil/bazel-generate.sh \
+  BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_BAZEL_FORCE_GENERATE=1" \
+  &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
+
+rm artifacts/buildshort.log
+if grep TODO DEPS.bzl; then
+    echo "Missing TODO comment in DEPS.bzl. Did you run \`./dev generate bazel --mirror\`?"
+    exit 1
+fi
+check_workspace_clean "Run \`./dev generate bazel\` to automatically regenerate these."


### PR DESCRIPTION
Up until this point, checking the release justification and whether all
generated files were up to date was done only in GitHub CI rather than
Bazel CI. We just copy those same checks into Bazel CI as well.

Closes #68385.

Release note: None