### PR TITLE
backupccl: allow user to compress parquet file from EXPORT PARQUET

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -276,16 +276,19 @@ func TestExportOrder(t *testing.T) {
 }
 
 // parquetTest provides information to validate a test of EXPORT PARQUET. All
-// fields below name and stmt validate some aspect of the exported parquet file.
+// fields below the stmt validate some aspect of the exported parquet file.
 // If a validation field is empty, then that field will not be used in the test.
 type parquetTest struct {
-	// name is the name of the test.
-	name string
+	// filePrefix provides the parquet file name in front of the parquetExportFilePattern
+	filePrefix string
+
+	// fileSuffix provides the compression type, if any, of the parquet file
+	fileSuffix string
 
 	// prep contains sql commands that will execute before the stmt.
 	prep []string
 
-	// stmt contains the EXPORT PARQUET statement.
+	// stmt contains the EXPORT PARQUET sql statement to test
 	stmt string
 
 	// colNames provides the expected column names for the parquet file.
@@ -427,7 +430,7 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 
 	tests := []parquetTest{
 		{
-			name: "basic",
+			filePrefix: "basic",
 			stmt: `EXPORT INTO PARQUET 'nodelocal://0/basic' FROM SELECT *
 							FROM foo WHERE y IS NOT NULL ORDER BY y ASC LIMIT 2 `,
 			colNames: []string{"i", "x", "y", "z", "a"},
@@ -435,7 +438,7 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 				{int64(2), "Bob", int64(2), 24.1, false}},
 		},
 		{
-			name: "null_vals",
+			filePrefix: "null_vals",
 			stmt: `EXPORT INTO PARQUET 'nodelocal://0/null_vals' FROM SELECT *
 							FROM foo ORDER BY x ASC LIMIT 2`,
 			vals: [][]interface{}{
@@ -443,13 +446,13 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 				{int64(4), "Alex", int64(3), 14.3, nil}},
 		},
 		{
-			name: "colname",
+			filePrefix: "colname",
 			stmt: `EXPORT INTO PARQUET 'nodelocal://0/colname' FROM SELECT avg(z), min(y) AS baz
 							FROM foo`,
 			colNames: []string{"avg", "baz"},
 		},
 		{
-			name: "nullable",
+			filePrefix: "nullable",
 			stmt: `EXPORT INTO PARQUET 'nodelocal://0/nullable' FROM SELECT y,z,x
 							FROM foo`,
 			colFieldRepType: []parquet.FieldRepetitionType{
@@ -465,7 +468,7 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 			// I already verified that the vendor's parquet writer can write arrays
 			// with null values just fine, so EXPORT PARQUET is bug free; however this
 			// roundtrip test would fail.
-			name: "arrays",
+			filePrefix: "arrays",
 			prep: []string{"CREATE TABLE atable (i INT PRIMARY KEY, x INT[])",
 				"INSERT INTO atable VALUES (1, ARRAY[1,2]), (2, ARRAY[2]), (3,ARRAY[1,13,5]),(4, NULL),(5, ARRAY[])"},
 			stmt:     `EXPORT INTO PARQUET 'nodelocal://0/arrays' FROM SELECT * FROM atable`,
@@ -478,25 +481,41 @@ false),(3, 'Carl', 1, 34.214,true),(4, 'Alex', 3, 14.3, NULL), (5, 'Bobby', 2, 3
 				{int64(5), []interface{}{}},
 			},
 		},
+		{
+			filePrefix: "compress_gzip",
+			fileSuffix: ".gz",
+			stmt: `EXPORT INTO PARQUET 'nodelocal://0/compress_gzip' WITH compression = gzip
+							FROM SELECT * FROM foo`,
+		},
+		{
+			filePrefix: "compress_snappy",
+			fileSuffix: ".snappy",
+			stmt: `EXPORT INTO PARQUET 'nodelocal://0/compress_snappy' WITH compression = snappy
+							FROM SELECT * FROM foo `,
+		},
+		{
+			filePrefix: "uncompress",
+			stmt: `EXPORT INTO PARQUET 'nodelocal://0/uncompress'
+							FROM SELECT * FROM foo `,
+		},
 	}
 
 	for _, test := range tests {
-		t.Logf("Test %s", test.name)
+		t.Logf("Test %s", test.filePrefix)
 		if test.prep != nil {
 			for _, cmd := range test.prep {
 				sqlDB.Exec(t, cmd)
 			}
 		}
 		sqlDB.Exec(t, test.stmt)
-		paths, err := filepath.Glob(filepath.Join(dir, test.name,
-			parquetExportFilePattern))
+
+		paths, err := filepath.Glob(filepath.Join(dir, test.filePrefix, parquetExportFilePattern+test.fileSuffix))
 		require.NoError(t, err)
 
 		require.Equal(t, 1, len(paths))
 
 		err = validateParquetFile(t, paths[0], test)
 		require.NoError(t, err)
-
 	}
 }
 

