### PR TITLE
release-21.2: [serverccl] Fix flaky tenant status test.

### DIFF
--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/sql/idxusage",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
@@ -54,6 +55,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Backport 1/1 commits from #72408.

/cc @cockroachdb/release

---

The Statements method on the tenant status server
relies on the sqlinstance system to retrieve SQL
pod information. The sqlinstance system was updated
recently to cache SQL pod data backed by a rangefeed.
This caused the tenant status test to fail occasionally
with make stress as there could be a race between
when the cache is populated and the statements are
queried. This PR updates the test to ensure this race
condition is eliminated.

Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/72079

--- 

Release Justification: Category 1: Non-production code changes