### PR TITLE
importccl: remove row data from import error

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -7045,7 +7045,7 @@ func TestImportRowErrorLargeRows(t *testing.T) {
 	importIntoQuery := `IMPORT INTO simple CSV DATA ($1)`
 	// Without truncation this would fail with:
 	// pq: job 715036628973879297: could not mark as reverting: job-update: command is too large: 33561185 bytes (max: 4194304)
-	sqlDB.ExpectErr(t, ".*error parsing row 2: expected 1 fields, got 4.*-- TRUNCATED", importIntoQuery, srv.URL)
+	sqlDB.ExpectErr(t, ".*error parsing row 2: expected 1 fields, got 4", importIntoQuery, srv.URL)
 }
 
 func TestImportJobEventLogging(t *testing.T) {

--- a/pkg/ccl/importccl/read_import_base.go
+++ b/pkg/ccl/importccl/read_import_base.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -388,21 +387,8 @@ type importRowError struct {
 	rowNum int64
 }
 
-const (
-	importRowErrMaxRuneCount    = 1024
-	importRowErrTruncatedMarker = " -- TRUNCATED"
-)
-
 func (e *importRowError) Error() string {
-	// The job system will truncate this error before saving it,
-	// but we will additionally truncate it here since it is
-	// separately written to the log and could easily result in
-	// very large log files.
-	rowForLog := e.row
-	if len(rowForLog) > importRowErrMaxRuneCount {
-		rowForLog = util.TruncateString(rowForLog, importRowErrMaxRuneCount) + importRowErrTruncatedMarker
-	}
-	return fmt.Sprintf("error parsing row %d: %v (row: %s)", e.rowNum, e.err, rowForLog)
+	return fmt.Sprintf("error parsing row %d: %v", e.rowNum, e.err)
 }
 
 func newImportRowError(err error, row string, num int64) error {


### PR DESCRIPTION
While this row data is redactable and while we have found it useful for quickly
resolving failed imports in the past, having this row data in the
error message is a problem for some users.

Release note (ops change): Truncated row data is no longer logged
during import failures.