### PR TITLE
backupccl: `defaultdb` is not restored as MR in cluster restore

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -162,6 +162,7 @@ go_test(
         "//pkg/blobs",
         "//pkg/ccl/kvccl",
         "//pkg/ccl/multiregionccl",
+        "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/multitenantccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
@@ -8926,4 +8927,81 @@ func TestBackupMemMonitorSSTSinkQueueSize(t *testing.T) {
 
 	// Now the backup should succeed because it is below the `byteLimit`.
 	sqlDB.Exec(t, `BACKUP INTO 'nodelocal://0/bar'`)
+}
+
+// TestBackupRestoreMRDefaultDB is a regression test for
+// https://github.com/cockroachdb/cockroach/issues/74586.
+//
+// A cluster restore does not restore the backed up `defaultdb` descriptor. As a
+// result of this, it did not set the `LocalityConfig` on the `defaultdb`
+// descriptor of the restoring cluster. If any table in the backed up
+// `defaultdb` is an MR table, we will fail to restore it since the restoring
+// cluster's `defaultdb` is incorrectly a non-MR database.
+func TestBackupRestoreMRDefaultDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "times out under stressrace")
+
+	clusterSize := 3
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, clusterSize, base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		}, multiregionccltestutils.WithBaseDirectory(dir),
+	)
+	defer cleanup()
+
+	_, err := sqlDB.Exec(`
+USE defaultdb;
+alter database defaultdb primary region "us-east3";
+alter database defaultdb add region "us-east2";
+alter database defaultdb add region "us-east1";`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`
+CREATE TABLE A (
+  a STRING PRIMARY KEY
+);
+
+alter table A set locality regional by row;
+insert into A (a) VALUES ('foo');
+`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`BACKUP INTO 'nodelocal://0/foo'`)
+	require.NoError(t, err)
+
+	_, sqlDBRestore, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, clusterSize, base.TestingKnobs{}, multiregionccltestutils.WithBaseDirectory(dir),
+	)
+	defer cleanup()
+
+	_, err = sqlDBRestore.Exec(`RESTORE FROM LATEST IN 'nodelocal://0/foo'`)
+	require.NoError(t, err)
+
+	checkRows := func() {
+		row, err := sqlDBRestore.Query(`SELECT * FROM defaultdb.a`)
+		require.NoError(t, err)
+		defer row.Close()
+		var a string
+		for row.Next() {
+			err := row.Scan(&a)
+			require.NoError(t, err)
+		}
+		require.Equal(t, "foo", a)
+	}
+	checkRows()
+
+	// Sanity check that database level `defaultdb` restore still works.
+	t.Run("restore-mr-defaultdb", func(t *testing.T) {
+		_, err = sqlDBRestore.Exec(`DROP DATABASE defaultdb CASCADE;`)
+		require.NoError(t, err)
+
+		_, err = sqlDBRestore.Exec(`RESTORE DATABASE defaultdb FROM LATEST IN 'nodelocal://0/foo';`)
+		require.NoError(t, err)
+
+		checkRows()
+	})
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -563,11 +563,11 @@ func loadBackupSQLDescs(
 	p sql.JobExecContext,
 	details jobspb.RestoreDetails,
 	encryption *jobspb.BackupEncryptionOptions,
-) ([]BackupManifest, BackupManifest, []catalog.Descriptor, error) {
+) ([]BackupManifest, BackupManifest, []catalog.Descriptor, catalog.DatabaseDescriptor, error) {
 	backupManifests, err := loadBackupManifests(ctx, details.URIs,
 		p.User(), p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, encryption)
 	if err != nil {
-		return nil, BackupManifest{}, nil, err
+		return nil, BackupManifest{}, nil, nil, err
 	}
 
 	allDescs, latestBackupManifest := loadSQLDescsFromBackupsAtTime(backupManifests, details.EndTime)
@@ -578,6 +578,7 @@ func loadBackupSQLDescs(
 		}
 	}
 
