### PR TITLE
release-21.1: sql: fix bugs in unsafe_upsert_descriptor

### DIFF
--- a/pkg/cli/testdata/doctor/test_examine_zipdir
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir
@@ -2,12 +2,12 @@ debug doctor examine zipdir testdata/doctor/debugzip
 ----
 debug doctor examine zipdir testdata/doctor/debugzip
 Examining 38 descriptors and 43 namespace entries...
-  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: descriptor not found
-  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: referenced descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
   ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found
 Examining 2 jobs...
 job 587337426984566785: running schema change GC refers to missing table descriptor(s) [59]; existing descriptors that still need to be dropped []; job safe to delete: true.

--- a/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
@@ -37,17 +37,17 @@ Examining 38 descriptors and 43 namespace entries...
   ParentID   1, ParentSchemaID 29: relation "sqlliveness" (39): processed
   ParentID   0, ParentSchemaID  0: database "defaultdb" (50): processed
   ParentID   0, ParentSchemaID  0: database "postgres" (51): processed
-  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "users" (53): processed
-  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicles" (54): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "vehicles" (54): processed
-  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "rides" (55): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "rides" (55): processed
-  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): processed
-  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): processed
-  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: descriptor not found
+  ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): processed
   ParentID   0, ParentSchemaID  0: namespace entry "defaultdb" (50): processed
   ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -163,7 +163,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			},
 		},
 		{ // 3
-			err: `schema mapping entry "schema1" (500): referenced schema ID 500: descriptor not found`,
+			err: `schema mapping entry "schema1" (500): referenced schema ID 500: referenced descriptor not found`,
 			desc: descpb.DatabaseDescriptor{
 				ID:   51,
 				Name: "db1",
@@ -207,7 +207,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			},
 		},
 		{ // 6
-			err: `multi-region enum: referenced type ID 500: descriptor not found`,
+			err: `multi-region enum: referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.DatabaseDescriptor{
 				ID:   51,
 				Name: "db1",

--- a/pkg/sql/catalog/desc_getter.go
+++ b/pkg/sql/catalog/desc_getter.go
@@ -35,21 +35,6 @@ type BatchDescGetter interface {
 	GetNamespaceEntries(ctx context.Context, requests []descpb.NameInfo) ([]descpb.ID, error)
 }
 
-// GetTableDescFromID retrieves the table descriptor for the table
-// ID passed in using an existing proto getter. Returns an error if the
-// descriptor doesn't exist or if it exists and is not a table.
-func GetTableDescFromID(ctx context.Context, dg DescGetter, id descpb.ID) (TableDescriptor, error) {
-	desc, err := dg.GetDesc(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	table, ok := desc.(TableDescriptor)
-	if !ok {
-		return nil, WrapTableDescRefErr(id, ErrDescriptorNotFound)
-	}
-	return table, nil
-}
-
 // MapDescGetter is an in-memory DescGetter implementation.
 type MapDescGetter struct {
 	Descriptors map[descpb.ID]Descriptor

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -82,6 +82,10 @@ func HasInactiveDescriptorError(err error) bool {
 // found with the given id.
 var ErrDescriptorNotFound = errors.New("descriptor not found")
 
+// ErrReferencedDescriptorNotFound is like ErrDescriptorNotFound but for
+// descriptors referenced within another descriptor.
+var ErrReferencedDescriptorNotFound = errors.New("referenced descriptor not found")
+
 // ErrDescriptorWrongType is returned to signal that a descriptor was found but
 // that it wasn't of the expected type.
 var ErrDescriptorWrongType = errors.New("unexpected descriptor type")

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -86,7 +86,7 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 			},
 		},
 		{ // 1
-			err: `referenced database ID 500: descriptor not found`,
+			err: `referenced database ID 500: referenced descriptor not found`,
 			desc: descpb.SchemaDescriptor{
 				ID:       52,
 				ParentID: 500,

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -301,20 +301,32 @@ func maybeUpgradeForeignKeyRepOnIndex(
 	idx *descpb.IndexDescriptor,
 	skipFKsWithNoMatchingTable bool,
 ) (bool, error) {
+	updateUnupgradedTablesMap := func(id descpb.ID) (err error) {
+		defer func() {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
+				err = nil
+			}
+		}()
+		if _, found := otherUnupgradedTables[id]; found {
+			return nil
+		}
+		d, err := dg.GetDesc(ctx, id)
+		if err != nil {
+			return err
+		}
+		tbl, ok := d.(catalog.TableDescriptor)
+		if !ok {
+			return catalog.WrapTableDescRefErr(id, catalog.ErrDescriptorNotFound)
+		}
+		otherUnupgradedTables[id] = tbl
+		return nil
+	}
+
 	var changed bool
 	if idx.ForeignKey.IsSet() {
 		ref := &idx.ForeignKey
-		if _, ok := otherUnupgradedTables[ref.Table]; !ok {
-			tbl, err := catalog.GetTableDescFromID(ctx, dg, ref.Table)
-			if err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
-					// Ignore this FK and keep going.
-				} else {
-					return false, err
-				}
-			} else {
-				otherUnupgradedTables[ref.Table] = tbl
-			}
+		if err := updateUnupgradedTablesMap(ref.Table); err != nil {
+			return false, err
 		}
 		if tbl, ok := otherUnupgradedTables[ref.Table]; ok {
 			referencedIndex, err := tbl.FindIndexWithID(ref.Index)
@@ -341,19 +353,9 @@ func maybeUpgradeForeignKeyRepOnIndex(
 
 	for refIdx := range idx.ReferencedBy {
 		ref := &(idx.ReferencedBy[refIdx])
-		if _, ok := otherUnupgradedTables[ref.Table]; !ok {
-			tbl, err := catalog.GetTableDescFromID(ctx, dg, ref.Table)
-			if err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) && skipFKsWithNoMatchingTable {
-					// Ignore this FK and keep going.
-				} else {
-					return false, err
-				}
-			} else {
-				otherUnupgradedTables[ref.Table] = tbl
-			}
+		if err := updateUnupgradedTablesMap(ref.Table); err != nil {
+			return false, err
 		}
-
 		if otherTable, ok := otherUnupgradedTables[ref.Table]; ok {
 			originIndexI, err := otherTable.FindIndexWithID(ref.Index)
 			if err != nil {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1123,7 +1123,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 	}{
 		// Foreign keys
 		{ // 0
-			err: `invalid foreign key: missing table=52: referenced table ID 52: descriptor not found`,
+			err: `invalid foreign key: missing table=52: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1169,7 +1169,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{ // 2
-			err: `invalid foreign key backreference: missing table=52: referenced table ID 52: descriptor not found`,
+			err: `invalid foreign key backreference: missing table=52: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1304,7 +1304,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 
 		// Interleaves
 		{ // 6
-			err: `invalid interleave: missing table=52 index=2: referenced table ID 52: descriptor not found`,
+			err: `invalid interleave: missing table=52 index=2: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1369,7 +1369,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{ // 9
-			err: `invalid interleave backreference table=52 index=2: referenced table ID 52: descriptor not found`,
+			err: `invalid interleave backreference table=52 index=2: referenced table ID 52: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1425,7 +1425,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{ // 12
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1448,7 +1448,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 		},
 		// Add some expressions with invalid type references.
 		{ // 13
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1471,7 +1471,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		{ // 14
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,
@@ -1494,7 +1494,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			},
 		},
 		{ // 15
-			err: `referenced type ID 500: descriptor not found`,
+			err: `referenced type ID 500: referenced descriptor not found`,
 			desc: descpb.TableDescriptor{
 				Name:                    "foo",
 				ID:                      51,

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -588,7 +588,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`referenced database ID 500: descriptor not found`,
+			`referenced database ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -600,7 +600,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`referenced schema ID 500: descriptor not found`,
+			`referenced schema ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -612,7 +612,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`arrayTypeID 500 does not exist for "ENUM": referenced type ID 500: descriptor not found`,
+			`arrayTypeID 500 does not exist for "ENUM": referenced type ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -624,7 +624,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			`arrayTypeID 500 does not exist for "MULTIREGION_ENUM": referenced type ID 500: descriptor not found`,
+			`arrayTypeID 500 does not exist for "MULTIREGION_ENUM": referenced type ID 500: referenced descriptor not found`,
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,
@@ -645,7 +645,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			"referenced table ID 500: descriptor not found",
+			"referenced table ID 500: referenced descriptor not found",
 			descpb.TypeDescriptor{
 				Name:                     "t",
 				ID:                       typeDescID,
@@ -658,7 +658,7 @@ func TestValidateTypeDesc(t *testing.T) {
 			},
 		},
 		{
-			"referenced table ID 500: descriptor not found",
+			"referenced table ID 500: referenced descriptor not found",
 			descpb.TypeDescriptor{
 				Name:           "t",
 				ID:             typeDescID,

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -365,7 +365,7 @@ func (vdg *validationDescGetterImpl) GetDatabaseDescriptor(
 ) (DatabaseDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapDatabaseDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapDatabaseDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsDatabaseDescriptor(desc)
 }
@@ -374,7 +374,7 @@ func (vdg *validationDescGetterImpl) GetDatabaseDescriptor(
 func (vdg *validationDescGetterImpl) GetSchemaDescriptor(id descpb.ID) (SchemaDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapSchemaDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapSchemaDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsSchemaDescriptor(desc)
 }
@@ -383,7 +383,7 @@ func (vdg *validationDescGetterImpl) GetSchemaDescriptor(id descpb.ID) (SchemaDe
 func (vdg *validationDescGetterImpl) GetTableDescriptor(id descpb.ID) (TableDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapTableDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapTableDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsTableDescriptor(desc)
 }
@@ -392,7 +392,7 @@ func (vdg *validationDescGetterImpl) GetTableDescriptor(id descpb.ID) (TableDesc
 func (vdg *validationDescGetterImpl) GetTypeDescriptor(id descpb.ID) (TypeDescriptor, error) {
 	desc, found := vdg.Descriptors[id]
 	if !found || desc == nil {
-		return nil, WrapTypeDescRefErr(id, ErrDescriptorNotFound)
+		return nil, WrapTypeDescRefErr(id, ErrReferencedDescriptorNotFound)
 	}
 	return AsTypeDescriptor(desc)
 }

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -442,7 +442,8 @@ SELECT
 				),
 				true
 			)
-		)
+		),
+		true
 	)
 FROM
 	system.descriptor
@@ -466,7 +467,7 @@ UPDATE system.namespace SET id = 12345 WHERE id = 53;
 	require.Equal(t, 53, id)
 	require.Equal(t, "", dbName)
 	require.Equal(t, "", schemaName)
-	require.Equal(t, `relation "test" (53): referenced database ID 52: descriptor not found`, errStr)
+	require.Equal(t, `relation "test" (53): referenced database ID 52: referenced descriptor not found`, errStr)
 
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(&id, &dbName, &schemaName, &objName, &errStr))
@@ -480,7 +481,7 @@ UPDATE system.namespace SET id = 12345 WHERE id = 53;
 	require.Equal(t, 55, id)
 	require.Equal(t, "defaultdb", dbName)
 	require.Equal(t, "public", schemaName)
-	require.Equal(t, `relation "tbl" (55): invalid foreign key: missing table=54: referenced table ID 54: descriptor not found`, errStr)
+	require.Equal(t, `relation "tbl" (55): invalid foreign key: missing table=54: referenced table ID 54: referenced descriptor not found`, errStr)
 
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(&id, &dbName, &schemaName, &objName, &errStr))

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -206,7 +206,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{ParentID: 2, Name: "schema"}, ID: 51},
 			},
 			expected: `Examining 1 descriptors and 1 namespace entries...
-  ParentID   2, ParentSchemaID  0: schema "schema" (51): referenced database ID 2: descriptor not found
+  ParentID   2, ParentSchemaID  0: schema "schema" (51): referenced database ID 2: referenced descriptor not found
 `,
 		},
 		{ // 9
@@ -246,8 +246,8 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 3},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID   3, ParentSchemaID  2: type "type" (1): referenced schema ID 2: descriptor not found
-  ParentID   3, ParentSchemaID  2: type "type" (1): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: descriptor not found
+  ParentID   3, ParentSchemaID  2: type "type" (1): referenced schema ID 2: referenced descriptor not found
+  ParentID   3, ParentSchemaID  2: type "type" (1): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: referenced descriptor not found
 `,
 		},
 		{ // 11
@@ -445,7 +445,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 2},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID   2, ParentSchemaID 29: relation "t" (1): invalid interleave backreference table=500 index=1: referenced table ID 500: descriptor not found
+  ParentID   2, ParentSchemaID 29: relation "t" (1): invalid interleave backreference table=500 index=1: referenced table ID 500: referenced descriptor not found
   ParentID   2, ParentSchemaID 29: relation "t" (1): unimplemented: primary key dropped without subsequent addition of new primary key in same transaction
 `,
 		},


### PR DESCRIPTION
Backport 1/1 commits from #74478.

/cc @cockroachdb/release

---

    sql: fix bugs in unsafe_upsert_descriptor
    
    This commit fixes some bugs in the implementation of the
    unsafe_upsert_descriptor repair function:
    - The descriptor read via the descriptor collection falls back to
      a Get operation followed by descriptor proto unmarshalling in cases
      where the existing descriptor is invalid and the force flag is set.
    - The existing descriptor hex encoding in the event log is less
      incorrect.
    - The version check has been tightened to only allow the existing
      descriptor version plus one.
    
    This commit also comes with some quality-of-life improvements in that
    the unsafe_upsert_descriptor function will override incorrect version
    and ID fields when the force flag is set.
    
    Furthermore this commit fixes a bug where ErrDescriptorNotFound was
    mistakenly returned when a descriptor references another descriptor that
    doesn't exist. This commit introduces a new error for missing referenced
    descriptors so that this class of errors gets treated differently when
    handling errors returned by the descs.Collection API.
        
    Release justification: fixes severe bugs in crdb_internal builtin functions.

    Fixes #74465.
    
    Release note: None
