### PR TITLE
release: publish qualification build metadata

### DIFF
--- a/build/release/teamcity-mark-build-qualified.sh
+++ b/build/release/teamcity-mark-build-qualified.sh
@@ -5,3 +5,4 @@ set -euxo pipefail
 source "$(dirname "${0}")/teamcity-mark-build.sh"
 
 mark_build "qualified"
+publish_qualify_metadata

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -31,3 +31,30 @@ mark_build() {
   gcloud container images add-tag "${gcr_repository}:${TC_BUILD_BRANCH}" "${gcr_repository}:latest-${release_branch}-${build_label}-build"
   tc_end_block "Push new docker image tag"
 }
+
+# Publish potential release metadata to a stable location.
+publish_qualify_metadata() {
+  gcs_bucket="release-automation-dev"
+  google_credentials=$GOOGLE_RELEASE_AUTOMATION_CREDENTIALS_DEV
+  if [[ -z "${DRY_RUN}" ]] ; then
+    gcs_bucket="release-automation-prod"
+    google_credentials=$GOOGLE_RELEASE_AUTOMATION_CREDENTIALS_PROD
+  fi
+
+  tc_start_block "Metadata"
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  metadata_file="artifacts/metadata.json"
+  mkdir -p artifacts
+  cat > "$metadata_file" << EOF
+{
+  "sha": "$BUILD_VCS_NUMBER",
+  "timestamp": "$timestamp",
+  "tag": "$TC_BUILD_BRANCH"
+}
+EOF
+  # Run jq to pretty print and validate JSON
+  jq . "$metadata_file"
+  log_into_gcloud
+  gsutil cp "$metadata_file" "gs://$gcs_bucket/release-qualification/$BUILD_VCS_NUMBER.json"
+  tc_end_block "Metadata"
+}


### PR DESCRIPTION
Previously, in order to pick a SHA for the next release, a release
driver would need to go to the TeamCity UI and select the last good
build, find all required metadata (SHA, tag, etc), and record these
values for the next week's release procedure.

This patch adds the ability to publish this metadata to a stable
location, where it can be picked up by the week 0 automation and copied
as an input for the week 1 steps.

Release note: None