### PR TITLE
dev: introduce common benchmarking flags

### DIFF
--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -19,6 +19,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	benchTimeFlag = "bench-time"
+	benchMemFlag  = "bench-mem"
+)
+
 // makeBenchCmd constructs the subcommand used to run the specified benchmarks.
 func makeBenchCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
 	benchCmd := &cobra.Command{
@@ -26,20 +31,39 @@ func makeBenchCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 		Short: `Run the specified benchmarks`,
 		Long:  `Run the specified benchmarks.`,
 		Example: `
-	dev bench pkg/sql/parser --filter=BenchmarkParse`,
+	dev bench pkg/sql/parser --filter=BenchmarkParse
+	dev bench pkg/bench -f='BenchmarkTracing/1node/scan/trace=off' --count=2 --bench-time=10x --bench-mem`,
 		Args: cobra.MinimumNArgs(0),
 		RunE: runE,
 	}
 	addCommonBuildFlags(benchCmd)
 	addCommonTestFlags(benchCmd)
+
+	benchCmd.Flags().BoolP(vFlag, "v", false, "show benchmark process output")
+	benchCmd.Flags().BoolP(showLogsFlag, "", false, "show crdb logs in-line")
+	benchCmd.Flags().Int(countFlag, 1, "run benchmark n times")
+	// We use a string flag for benchtime instead of a duration; the go test
+	// runner accepts input of the form "Nx" to run the benchmark N times (see
+	// `go help testflag`).
+	benchCmd.Flags().String(benchTimeFlag, "", "duration to run each benchmark for")
+	benchCmd.Flags().Bool(benchMemFlag, false, "print memory allocations for benchmarks")
+
 	return benchCmd
 }
 
-func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
+func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
+	pkgs, additionalBazelArgs := splitArgsAtDash(cmd, commandLine)
 	ctx := cmd.Context()
-	filter := mustGetFlagString(cmd, filterFlag)
-	timeout := mustGetFlagDuration(cmd, timeoutFlag)
-	short := mustGetFlagBool(cmd, shortFlag)
+	var (
+		filter    = mustGetFlagString(cmd, filterFlag)
+		timeout   = mustGetFlagDuration(cmd, timeoutFlag)
+		short     = mustGetFlagBool(cmd, shortFlag)
+		showLogs  = mustGetFlagBool(cmd, showLogsFlag)
+		verbose   = mustGetFlagBool(cmd, vFlag)
+		count     = mustGetFlagInt(cmd, countFlag)
+		benchTime = mustGetFlagString(cmd, benchTimeFlag)
+		benchMem  = mustGetFlagBool(cmd, benchMemFlag)
+	)
 
 	// Enumerate all benches to run.
 	if len(pkgs) == 0 {
@@ -87,13 +111,30 @@ func (d *dev) bench(cmd *cobra.Command, pkgs []string) error {
 	if numCPUs != 0 {
 		argsBase = append(argsBase, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
+	if verbose {
+		argsBase = append(argsBase, "--test_arg", "-test.v")
+	}
+	if showLogs {
+		argsBase = append(argsBase, "--test_arg", "-show-logs")
+	}
+	if count != 1 {
+		argsBase = append(argsBase, "--test_arg", fmt.Sprintf("-test.count=%d", count))
+	}
+	if benchTime != "" {
+		argsBase = append(argsBase, "--test_arg", fmt.Sprintf("-test.benchtime=%s", benchTime))
+	}
+	if benchMem {
+		argsBase = append(argsBase, "--test_arg", "-test.benchmem")
+	}
 
 	for _, bench := range benches {
 		args := make([]string, len(argsBase))
 		copy(args, argsBase)
 		base := filepath.Base(bench)
 		target := "//" + bench + ":" + base + "_test"
-		args = append(args, target, "--", "-test.run=-")
+		args = append(args, target)
+		args = append(args, additionalBazelArgs...)
+		args = append(args, "--", "-test.run=-")
 		if filter == "" {
 			args = append(args, "-test.bench=.")
 		} else {

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -66,6 +66,7 @@ func makeBuildCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Com
 // TODO(irfansharif): Make sure all the relevant binary targets are defined
 // above, and in usage docs.
 
+// buildTargetMapping maintains shorthands that map 1:1 with bazel targets.
 var buildTargetMapping = map[string]string{
 	"buildifier":       "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":        "@com_github_bazelbuild_buildtools//buildozer:buildozer",
@@ -234,7 +235,7 @@ func targetToBinBasename(target string) string {
 // (e.g. after translation, so short -> "//pkg/cmd/cockroach-short").
 func (d *dev) getBasicBuildArgs(
 	ctx context.Context, targets []string, skipGenerate bool,
-) (args []string, buildTargets []buildTarget, err error) {
+) (args []string, buildTargets []buildTarget, _ error) {
 	if len(targets) == 0 {
 		// Default to building the cockroach binary.
 		targets = append(targets, "cockroach")
@@ -256,8 +257,8 @@ func (d *dev) getBasicBuildArgs(
 			queryArgs := []string{"query", target, "--output=label_kind"}
 			labelKind, queryErr := d.exec.CommandContextSilent(ctx, "bazel", queryArgs...)
 			if queryErr != nil {
-				err = fmt.Errorf("could not run `bazel %s` (%w)", shellescape.QuoteCommand(queryArgs), queryErr)
-				return
+				return nil, nil, fmt.Errorf("could not run `bazel %s` (%w)",
+					shellescape.QuoteCommand(queryArgs), queryErr)
 			}
 			for _, line := range strings.Split(strings.TrimSpace(string(labelKind)), "\n") {
 				fields := strings.Fields(line)
@@ -278,10 +279,10 @@ func (d *dev) getBasicBuildArgs(
 			}
 			continue
 		}
+
 		aliased, ok := buildTargetMapping[target]
 		if !ok {
-			err = fmt.Errorf("unrecognized target: %s", target)
-			return
+			return nil, nil, fmt.Errorf("unrecognized target: %s", target)
 		}
 
 		args = append(args, aliased)
@@ -303,7 +304,7 @@ func (d *dev) getBasicBuildArgs(
 		args = append(args, "--config=test")
 	}
 
-	return
+	return args, buildTargets, nil
 }
 
 // Hoist generated code out of the sandbox and into the workspace.

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -57,6 +57,14 @@ func mustGetFlagBool(cmd *cobra.Command, name string) bool {
 	return val
 }
 
+func mustGetFlagInt(cmd *cobra.Command, name string) int {
+	val, err := cmd.Flags().GetInt(name)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	return val
+}
+
 func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
 	val, err := cmd.Flags().GetDuration(name)
 	if err != nil {


### PR DESCRIPTION
Specifically:
  --bench-mem (to print out memory allocations);
  --bench-time (to control how long each benchmark is run for);
  --count (how many times to run it, also added to `dev test`);
  -v and --show-logs (similar to `dev test`)

We also add supports for args-after-double-dash-are-for-bazel within
`dev bench`. This commit is light on testing (read: there isn't any), so
doesn't bump DEV_VERSION to roll it out to everyone just yet.

Release note: None