### PR TITLE
roachtest: fix silly bug in tlp roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -49,7 +49,7 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 	timeout := 10 * time.Minute
 	// Run 10 minute iterations of TLP in a loop for about the entire test,
 	// giving 5 minutes at the end to allow the test to shut down cleanly.
-	until := time.After(t.Spec().(registry.TestSpec).Timeout - 5*time.Minute)
+	until := time.After(t.Spec().(*registry.TestSpec).Timeout - 5*time.Minute)
 	done := ctx.Done()
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")


### PR DESCRIPTION
I thought that we'd get some basic coverage of roachtests in unit tests
at low duration or something, but I guess not.

Release note: None