### PR TITLE
release: automate Pick SHA step

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,6 +177,7 @@
 /pkg/cmd/publish-artifacts/  @cockroachdb/dev-inf
 /pkg/cmd/publish-provisional-artifacts/ @cockroachdb/dev-inf
 /pkg/cmd/reduce/             @cockroachdb/sql-queries
+/pkg/cmd/release/            @cockroachdb/dev-inf
 /pkg/cmd/returncheck/        @cockroachdb/dev-inf
 /pkg/cmd/roachprod/          @cockroachdb/dev-inf
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -201,6 +201,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_andygrunwald_go_jira",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/andygrunwald/go-jira",
+        sha256 = "89fc3ece1f9d367e211845ef4f33bed49273af58fdf65c561eb67903d3b72979",
+        strip_prefix = "github.com/andygrunwald/go-jira@v1.14.0",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/andygrunwald/go-jira/com_github_andygrunwald_go_jira-v1.14.0.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_antihax_optional",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/antihax/optional",
@@ -3259,6 +3269,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_golang_jwt_jwt",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/golang-jwt/jwt",
+        sha256 = "28d6dd7cc77d0a960699196e9c2170731f65d624d675888d2ababe7e8a422955",
+        strip_prefix = "github.com/golang-jwt/jwt@v3.2.2+incompatible",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/golang-jwt/jwt/com_github_golang_jwt_jwt-v3.2.2+incompatible.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_golang_jwt_jwt_v4",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/golang-jwt/jwt/v4",
@@ -4485,6 +4505,16 @@ def go_deps():
         strip_prefix = "github.com/jonboulle/clockwork@v0.1.0",
         urls = [
             "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jonboulle/clockwork/com_github_jonboulle_clockwork-v0.1.0.zip",
+        ],
+    )
+    go_repository(
+        name = "com_github_jordan_wright_email",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/jordan-wright/email",
+        sha256 = "6d35fa83ea02cfacd0e1ba9c9061381b963215cef84c8bf83ad5944cb304c390",
+        strip_prefix = "github.com/jordan-wright/email@v4.0.1-0.20210109023952-943e75fe5223+incompatible",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordan-wright/email/com_github_jordan_wright_email-v4.0.1-0.20210109023952-943e75fe5223+incompatible.zip",
         ],
     )
     go_repository(
@@ -7331,6 +7361,16 @@ def go_deps():
         strip_prefix = "github.com/toqueteos/webbrowser@v1.2.0",
         urls = [
             "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/toqueteos/webbrowser/com_github_toqueteos_webbrowser-v1.2.0.zip",
+        ],
+    )
+    go_repository(
+        name = "com_github_trivago_tgo",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/trivago/tgo",
+        sha256 = "795b3a41901f6b694195d6be9c6e7730a971fbc0ec4cd236e73cc845aca6cb7e",
+        strip_prefix = "github.com/trivago/tgo@v1.0.7",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/trivago/tgo/com_github_trivago_tgo-v1.0.7.zip",
         ],
     )
     go_repository(

--- a/build/teamcity/internal/cockroach/release/process/pick_sha.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Pick SHA Release Phase"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e JIRA_TOKEN -e JIRA_USERNAME -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_DEV -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_PROD -e RELEASE_SERIES -e SMTP_PASSWORD -e SMTP_USER" \
+  run_bazel build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+tc_end_block "Run Pick SHA Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+source "$dir/teamcity-support.sh"  # For log_into_gcloud
+
+google_credentials="$METADATA_PUBLISHER_GOOGLE_CREDENTIALS_DEV"
+to=dev-inf+release-dev@cockroachlabs.com
+qualify_bucket=release-automation-dev
+release_bucket=release-automation-dev
+
+# override dev defaults with production values
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Dry run"
+  google_credentials="$METADATA_PUBLISHER_GOOGLE_CREDENTIALS_PROD"
+  to=releases@cockroachlabs.com
+  qualify_bucket=release-automation-prod
+  release_bucket=release-automation-prod
+fi
+
+log_into_gcloud
+export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
+
+# run git fetch in order to get all remote branches
+git fetch -q origin
+bazel build --config=crosslinux //pkg/cmd/release
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  pick-sha \
+  ${DRY_RUN:+--dry-run} \
+  --release-series=$RELEASE_SERIES \
+  --smtp-user=cronjob@cockroachlabs.com \
+  --smtp-host=smtp.gmail.com \
+  --smtp-port=587 \
+  --to=$to \
+  --qualify-bucket=$qualify_bucket \
+  --qualify-object-prefix=release-qualification \
+  --release-bucket=$release_bucket \
+  --release-object-prefix=release-candidates

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/BurntSushi/toml v0.4.1
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718
 	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/Shopify/sarama v1.29.0
@@ -19,6 +20,7 @@ require (
 	github.com/abourget/teamcity v0.0.0-00010101000000-000000000000
 	github.com/alessio/shellescape v1.4.1
 	github.com/andy-kimball/arenaskl v0.0.0-20200617143215-f701008588b9
+	github.com/andygrunwald/go-jira v1.14.0
 	github.com/apache/arrow/go/arrow v0.0.0-20200923215132-ac86123a3f01
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/aws/aws-sdk-go v1.40.37
@@ -88,6 +90,7 @@ require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/jaegertracing/jaeger v1.18.1
+	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a
@@ -167,41 +170,22 @@ require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v1.1.0 // indirect
-	cloud.google.com/go/iam v0.1.1 // indirect
-	cloud.google.com/go/kms v1.1.0
-	github.com/abbot/go-http-auth v0.4.1-0.20181019201920-860ed7f246ff // indirect
-	github.com/djherbis/atime v1.1.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
-	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/minio/minio-go/v7 v7.0.21 // indirect
-	github.com/minio/sha256-simd v1.0.0 // indirect
-	github.com/mostynb/go-grpc-compression v1.1.12 // indirect
-	github.com/rs/xid v1.3.0 // indirect
-	github.com/slok/go-http-metrics v0.10.0 // indirect
-	github.com/urfave/cli/v2 v2.3.0 // indirect
-)
-
-require (
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.15 // indirect
-	github.com/Azure/go-autorest/autorest/azure/cli v0.4.3 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/DataDog/zstd v1.5.0 // indirect
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/abbot/go-http-auth v0.4.1-0.20181019201920-860ed7f246ff // indirect
 	github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5 // indirect
-	github.com/andybalholm/cascadia v1.2.0 // indirect
 	github.com/apache/thrift v0.15.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.4.2 // indirect
@@ -215,15 +199,13 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/log v0.1.0 // indirect
@@ -245,18 +227,15 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/status v1.1.0 // indirect
-	github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46 // indirect
-	github.com/golang-commonmark/linkify v0.0.0-20180910111149-f05efb453a0e // indirect
-	github.com/golang-commonmark/mdurl v0.0.0-20180910110917-8d018c6567d6 // indirect
-	github.com/golang-commonmark/puny v0.0.0-20180910110745-050be392d8b8 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
-	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.0 // indirect
@@ -279,14 +258,12 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.14.2 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.7 // indirect
-	github.com/mattn/go-zglob v0.0.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -298,10 +275,8 @@ require (
 	github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opennota/wd v0.0.0-20180911144301-b446539ab1e7 // indirect
 	github.com/openzipkin/zipkin-go v0.2.5 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
-	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.6.0 // indirect
@@ -309,7 +284,6 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/pseudomuto/protokit v0.2.0 // indirect
-	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
@@ -320,15 +294,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/toqueteos/webbrowser v1.2.0 // indirect
+	github.com/trivago/tgo v1.0.7 // indirect
 	github.com/twitchtv/twirp v8.1.0+incompatible // indirect
 	github.com/twpayne/go-kml v1.5.2 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	// The indicated commit is required on top of v1.0.0-RC3 because
-	// it fixes an import comment that otherwise breaks our prereqs tool.
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0-RC3.0.20210907151655-df2bdbbadb26 // indirect
 	go.opentelemetry.io/proto/otlp v0.9.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
@@ -336,9 +308,46 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+)
+
+require (
+	cloud.google.com/go/compute v1.1.0 // indirect
+	cloud.google.com/go/iam v0.1.1 // indirect
+	cloud.google.com/go/kms v1.1.0
+	github.com/djherbis/atime v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/minio/minio-go/v7 v7.0.21 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/mostynb/go-grpc-compression v1.1.12 // indirect
+	github.com/rs/xid v1.3.0 // indirect
+	github.com/slok/go-http-metrics v0.10.0 // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
+)
+
+require (
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.3 // indirect
+	github.com/DataDog/zstd v1.5.0 // indirect
+	github.com/andybalholm/cascadia v1.2.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
+	github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46 // indirect
+	github.com/golang-commonmark/linkify v0.0.0-20180910111149-f05efb453a0e // indirect
+	github.com/golang-commonmark/mdurl v0.0.0-20180910110917-8d018c6567d6 // indirect
+	github.com/golang-commonmark/puny v0.0.0-20180910110745-050be392d8b8 // indirect
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
+	github.com/klauspost/compress v1.14.2 // indirect
+	github.com/mattn/go-zglob v0.0.3 // indirect
+	github.com/opennota/wd v0.0.0-20180911144301-b446539ab1e7 // indirect
+	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea // indirect
+	github.com/russross/blackfriday v1.6.0 // indirect
+	// The indicated commit is required on top of v1.0.0-RC3 because
+	// it fixes an import comment that otherwise breaks our prereqs tool.
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0-RC3.0.20210907151655-df2bdbbadb26 // indirect
 	google.golang.org/grpc/examples v0.0.0-20210324172016-702608ffae4d // indirect
 	gopkg.in/ini.v1 v1.66.3 // indirect
-	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
 
 replace github.com/olekukonko/tablewriter => github.com/cockroachdb/tablewriter v0.0.5-0.20200105123400-bd15540e8847

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy86
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.16.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
@@ -252,6 +253,8 @@ github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
+github.com/andygrunwald/go-jira v1.14.0 h1:7GT/3qhar2dGJ0kq8w0d63liNyHOnxZsUZ9Pe4+AKBI=
+github.com/andygrunwald/go-jira v1.14.0/go.mod h1:KMo2f4DgMZA1C9FdImuLc04x4WQhn5derQpnsuBFgqE=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
@@ -689,6 +692,7 @@ github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod 
 github.com/fasthttp/router v1.4.4/go.mod h1:TiyF2kc+mogKcTxqkhUbiXpwklouv5dN58A0ZUo8J6s=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -957,6 +961,7 @@ github.com/golang-commonmark/mdurl v0.0.0-20180910110917-8d018c6567d6 h1:XkgfhPs
 github.com/golang-commonmark/mdurl v0.0.0-20180910110917-8d018c6567d6/go.mod h1:J66ZGl/dC2mj4ElzGfrLUq0N90HvQoUbrYgYNJUjuMs=
 github.com/golang-commonmark/puny v0.0.0-20180910110745-050be392d8b8 h1:DUgQdQmDg4sk4SfNR+qOkXcopGz36BL02vp/V7WbPQI=
 github.com/golang-commonmark/puny v0.0.0-20180910110745-050be392d8b8/go.mod h1:/8a6mcbf/Hwg6MjnHHp5vqCWw0Bsves9HLPObHAj7XA=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
@@ -1037,6 +1042,7 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
+github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -1339,6 +1345,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=
+github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible/go.mod h1:1c7szIrayyPPB/987hsnvNzLushdWf4o/79s3P08L8A=
 github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8 h1:FbSxO07tzDVa/yRmizUG+QKpPWCLsfNhT0Rno2SN+HU=
 github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8/go.mod h1:Qc93dJSt1iLNJCuG9Gy9ds0k/oh4ckhXGkD4AI3cEtM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -2006,6 +2014,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
+github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
+github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twitchtv/twirp v8.1.0+incompatible h1:KGXanpa9LXdVE/V5P/tA27rkKFmXRGCtSNT7zdeeVOY=
 github.com/twitchtv/twirp v8.1.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "release_lib",
+    srcs = [
+        "git.go",
+        "jira.go",
+        "mail.go",
+        "main.go",
+        "metadata.go",
+        "templates.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_andygrunwald_go_jira//:go-jira",
+        "@com_github_jordan_wright_email//:email",
+        "@com_github_masterminds_semver_v3//:semver",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_google_cloud_go_storage//:storage",
+    ],
+)
+
+go_binary(
+    name = "release",
+    embed = [":release_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cmd/release/git.go
+++ b/pkg/cmd/release/git.go
@@ -1,0 +1,196 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type releaseInfo struct {
+	prevReleaseVersion string
+	nextReleaseVersion string
+	buildInfo          buildInfo
+	// candidateCommits contains all merge commits that can be considered as release candidates
+	candidateCommits []string
+	// releaseSeries represents the major release prefix, e.g. 21.2
+	releaseSeries string
+}
+
+// findNextRelease finds all required information for the next release.
+func findNextRelease(releaseSeries string) (releaseInfo, error) {
+	prevReleaseVersion, err := findPreviousRelease(releaseSeries)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("cannot find previous release: %w", err)
+	}
+	nextReleaseVersion, err := bumpVersion(prevReleaseVersion)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("cannot bump version: %w", err)
+	}
+	candidateCommits, err := findCandidateCommits(prevReleaseVersion, releaseSeries)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("cannot find candidate commits: %w", err)
+	}
+	info, err := findHealthyBuild(candidateCommits)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("cannot find healthy build: %w", err)
+	}
+	releasedVersions, err := getVersionsContainingRef(info.SHA)
+	if err != nil {
+		return releaseInfo{}, fmt.Errorf("cannot check if the candidate sha was released: %w", err)
+	}
+	if len(releasedVersions) > 0 {
+		return releaseInfo{}, fmt.Errorf("%s has been already released as a part of the following tags: %s",
+			info.SHA, strings.Join(releasedVersions, ", "))
+	}
+	return releaseInfo{
+		prevReleaseVersion: prevReleaseVersion,
+		nextReleaseVersion: nextReleaseVersion,
+		buildInfo:          info,
+		candidateCommits:   candidateCommits,
+		releaseSeries:      releaseSeries,
+	}, nil
+}
+
+func getVersionsContainingRef(ref string) ([]string, error) {
+	cmd := exec.Command("git", "tag", "--contains", ref)
+	out, err := cmd.Output()
+	if err != nil {
+		return []string{}, fmt.Errorf("cannot list tags containing %s: %w", ref, err)
+	}
+	var versions []string
+	for _, v := range findVersions(string(out)) {
+		versions = append(versions, v.Original())
+	}
+	return versions, nil
+}
+
+func findVersions(text string) []*semver.Version {
+	var versions []*semver.Version
+	for _, line := range strings.Split(text, "\n") {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
+			continue
+		}
+		// Skip builds before alpha.1
+		if strings.Contains(trimmedLine, "-alpha.0000") {
+			continue
+		}
+		version, err := semver.NewVersion(trimmedLine)
+		if err != nil {
+			fmt.Printf("WARNING: cannot parse version '%s'\n", trimmedLine)
+			continue
+		}
+		versions = append(versions, version)
+	}
+	return versions
+}
+
+// findPreviousRelease finds the latest version tag for a particular release series.
+// It ignores non-semantic versions and tags with the alpha.0* suffix.
+func findPreviousRelease(releaseSeries string) (string, error) {
+	// TODO: filter version using semantic version, not a git pattern
+	cmd := exec.Command("git", "tag", "--list", fmt.Sprintf("v%s.*", releaseSeries))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("cannot get version from tags: %w", err)
+	}
+	versions := findVersions(string(output))
+	if len(versions) == 0 {
+		return "", fmt.Errorf("zero versions found")
+	}
+	sort.Sort(semver.Collection(versions))
+	return versions[len(versions)-1].Original(), nil
+}
+
+// bumpVersion increases the patch release version (the last digit) of a given version
+func bumpVersion(version string) (string, error) {
+	semanticVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse version: %w", err)
+	}
+	nextVersion := semanticVersion.IncPatch()
+	return nextVersion.Original(), nil
+}
+
+// filterPullRequests finds commits with a particular merge pattern in the commit message.
+// GitHub uses "Merge pull request #NNN" and Bors uses "Merge #NNN" in the generated commit messages.
+func filterPullRequests(text string) []string {
+	var shas []string
+	matchMerge := regexp.MustCompile(`Merge (#|pull request)`)
+	for _, line := range strings.Split(text, "\n") {
+		if !matchMerge.MatchString(line) {
+			continue
+		}
+		sha := strings.Fields(line)[0]
+		shas = append(shas, sha)
+	}
+	return shas
+}
+
+// getMergeCommits lists all merge commits within a range of two refs.
+func getMergeCommits(fromRef, toRef string) ([]string, error) {
+	cmd := exec.Command("git", "log", "--merges", "--format=format:%H %s", "--ancestry-path",
+		fmt.Sprintf("%s..%s", fromRef, toRef))
+	out, err := cmd.Output()
+	if err != nil {
+		return []string{}, fmt.Errorf("cannot read git log output: %w", err)
+	}
+	return filterPullRequests(string(out)), nil
+}
+
+func getCommonBaseRef(fromRef, toRef string) (string, error) {
+	cmd := exec.Command("git", "merge-base", fromRef, toRef)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// findCandidateCommits finds all potential merge commits that can be used for the current release.
+// It includes all merge commits since previous release.
+func findCandidateCommits(prevRelease string, releaseSeries string) ([]string, error) {
+	releaseBranch := fmt.Sprintf("origin/release-%s", releaseSeries)
+	commonBaseRef, err := getCommonBaseRef(prevRelease, releaseBranch)
+	if err != nil {
+		return []string{}, fmt.Errorf("cannot find common base ref: %w", err)
+	}
+	refs, err := getMergeCommits(commonBaseRef, releaseBranch)
+	if err != nil {
+		return []string{}, fmt.Errorf("cannot get merge commits: %w", err)
+	}
+	return refs, nil
+}
+
+// findHealthyBuild walks all potentials merge commits in reverse order and tries to find the latest healthy build.
+// The assumption is that every healthy build has a corresponding metadata file published to the release
+// qualification bucket.
+func findHealthyBuild(potentialRefs []string) (buildInfo, error) {
+	for _, ref := range potentialRefs {
+		fmt.Println("Fetching release qualification metadata for", ref)
+		meta, err := getBuildInfo(context.Background(), qualifyBucket,
+			fmt.Sprintf("%s/%s.json", qualifyObjectPrefix, ref))
+		if err != nil {
+			// TODO: retry if error is not 404
+			fmt.Println("no metadata qualification for", ref, err)
+			continue
+		}
+		return meta, nil
+	}
+	return buildInfo{}, fmt.Errorf("no ref found")
+}

--- a/pkg/cmd/release/jira.go
+++ b/pkg/cmd/release/jira.go
@@ -1,0 +1,244 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andygrunwald/go-jira"
+)
+
+const jiraBaseURL = "https://cockroachlabs.atlassian.net/"
+const dryRunProject = "RE"
+
+// for DeployToClusterIssue
+const customFieldHasSLAKey = "customfield_10073"
+
+// Jira uses Wiki syntax, see https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
+const trackingIssueTemplate = `
+* Version: *{{ .Version }}*
+* SHA: [{{ .SHA }}|https://github.com/cockroachlabs/release-staging/commit/{{ .SHA }}]
+* Tag: [{{ .Tag }}|https://github.com/cockroachlabs/release-staging/releases/tag/{{ .Tag }}]
+* SRE issue: [{{ .SREIssue }}]
+* Deployment status: _fillmein_
+* Publish Cockroach Release: _fillmein_
+
+h2. [Release process checklist|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process]
+
+* Assign the SRE issue [{{ .SREIssue }}] (use "/genie whoisoncall" in Slack). They will be notified by Jira.
+* [5-8. Verify node crash reports|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/328859690/Release+Qualification#Verify-node-crash-reports-appear-in-sentry.io]
+
+h2. Do not proceed below until the release date.
+
+Release date: _fillmein_
+
+* [9. Publish Cockroach Release|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-9.PublishTheRelease]
+* Ack security@ and release-engineering-team@ on the generated AWS S3 bucket write alert to confirm these writes were part of a planned release
+* [10. Check binaries|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-10.CheckBinaries]
+* [12. Announce the release is cut to releases@|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-13.Announcethereleaseiscuttoreleases@]
+* [13. Update version numbers|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-14.Updateversionnumbers]
+* For production or stable releases in the latest [major release|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-Knowifthereleaseisonthelatestmajorreleaseseries] series only (in August 2020, this is the v20.1 series):
+* Update [Brew Recipe|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-Brewrecipe]
+* Update [Orchestrator configurations:CRDB|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-Orchestratorconfigurations:CRDB]
+* Update [Orchestrator configurations:Helm Charts|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-Orchestratorconfigurations:HelmCharts]
+
+For all production or stable releases:
+* Create a ticket in the [Dev Inf tracker|https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/429097164/Submitting+Issues+Requests+to+the+Developer+Infrastructure+team] to update the Red Hat Container Image Repository
+* *After docs are updated* [Announce version to registration cluster|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-AnnounceVersionToRegCluster]
+* [Update version map in bin/roachtest (all stable releases) and regenerate test fixtures (only major release)|https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/73105625/Release+process#Releaseprocess-Updateversionmapinroachtestandregeneratetestfixtures]
+* Update docs (handled by Docs team)
+* External communications for release (handled by Marketing team)
+`
+const sreIssueTemplate = `
+Could you deploy the Docker image with the following tag to the release qualification CC cluster?
+
+* Version: {{ .Version }}
+* Build ID: {{ .Tag }}
+
+Please follow [this playbook|https://github.com/cockroachlabs/production/wiki/Deploy-release-qualification-versions]
+
+Thank you\!
+`
+
+type jiraClient struct {
+	client *jira.Client
+}
+
+type trackingIssueTemplateArgs struct {
+	Version  string
+	SHA      string
+	Tag      string
+	SREIssue string
+}
+
+type sreIssueTemplateArgs struct {
+	Version string
+	Tag     string
+}
+
+type issueDetails struct {
+	ID           string
+	Key          string
+	TypeName     string
+	ProjectKey   string
+	Summary      string
+	Description  string
+	CustomFields jira.CustomFields
+}
+
+// newJiraClient returns jira.Client for username and password (API token).
+// To generate an API token, go to https://id.atlassian.com/manage-profile/security/api-tokens.
+func newJiraClient(baseURL string, username string, password string) (*jiraClient, error) {
+	tp := jira.BasicAuthTransport{
+		Username: username,
+		Password: password,
+	}
+	client, err := jira.NewClient(tp.Client(), baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create Jira client: %w", err)
+	}
+	return &jiraClient{
+		client: client,
+	}, nil
+}
+
+// getIssueDetails stores a subset of details from jira.Issue into issueDetails.
+func (j *jiraClient) getIssueDetails(issueID string) (issueDetails, error) {
+	issue, _, err := j.client.Issue.Get(issueID, nil)
+	if err != nil {
+		return issueDetails{}, err
+	}
+	customFields, _, err := j.client.Issue.GetCustomFields(issueID)
+	if err != nil {
+		return issueDetails{}, err
+	}
+	return issueDetails{
+		ID:           issue.ID,
+		Key:          issue.Key,
+		TypeName:     issue.Fields.Type.Name,
+		ProjectKey:   issue.Fields.Project.Name,
+		Summary:      issue.Fields.Summary,
+		Description:  issue.Fields.Description,
+		CustomFields: customFields,
+	}, nil
+}
+
+func newIssue(details *issueDetails) *jira.Issue {
+	var issue jira.Issue
+	issue.Fields = &jira.IssueFields{}
+	issue.Fields.Project = jira.Project{
+		Key: details.ProjectKey,
+	}
+	issue.Fields.Type = jira.IssueType{
+		Name: details.TypeName,
+	}
+	issue.Fields.Summary = details.Summary
+	issue.Fields.Description = details.Description
+
+	if details.CustomFields != nil {
+		issue.Fields.Unknowns = make(map[string]interface{})
+		for key, value := range details.CustomFields {
+			issue.Fields.Unknowns[key] = map[string]string{"value": value}
+		}
+	}
+	return &issue
+}
+
+func (d issueDetails) url() string {
+	return fmt.Sprintf("%s/browse/%s", strings.TrimSuffix(jiraBaseURL, "/"), d.Key)
+}
+
+// createJiraIssue creates a **real** JIRA issue.
+func createJiraIssue(client *jiraClient, issue *jira.Issue) (issueDetails, error) {
+	newIssue, _, err := client.client.Issue.Create(issue)
+	if err != nil {
+		return issueDetails{}, err
+	}
+	details, err := client.getIssueDetails(newIssue.ID)
+	if err != nil {
+		return issueDetails{}, err
+	}
+	return details, nil
+}
+
+// createTrackingIssue creates a release tracking issue.
+// See example ticket:
+// - https://cockroachlabs.atlassian.net/browse/REL-3
+// - https://cockroachlabs.atlassian.net/rest/api/2/issue/REL-3
+func createTrackingIssue(
+	client *jiraClient, release releaseInfo, sreIssue issueDetails, dryRun bool,
+) (issueDetails, error) {
+	templateArgs := trackingIssueTemplateArgs{
+		Version:  release.nextReleaseVersion,
+		Tag:      release.buildInfo.Tag,
+		SHA:      release.buildInfo.SHA,
+		SREIssue: sreIssue.Key,
+	}
+	description, err := templateToText(trackingIssueTemplate, templateArgs)
+	if err != nil {
+		return issueDetails{}, fmt.Errorf("cannot parse tracking issue template: %w", err)
+	}
+	summary := fmt.Sprintf("Release: %s", release.nextReleaseVersion)
+	projectKey := "RE"
+	if dryRun {
+		projectKey = dryRunProject
+	}
+	issue := newIssue(&issueDetails{
+		// TODO: remove the following when ready
+		// Before sending the post request, let's override
+		// the `REL` project with our test `RE` project.
+		ProjectKey: projectKey,
+		// TODO: switch to TypeName: "CRDB Release", which requires some fields to be set
+		TypeName:    "Task",
+		Summary:     summary,
+		Description: description,
+	})
+	return createJiraIssue(client, issue)
+}
+
+// createSREIssue creates an SREOPS ticket to request release candidate qualification.
+// See example ticket:
+// - https://cockroachlabs.atlassian.net/browse/SREOPS-4037
+// - https://cockroachlabs.atlassian.net/rest/api/2/issue/SREOPS-4037
+// TODO(celia): [Future "week 0" work] We'll eventually want the ability to specify
+//  a qualification partition & friendly ID:
+// During the stability period, release managers may be qualifying multiple candidates
+// at the same time. If that's the case, release managers will want the ability to
+// explicitly specify which partition to use, so that we don't "overwrite" the
+// qualification of one release candidate by pushing a second release candidate
+// to the same cluster. Tracked in: https://cockroachlabs.atlassian.net/browse/RE-83
+func createSREIssue(client *jiraClient, release releaseInfo, dryRun bool) (issueDetails, error) {
+	templateArgs := sreIssueTemplateArgs{
+		Version: release.nextReleaseVersion,
+		Tag:     release.buildInfo.Tag,
+	}
+	description, err := templateToHTML(sreIssueTemplate, templateArgs)
+	if err != nil {
+		return issueDetails{}, fmt.Errorf("cannot parse SRE issue template: %w", err)
+	}
+	projectKey := "SREOPS"
+	summary := fmt.Sprintf("Deploy %s to release qualification cluster", release.nextReleaseVersion)
+	customFields := make(jira.CustomFields)
+	customFields[customFieldHasSLAKey] = "Yes"
+	if dryRun {
+		projectKey = dryRunProject
+		customFields = nil
+	}
+	issue := newIssue(&issueDetails{
+		ProjectKey:   projectKey,
+		TypeName:     "Task",
+		Summary:      summary,
+		Description:  description,
+		CustomFields: customFields,
+	})
+	return createJiraIssue(client, issue)
+}

