### PR TITLE
vars: add placeholder session variable for xmloption

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4722,6 +4722,7 @@ transaction_rows_read_log                             0
 transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
+xmloption                                             content
 
 # information_schema can be used with the anonymous database.
 # It should show information across all databases.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4126,6 +4126,7 @@ transaction_rows_written_err                          0                   NULL  
 transaction_rows_written_log                          0                   NULL      NULL        NULL        string
 transaction_status                                    NoTxn               NULL      NULL        NULL        string
 vectorize                                             on                  NULL      NULL        NULL        string
+xmloption                                             content             NULL      NULL        NULL        string
 
 skipif config 3node-tenant
 query TTTTTTT colnames
@@ -4235,6 +4236,7 @@ transaction_rows_written_err                          0                   NULL  
 transaction_rows_written_log                          0                   NULL  user     NULL      0                   0
 transaction_status                                    NoTxn               NULL  user     NULL      NoTxn               NoTxn
 vectorize                                             on                  NULL  user     NULL      on                  on
+xmloption                                             content             NULL  user     NULL      content             content
 
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings
@@ -4341,6 +4343,7 @@ transaction_rows_written_err                          NULL    NULL     NULL     
 transaction_rows_written_log                          NULL    NULL     NULL     NULL        NULL
 transaction_status                                    NULL    NULL     NULL     NULL        NULL
 vectorize                                             NULL    NULL     NULL     NULL        NULL
+xmloption                                             NULL    NULL     NULL     NULL        NULL
 
 # pg_catalog.pg_sequence
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -548,6 +548,24 @@ off
 statement error invalid value for parameter "default_with_oids": "true"
 SET default_with_oids = 'true'
 
+subtest xmloption_test
+
+query T
+SHOW xmloption
+----
+content
+
+statement ok
+SET xmloption = 'content'
+
+query T
+SHOW xmloption
+----
+content
+
+statement error invalid value for parameter "xmloption": "document"
+SET xmloption = 'document'
+
 subtest backslash_quote_test
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -124,6 +124,7 @@ transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
 vectorize                                             on
+xmloption                                             content
 
 query T colnames
 SELECT * FROM [SHOW CLUSTER SETTING sql.defaults.distsql]

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -203,6 +203,6 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	"wal_debug",
 	"work_mem",
 	"xmlbinary",
-	"xmloption",
+	// "xmloption",
 	"zero_damaged_pages",
 )

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1042,6 +1042,9 @@ var varGen = map[string]sessionVar{
 	// See https://www.postgresql.org/docs/9.5/runtime-config-compatible.html
 	`default_with_oids`: makeCompatBoolVar(`default_with_oids`, false, false),
 
+	// See https://www.postgresql.org/docs/current/datatype-xml.html.
+	`xmloption`: makeCompatStringVar(`xmloption`, `content`),
+
 	// Supported for PG compatibility only.
 	// See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 	`max_identifier_length`: {


### PR DESCRIPTION
Release note (sql change): The `xmloption` session variable is now
accepted, only taking in `content`. Note this does not do anything.