### PR TITLE
bazel: use `copy` mode for `go_path` generation rather than `link`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -260,7 +260,9 @@ nogo(
 
 go_path(
     name = "go_path",
-    mode = "link",
+    # TODO(ricky): change back to 'link' when https://github.com/bazelbuild/rules_go/issues/3041
+    # is resolved.
+    mode = "copy",
     deps = [
         "//pkg/cmd/cockroach-short",
         "//pkg/cmd/roachprod",


### PR DESCRIPTION
This results in more space being taken for the `go_path` but it avoids
the problem described in
https://github.com/bazelbuild/rules_go/issues/3041. I'm trying to come
up with a fix for upstream but am still working on it; this should get
`dev build`/`dev generate` working properly in the meantime.

Closes #74536.

Release note: None