### PR TITLE
build: fix Pebble nightly benchmarks

### DIFF
--- a/build/teamcity-nightly-pebble-common.sh
+++ b/build/teamcity-nightly-pebble-common.sh
@@ -32,6 +32,7 @@ build_tag=$(git describe --abbrev=0 --tags --match=v[0-9]*)
 export build_tag
 
 # Build the roachtest binary.
+make generate
 make bin/roachtest
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run


### PR DESCRIPTION
The Pebble nightly benchmarks stopped running due to a build error
stemming from the removal of the generated code from the codebase.

Release note: None