### PR TITLE
release-21.2: sql: avoid string formatting in reportSessionDataChanges when not necessary

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -844,15 +844,16 @@ func (ex *connExecutor) reportSessionDataChanges(fn func() error) error {
 			if err != nil {
 				return err
 			}
+			if v.Equal == nil {
+				return errors.AssertionFailedf("Equal for %s must be set", param.name)
+			}
 			if v.GetFromSessionData == nil {
 				return errors.AssertionFailedf("GetFromSessionData for %s must be set", param.name)
 			}
-			beforeVal := v.GetFromSessionData(before)
-			afterVal := v.GetFromSessionData(after)
-			if beforeVal != afterVal {
+			if !v.Equal(before, after) {
 				ex.dataMutatorIterator.paramStatusUpdater.BufferParamStatusUpdate(
 					param.name,
-					afterVal,
+					v.GetFromSessionData(after),
 				)
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #74338.

/cc @cockroachdb/release

Release justification: avoids superfluous heap allocations on each transaction.

---

This commit updates each of the `bufferableParamStatusUpdates`
`sessionVar`s to have an `Equal` function, which returns whether the
value of the variable is equal between two `SessionData` references.
This allows `connExecutor.reportSessionDataChanges` to compare the
values of each of the variables without resorting to string formatting.
Instead, the variables are only string formatted if they have actually
changed and need to be reported to the client.

Micro-benchmarks have revealed that the string formatting for variables
like "DateStyle" is a meaningful expense to incur on each transaction,
especially for small OLTP transactions.

```
name                   old time/op    new time/op    delta
KV/Scan/SQL/rows=1-10    94.7µs ± 8%    92.9µs ± 2%    ~     (p=0.762 n=10+8)

name                   old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10    20.1kB ± 0%    19.9kB ± 0%  -1.00%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-10       245 ± 0%       235 ± 0%  -4.08%  (p=0.000 n=10+9)
```