--- a/pkg/roachpb/io-formats.proto
+++ b/pkg/roachpb/io-formats.proto
@@ -24,6 +24,7 @@ message IOFileFormat {
     PgCopy = 4;
     PgDump = 5;
     Avro = 6;
+    Parquet = 7;
   }
 
   optional FileFormat format = 1 [(gogoproto.nullable) = false];
@@ -33,12 +34,14 @@ message IOFileFormat {
   optional MysqldumpOptions mysql_dump = 9 [(gogoproto.nullable) = false];
   optional PgDumpOptions pg_dump = 6 [(gogoproto.nullable) = false];
   optional AvroOptions avro = 8 [(gogoproto.nullable) = false];
+  optional ParquetOptions parquet = 10 [(gogoproto.nullable) = false];
 
   enum Compression {
     Auto = 0;
     None = 1;
     Gzip = 2;
     Bzip = 3;
+    Snappy = 4;
   }
   optional Compression compression = 5 [(gogoproto.nullable) = false];
   // If true, don't abort on failures but instead save the offending row and keep on.
@@ -62,9 +65,6 @@ message CSVOptions {
   // Indicates the number of rows to import per CSV file.
   // Must be a non-zero positive number. 
   optional int64 row_limit = 6 [(gogoproto.nullable) = false];
-}
-
-message ParquetOptions {
 }
 
 // MySQLOutfileOptions describe the format of mysql's outfile.
@@ -152,4 +152,9 @@ message AvroOptions {
   optional int32 max_record_size = 4 [(gogoproto.nullable) = false];
   optional int32 record_separator = 5 [(gogoproto.nullable) = false];
   optional int64 row_limit = 6 [(gogoproto.nullable) = false];
+}
+
+message ParquetOptions {
+  // col_nullability specifies which columns allow null values in the exported parquet file.
+  repeated bool col_nullability = 1 ;
 }

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -244,8 +244,7 @@ var (
 	errReadImportWrap                 = errors.New("core.ReadImport is not supported")
 	errBackupDataWrap                 = errors.New("core.BackupData is not supported")
 	errBackfillerWrap                 = errors.New("core.Backfiller is not supported (not an execinfra.RowSource)")
-	errCSVWriterWrap                  = errors.New("core.CSVWriter is not supported (not an execinfra.RowSource)")
-	errParquetWriterWrap              = errors.New("core.ParquetWriter is not supported (not an execinfra.RowSource)")
+	errExporterWrap                   = errors.New("core.Exporter is not supported (not an execinfra.RowSource)")
 	errSamplerWrap                    = errors.New("core.Sampler is not supported (not an execinfra.RowSource)")
 	errSampleAggregatorWrap           = errors.New("core.SampleAggregator is not supported (not an execinfra.RowSource)")
 	errExperimentalWrappingProhibited = errors.New("wrapping for non-JoinReader and non-LocalPlanNode cores is prohibited in vectorize=experimental_always")
@@ -271,10 +270,8 @@ func canWrap(mode sessiondatapb.VectorizeExecMode, spec *execinfrapb.ProcessorSp
 		return errBackfillerWrap
 	case spec.Core.ReadImport != nil:
 		return errReadImportWrap
-	case spec.Core.CSVWriter != nil:
-		return errCSVWriterWrap
-	case spec.Core.ParquetWriter != nil:
-		return errParquetWriterWrap
+	case spec.Core.Exporter != nil:
+		return errExporterWrap
 	case spec.Core.Sampler != nil:
 		return errSamplerWrap
 	case spec.Core.SampleAggregator != nil:

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3845,31 +3845,14 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 	}
 
 	var core execinfrapb.ProcessorCoreUnion
-
-	if n.csvOpts != nil {
-		core.CSVWriter = &execinfrapb.CSVWriterSpec{
-			Destination:      n.destination,
-			NamePattern:      n.fileNamePattern,
-			Options:          *n.csvOpts,
-			ChunkRows:        int64(n.chunkRows),
-			ChunkSize:        n.chunkSize,
-			CompressionCodec: n.fileCompression,
-			UserProto:        planCtx.planner.User().EncodeProto(),
-		}
-	} else if n.parquetOpts != nil {
-		core.ParquetWriter = &execinfrapb.ParquetWriterSpec{
-			Destination:    n.destination,
-			NamePattern:    n.fileNamePattern,
-			Options:        *n.parquetOpts,
-			ChunkRows:      int64(n.chunkRows),
-			ChunkSize:      n.chunkSize,
-			UserProto:      planCtx.planner.User().EncodeProto(),
-			ColNames:       n.colNames,
-			ColNullability: n.colNullability,
-		}
-	} else {
-		return nil, errors.AssertionFailedf("parquetOpts and csvOpts are both empty. " +
-			"One must be not nil")
+	core.Exporter = &execinfrapb.ExportSpec{
+		Destination: n.destination,
+		NamePattern: n.fileNamePattern,
+		Format:      n.format,
+		ChunkRows:   int64(n.chunkRows),
+		ChunkSize:   n.chunkSize,
+		ColNames:    n.colNames,
+		UserProto:   planCtx.planner.User().EncodeProto(),
 	}
 
 	resTypes := make([]*types.T, len(colinfo.ExportColumns))

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -39,17 +39,20 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 59
+const Version execinfrapb.DistSQLVersion = 60
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 58
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 60
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 60 (MinAcceptedVersion: 60):
+ - Deprecated ExportWriterSpec and ParquetWriterSpec and merged them into ExportSpec
 
 - Version: 59 (MinAcceptedVersion: 58)
   - final_regr_sxx, final_regr_sxy, and final_regr_syy aggregate functions were

--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -68,12 +68,7 @@ func (m *BackupDataSpec) User() security.SQLUsername {
 }
 
 // User accesses the user field.
-func (m *CSVWriterSpec) User() security.SQLUsername {
-	return m.UserProto.Decode()
-}
-
-// User accesses the user field.
-func (m *ParquetWriterSpec) User() security.SQLUsername {
+func (m *ExportSpec) User() security.SQLUsername {
 	return m.UserProto.Decode()
 }
 

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -520,8 +520,8 @@ func (c *ReadImportDataSpec) summary() (string, []string) {
 }
 
 // summary implements the diagramCellType interface.
-func (s *CSVWriterSpec) summary() (string, []string) {
-	return "CSVWriter", []string{s.Destination}
+func (s *ExportSpec) summary() (string, []string) {
+	return "Exporter", []string{s.Destination}
 }
 
 // summary implements the diagramCellType interface.

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -101,7 +101,7 @@ message ProcessorCoreUnion {
   optional BackfillerSpec backfiller = 11;
   optional ReadImportDataSpec readImport = 13;
   reserved 14;
-  optional CSVWriterSpec CSVWriter = 20;
+  reserved 20;
   optional SamplerSpec Sampler = 15;
   optional SampleAggregatorSpec SampleAggregator = 16;
   reserved 17;
@@ -123,8 +123,7 @@ message ProcessorCoreUnion {
   optional FiltererSpec filterer = 34;
   optional StreamIngestionDataSpec streamIngestionData = 35;
   optional StreamIngestionFrontierSpec streamIngestionFrontier = 36;
-  optional ParquetWriterSpec ParquetWriter = 37;
-
+  optional ExportSpec exporter = 37;
   reserved 6, 12;
 }
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -265,62 +265,27 @@ message SplitAndScatterSpec {
   repeated TenantRekey tenant_rekeys = 3 [(gogoproto.nullable) = false];
 }
 
-// FileCompression list of the compression codecs which are currently
-// supported for CSVWriter spec
-enum FileCompression {
-  None = 0;
-  Gzip = 1;
-}
-
-// CSVWriterSpec is the specification for a processor that consumes rows and
-// writes them to CSV files at uri. It outputs a row per file written with
+// ExporterSpec is the specification for a processor that consumes rows and
+// writes them to Parquet or CSV files at uri. It outputs a row per file written with
 // the file name, row count and byte size.
-message CSVWriterSpec {
+message ExportSpec {
   // destination as a cloud.ExternalStorage URI pointing to an export store
   // location (directory).
   optional string destination = 1 [(gogoproto.nullable) = false];
   optional string name_pattern = 2 [(gogoproto.nullable) = false];
-  optional roachpb.CSVOptions options = 3 [(gogoproto.nullable) = false];
-  // chunk_rows is num rows to write per file. 0 = no limit.
-  optional int64 chunk_rows = 4 [(gogoproto.nullable) = false];
-  // chunk_size is the target byte size per file.
-  optional int64 chunk_size = 7 [(gogoproto.nullable) = false];
-
-  // compression_codec specifies compression used for exported file.
-  optional FileCompression compression_codec = 5 [(gogoproto.nullable) = false];
-
-  // User who initiated the export. This is used to check access privileges
-  // when using FileTable ExternalStorage.
-  optional string user_proto = 6 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security.SQLUsernameProto"];
-}
-
-// ParquetWriterSpec is the specification for a processor that consumes rows and
-// writes them to Parquet files at uri. It outputs a row per file written with
-// the file name, row count and byte size.
-message ParquetWriterSpec {
-  // destination as a cloud.ExternalStorage URI pointing to an export store
-  // location (directory).
-  optional string destination = 1 [(gogoproto.nullable) = false];
-  optional string name_pattern = 2 [(gogoproto.nullable) = false];
-  optional roachpb.ParquetOptions options = 3 [(gogoproto.nullable) = false];
+  optional roachpb.IOFileFormat format = 3 [(gogoproto.nullable) = false];
 
   // chunk_rows is num rows to write per file. 0 = no limit.
   optional int64 chunk_rows = 4 [(gogoproto.nullable) = false];
   // chunk_size is the target byte size per file.
-  optional int64 chunk_size = 7 [(gogoproto.nullable) = false];
-
-  // compression_codec specifies compression used for exported file. THIS IS ISN'T USED RIGHT NOW
-  optional FileCompression compression_codec = 5 [(gogoproto.nullable) = false];
+  optional int64 chunk_size = 5 [(gogoproto.nullable) = false];
 
   // User who initiated the export. This is used to check access privileges
   // when using FileTable ExternalStorage.
   optional string user_proto = 6 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security.SQLUsernameProto"];
 
   // col_names specifies the logical column names for the exported parquet file.
-  repeated string col_names = 8 ;
-
-  // col_nullability specifies which columns allow null values in the exported parquet file.
-  repeated bool col_nullability = 9 ;
+  repeated string col_names = 7 ;
 }
 
 // BulkRowWriterSpec is the specification for a processor that consumes rows and

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -13,6 +13,7 @@ package rowexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -274,25 +275,17 @@ func NewProcessor(
 		}
 		return NewStreamIngestionDataProcessor(flowCtx, processorID, *core.StreamIngestionData, post, outputs[0])
 	}
-	if core.CSVWriter != nil {
+	if core.Exporter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		if NewCSVWriterProcessor == nil {
-			return nil, errors.New("CSVWriter processor unimplemented")
+
+		if core.Exporter.Format.Format == roachpb.IOFileFormat_Parquet {
+			return NewParquetWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
 		}
-		return NewCSVWriterProcessor(flowCtx, processorID, *core.CSVWriter, inputs[0], outputs[0])
+		return NewCSVWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
 	}
-	if core.ParquetWriter != nil {
-		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
-			return nil, err
-		}
-		if NewParquetWriterProcessor == nil {
-			return nil, errors.New("ParquetWriter processor unimplemented")
-		}
-		return NewParquetWriterProcessor(flowCtx, processorID, *core.ParquetWriter, inputs[0],
-			outputs[0])
-	}
+
 	if core.BulkRowWriter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
@@ -392,10 +385,10 @@ var NewRestoreDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.RestoreD
 var NewStreamIngestionDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewCSVWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewCSVWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.CSVWriterSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewCSVWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewParquetWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewParquetWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ParquetWriterSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewParquetWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewChangeAggregatorProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewChangeAggregatorProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ChangeAggregatorSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)


### PR DESCRIPTION
Previously, EXPORT PARQUET compressed all parquet files with snappy. Now EXPORT
PARQUET defaults to exporting an uncompressed file and provides the
'compression' option which can be either 'gzip' or 'snappy'.

To implement this cleanly, the ParquetWriterProcessor now uses the
CSVWriterSpec, deprecating the ParquetWriterSpec.

Informs #67710

Release note (sql change): EXPORT PARQUET has a new 'compression' option whose
value can be 'gzip' or 'snappy'. An example query:

`EXPORT INTO PARQUET 'nodelocal://0/compress_snappy' WITH compression = snappy
   FROM SELECT * FROM foo `

By default, the parquet file will be uncompressed. With compression, the file
name will be '[filename].parquet.gz' or '[filename].parquet.snappy'.