--- a/pkg/cmd/release/mail.go
+++ b/pkg/cmd/release/mail.go
@@ -1,0 +1,94 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	htmltemplate "html/template"
+	"net/smtp"
+	"net/textproto"
+
+	"github.com/jordan-wright/email"
+)
+
+var emailSubjectTemplate = "Release {{ .Version }}"
+var emailTextTemplate = `
+A candidate SHA has been selected for {{ .Version }}. Proceeding to qualification shortly.
+
+	SHA: {{ .SHA }}
+	Tracking Issue: {{ .TrackingIssueURL }}
+	List of changes since last release: {{ .DiffURL }}
+
+Thanks
+Release Engineering
+`
+var emailHTMLTemplate = `
+<html>
+<body>
+<p>A candidate SHA has been selected for <strong>{{ .Version }}</strong>. Proceeding to qualification shortly.</p>
+<ul>
+<li>SHA: <a href="https://github.com/cockroachlabs/release-staging/commit/{{ .SHA }}">{{ .SHA }}</a></li>
+<li>Tracking Issue: <a href="{{ .TrackingIssueURL }}">{{ .TrackingIssue }}</a></li>
+<li><a href="{{ .DiffURL }}">List of changes</a> since last release</li>
+</ul>
+<p>Thanks,<br />
+Release Engineering</p>
+</body>
+</html>
+`
+
+type emailArgs struct {
+	Version          string
+	SHA              string
+	TrackingIssue    string
+	TrackingIssueURL htmltemplate.URL
+	DiffURL          htmltemplate.URL
+}
+
+type smtpOpts struct {
+	host     string
+	port     int
+	user     string
+	password string
+	from     string
+	to       []string
+}
+
+// sendmail creates and sends an email to the releases mailing list
+func sendmail(args emailArgs, smtpOpts smtpOpts) error {
+	text, err := templateToText(emailTextTemplate, args)
+	if err != nil {
+		return fmt.Errorf("cannot use text template: %w", err)
+	}
+	subject, err := templateToText(emailSubjectTemplate, args)
+	if err != nil {
+		return fmt.Errorf("cannot use subject template: %w", err)
+	}
+	html, err := templateToHTML(emailHTMLTemplate, args)
+	if err != nil {
+		return fmt.Errorf("cannot use html template: %w", err)
+	}
+
+	e := &email.Email{
+		To:      smtpOpts.to,
+		From:    smtpOpts.from,
+		Subject: subject,
+		Text:    []byte(text),
+		HTML:    []byte(html),
+		Headers: textproto.MIMEHeader{},
+	}
+	emailAuth := smtp.PlainAuth("", smtpOpts.user, smtpOpts.password, smtpOpts.host)
+	addr := fmt.Sprintf("%s:%d", smtpOpts.host, smtpOpts.port)
+	if err := e.Send(addr, emailAuth); err != nil {
+		return fmt.Errorf("cannot send email: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -1,0 +1,158 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	qualifyBucket       string
+	qualifyObjectPrefix string
+	releaseBucket       string
+	releaseObjectPrefix string
+	releaseSeries       string
+	smtpUser            string
+	smtpPassword        string
+	smtpHost            string
+	smtpPort            int
+	emailAddresses      []string
+	jiraUsername        string
+	jiraToken           string
+	dryRun              bool
+)
+
+func main() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+}
+
+func run() error {
+	smtpPassword = os.Getenv("SMTP_PASSWORD")
+	if smtpPassword == "" {
+		return fmt.Errorf("SMTP_PASSWORD environment variable should be set")
+	}
+	jiraUsername = os.Getenv("JIRA_USERNAME")
+	if jiraUsername == "" {
+		return fmt.Errorf("JIRA_USERNAME environment variable should be set")
+	}
+	jiraToken = os.Getenv("JIRA_TOKEN")
+	if jiraToken == "" {
+		return fmt.Errorf("JIRA_TOKEN environment variable should be set")
+	}
+
+	cmdPickSHA := &cobra.Command{
+		Use:   "pick-sha",
+		Short: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
+		// TODO: improve Long description
+		Long: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
+		RunE: pickSHA,
+	}
+	// TODO: improve flag usage comments
+	cmdPickSHA.Flags().StringVar(&qualifyBucket, "qualify-bucket", "", "release qualification metadata GCS bucket")
+	cmdPickSHA.Flags().StringVar(&qualifyObjectPrefix, "qualify-object-prefix", "",
+		"release qualification object prefix")
+	cmdPickSHA.Flags().StringVar(&releaseBucket, "release-bucket", "", "release candidates metadata GCS bucket")
+	cmdPickSHA.Flags().StringVar(&releaseObjectPrefix, "release-object-prefix", "", "release candidate object prefix")
+	cmdPickSHA.Flags().StringVar(&releaseSeries, "release-series", "", "major release series")
+	cmdPickSHA.Flags().StringVar(&smtpUser, "smtp-user", os.Getenv("SMTP_USER"), "SMTP user name")
+	cmdPickSHA.Flags().StringVar(&smtpHost, "smtp-host", "", "SMTP host")
+	cmdPickSHA.Flags().IntVar(&smtpPort, "smtp-port", 0, "SMTP port")
+	cmdPickSHA.Flags().StringArrayVar(&emailAddresses, "to", []string{}, "email addresses")
+	cmdPickSHA.Flags().BoolVar(&dryRun, "dry-run", false, "use dry run Jira project for issues")
+	requiredFlags := []string{
+		"qualify-bucket",
+		"qualify-object-prefix",
+		"release-bucket",
+		"release-object-prefix",
+		"release-series",
+		"smtp-user",
+		"smtp-host",
+		"smtp-port",
+		"to",
+	}
+	for _, flag := range requiredFlags {
+		if err := cmdPickSHA.MarkFlagRequired(flag); err != nil {
+			return err
+		}
+	}
+	// TODO: improve rootCmd description
+	rootCmd := &cobra.Command{Use: "release"}
+	rootCmd.AddCommand(cmdPickSHA)
+	if err := rootCmd.Execute(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func pickSHA(_ *cobra.Command, _ []string) error {
+	nextRelease, err := findNextRelease(releaseSeries)
+	if err != nil {
+		return fmt.Errorf("cannot find next release: %w", err)
+	}
+	// TODO: improve stdout message
+	fmt.Println("Previous version:", nextRelease.prevReleaseVersion)
+	fmt.Println("Next version:", nextRelease.nextReleaseVersion)
+	fmt.Println("Release SHA:", nextRelease.buildInfo.SHA)
+
+	// TODO: before copying check if it's already there and bail if exists, can be forced by -f
+	releaseInfoPath := fmt.Sprintf("%s/%s.json", releaseObjectPrefix, nextRelease.nextReleaseVersion)
+	fmt.Println("Publishing release candidate metadata")
+	if err := publishReleaseCandidateInfo(context.Background(), nextRelease, releaseBucket, releaseInfoPath); err != nil {
+		return fmt.Errorf("cannot publish release metadata: %w", err)
+	}
+
+	fmt.Println("Creating SRE issue")
+	jiraClient, err := newJiraClient(jiraBaseURL, jiraUsername, jiraToken)
+	if err != nil {
+		return fmt.Errorf("cannot create Jira client: %w", err)
+	}
+	sreIssue, err := createSREIssue(jiraClient, nextRelease, dryRun)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Creating tracking issue")
+	trackingIssue, err := createTrackingIssue(jiraClient, nextRelease, sreIssue, dryRun)
+	if err != nil {
+		return fmt.Errorf("cannot create tracking issue: %w", err)
+	}
+	diffURL := template.URL(
+		fmt.Sprintf("https://github.com/cockroachdb/cockroach/compare/%s...%s",
+			nextRelease.prevReleaseVersion,
+			nextRelease.buildInfo.SHA))
+	args := emailArgs{
+		Version:          nextRelease.nextReleaseVersion,
+		SHA:              nextRelease.buildInfo.SHA,
+		TrackingIssue:    trackingIssue.Key,
+		TrackingIssueURL: template.URL(trackingIssue.url()),
+		DiffURL:          diffURL,
+	}
+	opts := smtpOpts{
+		from:     fmt.Sprintf("Justin Beaver <%s>", smtpUser),
+		host:     smtpHost,
+		port:     smtpPort,
+		user:     smtpUser,
+		password: smtpPassword,
+		to:       emailAddresses,
+	}
+	fmt.Println("Sending email")
+	if err := sendmail(args, opts); err != nil {
+		return fmt.Errorf("cannot send email: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/release/metadata.go
+++ b/pkg/cmd/release/metadata.go
@@ -1,0 +1,75 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"cloud.google.com/go/storage"
+)
+
+type buildInfo struct {
+	Tag       string `json:"tag"`
+	SHA       string `json:"sha"`
+	Timestamp string `json:"timestamp"`
+}
+
+// getBuildInfo retrieves the release qualification metadata file and returns its unmarshalled struct
+func getBuildInfo(ctx context.Context, bucket string, obj string) (buildInfo, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return buildInfo{}, fmt.Errorf("cannot create GCS client: %w", err)
+	}
+	reader, err := client.Bucket(bucket).Object(obj).NewReader(ctx)
+	if err != nil {
+		return buildInfo{}, fmt.Errorf("cannot create GCS reader: %w", err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return buildInfo{}, fmt.Errorf("cannot read GCS object: %w", err)
+	}
+	var info buildInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return buildInfo{}, fmt.Errorf("cannot unmarshal metadata: %w", err)
+	}
+	return info, nil
+}
+
+// publishReleaseCandidateInfo copies release candidate metadata to a separate location.
+// This file will be used by the week 1 automation.
+func publishReleaseCandidateInfo(
+	ctx context.Context, next releaseInfo, bucket string, obj string,
+) error {
+	marshalled, err := json.MarshalIndent(next.buildInfo, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshall buildInfo: %w", err)
+	}
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot create storage client: %w", err)
+	}
+	wc := client.Bucket(bucket).Object(obj).NewWriter(ctx)
+	wc.ContentType = "application/json"
+	if _, err := wc.Write(marshalled); err != nil {
+		return fmt.Errorf("cannot write to bucket: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("cannot close storage writer filehandle: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/release/templates.go
+++ b/pkg/cmd/release/templates.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	htmltemplate "html/template"
+	"text/template"
+)
+
+// templateToText is helper function to execute a template using the text/template package
+func templateToText(templateText string, args interface{}) (string, error) {
+	templ, err := template.New("").Parse(templateText)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = templ.Execute(&buf, args)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// templateToHTML is helper function to execute a template using the html/template package
+func templateToHTML(templateText string, args interface{}) (string, error) {
+	templ, err := htmltemplate.New("").Parse(templateText)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = templ.Execute(&buf, args)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute template: %w", err)
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
Previously, in order to pick a SHA for a release one has to click
through the TeamCity and GitHub UI to chose and verify a release
candidate SHA alongside with filing new issues to track the release and
deploy the candidate to the qualification cluster. These steps are also
followed by composing an email to the releases mailing lists with a lot
of copy/pasta.

These steps are error prone and can be automated.

This patch introduces a new CLI module which will be run via TeamCity
and automate the steps above.

Release note: None
