### PR TITLE
catalog: pre-compute more column slices

### DIFF
--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -153,50 +152,4 @@ func MustBeValueEncoded(semanticType *types.T) bool {
 		return true
 	}
 	return false
-}
-
-// GetColumnTypes populates the types of the columns with the given IDs into the
-// outTypes slice, returning it. You must use the returned slice, as this
-// function might allocate a new slice.
-func GetColumnTypes(
-	desc catalog.TableDescriptor, columnIDs []descpb.ColumnID, outTypes []*types.T,
-) ([]*types.T, error) {
-	if cap(outTypes) < len(columnIDs) {
-		outTypes = make([]*types.T, len(columnIDs))
-	} else {
-		outTypes = outTypes[:len(columnIDs)]
-	}
-	for i, id := range columnIDs {
-		col, err := desc.FindColumnWithID(id)
-		if err != nil {
-			return nil, err
-		}
-		if !col.Public() {
-			return nil, fmt.Errorf("column-id \"%d\" does not exist", id)
-		}
-		outTypes[i] = col.GetType()
-	}
-	return outTypes, nil
-}
-
-// GetColumnTypesFromColDescs populates the types of the columns with the given
-// IDs into the outTypes slice, returning it. You must use the returned slice,
-// as this function might allocate a new slice.
-func GetColumnTypesFromColDescs(
-	cols []catalog.Column, columnIDs []descpb.ColumnID, outTypes []*types.T,
-) []*types.T {
-	if cap(outTypes) < len(columnIDs) {
-		outTypes = make([]*types.T, len(columnIDs))
-	} else {
-		outTypes = outTypes[:len(columnIDs)]
-	}
-	for i, id := range columnIDs {
-		for j := range cols {
-			if id == cols[j].GetID() {
-				outTypes[i] = cols[j].GetType()
-				break
-			}
-		}
-	}
-	return outTypes
 }

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -479,9 +479,6 @@ type TableDescriptor interface {
 	// key columns in the specified Index, plus all key suffix columns if that
 	// index is not a unique index.
 	IndexFullColumnDirections(idx Index) []descpb.IndexDescriptor_Direction
-	// IndexCompositeColumns returns a slice of Column interfaces containing all
-	// composite columns among the key and key suffix in the specified Index.
-	IndexCompositeColumns(idx Index) []Column
 	// IndexStoredColumns returns a slice of Column interfaces containing all
 	// stored columns in the specified Index.
 	IndexStoredColumns(idx Index) []Column

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -465,6 +465,9 @@ type TableDescriptor interface {
 	// IndexKeyColumns returns a slice of Column interfaces containing all
 	// key columns in the specified Index.
 	IndexKeyColumns(idx Index) []Column
+	// IndexKeyColumnDirections returns a slice of column directions for all
+	// key columns in the specified Index.
+	IndexKeyColumnDirections(idx Index) []descpb.IndexDescriptor_Direction
 	// IndexKeySuffixColumns returns a slice of Column interfaces containing all
 	// key suffix columns in the specified Index.
 	IndexKeySuffixColumns(idx Index) []Column
@@ -472,6 +475,10 @@ type TableDescriptor interface {
 	// key columns in the specified Index, plus all key suffix columns if that
 	// index is not a unique index.
 	IndexFullColumns(idx Index) []Column
+	// IndexFullColumnDirections returns a slice of column directions for all
+	// key columns in the specified Index, plus all key suffix columns if that
+	// index is not a unique index.
+	IndexFullColumnDirections(idx Index) []descpb.IndexDescriptor_Direction
 	// IndexCompositeColumns returns a slice of Column interfaces containing all
 	// composite columns among the key and key suffix in the specified Index.
 	IndexCompositeColumns(idx Index) []Column

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -459,6 +459,26 @@ type TableDescriptor interface {
 	// colinfo.AllSystemColumnDescs.
 	SystemColumns() []Column
 
+	// IndexColumns returns a slice of Column interfaces containing all
+	// columns present in the specified Index in any capacity.
+	IndexColumns(idx Index) []Column
+	// IndexKeyColumns returns a slice of Column interfaces containing all
+	// key columns in the specified Index.
+	IndexKeyColumns(idx Index) []Column
+	// IndexKeySuffixColumns returns a slice of Column interfaces containing all
+	// key suffix columns in the specified Index.
+	IndexKeySuffixColumns(idx Index) []Column
+	// IndexFullColumns returns a slice of Column interfaces containing all
+	// key columns in the specified Index, plus all key suffix columns if that
+	// index is not a unique index.
+	IndexFullColumns(idx Index) []Column
+	// IndexCompositeColumns returns a slice of Column interfaces containing all
+	// composite columns among the key and key suffix in the specified Index.
+	IndexCompositeColumns(idx Index) []Column
+	// IndexStoredColumns returns a slice of Column interfaces containing all
+	// stored columns in the specified Index.
+	IndexStoredColumns(idx Index) []Column
+
 	// FindColumnWithID returns the first column found whose ID matches the
 	// provided target ID, in the canonical order.
 	// If no column is found then an error is also returned.

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -603,32 +603,6 @@ func FindDeleteOnlyNonPrimaryIndex(desc TableDescriptor, test func(idx Index) bo
 	return findIndex(desc.DeleteOnlyNonPrimaryIndexes(), test)
 }
 
-// FullIndexColumnIDs returns the index column IDs including any extra (implicit
-// or stored (old STORING encoding)) column IDs for non-unique indexes. It also
-// returns the direction with which each column was encoded. The returned slices
-// must not be modified.
-func FullIndexColumnIDs(idx Index) ([]descpb.ColumnID, []descpb.IndexDescriptor_Direction) {
-	if idx.IsUnique() {
-		idxDesc := idx.IndexDesc()
-		return idxDesc.KeyColumnIDs, idxDesc.KeyColumnDirections
-	}
-	// Non-unique indexes have some of the primary-key columns appended to
-	// their key.
-	n := idx.NumKeyColumns() + idx.NumKeySuffixColumns()
-	ids := make([]descpb.ColumnID, 0, n)
-	dirs := make([]descpb.IndexDescriptor_Direction, 0, n)
-	for i := 0; i < idx.NumKeyColumns(); i++ {
-		ids = append(ids, idx.GetKeyColumnID(i))
-		dirs = append(dirs, idx.GetKeyColumnDirection(i))
-	}
-	for i := 0; i < idx.NumKeySuffixColumns(); i++ {
-		// Extra columns are encoded in ascending order.
-		ids = append(ids, idx.GetKeySuffixColumnID(i))
-		dirs = append(dirs, descpb.IndexDescriptor_ASC)
-	}
-	return ids, dirs
-}
-
 // UserDefinedTypeColsHaveSameVersion returns whether one table descriptor's
 // columns with user defined type metadata have the same versions of metadata
 // as in the other descriptor. Note that this function is only valid on two

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -265,11 +265,11 @@ type columnCache struct {
 
 type indexColumnCache struct {
 	all       []catalog.Column
+	allDirs   []descpb.IndexDescriptor_Direction
 	key       []catalog.Column
 	keyDirs   []descpb.IndexDescriptor_Direction
 	stored    []catalog.Column
 	keySuffix []catalog.Column
-	composite []catalog.Column
 	full      []catalog.Column
 	fullDirs  []descpb.IndexDescriptor_Direction
 }
@@ -359,42 +359,42 @@ func newColumnCache(desc *descpb.TableDescriptor, mutations *mutationCache) *col
 
 // makeIndexColumnCache builds a cache of catalog.Column slices pertaining to
 // the columns referenced in an index.
-func makeIndexColumnCache(idx *descpb.IndexDescriptor, all []catalog.Column) indexColumnCache {
-	ic := indexColumnCache{
-		key:       filterColumnsByID(all, idx.KeyColumnIDs),
-		stored:    filterColumnsByID(all, idx.StoreColumnIDs),
-		keySuffix: filterColumnsByID(all, idx.KeySuffixColumnIDs),
-		composite: filterColumnsByID(all, idx.CompositeColumnIDs),
-	}
-	ic.all = make([]catalog.Column, 0, len(ic.key)+len(ic.keySuffix)+len(ic.stored))
-	ic.all = append(ic.all, ic.key...)
-	ic.all = append(ic.all, ic.keySuffix...)
-	ic.all = append(ic.all, ic.stored...)
-	ic.full = make([]catalog.Column, 0, len(ic.key)+len(ic.keySuffix))
-	ic.full = append(ic.full, ic.key...)
+func makeIndexColumnCache(idx *descpb.IndexDescriptor, all []catalog.Column) (ic indexColumnCache) {
+	nKey := len(idx.KeyColumnIDs)
+	nKeySuffix := len(idx.KeySuffixColumnIDs)
+	nStored := len(idx.StoreColumnIDs)
+	nAll := nKey + nKeySuffix + nStored
+	ic.allDirs = make([]descpb.IndexDescriptor_Direction, nAll)
+	// Only copy key column directions, others will remain at ASC (default value).
+	copy(ic.allDirs, idx.KeyColumnDirections)
+	ic.all = make([]catalog.Column, 0, nAll)
+	appendColumnsByID(&ic.all, all, idx.KeyColumnIDs)
+	appendColumnsByID(&ic.all, all, idx.KeySuffixColumnIDs)
+	appendColumnsByID(&ic.all, all, idx.StoreColumnIDs)
+	ic.key = ic.all[:nKey]
+	ic.keyDirs = ic.allDirs[:nKey]
+	ic.keySuffix = ic.all[nKey : nKey+nKeySuffix]
+	ic.stored = ic.all[nKey+nKeySuffix:]
+	nFull := nKey
 	if !idx.Unique {
-		ic.full = append(ic.full, ic.keySuffix...)
+		nFull = nFull + nKeySuffix
 	}
-	ic.fullDirs = make([]descpb.IndexDescriptor_Direction, len(ic.full))
-	// Only copy key column directions, key suffix directions will remain at their
-	// default value of ASC.
-	copy(ic.fullDirs, idx.KeyColumnDirections)
-	ic.keyDirs = ic.fullDirs[:len(ic.key)]
+	ic.full = ic.all[:nFull]
+	ic.fullDirs = ic.allDirs[:nFull]
 	return ic
 }
 
-// filterColumnsByID returns the subset of cols matching the desired ids.
-func filterColumnsByID(cols []catalog.Column, ids []descpb.ColumnID) []catalog.Column {
-	ret := make([]catalog.Column, len(ids))
-	for i, id := range ids {
-		for _, col := range cols {
-			if col.GetID() == id {
-				ret[i] = col
+func appendColumnsByID(slice *[]catalog.Column, source []catalog.Column, ids []descpb.ColumnID) {
+	for _, id := range ids {
+		var col catalog.Column
+		for _, candidate := range source {
+			if candidate.GetID() == id {
+				col = candidate
 				break
 			}
 		}
+		*slice = append(*slice, col)
 	}
-	return ret
 }
 
 func lazyAllocAppendColumn(slice *[]catalog.Column, col catalog.Column, cap int) {

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -266,10 +266,12 @@ type columnCache struct {
 type indexColumnCache struct {
 	all       []catalog.Column
 	key       []catalog.Column
+	keyDirs   []descpb.IndexDescriptor_Direction
 	stored    []catalog.Column
 	keySuffix []catalog.Column
 	composite []catalog.Column
 	full      []catalog.Column
+	fullDirs  []descpb.IndexDescriptor_Direction
 }
 
 // newColumnCache returns a fresh fully-populated columnCache struct for the
@@ -373,6 +375,11 @@ func makeIndexColumnCache(idx *descpb.IndexDescriptor, all []catalog.Column) ind
 	if !idx.Unique {
 		ic.full = append(ic.full, ic.keySuffix...)
 	}
+	ic.fullDirs = make([]descpb.IndexDescriptor_Direction, len(ic.full))
+	// Only copy key column directions, key suffix directions will remain at their
+	// default value of ASC.
+	copy(ic.fullDirs, idx.KeyColumnDirections)
+	ic.keyDirs = ic.fullDirs[:len(ic.key)]
 	return ic
 }
 

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -470,14 +470,6 @@ func (desc *wrapper) IndexFullColumnDirections(
 	return nil
 }
 
-// IndexCompositeColumns implements the TableDescriptor interface.
-func (desc *wrapper) IndexCompositeColumns(idx catalog.Index) []catalog.Column {
-	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
-		return ic.composite
-	}
-	return nil
-}
-
 // IndexStoredColumns implements the TableDescriptor interface.
 func (desc *wrapper) IndexStoredColumns(idx catalog.Index) []catalog.Column {
 	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -418,6 +418,67 @@ func (desc *wrapper) SystemColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().system
 }
 
+// IndexColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.all
+	}
+	return nil
+}
+
+// IndexKeyColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexKeyColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.key
+	}
+	return nil
+}
+
+// IndexKeySuffixColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexKeySuffixColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.keySuffix
+	}
+	return nil
+}
+
+// IndexFullColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexFullColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.full
+	}
+	return nil
+}
+
+// IndexCompositeColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexCompositeColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.composite
+	}
+	return nil
+}
+
+// IndexStoredColumns implements the TableDescriptor interface.
+func (desc *wrapper) IndexStoredColumns(idx catalog.Index) []catalog.Column {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.stored
+	}
+	return nil
+}
+
+// getExistingOrNewIndexColumnCache is a convenience method for Index*Columns
+// methods.
+func (desc *wrapper) getExistingOrNewIndexColumnCache(idx catalog.Index) *indexColumnCache {
+	if idx == nil {
+		return nil
+	}
+	c := desc.getExistingOrNewColumnCache()
+	if idx.Ordinal() >= len(c.index) {
+		return nil
+	}
+	return &c.index[idx.Ordinal()]
+}
+
 // FindColumnWithID implements the TableDescriptor interface.
 func (desc *wrapper) FindColumnWithID(id descpb.ColumnID) (catalog.Column, error) {
 	for _, col := range desc.AllColumns() {

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -434,6 +434,16 @@ func (desc *wrapper) IndexKeyColumns(idx catalog.Index) []catalog.Column {
 	return nil
 }
 
+// IndexKeyColumnDirections implements the TableDescriptor interface.
+func (desc *wrapper) IndexKeyColumnDirections(
+	idx catalog.Index,
+) []descpb.IndexDescriptor_Direction {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.keyDirs
+	}
+	return nil
+}
+
 // IndexKeySuffixColumns implements the TableDescriptor interface.
 func (desc *wrapper) IndexKeySuffixColumns(idx catalog.Index) []catalog.Column {
 	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
@@ -446,6 +456,16 @@ func (desc *wrapper) IndexKeySuffixColumns(idx catalog.Index) []catalog.Column {
 func (desc *wrapper) IndexFullColumns(idx catalog.Index) []catalog.Column {
 	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
 		return ic.full
+	}
+	return nil
+}
+
+// IndexFullColumnDirections implements the TableDescriptor interface.
+func (desc *wrapper) IndexFullColumnDirections(
+	idx catalog.Index,
+) []descpb.IndexDescriptor_Direction {
+	if ic := desc.getExistingOrNewIndexColumnCache(idx); ic != nil {
+		return ic.fullDirs
 	}
 	return nil
 }

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -377,10 +377,9 @@ func (rf *cFetcher) Init(
 		table.orderedColIdxMap.vals = make(descpb.ColumnIDs, 0, nCols)
 		table.orderedColIdxMap.ords = make([]int, 0, nCols)
 	}
-	colDescriptors := tableArgs.cols
-	for i := range colDescriptors {
+	for _, col := range tableArgs.cols {
 		//gcassert:bce
-		id := colDescriptors[i].GetID()
+		id := col.GetID()
 		table.orderedColIdxMap.vals = append(table.orderedColIdxMap.vals, id)
 		table.orderedColIdxMap.ords = append(table.orderedColIdxMap.ords, tableArgs.ColIdxMap.GetDefault(id))
 	}
@@ -408,7 +407,7 @@ func (rf *cFetcher) Init(
 			nonSystemColOffset = 0
 		}
 		for idx := nonSystemColOffset; idx < nCols; idx++ {
-			col := colDescriptors[idx].GetID()
+			colID := tableArgs.cols[idx].GetID()
 			// Set up extra metadata for system columns, if this is a system
 			// column.
 			//
@@ -416,7 +415,7 @@ func (rf *cFetcher) Init(
 			// but we don't want to include them in that set because the
 			// handling of system columns is separate from the standard value
 			// decoding process.
-			switch colinfo.GetSystemColumnKindFromColumnID(col) {
+			switch colinfo.GetSystemColumnKindFromColumnID(colID) {
 			case descpb.SystemColumnKind_MVCCTIMESTAMP:
 				table.timestampOutputIdx = idx
 				rf.mvccDecodeStrategy = row.MVCCDecodingRequired
@@ -430,26 +429,27 @@ func (rf *cFetcher) Init(
 
 	table.knownPrefixLength = len(rowenc.MakeIndexKeyPrefix(codec, table.desc.GetID(), table.index.GetID()))
 
-	var indexColumnIDs []descpb.ColumnID
-	indexColumnIDs, table.indexColumnDirs = catalog.FullIndexColumnIDs(table.index)
+	table.indexColumnDirs = table.desc.IndexFullColumnDirections(table.index)
+	fullColumns := table.desc.IndexFullColumns(table.index)
 
-	compositeColumnIDs := util.MakeFastIntSet()
-	for i := 0; i < table.index.NumCompositeColumns(); i++ {
-		id := table.index.GetCompositeColumnID(i)
-		compositeColumnIDs.Add(int(id))
-	}
+	compositeColumnIDs := table.index.CollectCompositeColumnIDs()
 
-	nIndexCols := len(indexColumnIDs)
+	nIndexCols := len(fullColumns)
 	if cap(table.indexColOrdinals) >= nIndexCols {
 		table.indexColOrdinals = table.indexColOrdinals[:nIndexCols]
 	} else {
 		table.indexColOrdinals = make([]int, nIndexCols)
 	}
 	indexColOrdinals := table.indexColOrdinals
-	_ = indexColOrdinals[len(indexColumnIDs)-1]
+	_ = indexColOrdinals[len(fullColumns)-1]
 	needToDecodeDecimalKey := false
-	for i, id := range indexColumnIDs {
-		colIdx, ok := tableArgs.ColIdxMap.Get(id)
+	for i, col := range fullColumns {
+		if col == nil {
+			//gcassert:bce
+			indexColOrdinals[i] = -1
+			continue
+		}
+		colIdx, ok := tableArgs.ColIdxMap.Get(col.GetID())
 		if ok {
 			//gcassert:bce
 			indexColOrdinals[i] = colIdx
@@ -457,7 +457,7 @@ func (rf *cFetcher) Init(
 			needToDecodeDecimalKey = needToDecodeDecimalKey || tableArgs.typs[colIdx].Family() == types.DecimalFamily
 			// A composite column might also have a value encoding which must be
 			// decoded. Others can be removed from neededValueColsByIdx.
-			if compositeColumnIDs.Contains(int(id)) {
+			if compositeColumnIDs.Contains(col.GetID()) {
 				table.compositeIndexColOrdinals.Add(colIdx)
 			} else {
 				table.neededValueColsByIdx.Remove(colIdx)
@@ -495,7 +495,7 @@ func (rf *cFetcher) Init(
 			id := table.index.GetKeySuffixColumnID(i)
 			colIdx, ok := tableArgs.ColIdxMap.Get(id)
 			if ok {
-				if compositeColumnIDs.Contains(int(id)) {
+				if compositeColumnIDs.Contains(id) {
 					table.compositeIndexColOrdinals.Add(colIdx)
 					table.neededValueColsByIdx.Remove(colIdx)
 				}
@@ -504,18 +504,14 @@ func (rf *cFetcher) Init(
 	}
 
 	// Prepare our index key vals slice.
-	table.keyValTypes = colinfo.GetColumnTypesFromColDescs(
-		colDescriptors, indexColumnIDs, table.keyValTypes,
-	)
+	table.keyValTypes = getColumnTypesFromCols(fullColumns, table.keyValTypes)
 	if table.index.NumKeySuffixColumns() > 0 {
 		// Unique secondary indexes have a value that is the
 		// primary index key.
 		// Primary indexes only contain ascendingly-encoded
 		// values. If this ever changes, we'll probably have to
 		// figure out the directions here too.
-		table.extraTypes = colinfo.GetColumnTypesFromColDescs(
-			colDescriptors, table.index.IndexDesc().KeySuffixColumnIDs, table.extraTypes,
-		)
+		table.extraTypes = getColumnTypesFromCols(table.desc.IndexKeySuffixColumns(table.index), table.extraTypes)
 		nExtraColumns := table.index.NumKeySuffixColumns()
 		if cap(table.extraValColOrdinals) >= nExtraColumns {
 			table.extraValColOrdinals = table.extraValColOrdinals[:nExtraColumns]
@@ -566,6 +562,21 @@ func (rf *cFetcher) Init(
 	rf.accountingHelper.Init(allocator, rf.table.typs)
 
 	return nil
+}
+
+func getColumnTypesFromCols(cols []catalog.Column, outTypes []*types.T) []*types.T {
+	if cap(outTypes) < len(cols) {
+		outTypes = make([]*types.T, len(cols))
+	} else {
+		outTypes = outTypes[:len(cols)]
+	}
+	for i, col := range cols {
+		if col == nil {
+			continue
+		}
+		outTypes[i] = col.GetType()
+	}
+	return outTypes
 }
 
 // StartScan initializes and starts the key-value scan. Can be used multiple

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -327,7 +327,7 @@ DROP INDEX t_secondary CASCADE;
 ALTER TABLE t DROP COLUMN b;
 INSERT INTO t SELECT a + 1 FROM t;
 
-statement error pgcode 23505 duplicate key value got decoding error: column-id "2" does not exist
+statement error pgcode 23505 duplicate key value got decoding error: column \"b\" \(2\) is not public
 UPSERT INTO t SELECT a + 1 FROM t;
 
 statement ok

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -361,28 +361,33 @@ func (rf *Fetcher) Init(
 		rowenc.MakeIndexKeyPrefix(codec, table.desc.GetID(), table.index.GetID()),
 	)
 
-	var indexColumnIDs []descpb.ColumnID
-	indexColumnIDs, table.indexColumnDirs = catalog.FullIndexColumnIDs(table.index)
+	table.indexColumnDirs = table.desc.IndexFullColumnDirections(table.index)
+	fullColumns := table.desc.IndexFullColumns(table.index)
 
 	table.neededValueColsByIdx = tableArgs.ValNeededForCol.Copy()
 	neededIndexCols := 0
-	nIndexCols := len(indexColumnIDs)
+	nIndexCols := len(fullColumns)
 	if cap(table.indexColIdx) >= nIndexCols {
 		table.indexColIdx = table.indexColIdx[:nIndexCols]
 	} else {
 		table.indexColIdx = make([]int, nIndexCols)
 	}
-	for i, id := range indexColumnIDs {
+	for i, col := range fullColumns {
+		if col == nil {
+			table.indexColIdx[i] = -1
+			continue
+		}
+		id := col.GetID()
 		colIdx, ok := table.colIdxMap.Get(id)
 		if ok {
 			table.indexColIdx[i] = colIdx
-			if table.neededCols.Contains(int(id)) {
+			if table.neededCols.Contains(int(col.GetID())) {
 				neededIndexCols++
 				table.neededValueColsByIdx.Remove(colIdx)
 			}
 		} else {
 			table.indexColIdx[i] = -1
-			if table.neededCols.Contains(int(id)) {
+			if table.neededCols.Contains(int(col.GetID())) {
 				return errors.AssertionFailedf("needed column %d not in colIdxMap", id)
 			}
 		}
@@ -421,7 +426,7 @@ func (rf *Fetcher) Init(
 	}
 
 	// Prepare our index key vals slice.
-	table.keyValTypes, err = colinfo.GetColumnTypes(table.desc, indexColumnIDs, table.keyValTypes)
+	table.keyValTypes, err = getColumnTypes(fullColumns, table.keyValTypes)
 	if err != nil {
 		return err
 	}
@@ -437,8 +442,9 @@ func (rf *Fetcher) Init(
 		// Primary indexes only contain ascendingly-encoded
 		// values. If this ever changes, we'll probably have to
 		// figure out the directions here too.
-		table.extraTypes, err = colinfo.GetColumnTypes(table.desc, table.index.IndexDesc().KeySuffixColumnIDs, table.extraTypes)
-		nExtraColumns := table.index.NumKeySuffixColumns()
+		keySuffixCols := table.desc.IndexKeySuffixColumns(table.index)
+		table.extraTypes, err = getColumnTypes(keySuffixCols, table.extraTypes)
+		nExtraColumns := len(keySuffixCols)
 		if cap(table.extraVals) >= nExtraColumns {
 			table.extraVals = table.extraVals[:nExtraColumns]
 		} else {
@@ -451,6 +457,24 @@ func (rf *Fetcher) Init(
 
 	rf.numKeysPerRow, err = table.desc.KeysPerRow(table.index.GetID())
 	return err
+}
+
+func getColumnTypes(columns []catalog.Column, outTypes []*types.T) ([]*types.T, error) {
+	if cap(outTypes) < len(columns) {
+		outTypes = make([]*types.T, len(columns))
+	} else {
+		outTypes = outTypes[:len(columns)]
+	}
+	for i, col := range columns {
+		if col == nil {
+			return nil, fmt.Errorf("column does not exist")
+		}
+		if !col.Public() {
+			return nil, fmt.Errorf("column %q (%d) is not public", col.GetName(), col.GetID())
+		}
+		outTypes[i] = col.GetType()
+	}
+	return outTypes, nil
 }
 
 // GetTable returns the table that this Fetcher was initialized with.

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -70,15 +70,14 @@ func MakeBuilder(
 		neededFamilies: nil,
 	}
 
-	var columnIDs descpb.ColumnIDs
-	columnIDs, s.indexColDirs = catalog.FullIndexColumnIDs(index)
-	if cap(s.indexColTypes) < len(columnIDs) {
-		s.indexColTypes = make([]*types.T, len(columnIDs))
+	s.indexColDirs = s.table.IndexFullColumnDirections(index)
+	columns := s.table.IndexFullColumns(index)
+	if cap(s.indexColTypes) < len(columns) {
+		s.indexColTypes = make([]*types.T, len(columns))
 	} else {
-		s.indexColTypes = s.indexColTypes[:len(columnIDs)]
+		s.indexColTypes = s.indexColTypes[:len(columns)]
 	}
-	for i, colID := range columnIDs {
-		col, _ := table.FindColumnWithID(colID)
+	for i, col := range columns {
 		// TODO (rohany): do I need to look at table columns with mutations here as well?
 		if col != nil && col.Public() {
 			s.indexColTypes[i] = col.GetType()


### PR DESCRIPTION
    catalog: remove FullIndexColumnIDs
    
    Calls to this function can now be replaced with recently-added
    IndexFullColumns and IndexFullColumnDirections method calls on the table
    descriptor.
    
    Release note: None


    catalog: add Index*ColumnDirections methods to table descriptor
    
    This complements the previous commit which added Index*Column methods to
    catalog.TableDescriptor.
    
    Release note: None


    catalog: add Index*Columns methods to table descriptor
    
    These methods return the columns referenced in indexes as
    []catalog.Column slices.
    
    Release note: None
