### PR TITLE
importccl: fix import pgdump target column bug

### DIFF
--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -1184,6 +1184,14 @@ func (m *pgDumpReader) readFile(
 					conv.TargetColOrds.Add(idx)
 					targetColMapIdx[j] = idx
 				}
+				// For any missing columns, fill those to NULL.
+				// These will get filled in with the correct default / computed
+				// expression if there are any for these columns.
+				for idx := range conv.VisibleCols {
+					if !conv.TargetColOrds.Contains(idx) {
+						conv.Datums[idx] = tree.DNull
+					}
+				}
 			}
 			for {
 				row, err := ps.Next()


### PR DESCRIPTION
Previously, if a COPY FROM statement had less columns than
the CREATE TABLE schema defined in the dump file,
 we would get a nil pointer exception. This is because
we were not filling the non-targeted columns with a NULL datum.
This change fixes that and aligns behvaiour with how INSERT
handles non-targeted columns.

Release note (bug fix): IMPORT TABLE ... PGDUMP with a
COPY FROM statement in the dump file that has less target columns
than the CREATE TABLE schema definition would result in a
nil pointer exception.