### PR TITLE
storage,roachpb: Add Key field to WriteTooOldError

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10213,7 +10213,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				ba.Add(&get, &put)
 				return
 			},
-			expErr: "write at timestamp .* too old",
+			expErr: "write for key .* at timestamp .* too old",
 		},
 		{
 			name: "serializable push without retry",
@@ -10242,7 +10242,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				assignSeqNumsForReqs(ba.Txn, &cput)
 				return
 			},
-			expErr: "write at timestamp .* too old",
+			expErr: "write for key .* at timestamp .* too old",
 		},
 		// Non-1PC serializable txn initput will fail with write too old error.
 		{
@@ -10257,7 +10257,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				assignSeqNumsForReqs(ba.Txn, &iput)
 				return
 			},
-			expErr: "write at timestamp .* too old",
+			expErr: "write for key .* at timestamp .* too old",
 		},
 		// Non-1PC serializable txn locking scan will fail with write too old error.
 		{
@@ -10272,7 +10272,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				ba.Add(scan)
 				return
 			},
-			expErr: "write at timestamp .* too old",
+			expErr: "write for key .* at timestamp .* too old",
 		},
 		// Non-1PC serializable txn cput with CanForwardReadTimestamp set to
 		// true will succeed with write too old error.

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -332,6 +332,13 @@ message WriteIntentError {
 message WriteTooOldError {
   optional util.hlc.Timestamp timestamp = 1 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp actual_timestamp = 2 [(gogoproto.nullable) = false];
+  // One of the keys at which this error was encountered. There's
+  // no need to return new WriteTooOldErrors for each colliding key; the key
+  // is just present for investigation / logging purposes, and is not expected
+  // to be used in any transaction logic. As a result, it's not even necessary
+  // for this key to be at actual_timestamp; it could be at any timestamp in
+  // between timestamp and actual_timestamp.
+  optional bytes key = 3 [(gogoproto.casttype) = "Key"];
 }
 
 // An OpRequiresTxnError indicates that a command required to be

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1640,7 +1640,7 @@ func mvccPutInternal(
 			// instead of allowing their transactions to continue and be retried
 			// before committing.
 			writeTimestamp.Forward(metaTimestamp.Next())
-			maybeTooOldErr = roachpb.NewWriteTooOldError(readTimestamp, writeTimestamp)
+			maybeTooOldErr = roachpb.NewWriteTooOldError(readTimestamp, writeTimestamp, key)
 			// If we're in a transaction, always get the value at the orig
 			// timestamp. Outside of a transaction, the read timestamp advances
 			// to the the latest value's timestamp + 1 as well. The new

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -427,7 +427,7 @@ func TestMVCCWriteWithOlderTimestampAfterDeletionOfNonexistentKey(t *testing.T) 
 			if err := MVCCPut(
 				context.Background(), engine, nil, testKey1, hlc.Timestamp{WallTime: 1}, value1, nil,
 			); !testutils.IsError(
-				err, "write at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
+				err, "write for key \"/db1\" at timestamp 0.000000001,0 too old; wrote at 0.000000003,1",
 			) {
 				t.Fatal(err)
 			}

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -221,7 +221,7 @@ func CheckSSTConflicts(
 		// be used in transactions so we don't need to check.
 		if sstKey.Timestamp.LessEq(extKey.Timestamp) {
 			return enginepb.MVCCStats{}, roachpb.NewWriteTooOldError(
-				sstKey.Timestamp, extKey.Timestamp.Next())
+				sstKey.Timestamp, extKey.Timestamp.Next(), sstKey.Key)
 		}
 
 		// If we are shadowing an existing key, we must update the stats accordingly

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -62,7 +62,7 @@ cput k=k v=v4 cond=v3 ts=123
 >> at end:
 data: "k"/124.000000000,1 -> /BYTES/v4
 data: "k"/124.000000000,0 -> /BYTES/v3
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 123.000000000,0 too old; wrote at 124.000000000,1
 
 # Reset for next test
 

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -25,7 +25,7 @@ cput ts=1 k=k v=v2 cond=v1
 >> at end:
 data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 1.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 10.000000000,1
 
 # Try a transactional put @t=1 with expectation of value2; should fail.
 run error
@@ -49,4 +49,4 @@ meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,
 data: "k"/10.000000000,2 -> /BYTES/v3
 data: "k"/10.000000000,1 -> /BYTES/v2
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 1.000000000,0 too old; wrote at 10.000000000,2
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 10.000000000,2

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -128,7 +128,7 @@ data: "c/123"/47.000000000,0 -> /<empty>
 data: "c/123"/44.000000000,0 -> /BYTES/abc
 data: "d"/44.000000000,0 -> /BYTES/abc
 data: "d/123"/44.000000000,0 -> /BYTES/abc
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 46.000000000,0 too old; wrote at 47.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 46.000000000,0 too old; wrote at 47.000000000,1
 
 run ok
 txn_remove t=A

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -63,7 +63,7 @@ data: "k"/0,1 -> /INT/2
 data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 2.000000000,0 too old; wrote at 3.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; wrote at 3.000000000,1
 
 # Ditto with transactional.
 run error
@@ -80,4 +80,4 @@ data: "r"/3.000000000,2 -> /INT/2
 data: "r"/3.000000000,1 -> /INT/3
 data: "r"/3.000000000,0 -> /INT/2
 data: "r"/1.000000000,0 -> /INT/1
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 2.000000000,0 too old; wrote at 3.000000000,2
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "r" at timestamp 2.000000000,0 too old; wrote at 3.000000000,2

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -37,7 +37,7 @@ run error
 get k=k1 ts=9,0 failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
 
 run ok
 get k=k1 ts=10,0
@@ -48,7 +48,7 @@ run error
 get k=k1 ts=10,0 failOnMoreRecent
 ----
 get: "k1" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
 
 run ok
 get k=k1 ts=11,0
@@ -69,7 +69,7 @@ run error
 scan k=k1 end=k2 ts=9,0 failOnMoreRecent
 ----
 scan: "k1"-"k2" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
 
 run ok
 scan k=k1 end=k2 ts=10,0
@@ -80,7 +80,7 @@ run error
 scan k=k1 end=k2 ts=10,0 failOnMoreRecent
 ----
 scan: "k1"-"k2" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
 
 run ok
 scan k=k1 end=k2 ts=11,0
@@ -180,7 +180,7 @@ run error
 scan k=k1 end=k3 ts=9,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; wrote at 10.000000000,1
 
 run error
 scan k=k1 end=k3 ts=10,0
@@ -192,7 +192,7 @@ run error
 scan k=k1 end=k3 ts=10,0 failOnMoreRecent
 ----
 scan: "k1"-"k3" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; wrote at 10.000000000,1
 
 run error
 scan k=k1 end=k3 ts=11,0
@@ -241,16 +241,16 @@ run error
 scan k=a end=b_next ts=9,0 failOnMoreRecent
 ----
 scan: "a"-"b_next" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
 
 run error
 scan k=a end=c_next ts=9,0 failOnMoreRecent
 ----
 scan: "a"-"c_next" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
 
 run error
 scan k=b end=c_next ts=9,0 failOnMoreRecent
 ----
 scan: "b"-"c_next" -> <no data>
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 9.000000000,0 too old; wrote at 13.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "b" at timestamp 9.000000000,0 too old; wrote at 13.000000000,1

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_old_version
@@ -14,7 +14,7 @@ put k=k v=v2 ts=0,1
 >> at end:
 data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 0,1 too old; wrote at 1.000000000,2
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 0,1 too old; wrote at 1.000000000,2
 
 # Earlier logical time.
 
@@ -25,4 +25,4 @@ put k=k v=v2 ts=1,0
 data: "k"/1.000000000,3 -> /BYTES/v2
 data: "k"/1.000000000,2 -> /BYTES/v2
 data: "k"/1.000000000,1 -> /BYTES/v
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 1.000000000,0 too old; wrote at 1.000000000,3
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; wrote at 1.000000000,3

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -24,7 +24,7 @@ txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=33.000000000,0 min=0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/44.000000000,1 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
 
 run ok
 resolve_intent t=A k=a status=ABORTED
@@ -47,7 +47,7 @@ txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=33.000000000,0 min=0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/44.000000000,1 -> /BYTES/def
 data: "a"/44.000000000,0 -> /BYTES/abc
-error: (*roachpb.WriteTooOldError:) WriteTooOldError: write at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; wrote at 44.000000000,1
 
 run ok
 resolve_intent t=B k=a status=ABORTED


### PR DESCRIPTION
Currently, WriteTooOldErrors that happen as part of a
ranged put operation (eg. MVCCClearTimeRange) can be very
opaque, as we don't know what key we tried to "write too old"
on. This change addresses that by adding a Key field to WriteTooOldError.
The field is optional, as retaining that key for an MVCCScan would not
really be worth it.

Informs #72476.

Release note: None.