### PR TITLE
teamcity-trigger: give `kvserver` package higher stress timeout

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -106,11 +106,11 @@ func runTC(queueBuild func(string, map[string]string)) {
 			} else {
 				opts["env.COCKROACH_KVNEMESIS_STEPS"] = "10000"
 			}
-		case baseImportPath + "sql/logictest":
-			// Stress logic tests with reduced parallelism (to avoid overloading the
+		case baseImportPath + "sql/logictest", baseImportPath + "kv/kvserver":
+			// Stress heavy with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2
-			// Increase logic test timeout.
+			// Increase test timeout to compensate.
 			testTimeout = 2 * time.Hour
 			maxTime = 3 * time.Hour
 		}


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/69519.

Release note: None
