### PR TITLE
spanconfig: make the SQLTranslator translation txn scoped

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/testutils",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -114,6 +115,7 @@ func TestDataDriven(t *testing.T) {
 				// Parse the args to get the object ID we're looking to
 				// translate.
 				var objID descpb.ID
+				descType := catalog.Any
 				switch {
 				case d.HasArg("named-zone"):
 					var zone string
@@ -132,15 +134,21 @@ func TestDataDriven(t *testing.T) {
 						var tbName string
 						d.ScanArgs(t, "table", &tbName)
 						objID = tenant.LookupTableByName(ctx, dbName, tbName).GetID()
+						descType = catalog.Table
 					} else {
 						objID = tenant.LookupDatabaseByName(ctx, dbName).GetID()
+						descType = catalog.Database
 					}
 				default:
 					d.Fatalf(t, "insufficient/improper args (%v) provided to translate", d.CmdArgs)
 				}
 
 				sqlTranslator := tenant.SpanConfigSQLTranslator().(spanconfig.SQLTranslator)
-				entries, _, err := sqlTranslator.Translate(ctx, descpb.IDs{objID})
+				descUpdates := []spanconfig.DescriptorUpdate{{
+					ID:             objID,
+					DescriptorType: descType,
+				}}
+				entries, err := sqlTranslator.IncrementalTranslate(ctx, descUpdates)
 				require.NoError(t, err)
 				sort.Slice(entries, func(i, j int) bool {
 					return entries[i].Span.Key.Compare(entries[j].Span.Key) < 0
@@ -155,7 +163,7 @@ func TestDataDriven(t *testing.T) {
 
 			case "full-translate":
 				sqlTranslator := tenant.SpanConfigSQLTranslator().(spanconfig.SQLTranslator)
-				entries, _, err := spanconfig.FullTranslate(ctx, sqlTranslator)
+				entries, _, err := sqlTranslator.FullTranslate(ctx)
 				require.NoError(t, err)
 
 				sort.Slice(entries, func(i, j int) bool {

--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
         "//pkg/sql/catalog",


### PR DESCRIPTION
This change modifies the SQLTranslator interface to
split the current Translate method into a Full and
Incremental translate method. It also pulls out the
txn used in the underlying translation to be passed in
by the caller instead of being synthesized during the
translation.

The motivation for this change is the ongoing work to make
protected timestamps supported in secondary tenants. We
anticipate having to do slightly different setup in full
and incremental reconciliation, prior to the internal translation.
This setup will need to be done in the same txn as the translation
as it will involve reading from the system.pts_records table
and so we would need a consistent snapshot of the table as of
the time we are performing the translation.

Informs: #73727

Release note: None