### PR TITLE
sql: fix enum hydration in distsql expression evaluation

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -13,6 +13,7 @@ package execinfrapb
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -181,6 +182,13 @@ func (eh *ExprHelper) Init(
 		// Bind IndexedVars to our eh.Vars.
 		eh.Vars.Rebind(eh.Expr)
 		return nil
+	}
+	distResolver, ok := semaCtx.TypeResolver.(*descs.DistSQLTypeResolver)
+	if ok {
+		err := distResolver.HydrateTypeSlice(evalCtx.Context, types)
+		if err != nil {
+			return err
+		}
 	}
 	var err error
 	eh.Expr, err = DeserializeExpr(expr.Expr, semaCtx, evalCtx, &eh.Vars)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -1,4 +1,4 @@
-# LogicTest: 5node-default-configs
+# LogicTest: 5node-default-configs !5node-metadata
 
 # Regression test for nested tuple enum hydration (#74189)
 statement ok
@@ -31,3 +31,61 @@ WITH w (col)
 ----
 hello     ("(hello,0)",0)
 
+# Regression test for nested tuple enum hydration (#74189)
+statement ok
+CREATE TABLE t1 (x INT PRIMARY KEY, y greeting); INSERT INTO t1(x, y) VALUES (0,'hello');
+CREATE TABLE t2 (x INT PRIMARY KEY, y greeting); INSERT INTO t2(x, y) VALUES (0,'hello');
+
+# split into ranges
+
+statement ok
+ALTER TABLE t1 SPLIT AT VALUES(0),(10),(20);
+ALTER TABLE t2 SPLIT AT VALUES(0),(10),(20);
+ALTER TABLE t1 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 10), (ARRAY[3], 20);
+ALTER TABLE t2 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 10), (ARRAY[3], 20);
+
+# Tickle stats to force lookup join
+statement ok
+ALTER TABLE t1 INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 100
+  }
+]'
+
+statement ok
+ALTER TABLE t2 INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  }
+]'
+
+query T nodeidx=1
+EXPLAIN (VEC)
+SELECT x from t1 WHERE EXISTS (SELECT x FROM t2 WHERE t1.x=t2.x AND t2.y='hello')
+----
+│
+├ Node 1
+│ └ *colrpc.Outbox
+│   └ *rowexec.joinReader
+│     └ *colfetcher.ColBatchScan
+├ Node 2
+│ └ *colexec.ParallelUnorderedSynchronizer
+│   ├ *colrpc.Inbox
+│   ├ *rowexec.joinReader
+│   │ └ *colfetcher.ColBatchScan
+│   └ *colrpc.Inbox
+└ Node 3
+  └ *colrpc.Outbox
+    └ *rowexec.joinReader
+      └ *colfetcher.ColBatchScan
+
+query I nodeidx=1
+SELECT x from t1 WHERE EXISTS (SELECT x FROM t2 WHERE t1.x=t2.x AND t2.y='hello')
+----
+0


### PR DESCRIPTION
Fixes: #74442

Previously in some circumstances we could fail to hydrate enum types
used in join predicate expressions and possibly other situations. Now
types used in ExprHelper are always hydrated during Init phase when a
distsql type resolver is being used. Also add a test case for the lookup
semi join repro case.

Release note (bug fix): Fix panic's possible in some distributed queries
using enum's in join predicates.