### PR TITLE
cdc: Allow webhook sink to provide client certificates to the remote webhook server

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
+++ b/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
@@ -52,6 +52,23 @@ func StartMockWebhookSink(certificate *tls.Certificate) (*MockWebhookSink, error
 	return s, nil
 }
 
+// StartMockWebhookSinkSecure creates and starts a mock webhook sink server that
+// requires clients to provide client certificates for authentication
+func StartMockWebhookSinkSecure(certificate *tls.Certificate) (*MockWebhookSink, error) {
+	s := makeMockWebhookSink()
+	if certificate == nil {
+		return nil, errors.Errorf("Must pass a CA cert when creating a mock webhook sink.")
+	}
+
+	s.server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{*certificate},
+		ClientAuth:   tls.RequireAnyClientCert,
+	}
+
+	s.server.StartTLS()
+	return s, nil
+}
+
 // StartMockWebhookSinkWithBasicAuth creates and starts a mock webhook sink for
 // tests with basic username/password auth.
 func StartMockWebhookSinkWithBasicAuth(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3332,6 +3332,16 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, webhook_sink_config='{"Retry":{"Max":"inf"}}'`,
 		`webhook-https://fake-host`,
 	)
+	sqlDB.ExpectErr(
+		t, `client_cert requires client_key to be set`,
+		`CREATE CHANGEFEED FOR foo INTO $1`,
+		`webhook-https://fake-host?client_cert=Zm9v`,
+	)
+	sqlDB.ExpectErr(
+		t, `client_key requires client_cert to be set`,
+		`CREATE CHANGEFEED FOR foo INTO $1`,
+		`webhook-https://fake-host?client_key=Zm9v`,
+	)
 
 	// Sanity check on_error option
 	sqlDB.ExpectErr(

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -323,6 +323,8 @@ func makeWebhookSink(
 	params := sinkURLParsed.Query()
 	params.Del(changefeedbase.SinkParamSkipTLSVerify)
 	params.Del(changefeedbase.SinkParamCACert)
+	params.Del(changefeedbase.SinkParamClientCert)
+	params.Del(changefeedbase.SinkParamClientKey)
 	sinkURLParsed.RawQuery = params.Encode()
 	sink.url = sinkURL{URL: sinkURLParsed}
 
@@ -354,6 +356,12 @@ func makeWebhookClient(u sinkURL, timeout time.Duration) (*httputil.Client, erro
 	if err := u.decodeBase64(changefeedbase.SinkParamCACert, &dialConfig.caCert); err != nil {
 		return nil, err
 	}
+	if err := u.decodeBase64(changefeedbase.SinkParamClientCert, &dialConfig.clientCert); err != nil {
+		return nil, err
+	}
+	if err := u.decodeBase64(changefeedbase.SinkParamClientKey, &dialConfig.clientKey); err != nil {
+		return nil, err
+	}
 
 	transport.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: dialConfig.tlsSkipVerify,
@@ -371,6 +379,20 @@ func makeWebhookClient(u sinkURL, timeout time.Duration) (*httputil.Client, erro
 			return nil, errors.Errorf("failed to parse certificate data:%s", string(dialConfig.caCert))
 		}
 		transport.TLSClientConfig.RootCAs = caCertPool
+	}
+
+	if dialConfig.clientCert != nil && dialConfig.clientKey == nil {
+		return nil, errors.Errorf(`%s requires %s to be set`, changefeedbase.SinkParamClientCert, changefeedbase.SinkParamClientKey)
+	} else if dialConfig.clientKey != nil && dialConfig.clientCert == nil {
+		return nil, errors.Errorf(`%s requires %s to be set`, changefeedbase.SinkParamClientKey, changefeedbase.SinkParamClientCert)
+	}
+
+	if dialConfig.clientCert != nil && dialConfig.clientKey != nil {
+		cert, err := tls.X509KeyPair(dialConfig.clientCert, dialConfig.clientKey)
+		if err != nil {
+			return nil, errors.Wrap(err, `invalid client certificate data provided`)
+		}
+		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	return client, nil


### PR DESCRIPTION
# Summary
Allow the webhook sink to provide client certificates to the remote webhook server.

Resolves #74230

# Testing

1. Install `certstrap` to help with creating the CA and other required certificates
```console
$ brew install certstrap
``` 
2. Create a CA
```console
$ certstrap init --common-name "ExampleCA"
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Created out/ExampleCA.key
Created out/ExampleCA.crt
Created out/ExampleCA.crl
```
3. Create the certificate for the server
```console
$ certstrap request-cert --domain  "localhost"
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Created out/localhost.key
Created out/localhost.csr
```
4. Create the certificate for the client
```console
$ certstrap request-cert --domain  "client"
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Created out/client.key
Created out/client.csr
```
5. Sign the certificate for the server
```console
$ certstrap sign localhost --CA ExampleCA
Created out/localhost.crt from out/localhost.csr signed by out/ExampleCA.key
```
6. Sign the certificate for the client
```console
$ certstrap sign client --CA ExampleCA 
Created out/client.crt from out/client.csr signed by out/ExampleCA.key
```
7. Pull the server code in this [file](https://github.com/youngkin/gohttps/blob/master/advserver/server.go), and then run the following in your console
```console
$ go build server.go
$ ./server -host "localhost" -srvcert "<path-to-server-cert>" -cacert "<path-to-ca-cert>" \
-srvkey "<path-to-server-key>" -port 3000 -certopt 4
```
8. Follow the steps to creating a webhook sink [here](https://www.cockroachlabs.com/docs/stable/stream-data-out-of-cockroachdb-using-changefeeds.html#create-a-changefeed-connected-to-a-webhook-sink), but use the following SQL command to create the changefeed
```sql
CREATE CHANGEFEED
    FOR TABLE movr.vehicles
    INTO 'webhook-https://localhost:3000?insecure_tls_skip_verify=true&client_cert=<client-cert>&client_key=<client-key>'
    WITH updated;
```
**Note: The client_cert and client_key must all be passed directly as base64-encoded values**

Release notes (enterprise change): Client certificates may now be provided for the webhook changefeed sink.