### PR TITLE
dev: enumerate explicit list of all generated `.go` files when hoisting

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -260,9 +260,7 @@ nogo(
 
 go_path(
     name = "go_path",
-    # TODO(ricky): change back to 'link' when https://github.com/bazelbuild/rules_go/issues/3041
-    # is resolved.
-    mode = "copy",
+    mode = "link",
     deps = [
         "//pkg/cmd/cockroach-short",
         "//pkg/cmd/roachprod",

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=2
+DEV_VERSION=3
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -44,7 +44,7 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg
 rm pkg/file_to_delete.go
-find /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach -name *.go
+bazel aquery --output=jsonproto //:go_path
 cat go/src/github.com/cockroachdb/cockroach/build/bazelutil/checked_in_genfiles.txt
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated-gen.go go/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated.go

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -26,7 +26,7 @@ bazel info workspace --color=no
 bazel info bazel-bin --color=no
 git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg
 rm pkg/file_to_delete.go
-find /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach -name *.go
+bazel aquery --output=jsonproto //:go_path
 cat go/src/github.com/cockroachdb/cockroach/build/bazelutil/checked_in_genfiles.txt
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go
 cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated-gen.go go/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated.go

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -112,13 +112,109 @@ git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg
 rm pkg/file_to_delete.go
 ----
 
-find /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach -name *.go
+bazel aquery --output=jsonproto //:go_path
 ----
 ----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated-gen.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/expr-gen.og.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator-gen.og.go
+{
+  "artifacts": [{
+    "id": 1,
+    "pathFragmentId": 1
+  }, {
+    "id": 2,
+    "pathFragmentId": 13
+  }, {
+    "id": 3,
+    "pathFragmentId": 15
+  }, {
+    "id": 4,
+    "pathFragmentId": 20
+  }],
+  "configuration": [{
+    "id": 1,
+    "mnemonic": "darwin-fastbuild",
+    "platformName": "darwin"
+  }],
+  "pathFragments": [{
+    "id": 1,
+    "label": "storage_services.pb.go",
+    "parentId": 2
+  }, {
+    "id": 2,
+    "label": "kvserver",
+    "parentId": 3
+  }, {
+    "id": 3,
+    "label": "kv",
+    "parentId": 4
+  }, {
+    "id": 4,
+    "label": "pkg",
+    "parentId": 5
+  }, {
+    "id": 5,
+    "label": "cockroach",
+    "parentId": 6
+  }, {
+    "id": 6,
+    "label": "cockroachdb",
+    "parentId": 7
+  }, {
+    "id": 7,
+    "label": "github.com",
+    "parentId": 8
+  }, {
+    "id": 8,
+    "label": "src",
+    "parentId": 9
+  }, {
+    "id": 9,
+    "label": "go_path",
+    "parentId": 10
+  }, {
+    "id": 10,
+    "label": "bin",
+    "parentId": 11
+  }, {
+    "id": 11,
+    "label": "darwin-fastbuild",
+    "parentId": 12
+  }, {
+    "id": 12,
+    "label": "bazel-out"
+  }, {
+    "id": 13,
+    "label": "batch_generated-gen.go",
+    "parentId": 14
+  }, {
+    "id": 14,
+    "label": "roachpb",
+    "parentId": 4
+  }, {
+    "id": 15,
+    "label": "expr-gen.og.go",
+    "parentId": 16
+  }, {
+    "id": 16,
+    "label": "lang",
+    "parentId": 17
+  }, {
+    "id": 17,
+    "label": "optgen",
+    "parentId": 18
+  }, {
+    "id": 18,
+    "label": "opt",
+    "parentId": 19
+  }, {
+    "id": 19,
+    "label": "sql",
+    "parentId": 4
+  }, {
+    "id": 20,
+    "label": "operator-gen.og.go",
+    "parentId": 16
+  }]
+}
 ----
 ----
 

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -128,13 +128,109 @@ git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg
 rm pkg/file_to_delete.go
 ----
 
-find /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach -name *.go
+bazel aquery --output=jsonproto //:go_path
 ----
 ----
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/storage_services.pb.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/roachpb/batch_generated-gen.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/expr-gen.og.go
-/private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/go_path/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang/operator-gen.og.go
+{
+  "artifacts": [{
+    "id": 1,
+    "pathFragmentId": 1
+  }, {
+    "id": 2,
+    "pathFragmentId": 13
+  }, {
+    "id": 3,
+    "pathFragmentId": 15
+  }, {
+    "id": 4,
+    "pathFragmentId": 20
+  }],
+  "configuration": [{
+    "id": 1,
+    "mnemonic": "darwin-fastbuild",
+    "platformName": "darwin"
+  }],
+  "pathFragments": [{
+    "id": 1,
+    "label": "storage_services.pb.go",
+    "parentId": 2
+  }, {
+    "id": 2,
+    "label": "kvserver",
+    "parentId": 3
+  }, {
+    "id": 3,
+    "label": "kv",
+    "parentId": 4
+  }, {
+    "id": 4,
+    "label": "pkg",
+    "parentId": 5
+  }, {
+    "id": 5,
+    "label": "cockroach",
+    "parentId": 6
+  }, {
+    "id": 6,
+    "label": "cockroachdb",
+    "parentId": 7
+  }, {
+    "id": 7,
+    "label": "github.com",
+    "parentId": 8
+  }, {
+    "id": 8,
+    "label": "src",
+    "parentId": 9
+  }, {
+    "id": 9,
+    "label": "go_path",
+    "parentId": 10
+  }, {
+    "id": 10,
+    "label": "bin",
+    "parentId": 11
+  }, {
+    "id": 11,
+    "label": "darwin-fastbuild",
+    "parentId": 12
+  }, {
+    "id": 12,
+    "label": "bazel-out"
+  }, {
+    "id": 13,
+    "label": "batch_generated-gen.go",
+    "parentId": 14
+  }, {
+    "id": 14,
+    "label": "roachpb",
+    "parentId": 4
+  }, {
+    "id": 15,
+    "label": "expr-gen.og.go",
+    "parentId": 16
+  }, {
+    "id": 16,
+    "label": "lang",
+    "parentId": 17
+  }, {
+    "id": 17,
+    "label": "optgen",
+    "parentId": 18
+  }, {
+    "id": 18,
+    "label": "opt",
+    "parentId": 19
+  }, {
+    "id": 19,
+    "label": "sql",
+    "parentId": 4
+  }, {
+    "id": 20,
+    "label": "operator-gen.og.go",
+    "parentId": 16
+  }]
+}
 ----
 ----
 


### PR DESCRIPTION
We should be able to `find _bazel/bin/go_path -type f -name '*.go'` and
list the generated files that way, but bazelbuild/rules_go#3041 is in
the way and I can't figure out how to resolve it. Instead we have to do
things the hard way: run `bazel aquery` and parse out the paths to all
the generated files. In this way we avoid accidentally hoisting out
stale symlinks from a previous build. If bazelbuild/rules_go#3041 is
resolved upstream then this change can be reverted.

Release note: None