+	var backedUpDefaultDBDesc catalog.DatabaseDescriptor
 	var sqlDescs []catalog.Descriptor
 	for _, desc := range allDescs {
 		id := desc.GetID()
@@ -586,6 +587,10 @@ func loadBackupSQLDescs(
 			if m, ok := details.DatabaseModifiers[id]; ok {
 				desc.SetRegionConfig(m.RegionConfig)
 			}
+
+			if desc.GetName() == catalogkeys.DefaultDatabaseName {
+				backedUpDefaultDBDesc = desc
+			}
 		}
 		if _, ok := details.DescriptorRewrites[id]; ok {
 			sqlDescs = append(sqlDescs, desc)
@@ -593,9 +598,10 @@ func loadBackupSQLDescs(
 	}
 
 	if err := maybeUpgradeDescriptors(ctx, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
-		return nil, BackupManifest{}, nil, err
+		return nil, BackupManifest{}, nil, nil, err
 	}
-	return backupManifests, latestBackupManifest, sqlDescs, nil
+
+	return backupManifests, latestBackupManifest, sqlDescs, backedUpDefaultDBDesc, nil
 }
 
 // restoreResumer should only store a reference to the job it's running. State
@@ -832,6 +838,7 @@ func createImportingDescriptors(
 	p sql.JobExecContext,
 	backupCodec keys.SQLCodec,
 	sqlDescs []catalog.Descriptor,
+	backedUpDefaultDBDesc catalog.DatabaseDescriptor,
 	r *restoreResumer,
 ) (*restorationDataBase, *mainRestorationData, error) {
 	details := r.job.Details().(jobspb.RestoreDetails)
@@ -1060,6 +1067,24 @@ func createImportingDescriptors(
 								return err
 							}
 						}
+					}
+				}
+			}
+
+			// In a cluster restore, we do not restore the database `defaultdb` from
+			// the BACKUP, but instead re-parent all backed up schema objects that
+			// were in `defaultdb` to point to the restoring cluster's `defaultdb`.
+			// This special handling is to account for the fact that every new cluster
+			// has a `defaultdb` at a static ID created on startup.
+			// As a result of this, we must set the RegionConfig of `defaultdb` on
+			// the restoring cluster, to match the config set on the backed up
+			// `defaultdb` descriptor.
+			if details.DescriptorCoverage == tree.AllDescriptors {
+				if backedUpDefaultDBDesc != nil && backedUpDefaultDBDesc.IsMultiRegion() {
+					backedUpDefaultDBRegionConfig := backedUpDefaultDBDesc.GetRegionConfig()
+					if err := r.setRegionConfigForDefaultDB(ctx, p, txn, descsCol,
+						backedUpDefaultDBRegionConfig); err != nil {
+						return err
 					}
 				}
 			}
@@ -1312,7 +1337,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
-	backupManifests, latestBackupManifest, sqlDescs, err := loadBackupSQLDescs(
+	backupManifests, latestBackupManifest, sqlDescs, backedUpDefaultDBDesc, err := loadBackupSQLDescs(
 		ctx, p, details, details.Encryption,
 	)
 	if err != nil {
@@ -1360,7 +1385,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		return err
 	}
 
-	preData, mainData, err := createImportingDescriptors(ctx, p, backupCodec, sqlDescs, r)
+	preData, mainData, err := createImportingDescriptors(ctx, p, backupCodec, sqlDescs, backedUpDefaultDBDesc, r)
 	if err != nil {
 		return err
 	}
@@ -1898,6 +1923,17 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}
 		}
 
 		if details.DescriptorCoverage == tree.AllDescriptors {
+			// In a cluster restore we do not restore the backed up `defaultdb`
+			// descriptor and so it will not be dropped in the cleanup above. Thus, we
+			// have to manually cleanup `defaultdb`'s LocalityConfig that the restore
+			// might have set. We can do this unconditionally because `defaultdb`
+			// could not have been an MR database prior to cluster restore. This is
+			// because we check for any schema objects in the cluster before we allow
+			// the restore to process, this includes the `crdb_region` enum.
+			if err := r.setRegionConfigForDefaultDB(ctx, p, txn, descsCol, nil /* regionCfg */); err != nil {
+				return err
+			}
+
 			// The temporary system table descriptors should already have been dropped
 			// in `dropDescriptors` but we still need to drop the temporary system db.
 			return r.cleanupTempSystemTables(ctx, txn)
@@ -2365,6 +2401,28 @@ func (r *restoreResumer) restoreSystemTables(
 	}
 
 	return nil
+}
+
+func (r *restoreResumer) setRegionConfigForDefaultDB(
+	ctx context.Context,
+	p sql.JobExecContext,
+	txn *kv.Txn,
+	descsCol *descs.Collection,
+	regionCfg *descpb.DatabaseDescriptor_RegionConfig,
+) error {
+	// Lookup the `defaultdb` in the restoring cluster.
+	defaultDBID, err := lookupDatabaseID(ctx, txn, p.ExecCfg().Codec,
+		catalogkeys.DefaultDatabaseName)
+	if err != nil {
+		return err
+	}
+	desc, err := descsCol.GetMutableDescriptorByID(ctx, defaultDBID, txn)
+	if err != nil {
+		return err
+	}
+	db := desc.(*dbdesc.Mutable)
+	db.SetRegionConfig(regionCfg)
+	return descsCol.WriteDesc(ctx, false /* kvTrace */, db, txn)
 }
 
 func (r *restoreResumer) cleanupTempSystemTables(ctx context.Context, txn *kv.Txn) error {


### PR DESCRIPTION
This change fixes a bug where a backed up `defaultdb` with a
MR LocalityConfig, is not restored as an MR database on cluster
restore.

In a cluster restore, we do not restore the database `defaultdb` from
the BACKUP, but instead re-parent all backed up schema objects that
were in `defaultdb` to point to the restoring cluster's `defaultdb`.
This special handling is to account for the fact that every new cluster
has a `defaultdb` at a static ID created on startup.
As a result of this, we must set the RegionConfig of `defaultdb` on
the restoring cluster, to match the config set on the backed up
`defaultdb` descriptor.

Fixes: #74586

Release note (bug fix): Fixes a bug where a backed up `defaultdb`
that is configured to be MR, is not restored as a MR database on
cluster restore.

Release justification: bug fix.