### PR TITLE
sql: transaction ID cache provisional value 

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -81,6 +81,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number o
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.contention.txn_id_cache.max_size	byte size	64 MiB	the maximum byte size TxnID cache will use
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed
 sql.cross_db_sequence_references.enabled	boolean	false	if true, sequences referenced by tables from other databases are allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -88,6 +88,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the maximum byte size TxnID cache will use</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_references.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, sequences referenced by tables from other databases are allowed</td></tr>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -238,6 +238,7 @@ ALL_TESTS = [
     "//pkg/sql/colflow/colrpc:colrpc_test",
     "//pkg/sql/colflow:colflow_test",
     "//pkg/sql/colmem:colmem_test",
+    "//pkg/sql/contention/txnidcache:txnidcache_test",
     "//pkg/sql/contention:contention_test",
     "//pkg/sql/covering:covering_test",
     "//pkg/sql/distsql:distsql_test",

--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -60,6 +60,9 @@ func ConstructStatementFingerprintID(
 // individual statement fingerprint IDs that comprise the transaction.
 type TransactionFingerprintID uint64
 
+// InvalidTransactionFingerprintID denotes an invalid transaction fingerprint ID.
+const InvalidTransactionFingerprintID = TransactionFingerprintID(0)
+
 // Size returns the size of the TransactionFingerprintID.
 func (t TransactionFingerprintID) Size() int64 {
 	return 8

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -312,6 +312,7 @@ go_library(
         "//pkg/sql/colflow",
         "//pkg/sql/commenter",
         "//pkg/sql/contention",
+        "//pkg/sql/contention/txnidcache",
         "//pkg/sql/covering",
         "//pkg/sql/delegate",
         "//pkg/sql/distsql",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -599,6 +599,7 @@ go_test(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/contention/txnidcache",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -811,6 +811,7 @@ func (s *Server) newConnExecutor(
 		state: txnState{
 			mon:                          txnMon,
 			connCtx:                      ctx,
+			txnIDCacheWriter:             s.txnIDCache,
 			testingForceRealTracingSpans: s.cfg.TestingKnobs.ForceRealTracingSpans,
 		},
 		transitionCtx: transitionCtx{

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -63,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"golang.org/x/net/trace"
@@ -279,6 +281,10 @@ type Server struct {
 	// node as gateway node.
 	indexUsageStats *idxusage.LocalIndexUsageStats
 
+	// txnIDCache stores the mapping from transaction ID to transaction
+	// fingerprint IDs for all recently executed transactions.
+	txnIDCache *txnidcache.Cache
+
 	// Metrics is used to account normal queries.
 	Metrics Metrics
 
@@ -319,6 +325,10 @@ type Metrics struct {
 type ServerMetrics struct {
 	// StatsMetrics contains metrics for SQL statistics collection.
 	StatsMetrics StatsMetrics
+
+	// ContentionSubsystemMetrics contains metrics related to contention
+	// subsystem.
+	ContentionSubsystemMetrics txnidcache.Metrics
 }
 
 // NewServer creates a new Server. Start() needs to be called before the Server
@@ -361,6 +371,9 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 			ChannelSize: idxusage.DefaultChannelSize,
 			Setting:     cfg.Settings,
 		}),
+		txnIDCache: txnidcache.NewTxnIDCache(
+			cfg.Settings,
+			&serverMetrics.ContentionSubsystemMetrics),
 	}
 
 	telemetryLoggingMetrics := &TelemetryLoggingMetrics{}
@@ -451,6 +464,7 @@ func makeServerMetrics(cfg *ExecutorConfig) ServerMetrics {
 				MetaSQLTxnStatsCollectionOverhead, 6*metricsSampleInterval,
 			),
 		},
+		ContentionSubsystemMetrics: txnidcache.NewMetrics(),
 	}
 }
 
@@ -462,6 +476,8 @@ func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
 	// accumulated in the reporter when the telemetry server fails.
 	// Usually it is telemetry's reporter's job to clear the reporting SQL Stats.
 	s.reportedStats.Start(ctx, stopper)
+
+	s.txnIDCache.Start(ctx, stopper)
 }
 
 // GetSQLStatsController returns the persistedsqlstats.Controller for current
@@ -485,6 +501,11 @@ func (s *Server) GetSQLStatsProvider() sqlstats.Provider {
 // sql.Server's reported SQL Stats.
 func (s *Server) GetReportedSQLStatsController() *sslocal.Controller {
 	return s.reportedStatsController
+}
+
+// GetTxnIDCache returns the txnidcache.Cache for the current sql.Server.
+func (s *Server) GetTxnIDCache() *txnidcache.Cache {
+	return s.txnIDCache
 }
 
 // GetScrubbedStmtStats returns the statement statistics by app, with the
@@ -814,6 +835,7 @@ func (s *Server) newConnExecutor(
 		hasCreatedTemporarySchema: false,
 		stmtDiagnosticsRecorder:   s.cfg.StmtDiagnosticsRecorder,
 		indexUsageStats:           s.indexUsageStats,
+		txnIDCacheWriter:          s.txnIDCache,
 	}
 
 	ex.state.txnAbortCount = ex.metrics.EngineMetrics.TxnAbortCount
@@ -986,7 +1008,14 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.sessionEventf(ctx, "finishing connExecutor")
 
 	txnEv := noEvent
+	txnID := uuid.UUID{}
 	if _, noTxn := ex.machine.CurState().(stateNoTxn); !noTxn {
+		ex.state.mu.RLock()
+		txnID = uuid.UUID{}
+		if ex.state.mu.txn != nil {
+			txnID = ex.state.mu.txn.ID()
+		}
+		ex.state.mu.RUnlock()
 		txnEv = txnRollback
 	}
 
@@ -1019,7 +1048,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 		ex.state.finishExternalTxn()
 	}
 
-	if err := ex.resetExtraTxnState(ctx, txnEv); err != nil {
+	if err := ex.resetExtraTxnState(ctx, txnEv, txnID); err != nil {
 		log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
 	}
 
@@ -1401,6 +1430,10 @@ type connExecutor struct {
 
 	// indexUsageStats is used to track index usage stats.
 	indexUsageStats *idxusage.LocalIndexUsageStats
+
+	// txnIDCacheWriter is used to write txnidcache.ResolvedTxnID to the
+	// Transaction ID Cache.
+	txnIDCacheWriter txnidcache.Writer
 }
 
 // ctxHolder contains a connection's context and, while session tracing is
@@ -1516,8 +1549,15 @@ func (ns *prepStmtNamespace) resetTo(
 }
 
 // resetExtraTxnState resets the fields of ex.extraTxnState when a transaction
-// commits, rolls back or restarts.
-func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) error {
+// finishes execution (either commits, rolls back or restarts). Based on the
+// transaction event, resetExtraTxnState invokes corresponding callbacks
+// (e.g. onTxnFinish() and onTxnRestart()). This method also takes in the
+// transaction ID of the transaction that has just finished execution. This
+// value will later be stored with the corresponding transaction fingerprint ID
+// in the transaction ID cache.
+func (ex *connExecutor) resetExtraTxnState(
+	ctx context.Context, ev txnEvent, txnID uuid.UUID,
+) error {
 	ex.extraTxnState.jobs = nil
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 	ex.extraTxnState.schemaChangerState = SchemaChangerState{
@@ -1543,7 +1583,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 			delete(ex.extraTxnState.prepStmtsNamespaceAtTxnRewindPos.portals, name)
 		}
 		ex.extraTxnState.savepoints.clear()
-		ex.onTxnFinish(ctx, ev)
+		ex.onTxnFinish(ctx, ev, txnID)
 	case txnRestart:
 		ex.onTxnRestart()
 		ex.state.mu.Lock()
@@ -2227,8 +2267,8 @@ func (ex *connExecutor) execCopyIn(
 		}
 	} else {
 		txnOpt = copyTxnOpt{
-			resetExtraTxnState: func(ctx context.Context) error {
-				return ex.resetExtraTxnState(ctx, noEvent)
+			resetExtraTxnState: func(ctx context.Context, txnID uuid.UUID) error {
+				return ex.resetExtraTxnState(ctx, noEvent, txnID)
 			},
 		}
 	}
@@ -2653,6 +2693,23 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		txnIsOpen = true
 	}
 
+	// Retrieve the transaction ID from the current transaction before the
+	// state machine advance to the next state. This is then passed into
+	// ex.resetExtraTxnState() function, which calls to onTxnFinish() callback
+	// and record this transaction ID along with its transaction fingerprint ID
+	// in Transaction ID Cache (txnidcache.Cache).
+	//
+	// It is important to retrieve the txnID before the state machine advance
+	// since onc ethe connExecutor's state machine advances (e.g. by
+	// COMMIT / ABORT events), ex.state.mu.txn object will be reset by the state
+	// machine and the transaction ID information will be lost.
+	ex.state.mu.RLock()
+	txnID := uuid.UUID{}
+	if ex.state.mu.txn != nil {
+		txnID = ex.state.mu.txn.ID()
+	}
+	ex.state.mu.RUnlock()
+
 	ex.mu.Lock()
 	err := ex.machine.ApplyWithPayload(withStatement(ex.Ctx(), ex.curStmtAST), ev, payload)
 	ex.mu.Unlock()
@@ -2776,7 +2833,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 
 		fallthrough
 	case txnRestart, txnRollback:
-		if err := ex.resetExtraTxnState(ex.Ctx(), advInfo.txnEvent); err != nil {
+		if err := ex.resetExtraTxnState(ex.Ctx(), advInfo.txnEvent, txnID); err != nil {
 			return advanceInfo{}, err
 		}
 	default:

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -51,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -1920,7 +1922,7 @@ func (ex *connExecutor) recordTransactionStart() {
 	}
 }
 
-func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
+func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnID uuid.UUID) {
 	if ex.extraTxnState.shouldExecuteOnTxnFinish {
 		ex.extraTxnState.shouldExecuteOnTxnFinish = false
 		txnStart := ex.extraTxnState.txnFinishClosure.txnStartTime
@@ -1934,7 +1936,14 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 				transactionFingerprintID,
 			)
 		}
-		err := ex.recordTransaction(ctx, transactionFingerprintID, ev, implicit, txnStart)
+		if ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded != nil {
+			ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded(
+				ex.sessionData(),
+				txnID,
+				transactionFingerprintID,
+			)
+		}
+		err := ex.recordTransaction(ctx, txnID, transactionFingerprintID, ev, implicit, txnStart)
 		if err != nil {
 			if log.V(1) {
 				log.Warningf(ctx, "failed to record transaction stats: %s", err)
@@ -1965,6 +1974,7 @@ func (ex *connExecutor) onTxnRestart() {
 
 func (ex *connExecutor) recordTransaction(
 	ctx context.Context,
+	transactionID uuid.UUID,
 	transactionFingerprintID roachpb.TransactionFingerprintID,
 	ev txnEvent,
 	implicit bool,
@@ -1990,6 +2000,11 @@ func (ex *connExecutor) recordTransaction(
 	txnTime := txnEnd.Sub(txnStart)
 	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)
 	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
+
+	ex.txnIDCacheWriter.Record(txnidcache.ResolvedTxnID{
+		TxnID:            transactionID,
+		TxnFingerprintID: transactionFingerprintID,
+	})
 
 	txnServiceLat := ex.phaseTimes.GetTransactionServiceLatency()
 	txnRetryLat := ex.phaseTimes.GetTransactionRetryLatency()

--- a/pkg/sql/contention/txnidcache/BUILD.bazel
+++ b/pkg/sql/contention/txnidcache/BUILD.bazel
@@ -1,0 +1,53 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "txnidcache",
+    srcs = [
+        "cluster_settings.go",
+        "concurrent_write_buffer.go",
+        "metrics.go",
+        "txn_id_cache.go",
+        "writer.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb:with-mocks",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/util/cache",
+        "//pkg/util/encoding",
+        "//pkg/util/metric",
+        "//pkg/util/stop",
+        "//pkg/util/syncutil",
+        "//pkg/util/uuid",
+    ],
+)
+
+go_test(
+    name = "txnidcache_test",
+    srcs = [
+        "main_test.go",
+        "txn_id_cache_test.go",
+    ],
+    deps = [
+        ":txnidcache",
+        "//pkg/kv",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/sql/sessiondata",
+        "//pkg/sql/tests",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/sql/contention/txnidcache/BUILD.bazel
+++ b/pkg/sql/contention/txnidcache/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
         "txn_id_cache_test.go",
     ],
     deps = [
-        ":txnidcache",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
@@ -46,6 +45,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/contention/txnidcache/cluster_settings.go
+++ b/pkg/sql/contention/txnidcache/cluster_settings.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache
+
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+// MaxSize limits the maximum byte size can be used by the TxnIDCache.
+var MaxSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	`sql.contention.txn_id_cache.max_size`,
+	"the maximum byte size TxnID cache will use",
+	64*1024*1024, // 64 MB
+).WithPublic()

--- a/pkg/sql/contention/txnidcache/concurrent_write_buffer.go
+++ b/pkg/sql/contention/txnidcache/concurrent_write_buffer.go
@@ -1,0 +1,118 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+const messageBlockSize = 1024
+
+type messageBlock [messageBlockSize]ResolvedTxnID
+
+// concurrentWriteBuffer is a data structure that optimizes for concurrent
+// writes and also implements the Writer interface.
+//
+// Any write requests initially starts by holding a read lock (flushSyncLock)
+// and then reserves an index to the messageBlock (a fixed-length array). If the
+// reserved index is valid, concurrentWriteBuffer immediately writes to the
+// array at the reserved index. However, if the reserved index is not valid,
+// (that is, array index out of bound), there are two scenarios:
+// 1. If the reserved index == size of the array, then the caller of Record()
+//    method is responsible for flushing the entire array into the channel. The
+//    caller does so by upgrading the read-lock to a write-lock, therefore
+//    blocks all future writers from writing to the shared array. After the
+//    flush is performed, the write-lock is then downgraded to a read-lock.
+// 2. If the reserved index > size of the array, then the caller of Record()
+//    is blocked until the array is flushed. This is achieved by waiting on the
+//    conditional variable (flushDone) while holding onto the read-lock. After
+//    the flush is completed, the writer is unblocked and allowed to retry.
+type concurrentWriteBuffer struct {
+	flushSyncLock syncutil.RWMutex
+	flushDone     sync.Cond
+
+	msgBlockPool *sync.Pool
+
+	// msgBlock is the temporary buffer that concurrentWriteBuffer uses to batch
+	// write requests before sending them into the channel.
+	msgBlock *messageBlock
+
+	// atomicIdx is the index pointing into the fixed-length array within the
+	// msgBlock.This should only be accessed using atomic package.
+	atomicIdx int64
+
+	// sink is the flush target that concurrentWriteBuffer flushes to once
+	// msgBlock is full.
+	sink messageSink
+}
+
+var _ Writer = &concurrentWriteBuffer{}
+
+// newConcurrentWriteBuffer returns a new instance of concurrentWriteBuffer.
+func newConcurrentWriteBuffer(sink messageSink, msgBlockPool *sync.Pool) *concurrentWriteBuffer {
+	writeBuffer := &concurrentWriteBuffer{
+		sink:         sink,
+		msgBlockPool: msgBlockPool,
+		msgBlock:     msgBlockPool.Get().(*messageBlock),
+	}
+	writeBuffer.flushDone.L = writeBuffer.flushSyncLock.RLocker()
+	return writeBuffer
+}
+
+// Record records a mapping from txnID to its corresponding transaction
+// fingerprint ID. Record is safe to be used concurrently.
+func (c *concurrentWriteBuffer) Record(resolvedTxnID ResolvedTxnID) {
+	c.flushSyncLock.RLock()
+	defer c.flushSyncLock.RUnlock()
+	for {
+		reservedIdx := c.reserveMsgBlockIndex()
+		if reservedIdx < messageBlockSize {
+			c.msgBlock[reservedIdx] = resolvedTxnID
+			return
+		} else if reservedIdx == messageBlockSize {
+			c.flushMsgBlockToChannelRLocked()
+		} else {
+			c.flushDone.Wait()
+		}
+	}
+}
+
+// Flush flushes concurrentWriteBuffer into the channel. It implements the
+// txnidcache.Writer interface.
+func (c *concurrentWriteBuffer) Flush() {
+	c.flushSyncLock.Lock()
+	c.flushMsgBlockToChannelLocked()
+	c.flushSyncLock.Unlock()
+}
+
+func (c *concurrentWriteBuffer) flushMsgBlockToChannelRLocked() {
+	// We upgrade the read-lock to a write-lock, then when we are done flushing,
+	// the lock is downgraded to a read-lock.
+	c.flushSyncLock.RUnlock()
+	defer c.flushSyncLock.RLock()
+	c.flushSyncLock.Lock()
+	defer c.flushSyncLock.Unlock()
+	c.flushMsgBlockToChannelLocked()
+}
+
+func (c *concurrentWriteBuffer) flushMsgBlockToChannelLocked() {
+	c.sink.push(c.msgBlock)
+	c.msgBlock = c.msgBlockPool.Get().(*messageBlock)
+	c.flushDone.Broadcast()
+	atomic.StoreInt64(&c.atomicIdx, 0)
+}
+
+func (c *concurrentWriteBuffer) reserveMsgBlockIndex() int64 {
+	return atomic.AddInt64(&c.atomicIdx, 1) - 1 // since array is 0-indexed.
+}

--- a/pkg/sql/contention/txnidcache/main_test.go
+++ b/pkg/sql/contention/txnidcache/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/contention/txnidcache/metrics.go
+++ b/pkg/sql/contention/txnidcache/metrics.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics is a structs that include all metrics related to contention
+// subsystem.
+type Metrics struct {
+	DiscardedResolvedTxnIDCount *metric.Counter
+	EvictedTxnIDCacheCount      *metric.Counter
+}
+
+var _ metric.Struct = Metrics{}
+
+// MetricStruct implements the metric.Struct interface.
+func (Metrics) MetricStruct() {}
+
+// NewMetrics returns a new instance of Metrics.
+func NewMetrics() Metrics {
+	return Metrics{
+		DiscardedResolvedTxnIDCount: metric.NewCounter(metric.Metadata{
+			Name:        "sql.contention.txn_id_cache.discarded_count",
+			Help:        "Number of discarded resolved transaction IDs",
+			Measurement: "Discarded Resolved Transaction IDs",
+			Unit:        metric.Unit_COUNT,
+		}),
+		EvictedTxnIDCacheCount: metric.NewCounter(metric.Metadata{
+			Name:        "sql.contention.txn_id_cache.evicted_count",
+			Help:        "Number of evicted resolved transaction IDs",
+			Measurement: "Evicted Resolved Transaction IDs",
+			Unit:        metric.Unit_COUNT,
+		}),
+	}
+}

--- a/pkg/sql/contention/txnidcache/txn_id_cache.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache.go
@@ -133,7 +133,7 @@ type ResolvedTxnID struct {
 }
 
 func (r *ResolvedTxnID) valid() bool {
-	return r.TxnFingerprintID != roachpb.InvalidTransactionFingerprintID
+	return r.TxnID != uuid.UUID{}
 }
 
 var (

--- a/pkg/sql/contention/txnidcache/txn_id_cache.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache.go
@@ -1,0 +1,237 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// Reader is the interface that can be used to query the transaction fingerprint
+// ID of a transaction ID.
+type Reader interface {
+	// Lookup returns the corresponding transaction fingerprint ID for a given txnID,
+	// if the given txnID has no entry in the Cache, the returned "found" boolean
+	// will be false.
+	// TODO(azhng): we eventually want to implement a batch-lookup API.
+	Lookup(txnID uuid.UUID) (result roachpb.TransactionFingerprintID, found bool)
+}
+
+// Writer is the interface that can be used to write to txnidcache.
+type Writer interface {
+	// Record writes a pair of transactionID and transaction fingerprint ID
+	// into a temporary buffer. This buffer will eventually be flushed into
+	// the transaction ID cache asynchronously.
+	Record(resolvedTxnID ResolvedTxnID)
+
+	// Flush starts the flushing process of writer's temporary buffer.
+	Flush()
+}
+
+type messageSink interface {
+	// push allows a messageBlock to be pushed into the pusher.
+	push(*messageBlock)
+}
+
+const channelSize = 128
+
+// Cache stores the mapping from the Transaction IDs (UUID) of recently
+// executed transactions to their corresponding Transaction Fingerprint ID (uint64).
+// The size of Cache is controlled via sql.contention.txn_id_cache.max_size
+// cluster setting, and it follows FIFO eviction policy once the cache size
+// reaches the limit defined by the cluster setting.
+//
+// Cache's overall architecture is as follows:
+//   +------------------------------------------------------------+
+//   | connExecutor  --------*                                    |
+//   |                       |  writes resolvedTxnID to Writer    |
+//   |                       v                                    |
+//   |      +---------------------------------------------------+ |
+//   |      | Writer                                            | |
+//   |      |                                                   | |
+//   |      |  Writer contains multiple shards of concurrent    | |
+//   |      |  write buffer. Each incoming resolvedTxnID is     | |
+//   |      |  first hashed to a corresponding shard, and then  | |
+//   |      |  is written to the concurrent write buffer        | |
+//   |      |  backing that shard. Once the concurrent write    | |
+//   |      |  buffer is full, a flush is performed and the     | |
+//   |      |  content of the buffer is send into the channel.  | |
+//   |      |                                                   | |
+//   |      | +------------+                                    | |
+//   |      | | shard1     |                                    | |
+//   |      | +------------+                                    | |
+//   |      | | shard2     |                                    | |
+//   |      | +------------+                                    | |
+//   |      | | shard3     |                                    | |
+//   |      | +------------+                                    | |
+//   |      | | .....      |                                    | |
+//   |      | | .....      |                                    | |
+//   |      | +------------+                                    | |
+//   |      | | shard128   |                                    | |
+//   |      | +------------+                                    | |
+//   |      |                                                   | |
+//   |      +-----+---------------------------------------------+ |
+//   +------------|-----------------------------------------------+
+//                |
+//                |
+//                V
+//               channel
+//                ^
+//                |
+//               Cache polls the channel using a goroutine and push the
+//                |   messageBlock into its storage.
+//                |
+//   +----------------------------------+
+//   |    Cache:                        |
+//   |     The cache contains a         |
+//   |     FIFO buffer backed by        |
+//   |     cache.UnorderedCache         |
+//   +----------------------------------+
+type Cache struct {
+	st *cluster.Settings
+
+	msgChan chan *messageBlock
+
+	mu struct {
+		syncutil.RWMutex
+
+		store *cache.UnorderedCache
+	}
+
+	messageBlockPool *sync.Pool
+
+	writer Writer
+
+	metrics *Metrics
+}
+
+var (
+	entrySize = int64(uuid.UUID{}.Size()) +
+		roachpb.TransactionFingerprintID(0).Size()
+)
+
+// ResolvedTxnID represents a TxnID that is resolved to its corresponding
+// TxnFingerprintID.
+type ResolvedTxnID struct {
+	TxnID            uuid.UUID
+	TxnFingerprintID roachpb.TransactionFingerprintID
+}
+
+func (r *ResolvedTxnID) valid() bool {
+	return r.TxnFingerprintID != roachpb.InvalidTransactionFingerprintID
+}
+
+var (
+	_ Reader      = &Cache{}
+	_ Writer      = &Cache{}
+	_ messageSink = &Cache{}
+)
+
+// NewTxnIDCache creates a new instance of Cache.
+func NewTxnIDCache(st *cluster.Settings, metrics *Metrics) *Cache {
+	t := &Cache{
+		st:      st,
+		metrics: metrics,
+		msgChan: make(chan *messageBlock, channelSize),
+	}
+
+	t.messageBlockPool = &sync.Pool{
+		New: func() interface{} {
+			return &messageBlock{}
+		},
+	}
+
+	t.mu.store = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheFIFO,
+		ShouldEvict: func(size int, _, _ interface{}) bool {
+			return int64(size)*entrySize > MaxSize.Get(&st.SV)
+		},
+		OnEvictedEntry: func(_ *cache.Entry) {
+			metrics.EvictedTxnIDCacheCount.Inc(1)
+		},
+	})
+
+	t.writer = newWriter(t, t.messageBlockPool)
+	return t
+}
+
+// Start implements the Provider interface.
+func (t *Cache) Start(ctx context.Context, stopper *stop.Stopper) {
+	_ = stopper.RunAsyncTask(ctx, "txn-id-cache-ingest", func(ctx context.Context) {
+		for {
+			select {
+			case msgBlock := <-t.msgChan:
+				func() {
+					t.mu.Lock()
+					defer t.mu.Unlock()
+					for blockIdx := range msgBlock {
+						if !msgBlock[blockIdx].valid() {
+							break
+						}
+						t.mu.store.Add(msgBlock[blockIdx].TxnID, msgBlock[blockIdx].TxnFingerprintID)
+					}
+				}()
+				// Zero out the block and put it back into the pool.
+				*msgBlock = messageBlock{}
+				t.messageBlockPool.Put(msgBlock)
+			case <-stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+}
+
+// Lookup implements the Reader interface.
+func (t *Cache) Lookup(txnID uuid.UUID) (result roachpb.TransactionFingerprintID, found bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	txnFingerprintID, ok := t.mu.store.Get(txnID)
+	if !ok {
+		return roachpb.InvalidTransactionFingerprintID, false /* found */
+	}
+
+	return txnFingerprintID.(roachpb.TransactionFingerprintID), true /* found */
+}
+
+// Record implements the Writer interface.
+func (t *Cache) Record(resolvedTxnID ResolvedTxnID) {
+	t.writer.Record(resolvedTxnID)
+}
+
+// push implements the messageSink interface.
+func (t *Cache) push(msg *messageBlock) {
+	select {
+	case t.msgChan <- msg:
+		// noop.
+	default:
+		t.metrics.DiscardedResolvedTxnIDCount.Inc(messageBlockSize)
+	}
+}
+
+// Flush flushes the resolved txn IDs in the Writer into the Cache.
+func (t *Cache) Flush() {
+	t.writer.Flush()
+}
+
+// Size return the current size of the Cache.
+func (t *Cache) Size() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return int64(t.mu.store.Len()) * entrySize
+}

--- a/pkg/sql/contention/txnidcache/txn_id_cache_test.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache_test.go
@@ -1,0 +1,204 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransactionIDCache tests the correctness of the txnidcache.Cache.
+func TestTransactionIDCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+
+	appName := "txnIDCacheTest"
+	expectedTxnIDToUUIDMapping := make(map[uuid.UUID]roachpb.TransactionFingerprintID)
+
+	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+		BeforeTxnStatsRecorded: func(
+			sessionData *sessiondata.SessionData,
+			txnID uuid.UUID,
+			txnFingerprintID roachpb.TransactionFingerprintID,
+		) {
+			if strings.Contains(sessionData.ApplicationName, appName) {
+				expectedTxnIDToUUIDMapping[txnID] = txnFingerprintID
+			}
+		},
+	}
+
+	testServer, sqlConn, kvDB := serverutils.StartServer(t, params)
+	defer func() {
+		require.NoError(t, sqlConn.Close())
+		testServer.Stopper().Stop(ctx)
+	}()
+
+	testConn := sqlutils.MakeSQLRunner(sqlConn)
+
+	// Set the cache size limit to a very generous amount to prevent premature
+	// eviction.
+	testConn.Exec(t, "SET CLUSTER SETTING sql.contention.txn_id_cache.max_size = '1GB'")
+
+	testConn.Exec(t, "CREATE DATABASE txnIDTest")
+	testConn.Exec(t, "USE txnIDTest")
+	testConn.Exec(t, "CREATE TABLE t AS SELECT generate_series(1, 10)")
+	testConn.Exec(t, "SET application_name = $1", appName)
+
+	testCases := []struct {
+		stmts    []string
+		explicit bool
+	}{
+		// Implicit transactions that will have same statement fingerprint.
+		{
+			stmts:    []string{"SELECT 1"},
+			explicit: false,
+		},
+		{
+			stmts:    []string{"SELECT 2"},
+			explicit: false,
+		},
+
+		// Implicit transaction that have different statement fingerprints.
+		{
+			stmts:    []string{"SELECT 1, 1"},
+			explicit: false,
+		},
+		{
+			stmts:    []string{"SELECT 1, 1, 2"},
+			explicit: false,
+		},
+
+		// Explicit Transactions.
+		{
+			stmts:    []string{"SELECT 1"},
+			explicit: true,
+		},
+		{
+			stmts:    []string{"SELECT 5"},
+			explicit: true,
+		},
+		{
+			stmts:    []string{"SELECT 5", "SELECT 6, 7"},
+			explicit: true,
+		},
+	}
+
+	// Send test statements into both regular SQL connection and internal
+	// executor to test both code paths.
+	for _, tc := range testCases {
+		if tc.explicit {
+			testConn.Exec(t, "BEGIN")
+		}
+		{
+			for _, stmt := range tc.stmts {
+				testConn.Exec(t, stmt)
+			}
+		}
+		if tc.explicit {
+			testConn.Exec(t, "COMMIT")
+		}
+	}
+
+	ie := testServer.InternalExecutor().(*sql.InternalExecutor)
+
+	for _, tc := range testCases {
+		// Send statements one by one since internal executor doesn't support
+		// sending a batch of statements.
+		for _, stmt := range tc.stmts {
+			var txn *kv.Txn
+			if tc.explicit {
+				txn = kvDB.NewTxn(ctx, "")
+			}
+			_, err := ie.QueryRowEx(
+				ctx,
+				appName,
+				txn,
+				sessiondata.InternalExecutorOverride{
+					User: security.RootUserName(),
+				},
+				stmt,
+			)
+			require.NoError(t, err)
+			if tc.explicit {
+				require.NoError(t, txn.Commit(ctx))
+			}
+
+			require.NoError(t, err)
+		}
+	}
+
+	// Ensure we have intercepted all transactions, the expected size is
+	// calculated as:
+	// # stmt executed in regular executor
+	//  + # stmt executed in internal executor
+	//  + 1 (`SET application_name` executed previously in regular SQL Conn)
+	//  - 3 (explicit txns executed in internal executor due to
+	//       https://github.com/cockroachdb/cockroach/issues/73091)
+	expectedTxnIDCacheSize := len(testCases)*2 + 1 - 3
+	require.Equal(t, expectedTxnIDCacheSize, len(expectedTxnIDToUUIDMapping))
+
+	sqlServer := testServer.SQLServer().(*sql.Server)
+	txnIDCache := sqlServer.GetTxnIDCache()
+
+	txnIDCache.Flush()
+	testutils.SucceedsWithin(t, func() error {
+		for txnID, expectedTxnFingerprintID := range expectedTxnIDToUUIDMapping {
+			actualTxnFingerprintID, ok := txnIDCache.Lookup(txnID)
+			if !ok {
+				return errors.Newf("expected to find txn(%s) with fingerprintID: "+
+					"%d, but it was not found.",
+					txnID, expectedTxnFingerprintID,
+				)
+			}
+			if expectedTxnFingerprintID != actualTxnFingerprintID {
+				return errors.Newf("expected to find txn(%s) with fingerprintID: %d, but the actual fingerprintID is: %d", txnID, expectedTxnFingerprintID, actualTxnFingerprintID)
+			}
+
+		}
+		return nil
+	}, 3*time.Second)
+
+	sizePreEviction := txnIDCache.Size()
+	testConn.Exec(t, "SET CLUSTER SETTING sql.contention.txn_id_cache.max_size = '10B'")
+
+	// Execute additional queries to ensure we are overflowing the size limit.
+	testConn.Exec(t, "SELECT 1")
+
+	txnIDCache.Flush()
+	testutils.SucceedsWithin(t, func() error {
+		sizePostEviction := txnIDCache.Size()
+		if sizePostEviction >= sizePreEviction {
+			return errors.Newf("expected txn id cache size to shrink below, "+
+				"but it has increased to %d", sizePreEviction, sizePostEviction)
+		}
+		return nil
+	}, 3*time.Second)
+}

--- a/pkg/sql/contention/txnidcache/writer.go
+++ b/pkg/sql/contention/txnidcache/writer.go
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package txnidcache
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+const shardCount = 128
+
+type writer struct {
+	shards [shardCount]*concurrentWriteBuffer
+
+	sink         messageSink
+	msgBlockPool *sync.Pool
+}
+
+var _ Writer = &writer{}
+
+func newWriter(sink messageSink, msgBlockPool *sync.Pool) *writer {
+	w := &writer{
+		sink:         sink,
+		msgBlockPool: msgBlockPool,
+	}
+
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		w.shards[shardIdx] = newConcurrentWriteBuffer(sink, msgBlockPool)
+	}
+
+	return w
+}
+
+// Record implements the Writer interface.
+func (w *writer) Record(resolvedTxnID ResolvedTxnID) {
+	shardIdx := hashTxnID(resolvedTxnID.TxnID)
+	buffer := w.shards[shardIdx]
+	buffer.Record(resolvedTxnID)
+}
+
+// Flush implements the Writer interface.
+func (w *writer) Flush() {
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		w.shards[shardIdx].Flush()
+	}
+}
+
+func hashTxnID(txnID uuid.UUID) int {
+	b := txnID.GetBytes()
+	b, val, err := encoding.DecodeUint64Descending(b)
+	if err != nil {
+		panic(err)
+	}
+	return int(val % shardCount)
+}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -217,7 +218,7 @@ type copyTxnOpt struct {
 
 	// resetExecutor should be called upon completing a batch from the copy
 	// machine when the copy machine handles its own transaction.
-	resetExtraTxnState func(ctx context.Context) error
+	resetExtraTxnState func(ctx context.Context, txnID uuid.UUID) error
 }
 
 // run consumes all the copy-in data from the network connection and inserts it
@@ -629,7 +630,7 @@ func (p *planner) preparePlannerForCopy(
 			defer func() {
 				// Note: combine errors will return nil if both are nil and the
 				// non-nil error in the case that there's just one.
-				err = errors.CombineErrors(err, txnOpt.resetExtraTxnState(ctx))
+				err = errors.CombineErrors(err, txnOpt.resetExtraTxnState(ctx, txn.ID()))
 			}()
 		}
 		if prevErr == nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1406,6 +1406,14 @@ type ExecutorTestingKnobs struct {
 
 	// OnTxnRetry, if set, will be called if there is a transaction retry.
 	OnTxnRetry func(autoRetryReason error, evalCtx *tree.EvalContext)
+
+	// BeforeTxnStatsRecorded, if set, will be called before the statistics
+	// of a transaction is being recorded.
+	BeforeTxnStatsRecorded func(
+		sessionData *sessiondata.SessionData,
+		txnID uuid.UUID,
+		txnFingerprintID roachpb.TransactionFingerprintID,
+	)
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -378,6 +378,7 @@ func (s *Server) Metrics() (res []interface{}) {
 		&s.SQLServer.InternalMetrics.EngineMetrics,
 		&s.SQLServer.InternalMetrics.GuardrailMetrics,
 		&s.SQLServer.ServerMetrics.StatsMetrics,
+		&s.SQLServer.ServerMetrics.ContentionSubsystemMetrics,
 	}
 }
 

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -115,6 +117,10 @@ type txnState struct {
 	// testingForceRealTracingSpans is a test-only knob that forces the use of
 	// real (i.e. not no-op) tracing spans for every statement.
 	testingForceRealTracingSpans bool
+
+	// txnIDCacheWriter is a writer that allows the txnState writes to the
+	// transaction ID Cache.
+	txnIDCacheWriter txnidcache.Writer
 }
 
 // txnType represents the type of a SQL transaction.
@@ -214,6 +220,16 @@ func (ts *txnState) resetForNewSQLTxn(
 	}
 	if err := ts.setReadOnlyMode(readOnly); err != nil {
 		panic(err)
+	}
+
+	txnID, ok := ts.tryGetCurrentTxnID()
+	if ok {
+		// We will come back to update the TxnFingerprintID once the transaction
+		// finishes execution.
+		ts.txnIDCacheWriter.Record(txnidcache.ResolvedTxnID{
+			TxnID:            txnID,
+			TxnFingerprintID: roachpb.InvalidTransactionFingerprintID,
+		})
 	}
 }
 
@@ -440,4 +456,16 @@ func (ts *txnState) consumeAdvanceInfo() advanceInfo {
 	adv := ts.adv
 	ts.adv = advanceInfo{}
 	return adv
+}
+
+func (ts *txnState) tryGetCurrentTxnID() (uuid.UUID, bool) {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	if ts.mu.txn == nil {
+		return uuid.UUID{}, false
+	}
+
+	id := ts.mu.txn
+	return id.ID(), true
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1880,6 +1880,19 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{SQLLayer, "Contention"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Number of discarded resolved transaction IDs",
+				Metrics: []string{"sql.contention.txn_id_cache.discarded_count"},
+			},
+			{
+				Title:   "Evicted Resolved Transaction IDs",
+				Metrics: []string{"sql.contention.txn_id_cache.evicted_count"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{SQLLayer, "Bulk"}},
 		Charts: []chartDescription{
 			{


### PR DESCRIPTION
Follow up to #74115

---

Previously, the transaction ID cache recorded the mapping from
transaction ID to transaction fingerprint ID once the transaction
finished executing. This introduced a problem where, when we queried the
transaction ID cache with a transaction ID, and we were not able to
distinguish between the case where transaction ID entry was being
evicted, or the transaction with that ID was still executing.

This commit addresses this problem by immediately starting a write
operation to write a provisional transaction fingerprint ID into
transaction ID cache once the transaction ID for a transaction is
determined. This is then followed up with additional write operation
once the transaction finishes execution where the transaction
fingerprint ID is then determined. Since transaction ID Cache always
returns the most-recent written value for a given key, the the
provisional transaction fingerprint ID will not be returned once the
actual transaction fingerprint ID is written.

Related #74485.

Release note: None