### PR TITLE
schemachanger: address error message inconsistencies with legacy schema changer

### DIFF
--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -102,7 +102,7 @@ func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode,
 			}
 			if !(isAdmin || hasOwnership) {
 				return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
-					"permission denied to drop schema %q", sc.GetName())
+					"must be owner of schema %q", sc.GetName())
 			}
 			namesBefore := len(d.objectNamesToDelete)
 			if err := d.collectObjectsInSchema(ctx, p, db, sc); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1254,3 +1254,26 @@ subtest empty-database
 
 statement error empty database name
 DROP DATABASE ""
+
+subtest schema-permission-error
+
+user root
+
+statement ok
+CREATE SCHEMA sc1;
+
+statement ok
+CREATE DATABASE db1;
+
+user testuser
+
+statement ok
+SET experimental_use_new_schema_changer = 'on'
+
+statement error must be owner of schema \"sc1\"
+DROP SCHEMA sc1;
+
+statement error user testuser does not have DROP privilege on database db1
+DROP DATABASE db1;
+
+user root

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -391,7 +391,7 @@ CREATE VIEW v4Dep AS (SELECT n2, n1 FROM v2Dep);
 statement ok
 explain (DDL, DEPS) DROP VIEW v1Dep CASCADE;
 
-statement error pq: cannot drop view "v1dep" because view "v2dep" depends on it
+statement error pq: cannot drop relation "v1dep" because view "v2dep" depends on it
 DROP VIEW v1Dep RESTRICT;
 
 statement error pq: "v1dep" is not a materialized view
@@ -453,6 +453,15 @@ statement ok
 CREATE SEQUENCE defaultdb.sq1 OWNED BY defaultdb.shipments.carrier;
 
 statement ok
+CREATE TABLE defaultdb.sq1dep (
+	rand_col INT8 DEFAULT nextval('defaultdb.sq1')
+);
+
+statement error cannot drop table a because other objects depend on it
+DROP TABLE defaultdb.shipments;
+
+statement ok
+DROP TABLE defaultdb.sq1dep;
 DROP TABLE defaultdb.shipments;
 
 statement ok
@@ -466,11 +475,10 @@ CREATE TABLE defaultdb.shipments (
     CONSTRAINT fk_orders FOREIGN KEY (customer_id) REFERENCES defaultdb.orders(customer)
  );
 
-
 statement ok
 CREATE VIEW defaultdb.v1 as (select customer_id, carrier from defaultdb.shipments);
 
-statement error pq: cannot drop table "defaultdb.public.shipments" because view "defaultdb.public.v1" depends on it
+statement error pq: cannot drop relation "shipments" because view "v1" depends on it
 DROP TABLE defaultdb.shipments;
 
 statement ok
@@ -642,7 +650,7 @@ CREATE VIEW db1.sc1.v5 AS (SELECT 'a'::db1.sc1.typ::string AS k, n2, n1 from db1
 statement error schema "sc1" is not empty and CASCADE was not specified
 DROP SCHEMA db1.sc1
 
-statement error database "db1" has a non-empty schema "public" and CASCADE was not specified
+statement error database "db1" is not empty and RESTRICT was specified
 DROP DATABASE db1 RESTRICT
 
 statement ok
@@ -1241,3 +1249,8 @@ DROP TABLE ttc3;
 
 statement ok
 DROP TYPE d_tc;
+
+subtest empty-database
+
+statement error empty database name
+DROP DATABASE ""

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -423,7 +423,7 @@ CREATE TYPE privs.denied AS ENUM ('denied')
 statement error pq: must be owner of schema "privs"
 ALTER SCHEMA privs RENAME TO denied
 
-statement error pq: permission denied to drop schema "privs"
+statement error must be owner of schema \"privs\"
 DROP SCHEMA privs
 
 # Test the usage privilege.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
@@ -48,7 +48,7 @@ func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
 			// Block drops if cascade is not set.
 			if n.DropBehavior == tree.DropRestrict && (nodeAdded || !schemaDroppedIDs.Empty()) {
 				panic(pgerror.Newf(pgcode.DependentObjectsStillExist,
-					"database %q has a non-empty schema %q and CASCADE was not specified", db.GetName(), schema.GetName()))
+					"database %q is not empty and RESTRICT was specified", db.GetName()))
 			}
 			// If no schema exists to depend on, then depend on dropped IDs
 			if !nodeAdded {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
@@ -42,11 +42,6 @@ func dropSchema(
 	behavior tree.DropBehavior,
 ) (nodeAdded bool, dropIDs catalog.DescriptorIDSet) {
 	descsThatNeedElements := catalog.DescriptorIDSet{}
-	// For non-user defined schemas, another check will be
-	// done each object as we go to drop them.
-	if sc.SchemaKind() == catalog.SchemaUserDefined {
-		b.MustOwn(sc)
-	}
 	_, objectIDs := b.CatalogReader().ReadObjectNamesAndIDs(b, db, sc)
 	for _, id := range objectIDs {
 		// For dependency tracking we will still track that these elements were

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
@@ -94,13 +94,13 @@ func dropViewDependents(b BuildCtx, view catalog.TableDescriptor, behavior tree.
 			if dependentDesc.GetParentID() != view.GetParentID() {
 				panic(errors.WithHintf(sqlerrors.NewDependentObjectErrorf("cannot drop relation %q because view %q depends on it",
 					name.Object(), depViewName.FQString()),
-						"you can drop %s instead.", depViewName.Object()))
+					"you can drop %s instead.", depViewName.Object()))
 			} else {
 				panic(sqlerrors.NewDependentObjectErrorf("cannot drop relation %q because view %q depends on it",
-						name.Object(), depViewName.Object()))
-				}
+					name.Object(), depViewName.Object()))
 			}
