### PR TITLE
vendor: bump Pebble to c75a2e96a7e8

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1218,10 +1218,10 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sha256 = "01bbbd8a079753674a8a5698054506ea2db167e94be52a094c2ee0779a88d9c6",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220104184117-a71dc5a033cf",
+        sha256 = "00fb9a072e2ac79ba16462bcb58b892f0625a259b87bd84722cb47016706afd4",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220107174839-c75a2e96a7e8",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220104184117-a71dc5a033cf.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220107174839-c75a2e96a7e8.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf
+	github.com/cockroachdb/pebble v0.0.0-20220107174839-c75a2e96a7e8
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf h1:jjRy2qNBIrU2zyo4MQy4ywP9PkRhHTowAYoxP7RCMGM=
-github.com/cockroachdb/pebble v0.0.0-20220104184117-a71dc5a033cf/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220107174839-c75a2e96a7e8 h1:LnM9wPinzvGmAXZ/O8eOGXBaMESPVtMrOnmUcJpBgxI=
+github.com/cockroachdb/pebble v0.0.0-20220107174839-c75a2e96a7e8/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.0/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
c75a2e96 db: expose range-key masking
90d9c97f db: fix merge skew
72d69b8e internal/rangekey: implement range-key masking
61aa2e84 db: add experimental, in-memory range keys implementation
35095493 batch: exclude range keys from primary flushable batch iterator
```

Release note: None