-			// Decompose and recursively attempt to drop.
-			dropView(b, dependentDesc, behavior)
-		})
+		}
+		// Decompose and recursively attempt to drop.
+		dropView(b, dependentDesc, behavior)
+	})
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
@@ -92,16 +92,15 @@ func dropViewDependents(b BuildCtx, view catalog.TableDescriptor, behavior tree.
 			depViewName, err := b.CatalogReader().GetQualifiedTableNameByID(b, int64(dep.DependedOnBy), tree.ResolveRequireViewDesc)
 			onErrPanic(err)
 			if dependentDesc.GetParentID() != view.GetParentID() {
-				panic(sqlerrors.NewDependentObjectErrorf("cannot drop view %q because view %q depends on it",
-					name.FQString(), depViewName.FQString()))
+				panic(errors.WithHintf(sqlerrors.NewDependentObjectErrorf("cannot drop relation %q because view %q depends on it",
+					name.Object(), depViewName.FQString()),
+						"you can drop %s instead.", depViewName.Object()))
 			} else {
-				panic(errors.WithHintf(
-					sqlerrors.NewDependentObjectErrorf("cannot drop view %q because view %q depends on it",
-						name.Object(), depViewName.Object()),
-					"you can drop %s instead.", depViewName.Object()))
+				panic(sqlerrors.NewDependentObjectErrorf("cannot drop relation %q because view %q depends on it",
+						name.Object(), depViewName.Object()))
+				}
 			}
-		}
-		// Decompose and recursively attempt to drop.
-		dropView(b, dependentDesc, behavior)
-	})
+			// Decompose and recursively attempt to drop.
+			dropView(b, dependentDesc, behavior)
+		})
 }

--- a/pkg/sql/schemachanger/scbuild/name_resolver.go
+++ b/pkg/sql/schemachanger/scbuild/name_resolver.go
@@ -53,7 +53,7 @@ func (b buildCtx) ResolveSchema(
 		if p.IsExistenceOptional {
 			return db, nil
 		}
-		panic(sqlerrors.NewUndefinedSchemaError(name.String()))
+		panic(sqlerrors.NewUndefinedSchemaError(name.Schema()))
 	}
 	switch sc.SchemaKind() {
 	case catalog.SchemaPublic, catalog.SchemaVirtual, catalog.SchemaTemporary:

--- a/pkg/sql/schemachanger/scbuild/name_resolver.go
+++ b/pkg/sql/schemachanger/scbuild/name_resolver.go
@@ -33,6 +33,9 @@ func (b buildCtx) ResolveDatabase(
 		if p.IsExistenceOptional {
 			return nil
 		}
+		if string(name) == "" {
+			panic(pgerror.New(pgcode.Syntax, "empty database name"))
+		}
 		panic(sqlerrors.NewUndefinedDatabaseError(name.String()))
 	}
 	if err := b.AuthorizationAccessor().CheckPrivilege(b, db, p.RequiredPrivilege); err != nil {

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -130,6 +130,7 @@ func (d *txnDeps) GetFullyQualifiedName(ctx context.Context, id descpb.ID) (stri
 		tree.CommonLookupFlags{
 			Required:       true,
 			IncludeDropped: true,
+			AvoidLeased:    true,
 		})
 	if err != nil {
 		return "", err
@@ -144,6 +145,7 @@ func (d *txnDeps) GetFullyQualifiedName(ctx context.Context, id descpb.ID) (stri
 			tree.CommonLookupFlags{
 				IncludeDropped: true,
 				Required:       true,
+				AvoidLeased:    true,
 			})
 		if err != nil {
 			return "", err
@@ -151,7 +153,9 @@ func (d *txnDeps) GetFullyQualifiedName(ctx context.Context, id descpb.ID) (stri
 		schemaDesc, err := d.descsCollection.GetImmutableSchemaByID(ctx, d.txn, objectDesc.GetParentSchemaID(),
 			tree.SchemaLookupFlags{
 				Required:       true,
-				IncludeDropped: true})
+				IncludeDropped: true,
+				AvoidLeased:    true,
+			})
 		if err != nil {
 			return "", err
 		}
@@ -168,6 +172,7 @@ func (d *txnDeps) GetFullyQualifiedName(ctx context.Context, id descpb.ID) (stri
 			tree.CommonLookupFlags{
 				IncludeDropped: true,
 				Required:       true,
+				AvoidLeased:    true,
 			})
 		if err != nil {
 			return "", err


### PR DESCRIPTION
These changes will address the following issues, which will also allow us to enable logictest support in a separate PR:

1. Cases where the declarative schema changer currently either does not generate an error message or generates a message that is inconsistent with the legacy schema changer.
2. A case inside DROP SCHEMA inside the legacy schema changer, where the message generated for privilege errors is not consistent with other DROP operations.
3. Fixing an issue inside the declarative schema changer where we should have been avoiding leased descriptors for event logging.